### PR TITLE
Zendesk: Add tag for self-hosted current site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -463,8 +463,8 @@ private fun buildZendeskTags(
 
     // Add selectedSiteSelfHostedTag if selected site is self-hosted irrespective of the connection type
     selectedSite?.let {
-        val isSelectedSiteSelfHosted = !SiteUtils.isAccessedViaWPComRest(it)
-                || (it.isJetpackConnected && !it.isWPComAtomic)
+        val isSelectedSiteSelfHosted = !SiteUtils.isAccessedViaWPComRest(it) ||
+                (it.isJetpackConnected && !it.isWPComAtomic)
         if (isSelectedSiteSelfHosted) tags.add(ZendeskConstants.selectedSiteSelfHostedTag)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -461,7 +461,12 @@ private fun buildZendeskTags(
 
     selectedSite?.zendeskAddOns?.takeIf { it.isNotEmpty() }?.let { tags.addAll(it.split(",")) }
 
-    if (selectedSite?.isUsingWpComRestApi == false) { tags.add(ZendeskConstants.mobileSelfHostedTag) }
+    // Add selectedSiteSelfHostedTag if selected site is self-hosted irrespective of the connection type
+    selectedSite?.let {
+        val isSelectedSiteSelfHosted = !SiteUtils.isAccessedViaWPComRest(it)
+                || (it.isJetpackConnected && !it.isWPComAtomic)
+        if (isSelectedSiteSelfHosted) tags.add(ZendeskConstants.selectedSiteSelfHostedTag)
+    }
 
     return tags
 }
@@ -495,7 +500,7 @@ private val wpcomPushNotificationDeviceToken: String?
 private object ZendeskConstants {
     const val blogSeparator = "\n----------\n"
     const val jetpackTag = "jetpack"
-    const val mobileSelfHostedTag = "mobile_self_hosted"
+    const val selectedSiteSelfHostedTag = "selected_site_self_hosted"
     const val networkWifi = "WiFi"
     const val networkWWAN = "Mobile"
     const val networkTypeLabel = "Network Type:"

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -461,6 +461,8 @@ private fun buildZendeskTags(
 
     selectedSite?.zendeskAddOns?.takeIf { it.isNotEmpty() }?.let { tags.addAll(it.split(",")) }
 
+    if (selectedSite?.isUsingWpComRestApi == false) { tags.add(ZendeskConstants.mobileSelfHostedTag) }
+
     return tags
 }
 
@@ -493,6 +495,7 @@ private val wpcomPushNotificationDeviceToken: String?
 private object ZendeskConstants {
     const val blogSeparator = "\n----------\n"
     const val jetpackTag = "jetpack"
+    const val mobileSelfHostedTag = "mobile_self_hosted"
     const val networkWifi = "WiFi"
     const val networkWWAN = "Mobile"
     const val networkTypeLabel = "Network Type:"


### PR DESCRIPTION
This PR adds a tag for Zendesk if the selected site is self-hosted as requested in p4a5px-2CT-p2#comment-11989 and clarified in p4a5px-2CT-p2#comment-12179.

There’s a set of subcases for self-hosted sites (see table below), and the tag is added for such sites irrespective of the connection type. 

Condition used in the app to identify self-hosted site - 6bef991
`val isSelectedSiteSelfHosted = !SiteUtils.isAccessedViaWPComRest(it) || (it.isJetpackConnected && !it.isWPComAtomic)`

 No.  | Self-hosted subcase| Condition making it self-hosted
--|---------|--------
1 | Self-hosted without Jetpack, which means accessed via XMLRPC at the moment. | `site.origin == ORIGIN_XMLRPC`
2 | Self-hosted with Jetpack installed. XMLRPC connection in this case too.| `site.origin == ORIGIN_XMLRPC`
3 | Self-hosted with Jetpack installed and connected to WPCOM. Still XMLRPC here.| `site.origin == ORIGIN_XMLRPC`
4 | Self-hosted connected via a WPCOM account (Jetpack is installed and connected on the site). App accesses the selfhosted site via WPCOM’s REST API.| `site.origin == ORIGIN_WPCOM_REST`, `site.isJetpackConnected && !site.isWPComAtomic`


Tested via Zendesk ticket: 4126885-zd-woothemes

<img width="241" alt="Screenshot 2021-07-09 at 10 28 24 AM" src="https://user-images.githubusercontent.com/1405144/125025713-cafe8880-e0a0-11eb-85b7-3c576be1737a.png">

<img width="242" alt="Screenshot 2021-07-09 at 10 28 07 AM" src="https://user-images.githubusercontent.com/1405144/125025720-cd60e280-e0a0-11eb-97b9-be9f82c3d29f.png">

### To test:

I used below manual testing steps to verify that the tag is set correctly:

Prerequisites: 

- Create a new Jurassic-Ninja site (do not install Jetpack yet)
- Add breakpoint on this line (test wth debugging enabled): 
https://github.com/wordpress-mobile/WordPress-Android/blob/6bef9915be713f4d0472fe6f46f9277c2e122493/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt#L468

Subcase 1 
1. Login in the app using the newly created Jurassic-Ninja site address.
2. Go to My Site -> Me profile -> Help and Support -> Contact Support.
3. Notice that `isSelectedSiteSelfHosted` is set to true.

Subcase 2 & 3
1. Install Jetpack on the site using wp-admin > Setup Jetpack (do not connect to account yet). - For Subcase2
<img width="1022" alt="Screenshot 2021-07-09 at 11 27 26 AM" src="https://user-images.githubusercontent.com/1405144/125030398-b4f4c600-e0a8-11eb-83b7-20fc0c509b90.png">

2. Check that the site is connected to wpcom using wp-admin > Jetpack and scroll down to Connections. See that it is not connected to wp account yet. - For Subcase3
![118121376-10cd0680-b3fa-11eb-952b-1102a7607f4c](https://user-images.githubusercontent.com/1405144/125028331-74e01400-e0a5-11eb-8ccf-00cd5c564c4d.png)
3. Refresh the site in the app using the site picker.
4. Go to My Site -> Me profile -> Help and Support -> Contact Support.
5. Notice that `isSelectedSiteSelfHosted` is set to true.

Subcase 4
1. Connect to WordPress account using wp-admin > Jetpack and scroll down to Connections -> Connect to WordPress.com account
2. Login to the app using the  WordPress.com account
3. Go to My Site -> Choose the site from the site picker -> Me profile -> Help and Support -> Contact Support.
3. Notice that `isSelectedSiteSelfHosted` is set to true.

## Regression Notes
1. Potential unintended areas of impact 
N/A - added a new tag to the existing list of tags passed to Zendesk, has minimal impact.


2. What I did to test those areas of impact (or what existing automated tests I relied on) 
Tested manually.


3. What automated tests I added (or what prevented me from doing so) 
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.