### PR TITLE
[Gutenberg] Add /oembed/1.0 endpoint support for wpcom API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
     ext.wordPressLoginVersion = '0.0.2'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3704-d88b8014a67a4bf8ffe1dc7e5940b6fd542f8fb3'
+    ext.gutenbergMobileVersion = 'v1.57.0-alpha3'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '3594abbef5d15a1e660496eee4d90b64268035da'
+    fluxCVersion = '1.21.0-beta-5'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
     ext.wordPressLoginVersion = '0.0.2'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.57.0-alpha2'
+    ext.gutenbergMobileVersion = '3704-d88b8014a67a4bf8ffe1dc7e5940b6fd542f8fb3'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.21.0-beta-4'
+    fluxCVersion = '3594abbef5d15a1e660496eee4d90b64268035da'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/33260
Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3704
WordPress-FluxC-Android PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2048

To test: See Gutenberg PR

## Regression Notes
1. Potential unintended areas of impact
Gutenberg network calls and errors.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tried adding a "Latest Posts" block, which fetches the categories via network calls and verified if they're correct.

3. What automated tests I added (or what prevented me from doing so)
We don't have any automated testing infrastructure around Gutenberg network calls yet.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
