### PR TITLE
Jetpack Scan: Fix start scan behavior

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -55,8 +55,13 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         recyclerView.addItemDecoration(
                 HorizontalMarginItemDecoration(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
         )
-        recyclerView.setEmptyView(actionableEmptyView)
         initAdapter()
+        initActionableEmptyView()
+    }
+
+    private fun ScanFragmentBinding.initActionableEmptyView() {
+        recyclerView.setEmptyView(actionableEmptyView)
+        uiHelpers.updateVisibility(actionableEmptyView, false)
     }
 
     private fun ScanFragmentBinding.initAdapter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -96,11 +96,15 @@ class ScanViewModel @Inject constructor(
             scanStateModel?.let {
                 if (fixableThreatIds.isNotEmpty()) fetchFixThreatsStatus(fixableThreatIds, isInvokedByUser = false)
             }
-            fetchScanState()
+            fetchScanState(isInvokedFromInit = true)
         }
     }
 
-    private fun fetchScanState(invokedByUser: Boolean = false, isRetry: Boolean = false) {
+    private fun fetchScanState(
+        invokedByUser: Boolean = false,
+        isRetry: Boolean = false,
+        isInvokedFromInit: Boolean = false
+    ) {
         launch {
             if (isRetry) delay(RETRY_DELAY)
 
@@ -120,7 +124,7 @@ class ScanViewModel @Inject constructor(
 
                             is FetchScanState.Failure.NetworkUnavailable -> {
                                 scanTracker.trackOnError(ErrorAction.FETCH_SCAN_STATE, ErrorCause.OFFLINE)
-                                scanStateModel
+                                scanStateModel?.takeIf { !isInvokedFromInit }
                                         ?.let {
                                             updateSnackbarMessageEvent(UiStringRes(R.string.error_generic_network))
                                         }
@@ -129,7 +133,7 @@ class ScanViewModel @Inject constructor(
 
                             is FetchScanState.Failure.RemoteRequestFailure -> {
                                 scanTracker.trackOnError(ErrorAction.FETCH_SCAN_STATE, ErrorCause.REMOTE)
-                                scanStateModel
+                                scanStateModel?.takeIf { !isInvokedFromInit }
                                         ?.let {
                                             updateSnackbarMessageEvent(UiStringRes(R.string.request_failed_message))
                                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -255,7 +255,7 @@ class ScanViewModel @Inject constructor(
                     buildContentUiState(model = requireNotNull(scanStateModel), fixingThreatIds = fixingThreatIds)
             )
 
-            messageRes?.let { updateSnackbarMessageEvent(UiStringRes(it)) }
+            if (isInvokedByUser) messageRes?.let { updateSnackbarMessageEvent(UiStringRes(it)) }
         }
 
         return someOrAllThreatFixed

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -90,10 +90,10 @@ class ScanViewModel @Inject constructor(
     }
 
     private fun init() {
+        updateUiState(FullScreenLoadingUiState)
         launch {
             scanStateModel = scanStore.getScanStateForSite(this@ScanViewModel.site)
             scanStateModel?.let {
-                updateUiState(buildContentUiState(it))
                 if (fixableThreatIds.isNotEmpty()) fetchFixThreatsStatus(fixableThreatIds, isInvokedByUser = false)
             }
             fetchScanState()
@@ -102,7 +102,6 @@ class ScanViewModel @Inject constructor(
 
     private fun fetchScanState(invokedByUser: Boolean = false, isRetry: Boolean = false) {
         launch {
-            if (scanStateModel == null) updateUiState(FullScreenLoadingUiState)
             if (isRetry) delay(RETRY_DELAY)
 
             fetchScanStateUseCase.fetchScanState(site = site, startWithDelay = invokedByUser)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -251,9 +251,12 @@ class ScanViewModel @Inject constructor(
                     }
                 }
             }
-            updateUiState(
-                    buildContentUiState(model = requireNotNull(scanStateModel), fixingThreatIds = fixingThreatIds)
-            )
+
+            if (status is FetchFixThreatsState.InProgress || status is FetchFixThreatsState.Complete) {
+                updateUiState(
+                        buildContentUiState(model = requireNotNull(scanStateModel), fixingThreatIds = fixingThreatIds)
+                )
+            }
 
             if (isInvokedByUser) messageRes?.let { updateSnackbarMessageEvent(UiStringRes(it)) }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -246,13 +246,14 @@ class ScanViewModel @Inject constructor(
                     }
                     if (!status.containsOnlyErrors) {
                         someOrAllThreatFixed = true
-                    } else if (isInvokedByUser) {
+                    } else {
                         messageRes = R.string.threat_fix_all_status_error_message
                     }
                 }
             }
 
-            if (status is FetchFixThreatsState.InProgress || status is FetchFixThreatsState.Complete) {
+            val shouldUpdateUi = status is FetchFixThreatsState.InProgress || status is FetchFixThreatsState.Complete
+            if (shouldUpdateUi) {
                 updateUiState(
                         buildContentUiState(model = requireNotNull(scanStateModel), fixingThreatIds = fixingThreatIds)
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
@@ -22,6 +22,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlin.math.max
 
+const val START_WITH_DELAY_MILLIS = 5000L
 const val FETCH_SCAN_STATE_DELAY_MILLIS = 1000L
 const val MAX_RETRY = 3
 
@@ -39,7 +40,7 @@ class FetchScanStateUseCase @Inject constructor(
     ): Flow<FetchScanState> = flow {
         var retryAttempts = 0
         if (startWithDelay) {
-            delay(FETCH_SCAN_STATE_DELAY_MILLIS)
+            delay(START_WITH_DELAY_MILLIS)
         }
 
         while (true) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -127,6 +127,14 @@ class ScanViewModelTest : BaseUnitTest() {
             }
 
     @Test
+    fun `given last scan state present in db, when vm starts, then app displays full screen loading scan state`() =
+            test {
+                val uiStates = init().uiStates
+
+                assertThat(uiStates.first()).isInstanceOf(FullScreenLoadingUiState::class.java)
+            }
+
+    @Test
     fun `when vm starts, fetch scan state is triggered`() = test {
         viewModel.start(site)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -146,7 +146,7 @@ class ScanViewModelTest : BaseUnitTest() {
             }
 
     @Test
-    fun `given no network, when scan state fetched on init, then app reaches no connection state`() = test {
+    fun `given no network, when scan state fetch not invoked by user, then app reaches no connection state`() = test {
         val observers = initObservers()
 
         fetchScanStateStatusForState(state = Failure.NetworkUnavailable, observers = observers, invokedByUser = false)
@@ -155,7 +155,7 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given no connection state, when scan state fetched on init, then no network ui is shown`() = test {
+    fun `given no connection state, when scan state fetch not invoked by user, then no network ui is shown`() = test {
         val observers = initObservers()
 
         fetchScanStateStatusForState(state = Failure.NetworkUnavailable, observers = observers, invokedByUser = false)
@@ -180,7 +180,7 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given fetch scan fails, when scan state fetched on init, then app reaches failed ui state`() = test {
+    fun `given fetch scan fails, when scan state fetch not invoked by user, then app reaches failed ui state`() = test {
         val observers = initObservers()
 
         fetchScanStateStatusForState(state = Failure.RemoteRequestFailure, observers = observers, invokedByUser = false)
@@ -189,19 +189,24 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given request failed ui state, when scan state fetched on init, then request failed ui shown`() = test {
-        val observers = initObservers()
+    fun `given request failed ui state, when scan state fetch not invoked by user, then request failed ui shown`() =
+            test {
+                val observers = initObservers()
 
-        fetchScanStateStatusForState(state = Failure.RemoteRequestFailure, observers = observers, invokedByUser = false)
+                fetchScanStateStatusForState(
+                        state = Failure.RemoteRequestFailure,
+                        observers = observers,
+                        invokedByUser = false
+                )
 
-        val state = observers.uiStates.last() as ErrorUiState
-        with(state) {
-            assertThat(image).isEqualTo(R.drawable.img_illustration_cloud_off_152dp)
-            assertThat(title).isEqualTo(UiStringRes(R.string.scan_request_failed_title))
-            assertThat(subtitle).isEqualTo(UiStringRes(R.string.scan_request_failed_subtitle))
-            assertThat(buttonText).isEqualTo(UiStringRes(R.string.contact_support))
-        }
-    }
+                val state = observers.uiStates.last() as ErrorUiState
+                with(state) {
+                    assertThat(image).isEqualTo(R.drawable.img_illustration_cloud_off_152dp)
+                    assertThat(title).isEqualTo(UiStringRes(R.string.scan_request_failed_title))
+                    assertThat(subtitle).isEqualTo(UiStringRes(R.string.scan_request_failed_subtitle))
+                    assertThat(buttonText).isEqualTo(UiStringRes(R.string.contact_support))
+                }
+            }
 
     @Test
     fun `given fetch scan state fails, when scan state fetch invoked by user, then request failed msg shown`() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -119,16 +119,7 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given last scan state not present in db, when vm starts, then app displays full screen loading scan state`() =
-            test {
-                whenever(scanStore.getScanStateForSite(site)).thenReturn(null)
-                val uiStates = init().uiStates
-
-                assertThat(uiStates.first()).isInstanceOf(FullScreenLoadingUiState::class.java)
-            }
-
-    @Test
-    fun `given last scan state present in db, when vm starts, then app displays full screen loading scan state`() =
+    fun `when vm starts, then app displays full screen loading scan state`() =
             test {
                 val uiStates = init().uiStates
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.ui.jetpack.scan.builders.ScanStateListItemsBuilder
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchScanStateUseCase
+import org.wordpress.android.ui.jetpack.scan.usecases.FetchScanStateUseCase.FetchScanState
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchScanStateUseCase.FetchScanState.Failure
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchScanStateUseCase.FetchScanState.Success
 import org.wordpress.android.ui.jetpack.scan.usecases.FixThreatsUseCase
@@ -154,75 +155,72 @@ class ScanViewModelTest : BaseUnitTest() {
             }
 
     @Test
-    fun `given no network, when scan state fetched over empty scan state, then app reaches no connection state`() =
-            test {
-                whenever(scanStore.getScanStateForSite(site)).thenReturn(null)
-                whenever(fetchScanStateUseCase.fetchScanState(site)).thenReturn(flowOf(Failure.NetworkUnavailable))
-                val uiStates = init().uiStates
+    fun `given no network, when scan state fetched on init, then app reaches no connection state`() = test {
+        val observers = initObservers()
 
-                assertThat(uiStates.last()).isInstanceOf(ErrorUiState.NoConnection::class.java)
-            }
+        fetchScanStateStatusForState(state = Failure.NetworkUnavailable, observers = observers, invokedByUser = false)
 
-    @Test
-    fun `given no connection state, when scan state fetched over empty scan state, then no network ui is shown`() =
-            test {
-                whenever(scanStore.getScanStateForSite(site)).thenReturn(null)
-                whenever(fetchScanStateUseCase.fetchScanState(site)).thenReturn(flowOf(Failure.NetworkUnavailable))
-                val uiStates = init().uiStates
-
-                val error = uiStates.last() as ErrorUiState
-                with(error) {
-                    assertThat(image).isEqualTo(R.drawable.img_illustration_cloud_off_152dp)
-                    assertThat(title).isEqualTo(UiStringRes(R.string.scan_no_network_title))
-                    assertThat(subtitle).isEqualTo(UiStringRes(R.string.scan_no_network_subtitle))
-                    assertThat(buttonText).isEqualTo(UiStringRes(R.string.retry))
-                }
-            }
+        assertThat(observers.uiStates.last()).isInstanceOf(ErrorUiState.NoConnection::class.java)
+    }
 
     @Test
-    fun `given no network, when scan state fetched over last scan state, then no network msg is shown`() = test {
-        whenever(fetchScanStateUseCase.fetchScanState(site)).thenReturn(flowOf(Failure.NetworkUnavailable))
-        val observers = init()
+    fun `given no connection state, when scan state fetched on init, then no network ui is shown`() = test {
+        val observers = initObservers()
+
+        fetchScanStateStatusForState(state = Failure.NetworkUnavailable, observers = observers, invokedByUser = false)
+
+        val error = observers.uiStates.last() as ErrorUiState
+        with(error) {
+            assertThat(image).isEqualTo(R.drawable.img_illustration_cloud_off_152dp)
+            assertThat(title).isEqualTo(UiStringRes(R.string.scan_no_network_title))
+            assertThat(subtitle).isEqualTo(UiStringRes(R.string.scan_no_network_subtitle))
+            assertThat(buttonText).isEqualTo(UiStringRes(R.string.retry))
+        }
+    }
+
+    @Test
+    fun `given no network, when scan state fetch invoked by user, then no network msg is shown`() = test {
+        val observers = initObservers()
+
+        fetchScanStateStatusForState(state = Failure.NetworkUnavailable, observers = observers, invokedByUser = true)
 
         val snackBarMsg = observers.snackBarMsgs.last().peekContent()
         assertThat(snackBarMsg).isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.error_generic_network)))
     }
 
     @Test
-    fun `given fetch scan fails, when scan state fetched over empty scan state, then app reaches failed ui state`() =
-            test {
-                whenever(scanStore.getScanStateForSite(site)).thenReturn(null)
-                whenever(fetchScanStateUseCase.fetchScanState(site)).thenReturn(flowOf(Failure.RemoteRequestFailure))
-                val uiStates = init().uiStates
+    fun `given fetch scan fails, when scan state fetched on init, then app reaches failed ui state`() = test {
+        val observers = initObservers()
 
-                assertThat(uiStates.last()).isInstanceOf(ErrorUiState.GenericRequestFailed::class.java)
-            }
+        fetchScanStateStatusForState(state = Failure.RemoteRequestFailure, observers = observers, invokedByUser = false)
 
-    @Test
-    fun `given request failed ui state, when scan state fetched over empty scan state, then request failed ui shown`() =
-            test {
-                whenever(scanStore.getScanStateForSite(site)).thenReturn(null)
-                whenever(fetchScanStateUseCase.fetchScanState(site)).thenReturn(flowOf(Failure.RemoteRequestFailure))
-                val uiStates = init().uiStates
-
-                val state = uiStates.last() as ErrorUiState
-                with(state) {
-                    assertThat(image).isEqualTo(R.drawable.img_illustration_cloud_off_152dp)
-                    assertThat(title).isEqualTo(UiStringRes(R.string.scan_request_failed_title))
-                    assertThat(subtitle).isEqualTo(UiStringRes(R.string.scan_request_failed_subtitle))
-                    assertThat(buttonText).isEqualTo(UiStringRes(R.string.contact_support))
-                }
-            }
+        assertThat(observers.uiStates.last()).isInstanceOf(ErrorUiState.GenericRequestFailed::class.java)
+    }
 
     @Test
-    fun `given fetch scan state fails, when scan state fetched over last scan state, then request failed msg shown`() =
-            test {
-                whenever(fetchScanStateUseCase.fetchScanState(site)).thenReturn(flowOf(Failure.RemoteRequestFailure))
-                val observers = init()
+    fun `given request failed ui state, when scan state fetched on init, then request failed ui shown`() = test {
+        val observers = initObservers()
 
-                val snackBarMsg = observers.snackBarMsgs.last().peekContent()
-                assertThat(snackBarMsg).isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.request_failed_message)))
-            }
+        fetchScanStateStatusForState(state = Failure.RemoteRequestFailure, observers = observers, invokedByUser = false)
+
+        val state = observers.uiStates.last() as ErrorUiState
+        with(state) {
+            assertThat(image).isEqualTo(R.drawable.img_illustration_cloud_off_152dp)
+            assertThat(title).isEqualTo(UiStringRes(R.string.scan_request_failed_title))
+            assertThat(subtitle).isEqualTo(UiStringRes(R.string.scan_request_failed_subtitle))
+            assertThat(buttonText).isEqualTo(UiStringRes(R.string.contact_support))
+        }
+    }
+
+    @Test
+    fun `given fetch scan state fails, when scan state fetch invoked by user, then request failed msg shown`() = test {
+        val observers = initObservers()
+
+        fetchScanStateStatusForState(state = Failure.RemoteRequestFailure, observers = observers, invokedByUser = true)
+
+        val snackBarMsg = observers.snackBarMsgs.last().peekContent()
+        assertThat(snackBarMsg).isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.request_failed_message)))
+    }
 
     @Test
     fun `given fetch scan state succeeds with valid state, when scan state is fetched, then ui updated with content`() =
@@ -711,6 +709,26 @@ class ScanViewModelTest : BaseUnitTest() {
         triggerFixThreatsAction(observers)
     }
 
+    private suspend fun fetchScanStateStatusForState(
+        state: FetchScanState,
+        observers: Observers? = null,
+        invokedByUser: Boolean = false
+    ) {
+        whenever(fetchScanStateUseCase.fetchScanState(site))
+                .thenReturn(flowOf(if (!invokedByUser) state else Success(fakeScanStateModel)))
+
+        // Fetch scan state on init
+        viewModel.start(site)
+        if (invokedByUser) {
+            whenever(fetchScanStateUseCase.fetchScanState(site, startWithDelay = true)).thenReturn(flowOf(state))
+            whenever(startScanUseCase.startScan(any())).thenReturn(flowOf(StartScanState.Success))
+
+            // Fetch scan state on scan start (invoked by user)
+            (observers?.uiStates?.last() as? ContentUiState)?.items
+                    ?.filterIsInstance<ActionButtonState>()?.first()?.onClick?.invoke()
+        }
+    }
+
     private fun createDummyScanStateListItems(
         onStartScanButtonClicked: (() -> Unit),
         onFixAllButtonClicked: (() -> Unit),
@@ -754,6 +772,14 @@ class ScanViewModelTest : BaseUnitTest() {
     )
 
     private fun init(): Observers {
+        val observers = initObservers()
+
+        viewModel.start(site)
+
+        return observers
+    }
+
+    private fun initObservers(): Observers {
         val uiStates = mutableListOf<UiState>()
         viewModel.uiState.observeForever {
             uiStates.add(it)
@@ -766,9 +792,6 @@ class ScanViewModelTest : BaseUnitTest() {
         viewModel.navigationEvents.observeForever {
             navigation.add(it)
         }
-
-        viewModel.start(site)
-
         return Observers(uiStates, snackbarMsgs, navigation)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -692,6 +692,63 @@ class ScanViewModelTest : BaseUnitTest() {
                 assertThat(observers.snackBarMsgs.isEmpty()).isTrue
             }
 
+    @Test
+    fun `given no network, when fetch fix status invoked by user, then snackbar is shown`() = test {
+        val observers = initObservers()
+
+        fetchFixThreatsStatusForState(FetchFixThreatsState.Failure.NetworkUnavailable, invokedByUser = true)
+
+        assertThat(observers.snackBarMsgs.last().peekContent())
+                .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.error_generic_network)))
+    }
+
+    @Test
+    fun `given no network, when fetch fix status not invoked by user, then snackbar is not shown`() = test {
+        val observers = initObservers()
+
+        fetchFixThreatsStatusForState(FetchFixThreatsState.Failure.NetworkUnavailable, invokedByUser = false)
+
+        assertThat(observers.snackBarMsgs.isEmpty()).isTrue
+    }
+
+    @Test
+    fun `given request failed, when fetch fix status invoked by user, then snackbar is shown`() = test {
+        val observers = initObservers()
+
+        fetchFixThreatsStatusForState(FetchFixThreatsState.Failure.RemoteRequestFailure, invokedByUser = true)
+
+        assertThat(observers.snackBarMsgs.last().peekContent())
+                .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.threat_fix_all_status_error_message)))
+    }
+
+    @Test
+    fun `given request failed, when fetch fix status not invoked by user, then snackbar is not shown`() = test {
+        val observers = initObservers()
+
+        fetchFixThreatsStatusForState(FetchFixThreatsState.Failure.RemoteRequestFailure, invokedByUser = false)
+
+        assertThat(observers.snackBarMsgs.isEmpty()).isTrue
+    }
+
+    @Test
+    fun `given request succeeds, when fetch fix status invoked by user, then snackbar is shown`() = test {
+        val observers = initObservers()
+
+        fetchFixThreatsStatusForState(FetchFixThreatsState.Complete(fixedThreatsCount = 1), invokedByUser = true)
+
+        assertThat(observers.snackBarMsgs.last().peekContent())
+                .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.threat_fix_all_status_success_message_singular)))
+    }
+
+    @Test
+    fun `given request succeeds, when fetch fix status not invoked by user, then snackbar is not shown`() = test {
+        val observers = initObservers()
+
+        fetchFixThreatsStatusForState(FetchFixThreatsState.Complete(fixedThreatsCount = 1), invokedByUser = false)
+
+        assertThat(observers.snackBarMsgs.isEmpty()).isTrue
+    }
+
     private fun triggerFixThreatsAction(observers: Observers) {
         (observers.uiStates.last() as ContentUiState)
                 .items.filterIsInstance<ActionButtonState>().last().onClick.invoke()


### PR DESCRIPTION
### Description
On triggering scan start, the scan state status from the server is returned as `SCANNING` after a few secs delay. If the scan state status is fetched before this interval, an inappropriate status (e.g. `IDLE`) [stops the scanning progress display](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt#L63-L65) before the scanning completes.

To overcome this issue, this PR:
1. Reverts start delay time from 1 ms (reduced during retry logic implementation) to 5 ms in `FetchScanStateUseCase`. 
2. So that the scan action cannot be triggered immediately with fetch scan state request on VM init incorrectly updating the scanning progress display, 
    1. Displays a full-screen loading on VM init, and displays UI content (having scan button) only after the fetch scan state request completes. 
    2. Updates UI for threats fixing on VM init only when fix threats state status is `InProgress` or `Complete`, UI for which does not show scan button.

### To test

Test 1

- Login with a wpcom account with a site having scan capability and at least 1 threat e.g. [pressable-jetpack-daily-scan](http://pressable-jetpack-daily-scan.mystagingwebsite.com/).
- Switch to the site and click the Scan menu on the My site tab.
- Notice that a loading bar is displayed. 
- Wait for few secs till loading completes.
- Start scan.
- Wait till scanning completes, notice that scanning progress does not end prematurely.

Test 2
- Continue from above and return to the My site tab.
- Enable Airplane mode.
- Click the Scan menu on the My site tab.
- Notice that the network unavailable message is displayed full screen instead of as a snack bar over an empty screen.

Test 3
- Continue from above and return to the My site tab.
- Disable Airplane mode.
- Click the Scan menu on the My site tab.
- Click Fix all.
- Return to My site tab.
- Click Scan again (while threats are fixing).
- Notice that fixing threats UI is displayed.

## Regression Notes
1. Potential unintended areas of impact

    Error messages (for fetch scan state request on VM init) which were shown as snackbars on VM init should now be shown in a full-screen error UI.

    Error messages (for fix threats state request) are shown only when the request is invoked by the user.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Updated existing tests touching the flow and added additional unit tests in `ScanViewModelTest`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
