### PR TITLE
Merge release/17.8 into develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+17.9
+-----
+
+
 17.8
 -----
 * [*] Fixed a bug where the web version of the editor did not load when using an account created before December 2018. [#14762]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,6 @@
 -----
 * [*] Fixed a bug where the web version of the editor did not load when using an account created before December 2018. [#14762]
 * [*] Block editor: Update loading and failed screens for web version of the editor [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3573]
-* [*] Block editor: Handle floating keyboard case - Fix issue with the block selector on iPad. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3687]
 * [**] Block editor: Added color/background customization for text blocks. [https://github.com/WordPress/gutenberg/pull/33250]
 
 17.7

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,1 +1,5 @@
-Block editor: New block layout grid, Badge style tweaks, Fixed new block not created when pressing enter inside text-based block, Tablet view fixes for inserter button
+* [*] Fixed a bug where the web version of the editor did not load when using an account created before December 2018. [#14762]
+* [*] Block editor: Update loading and failed screens for web version of the editor [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3573]
+* [*] Block editor: Handle floating keyboard case - Fix issue with the block selector on iPad. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3687]
+* [**] Block editor: Added color/background customization for text blocks. [https://github.com/WordPress/gutenberg/pull/33250]
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,4 +1,5 @@
-- New! Get blogging reminder prompts on days of your choice
-- Block editor: New block layout grid, Badge style tweaks, Fixed new block not created when pressing enter inside text-based block, Tablet view fixes for inserter button
-- Fixed Reader duplicate post issue
-- Added ability to subscribe to conversations by email from Reader
+* [*] Fixed a bug where the web version of the editor did not load when using an account created before December 2018. [#14762]
+* [*] Block editor: Update loading and failed screens for web version of the editor [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3573]
+* [*] Block editor: Handle floating keyboard case - Fix issue with the block selector on iPad. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3687]
+* [**] Block editor: Added color/background customization for text blocks. [https://github.com/WordPress/gutenberg/pull/33250]
+

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3248,7 +3248,8 @@
     <string name="gutenberg_native_add_image" tools:ignore="UnusedResources">ADD IMAGE</string>
     <string name="gutenberg_native_add_image_or_video" tools:ignore="UnusedResources">ADD IMAGE OR VIDEO</string>
     <string name="gutenberg_native_add_image_or_video_b7b3d22b" tools:ignore="UnusedResources">Add image or video</string>
-    <string name="gutenberg_native_add_link" tools:ignore="UnusedResources">ADD LINK</string>
+    <string name="gutenberg_native_add_link" tools:ignore="UnusedResources">Add link</string>
+    <string name="gutenberg_native_add_link_0fcaed3b" tools:ignore="UnusedResources">ADD LINK</string>
     <string name="gutenberg_native_add_link_text" tools:ignore="UnusedResources">Add link text</string>
     <!-- translators: %s: social link name e.g: "Instagram". -->
     <string name="gutenberg_native_add_link_to_s" tools:ignore="UnusedResources">Add link to %s</string>
@@ -3352,11 +3353,19 @@
     <string name="gutenberg_native_edit_cover_media" tools:ignore="UnusedResources">Edit cover media</string>
     <string name="gutenberg_native_edit_file" tools:ignore="UnusedResources">Edit file</string>
     <string name="gutenberg_native_edit_focal_point" tools:ignore="UnusedResources">Edit focal point</string>
+    <string name="gutenberg_native_edit_link" tools:ignore="UnusedResources">EDIT LINK</string>
     <string name="gutenberg_native_edit_media" tools:ignore="UnusedResources">Edit media</string>
     <string name="gutenberg_native_edit_using_web_editor" tools:ignore="UnusedResources">Edit using web editor</string>
     <string name="gutenberg_native_edit_video" tools:ignore="UnusedResources">Edit video</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_and" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for Android</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_ios" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for iOS</string>
+    <!-- translators: accessibility text. Empty Embed caption. -->
+    <string name="gutenberg_native_embed_caption_empty" tools:ignore="UnusedResources">Embed caption. Empty</string>
+    <!-- translators: accessibility text. %s: Embed caption. -->
+    <string name="gutenberg_native_embed_caption_s" tools:ignore="UnusedResources">Embed caption. %s</string>
+    <string name="gutenberg_native_embed_link" tools:ignore="UnusedResources">Embed link</string>
+    <!-- translators: %s: host providing embed content e.g: www.youtube.com -->
+    <string name="gutenberg_native_embedded_content_from_s_can_t_be_viewed_in_the_mobile_editor_at_t" tools:ignore="UnusedResources">Embedded content from %s can\'t be viewed in the mobile editor at the moment. Please preview the page to see the embedded content.</string>
     <string name="gutenberg_native_error" tools:ignore="UnusedResources">Error</string>
     <string name="gutenberg_native_excerpt_length_words" tools:ignore="UnusedResources">Excerpt length (words)</string>
     <string name="gutenberg_native_failed_to_insert_audio_file" tools:ignore="UnusedResources">Failed to insert audio file.</string>
@@ -3383,6 +3392,7 @@
     <string name="gutenberg_native_insert_mention" tools:ignore="UnusedResources">Insert mention</string>
     <string name="gutenberg_native_inside" tools:ignore="UnusedResources">Inside</string>
     <string name="gutenberg_native_invalid_url_audio_file_not_found" tools:ignore="UnusedResources">Invalid URL. Audio file not found.</string>
+    <string name="gutenberg_native_invalid_url_please_enter_a_valid_url" tools:ignore="UnusedResources">Invalid URL. Please enter a valid URL.</string>
     <string name="gutenberg_native_link_inserted" tools:ignore="UnusedResources">Link inserted</string>
     <string name="gutenberg_native_link_settings" tools:ignore="UnusedResources">Link Settings</string>
     <string name="gutenberg_native_link_text" tools:ignore="UnusedResources">Link text</string>
@@ -3466,9 +3476,7 @@
     <string name="gutenberg_native_s_social_icon" tools:ignore="UnusedResources">%s social icon</string>
     <string name="gutenberg_native_scrollable_block_menu_closed" tools:ignore="UnusedResources">Scrollable block menu closed.</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block" tools:ignore="UnusedResources">Scrollable block menu opened. Select a block.</string>
-    <string name="gutenberg_native_search_block" tools:ignore="UnusedResources">Search block</string>
     <string name="gutenberg_native_search_block_label_current_text_is" tools:ignore="UnusedResources">Search block label. Current text is</string>
-    <string name="gutenberg_native_search_blocks" tools:ignore="UnusedResources">Search blocks</string>
     <string name="gutenberg_native_search_button_current_button_text_is" tools:ignore="UnusedResources">Search button. Current button text is</string>
     <string name="gutenberg_native_search_input_field" tools:ignore="UnusedResources">Search input field.</string>
     <string name="gutenberg_native_search_or_type_url" tools:ignore="UnusedResources">Search or type URL</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
@@ -84,7 +84,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Test
     fun `sets blogging reminders as shown on PROLOGUE`() {
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
 
         verify(bloggingRemindersManager).bloggingRemindersShown(siteId)
     }
@@ -102,7 +102,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     fun `shows bottom sheet on showBottomSheet`() {
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
 
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
 
         assertThat(events).containsExactly(true)
     }
@@ -112,7 +112,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         val uiItems = initPrologueBuilder()
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
 
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
 
         assertThat(uiState.last().uiItems).isEqualTo(uiItems)
     }
@@ -170,7 +170,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     fun `switches from prologue do day selection on primary button click`() {
         initPrologueBuilder()
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
 
         clickPrimaryButton()
 
@@ -221,7 +221,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     fun `showBottomSheet sets tracker site id`() {
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
 
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
 
         verify(analyticsTracker).setSite(siteId)
     }
@@ -231,7 +231,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
         viewModel.onSettingsItemClicked(siteId)
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
 
         verify(analyticsTracker).trackFlowStart(BLOG_SETTINGS)
         verify(analyticsTracker).trackFlowStart(PUBLISH_FLOW)
@@ -241,7 +241,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     fun `showBottomSheet tracks screen shown with correct screen`() = test {
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
         viewModel.onSettingsItemClicked(siteId)
 
         verify(analyticsTracker).trackScreenShown(PROLOGUE)
@@ -251,8 +251,8 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Test
     fun `showBottomSheet tracks screen shown more than once`() {
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
-        viewModel.onPostCreated(siteId, true)
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
 
         verify(analyticsTracker, times(2)).trackScreenShown(PROLOGUE)
     }
@@ -261,7 +261,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     fun `clicking primary button on prologue screen tracks correct events`() {
         initPrologueBuilder()
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
 
         clickPrimaryButton()
 
@@ -295,7 +295,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Test
     fun `dismissing bottom sheet on prologue screen tracks dismiss event`() {
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
-        viewModel.onPostCreated(siteId, true)
+        viewModel.onPublishingPost(siteId, true)
         viewModel.onBottomSheetDismissed()
 
         verify(analyticsTracker).trackFlowDismissed(PROLOGUE)

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.21.0-beta-6'
+    fluxCVersion = '1.21.0'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -133,9 +133,9 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Creates a new release branch from the current develop"
   lane :code_freeze do | options |
-    old_version = android_codefreeze_prechecks(options)
+    old_version = '17.7' # android_codefreeze_prechecks(options)
 
-    android_bump_version_release(app: 'wordpress')
+    # android_bump_version_release(app: 'wordpress')
     new_version = android_get_app_version(app: 'wordpress')
 
     # FIXME: Calling android_bump_version_release(app: 'jetpack') won't work here because that action check we're on develop and also creates the branch,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -133,9 +133,9 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Creates a new release branch from the current develop"
   lane :code_freeze do | options |
-    old_version = '17.7' # android_codefreeze_prechecks(options)
+    old_version = android_codefreeze_prechecks(options)
 
-    # android_bump_version_release(app: 'wordpress')
+    android_bump_version_release(app: 'wordpress')
     new_version = android_get_app_version(app: 'wordpress')
 
     # FIXME: Calling android_bump_version_release(app: 'jetpack') won't work here because that action check we're on develop and also creates the branch,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,15 +135,18 @@ REPOSITORY_NAME="WordPress-Android"
   lane :code_freeze do | options |
     old_version = android_codefreeze_prechecks(options)
 
-    app = options[:app]
     android_bump_version_release(app: 'wordpress')
     new_version = android_get_app_version(app: 'wordpress')
 
     # FIXME: Calling android_bump_version_release(app: 'jetpack') won't work here because that action check we're on develop and also creates the branch,
     #   which won't work since we already ran this action for wordpress and are already in release branch. Patch it manually for now, by applying the same versionName and versionCOde as the ones from WordPress
-    new_version_code = android_get_release_version(app: 'wordpress')['code']
-    sh('./gradlew', 'updateVersionProperties', "-Pkey=jetpack.versionName", "-Pvalue=#{new_version}")
-    sh('./gradlew', 'updateVersionProperties', "-Pkey=jetpack.versionCode", "-Pvalue=#{new_version_code}")
+    new_version_tuple = android_get_release_version(app: 'wordpress')
+    Dir.chdir('..') do
+      sh('./gradlew', 'updateVersionProperties', "-Pkey=jetpack.versionName", "-Pvalue=#{new_version_tuple['name']}")
+      sh('./gradlew', 'updateVersionProperties', "-Pkey=jetpack.versionCode", "-Pvalue=#{new_version_tuple['code']}")
+      sh('git', 'add', 'version.properties')
+      sh('git', 'commit', '-m', 'Bump Jetpack version number')
+    end
 
     # need to get prs list before version update to frozen tag
     get_prs_list(repository: GHHELPER_REPO, milestone: new_version, report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{new_version}.txt")
@@ -153,7 +156,13 @@ REPOSITORY_NAME="WordPress-Android"
       release_notes_file_path: "#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt",
       extracted_notes_file_path: release_notes_path('wordpress')
     )
-    FileUtils.cp(release_notes_path('wordpress'), release_notes_path('jetpack')) # Jetpack Release notes are based on WP Release notes
+    # Jetpack Release notes are based on WP Release notes
+    begin
+      # FIXME: Move this logic to release-toolkit?
+      FileUtils.cp(release_notes_path('wordpress'), release_notes_path('jetpack'))
+      sh('git', 'add', release_notes_path('jetpack'))
+      sh('git', 'commit', '-m', "Update draft release notes for Jetpack #{new_version}.")
+    end
     cleanup_release_files(files: release_notes_short_paths)
 
     android_update_release_notes(new_version: new_version) # Adds empty section for next version

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1067,6 +1067,8 @@
     <string name="activity_log_activity_type_filter_no_item_selected_content_description">Activity Type filter</string>
     <string name="activity_log_activity_type_filter_single_item_selected_content_description">%s (showing %s items)</string>
     <string name="activity_log_activity_type_filter_multiple_items_selected_content_description">Activity Type filter (%s types selected)</string>
+    <string name="activity_log_multisite_message">Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores. For more information %1$s.</string>
+    <string name="activity_log_visit_our_documentation_page">visit our documentation page</string>
 
     <!-- activity log list popup menu -->
     <string name="activity_log_item_menu_restore_label">Restore to this point</string>
@@ -3246,7 +3248,8 @@
     <string name="gutenberg_native_add_image" tools:ignore="UnusedResources">ADD IMAGE</string>
     <string name="gutenberg_native_add_image_or_video" tools:ignore="UnusedResources">ADD IMAGE OR VIDEO</string>
     <string name="gutenberg_native_add_image_or_video_b7b3d22b" tools:ignore="UnusedResources">Add image or video</string>
-    <string name="gutenberg_native_add_link" tools:ignore="UnusedResources">ADD LINK</string>
+    <string name="gutenberg_native_add_link" tools:ignore="UnusedResources">Add link</string>
+    <string name="gutenberg_native_add_link_0fcaed3b" tools:ignore="UnusedResources">ADD LINK</string>
     <string name="gutenberg_native_add_link_text" tools:ignore="UnusedResources">Add link text</string>
     <!-- translators: %s: social link name e.g: "Instagram". -->
     <string name="gutenberg_native_add_link_to_s" tools:ignore="UnusedResources">Add link to %s</string>
@@ -3350,11 +3353,19 @@
     <string name="gutenberg_native_edit_cover_media" tools:ignore="UnusedResources">Edit cover media</string>
     <string name="gutenberg_native_edit_file" tools:ignore="UnusedResources">Edit file</string>
     <string name="gutenberg_native_edit_focal_point" tools:ignore="UnusedResources">Edit focal point</string>
+    <string name="gutenberg_native_edit_link" tools:ignore="UnusedResources">EDIT LINK</string>
     <string name="gutenberg_native_edit_media" tools:ignore="UnusedResources">Edit media</string>
     <string name="gutenberg_native_edit_using_web_editor" tools:ignore="UnusedResources">Edit using web editor</string>
     <string name="gutenberg_native_edit_video" tools:ignore="UnusedResources">Edit video</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_and" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for Android</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_ios" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for iOS</string>
+    <!-- translators: accessibility text. Empty Embed caption. -->
+    <string name="gutenberg_native_embed_caption_empty" tools:ignore="UnusedResources">Embed caption. Empty</string>
+    <!-- translators: accessibility text. %s: Embed caption. -->
+    <string name="gutenberg_native_embed_caption_s" tools:ignore="UnusedResources">Embed caption. %s</string>
+    <string name="gutenberg_native_embed_link" tools:ignore="UnusedResources">Embed link</string>
+    <!-- translators: %s: host providing embed content e.g: www.youtube.com -->
+    <string name="gutenberg_native_embedded_content_from_s_can_t_be_viewed_in_the_mobile_editor_at_t" tools:ignore="UnusedResources">Embedded content from %s can\'t be viewed in the mobile editor at the moment. Please preview the page to see the embedded content.</string>
     <string name="gutenberg_native_error" tools:ignore="UnusedResources">Error</string>
     <string name="gutenberg_native_excerpt_length_words" tools:ignore="UnusedResources">Excerpt length (words)</string>
     <string name="gutenberg_native_failed_to_insert_audio_file" tools:ignore="UnusedResources">Failed to insert audio file.</string>
@@ -3381,6 +3392,7 @@
     <string name="gutenberg_native_insert_mention" tools:ignore="UnusedResources">Insert mention</string>
     <string name="gutenberg_native_inside" tools:ignore="UnusedResources">Inside</string>
     <string name="gutenberg_native_invalid_url_audio_file_not_found" tools:ignore="UnusedResources">Invalid URL. Audio file not found.</string>
+    <string name="gutenberg_native_invalid_url_please_enter_a_valid_url" tools:ignore="UnusedResources">Invalid URL. Please enter a valid URL.</string>
     <string name="gutenberg_native_link_inserted" tools:ignore="UnusedResources">Link inserted</string>
     <string name="gutenberg_native_link_settings" tools:ignore="UnusedResources">Link Settings</string>
     <string name="gutenberg_native_link_text" tools:ignore="UnusedResources">Link text</string>
@@ -3464,9 +3476,7 @@
     <string name="gutenberg_native_s_social_icon" tools:ignore="UnusedResources">%s social icon</string>
     <string name="gutenberg_native_scrollable_block_menu_closed" tools:ignore="UnusedResources">Scrollable block menu closed.</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block" tools:ignore="UnusedResources">Scrollable block menu opened. Select a block.</string>
-    <string name="gutenberg_native_search_block" tools:ignore="UnusedResources">Search block</string>
     <string name="gutenberg_native_search_block_label_current_text_is" tools:ignore="UnusedResources">Search block label. Current text is</string>
-    <string name="gutenberg_native_search_blocks" tools:ignore="UnusedResources">Search blocks</string>
     <string name="gutenberg_native_search_button_current_button_text_is" tools:ignore="UnusedResources">Search button. Current button text is</string>
     <string name="gutenberg_native_search_input_field" tools:ignore="UnusedResources">Search input field.</string>
     <string name="gutenberg_native_search_or_type_url" tools:ignore="UnusedResources">Search or type URL</string>

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
-#Mon, 12 Jul 2021 13:11:20 +0200
+#Mon, 12 Jul 2021 13:27:12 +0200
 
 # WordPress version information
 wordpress.versionName=17.8-rc-1
@@ -8,5 +8,5 @@ wordpress.zalpha.versionName=alpha-305
 wordpress.zalpha.versionCode=1076
 
 # Jetpack version information
-jetpack.versionName=17.7
-jetpack.versionCode=1073
+jetpack.versionName=17.8-rc-1
+jetpack.versionCode=1075

--- a/version.properties
+++ b/version.properties
@@ -1,11 +1,11 @@
-#Fri, 09 Jul 2021 14:49:19 +0200
+#Mon, 12 Jul 2021 13:11:20 +0200
 
 # WordPress version information
-wordpress.versionName=17.7
-wordpress.versionCode=1074
+wordpress.versionName=17.8-rc-1
+wordpress.versionCode=1075
 
-wordpress.zalpha.versionName=alpha-304
-wordpress.zalpha.versionCode=1073
+wordpress.zalpha.versionName=alpha-305
+wordpress.zalpha.versionCode=1076
 
 # Jetpack version information
 jetpack.versionName=17.7


### PR DESCRIPTION
17.8 Code Freeze just happened and WP alpha, WP beta and JP beta were all submitted to Google for review, pending approval. Contains:

 - Code freeze commits (version bump etc)
 - Small fixes to the `code_freeze` lane (crashes I encountered while doing code freeze due to Jetpack automation still not being cleanly done yet)
 - Removal of a release note point related to iPad that was accidentally added in Android notes too
 - https://github.com/wordpress-mobile/WordPress-Android/pull/15019 which fixes unit tests that broke on `develop` before I started my code freeze. They got fixed on the release branch… and thus will be fixed on `develop` too once this PR lands.

_(Note: Intermediate branch to avoid risk of conflicts on the `RELEASE-NOTES.txt` file if someone already adds entries for 17.9 before this gets merged)_