### PR TITLE
Jetpack: Hide Restore Option for Unavailable Rewind State

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -138,6 +138,7 @@ import static org.wordpress.android.ui.stories.StoryComposerActivity.KEY_LAUNCHE
 import static org.wordpress.android.ui.stories.StoryComposerActivity.KEY_POST_LOCAL_ID;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_ID_KEY;
+import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogViewModelKt.ACTIVITY_LOG_REWINDABLE_ONLY_KEY;
 
 public class ActivityLauncher {
@@ -688,6 +689,7 @@ public class ActivityLauncher {
             SiteModel site,
             String activityId,
             boolean isButtonVisible,
+            boolean isRestoreHidden,
             boolean rewindableOnly
     ) {
         Map<String, Object> properties = new HashMap<>();
@@ -705,6 +707,7 @@ public class ActivityLauncher {
         intent.putExtra(WordPress.SITE, site);
         intent.putExtra(ACTIVITY_LOG_ID_KEY, activityId);
         intent.putExtra(ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY, isButtonVisible);
+        intent.putExtra(ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY, isRestoreHidden);
         intent.putExtra(SOURCE_TRACK_EVENT_PROPERTY_KEY, source);
         activity.startActivityForResult(intent, RequestCodes.ACTIVITY_LOG_DETAIL);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -100,7 +100,7 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
                     }
                 })
 
-                viewModel.start(site, activityLogId, areButtonsVisible)
+                viewModel.start(site, activityLogId, areButtonsVisible, false)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_ID_KEY
+import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY
 import org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModel
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -59,6 +60,7 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
             with(ActivityLogItemDetailBinding.bind(view)) {
                 val (site, activityLogId) = sideAndActivityId(savedInstanceState, activity.intent)
                 val areButtonsVisible = areButtonsVisible(savedInstanceState, activity.intent)
+                val isRestoreHidden = isRestoreHidden(savedInstanceState, activity.intent)
 
                 viewModel.activityLogItem.observe(viewLifecycleOwner, { activityLogModel ->
                     loadLogItem(activityLogModel, activity)
@@ -100,7 +102,7 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
                     }
                 })
 
-                viewModel.start(site, activityLogId, areButtonsVisible, false)
+                viewModel.start(site, activityLogId, areButtonsVisible, isRestoreHidden)
             }
         }
     }
@@ -176,11 +178,20 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
         else -> throw Throwable("Couldn't initialize Activity Log view model")
     }
 
+    private fun isRestoreHidden(savedInstanceState: Bundle?, intent: Intent?) = when {
+        savedInstanceState != null ->
+            requireNotNull(savedInstanceState.getBoolean(ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY, false))
+        intent != null ->
+            intent.getBooleanExtra(ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY, false)
+        else -> throw Throwable("Couldn't initialize Activity Log view model")
+    }
+
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putSerializable(WordPress.SITE, viewModel.site)
         outState.putString(ACTIVITY_LOG_ID_KEY, viewModel.activityLogId)
         outState.putBoolean(ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY, viewModel.areButtonsVisible)
+        outState.putBoolean(ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY, viewModel.isRestoreHidden)
     }
 
     private fun ActivityLogItemDetailBinding.setActorIcon(actorIcon: String?, showJetpackIcon: Boolean?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.ActivityLauncher.SOURCE_TRACK_EVENT_PROPERTY_KEY
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEvents.ShowBackupDownload
+import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEvents.ShowDocumentationPage
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEvents.ShowRestore
 import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan
 import org.wordpress.android.ui.notifications.utils.FormattableContentClickHandler
@@ -87,13 +88,14 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
                                 RequestCodes.BACKUP_DOWNLOAD,
                                 buildTrackingSource()
                         )
-                    is ShowRestore -> ActivityLauncher.showRestoreForResult(
-                            requireActivity(),
-                            viewModel.site,
-                            it.model.activityID,
-                            RequestCodes.RESTORE,
-                            buildTrackingSource()
-                    )
+                        is ShowRestore -> ActivityLauncher.showRestoreForResult(
+                                requireActivity(),
+                                viewModel.site,
+                                it.model.activityID,
+                                RequestCodes.RESTORE,
+                                buildTrackingSource()
+                        )
+                        is ShowDocumentationPage -> ActivityLauncher.openUrlExternal(requireContext(), it.url)
                 }
             })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.activitylog.detail
 
 import android.content.Intent
 import android.os.Bundle
+import android.text.SpannableString
+import android.text.method.LinkMovementMethod
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -72,16 +74,19 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
                 viewModel.downloadBackupVisible.observe(viewLifecycleOwner, { available ->
                     activityDownloadBackupButton.visibility = if (available == true) View.VISIBLE else View.GONE
                 })
+                viewModel.multisiteVisible.observe(viewLifecycleOwner, { available ->
+                    checkAndShowMultisiteMessage(available)
+                })
 
