### PR TITLE
Onboarding Improvements: Fix Feature Flag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/OnboardingImprovementsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/OnboardingImprovementsFeatureConfig.kt
@@ -10,4 +10,4 @@ import javax.inject.Inject
 @FeatureInDevelopment
 class OnboardingImprovementsFeatureConfig @Inject constructor(
     appConfig: AppConfig
-) : FeatureConfig(appConfig, BuildConfig.GLOBAL_STYLE_SUPPORT)
+) : FeatureConfig(appConfig, BuildConfig.ONBOARDING_IMPROVEMENTS)


### PR DESCRIPTION
Parent #14989
Relates to: #14997

This is a fix that relates to the #14997 PR where the `BuildConfig` was pointing to the wrong configuration.

To test:
- Follow the `To test` steps on the related #14997 PR.

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

N/A

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
