### PR TITLE
Fix Blogging Reminders post-publishing prompt behavior

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -178,6 +178,12 @@ class BloggingRemindersViewModel @Inject constructor(
         }
     }
 
+    fun onPublishingPost(siteId: Int, isFirstTimePublishing: Boolean?) {
+        if (isFirstTimePublishing == true && bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)) {
+            showBottomSheet(siteId, PROLOGUE, PUBLISH_FLOW)
+        }
+    }
+
     fun onSettingsItemClicked(siteId: Int) {
         launch {
                 val screen = if (bloggingRemindersStore.hasModifiedBloggingReminders(siteId)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -172,12 +172,6 @@ class BloggingRemindersViewModel @Inject constructor(
         _isFirstTimeFlow.value = state.getBoolean(IS_FIRST_TIME_FLOW)
     }
 
-    fun onPostCreated(siteId: Int, isNewPost: Boolean?) {
-        if (isNewPost == true && bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)) {
-            showBottomSheet(siteId, PROLOGUE, PUBLISH_FLOW)
-        }
-    }
-
     fun onPublishingPost(siteId: Int, isFirstTimePublishing: Boolean?) {
         if (isFirstTimePublishing == true && bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)) {
             showBottomSheet(siteId, PROLOGUE, PUBLISH_FLOW)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1097,7 +1097,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 SiteModel selectedSite = mSelectedSiteRepository.getSelectedSite();
                 if (selectedSite != null) {
                     boolean isNewStory = data == null || data.getStringExtra(ARG_STORY_BLOCK_ID) == null;
-                    mBloggingRemindersViewModel.onPostCreated(
+                    mBloggingRemindersViewModel.onPublishingPost(
                             selectedSite.getId(),
                             isNewStory
                     );

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1086,10 +1086,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
                                 public void onClick(View v) {
                                     UploadUtils.publishPost(WPMainActivity.this, post, site, mDispatcher);
                                 }
-                            });
-                    mBloggingRemindersViewModel.onPostCreated(
-                            site.getId(),
-                            data.getBooleanExtra(EditPostActivity.EXTRA_IS_NEW_POST, false)
+                            },
+                            isFirstTimePublishing -> mBloggingRemindersViewModel
+                                    .onPublishingPost(site.getId(), isFirstTimePublishing)
                     );
                 }
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1527,7 +1527,10 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         event.isFirstTimePublish,
                         event.post,
                         null,
-                        targetSite);
+                        targetSite,
+                        isFirstTimePublishing -> mBloggingRemindersViewModel
+                                .onPublishingPost(targetSite.getId(), isFirstTimePublishing)
+                );
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -451,14 +451,15 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
                         data,
                         post,
                         site,
-                        uploadActionUseCase.getUploadAction(post)
-                ) {
-                    uploadUtilsWrapper.publishPost(
-                            activity,
-                            post,
-                            site
-                    )
-                }
+                        uploadActionUseCase.getUploadAction(post),
+                        {
+                            uploadUtilsWrapper.publishPost(
+                                    activity,
+                                    post,
+                                    site
+                            )
+                        }
+                )
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
@@ -76,7 +76,8 @@ fun handleUploadAction(
                     activity,
                     action.post,
                     action.site,
-                    action.dispatcher
+                    action.dispatcher,
+                    onPublishingCallback
             )
         }
         is PostUploadAction.PostUploadedSnackbar -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
@@ -88,7 +88,8 @@ fun handleUploadAction(
                     action.isFirstTimePublish,
                     action.post,
                     action.errorMessage,
-                    action.site
+                    action.site,
+                    onPublishingCallback
             )
         }
         is PostUploadAction.MediaUploadedSnackbar -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadAction.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadUtils
