### PR TITLE
Adds back GSS build flag and disables the feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 17.9
 -----
-* [*] Enables Support for Global Style Colors with Full Site Editing Themes [#15002]
+
 
 17.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 17.9
 -----
-* [*] Enables Support for Global Style Colors with Full Site Editing Themes [https://github.com/wordpress-mobile/WordPress-Android/pull/15002]
+* [*] Enables Support for Global Style Colors with Full Site Editing Themes [#15002]
 
 17.8
 -----

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -106,6 +106,7 @@ android {
         buildConfigField "boolean", "MP4_COMPOSER_VIDEO_OPTIMIZATION", "false"
         buildConfigField "boolean", "BLOGGING_REMINDERS", "false"
         buildConfigField "boolean", "MANAGE_CATEGORIES", "false"
+        buildConfigField "boolean", "GLOBAL_STYLE_SUPPORT", "false"
         buildConfigField "boolean", "ONBOARDING_IMPROVEMENTS", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -213,6 +213,7 @@ import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSou
 import org.wordpress.android.util.config.ContactInfoBlockFeatureConfig;
 import org.wordpress.android.util.config.LayoutGridBlockFeatureConfig;
 import org.wordpress.android.util.crashlogging.CrashLoggingExtKt;
+import org.wordpress.android.util.config.GlobalStyleSupportFeatureConfig;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.android.util.image.ImageManager;
@@ -411,6 +412,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     @Inject StoriesEventListener mStoriesEventListener;
     @Inject ContactInfoBlockFeatureConfig mContactInfoBlockFeatureConfig;
     @Inject UpdateFeaturedImageUseCase mUpdateFeaturedImageUseCase;
+    @Inject GlobalStyleSupportFeatureConfig mGlobalStyleSupportFeatureConfig;
     @Inject LayoutGridBlockFeatureConfig mLayoutGridBlockFeatureConfig;
 
     private StorePostViewModel mViewModel;
@@ -3612,7 +3614,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     private void refreshEditorTheme() {
-        FetchEditorThemePayload payload = new FetchEditorThemePayload(mSite);
+        FetchEditorThemePayload payload =
+                new FetchEditorThemePayload(mSite, mGlobalStyleSupportFeatureConfig.isEnabled());
         mDispatcher.dispatch(EditorThemeActionBuilder.newFetchEditorThemeAction(payload));
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/config/GlobalStyleSupportFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/GlobalStyleSupportFeatureConfig.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.BuildConfig.GLOBAL_STYLE_SUPPORT
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration of the Global Style Support
+ */
+@FeatureInDevelopment
+class GlobalStyleSupportFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.GLOBAL_STYLE_SUPPORT)

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'aef844716b62b74f5f0ec8a66007e074366b1f4f'
+    fluxCVersion = '1.22.0-beta-5'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.22.0-beta-4'
+    fluxCVersion = 'aef844716b62b74f5f0ec8a66007e074366b1f4f'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
### Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2068

## Description
This PR reverts the changes applied with https://github.com/wordpress-mobile/WordPress-Android/pull/15050 and disables Global Style Settings feature by default.
This is a temporary change to unblock `1.58` [gutenberg-mobile ](https://github.com/wordpress-mobile/WordPress-Android/pull/15054#issuecomment-884923645)release.

## To test:
Verify that [this reported issue](https://github.com/wordpress-mobile/WordPress-Android/pull/15054#issuecomment-884923645) does not occur with the APK from this PR.
⚠️ Note: Please uninstall the any previous version of the app that exhibited the bug to avoid getting cached data

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