-            viewModel.navigationEvents.observeEvent(viewLifecycleOwner, {
-                when (it) {
-                    is ShowBackupDownload -> ActivityLauncher.showBackupDownloadForResult(
-                            requireActivity(),
-                            viewModel.site,
-                            it.model.activityID,
-                            RequestCodes.BACKUP_DOWNLOAD,
-                            buildTrackingSource()
-                    )
+                viewModel.navigationEvents.observeEvent(viewLifecycleOwner, {
+                    when (it) {
+                        is ShowBackupDownload -> ActivityLauncher.showBackupDownloadForResult(
+                                requireActivity(),
+                                viewModel.site,
+                                it.model.activityID,
+                                RequestCodes.BACKUP_DOWNLOAD,
+                                buildTrackingSource()
+                        )
                     is ShowRestore -> ActivityLauncher.showRestoreForResult(
                             requireActivity(),
                             viewModel.site,
@@ -104,6 +109,20 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
 
                 viewModel.start(site, activityLogId, areButtonsVisible, isRestoreHidden)
             }
+        }
+    }
+
+    private fun ActivityLogItemDetailBinding.checkAndShowMultisiteMessage(available: Pair<Boolean, SpannableString?>) {
+        if (available.first) {
+            with(multisiteMessage) {
+                linksClickable = true
+                isClickable = true
+                movementMethod = LinkMovementMethod.getInstance()
+                text = available.second
+                visibility = View.VISIBLE
+            }
+        } else {
+            multisiteMessage.visibility = View.GONE
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailNavigationEvents.kt
@@ -1,6 +1,9 @@
 package org.wordpress.android.ui.activitylog.detail
 
+const val DOCUMENTATION_PAGE_URL = "https://jetpack.com/support/backup/"
+
 sealed class ActivityLogDetailNavigationEvents {
     data class ShowBackupDownload(val model: ActivityLogDetailModel) : ActivityLogDetailNavigationEvents()
     data class ShowRestore(val model: ActivityLogDetailModel) : ActivityLogDetailNavigationEvents()
+    data class ShowDocumentationPage(val url: String = DOCUMENTATION_PAGE_URL) : ActivityLogDetailNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -179,6 +179,7 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
                         viewModel.site,
                         it.activityId,
                         it.isButtonVisible,
+                        it.isRestoreHidden,
                         viewModel.rewindableOnly
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
@@ -30,7 +30,8 @@ sealed class ActivityLogListItem(val type: ViewType) {
         val rewindId: String?,
         val date: Date,
         override val isButtonVisible: Boolean,
-        val buttonIcon: Icon
+        val buttonIcon: Icon,
+        val isRestoreHidden: Boolean
     ) : ActivityLogListItem(EVENT), IActionableItem {
         val formattedDate: String = date.toFormattedDateString()
         val icon = Icon.fromValue(gridIcon)
@@ -38,7 +39,8 @@ sealed class ActivityLogListItem(val type: ViewType) {
 
         constructor(
             model: ActivityLogModel,
-            rewindDisabled: Boolean = false
+            rewindDisabled: Boolean,
+            isRestoreHidden: Boolean
         ) : this(
                 activityId = model.activityID,
                 title = model.summary,
@@ -49,7 +51,8 @@ sealed class ActivityLogListItem(val type: ViewType) {
                 rewindId = model.rewindID,
                 date = model.published,
                 isButtonVisible = !rewindDisabled && model.rewindable ?: false,
-                buttonIcon = MORE
+                buttonIcon = MORE,
+                isRestoreHidden = isRestoreHidden
         )
 
         override fun longId(): Long = activityId.hashCode().toLong()

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItemMenuAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItemMenuAdapter.kt
@@ -10,8 +10,6 @@ import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
 import org.wordpress.android.R
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.RESTORE
 import org.wordpress.android.util.ColorUtils.setImageResourceWithTint
 import org.wordpress.android.util.getColorResIdFromAttribute
 
@@ -48,11 +46,11 @@ class ActivityLogListItemMenuAdapter(
         val iconRes: Int
         val colorRes = view.context.getColorResIdFromAttribute(R.attr.wpColorOnSurfaceMedium)
         when (items[position]) {
-            RESTORE -> {
+            SecondaryAction.RESTORE -> {
                 textRes = R.string.activity_log_item_menu_restore_label
                 iconRes = R.drawable.ic_history_white_24dp
             }
-            DOWNLOAD_BACKUP -> {
+            SecondaryAction.DOWNLOAD_BACKUP -> {
                 textRes = R.string.activity_log_item_menu_download_backup_label
                 iconRes = R.drawable.ic_get_app_white_24dp
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItemMenuAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItemMenuAdapter.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.util.getColorResIdFromAttribute
 
 class ActivityLogListItemMenuAdapter(
     context: Context,
-    isRestoreHidden: Boolean,
+    isRestoreHidden: Boolean
 ) : BaseAdapter() {
     private val inflater: LayoutInflater = LayoutInflater.from(context)
     private val items: List<SecondaryAction> = SecondaryAction.values()

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItemMenuAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItemMenuAdapter.kt
@@ -14,10 +14,14 @@ import org.wordpress.android.util.ColorUtils.setImageResourceWithTint
 import org.wordpress.android.util.getColorResIdFromAttribute
 
 class ActivityLogListItemMenuAdapter(
-    context: Context
+    context: Context,
+    isRestoreHidden: Boolean,
 ) : BaseAdapter() {
     private val inflater: LayoutInflater = LayoutInflater.from(context)
-    private val items: List<SecondaryAction> = SecondaryAction.values().toList()
+    private val items: List<SecondaryAction> = SecondaryAction.values()
+            .toList()
+            .filter { !(it == SecondaryAction.RESTORE && isRestoreHidden) }
+
     override fun getCount(): Int {
         return items.size
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/EventItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/EventItemViewHolder.kt
@@ -60,10 +60,13 @@ class EventItemViewHolder(
         actionButton.setOnClickListener { renderMoreMenu(activity, it) }
     }
 
-    private fun renderMoreMenu(event: ActivityLogListItem, v: View) {
+    private fun renderMoreMenu(
+        event: Event,
+        v: View
+    ) {
         val popup = ListPopupWindow(v.context)
         popup.width = v.context.resources.getDimensionPixelSize(R.dimen.menu_item_width)
-        popup.setAdapter(ActivityLogListItemMenuAdapter(v.context))
+        popup.setAdapter(ActivityLogListItemMenuAdapter(v.context, event.isRestoreHidden))
         popup.setDropDownGravity(Gravity.END)
         popup.anchorView = v
         popup.isModal = true

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreStates.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreStates.kt
@@ -114,6 +114,8 @@ sealed class RestoreRequestState {
         val published: Date? = null
     ) : RestoreRequestState()
 
+    object Multisite : RestoreRequestState()
+
     object Empty : RestoreRequestState()
 
     data class AwaitingCredentials(val isAwaitingCredentials: Boolean) : RestoreRequestState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Reason.MULTISITE_NOT_SUPPORTED
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.FAILED
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.FINISHED
@@ -17,12 +18,13 @@ import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchRewindStatePayload
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState
+import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.AwaitingCredentials
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Complete
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Empty
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Failure
-import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.AwaitingCredentials
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Failure.NetworkUnavailable
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Failure.RemoteRequestFailure
+import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Multisite
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Progress
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -73,7 +75,11 @@ class GetRestoreStatusUseCase @Inject constructor(
                 break
             }
             if (rewind == null) {
-                emit(Empty)
+                if (rewindStatus?.reason == MULTISITE_NOT_SUPPORTED) {
+                    emit(Multisite)
+                } else {
+                    emit(Empty)
+                }
                 break
             }
             if (restoreId == null || rewind.restoreId == restoreId) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -20,6 +20,7 @@ import javax.inject.Inject
 
 const val ACTIVITY_LOG_ID_KEY: String = "activity_log_id_key"
 const val ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY: String = "activity_log_are_buttons_visible_key"
+const val ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY: String = "activity_log_is_restore_hidden_key"
 
 class ActivityLogDetailViewModel
 @Inject constructor(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -29,6 +29,7 @@ class ActivityLogDetailViewModel
     lateinit var site: SiteModel
     lateinit var activityLogId: String
     var areButtonsVisible = false
+    var isRestoreHidden = false
 
     private val _navigationEvents = MutableLiveData<Event<ActivityLogDetailNavigationEvents>>()
     val navigationEvents: LiveData<Event<ActivityLogDetailNavigationEvents>>
@@ -50,10 +51,16 @@ class ActivityLogDetailViewModel
     val downloadBackupVisible: LiveData<Boolean>
         get() = _downloadBackupVisible
 
-    fun start(site: SiteModel, activityLogId: String, areButtonsVisible: Boolean) {
+    fun start(
+        site: SiteModel,
+        activityLogId: String,
+        areButtonsVisible: Boolean,
+        isRestoreHidden: Boolean,
+    ) {
         this.site = site
         this.activityLogId = activityLogId
         this.areButtonsVisible = areButtonsVisible
+        this.isRestoreHidden = isRestoreHidden
 
         _restoreVisible.value = areButtonsVisible
         _downloadBackupVisible.value = areButtonsVisible

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -19,8 +19,6 @@ import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEv
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.ACTIVITY_LOG
-import org.wordpress.android.util.toFormattedDateString
-import org.wordpress.android.util.toFormattedTimeString
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -69,7 +67,7 @@ class ActivityLogDetailViewModel @Inject constructor(
         site: SiteModel,
         activityLogId: String,
         areButtonsVisible: Boolean,
-        isRestoreHidden: Boolean,
+        isRestoreHidden: Boolean
     ) {
         this.site = site
         this.activityLogId = activityLogId

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -19,6 +19,8 @@ import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEv
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.ACTIVITY_LOG
+import org.wordpress.android.util.toFormattedDateString
+import org.wordpress.android.util.toFormattedTimeString
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.SingleLiveEvent

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.viewmodel.activitylog
 
+import android.text.SpannableString
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -51,6 +52,10 @@ class ActivityLogDetailViewModel
     private val _downloadBackupVisible = MutableLiveData<Boolean>()
     val downloadBackupVisible: LiveData<Boolean>
         get() = _downloadBackupVisible
+
+    private val _multisiteVisible = MutableLiveData<Pair<Boolean, SpannableString?>>()
+    val multisiteVisible: LiveData<Pair<Boolean, SpannableString?>>
+        get() = _multisiteVisible
 
     fun start(
         site: SiteModel,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailModel
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEvents
+import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEvents.ShowDocumentationPage
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.ACTIVITY_LOG
@@ -116,7 +117,7 @@ class ActivityLogDetailViewModel @Inject constructor(
     ): SpannableString {
         val clickableSpan = object : ClickableSpan() {
             override fun onClick(widget: View) {
-                TODO()
+                _navigationEvents.postValue(Event(ShowDocumentationPage()))
             }
         }
         val clickableStartIndex = multisiteMessage.indexOf(clickableText)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -62,7 +62,7 @@ class ActivityLogDetailViewModel
         this.areButtonsVisible = areButtonsVisible
         this.isRestoreHidden = isRestoreHidden
 
-        _restoreVisible.value = areButtonsVisible
+        _restoreVisible.value = areButtonsVisible && !isRestoreHidden
         _downloadBackupVisible.value = areButtonsVisible
 
         if (activityLogId != _item.value?.activityID) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -203,7 +203,7 @@ class ActivityLogViewModel @Inject constructor(
             val currentItem = ActivityLogListItem.Event(
                     model = model,
                     rewindDisabled = withRestoreProgressItem || withBackupDownloadProgressItem,
-                    isRestoreHidden = false
+                    isRestoreHidden = restoreEvent.isRestoreHidden
             )
             val lastItem = items.lastOrNull() as? ActivityLogListItem.Event
             if (lastItem == null || lastItem.formattedDate != currentItem.formattedDate) {
@@ -585,10 +585,20 @@ class ActivityLogViewModel @Inject constructor(
 
     private fun handleRestoreStatus(state: RestoreRequestState) {
         when (state) {
+            is RestoreRequestState.Multisite -> handleRestoreStatusForMultisite()
             is RestoreRequestState.Progress -> handleRestoreStatusForProgress(state)
             is RestoreRequestState.Complete -> handleRestoreStatusForComplete(state)
             else -> Unit // Do nothing
         }
+    }
+
+    private fun handleRestoreStatusForMultisite() {
+        reloadEvents(
+                restoreEvent = RestoreEvent(
+                        displayProgress = false,
+                        isRestoreHidden = true
+                )
+        )
     }
 
     private fun handleRestoreStatusForProgress(state: RestoreRequestState.Progress) {
@@ -706,6 +716,7 @@ class ActivityLogViewModel @Inject constructor(
 
     data class RestoreEvent(
         val displayProgress: Boolean,
+        val isRestoreHidden: Boolean = false,
         val isCompleted: Boolean = false,
         val rewindId: String? = null,
         val published: Date? = null

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -201,8 +201,9 @@ class ActivityLogViewModel @Inject constructor(
         }
         eventList.forEach { model ->
             val currentItem = ActivityLogListItem.Event(
-                    model,
-                    withRestoreProgressItem || withBackupDownloadProgressItem
+                    model = model,
+                    rewindDisabled = withRestoreProgressItem || withBackupDownloadProgressItem,
+                    isRestoreHidden = false
             )
             val lastItem = items.lastOrNull() as? ActivityLogListItem.Event
             if (lastItem == null || lastItem.formattedDate != currentItem.formattedDate) {

--- a/WordPress/src/main/res/layout/activity_log_item_detail.xml
+++ b/WordPress/src/main/res/layout/activity_log_item_detail.xml
@@ -178,6 +178,16 @@
 
         </LinearLayout>
 
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/multisiteMessage"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="24dp"
+            android:textAppearance="?attr/textAppearanceBody1"
+            android:visibility="gone"
+            tools:text="Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores. For more information visit our documentation page."
+            tools:visibility="visible" />
+
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1067,6 +1067,8 @@
     <string name="activity_log_activity_type_filter_no_item_selected_content_description">Activity Type filter</string>
     <string name="activity_log_activity_type_filter_single_item_selected_content_description">%s (showing %s items)</string>
     <string name="activity_log_activity_type_filter_multiple_items_selected_content_description">Activity Type filter (%s types selected)</string>
+    <string name="activity_log_multisite_message">Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores. For more information %1$s.</string>
+    <string name="activity_log_visit_our_documentation_page">visit our documentation page</string>
 
     <!-- activity log list popup menu -->
     <string name="activity_log_item_menu_restore_label">Restore to this point</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_REWIND_STATE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Reason
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.State
 import org.wordpress.android.fluxc.store.ActivityLogStore
@@ -343,7 +344,7 @@ class GetRestoreStatusUseCaseTest {
         state: State = State.ACTIVE
     ) = RewindStatusModel(
             state = state,
-            reason = null,
+            reason = Reason.NO_REASON,
             lastUpdated = PUBLISHED,
             canAutoconfigure = null,
             credentials = null,

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.ui.jetpack.restore.RestoreRequestState
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.AwaitingCredentials
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Complete
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Failure
-import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Failure.RemoteRequestFailure
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Progress
 import org.wordpress.android.util.NetworkUtilsWrapper
 import java.util.Date
@@ -254,7 +253,7 @@ class GetRestoreStatusUseCaseTest {
                 val result = useCase.getRestoreStatus(site, null).toList()
 
                 assertThat(result).size().isEqualTo(1)
-                assertThat(result).isEqualTo(listOf(RemoteRequestFailure))
+                assertThat(result).isEqualTo(listOf(Failure.RemoteRequestFailure))
             }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
@@ -225,6 +225,26 @@ class GetRestoreStatusUseCaseTest {
             }
 
     @Test
+    fun `given unavailable multisite without restoreId, when restore status triggers, then return multisite`() = test {
+        whenever(activityLogStore.getRewindStatusForSite(site))
+                .thenReturn(rewindStatusModel(null, null, State.UNAVAILABLE, Reason.MULTISITE_NOT_SUPPORTED))
+
+        val result = useCase.getRestoreStatus(site, null).toList()
+
+        assertThat(result).contains(RestoreRequestState.Multisite)
+    }
+
+    @Test
+    fun `given unavailable multisite with restoreId, when restore status triggers, then return multisite`() = test {
+        whenever(activityLogStore.getRewindStatusForSite(site))
+                .thenReturn(rewindStatusModel(null, null, State.UNAVAILABLE, Reason.MULTISITE_NOT_SUPPORTED))
+
+        val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+
+        assertThat(result).contains(RestoreRequestState.Multisite)
+    }
+
+    @Test
     fun `given unavailable without restoreId, when restore status triggers, then return empty`() = test {
         whenever(activityLogStore.getRewindStatusForSite(site))
                 .thenReturn(rewindStatusModel(null, null, State.UNAVAILABLE))
@@ -342,10 +362,11 @@ class GetRestoreStatusUseCaseTest {
     private fun rewindStatusModel(
         rewindId: String?,
         status: Rewind.Status? = null,
-        state: State = State.ACTIVE
+        state: State = State.ACTIVE,
+        reason: Reason = Reason.NO_REASON
     ) = RewindStatusModel(
             state = state,
-            reason = Reason.NO_REASON,
+            reason = reason,
             lastUpdated = PUBLISHED,
             canAutoconfigure = null,
             credentials = null,

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
@@ -225,8 +225,9 @@ class GetRestoreStatusUseCaseTest {
             }
 
     @Test
-    fun `given get status model is null without restoreId, when restore status triggers, then return empty`() = test {
-        whenever(activityLogStore.getRewindStatusForSite(site)).thenReturn(null)
+    fun `given unavailable without restoreId, when restore status triggers, then return empty`() = test {
+        whenever(activityLogStore.getRewindStatusForSite(site))
+                .thenReturn(rewindStatusModel(null, null, State.UNAVAILABLE))
 
         val result = useCase.getRestoreStatus(site, null).toList()
 
@@ -234,8 +235,9 @@ class GetRestoreStatusUseCaseTest {
     }
 
     @Test
-    fun `given get status model is null with restoreId, when restore status triggers, then return empty`() = test {
-        whenever(activityLogStore.getRewindStatusForSite(site)).thenReturn(null)
+    fun `given unavailable with restoreId, when restore status triggers, then return empty`() = test {
+        whenever(activityLogStore.getRewindStatusForSite(site))
+                .thenReturn(rewindStatusModel(null, null, State.UNAVAILABLE))
 
         val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
 
@@ -347,7 +349,11 @@ class GetRestoreStatusUseCaseTest {
             lastUpdated = PUBLISHED,
             canAutoconfigure = null,
             credentials = null,
-            rewind = if (state != State.AWAITING_CREDENTIALS) rewind(rewindId, status as Rewind.Status) else null
+            rewind = if (state == State.AWAITING_CREDENTIALS || state == State.UNAVAILABLE) {
+                null
+            } else {
+                rewind(rewindId, status as Rewind.Status)
+            }
     )
 
     private fun rewind(

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/PostRestoreUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/PostRestoreUseCaseTest.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.action.ActivityLogAction
 import org.wordpress.android.fluxc.action.ActivityLogAction.REWIND
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Reason
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.QUEUED
@@ -144,7 +145,7 @@ class PostRestoreUseCaseTest : BaseUnitTest() {
 
     private fun buildStatusModel(status: Status) = RewindStatusModel(
             state = ACTIVE,
-            reason = null,
+            reason = Reason.NO_REASON,
             lastUpdated = Date(1609690147756),
             canAutoconfigure = null,
             credentials = null,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -87,7 +87,7 @@ class ActivityLogDetailViewModelTest {
     }
 
     @Test
-    fun `given buttons are not visible, when view model starts, then restore button is not shown`() {
+    fun `given buttons not visible and restore not hidden, when view model starts, then restore button is not shown`() {
         val areButtonsVisible = false
         val isRestoreHidden = false
 
@@ -97,7 +97,17 @@ class ActivityLogDetailViewModelTest {
     }
 
     @Test
-    fun `given buttons are visible, when view model starts, then restore button is shown`() {
+    fun `given button not visible and restore hidden, when view model starts, then restore button is not shown`() {
+        val areButtonsVisible = false
+        val isRestoreHidden = true
+
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+
+        assertEquals(false, restoreVisible)
+    }
+
+    @Test
+    fun `given buttons visible and restore not hidden, when view model starts, then restore button is shown`() {
         val areButtonsVisible = true
         val isRestoreHidden = false
 
@@ -107,7 +117,17 @@ class ActivityLogDetailViewModelTest {
     }
 
     @Test
-    fun `given buttons are not visible, when view model starts, then download backup button is not shown`() {
+    fun `given button visible and restore hidden, when view model starts, then restore button is not shown`() {
+        val areButtonsVisible = true
+        val isRestoreHidden = true
+
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+
+        assertEquals(false, restoreVisible)
+    }
+
+    @Test
+    fun `given buttons not visible, when view model starts, then download backup button is not shown`() {
         val areButtonsVisible = false
         val isRestoreHidden = false
 
@@ -117,7 +137,7 @@ class ActivityLogDetailViewModelTest {
     }
 
     @Test
-    fun `given buttons are visible, when view model starts, then download backup button is shown`() {
+    fun `given buttons visible, when view model starts, then download backup button is shown`() {
         val areButtonsVisible = true
         val isRestoreHidden = false
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -1,10 +1,12 @@
 package org.wordpress.android.viewmodel.activitylog
 
+import android.text.SpannableString
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -67,6 +69,7 @@ class ActivityLogDetailViewModelTest {
     private var lastEmittedItem: ActivityLogDetailModel? = null
     private var restoreVisible: Boolean = false
     private var downloadBackupVisible: Boolean = false
+    private var multisiteVisible: Pair<Boolean, SpannableString?> = Pair(false, null)
     private var navigationEvents: MutableList<Event<ActivityLogDetailNavigationEvents?>> = mutableListOf()
 
     @Before
@@ -78,6 +81,7 @@ class ActivityLogDetailViewModelTest {
         viewModel.activityLogItem.observeForever { lastEmittedItem = it }
         viewModel.restoreVisible.observeForever { restoreVisible = it }
         viewModel.downloadBackupVisible.observeForever { downloadBackupVisible = it }
+        viewModel.multisiteVisible.observeForever { multisiteVisible = it }
         viewModel.navigationEvents.observeForever { navigationEvents.add(it) }
     }
 
@@ -144,6 +148,28 @@ class ActivityLogDetailViewModelTest {
         viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
 
         assertEquals(true, downloadBackupVisible)
+    }
+
+    @Test
+    fun `given restore not hidden, when view model starts, then multisite message is not shown`() {
+        val areButtonsVisible = true
+        val isRestoreHidden = false
+
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+
+        assertFalse(multisiteVisible.first)
+        assertNull(multisiteVisible.second)
+    }
+
+    @Test
+    fun `given restore hidden, when view model starts, then multisite message is shown`() {
+        val areButtonsVisible = true
+        val isRestoreHidden = true
+
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+
+        assertTrue(multisiteVisible.first)
+        assertNotNull(multisiteVisible.second)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.viewmodel.activitylog
 
 import android.text.SpannableString
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.After
@@ -14,6 +15,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.Dispatcher
@@ -24,7 +26,9 @@ import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailModel
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEvents
+import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
@@ -33,6 +37,8 @@ class ActivityLogDetailViewModelTest {
 
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var activityLogStore: ActivityLogStore
+    @Mock private lateinit var resourceProvider: ResourceProvider
+    @Mock private lateinit var htmlMessageUtils: HtmlMessageUtils
     @Mock private lateinit var site: SiteModel
     private lateinit var viewModel: ActivityLogDetailViewModel
 
@@ -76,13 +82,21 @@ class ActivityLogDetailViewModelTest {
     fun setUp() {
         viewModel = ActivityLogDetailViewModel(
                 dispatcher,
-                activityLogStore
+                activityLogStore,
+                resourceProvider,
+                htmlMessageUtils
         )
         viewModel.activityLogItem.observeForever { lastEmittedItem = it }
         viewModel.restoreVisible.observeForever { restoreVisible = it }
         viewModel.downloadBackupVisible.observeForever { downloadBackupVisible = it }
         viewModel.multisiteVisible.observeForever { multisiteVisible = it }
         viewModel.navigationEvents.observeForever { navigationEvents.add(it) }
+        setUpMocks()
+    }
+
+    private fun setUpMocks() {
+        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), any())).thenReturn("")
+        whenever(resourceProvider.getString(anyInt())).thenReturn("")
     }
 
     @After

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -117,6 +117,16 @@ class ActivityLogDetailViewModelTest {
     }
 
     @Test
+    fun `given buttons are visible, when view model starts, then download backup button is shown`() {
+        val areButtonsVisible = true
+        val isRestoreHidden = false
+
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+
+        assertEquals(true, downloadBackupVisible)
+    }
+
+    @Test
     fun emitsUIModelOnStart() {
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(activityLogModel))
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -35,6 +35,7 @@ class ActivityLogDetailViewModelTest {
     private lateinit var viewModel: ActivityLogDetailViewModel
 
     private val areButtonsVisible = true
+    private val isRestoreHidden = false
 
     private val activityID = "id1"
     private val summary = "Jetpack"
@@ -87,21 +88,30 @@ class ActivityLogDetailViewModelTest {
 
     @Test
     fun `given buttons are not visible, when view model starts, then restore button is not shown`() {
-        viewModel.start(site, activityID, false)
+        val areButtonsVisible = false
+        val isRestoreHidden = false
+
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
 
         assertEquals(false, restoreVisible)
     }
 
     @Test
     fun `given buttons are visible, when view model starts, then restore button is shown`() {
-        viewModel.start(site, activityID, true)
+        val areButtonsVisible = true
+        val isRestoreHidden = false
+
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
 
         assertEquals(true, restoreVisible)
     }
 
     @Test
     fun `given buttons are not visible, when view model starts, then download backup button is not shown`() {
-        viewModel.start(site, activityID, false)
+        val areButtonsVisible = false
+        val isRestoreHidden = false
+
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
 
         assertEquals(false, downloadBackupVisible)
     }
@@ -110,7 +120,7 @@ class ActivityLogDetailViewModelTest {
     fun emitsUIModelOnStart() {
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(activityLogModel))
 
-        viewModel.start(site, activityID, areButtonsVisible)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -129,7 +139,7 @@ class ActivityLogDetailViewModelTest {
         )
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(updatedActivity))
 
-        viewModel.start(site, activityID, areButtonsVisible)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -149,7 +159,7 @@ class ActivityLogDetailViewModelTest {
         )
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(updatedActivity))
 
-        viewModel.start(site, activityID, areButtonsVisible)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -162,11 +172,11 @@ class ActivityLogDetailViewModelTest {
     fun doesNotReemitUIModelOnStartWithTheSameActivityID() {
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(activityLogModel))
 
-        viewModel.start(site, activityID, areButtonsVisible)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
 
         lastEmittedItem = null
 
-        viewModel.start(site, activityID, areButtonsVisible)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
 
         assertNull(lastEmittedItem)
     }
@@ -179,11 +189,11 @@ class ActivityLogDetailViewModelTest {
         val secondActivity = activityLogModel.copy(activityID = activityID2, content = updatedContent)
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(activityLogModel, secondActivity))
 
-        viewModel.start(site, activityID, areButtonsVisible)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
 
         lastEmittedItem = null
 
-        viewModel.start(site, activityID2, areButtonsVisible)
+        viewModel.start(site, activityID2, areButtonsVisible, isRestoreHidden)
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -198,7 +208,7 @@ class ActivityLogDetailViewModelTest {
 
         lastEmittedItem = mock()
 
-        viewModel.start(site, activityID, areButtonsVisible)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
 
         assertNull(lastEmittedItem)
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -1446,6 +1446,7 @@ class ActivityLogViewModelTest {
         backupProgressWithDate: Boolean = false,
         emptyList: Boolean = false,
         rewindDisabled: Boolean = true,
+        isRestoreHidden: Boolean = false,
         isLastPageAndFreeSite: Boolean = false,
         canLoadMore: Boolean = false,
         withFooter: Boolean = false
@@ -1469,12 +1470,12 @@ class ActivityLogViewModelTest {
             }
         }
         if (!emptyList) {
-            firstItem(rewindDisabled).let {
+            firstItem(rewindDisabled, isRestoreHidden).let {
                 list.add(ActivityLogListItem.Header(it.formattedDate))
                 list.add(it)
             }
-            list.add(secondItem(rewindDisabled))
-            thirdItem(rewindDisabled).let {
+            list.add(secondItem(rewindDisabled, isRestoreHidden))
+            thirdItem(rewindDisabled, isRestoreHidden).let {
                 list.add(ActivityLogListItem.Header(it.formattedDate))
                 list.add(it)
             }
@@ -1492,19 +1493,22 @@ class ActivityLogViewModelTest {
         return list
     }
 
-    private fun firstItem(rewindDisabled: Boolean) = ActivityLogListItem.Event(
+    private fun firstItem(rewindDisabled: Boolean, isRestoreHidden: Boolean) = ActivityLogListItem.Event(
             model = activityList[0],
-            rewindDisabled = rewindDisabled
+            rewindDisabled = rewindDisabled,
+            isRestoreHidden = isRestoreHidden
     )
 
-    private fun secondItem(rewindDisabled: Boolean) = ActivityLogListItem.Event(
+    private fun secondItem(rewindDisabled: Boolean, isRestoreHidden: Boolean) = ActivityLogListItem.Event(
             model = activityList[1],
-            rewindDisabled = rewindDisabled
+            rewindDisabled = rewindDisabled,
+            isRestoreHidden = isRestoreHidden
     )
 
-    private fun thirdItem(rewindDisabled: Boolean) = ActivityLogListItem.Event(
+    private fun thirdItem(rewindDisabled: Boolean, isRestoreHidden: Boolean) = ActivityLogListItem.Event(
             model = activityList[2],
-            rewindDisabled = rewindDisabled
+            rewindDisabled = rewindDisabled,
+            isRestoreHidden = isRestoreHidden
     )
 
     private suspend fun assertFetchEvents(canLoadMore: Boolean = false) {
@@ -1526,7 +1530,8 @@ class ActivityLogViewModelTest {
             rewindId = null,
             date = Date(),
             isButtonVisible = true,
-            buttonIcon = ActivityLogListItem.Icon.DEFAULT
+            buttonIcon = ActivityLogListItem.Icon.DEFAULT,
+            isRestoreHidden = false
     )
 
     private fun backupDownloadCompleteEvent() = BackupDownloadEvent(

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -1224,6 +1224,29 @@ class ActivityLogViewModelTest {
     }
 
     @Test
+    fun `given status is multisite, when query restore status, then reload events for multisite`() = test {
+        whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID))
+                .thenReturn(flow { emit(RestoreRequestState.Multisite) })
+        initRestoreProgressMocks()
+
+        viewModel.onQueryRestoreStatus(REWIND_ID, RESTORE_ID)
+
+        assertEquals(
+                viewModel.events.value,
+                expectedActivityList(
+                        displayRestoreProgress = false,
+                        restoreProgressWithDate = false,
+                        emptyList = false,
+                        rewindDisabled = false,
+                        isRestoreHidden = true,
+                        isLastPageAndFreeSite = false,
+                        canLoadMore = true,
+                        withFooter = false
+                )
+        )
+    }
+
+    @Test
     fun `given status is a progress, when query restore status, then reload events for progress`() = test {
         val progress = RestoreRequestState.Progress(REWIND_ID, 50)
         whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID)).thenReturn(flow { emit(progress) })

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'ef0351a561c1f873cf89ad2b5508cb8968e65f08'
+    fluxCVersion = '0e8ba43d06bd4125c08d413cfa4b560bdf1a5ef5'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '0e8ba43d06bd4125c08d413cfa4b560bdf1a5ef5'
+    fluxCVersion = '1.21.0-beta-3'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.21.0-beta-2'
+    fluxCVersion = 'ef0351a561c1f873cf89ad2b5508cb8968e65f08'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #14945
Related to: [WordPress-FluxC-Android#2044](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2044)

This PR is using its related PR, which provides the new `Reason` enum, to utilise that with the `GetRestoreStatusUseCase.kt` use case in order to emit the new `RestoreRequestState.Multisite` state to hide the restore option for an unavailable rewind state on multisites.

There are two screens that are affected by this change, those are the:
- `Activity Log` (or `Backup`) screen and
- `Event Details` screen

Site | Activity Log | Event Details
-----|-----|-----
Not Multisite | <img width="250" height="500" alt="activity_log_not_multisite" src="https://user-images.githubusercontent.com/9729923/124434846-0a656600-dd7d-11eb-9d1b-cc4f042f0131.png"> | <img width="250" height="500" alt="event_details_not_multisite" src="https://user-images.githubusercontent.com/9729923/124434979-2e28ac00-dd7d-11eb-83eb-a1532ed3bba4.png">
Multisite | <img width="250" height="500" alt="activity_log_multisite" src="https://user-images.githubusercontent.com/9729923/124435010-37197d80-dd7d-11eb-84d7-02a49e0e8e70.png"> | <img width="250" height="500" alt="event_details_multisite" src="https://user-images.githubusercontent.com/9729923/124435047-400a4f00-dd7d-11eb-875f-5c6487b4d944.png">

To test:
1) Open the `Jurassic Ninja` site: https://jurassic.ninja/specialops/
2) Pick a Jetpack plan (use `Jetpack Complete`).
3) Launch a `Jetpack Mutlisite on subdomains` site.
4) Connect to this site and open the app.
5) Go to: `My Site` -> `Activity Log` (or `Backup`)
6) Tap the menu option (`3 dots`) on an activity log item
7) Verify that the `Restore to this point` option is not available.
8) Tap on the activity log item itself to enter the `Event Details` screen.
9) Verify that the `RESTORE` button is not available.
10) Verify that a mutlisite message at the bottom is displayed, which informs the users about downloadable backups.
11) Tap on the `visit our documentation page` link within the multisite message itself.
12) Verify that you get redirected to: https://jetpack.com/support/backup/

#### Note:
Due to the nature of the `Activity Log` (or `Backup`) and `Event Details` screens, being too quick when tapping on the menu option on an activity log item or the activity log item itself, might not hide the `Restore to this point` option or `RESTORE` button. This is due to the fact that the call to check and hide those is happening after entering the screen and as such a potential 1/2' seconds delay exists in updating the screen(s) with the new state.

#### Merge Instructions:
- ~~Review [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2044), then merge and create a new beta tag.~~
- ~~Replace `fluxCVersion` hash with the beta tag in `build.gradle`.~~
- ~~Remove the `[Status] Not Ready for Merge` label.~~
- Merge this PR.

## Regression Notes
1. Potential unintended areas of impact

- `Activity Log` or `Backup` screen and flows.
- `Event Details` screen and flows.
- `Restore` screen and flows.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested as described above in the `To test` section.

3. What automated tests I added (or what prevented me from doing so)

New tests within the below test suites:
- `GetRestoreStatusUseCaseTest.kt`
- `ActivityLogViewModelTest.kt`
- `ActivityLogDetailViewModelTest.kt`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
