### PR TITLE
Blogging reminders cleanup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersModelMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersModelMapper.kt
@@ -1,0 +1,37 @@
+package org.wordpress.android.ui.bloggingreminders
+
+import org.wordpress.android.fluxc.model.BloggingRemindersModel
+import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day
+import java.time.DayOfWeek
+import java.time.DayOfWeek.FRIDAY
+import java.time.DayOfWeek.MONDAY
+import java.time.DayOfWeek.SATURDAY
+import java.time.DayOfWeek.SUNDAY
+import java.time.DayOfWeek.THURSDAY
+import java.time.DayOfWeek.TUESDAY
+import java.time.DayOfWeek.WEDNESDAY
+import javax.inject.Inject
+
+class BloggingRemindersModelMapper
+@Inject constructor() {
+    fun toDomainModel(uiModel: BloggingRemindersUiModel): BloggingRemindersModel {
+        return BloggingRemindersModel(uiModel.siteId, uiModel.enabledDays.map {
+            when (it) {
+                SATURDAY -> Day.SATURDAY
+                MONDAY -> Day.MONDAY
+                TUESDAY -> Day.TUESDAY
+                WEDNESDAY -> Day.WEDNESDAY
+                THURSDAY -> Day.THURSDAY
+                FRIDAY -> Day.FRIDAY
+                SUNDAY -> Day.SUNDAY
+            }
+        }.toSet())
+    }
+
+    fun toUiModel(domainModel: BloggingRemindersModel): BloggingRemindersUiModel {
+        return BloggingRemindersUiModel(
+                domainModel.siteId,
+                domainModel.enabledDays.map { DayOfWeek.valueOf(it.name) }.toSet()
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.bloggingreminders
+
+import java.time.DayOfWeek
+
+data class BloggingRemindersUiModel(val siteId: Int, val enabledDays: Set<DayOfWeek> = setOf()) {
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
@@ -2,5 +2,4 @@ package org.wordpress.android.ui.bloggingreminders
 
 import java.time.DayOfWeek
 
-data class BloggingRemindersUiModel(val siteId: Int, val enabledDays: Set<DayOfWeek> = setOf()) {
-}
+data class BloggingRemindersUiModel(val siteId: Int, val enabledDays: Set<DayOfWeek> = setOf())

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -101,7 +101,7 @@ class BloggingRemindersViewModel @Inject constructor(
         }.asLiveData(mainDispatcher)
     }
 
-    fun showBottomSheet(siteId: Int, screen: Screen, source: Source) {
+    private fun showBottomSheet(siteId: Int, screen: Screen, source: Source) {
         analyticsTracker.setSite(siteId)
         analyticsTracker.trackFlowStart(source)
         val isPrologueScreen = screen == PROLOGUE || screen == PROLOGUE_SETTINGS

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -8,8 +8,6 @@ import androidx.lifecycle.distinctUntilChanged
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
-import org.wordpress.android.fluxc.model.BloggingRemindersModel
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source
@@ -42,13 +40,14 @@ class BloggingRemindersViewModel @Inject constructor(
     private val epilogueBuilder: EpilogueBuilder,
     private val dayLabelUtils: DayLabelUtils,
     private val analyticsTracker: BloggingRemindersAnalyticsTracker,
-    private val reminderScheduler: ReminderScheduler
+    private val reminderScheduler: ReminderScheduler,
+    private val mapper: BloggingRemindersModelMapper
 ) : ScopedViewModel(mainDispatcher) {
     private val _isBottomSheetShowing = MutableLiveData<Event<Boolean>>()
     val isBottomSheetShowing = _isBottomSheetShowing as LiveData<Event<Boolean>>
     private val _selectedScreen = MutableLiveData<Screen>()
     private val selectedScreen = _selectedScreen.perform { onScreenChanged(it) }
-    private val _bloggingRemindersModel = MutableLiveData<BloggingRemindersModel>()
+    private val _bloggingRemindersModel = MutableLiveData<BloggingRemindersUiModel>()
     private val _isFirstTimeFlow = MutableLiveData<Boolean>()
     val uiState: LiveData<UiState> = merge(
             selectedScreen,
@@ -97,7 +96,7 @@ class BloggingRemindersViewModel @Inject constructor(
 
     fun getSettingsState(siteId: Int): LiveData<UiString> {
         return bloggingRemindersStore.bloggingRemindersModel(siteId).map {
-            dayLabelUtils.buildNTimesLabel(it)
+            mapper.toUiModel(it).let { uiModel -> dayLabelUtils.buildNTimesLabel(uiModel) }
         }.asLiveData(mainDispatcher)
     }
 
@@ -113,12 +112,12 @@ class BloggingRemindersViewModel @Inject constructor(
         _selectedScreen.value = screen
         launch {
             bloggingRemindersStore.bloggingRemindersModel(siteId).collect {
-                _bloggingRemindersModel.value = it
+                _bloggingRemindersModel.value = mapper.toUiModel(it)
             }
         }
     }
 
-    fun selectDay(day: Day) {
+    fun selectDay(day: DayOfWeek) {
         val currentState = _bloggingRemindersModel.value!!
         val enabledDays = currentState.enabledDays.toMutableSet()
         if (enabledDays.contains(day)) {
@@ -129,11 +128,15 @@ class BloggingRemindersViewModel @Inject constructor(
         _bloggingRemindersModel.value = currentState.copy(enabledDays = enabledDays)
     }
 
-    private fun showEpilogue(bloggingRemindersModel: BloggingRemindersModel?) {
+    private fun showEpilogue(bloggingRemindersModel: BloggingRemindersUiModel?) {
         analyticsTracker.trackPrimaryButtonPressed(SELECTION)
         if (bloggingRemindersModel != null) {
             launch {
-                bloggingRemindersStore.updateBloggingReminders(bloggingRemindersModel)
+                bloggingRemindersStore.updateBloggingReminders(
+                        mapper.toDomainModel(
+                                bloggingRemindersModel
+                        )
+                )
                 val daysCount = bloggingRemindersModel.enabledDays.size
                 if (daysCount > 0) {
                     reminderScheduler.schedule(bloggingRemindersModel.siteId, bloggingRemindersModel.toReminderConfig())
@@ -166,8 +169,8 @@ class BloggingRemindersViewModel @Inject constructor(
         }
         val siteId = state.getInt(SITE_ID)
         if (siteId != 0) {
-            val enabledDays = state.getStringArrayList(SELECTED_DAYS)?.map { Day.valueOf(it) }?.toSet() ?: setOf()
-            _bloggingRemindersModel.value = BloggingRemindersModel(siteId, enabledDays)
+            val enabledDays = state.getStringArrayList(SELECTED_DAYS)?.map { DayOfWeek.valueOf(it) }?.toSet() ?: setOf()
+            _bloggingRemindersModel.value = BloggingRemindersUiModel(siteId, enabledDays)
         }
         _isFirstTimeFlow.value = state.getBoolean(IS_FIRST_TIME_FLOW)
     }
@@ -180,11 +183,11 @@ class BloggingRemindersViewModel @Inject constructor(
 
     fun onSettingsItemClicked(siteId: Int) {
         launch {
-                val screen = if (bloggingRemindersStore.hasModifiedBloggingReminders(siteId)) {
-                    SELECTION
-                } else {
-                    PROLOGUE_SETTINGS
-                }
+            val screen = if (bloggingRemindersStore.hasModifiedBloggingReminders(siteId)) {
+                SELECTION
+            } else {
+                PROLOGUE_SETTINGS
+            }
             showBottomSheet(siteId, screen, BLOG_SETTINGS)
         }
     }
@@ -198,8 +201,8 @@ class BloggingRemindersViewModel @Inject constructor(
         }
     }
 
-    private fun BloggingRemindersModel.toReminderConfig() =
-            WeeklyReminder(enabledDays.map { DayOfWeek.of(it.ordinal + 1) }.toSet())
+    private fun BloggingRemindersUiModel.toReminderConfig() =
+            WeeklyReminder(this.enabledDays)
 
     enum class Screen(val trackingName: String) {
         PROLOGUE("main"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DayLabelUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DayLabelUtils.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.bloggingreminders
 
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.BloggingRemindersModel
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DayLabelUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DayLabelUtils.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 class DayLabelUtils
 @Inject constructor(private val resourceProvider: ResourceProvider) {
-    fun buildNTimesLabel(bloggingRemindersModel: BloggingRemindersModel?): UiString {
+    fun buildNTimesLabel(bloggingRemindersModel: BloggingRemindersUiModel?): UiString {
         val counts = resourceProvider.getStringArray(R.array.blogging_reminders_count)
         val size = bloggingRemindersModel?.enabledDays?.size ?: 0
         return if (size > 0) {
@@ -25,7 +25,7 @@ class DayLabelUtils
         }
     }
 
-    fun buildLowercaseNTimesLabel(bloggingRemindersModel: BloggingRemindersModel?): String? {
+    fun buildLowercaseNTimesLabel(bloggingRemindersModel: BloggingRemindersUiModel?): String? {
         val counts = resourceProvider.getStringArray(R.array.blogging_reminders_count).map {
             it.toLowerCase(Locale.getDefault())
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaysProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaysProvider.kt
@@ -9,6 +9,10 @@ class DaysProvider
 @Inject constructor(private val localeManagerWrapper: LocaleManagerWrapper) {
     fun getDaysOfWeekByLocale(): List<DayOfWeek> {
         val firstDayOfTheWeek = WeekFields.of(localeManagerWrapper.getLocale()).firstDayOfWeek
-        return (0..6L).map { firstDayOfTheWeek.plus(it) }
+        return (START_OFFSET..END_OFFSET).map { firstDayOfTheWeek.plus(it) }
+    }
+    companion object {
+        private const val START_OFFSET = 0
+        private const val END_OFFSET = 6L
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaysProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaysProvider.kt
@@ -1,34 +1,14 @@
 package org.wordpress.android.ui.bloggingreminders
 
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.FRIDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.MONDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.SATURDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.SUNDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.THURSDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.TUESDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.WEDNESDAY
-import org.wordpress.android.ui.reader.utils.DateProvider
-import java.util.Calendar
+import org.wordpress.android.util.LocaleManagerWrapper
+import java.time.DayOfWeek
+import java.time.temporal.WeekFields
 import javax.inject.Inject
 
 class DaysProvider
-@Inject constructor(private val dateProvider: DateProvider) {
-    // TODO replace all the calendar references with DayOfWeek interface
-    private val days = listOf(
-            Calendar.SUNDAY to SUNDAY,
-            Calendar.MONDAY to MONDAY,
-            Calendar.TUESDAY to TUESDAY,
-            Calendar.WEDNESDAY to WEDNESDAY,
-            Calendar.THURSDAY to THURSDAY,
-            Calendar.FRIDAY to FRIDAY,
-            Calendar.SATURDAY to SATURDAY
-    )
-
-    fun getDays(): List<Pair<String, Day>> {
-        val offset = dateProvider.getFirstDayOfTheWeek() - 1
-        val shortWeekdays = dateProvider.getShortWeekdays()
-        val orderedDays = days.takeLast(days.size - offset) + days.take(offset)
-        return orderedDays.map { shortWeekdays[it.first] to it.second }
+@Inject constructor(private val localeManagerWrapper: LocaleManagerWrapper) {
+    fun getDaysOfWeekByLocale(): List<DayOfWeek> {
+        val firstDayOfTheWeek = WeekFields.of(localeManagerWrapper.getLocale()).firstDayOfWeek
+        return (0..6L).map { firstDayOfTheWeek.plus(it) }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/EpilogueBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/EpilogueBuilder.kt
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.bloggingreminders
 
 import org.wordpress.android.R.drawable
 import org.wordpress.android.R.string
-import org.wordpress.android.fluxc.model.BloggingRemindersModel
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Caption
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.EmphasizedText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.HighEmphasisText
@@ -27,7 +25,7 @@ class EpilogueBuilder @Inject constructor(
     private val htmlMessageUtils: HtmlMessageUtils
 ) {
     fun buildUiItems(
-        bloggingRemindersModel: BloggingRemindersModel?
+        bloggingRemindersModel: BloggingRemindersUiModel?
     ): List<BloggingRemindersItem> {
         val enabledDays = bloggingRemindersModel?.enabledDays ?: setOf()
 
@@ -76,9 +74,9 @@ class EpilogueBuilder @Inject constructor(
         )
     }
 
-    private fun Set<Day>.print(): List<String> {
+    private fun Set<DayOfWeek>.print(): List<String> {
         return this.sorted().map {
-            DayOfWeek.valueOf(it.name).getDisplayName(TextStyle.FULL, localeManagerWrapper.getLocale())
+            it.getDisplayName(TextStyle.FULL, localeManagerWrapper.getLocale())
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/DateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/DateProvider.kt
@@ -1,13 +1,8 @@
 package org.wordpress.android.ui.reader.utils
 
-import java.text.DateFormatSymbols
-import java.util.Calendar
 import java.util.Date
-import java.util.Locale
 import javax.inject.Inject
 
 class DateProvider @Inject constructor() {
     fun getCurrentDate() = Date()
-    fun getFirstDayOfTheWeek() = Calendar.getInstance().firstDayOfWeek
-    fun getShortWeekdays() = DateFormatSymbols(Locale.getDefault()).shortWeekdays
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
@@ -84,21 +84,26 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
 
     @Test
     fun `sets blogging reminders as shown on PROLOGUE`() {
-        viewModel.showBottomSheet(siteId, PROLOGUE, BLOG_SETTINGS)
+        whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
+        viewModel.onPostCreated(siteId, true)
 
         verify(bloggingRemindersManager).bloggingRemindersShown(siteId)
     }
 
     @Test
-    fun `sets blogging reminders as shown on PROLOGUE from SiteSettings`() {
-        viewModel.showBottomSheet(siteId, PROLOGUE_SETTINGS, BLOG_SETTINGS)
+    fun `sets blogging reminders as shown from SiteSettings when has no previous blogging reminders`() = test {
+        whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(false)
+
+        viewModel.onSettingsItemClicked(siteId)
 
         verify(bloggingRemindersManager).bloggingRemindersShown(siteId)
     }
 
     @Test
     fun `shows bottom sheet on showBottomSheet`() {
-        viewModel.showBottomSheet(siteId, PROLOGUE, BLOG_SETTINGS)
+        whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
+
+        viewModel.onPostCreated(siteId, true)
 
         assertThat(events).containsExactly(true)
     }
@@ -106,28 +111,31 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Test
     fun `shows prologue ui state on PROLOGUE`() {
         val uiItems = initPrologueBuilder()
+        whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
 
-        viewModel.showBottomSheet(siteId, PROLOGUE, BLOG_SETTINGS)
+        viewModel.onPostCreated(siteId, true)
 
         assertThat(uiState.last().uiItems).isEqualTo(uiItems)
     }
 
     @Test
-    fun `shows prologue ui state on PROLOGUE from SiteSettings`() {
+    fun `shows prologue ui state on PROLOGUE from SiteSettings`() = test {
         val uiItems = initPrologueBuilderForSiteSettings()
+        whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(false)
 
-        viewModel.showBottomSheet(siteId, PROLOGUE_SETTINGS, BLOG_SETTINGS)
+        viewModel.onSettingsItemClicked(siteId)
 
         assertThat(uiState.last().uiItems).isEqualTo(uiItems)
     }
 
     @Test
-    fun `date selection selected`() {
+    fun `date selection selected`() = test {
         val model = initEmptyStore()
         val daySelectionScreen = listOf<BloggingRemindersItem>()
         whenever(daySelectionBuilder.buildSelection(eq(model), any())).thenReturn(daySelectionScreen)
+        whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
 
-        viewModel.showBottomSheet(siteId, SELECTION, BLOG_SETTINGS)
+        viewModel.onSettingsItemClicked(siteId)
 
         assertThat(uiState.last().uiItems).isEqualTo(daySelectionScreen)
     }
@@ -157,8 +165,8 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Test
     fun `switches from prologue do day selection on primary button click`() {
         initPrologueBuilder()
-
-        viewModel.showBottomSheet(siteId, PROLOGUE, BLOG_SETTINGS)
+        whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
+        viewModel.onPostCreated(siteId, true)
 
         clickPrimaryButton()
 
@@ -166,7 +174,13 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `switches from day selection do epilogue on primary button click`() {
+    fun `switches from day selection do epilogue on primary button click`() = test {
+        openEpilogue()
+
+        assertEpilogue()
+    }
+
+    private suspend fun openEpilogue() {
         val model = BloggingRemindersModel(
                 siteId,
                 setOf(MONDAY)
@@ -178,23 +192,17 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         )
 
         initDaySelectionBuilder()
+        initEpilogueBuilder()
+        whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
 
-        viewModel.showBottomSheet(siteId, SELECTION, BLOG_SETTINGS)
+        viewModel.onSettingsItemClicked(siteId)
 
         clickPrimaryButton()
-
-        initEpilogueBuilder()
-
-        viewModel.showBottomSheet(siteId, EPILOGUE, BLOG_SETTINGS)
-
-        assertEpilogue()
     }
 
     @Test
-    fun `closes bottom sheet from epilogue on primary button click`() {
-        initEpilogueBuilder()
-
-        viewModel.showBottomSheet(siteId, EPILOGUE, BLOG_SETTINGS)
+    fun `closes bottom sheet from epilogue on primary button click`() = test {
+        openEpilogue()
 
         assertEpilogue()
 
@@ -207,24 +215,30 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
 
     @Test
     fun `showBottomSheet sets tracker site id`() {
-        viewModel.showBottomSheet(siteId, PROLOGUE, BLOG_SETTINGS)
+        whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
+
+        viewModel.onPostCreated(siteId, true)
 
         verify(analyticsTracker).setSite(siteId)
     }
 
     @Test
-    fun `showBottomSheet tracks flow start with correct source`() {
-        viewModel.showBottomSheet(siteId, PROLOGUE, BLOG_SETTINGS)
-        viewModel.showBottomSheet(siteId, PROLOGUE, PUBLISH_FLOW)
+    fun `showBottomSheet tracks flow start with correct source`() = test {
+        whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
+        viewModel.onSettingsItemClicked(siteId)
+        whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
+        viewModel.onPostCreated(siteId, true)
 
         verify(analyticsTracker).trackFlowStart(BLOG_SETTINGS)
         verify(analyticsTracker).trackFlowStart(PUBLISH_FLOW)
     }
 
     @Test
-    fun `showBottomSheet tracks screen shown with correct screen`() {
-        viewModel.showBottomSheet(siteId, PROLOGUE, BLOG_SETTINGS)
-        viewModel.showBottomSheet(siteId, SELECTION, BLOG_SETTINGS)
+    fun `showBottomSheet tracks screen shown with correct screen`() = test {
+        whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
+        whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
+        viewModel.onPostCreated(siteId, true)
+        viewModel.onSettingsItemClicked(siteId)
 
         verify(analyticsTracker).trackScreenShown(PROLOGUE)
         verify(analyticsTracker).trackScreenShown(SELECTION)
@@ -232,8 +246,9 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
 
     @Test
     fun `showBottomSheet tracks screen shown more than once`() {
-        viewModel.showBottomSheet(siteId, PROLOGUE, BLOG_SETTINGS)
-        viewModel.showBottomSheet(siteId, PROLOGUE, BLOG_SETTINGS)
+        whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
+        viewModel.onPostCreated(siteId, true)
+        viewModel.onPostCreated(siteId, true)
 
         verify(analyticsTracker, times(2)).trackScreenShown(PROLOGUE)
     }
@@ -241,8 +256,8 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Test
     fun `clicking primary button on prologue screen tracks correct events`() {
         initPrologueBuilder()
-
-        viewModel.showBottomSheet(siteId, PROLOGUE, BLOG_SETTINGS)
+        whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
+        viewModel.onPostCreated(siteId, true)
 
         clickPrimaryButton()
 
@@ -251,11 +266,12 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `clicking primary button on selection screen tracks correct events`() {
+    fun `clicking primary button on selection screen tracks correct events`() = test {
         initEmptyStore()
         initDaySelectionBuilder()
+        whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
 
-        viewModel.showBottomSheet(siteId, SELECTION, BLOG_SETTINGS)
+        viewModel.onSettingsItemClicked(siteId)
 
         clickPrimaryButton()
 
@@ -264,9 +280,8 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `clicking primary button on epilogue screen tracks correct events`() {
-        initEpilogueBuilder()
-        viewModel.showBottomSheet(siteId, EPILOGUE, BLOG_SETTINGS)
+    fun `clicking primary button on epilogue screen tracks correct events`() = test {
+        openEpilogue()
 
         clickPrimaryButton()
 
@@ -275,35 +290,38 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
 
     @Test
     fun `dismissing bottom sheet on prologue screen tracks dismiss event`() {
-        viewModel.showBottomSheet(siteId, PROLOGUE, BLOG_SETTINGS)
+        whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
+        viewModel.onPostCreated(siteId, true)
         viewModel.onBottomSheetDismissed()
 
         verify(analyticsTracker).trackFlowDismissed(PROLOGUE)
     }
 
     @Test
-    fun `dismissing bottom sheet on selection screen tracks dismiss event`() {
-        viewModel.showBottomSheet(siteId, SELECTION, BLOG_SETTINGS)
+    fun `dismissing bottom sheet on selection screen tracks dismiss event`() = test {
+        whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
+        viewModel.onSettingsItemClicked(siteId)
         viewModel.onBottomSheetDismissed()
 
         verify(analyticsTracker).trackFlowDismissed(SELECTION)
     }
 
     @Test
-    fun `dismissing bottom sheet on epilogue screen tracks completed event`() {
-        viewModel.showBottomSheet(siteId, EPILOGUE, BLOG_SETTINGS)
+    fun `dismissing bottom sheet on epilogue screen tracks completed event`() = test {
+        openEpilogue()
         viewModel.onBottomSheetDismissed()
 
         verify(analyticsTracker).trackFlowCompleted()
     }
 
     @Test
-    fun `clicking primary button on selection screen schedule reminders with correct days`() {
+    fun `clicking primary button on selection screen schedule reminders with correct days`() = test {
         val model = BloggingRemindersModel(siteId, setOf(MONDAY, WEDNESDAY, FRIDAY))
         whenever(bloggingRemindersStore.bloggingRemindersModel(siteId)).thenReturn(flowOf(model))
         initDaySelectionBuilder()
+        whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
 
-        viewModel.showBottomSheet(siteId, SELECTION, BLOG_SETTINGS)
+        viewModel.onSettingsItemClicked(siteId)
 
         clickPrimaryButton()
 
@@ -314,11 +332,12 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `clicking primary button on empty selection screen cancel reminders`() {
+    fun `clicking primary button on empty selection screen cancel reminders`() = test {
         initEmptyStore()
         initDaySelectionBuilder()
+        whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
 
-        viewModel.showBottomSheet(siteId, SELECTION, BLOG_SETTINGS)
+        viewModel.onSettingsItemClicked(siteId)
 
         clickPrimaryButton()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
@@ -8,10 +8,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.BloggingRemindersModel
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.SUNDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.WEDNESDAY
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons.DayItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.EmphasizedText
@@ -24,35 +20,41 @@ import org.wordpress.android.ui.utils.ListItemInteraction.Companion
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.LocaleManagerWrapper
+import java.time.DayOfWeek
+import java.time.DayOfWeek.SUNDAY
+import java.time.DayOfWeek.WEDNESDAY
+import java.time.format.TextStyle.SHORT_STANDALONE
+import java.util.Locale
 
 @RunWith(MockitoJUnitRunner::class)
 class DaySelectionBuilderTest {
     @Mock lateinit var daysProvider: DaysProvider
     @Mock lateinit var dayLabelUtils: DayLabelUtils
+    @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
     private lateinit var daySelectionBuilder: DaySelectionBuilder
-    private var daySelected: Day? = null
+    private var daySelected: DayOfWeek? = null
     private var confirmed = false
 
-    private val onSelectDay: (Day) -> Unit = {
+    private val onSelectDay: (DayOfWeek) -> Unit = {
         daySelected = it
     }
-    private val onConfirm: (BloggingRemindersModel?) -> Unit = {
+    private val onConfirm: (BloggingRemindersUiModel?) -> Unit = {
         confirmed = true
     }
 
     @Before
     fun setUp() {
-        daySelectionBuilder = DaySelectionBuilder(daysProvider, dayLabelUtils)
-        whenever(daysProvider.getDays()).thenReturn(Day.values().map {
-            it.name to it
-        })
+        daySelectionBuilder = DaySelectionBuilder(daysProvider, dayLabelUtils, localeManagerWrapper)
+        whenever(daysProvider.getDaysOfWeekByLocale()).thenReturn(DayOfWeek.values().toList())
+        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
         daySelected = null
         confirmed = false
     }
 
     @Test
     fun `builds UI model with no selected days`() {
-        val bloggingRemindersModel = BloggingRemindersModel(1)
+        val bloggingRemindersModel = BloggingRemindersUiModel(1)
         val dayLabel = UiStringText("Not set")
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
                 .thenReturn(dayLabel)
@@ -64,7 +66,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `builds UI model with selected days`() {
-        val bloggingRemindersModel = BloggingRemindersModel(1, setOf(WEDNESDAY, SUNDAY))
+        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY))
         val dayLabel = UiStringText("Twice a week")
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
                 .thenReturn(dayLabel)
@@ -79,12 +81,12 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `click on a day select day`() {
-        val bloggingRemindersModel = BloggingRemindersModel(1)
+        val bloggingRemindersModel = BloggingRemindersUiModel(1)
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel)).thenReturn(UiStringText("Once a week"))
 
         val uiModel = daySelectionBuilder.buildSelection(bloggingRemindersModel, onSelectDay)
 
-        Day.values().forEachIndexed { index, day ->
+        DayOfWeek.values().forEachIndexed { index, day ->
             uiModel.clickOnDayItem(index)
             assertThat(daySelected).isEqualTo(day)
         }
@@ -92,7 +94,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `primary button disabled when model is empty and is first time flow`() {
-        val bloggingRemindersModel = BloggingRemindersModel(1)
+        val bloggingRemindersModel = BloggingRemindersUiModel(1)
 
         val primaryButton = daySelectionBuilder.buildPrimaryButton(bloggingRemindersModel, true, onConfirm)
 
@@ -107,7 +109,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `primary button enabled when model is not empty and is first time flow`() {
-        val bloggingRemindersModel = BloggingRemindersModel(1, setOf(WEDNESDAY, SUNDAY))
+        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY))
 
         val primaryButton = daySelectionBuilder.buildPrimaryButton(bloggingRemindersModel, true, onConfirm)
 
@@ -122,7 +124,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `primary button enabled when model is empty and is not first time flow`() {
-        val bloggingRemindersModel = BloggingRemindersModel(1)
+        val bloggingRemindersModel = BloggingRemindersUiModel(1)
 
         val primaryButton = daySelectionBuilder.buildPrimaryButton(bloggingRemindersModel, false, onConfirm)
 
@@ -137,7 +139,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `click on primary button confirm selection`() {
-        val bloggingRemindersModel = BloggingRemindersModel(1, setOf(WEDNESDAY, SUNDAY))
+        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY))
 
         val primaryButton = daySelectionBuilder.buildPrimaryButton(bloggingRemindersModel, false, onConfirm)
 
@@ -148,7 +150,7 @@ class DaySelectionBuilderTest {
 
     private fun assertModel(
         uiModel: List<BloggingRemindersItem>,
-        selectedDays: Set<Day>,
+        selectedDays: Set<DayOfWeek>,
         dayLabel: UiString
     ) {
         assertThat(uiModel[0]).isEqualTo(Illustration(R.drawable.img_illustration_calendar))
@@ -158,9 +160,9 @@ class DaySelectionBuilderTest {
         )
         assertThat(uiModel[3]).isEqualTo(
                 DayButtons(
-                        Day.values().map {
+                        DayOfWeek.values().map {
                             DayItem(
-                                    UiStringText(it.name),
+                                    UiStringText(it.getDisplayName(SHORT_STANDALONE, Locale.US)),
                                     selectedDays.contains(it),
                                     ListItemInteraction.create(it, onSelectDay)
                             )

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaysProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaysProviderTest.kt
@@ -7,95 +7,57 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.FRIDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.MONDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.SATURDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.SUNDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.THURSDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.TUESDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.WEDNESDAY
-import org.wordpress.android.ui.reader.utils.DateProvider
-import java.util.Calendar
+import org.wordpress.android.util.LocaleManagerWrapper
+import java.time.DayOfWeek.FRIDAY
+import java.time.DayOfWeek.MONDAY
+import java.time.DayOfWeek.SATURDAY
+import java.time.DayOfWeek.SUNDAY
+import java.time.DayOfWeek.THURSDAY
+import java.time.DayOfWeek.TUESDAY
+import java.time.DayOfWeek.WEDNESDAY
+import java.util.Locale
 
 @RunWith(MockitoJUnitRunner::class)
 class DaysProviderTest {
-    @Mock lateinit var dateProvider: DateProvider
+    @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
     private lateinit var daysProvider: DaysProvider
 
     @Before
     fun setUp() {
-        daysProvider = DaysProvider(dateProvider)
-        whenever(dateProvider.getShortWeekdays()).thenReturn(
-                arrayOf(
-                        "",
-                        SUNDAY_TEXT,
-                        MONDAY_TEXT,
-                        TUESDAY_TEXT,
-                        WEDNESDAY_TEXT,
-                        THURSDAY_TEXT,
-                        FRIDAY_TEXT,
-                        SATURDAY_TEXT
-                )
-        )
+        daysProvider = DaysProvider(localeManagerWrapper)
     }
 
     @Test
     fun `returns list starting with sunday`() {
-        whenever(dateProvider.getFirstDayOfTheWeek()).thenReturn(Calendar.SUNDAY)
+        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
 
-        val days = daysProvider.getDays()
+        val days = daysProvider.getDaysOfWeekByLocale()
 
         assertThat(days).containsExactly(
-                SUNDAY_TEXT to SUNDAY,
-                MONDAY_TEXT to MONDAY,
-                TUESDAY_TEXT to TUESDAY,
-                WEDNESDAY_TEXT to WEDNESDAY,
-                THURSDAY_TEXT to THURSDAY,
-                FRIDAY_TEXT to FRIDAY,
-                SATURDAY_TEXT to SATURDAY
+                SUNDAY,
+                MONDAY,
+                TUESDAY,
+                WEDNESDAY,
+                THURSDAY,
+                FRIDAY,
+                SATURDAY
         )
     }
 
     @Test
     fun `returns list starting with monday`() {
-        whenever(dateProvider.getFirstDayOfTheWeek()).thenReturn(Calendar.MONDAY)
+        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.GERMANY)
 
-        val days = daysProvider.getDays()
-
-        assertThat(days).containsExactly(
-                MONDAY_TEXT to MONDAY,
-                TUESDAY_TEXT to TUESDAY,
-                WEDNESDAY_TEXT to WEDNESDAY,
-                THURSDAY_TEXT to THURSDAY,
-                FRIDAY_TEXT to FRIDAY,
-                SATURDAY_TEXT to SATURDAY,
-                SUNDAY_TEXT to SUNDAY
-        )
-    }
-
-    @Test
-    fun `returns list starting with saturday`() {
-        whenever(dateProvider.getFirstDayOfTheWeek()).thenReturn(Calendar.SATURDAY)
-
-        val days = daysProvider.getDays()
+        val days = daysProvider.getDaysOfWeekByLocale()
 
         assertThat(days).containsExactly(
-                SATURDAY_TEXT to SATURDAY,
-                SUNDAY_TEXT to SUNDAY,
-                MONDAY_TEXT to MONDAY,
-                TUESDAY_TEXT to TUESDAY,
-                WEDNESDAY_TEXT to WEDNESDAY,
-                THURSDAY_TEXT to THURSDAY,
-                FRIDAY_TEXT to FRIDAY
+                MONDAY,
+                TUESDAY,
+                WEDNESDAY,
+                THURSDAY,
+                FRIDAY,
+                SATURDAY,
+                SUNDAY
         )
-    }
-    companion object {
-        private const val SUNDAY_TEXT = "Sun"
-        private const val MONDAY_TEXT = "Mon"
-        private const val TUESDAY_TEXT = "Tue"
-        private const val WEDNESDAY_TEXT = "Wed"
-        private const val THURSDAY_TEXT = "Thu"
-        private const val FRIDAY_TEXT = "Fri"
-        private const val SATURDAY_TEXT = "Sat"
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/EpilogueBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/EpilogueBuilderTest.kt
@@ -9,14 +9,6 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R.drawable
 import org.wordpress.android.R.string
-import org.wordpress.android.fluxc.model.BloggingRemindersModel
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.FRIDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.MONDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.SATURDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.SUNDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.THURSDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.TUESDAY
-import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.WEDNESDAY
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.EmphasizedText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.HighEmphasisText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Illustration
@@ -28,6 +20,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.ListFormatterUtils
 import org.wordpress.android.util.LocaleManagerWrapper
+import java.time.DayOfWeek
 import java.util.Locale
 
 @RunWith(MockitoJUnitRunner::class)
@@ -52,7 +45,7 @@ class EpilogueBuilderTest {
 
     @Test
     fun `builds UI model with no selected days`() {
-        val bloggingRemindersModel = BloggingRemindersModel(1, setOf())
+        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf())
         val uiModel = epilogueBuilder.buildUiItems(bloggingRemindersModel)
 
         assertModelWithNoSelection(uiModel)
@@ -60,7 +53,7 @@ class EpilogueBuilderTest {
 
     @Test
     fun `builds UI model with selected days`() {
-        val bloggingRemindersModel = BloggingRemindersModel(1, setOf(WEDNESDAY, SUNDAY))
+        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(DayOfWeek.WEDNESDAY, DayOfWeek.SUNDAY))
         val dayLabel = "twice"
         whenever(dayLabelUtils.buildLowercaseNTimesLabel(bloggingRemindersModel))
                 .thenReturn(dayLabel)
@@ -82,9 +75,9 @@ class EpilogueBuilderTest {
 
     @Test
     fun `builds UI model with all days selected`() {
-        val bloggingRemindersModel = BloggingRemindersModel(
+        val bloggingRemindersModel = BloggingRemindersUiModel(
                 1,
-                setOf(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
+                DayOfWeek.values().toSet()
         )
         val message = "You'll get reminders to blog <b>everyday</b>."
         whenever(


### PR DESCRIPTION
This PR cleans up some remaining issues left from blogging reminders. I've added a model between FluxC and the presentation layer in order to use DayOfWeek interface. Most changes are about using the DayOfWeek in the whole feature.


To test:
- Test the blogging reminders 

## Regression Notes
1. Potential unintended areas of impact
- None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
