### PR TITLE
Fix infinite loading spinner when creating a page with a template

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -517,7 +517,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         );
 
         mMLPViewModel.getOnCreateNewPageRequested().observe(this, request -> {
-            handleNewPageAction(request.getTitle(), request.getContent(), request.getTemplate(),
+            handleNewPageAction(request.getTitle(), "", request.getTemplate(),
                     PagePostCreationSourcesDetail.PAGE_FROM_MY_SITE);
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -486,7 +486,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
 
     private fun setupMlpObservers(activity: FragmentActivity) {
         mlpViewModel.onCreateNewPageRequested.observe(viewLifecycleOwner, { request ->
-            createNewPage(request.title, request.content, request.template)
+            createNewPage(request.title, "", request.template)
         })
         mlpViewModel.isModalLayoutPickerShowing.observeEvent(viewLifecycleOwner, { isShowing ->
             val fm = activity.supportFragmentManager

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -455,7 +455,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         mShortcutUtils.reportShortcutUsed(Shortcut.CREATE_NEW_POST);
     }
 
-    private void newPageFromLayoutPickerSetup(String title, String content) {
+    private void newPageFromLayoutPickerSetup(String title, String layoutSlug) {
         mIsNewPost = true;
 
         if (mSite == null) {
@@ -466,12 +466,11 @@ public class EditPostActivity extends LocaleAwareActivity implements
             showErrorAndFinish(R.string.error_blog_hidden);
             return;
         }
-
+        String content = mSiteStore.getBlockLayoutContent(mSite, layoutSlug);
         // Create a new post
         mEditPostRepository.set(() -> {
-            PostModel post = mPostStore.instantiatePostModel(mSite, mIsPage, title, content, null,
+            PostModel post = mPostStore.instantiatePostModel(mSite, mIsPage, title, content, PostStatus.DRAFT.toString(),
                     null, null, false);
-            post.setStatus(PostStatus.DRAFT.toString());
             return post;
         });
         mEditPostRepository.savePostSnapshot();
@@ -559,7 +558,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 mIsPage = extras.getBoolean(EXTRA_IS_PAGE);
                 if (mIsPage && !TextUtils.isEmpty(extras.getString(EXTRA_PAGE_TITLE))) {
                     newPageFromLayoutPickerSetup(extras.getString(EXTRA_PAGE_TITLE),
-                            extras.getString(EXTRA_PAGE_CONTENT));
+                            extras.getString(EXTRA_PAGE_TEMPLATE));
                 } else {
                     newPostSetup();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -469,8 +469,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
         String content = mSiteStore.getBlockLayoutContent(mSite, layoutSlug);
         // Create a new post
         mEditPostRepository.set(() -> {
-            PostModel post = mPostStore.instantiatePostModel(mSite, mIsPage, title, content, PostStatus.DRAFT.toString(),
-                    null, null, false);
+            PostModel post = mPostStore.instantiatePostModel(mSite, mIsPage, title, content,
+                    PostStatus.DRAFT.toString(), null, null, false);
             return post;
         });
         mEditPostRepository.savePostSnapshot();

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
@@ -72,12 +72,11 @@ class ModalLayoutPickerViewModel @Inject constructor(
             state.selectedLayoutSlug?.let { siteStore.getBlockLayout(site, it) }?.let { LayoutModel(it) }
         }
 
-    sealed class PageRequest(val template: String?, val content: String) {
-        open class Create(template: String?, content: String, val title: String) : PageRequest(template, content)
-        object Blank : Create(null, "", "")
-        class Preview(template: String?, content: String, val site: SiteModel, val demoUrl: String?) : PageRequest(
-                template,
-                content
+    sealed class PageRequest(val template: String?) {
+        open class Create(template: String?, val title: String) : PageRequest(template)
+        object Blank : Create(null, "")
+        class Preview(template: String?, val content: String, val site: SiteModel, val demoUrl: String?) : PageRequest(
+                template
         )
     }
 
@@ -174,8 +173,7 @@ class ModalLayoutPickerViewModel @Inject constructor(
      */
     private fun createPage() {
         selectedLayout?.let { layout ->
-            val content: String = siteStore.getBlockLayoutContent(site, layout.slug) ?: ""
-            _onCreateNewPageRequested.value = PageRequest.Create(layout.slug, content, layout.title)
+            _onCreateNewPageRequested.value = PageRequest.Create(layout.slug, layout.title)
             return
         }
         _onCreateNewPageRequested.value = PageRequest.Blank


### PR DESCRIPTION
Adjust layout picker configuration to pass the slug instead of the full content

**Fixes** https://github.com/wordpress-mobile/WordPress-Android/issues/15025

📓 This area of code can probably use some additional refactoring and clean-up to remove more of the references to the content that is being passed around. I held off on making those changes for now to minimize the risk for the beta fix.

## To test:
To test you'll want to create a page under the following scenarios then validate the content loads in the editor. 

- [ ] Create a Page from the My Site FAB icon - Choose a Template
- [ ] Create a Page from the My Site FAB icon - Choose Blank
- [ ] Create a Page from the Pages FAB icon - Choose a Template
- [ ] Create a Page from the Pages FAB icon - Choose Blank

## Regression Notes
1. Potential unintended areas of impact
We should also validate the preview and creating pages from the preview flow to insure nothing breaks there. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Create a Page
- Select a layout
- Choose Preview
- Complete the Page creation flow

3. What automated tests I added (or what prevented me from doing so)
The existing tests validate that no regressions were introduced. 

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
