### PR TITLE
Reader: Show ellipse for posts with long titles

### DIFF
--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -148,6 +148,8 @@
             android:paddingTop="@dimen/margin_extra_large"
             android:includeFontPadding="false"
             android:textAlignment="viewStart"
+            android:ellipsize="end"
+            android:maxLines="3"
             app:layout_constraintStart_toStartOf="@id/guideline_beginning"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintBottom_toTopOf="@+id/text_excerpt"

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -148,8 +148,6 @@
             android:paddingTop="@dimen/margin_extra_large"
             android:includeFontPadding="false"
             android:textAlignment="viewStart"
-            android:ellipsize="end"
-            android:maxLines="3"
             app:layout_constraintStart_toStartOf="@id/guideline_beginning"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintBottom_toTopOf="@+id/text_excerpt"

--- a/WordPress/src/main/res/layout/reader_cardview_xpost.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_xpost.xml
@@ -53,8 +53,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_extra_large"
-            android:ellipsize="end"
-            android:maxLines="3"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/image_avatar"

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -82,6 +82,7 @@
         <item name="android:fontFamily">serif</item>
         <item name="android:lineSpacingMultiplier">1.2</item>
         <item name="android:includeFontPadding">false</item>
+        <item name="android:ellipsize">end</item>
     </style>
 
     <style name="ReaderTextView.Post.Excerpt" parent="ReaderTextView">

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -70,6 +70,7 @@
         <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
         <item name="android:lineSpacingMultiplier">1.3</item>
         <item name="android:textStyle">bold</item>
+        <item name="android:ellipsize">end</item>
         <item name="android:maxLines">3</item>
         <item name="android:fontFamily">serif</item>
         <item name="android:alpha">@dimen/material_emphasis_high_type</item>
@@ -82,7 +83,6 @@
         <item name="android:fontFamily">serif</item>
         <item name="android:lineSpacingMultiplier">1.2</item>
         <item name="android:includeFontPadding">false</item>
-        <item name="android:ellipsize">end</item>
     </style>
 
     <style name="ReaderTextView.Post.Excerpt" parent="ReaderTextView">


### PR DESCRIPTION
Fixes #15031

This PR adds the following attributes to support long post titles:
 Reader Post Card title:  `maxLines=3` and `ellipsize=end`
 Reader Post Detail title: `ellipsize=end`  **NOTE**: maxLines is preexisting and set to 5

Reader Post | Reader Post Detail
-- | --
<img width="250" height="500" alt="Reader Post" src="https://user-images.githubusercontent.com/506707/126370875-e4671e8d-9aec-4044-b03c-c1e5115c3c9f.png"> | <img width="250" height="500" alt="Reader Post Detail" src="https://user-images.githubusercontent.com/506707/126370919-6b123027-fcfa-46d5-92b7-0f15e0adf8d2.png">


**To test:**
Prep: Create a post with a long title (longer than 5 lines) OR follow https://kirbyatomicbusinesssite.wpcomstaging.com
- Navigate to Reader
- Tap Follow tab
- Filter to site with long post title (prep step)
- Note that the title is maxed at three lines and has an ellipse at the end
- Tap on the long title post to open the post detail view
- Note that the title is maxes at five lines and has an ellipse at the end

## Regression Notes
1. Potential unintended areas of impact 🍏 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
Visually tested long and short titles in posts
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
