### PR TITLE
[Editor] Enable inserter block search

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -23,6 +23,7 @@
 -----
 * [***] Block editor: New Block: Embed block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3727]
 * [*] Added webp image format support [https://github.com/wordpress-mobile/WordPress-Android/pull/15068]
+* [***] Block Editor: Add Inserter Block Seach [https://github.com/WordPress/gutenberg/pull/33237]
 
 17.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 18.2
 -----
-
+* [***] Block Editor: Add Inserter Block Search [https://github.com/WordPress/gutenberg/pull/33237]
 
 18.1
 -----
@@ -23,7 +23,6 @@
 -----
 * [***] Block editor: New Block: Embed block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3727]
 * [*] Added webp image format support [https://github.com/wordpress-mobile/WordPress-Android/pull/15068]
-* [***] Block Editor: Add Inserter Block Seach [https://github.com/WordPress/gutenberg/pull/33237]
 
 17.8
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3867-1909b642a6aecf6f0e26d5981ecdce7ee705d2cd'
+    ext.gutenbergMobileVersion = '3867-4e6e3138367c6330109c254766516411d7ac678c'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3867-c246fa5349593751a1a2a89d7e5d6e72dc024594'
+    ext.gutenbergMobileVersion = '3867-1909b642a6aecf6f0e26d5981ecdce7ee705d2cd'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3735-b03454acc519c83b34ae68183693c3eef28ea43d'
+    ext.gutenbergMobileVersion = '3735-e472472d123ec2beb432db077ee4094a7e460bee'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3735-13d890193e936b96907b8bf22890d5fe9986167a'
+    ext.gutenbergMobileVersion = '3867-c246fa5349593751a1a2a89d7e5d6e72dc024594'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.60.0'
+    ext.gutenbergMobileVersion = '3735-b03454acc519c83b34ae68183693c3eef28ea43d'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3867-4e6e3138367c6330109c254766516411d7ac678c'
+    ext.gutenbergMobileVersion = '3867-737b365957b963cb446bc5fda823187a3278168a'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3867-737b365957b963cb446bc5fda823187a3278168a'
+    ext.gutenbergMobileVersion = '3867-d3ec1a77064a90acabcf1781ee419702ff1d8d8e'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3735-e472472d123ec2beb432db077ee4094a7e460bee'
+    ext.gutenbergMobileVersion = '3735-13d890193e936b96907b8bf22890d5fe9986167a'
 
     repositories {
         maven {


### PR DESCRIPTION
Enables inserter block search in the editor 
See https://github.com/wordpress-mobile/gutenberg-mobile/pull/3867

To test:
See https://github.com/wordpress-mobile/gutenberg-mobile/pull/3867

## Regression Notes
1. Potential unintended areas of impact 
Editor: Block Inserter Menu


2. What I did to test those areas of impact (or what existing automated tests I relied on)
See https://github.com/wordpress-mobile/gutenberg-mobile/pull/3867


3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
