### PR TITLE
Issue/bring back paging 3

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -303,6 +303,8 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
     // ProcessLifecycleOwner
     implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
+    // Paging Library
+    implementation("androidx.paging:paging-runtime-ktx:$pagingVersion")
 
     testImplementation("androidx.arch.core:core-testing:$androidxArchCoreVersion", {
         exclude group: 'com.android.support', module: 'support-compat'

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentPagingSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentPagingSource.kt
@@ -1,55 +1,58 @@
 package org.wordpress.android.ui.comments.unified
 
-/**
- * Temporarily commented out until migration between Paging 2 and 3 is sorted out.
- */
-class CommentPagingSource {
-//    : PagingSource<Int, CommentModel>() {
-//    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, CommentModel> {
-//        return LoadResult.Page(
-//                data = generateComments(params.loadSize),
-//                prevKey = null, // Only paging forward
-//                nextKey = null // Only one page for now
-//        )
-//    }
-//
-//    override fun getRefreshKey(state: PagingState<Int, CommentModel>): Int? {
-//        return state.anchorPosition?.let { anchorPosition ->
-//            val anchorPage = state.closestPageToPosition(anchorPosition)
-//            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
-//        }
-//    }
-//
-//    // TODO for testing purposes only. Remove after attaching real data source.
-//    @Suppress("MagicNumber")
-//    fun generateComments(num: Int): List<CommentModel> {
-//        val commentListItems = ArrayList<CommentModel>()
-//        var startTimestamp = System.currentTimeMillis() / 1000 - (30000 * num)
-//
-//        for (i in 0..num) {
-//            val commentModel = CommentModel()
-//            commentModel.id = i
-//            commentModel.remoteCommentId = i.toLong()
-//            commentModel.postTitle = "Post $i"
-//            commentModel.authorName = "Author $i"
-//            commentModel.authorEmail = "authors_email$i@wordpress.org"
-//            commentModel.content = "Generated <b>Comment</b> <i>Content</i> for Comment with remote ID $i"
-//            startTimestamp -= 30000
-//            commentModel.publishedTimestamp = startTimestamp
-//            commentModel.datePublished = DateTimeUtils.iso8601FromDate(Date(startTimestamp * 1000))
-//            commentModel.authorProfileImageUrl = ""
-//            if (i % 3 == 0) {
-//                commentModel.status = CommentStatus.UNAPPROVED.toString()
-//                commentModel.authorProfileImageUrl =
-//                        "https://0.gravatar.com/avatar/cec64efa352617c35743d8ed233ab410?s=96&d=identicon&r=G"
-//            } else {
-//                commentModel.status = CommentStatus.APPROVED.toString()
-//                commentModel.authorProfileImageUrl =
-//                        "https://0.gravatar.com/avatar/cdc72cf084621e5cf7e42913f3197c13?s=256&d=identicon&r=G"
-//            }
-//
-//            commentListItems.add(commentModel)
-//        }
-//        return commentListItems
-//    }
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+
+class CommentPagingSource : PagingSource<Int, CommentModel>() {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, CommentModel> {
+        return LoadResult.Page(
+                data = generateComments(params.loadSize),
+                prevKey = null, // Only paging forward
+                nextKey = null // Only one page for now
+        )
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, CommentModel>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            val anchorPage = state.closestPageToPosition(anchorPosition)
+            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }
+    }
+
+    // TODO for testing purposes only. Remove after attaching real data source.
+    @Suppress("MagicNumber")
+    fun generateComments(num: Int): List<CommentModel> {
+        val commentListItems = ArrayList<CommentModel>()
+        var startTimestamp = System.currentTimeMillis() / 1000 - (30000 * num)
+
+        for (i in 0..num) {
+            val commentModel = CommentModel()
+            commentModel.id = i
+            commentModel.remoteCommentId = i.toLong()
+            commentModel.postTitle = "Post $i"
+            commentModel.authorName = "Author $i"
+            commentModel.authorEmail = "authors_email$i@wordpress.org"
+            commentModel.content = "Generated <b>Comment</b> <i>Content</i> for Comment with remote ID $i"
+            startTimestamp -= 30000
+            commentModel.publishedTimestamp = startTimestamp
+            commentModel.datePublished = DateTimeUtils.iso8601FromDate(Date(startTimestamp * 1000))
+            commentModel.authorProfileImageUrl = ""
+            if (i % 3 == 0) {
+                commentModel.status = CommentStatus.UNAPPROVED.toString()
+                commentModel.authorProfileImageUrl =
+                        "https://0.gravatar.com/avatar/cec64efa352617c35743d8ed233ab410?s=96&d=identicon&r=G"
+            } else {
+                commentModel.status = CommentStatus.APPROVED.toString()
+                commentModel.authorProfileImageUrl =
+                        "https://0.gravatar.com/avatar/cdc72cf084621e5cf7e42913f3197c13?s=256&d=identicon&r=G"
+            }
+
+            commentListItems.add(commentModel)
+        }
+        return commentListItems
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListAdapter.kt
@@ -1,47 +1,61 @@
 package org.wordpress.android.ui.comments.unified
 
 import android.content.Context
+import android.view.ViewGroup
+import androidx.paging.PagingDataAdapter
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.Comment
+import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.CommentListItemType.COMMENT
+import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.CommentListItemType.SUB_HEADER
+import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.SubHeader
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.GravatarUtilsWrapper
+import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.viewmodel.ResourceProvider
+import javax.inject.Inject
 
-/**
- * Temporarily commented out untill migration between Paging 2 and 3 is sorted out.
- */
-class UnifiedCommentListAdapter(context: Context) {
-// : PagingDataAdapter<UnifiedCommentListItem,
-// UnifiedCommentListViewHolder<*>>(
-//                diffCallback
-//        ) {
-//    init {
-//        (context.applicationContext as WordPress).component().inject(this)
-//    }
-//
-//    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UnifiedCommentListViewHolder<*> {
-//        return when (viewType) {
-//            SUB_HEADER.ordinal -> UnifiedCommentSubHeaderViewHolder(parent)
-//            COMMENT.ordinal -> UnifiedCommentViewHolder(
-//                    parent,
-//                    imageManager,
-//                    uiHelpers,
-//                    commentListUiUtils,
-//                    resourceProvider,
-//                    gravatarUtilsWrapper
-//            )
-//            else -> throw IllegalArgumentException("Unexpected view holder in UnifiedCommentListAdapter")
-//        }
-//    }
-//
-//    override fun onBindViewHolder(holder: UnifiedCommentListViewHolder<*>, position: Int) {
-//        if (holder is UnifiedCommentSubHeaderViewHolder) {
-//            holder.bind((getItem(position) as SubHeader))
-//        } else if (holder is UnifiedCommentViewHolder) {
-//            holder.bind(getItem(position) as Comment)
-//        }
-//    }
-//
-//    override fun getItemViewType(position: Int): Int {
-//        return getItem(position)!!.type.ordinal
-//    }
-//
-//    companion object {
-//        private val diffCallback = UnifiedCommentsListDiffCallback()
-//    }
+class UnifiedCommentListAdapter(context: Context) : PagingDataAdapter<UnifiedCommentListItem,
+        UnifiedCommentListViewHolder<*>>(
+        diffCallback
+) {
+    @Inject lateinit var imageManager: ImageManager
+    @Inject lateinit var uiHelpers: UiHelpers
+    @Inject lateinit var commentListUiUtils: CommentListUiUtils
+    @Inject lateinit var resourceProvider: ResourceProvider
+    @Inject lateinit var gravatarUtilsWrapper: GravatarUtilsWrapper
+
+    init {
+        (context.applicationContext as WordPress).component().inject(this)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UnifiedCommentListViewHolder<*> {
+        return when (viewType) {
+            SUB_HEADER.ordinal -> UnifiedCommentSubHeaderViewHolder(parent)
+            COMMENT.ordinal -> UnifiedCommentViewHolder(
+                    parent,
+                    imageManager,
+                    uiHelpers,
+                    commentListUiUtils,
+                    resourceProvider,
+                    gravatarUtilsWrapper
+            )
+            else -> throw IllegalArgumentException("Unexpected view holder in UnifiedCommentListAdapter")
+        }
+    }
+
+    override fun onBindViewHolder(holder: UnifiedCommentListViewHolder<*>, position: Int) {
+        if (holder is UnifiedCommentSubHeaderViewHolder) {
+            holder.bind((getItem(position) as SubHeader))
+        } else if (holder is UnifiedCommentViewHolder) {
+            holder.bind(getItem(position) as Comment)
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return getItem(position)!!.type.ordinal
+    }
+
+    companion object {
+        private val diffCallback = UnifiedCommentsListDiffCallback()
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
@@ -6,19 +6,18 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import kotlinx.coroutines.flow.collect
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.CommentListFragmentBinding
+import org.wordpress.android.ui.comments.unified.UnifiedCommentListViewModel.CommentsListUiModel
 import javax.inject.Inject
 
-/**
- * Temporarily commented out until migration between Paging 2 and 3 is sorted out.
- */
 class UnifiedCommentListFragment : Fragment(R.layout.comment_list_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
     private lateinit var viewModel: UnifiedCommentListViewModel
-//    private lateinit var adapter: UnifiedCommentListAdapter
+    private lateinit var adapter: UnifiedCommentListAdapter
 
     private var binding: CommentListFragmentBinding? = null
 
@@ -41,27 +40,27 @@ class UnifiedCommentListFragment : Fragment(R.layout.comment_list_fragment) {
         commentsRecyclerView.layoutManager = layoutManager
         commentsRecyclerView.addItemDecoration(UnifiedCommentListItemDecoration(commentsRecyclerView.context))
 
-//        adapter = UnifiedCommentListAdapter(requireContext())
-//        commentsRecyclerView.adapter = adapter
+        adapter = UnifiedCommentListAdapter(requireContext())
+        commentsRecyclerView.adapter = adapter
     }
 
     private fun CommentListFragmentBinding.setupObservers() {
         lifecycleScope.launchWhenStarted {
-//            viewModel.uiState.collect { uiState ->
-//                setupCommentsList(uiState.commentsListUiModel)
-//            }
+            viewModel.uiState.collect { uiState ->
+                setupCommentsList(uiState.commentsListUiModel)
+            }
         }
     }
 
-//    private fun CommentListFragmentBinding.setupCommentsList(commentsListUiModel: CommentsListUiModel) {
-//        when (commentsListUiModel) {
-//            is CommentsListUiModel.Data -> {
-//                adapter.submitData(lifecycle, commentsListUiModel.pagingData)
-//            }
-//            else -> {
-//            }
-//        }
-//    }
+    private fun CommentListFragmentBinding.setupCommentsList(commentsListUiModel: CommentsListUiModel) {
+        when (commentsListUiModel) {
+            is CommentsListUiModel.Data -> {
+                adapter.submitData(lifecycle, commentsListUiModel.pagingData)
+            }
+            else -> {
+            }
+        }
+    }
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
@@ -1,76 +1,94 @@
 package org.wordpress.android.ui.comments.unified
 
+import androidx.lifecycle.viewModelScope
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import androidx.paging.insertSeparators
+import androidx.paging.map
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.ClickAction
+import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.Comment
+import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.SubHeader
+import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.ToggleAction
+import org.wordpress.android.ui.comments.unified.UnifiedCommentListViewModel.CommentsListUiModel.Data
+import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
-/**
- * Temporarily commented out until migration between Paging 2 and 3 is sorted out.
- */
 class UnifiedCommentListViewModel @Inject constructor(
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {
     private var isStarted = false
-//
-//    // TODO we would like to explore moving PagingSource into the repository
-//    val commentListItemPager = Pager(PagingConfig(pageSize = 30, initialLoadSize = 30)) { CommentPagingSource() }
-//
-//    private val _selectedIds = MutableStateFlow(emptyList<Long>())
-//    val commentListItems: Flow<PagingData<CommentModel>> = commentListItemPager.flow.cachedIn(viewModelScope)
-//
-//    val uiState: StateFlow<CommentsUiModel> = combine(commentListItems, _selectedIds) { commentListItems,
-//    selectedIds ->
-//        val mappedCommentListItems = commentListItems.map { commentModel ->
-//            val toggleAction = ToggleAction(commentModel.remoteCommentId, this::toggleItem)
-//            val clickAction = ClickAction(commentModel.remoteCommentId, this::clickItem)
-//
-//            val isSelected = selectedIds.contains(commentModel.remoteCommentId)
-//            val isPending = commentModel.status == UNAPPROVED.toString()
-//
-//            Comment(
-//                    remoteCommentId = commentModel.remoteCommentId,
-//                    postTitle = commentModel.postTitle,
-//                    authorName = commentModel.authorName,
-//                    authorEmail = commentModel.authorEmail,
-//                    content = commentModel.content,
-//                    publishedDate = commentModel.datePublished,
-//                    publishedTimestamp = commentModel.publishedTimestamp,
-//                    authorAvatarUrl = commentModel.authorProfileImageUrl,
-//                    isPending = isPending,
-//                    isSelected = isSelected,
-//                    clickAction = clickAction,
-//                    toggleAction = toggleAction
-//            )
-//        }
-//                .insertSeparators { before, current ->
-//                    when {
-//                        before == null && current != null -> SubHeader(getFormattedDate(current), -1)
-//                        before != null && current != null && shouldAddSeparator(before, current) -> SubHeader(
-//                                getFormattedDate(current),
-//                                -1
-//                        )
-//                        else -> null
-//                    }
-//                }
-//
-//        CommentsUiModel(Data(mappedCommentListItems))
-//    }.stateIn(
-//            scope = viewModelScope,
-//            started = SharingStarted.Companion.WhileSubscribed(UI_STATE_FLOW_TIMEOUT_MS),
-//            initialValue = CommentsUiModel.buildInitialState()
-//    )
-//
-//    fun shouldAddSeparator(before: Comment, after: Comment): Boolean {
-//        return getFormattedDate(before) != getFormattedDate(after)
-//    }
-//
-//    private fun getFormattedDate(comment: Comment): String {
-//        return dateTimeUtilsWrapper.javaDateToTimeSpan(DateTimeUtils.dateFromIso8601(comment.publishedDate))
-//    }
+
+    // TODO we would like to explore moving PagingSource into the repository
+    val commentListItemPager = Pager(PagingConfig(pageSize = 30, initialLoadSize = 30)) { CommentPagingSource() }
+
+    private val _selectedIds = MutableStateFlow(emptyList<Long>())
+    val commentListItems: Flow<PagingData<CommentModel>> = commentListItemPager.flow.cachedIn(viewModelScope)
+
+    val uiState: StateFlow<CommentsUiModel> = combine(commentListItems, _selectedIds) { commentListItems,
+        selectedIds ->
+        val mappedCommentListItems = commentListItems.map { commentModel ->
+            val toggleAction = ToggleAction(commentModel.remoteCommentId, this::toggleItem)
+            val clickAction = ClickAction(commentModel.remoteCommentId, this::clickItem)
+
+            val isSelected = selectedIds.contains(commentModel.remoteCommentId)
+            val isPending = commentModel.status == UNAPPROVED.toString()
+
+            Comment(
+                    remoteCommentId = commentModel.remoteCommentId,
+                    postTitle = commentModel.postTitle,
+                    authorName = commentModel.authorName,
+                    authorEmail = commentModel.authorEmail,
+                    content = commentModel.content,
+                    publishedDate = commentModel.datePublished,
+                    publishedTimestamp = commentModel.publishedTimestamp,
+                    authorAvatarUrl = commentModel.authorProfileImageUrl,
+                    isPending = isPending,
+                    isSelected = isSelected,
+                    clickAction = clickAction,
+                    toggleAction = toggleAction
+            )
+        }
+                .insertSeparators { before, current ->
+                    when {
+                        before == null && current != null -> SubHeader(getFormattedDate(current), -1)
+                        before != null && current != null && shouldAddSeparator(before, current) -> SubHeader(
+                                getFormattedDate(current),
+                                -1
+                        )
+                        else -> null
+                    }
+                }
+
+        CommentsUiModel(Data(mappedCommentListItems))
+    }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Companion.WhileSubscribed(UI_STATE_FLOW_TIMEOUT_MS),
+            initialValue = CommentsUiModel.buildInitialState()
+    )
+
+    fun shouldAddSeparator(before: Comment, after: Comment): Boolean {
+        return getFormattedDate(before) != getFormattedDate(after)
+    }
+
+    private fun getFormattedDate(comment: Comment): String {
+        return dateTimeUtilsWrapper.javaDateToTimeSpan(DateTimeUtils.dateFromIso8601(comment.publishedDate))
+    }
 
     fun start() {
         if (isStarted) return
@@ -85,26 +103,26 @@ class UnifiedCommentListViewModel @Inject constructor(
         // TODO open comment details
     }
 
-//    data class CommentsUiModel(
-//        val commentsListUiModel: CommentsListUiModel
-//    ) {
-//        companion object {
-//            fun buildInitialState(): CommentsUiModel {
-//                return CommentsUiModel(
-//                        commentsListUiModel = CommentsListUiModel.Initial
-//                )
-//            }
-//        }
-//    }
+    data class CommentsUiModel(
+        val commentsListUiModel: CommentsListUiModel
+    ) {
+        companion object {
+            fun buildInitialState(): CommentsUiModel {
+                return CommentsUiModel(
+                        commentsListUiModel = CommentsListUiModel.Initial
+                )
+            }
+        }
+    }
 
-//    sealed class CommentsListUiModel {
-//        data class Data(val pagingData: PagingData<UnifiedCommentListItem>) :
-//                CommentsListUiModel()
-//
-//        object Initial : CommentsListUiModel()
-//    }
-//
-//    companion object {
-//        private const val UI_STATE_FLOW_TIMEOUT_MS = 5000L
-//    }
+    sealed class CommentsListUiModel {
+        data class Data(val pagingData: PagingData<UnifiedCommentListItem>) :
+                CommentsListUiModel()
+
+        object Initial : CommentsListUiModel()
+    }
+
+    companion object {
+        private const val UI_STATE_FLOW_TIMEOUT_MS = 5000L
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'e2d5297ff93ca75668c821942b92f5ffd4cdd764'
+    fluxCVersion = '83f4a9420c193da71ddc27c441e8e502f47e43c9'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '83f4a9420c193da71ddc27c441e8e502f47e43c9'
+    fluxCVersion = '9290c73e82d034bd418daa939239acb6ea45bd69'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,11 +133,12 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.20.1-beta-1'
+    fluxCVersion = '1596ace27d02e34c3af46dd5b4fa9aa0c6f3164a'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'
     lifecycleVersion = '2.2.0'
+    pagingVersion = '3.0.0'
     constraintLayoutVersion = '1.1.3'
     materialVersion = '1.2.1'
     preferenceVersion = '1.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1596ace27d02e34c3af46dd5b4fa9aa0c6f3164a'
+    fluxCVersion = '76e28282694882d2c4cedef343185c37f99f5f78'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '76e28282694882d2c4cedef343185c37f99f5f78'
+    fluxCVersion = 'e2d5297ff93ca75668c821942b92f5ffd4cdd764'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
The real fix for #14860

Companion Flux-C PR is [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2042).

This PR brings back Paging 3 and points to the updated Flux-C branch.

To test:
- Using clean install (to get rid of cached posts) select a site with a large number of posts.
- Open the Posts list and confirm that posts are loading as expected.
- Scroll down really fast and keep scroll for some time.
- Confirm that posts are loaded as expected, and nothing crashes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