+import org.wordpress.android.ui.uploads.UploadUtils.OnPublishingCallback
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 
 sealed class PostUploadAction {
@@ -48,12 +49,14 @@ sealed class PostUploadAction {
     class CancelPostAndMediaUpload(val post: PostModel) : PostUploadAction()
 }
 
+@Suppress("LongParameterList")
 fun handleUploadAction(
     action: PostUploadAction,
     activity: Activity,
     snackbarAttachView: View,
     uploadActionUseCase: UploadActionUseCase,
-    uploadUtilsWrapper: UploadUtilsWrapper
+    uploadUtilsWrapper: UploadUtilsWrapper,
+    onPublishingCallback: OnPublishingCallback
 ) {
     when (action) {
         is PostUploadAction.EditPostResult -> {
@@ -64,7 +67,8 @@ fun handleUploadAction(
                     action.post,
                     action.site,
                     uploadActionUseCase.getUploadAction(action.post),
-                    View.OnClickListener { action.publishAction() }
+                    { action.publishAction() },
+                    onPublishingCallback
             )
         }
         is PostUploadAction.PublishPost -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -363,7 +363,9 @@ class PostsListActivity : LocaleAwareActivity(),
                         findViewById(R.id.coordinator),
                         uploadActionUseCase,
                         uploadUtilsWrapper
-                )
+                ) { isFirstTimePublishing ->
+                    bloggingRemindersViewModel.onPublishingPost(site.id, isFirstTimePublishing)
+                }
             }
         })
     }
@@ -466,10 +468,6 @@ class PostsListActivity : LocaleAwareActivity(),
                 }
 
                 viewModel.handleEditPostResult(data)
