### PR TITLE
Add Blogging Reminders preference back for self-hosted sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1929,10 +1929,13 @@ public class SiteSettingsFragment extends PreferenceFragment
                 R.string.pref_key_jetpack_performance_settings);
     }
 
-    // This removes all preferences from the General preference group, except for Blogging Reminders – in practice it is
-    // removed as well, but then added back.
-    // In the future, we should consider either moving the Blogging Reminders preference to its own group or replace
-    // this approach with something more scalable and efficient.
+    /**
+     * This removes all preferences from the General preference group, except for Blogging Reminders – in practice it
+     * is removed as well, but then added back.
+     *
+     * In the future, we should consider either moving the Blogging Reminders preference to its own group or
+     * replace this approach with something more scalable and efficient.
+     */
     private void removeGeneralSettingsExceptBloggingReminders() {
         PreferenceGroup group = (PreferenceGroup) findPreference(getString(R.string.pref_key_site_general));
         if (group != null && mBloggingRemindersPref != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -13,6 +13,7 @@ import android.preference.EditTextPreference;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
+import android.preference.PreferenceGroup;
 import android.preference.PreferenceScreen;
 import android.provider.ContactsContract;
 import android.text.TextUtils;
@@ -1918,7 +1919,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     private void removeNonSelfHostedPreferences() {
         mUsernamePref.setEnabled(true);
         mPasswordPref.setEnabled(true);
-        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_general);
+        removeGeneralSettingsExceptBloggingReminders();
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_writing);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_discussion);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_advanced);
@@ -1926,6 +1927,18 @@ public class SiteSettingsFragment extends PreferenceFragment
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_jetpack_settings);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen,
                 R.string.pref_key_jetpack_performance_settings);
+    }
+
+    // This removes all preferences from the General preference group, except for Blogging Reminders – in practice it is
+    // removed as well, but then added back.
+    // In the future, we should consider either moving the Blogging Reminders preference to its own group or replace
+    // this approach with something more scalable and efficient.
+    private void removeGeneralSettingsExceptBloggingReminders() {
+        PreferenceGroup group = (PreferenceGroup) findPreference(getString(R.string.pref_key_site_general));
+        if (group != null && mBloggingRemindersPref != null) {
+            group.removeAll();
+            group.addPreference(mBloggingRemindersPref);
+        }
     }
 
     private void removeNonJetpackPreferences() {


### PR DESCRIPTION
Fixes #14981

This PR changes the logic that hides non-self-hosted settings on `SiteSettingsFragment` to make an exception for the Blogging Reminders option, which shouldn't be hidden:

<img width=300 src="https://user-images.githubusercontent.com/830056/124513851-17507c80-ddb2-11eb-9750-c7024d32e449.png"/>

Note: I'm not sure if this should be targeting the frozen branch or not, so I'm keeping this as a draft until further confirmation.

### To test

1. Clear app data.
1. Login with a self-hosted site using WP admin credentials (you can use [jurassic.ninja](https://jurassic.ninja/) to generate a test site).
1. Go to the Site Settings screen.
1. Notice the _Blogging reminders_ option under the _General_ group.
1. Go through the flow and make sure everything works as expected.

## Regression Notes
1. Potential unintended areas of impact
Other self-hosted settings.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None, as `SiteSettingsFragment` isn't really testable right now.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
