### PR TITLE
Fix Blogging Reminders days of week formatting

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
@@ -14,7 +14,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
 import java.time.DayOfWeek
-import java.time.format.TextStyle.SHORT_STANDALONE
+import java.time.format.TextStyle.SHORT
 import javax.inject.Inject
 
 class DaySelectionBuilder
@@ -39,7 +39,7 @@ class DaySelectionBuilder
                 MediumEmphasisText(UiStringRes(R.string.blogging_reminders_select_days_message)),
                 DayButtons(daysOfWeek.map {
                     DayItem(
-                            UiStringText(it.getDisplayName(SHORT_STANDALONE, localeManagerWrapper.getLocale())),
+                            UiStringText(it.getDisplayName(SHORT, localeManagerWrapper.getLocale())),
                             bloggingRemindersModel?.enabledDays?.contains(it) == true,
                             ListItemInteraction.create(it, onSelectDay)
                     )


### PR DESCRIPTION
Fixes #15026

After spending quite some time investigating this bug, I found that it can only be reproduced on release builds. While I haven't figured out exactly why that happens, I did find that simply changing the `TextStyle` used to format the days of week names from `SHORT_STANDALONE` to `SHORT` seems to resolve the issue, so that's what this PR does.

Of course, since this doesn't address why this bug only affects release builds, I can't say it's an ideal solution, but I'd guess it has something to do with either Proguard erroneously removing some necessary class or some other bug with the desugaring process, which is needed to make the formatting methods we use available. Either way, the solution in this PR seems sufficient for now given our current constraints.

### To test

1. Build a release variant of the app, like `wordpressWasabiRelease`.
1. Login.
1. On the My Site screen, tap Settings.
1. On the Settings screen, tap Blogging Reminders.
1. On the first screen of the Blogging Reminders flow, tap Continue.
1. On the day selection screen, notice all days have their names correctly formatted according to the current locale.

Bonus: test with different languages and verify that they all behave the same.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