-                bloggingRemindersViewModel.onPostCreated(
-                        site.id,
-                        data?.getBooleanExtra(EditPostActivity.EXTRA_IS_NEW_POST, false)
-                )
             }
             requestCode == RequestCodes.REMOTE_PREVIEW_POST -> {
                 viewModel.handleRemotePreviewClosing()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -486,7 +486,7 @@ class PostsListActivity : LocaleAwareActivity(),
             }
             requestCode == RequestCodes.CREATE_STORY -> {
                 val isNewStory = data?.getStringExtra(GutenbergEditorFragment.ARG_STORY_BLOCK_ID) == null
-                bloggingRemindersViewModel.onPostCreated(
+                bloggingRemindersViewModel.onPublishingPost(
                         site.id,
                         isNewStory
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -679,4 +679,8 @@ public class UploadUtils {
         }
         return messageRes;
     }
+
+    public interface OnPublishingCallback {
+        void onPublishing(boolean isFirstTimePublish);
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import com.google.android.material.snackbar.Snackbar;
@@ -196,7 +197,8 @@ public class UploadUtils {
                                                           @NonNull final SiteModel site,
                                                           @NonNull final UploadAction uploadAction,
                                                           SnackbarSequencer sequencer,
-                                                          View.OnClickListener publishPostListener) {
+                                                          View.OnClickListener publishPostListener,
+                                                          @Nullable OnPublishingCallback onPublishingCallback) {
         boolean hasChanges = data.getBooleanExtra(EditPostActivity.EXTRA_HAS_CHANGES, false);
         if (!hasChanges) {
             // if there are no changes, we don't need to do anything
@@ -255,6 +257,9 @@ public class UploadUtils {
             } else {
                 showSnackbar(snackbarAttachView,
                         post.isPage() ? R.string.editor_uploading_page : R.string.editor_uploading_post, sequencer);
+                if (onPublishingCallback != null) {
+                    onPublishingCallback.onPublishing(PostUtils.isFirstTimePublish(post));
+                }
             }
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -435,6 +435,11 @@ public class UploadUtils {
     }
 
     public static void publishPost(Activity activity, final PostModel post, SiteModel site, Dispatcher dispatcher) {
+        publishPost(activity, post, site, dispatcher, null);
+    }
+
+    public static void publishPost(Activity activity, final PostModel post, SiteModel site, Dispatcher dispatcher,
+                                   @Nullable OnPublishingCallback onPublishingCallback) {
         // If the post is empty, don't publish
         if (!PostUtils.isPublishable(post)) {
             String message = activity.getString(
@@ -452,6 +457,9 @@ public class UploadUtils {
 
         if (NetworkUtils.isNetworkAvailable(activity)) {
             UploadService.uploadPost(activity, post.getId(), isFirstTimePublish);
+            if (onPublishingCallback != null) {
+                onPublishingCallback.onPublishing(isFirstTimePublish);
+            }
         }
         PostUtils.trackSavePostAnalytics(post, site);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -478,7 +478,8 @@ public class UploadUtils {
                                                      final PostModel post,
                                                      final String errorMessage,
                                                      final SiteModel site, final Dispatcher dispatcher,
-                                                     SnackbarSequencer sequencer) {
+                                                     SnackbarSequencer sequencer,
+                                                     @Nullable OnPublishingCallback onPublishingCallback) {
         boolean userCanPublish = userCanPublish(site);
         if (isError) {
             if (errorMessage != null) {
@@ -519,7 +520,7 @@ public class UploadUtils {
                             publishPostListener = new View.OnClickListener() {
                                 @Override
                                 public void onClick(View v) {
-                                    UploadUtils.publishPost(activity, post, site, dispatcher);
+                                    UploadUtils.publishPost(activity, post, site, dispatcher, onPublishingCallback);
                                 }
                             };
                             snackbarButtonRes = R.string.button_publish;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
@@ -133,6 +133,10 @@ class UploadUtilsWrapper @Inject constructor(
             isEligibleForAutoUpload
     )
 
-    fun publishPost(activity: Activity, post: PostModel, site: SiteModel) =
-            UploadUtils.publishPost(activity, post, site, dispatcher)
+    fun publishPost(
+        activity: Activity,
+        post: PostModel,
+        site: SiteModel,
+        onPublishingCallback: OnPublishingCallback? = null
+    ) = UploadUtils.publishPost(activity, post, site, dispatcher, onPublishingCallback)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PostStore.PostError
 import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction
+import org.wordpress.android.ui.uploads.UploadUtils.OnPublishingCallback
 import org.wordpress.android.util.SnackbarSequencer
 import javax.inject.Inject
 
@@ -67,6 +68,8 @@ class UploadUtilsWrapper @Inject constructor(
             sequencer
     )
 
+    @JvmOverloads
+    @Suppress("LongParameterList")
     fun handleEditPostResultSnackbars(
         activity: Activity,
         snackbarAttachView: View,
@@ -74,7 +77,8 @@ class UploadUtilsWrapper @Inject constructor(
         post: PostModel,
         site: SiteModel,
         uploadAction: UploadAction,
-        publishPostListener: OnClickListener?
+        publishPostListener: OnClickListener?,
+        onPublishingCallback: OnPublishingCallback? = null
     ) = UploadUtils.handleEditPostModelResultSnackbars(
             activity,
             dispatcher,
@@ -84,7 +88,8 @@ class UploadUtilsWrapper @Inject constructor(
             site,
             uploadAction,
             sequencer,
-            publishPostListener
+            publishPostListener,
+            onPublishingCallback
     )
 
     fun showSnackbarError(

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
@@ -48,6 +48,8 @@ class UploadUtilsWrapper @Inject constructor(
             sequencer
     )
 
+    @JvmOverloads
+    @Suppress("LongParameterList")
     fun onPostUploadedSnackbarHandler(
         activity: Activity?,
         snackbarAttachView: View?,
@@ -55,7 +57,8 @@ class UploadUtilsWrapper @Inject constructor(
         isFirstTimePublish: Boolean,
         post: PostModel?,
         errorMessage: String?,
-        site: SiteModel?
+        site: SiteModel?,
+        onPublishingCallback: OnPublishingCallback? = null
     ) = UploadUtils.onPostUploadedSnackbarHandler(
             activity,
             snackbarAttachView,
@@ -65,7 +68,8 @@ class UploadUtilsWrapper @Inject constructor(
             errorMessage,
             site,
             dispatcher,
-            sequencer
+            sequencer,
+            onPublishingCallback
     )
 
     @JvmOverloads

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
@@ -326,32 +326,32 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `onPostCreated shows prologue when post is new and prompt was not shown before`() {
+    fun `onPublishingPost shows prologue when publishing for the first time and prompt was not shown before`() {
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
 
         initPrologueBuilder()
 
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
 
         assertPrologue()
     }
 
     @Test
-    fun `onPostCreated does not show prologue when post is old and prompt was not shown before`() {
+    fun `onPublishingPost does not show prologue when post was already published and prompt was not shown before`() {
         initPrologueBuilder()
 
-        viewModel.onPostCreated(siteId, false)
+        viewModel.onPublishingPost(siteId, false)
 
         assertThat(uiState.last().uiItems).isEqualTo(emptyList<BloggingRemindersItem>())
     }
 
     @Test
-    fun `onPostCreated does not show prologue when post is new and prompt was shown before`() {
+    fun `onPublishingPost does not show prologue when publishing for the first time and prompt was shown before`() {
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(false)
 
         initPrologueBuilder()
 
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
 
         assertThat(uiState.last().uiItems).isEqualTo(emptyList<BloggingRemindersItem>())
     }


### PR DESCRIPTION
Fixes #14987

This PR replaces the `onPostCreated` method in the BloggingReminders ViewModel with a new `onPublishingPost` which is called only when a post is being published (as opposed to after it was created). This method receives a `isFirstTimePublishing` parameter which we check inside the view model (just like we did with the `isNewPost` parameter) to make sure we only show the prompt for posts being published for the first time.

While this PR touches quite a few classes, I tried to keep the changes as minimal as possible, which hopefully should make them easy to follow. Let me know if you have any questions, though.

For Story posts the change was pretty straightforward, we just needed to replace the old method with the new one, and since we don't have Story drafts and we are listening to the `CREATE_STORY` event, we can safely assume all new stories are being published for the first time.

For regular posts, we need to call `onPublishingPost` from a few different places. The simplest way I've found to do this was by introducing a new callback class – `OnPublishingCallback` – to a few methods inside `UploadUtils`, which help us cover the most common scenarios in both the main screen and posts list screen:
- `UploadUtils.handleEditPostModelResultSnackbars`: Adding the callback to this method allows us to show the prompt after the user hits the Publish button from the Editor. We take advantage of the existing logic there to make sure the prompt is only shown when the "uploading draft" Snackbar would also be shown.
- `UploadUtils.publishPost`: Adding the callback to this method allows us to show the prompt after the user hits the Publish button from a draft post item in the Posts List screen:

<img width=300 src="https://user-images.githubusercontent.com/830056/124969275-e2843580-dffc-11eb-92e3-357025663a51.png"/>


We also take advantage of the existing logic there to make sure the prompt is only shown after the post is actually being published. 
- `UploadUtils.onPostUploadedSnackbarHandler`: Finally, adding the callback to this method allows us to show the prompt after the user hits the Publish button from a Snackbar (for example, after a draft post is correctly uploaded):

<img width=300 src="https://user-images.githubusercontent.com/830056/124969332-efa12480-dffc-11eb-9ac7-864a3315b991.png"/>


`UploadUtils.publishPost` is called internally from this method, so we also take advantage of the existing logic there.

### To test

There are quite a few test scenarios to test, but they should all be pretty simple to follow. To make it easier, I recommend temporarily changing the `BloggingRemindersManager.shouldShowBloggingRemindersPrompt` so that it doesn't check for the `isBloggingRemindersShown` flag. Otherwise, make sure to clear the app data after each of the tests below.

#### Publish story

1. On the Main screen, tap the FAB.
1. Tap the *Story post* option.
1. Create a new story and publish it.
1. Notice the Blogging Reminders prompt is shown.

Repeat for the Posts List screen and make sure the prompt is shown there as well.

#### Publish post

1. On the Main screen, tap the FAB.
1. Tap the *Blog post* option.
1. Create a new post and publish it.
1. Notice the Blogging Reminders prompt is shown.

Repeat for the Posts List screen and make sure the prompt is shown there as well.

#### Publish post from Snackbar

1. On the Main screen, tap the FAB.
1. Tap the *Blog post* option.
1. Create a new post and make sure it isn't empty. **Don't publish it.**
1. Press back.
1. Notice the Blogging Reminders prompt **is not shown**.
1. Notice the "Your draft is uploading" Snackbar is shown.
1. Notice the "Draft saved online" Snackbar is shown afterward.
1. Tap the *Publish* button on the Snackbar.
1. Notice the Blogging Reminders prompt is shown.

Repeat for the Posts List screen and make sure the same behavior happens there as well.

#### Publish post from the Posts List screen's list item

1. On the Posts List screen, tap the *Drafts* tab. 
1. On a draft post item, tap *Publish*.
1. Notice the Blogging Reminders prompt is shown.

## Regression Notes
1. Potential unintended areas of impact
Post publishing Snackbars.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Extensive manual testing.

3. What automated tests I added (or what prevented me from doing so)
I have updated the existing tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
