### PR TITLE
Onboarding Improvements: New Login Epilogue Screen Design

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -243,8 +243,12 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
         if (hasSites) {
             holder.showSitesHeading(StringUtils.getQuantityString(
-                    requireActivity(), R.string.login_epilogue_mysites_one, R.string.login_epilogue_mysites_one,
-                    R.string.login_epilogue_mysites_other, sites.size()));
+                    requireActivity(),
+                    R.string.login_epilogue_mysites_one,
+                    R.string.login_epilogue_mysites_one,
+                    R.string.login_epilogue_mysites_other,
+                    sites.size())
+            );
         } else {
             holder.hideSitesHeading();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -211,21 +211,25 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         };
     }
 
-    @NonNull
+    @Nullable
     private ViewHolderHandler<LoginFooterViewHolder> footerHandler() {
-        return new ViewHolderHandler<LoginFooterViewHolder>() {
-            @Override
-            public LoginFooterViewHolder onCreateViewHolder(LayoutInflater layoutInflater, ViewGroup parent,
-                                                            boolean attachToRoot) {
-                return new LoginFooterViewHolder(
-                        layoutInflater.inflate(R.layout.login_epilogue_footer, parent, false));
-            }
+        if (mOnboardingImprovementsFeatureConfig.isEnabled()) {
+            return null;
+        } else {
+            return new ViewHolderHandler<LoginFooterViewHolder>() {
+                @Override
+                public LoginFooterViewHolder onCreateViewHolder(LayoutInflater layoutInflater, ViewGroup parent,
+                                                                boolean attachToRoot) {
+                    return new LoginFooterViewHolder(
+                            layoutInflater.inflate(R.layout.login_epilogue_footer, parent, false));
+                }
 
-            @Override
-            public void onBindViewHolder(LoginFooterViewHolder holder, SiteList sites) {
-                bindFooterViewHolder(holder, sites);
-            }
-        };
+                @Override
+                public void onBindViewHolder(LoginFooterViewHolder holder, SiteList sites) {
+                    bindFooterViewHolder(holder, sites);
+                }
+            };
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -99,7 +99,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     protected void setupContent(ViewGroup rootView) {
         mBottomShadow = rootView.findViewById(R.id.bottom_shadow);
         mSitesList = rootView.findViewById(R.id.recycler_view);
-        mSitesList.setLayoutManager(new LinearLayoutManager(getActivity()));
+        mSitesList.setLayoutManager(new LinearLayoutManager(requireActivity()));
         mSitesList.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
         mSitesList.setItemAnimator(null);
         mSitesList.setAdapter(getAdapter());
@@ -118,7 +118,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        ((WordPress) getActivity().getApplication()).component().inject(this);
+        ((WordPress) requireActivity().getApplication()).component().inject(this);
 
         mDoLoginUpdate = getArguments().getBoolean(ARG_DO_LOGIN_UPDATE);
         mShowAndReturn = getArguments().getBoolean(ARG_SHOW_AND_RETURN);
@@ -144,7 +144,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
     private void setNewAdapter() {
         mAdapter = new SitePickerAdapter(
-                getActivity(), R.layout.login_epilogue_sites_listitem, 0, "", false,
+                requireActivity(), R.layout.login_epilogue_sites_listitem, 0, "", false,
                 new SitePickerAdapter.OnDataLoadedListener() {
                     @Override
                     public void onBeforeLoad(boolean isEmpty) {
@@ -236,7 +236,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
         if (hasSites) {
             holder.showSitesHeading(StringUtils.getQuantityString(
-                    getActivity(), R.string.login_epilogue_mysites_one, R.string.login_epilogue_mysites_one,
+                    requireActivity(), R.string.login_epilogue_mysites_one, R.string.login_epilogue_mysites_one,
                     R.string.login_epilogue_mysites_other, sites.size()));
         } else {
             holder.hideSitesHeading();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -120,9 +120,9 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         super.onCreate(savedInstanceState);
         ((WordPress) requireActivity().getApplication()).component().inject(this);
 
-        mDoLoginUpdate = getArguments().getBoolean(ARG_DO_LOGIN_UPDATE);
-        mShowAndReturn = getArguments().getBoolean(ARG_SHOW_AND_RETURN);
-        mOldSitesIds = getArguments().getIntegerArrayList(ARG_OLD_SITES_IDS);
+        mDoLoginUpdate = requireArguments().getBoolean(ARG_DO_LOGIN_UPDATE, false);
+        mShowAndReturn = requireArguments().getBoolean(ARG_SHOW_AND_RETURN, false);
+        mOldSitesIds = requireArguments().getIntegerArrayList(ARG_OLD_SITES_IDS);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -144,7 +144,11 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
     private void setNewAdapter() {
         mAdapter = new SitePickerAdapter(
-                requireActivity(), R.layout.login_epilogue_sites_listitem, 0, "", false,
+                requireActivity(),
+                R.layout.login_epilogue_sites_listitem,
+                0,
+                "",
+                false,
                 new SitePickerAdapter.OnDataLoadedListener() {
                     @Override
                     public void onBeforeLoad(boolean isEmpty) {
@@ -190,7 +194,10 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
                     public void onBindViewHolder(LoginFooterViewHolder holder, SiteList sites) {
                         bindFooterViewHolder(holder, sites);
                     }
-                }, mOldSitesIds, SitePickerMode.DEFAULT_MODE);
+                },
+                mOldSitesIds,
+                SitePickerMode.DEFAULT_MODE
+        );
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -48,7 +48,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     private static final String ARG_OLD_SITES_IDS = "ARG_OLD_SITES_IDS";
 
     private RecyclerView mSitesList;
-    private View mBottomShadow;
+    @Nullable private View mBottomShadow;
 
     private SitePickerAdapter mAdapter;
     private boolean mDoLoginUpdate;
@@ -175,10 +175,12 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
                         return;
                     }
 
-                    if (mSitesList.computeVerticalScrollRange() > mSitesList.getHeight()) {
-                        mBottomShadow.setVisibility(View.VISIBLE);
-                    } else {
-                        mBottomShadow.setVisibility(View.GONE);
+                    if (mBottomShadow != null) {
+                        if (mSitesList.computeVerticalScrollRange() > mSitesList.getHeight()) {
+                            mBottomShadow.setVisibility(View.VISIBLE);
+                        } else {
+                            mBottomShadow.setVisibility(View.GONE);
+                        }
                     }
                 });
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -156,11 +156,10 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         }
     }
 
-    private SitePickerAdapter initAdapter() {
+    private void initAdapter() {
         if (mAdapter == null) {
             setNewAdapter();
         }
-        return mAdapter;
     }
 
     private void setNewAdapter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -47,6 +47,8 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     private static final String ARG_SHOW_AND_RETURN = "ARG_SHOW_AND_RETURN";
     private static final String ARG_OLD_SITES_IDS = "ARG_OLD_SITES_IDS";
 
+    private static final int EXPANDED_UI_THRESHOLD = 3;
+
     private RecyclerView mSitesList;
     @Nullable private View mBottomShadow;
 
@@ -102,7 +104,11 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     @LayoutRes
     private int loginEpilogueScreenResource() {
         if (mOnboardingImprovementsFeatureConfig.isEnabled()) {
-            return R.layout.login_epilogue_screen_new;
+            if (mAdapter.getBlogsForCurrentView().size() <= EXPANDED_UI_THRESHOLD) {
+                return R.layout.login_epilogue_screen_new;
+            } else {
+                return R.layout.login_epilogue_screen_new_expanded;
+            }
         } else {
             return R.layout.login_epilogue_screen;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.accounts.UnifiedLoginTracker;
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Click;
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step;
 import org.wordpress.android.ui.main.SitePickerAdapter;
+import org.wordpress.android.ui.main.SitePickerAdapter.OnDataLoadedListener;
 import org.wordpress.android.ui.main.SitePickerAdapter.SiteList;
 import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode;
 import org.wordpress.android.ui.main.SitePickerAdapter.ViewHolderHandler;
@@ -152,64 +153,79 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
                 0,
                 "",
                 false,
-                new SitePickerAdapter.OnDataLoadedListener() {
-                    @Override
-                    public void onBeforeLoad(boolean isEmpty) {
-                    }
-
-                    @Override
-                    public void onAfterLoad() {
-                        mSitesList.post(() -> {
-                            if (!isAdded()) {
-                                return;
-                            }
-
-                            if (mSitesList.computeVerticalScrollRange() > mSitesList.getHeight()) {
-                                mBottomShadow.setVisibility(View.VISIBLE);
-                            } else {
-                                mBottomShadow.setVisibility(View.GONE);
-                            }
-                        });
-                    }
-                },
-                new SitePickerAdapter.ViewHolderHandler<LoginHeaderViewHolder>() {
-                    @Override
-                    public LoginHeaderViewHolder onCreateViewHolder(LayoutInflater layoutInflater, ViewGroup parent,
-                                                                    boolean attachToRoot) {
-                        if (mOnboardingImprovementsFeatureConfig.isEnabled()) {
-                            return new LoginHeaderViewHolder(
-                                    layoutInflater.inflate(R.layout.login_epilogue_header_new, parent, false),
-                                    true
-                            );
-                        } else {
-                            return new LoginHeaderViewHolder(
-                                    layoutInflater.inflate(R.layout.login_epilogue_header, parent, false),
-                                    false
-                            );
-                        }
-                    }
-
-                    @Override
-                    public void onBindViewHolder(LoginHeaderViewHolder holder, SiteList sites) {
-                        bindHeaderViewHolder(holder, sites);
-                    }
-                },
-                new ViewHolderHandler<LoginFooterViewHolder>() {
-                    @Override
-                    public LoginFooterViewHolder onCreateViewHolder(LayoutInflater layoutInflater, ViewGroup parent,
-                                                                    boolean attachToRoot) {
-                        return new LoginFooterViewHolder(
-                                layoutInflater.inflate(R.layout.login_epilogue_footer, parent, false));
-                    }
-
-                    @Override
-                    public void onBindViewHolder(LoginFooterViewHolder holder, SiteList sites) {
-                        bindFooterViewHolder(holder, sites);
-                    }
-                },
+                dataLoadedListener(),
+                headerHandler(),
+                footerHandler(),
                 mOldSitesIds,
                 SitePickerMode.DEFAULT_MODE
         );
+    }
+
+    @NonNull
+    private OnDataLoadedListener dataLoadedListener() {
+        return new OnDataLoadedListener() {
+            @Override
+            public void onBeforeLoad(boolean isEmpty) {
+            }
+
+            @Override
+            public void onAfterLoad() {
+                mSitesList.post(() -> {
+                    if (!isAdded()) {
+                        return;
+                    }
+
+                    if (mSitesList.computeVerticalScrollRange() > mSitesList.getHeight()) {
+                        mBottomShadow.setVisibility(View.VISIBLE);
+                    } else {
+                        mBottomShadow.setVisibility(View.GONE);
+                    }
+                });
+            }
+        };
+    }
+
+    @NonNull
+    private ViewHolderHandler<LoginHeaderViewHolder> headerHandler() {
+        return new ViewHolderHandler<LoginHeaderViewHolder>() {
+            @Override
+            public LoginHeaderViewHolder onCreateViewHolder(LayoutInflater layoutInflater, ViewGroup parent,
+                                                            boolean attachToRoot) {
+                if (mOnboardingImprovementsFeatureConfig.isEnabled()) {
+                    return new LoginHeaderViewHolder(
+                            layoutInflater.inflate(R.layout.login_epilogue_header_new, parent, false),
+                            true
+                    );
+                } else {
+                    return new LoginHeaderViewHolder(
+                            layoutInflater.inflate(R.layout.login_epilogue_header, parent, false),
+                            false
+                    );
+                }
+            }
+
+            @Override
+            public void onBindViewHolder(LoginHeaderViewHolder holder, SiteList sites) {
+                bindHeaderViewHolder(holder, sites);
+            }
+        };
+    }
+
+    @NonNull
+    private ViewHolderHandler<LoginFooterViewHolder> footerHandler() {
+        return new ViewHolderHandler<LoginFooterViewHolder>() {
+            @Override
+            public LoginFooterViewHolder onCreateViewHolder(LayoutInflater layoutInflater, ViewGroup parent,
+                                                            boolean attachToRoot) {
+                return new LoginFooterViewHolder(
+                        layoutInflater.inflate(R.layout.login_epilogue_footer, parent, false));
+            }
+
+            @Override
+            public void onBindViewHolder(LoginFooterViewHolder holder, SiteList sites) {
+                bindFooterViewHolder(holder, sites);
+            }
+        };
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -32,6 +32,7 @@ import org.wordpress.android.ui.main.SitePickerAdapter.ViewHolderHandler;
 import org.wordpress.android.util.BuildConfigWrapper;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.config.OnboardingImprovementsFeatureConfig;
 import org.wordpress.android.util.image.ImageManager;
 
 import java.util.ArrayList;
@@ -58,6 +59,8 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     @Inject ImageManager mImageManager;
     @Inject UnifiedLoginTracker mUnifiedLoginTracker;
     @Inject BuildConfigWrapper mBuildConfigWrapper;
+
+    @Inject OnboardingImprovementsFeatureConfig mOnboardingImprovementsFeatureConfig;
 
     public static LoginEpilogueFragment newInstance(boolean doLoginUpdate, boolean showAndReturn,
                                                     ArrayList<Integer> oldSitesIds) {
@@ -173,8 +176,17 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
                     @Override
                     public LoginHeaderViewHolder onCreateViewHolder(LayoutInflater layoutInflater, ViewGroup parent,
                                                                     boolean attachToRoot) {
-                        return new LoginHeaderViewHolder(
-                                layoutInflater.inflate(R.layout.login_epilogue_header, parent, false));
+                        if (mOnboardingImprovementsFeatureConfig.isEnabled()) {
+                            return new LoginHeaderViewHolder(
+                                    layoutInflater.inflate(R.layout.login_epilogue_header_new, parent, false),
+                                    true
+                            );
+                        } else {
+                            return new LoginHeaderViewHolder(
+                                    layoutInflater.inflate(R.layout.login_epilogue_header, parent, false),
+                                    false
+                            );
+                        }
                     }
 
                     @Override
@@ -242,13 +254,17 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         }
 
         if (hasSites) {
-            holder.showSitesHeading(StringUtils.getQuantityString(
-                    requireActivity(),
-                    R.string.login_epilogue_mysites_one,
-                    R.string.login_epilogue_mysites_one,
-                    R.string.login_epilogue_mysites_other,
-                    sites.size())
-            );
+            if (mOnboardingImprovementsFeatureConfig.isEnabled()) {
+                holder.showSitesHeading();
+            } else {
+                holder.showSitesHeading(StringUtils.getQuantityString(
+                        requireActivity(),
+                        R.string.login_epilogue_mysites_one,
+                        R.string.login_epilogue_mysites_one,
+                        R.string.login_epilogue_mysites_other,
+                        sites.size())
+                );
+            }
         } else {
             holder.hideSitesHeading();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -96,7 +96,16 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
     @Override
     protected ViewGroup createMainView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        return (ViewGroup) inflater.inflate(R.layout.login_epilogue_screen, container, false);
+        return (ViewGroup) inflater.inflate(loginEpilogueScreenResource(), container, false);
+    }
+
+    @LayoutRes
+    private int loginEpilogueScreenResource() {
+        if (mOnboardingImprovementsFeatureConfig.isEnabled()) {
+            return R.layout.login_epilogue_screen_new;
+        } else {
+            return R.layout.login_epilogue_screen;
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -106,7 +106,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         mSitesList.setLayoutManager(new LinearLayoutManager(requireActivity()));
         mSitesList.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
         mSitesList.setItemAnimator(null);
-        mSitesList.setAdapter(getAdapter());
+        mSitesList.setAdapter(mAdapter);
     }
 
     @Override
@@ -127,6 +127,8 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         mDoLoginUpdate = requireArguments().getBoolean(ARG_DO_LOGIN_UPDATE, false);
         mShowAndReturn = requireArguments().getBoolean(ARG_SHOW_AND_RETURN, false);
         mOldSitesIds = requireArguments().getIntegerArrayList(ARG_OLD_SITES_IDS);
+
+        initAdapter();
     }
 
     @Override
@@ -139,7 +141,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         }
     }
 
-    private SitePickerAdapter getAdapter() {
+    private SitePickerAdapter initAdapter() {
         if (mAdapter == null) {
             setNewAdapter();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginHeaderViewHolder.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginHeaderViewHolder.java
@@ -4,8 +4,10 @@ import android.content.Context;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.wordpress.android.R;
@@ -25,14 +27,22 @@ class LoginHeaderViewHolder extends RecyclerView.ViewHolder {
     private final ImageView mAvatarImageView;
     private final TextView mDisplayNameTextView;
     private final TextView mUsernameTextView;
-    private final TextView mMySitesHeadingTextView;
 
-    LoginHeaderViewHolder(View view) {
+    private final boolean mIsOnboardingImprovementsEnabled;
+    @Nullable private TextView mMySitesHeadingTextView;
+    @Nullable private LinearLayout mMySitesHeadingContainer;
+
+    LoginHeaderViewHolder(View view, boolean isOnboardingImprovementsEnabled) {
         super(view);
+        mIsOnboardingImprovementsEnabled = isOnboardingImprovementsEnabled;
         mAvatarImageView = view.findViewById(R.id.login_epilogue_header_avatar);
         mDisplayNameTextView = view.findViewById(R.id.login_epilogue_header_title);
         mUsernameTextView = view.findViewById(R.id.login_epilogue_header_subtitle);
-        mMySitesHeadingTextView = view.findViewById(R.id.login_epilogue_header_sites_subheader);
+        if (isOnboardingImprovementsEnabled) {
+            mMySitesHeadingContainer = view.findViewById(R.id.login_epilogue_header_sites_header);
+        } else {
+            mMySitesHeadingTextView = view.findViewById(R.id.login_epilogue_header_sites_subheader);
+        }
     }
 
     void updateLoggedInAsHeading(Context context, ImageManager imageManager, AccountModel account) {
@@ -62,12 +72,24 @@ class LoginHeaderViewHolder extends RecyclerView.ViewHolder {
     }
 
     void showSitesHeading(String text) {
-        mMySitesHeadingTextView.setVisibility(View.VISIBLE);
-        mMySitesHeadingTextView.setText(text);
+        if (!mIsOnboardingImprovementsEnabled) {
+            mMySitesHeadingTextView.setVisibility(View.VISIBLE);
+            mMySitesHeadingTextView.setText(text);
+        }
+    }
+
+    void showSitesHeading() {
+        if (mIsOnboardingImprovementsEnabled) {
+            mMySitesHeadingContainer.setVisibility(View.VISIBLE);
+        }
     }
 
     void hideSitesHeading() {
-        mMySitesHeadingTextView.setVisibility(View.GONE);
+        if (mIsOnboardingImprovementsEnabled) {
+            mMySitesHeadingContainer.setVisibility(View.VISIBLE);
+        } else {
+            mMySitesHeadingTextView.setVisibility(View.GONE);
+        }
     }
 
     private int getAvatarSize(Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -129,7 +129,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final TextView mTxtTitle;
         private final TextView mTxtDomain;
         private final ImageView mImgBlavatar;
-        private final View mDivider;
+        @Nullable private final View mDivider;
         private Boolean mIsSiteHidden;
         private final RadioButton mSelectedRadioButton;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.graphics.ColorUtils;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -92,8 +93,8 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private final LayoutInflater mInflater;
     private final HashSet<Integer> mSelectedPositions = new HashSet<>();
-    private final ViewHolderHandler mHeaderHandler;
-    private final ViewHolderHandler mFooterHandler;
+    @Nullable private final ViewHolderHandler mHeaderHandler;
+    @Nullable private final ViewHolderHandler mFooterHandler;
 
     private boolean mIsMultiSelectEnabled;
     private final boolean mIsInSearchMode;
@@ -101,11 +102,11 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private boolean mShowSelfHostedSites = true;
     private String mLastSearch;
     private SiteList mAllSites;
-    private ArrayList<Integer> mIgnoreSitesIds;
+    @Nullable private final ArrayList<Integer> mIgnoreSitesIds;
 
     private OnSiteClickListener mSiteSelectedListener;
     private OnSelectedCountChangedListener mSelectedCountListener;
-    private OnDataLoadedListener mDataLoadedListener;
+    @NonNull private final OnDataLoadedListener mDataLoadedListener;
 
     private boolean mIsSingleItemSelectionEnabled;
     private int mSelectedItemPos;
@@ -149,7 +150,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              int currentLocalBlogId,
                              String lastSearch,
                              boolean isInSearchMode,
-                             OnDataLoadedListener dataLoadedListener,
+                             @NonNull OnDataLoadedListener dataLoadedListener,
                              SitePickerMode sitePickerMode,
                              boolean isInEditMode
     ) {
@@ -162,9 +163,9 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              int currentLocalBlogId,
                              String lastSearch,
                              boolean isInSearchMode,
-                             OnDataLoadedListener dataLoadedListener,
-                             ViewHolderHandler<?> headerHandler,
-                             ArrayList<Integer> ignoreSitesIds
+                             @NonNull OnDataLoadedListener dataLoadedListener,
+                             @NonNull ViewHolderHandler<?> headerHandler,
+                             @Nullable ArrayList<Integer> ignoreSitesIds
     ) {
         this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener,
                 headerHandler, null, ignoreSitesIds, SitePickerMode.DEFAULT_MODE, false);
@@ -175,9 +176,9 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              int currentLocalBlogId,
                              String lastSearch,
                              boolean isInSearchMode,
-                             OnDataLoadedListener dataLoadedListener,
-                             ViewHolderHandler<?> headerHandler,
-                             ViewHolderHandler<?> footerHandler,
+                             @NonNull OnDataLoadedListener dataLoadedListener,
+                             @NonNull ViewHolderHandler<?> headerHandler,
+                             @Nullable ViewHolderHandler<?> footerHandler,
                              ArrayList<Integer> ignoreSitesIds,
                              SitePickerMode sitePickerMode
     ) {
@@ -190,10 +191,10 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              int currentLocalBlogId,
                              String lastSearch,
                              boolean isInSearchMode,
-                             OnDataLoadedListener dataLoadedListener,
-                             ViewHolderHandler<?> headerHandler,
-                             ViewHolderHandler<?> footerHandler,
-                             ArrayList<Integer> ignoreSitesIds,
+                             @NonNull OnDataLoadedListener dataLoadedListener,
+                             @Nullable ViewHolderHandler<?> headerHandler,
+                             @Nullable ViewHolderHandler<?> footerHandler,
+                             @Nullable ArrayList<Integer> ignoreSitesIds,
                              SitePickerMode sitePickerMode,
                              boolean isInEditMode
     ) {
@@ -660,10 +661,8 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
-            if (mDataLoadedListener != null) {
-                boolean isEmpty = mSites == null || mSites.size() == 0;
-                mDataLoadedListener.onBeforeLoad(isEmpty);
-            }
+            boolean isEmpty = mSites == null || mSites.size() == 0;
+            mDataLoadedListener.onBeforeLoad(isEmpty);
         }
 
         @Override
@@ -732,9 +731,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 mSites = updatedSiteLists[1];
                 notifyDataSetChanged();
             }
-            if (mDataLoadedListener != null) {
-                mDataLoadedListener.onAfterLoad();
-            }
+            mDataLoadedListener.onAfterLoad();
         }
 
         private List<SiteModel> getBlogsForCurrentView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -659,6 +659,30 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         return filteredSiteList;
     }
 
+    public List<SiteModel> getBlogsForCurrentView() {
+        if (mSitePickerMode.isReblogMode()) {
+            // If we are reblogging we only want to select or search into the WPCom visible sites.
+            return mSiteStore.getVisibleSitesAccessedViaWPCom();
+        } else if (mIsInSearchMode) {
+            return mSiteStore.getSites();
+        }
+        if (mShowHiddenSites) {
+            if (mShowSelfHostedSites) {
+                return mSiteStore.getSites();
+            } else {
+                return mSiteStore.getSitesAccessedViaWPComRest();
+            }
+        } else {
+            if (mShowSelfHostedSites) {
+                List<SiteModel> out = mSiteStore.getVisibleSitesAccessedViaWPCom();
+                out.addAll(mSiteStore.getSitesAccessedViaXMLRPC());
+                return out;
+            } else {
+                return mSiteStore.getVisibleSitesAccessedViaWPCom();
+            }
+        }
+    }
+
     /*
      * AsyncTask which loads sites from database and populates the adapter
      */
@@ -738,30 +762,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 notifyDataSetChanged();
             }
             mDataLoadedListener.onAfterLoad();
-        }
-
-        private List<SiteModel> getBlogsForCurrentView() {
-            if (mSitePickerMode.isReblogMode()) {
-                // If we are reblogging we only want to select or search into the WPCom visible sites.
-                return mSiteStore.getVisibleSitesAccessedViaWPCom();
-            } else if (mIsInSearchMode) {
-                return mSiteStore.getSites();
-            }
-            if (mShowHiddenSites) {
-                if (mShowSelfHostedSites) {
-                    return mSiteStore.getSites();
-                } else {
-                    return mSiteStore.getSitesAccessedViaWPComRest();
-                }
-            } else {
-                if (mShowSelfHostedSites) {
-                    List<SiteModel> out = mSiteStore.getVisibleSitesAccessedViaWPCom();
-                    out.addAll(mSiteStore.getSitesAccessedViaXMLRPC());
-                    return out;
-                } else {
-                    return mSiteStore.getVisibleSitesAccessedViaWPCom();
-                }
-            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -129,6 +129,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final TextView mTxtTitle;
         private final TextView mTxtDomain;
         private final ImageView mImgBlavatar;
+        @Nullable private final View mItemDivider;
         @Nullable private final View mDivider;
         private Boolean mIsSiteHidden;
         private final RadioButton mSelectedRadioButton;
@@ -139,6 +140,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             mTxtTitle = view.findViewById(R.id.text_title);
             mTxtDomain = view.findViewById(R.id.text_domain);
             mImgBlavatar = view.findViewById(R.id.image_blavatar);
+            mItemDivider = view.findViewById(R.id.item_divider);
             mDivider = view.findViewById(R.id.divider);
             mIsSiteHidden = null;
             mSelectedRadioButton = view.findViewById(R.id.radio_selected);
@@ -334,6 +336,10 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             holder.mImgBlavatar.setAlpha(site.mIsHidden ? mDisabledSiteOpacity : 1f);
         }
 
+        if (holder.mItemDivider != null) {
+            boolean showDivider = position < getItemCount() - 1;
+            holder.mItemDivider.setVisibility(showDivider ? View.VISIBLE : View.GONE);
+        }
         if (holder.mDivider != null) {
             // only show divider after last recent pick
             boolean showDivider = site.mIsRecentPick

--- a/WordPress/src/main/res/layout/login_epilogue_header_new.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_header_new.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingEnd="@dimen/margin_extra_large"
+    android:paddingStart="@dimen/margin_extra_large"
+    android:paddingTop="@dimen/margin_extra_large">
+
+    <include layout="@layout/login_include_epilogue_header" />
+
+    <include layout="@layout/login_include_epilogue_sites_subheader_new" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/login_epilogue_screen_new.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_screen_new.xml
@@ -26,35 +26,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <FrameLayout
+§    <include
         android:id="@+id/orLayout"
+        layout="@layout/login_or_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_extra_medium_large"
-        android:paddingBottom="@dimen/margin_medium"
-        android:paddingTop="@dimen/margin_medium"
         app:layout_constraintBottom_toTopOf="@+id/bottom_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/recycler_view">
-
-        <TextView
-            style="@style/Widget.LoginFlow.TextView.DividerText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:paddingEnd="@dimen/margin_small"
-            android:paddingStart="@dimen/margin_small"
-            android:text="@string/login_or" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_gravity="center_vertical"
-            android:alpha="0.12"
-            android:background="?attr/colorOnSurface" />
-
-    </FrameLayout>
+        app:layout_constraintTop_toBottomOf="@+id/recycler_view" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/bottom_button"
@@ -64,7 +45,6 @@
         android:layout_marginBottom="@dimen/margin_extra_large"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
-        android:layout_marginTop="@dimen/margin_small_medium"
         android:text="@string/login_epilogue_create_new_site_button"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/orLayout" />

--- a/WordPress/src/main/res/layout/login_epilogue_screen_new.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_screen_new.xml
@@ -26,7 +26,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-§    <include
+    <include
         android:id="@+id/orLayout"
         layout="@layout/login_or_layout"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/login_epilogue_screen_new.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_screen_new.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ProgressBar
+        android:id="@+id/sites_progress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="vertical"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <FrameLayout
+        android:id="@+id/orLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_medium_large"
+        android:paddingBottom="@dimen/margin_medium"
+        android:paddingTop="@dimen/margin_medium"
+        app:layout_constraintBottom_toTopOf="@+id/bottom_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/recycler_view">
+
+        <TextView
+            style="@style/Widget.LoginFlow.TextView.DividerText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:paddingEnd="@dimen/margin_small"
+            android:paddingStart="@dimen/margin_small"
+            android:text="@string/login_or" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_gravity="center_vertical"
+            android:alpha="0.12"
+            android:background="?attr/colorOnSurface" />
+
+    </FrameLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/bottom_button"
+        style="@style/Widget.LoginFlow.Button.Secondary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_small_medium"
+        android:text="@string/login_epilogue_create_new_site_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/orLayout" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/login_epilogue_screen_new_expanded.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_screen_new_expanded.xml
@@ -37,33 +37,14 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <FrameLayout
+    <include
         android:id="@+id/orLayout"
+        layout="@layout/login_or_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_small_medium"
-        android:paddingTop="@dimen/margin_medium"
         app:layout_constraintBottom_toTopOf="@+id/bottom_button"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
-
-        <TextView
-            style="@style/Widget.LoginFlow.TextView.DividerText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:paddingEnd="@dimen/margin_small"
-            android:paddingStart="@dimen/margin_small"
-            android:text="@string/login_or" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_gravity="center_vertical"
-            android:alpha="0.12"
-            android:background="?attr/colorOnSurface" />
-
-    </FrameLayout>
+        app:layout_constraintStart_toStartOf="parent" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/bottom_button"

--- a/WordPress/src/main/res/layout/login_epilogue_screen_new_expanded.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_screen_new_expanded.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ProgressBar
+        android:id="@+id/sites_progress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:scrollbars="vertical"
+        app:layout_constraintBottom_toTopOf="@id/orLayout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0" />
+
+    <View
+        android:id="@+id/bottom_shadow"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/button_container_shadow_height"
+        android:background="@drawable/login_shadow"
+        app:layout_constraintBottom_toTopOf="@+id/orLayout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <FrameLayout
+        android:id="@+id/orLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_small_medium"
+        android:paddingTop="@dimen/margin_medium"
+        app:layout_constraintBottom_toTopOf="@+id/bottom_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <TextView
+            style="@style/Widget.LoginFlow.TextView.DividerText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:paddingEnd="@dimen/margin_small"
+            android:paddingStart="@dimen/margin_small"
+            android:text="@string/login_or" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_gravity="center_vertical"
+            android:alpha="0.12"
+            android:background="?attr/colorOnSurface" />
+
+    </FrameLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/bottom_button"
+        style="@style/Widget.LoginFlow.Button.Secondary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:text="@string/login_epilogue_create_new_site_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/login_include_epilogue_sites_subheader_new.xml
+++ b/WordPress/src/main/res/layout/login_include_epilogue_sites_subheader_new.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/login_epilogue_header_sites_header"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/margin_extra_large"
+    android:paddingTop="@dimen/margin_extra_medium_large">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/login_epilogue_mysites_heading"
+        android:textColor="@color/login_on_surface_high_selector"
+        android:textSize="@dimen/text_sz_extra_large"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/margin_medium"
+        android:text="@string/login_epilogue_mysites_subheading"
+        android:textColor="@color/login_on_surface_medium_selector"
+        android:textSize="@dimen/text_sz_large" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/login_include_epilogue_sites_subheader_new.xml
+++ b/WordPress/src/main/res/layout/login_include_epilogue_sites_subheader_new.xml
@@ -12,7 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/login_epilogue_mysites_heading"
-        android:textAppearance="?attr/textAppearanceHeadline6"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
         android:textColor="@color/login_on_surface_high_selector" />
 
     <TextView

--- a/WordPress/src/main/res/layout/login_include_epilogue_sites_subheader_new.xml
+++ b/WordPress/src/main/res/layout/login_include_epilogue_sites_subheader_new.xml
@@ -12,16 +12,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/login_epilogue_mysites_heading"
-        android:textColor="@color/login_on_surface_high_selector"
-        android:textSize="@dimen/text_sz_extra_large"
-        android:textStyle="bold" />
+        android:textAppearance="?attr/textAppearanceHeadline6"
+        android:textColor="@color/login_on_surface_high_selector" />
 
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/margin_medium"
+        android:paddingTop="@dimen/margin_small"
         android:text="@string/login_epilogue_mysites_subheading"
-        android:textColor="@color/login_on_surface_medium_selector"
-        android:textSize="@dimen/text_sz_large" />
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/login_on_surface_medium_selector" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2701,6 +2701,8 @@
     <string name="login_email_client_not_found">Can\'t detect your email client app</string>
     <string name="login_epilogue_mysites_one">My site</string>
     <string name="login_epilogue_mysites_other">My sites</string>
+    <string name="login_epilogue_mysites_heading">Choose a site to open</string>
+    <string name="login_epilogue_mysites_subheading">You can switch sites any time.</string>
     <string name="continue_google_button_suffix">Continue with Google</string>
     <string name="continue_site_credentials">Continue with store credentials</string>
     <string name="login_or">or</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2703,6 +2703,7 @@
     <string name="login_epilogue_mysites_other">My sites</string>
     <string name="login_epilogue_mysites_heading">Choose a site to open</string>
     <string name="login_epilogue_mysites_subheading">You can switch sites any time.</string>
+    <string name="login_epilogue_create_new_site_button">Create a new site</string>
     <string name="continue_google_button_suffix">Continue with Google</string>
     <string name="continue_site_credentials">Continue with store credentials</string>
     <string name="login_or">or</string>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
-    ext.wordPressLoginVersion = '0.0.2'
+    ext.wordPressLoginVersion = '60-5ccf3aee6550ebf528dfb1fa6b1ac6be0e83d97a'
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'develop-8ff5066549a46d78e92b0e0451952fd44c18150b'
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
-    ext.wordPressLoginVersion = '60-5ccf3aee6550ebf528dfb1fa6b1ac6be0e83d97a'
+    ext.wordPressLoginVersion = 'develop-5007ecf737918be639e1d80ff2c6e07fd73f64cf'
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'develop-8ff5066549a46d78e92b0e0451952fd44c18150b'
 


### PR DESCRIPTION
Parent #14990

This PR adds a couple of new designs to the login epilogue screen, the `normal` and `expanded` ones.
- The `normal` design is the one that will be shown when the number of sites equal to 2-3 or less.
- The `expanded` design is the one that will be shown when the number of sites end up being more than 3.

Sites | Existing | New
-----|-----|-----
2-3 or less<br/>(`normal`) | <img width="250" height="500" alt="existing_normal" src="https://user-images.githubusercontent.com/9729923/125948450-1f6172b0-8b4c-4fca-b518-b659d2ad731f.png"> | <img width="250" height="500" alt="new_normal" src="https://user-images.githubusercontent.com/9729923/126322869-39a734e9-f55c-4778-8830-b706a89c4873.png">
More than 3<br/>(`expanded`) | <img width="250" height="500" alt="existing_expanded" src="https://user-images.githubusercontent.com/9729923/125948499-fc11eeec-1fa8-41c9-a997-7d6d0fe73ffc.png"> | <img width="250" height="500" alt="new_expanded" src="https://user-images.githubusercontent.com/9729923/126322877-025659f7-60f4-49aa-8d0e-6c9379bd0067.png">

-----

To test:

#### Scenario: `normal`
1. Find an account which has lots of sites and log-in to the app.
2. Go to the `Side Chooser` screen and hide all but 3 of the existing sites. You should at max have no more than 3 sites shown.
2. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
3. Enable the `OnboardingImprovementsFeatureConfig` feature flag.
4. Log-out and log-in to the app again.
5. Make sure the new `Login Epilogue` screen looks as expected, the `normal` design is shown.

#### Scenario: `expanded`
1. Find an account which has lots of sites and log-in to the app.
2. Go to the `Side Chooser` screen and unhide all sites. You should at least have more that 3 sites shown.
2. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
3. Enable the `OnboardingImprovementsFeatureConfig` feature flag.
4. Log-out and log-in to the app again.
5. Make sure the new `Login Epilogue` screen looks as expected, the `expanded` design is shown.

-----

#### Merge Instructions:
- ~~@osullivanchris to do a design review of both the new `Login Epilogue` screens (`normal` and `expanded`).~~
- ~~Remove the `[Status] Needs Design Review`.~~
- ~~Merge [WordPress-Login-Flow-Android#60](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/60).~~
- ~~Update `Login` hash from the PR (`60-{sha1}`) to `develop-{sha1}`.~~
- Merge this PR.

-----

#### Notes

This PR is UI related only, the below functionality will be handled in separate PRs:
- Selecting a `Site`, which will either show the `Quick Start Prompt` or navigate to `My Site` directly.
- Clicking the `Create a new site` button, which will start the `WordPress.com` site creation flow.
- `Landscape` UI, which requires a bit more fine tuning before being ready.

-----

## Regression Notes
1. Potential unintended areas of impact

The existing `Login Epilogue` screen might be somehow affected by all the changes in this PR since all 3 screen are sharing all the logic, that is code-wise.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
