### PR TITLE
Reminder notification should open in DRAFTS tab on Blog Posts screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -264,6 +264,9 @@ class PostsListActivity : LocaleAwareActivity(),
             }
         })
 
+        // Notification opens in Drafts tab
+        if (actionsShownByDefault) tabLayout.getTabAt(PostListType.DRAFTS.ordinal)?.select()
+
         postListCreateMenuViewModel.start(site, actionsShownByDefault)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -166,12 +166,13 @@ class PostsListActivity : LocaleAwareActivity(),
             }
 
             val actionsShownByDefault = intent.getBooleanExtra(ACTIONS_SHOWN_BY_DEFAULT, false)
+            val tabIndex = intent.getIntExtra(TAB_INDEX, PostListType.PUBLISHED.ordinal)
 
             setupActionBar()
             setupContent()
             initViewModel(initPreviewState, currentBottomSheetPostId)
             initBloggingReminders()
-            initCreateMenuViewModel(actionsShownByDefault)
+            initCreateMenuViewModel(tabIndex, actionsShownByDefault)
             loadIntentData(intent)
         }
     }
@@ -222,7 +223,7 @@ class PostsListActivity : LocaleAwareActivity(),
         postPager.adapter = postsPagerAdapter
     }
 
-    private fun PostListActivityBinding.initCreateMenuViewModel(actionsShownByDefault: Boolean) {
+    private fun PostListActivityBinding.initCreateMenuViewModel(tabIndex: Int, actionsShownByDefault: Boolean) {
         postListCreateMenuViewModel = ViewModelProvider(this@PostsListActivity, viewModelFactory)
                 .get(PostListCreateMenuViewModel::class.java)
 
@@ -265,7 +266,7 @@ class PostsListActivity : LocaleAwareActivity(),
         })
 
         // Notification opens in Drafts tab
-        if (actionsShownByDefault) tabLayout.getTabAt(PostListType.DRAFTS.ordinal)?.select()
+        tabLayout.getTabAt(tabIndex)?.select()
 
         postListCreateMenuViewModel.start(site, actionsShownByDefault)
     }
@@ -651,19 +652,26 @@ class PostsListActivity : LocaleAwareActivity(),
     companion object {
         private const val BLOGGING_REMINDERS_FRAGMENT_TAG = "blogging_reminders_fragment_tag"
         private const val ACTIONS_SHOWN_BY_DEFAULT = "actions_shown_by_default"
+        private const val TAB_INDEX = "tab_index"
 
         @JvmStatic
         fun buildIntent(context: Context, site: SiteModel): Intent {
             val intent = Intent(context, PostsListActivity::class.java)
             intent.putExtra(WordPress.SITE, site)
-            return buildIntent(context, site, false)
+            return buildIntent(context, site, PostListType.PUBLISHED, false)
         }
 
         @JvmStatic
-        fun buildIntent(context: Context, site: SiteModel, actionsShownByDefault: Boolean): Intent {
+        fun buildIntent(
+            context: Context,
+            site: SiteModel,
+            postListType: PostListType,
+            actionsShownByDefault: Boolean
+        ): Intent {
             val intent = Intent(context, PostsListActivity::class.java)
             intent.putExtra(WordPress.SITE, site)
             intent.putExtra(ACTIONS_SHOWN_BY_DEFAULT, actionsShownByDefault)
+            intent.putExtra(TAB_INDEX, postListType.ordinal)
             return intent
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.push.NotificationPushIds.REMINDER_NOTIFICATION_ID
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker
+import org.wordpress.android.ui.posts.PostListType
 import org.wordpress.android.ui.posts.PostsListActivity
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.viewmodel.ContextProvider
@@ -34,7 +35,12 @@ class ReminderNotifier @Inject constructor(
                     PendingIntent.getActivity(
                             context,
                             REMINDER_NOTIFICATION_ID + siteId,
-                            PostsListActivity.buildIntent(context, site, actionsShownByDefault = true),
+                            PostsListActivity.buildIntent(
+                                    context,
+                                    site,
+                                    PostListType.DRAFTS,
+                                    actionsShownByDefault = true
+                            ),
                             FLAG_CANCEL_CURRENT
                     )
                 },


### PR DESCRIPTION
Reminder notification should open in DRAFTS tab on Blog Posts screen

Fixes #15039 

<img width=240 src="https://user-images.githubusercontent.com/990349/126100906-e24cf713-4702-4399-b98c-09650b03beb5.png" />


To test:

- Turn on the blogging reminders flag (Me/App settings/Test feature configuration - BloggingRemindersFeatureConfig)
- Notice the blogging reminders option appears (My Site > Settings > Blogging reminders)
- Click on button under Blogging goals setting
- Click on "Set goals" on bottomsheet
- Select a day/s for blogging when screen is shown, then ensure "Update" button is enabled
- Click on "Update" button
- Clicking Done button on next screen
- Wait for the selected day, verify that notifications appear for all the sites that have been setup for reminders
- **Click on a notification**
- **It should open Blog Posts screen in DRAFTS tab with a bottom sheet and add new actions**


## Regression Notes
1. Potential unintended areas of impact
Post list actions

2. What I did to test those areas of impact (or what existing automated tests I relied on)
NA

3. What automated tests I added (or what prevented me from doing so)
Unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
