### PR TITLE
Adds full url to the release note for GSS

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 17.9
 -----
-* [*] Enables Support for Global Style Colors with Full Site Editing Themes [#15002]
+* [*] Enables Support for Global Style Colors with Full Site Editing Themes [https://github.com/wordpress-mobile/WordPress-Android/pull/15002]
 
 17.8
 -----


### PR DESCRIPTION
## Description
Updates the release note added with https://github.com/wordpress-mobile/WordPress-Android/pull/15050 to include the full url

To test:
Verify that the release not is the expected

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
