### PR TITLE
Onboarding Improvements: Ignore the logic for "Never" selection from quick start prompt dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -157,6 +157,7 @@ import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.util.config.OnboardingImprovementsFeatureConfig
 import org.wordpress.android.util.config.UnifiedCommentsListFeatureConfig
 import org.wordpress.android.util.getColorFromAttribute
 import org.wordpress.android.util.image.BlavatarShape.SQUARE
@@ -214,6 +215,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     @Inject lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
     @Inject lateinit var buildConfigWrapper: BuildConfigWrapper
     @Inject lateinit var unifiedCommentsListFeatureConfig: UnifiedCommentsListFeatureConfig
+    @Inject lateinit var onboardingImprovementsFeatureConfig: OnboardingImprovementsFeatureConfig
     @Inject @Named(UI_THREAD) lateinit var uiDispatcher: CoroutineDispatcher
     @Inject @Named(BG_THREAD) lateinit var bgDispatcher: CoroutineDispatcher
     lateinit var uiScope: CoroutineScope
@@ -1316,6 +1318,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     override fun onNeutralClicked(instanceTag: String) {
+        if (onboardingImprovementsFeatureConfig.isEnabled()) return
+
         if (TAG_QUICK_START_DIALOG == instanceTag) {
             AppPrefs.setQuickStartDisabled(true)
             AnalyticsTracker.track(QUICK_START_REQUEST_DIALOG_NEUTRAL_TAPPED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1190,9 +1190,11 @@ public class WPMainActivity extends LocaleAwareActivity implements
     }
 
     private void showQuickStartDialog() {
-        if (AppPrefs.isQuickStartDisabled()
-            || getSelectedSite() == null
-            || !QuickStartUtils.isQuickStartAvailableForTheSite(getSelectedSite())) {
+        if (
+                AppPrefs.isQuickStartDisabled()
+                || getSelectedSite() == null
+                || !QuickStartUtils.isQuickStartAvailableForTheSite(getSelectedSite())
+        ) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1191,7 +1191,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
     private void showQuickStartDialog() {
         if (
-                AppPrefs.isQuickStartDisabled()
+                (AppPrefs.isQuickStartDisabled() && !mOnboardingImprovementsFeatureConfig.isEnabled())
                 || getSelectedSite() == null
                 || !QuickStartUtils.isQuickStartAvailableForTheSite(getSelectedSite())
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
@@ -50,10 +50,14 @@ public class QuickStartReminderReceiver extends BroadcastReceiver {
                 .getSerializable(QuickStartTaskDetails.KEY);
 
         // Failsafes
-        if (quickStartTaskDetails == null || siteLocalId == -1 || AppPrefs.isQuickStartDisabled()
-            || !mQuickStartStore.hasDoneTask(siteLocalId, QuickStartTask.CREATE_SITE)
-            || mQuickStartStore.getQuickStartCompleted(siteLocalId)
-            || mQuickStartStore.hasDoneTask(siteLocalId, quickStartTaskDetails.getTask())) {
+        if (
+                quickStartTaskDetails == null
+                || siteLocalId == -1
+                || AppPrefs.isQuickStartDisabled()
+                || !mQuickStartStore.hasDoneTask(siteLocalId, QuickStartTask.CREATE_SITE)
+                || mQuickStartStore.getQuickStartCompleted(siteLocalId)
+                || mQuickStartStore.hasDoneTask(siteLocalId, quickStartTaskDetails.getTask())
+        ) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.main.MySiteFragment;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
 import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.util.config.OnboardingImprovementsFeatureConfig;
 
 import javax.inject.Inject;
 
@@ -33,6 +34,7 @@ public class QuickStartReminderReceiver extends BroadcastReceiver {
 
     @Inject QuickStartStore mQuickStartStore;
     @Inject SystemNotificationsTracker mSystemNotificationsTracker;
+    @Inject OnboardingImprovementsFeatureConfig mOnboardingImprovementsFeatureConfig;
 
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -53,7 +55,7 @@ public class QuickStartReminderReceiver extends BroadcastReceiver {
         if (
                 quickStartTaskDetails == null
                 || siteLocalId == -1
-                || AppPrefs.isQuickStartDisabled()
+                || (AppPrefs.isQuickStartDisabled() && !mOnboardingImprovementsFeatureConfig.isEnabled())
                 || !mQuickStartStore.hasDoneTask(siteLocalId, QuickStartTask.CREATE_SITE)
                 || mQuickStartStore.getQuickStartCompleted(siteLocalId)
                 || mQuickStartStore.hasDoneTask(siteLocalId, quickStartTaskDetails.getTask())


### PR DESCRIPTION
Parent Issue #14991

This PR ignores the "Never" selection from the quick start prompt dialog when the `onboardingImprovementsFeatureConfig`  is enabled.

**To Test**

Original Dialog

1. Launch the app with OnboardingImprovementsFeatureConfig unset.
2. Create a new site using the menu option in the "My Site" tab -> Site Picker.
3. Notice that the old quick start prompt is shown.
4. Click the Never option.
5. Create another site.
6. Notice that the quick start prompt is not shown.

Updated Dialog

1. Without clearing the app storage, go to My Site -> Me profile -> App Setiings -> Test feature configuration.
2. Enable `OnboardingImprovementsFeatureConfig` and restart app.
3. Create a new site using the menu option in the "My Site" -> Site Picker.
4. Notice that the new quick start prompt dialog is shown ignoring the never selection done earlier.

**Merge instructions**

1. Since this PR is built on top of another unmerged PR #15048, wait till that PR is merged.
2. Remove "Not Ready fo Merge" label.
3. Merge the PR.

## Regression Notes
1. Potential unintended areas of impact
Changes have minimal impact.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
See "To Test" section

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
