### PR TITLE
Add Create Site notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1275,11 +1275,17 @@ public class ActivityLauncher {
         // If we just wanted to have WPMainActivity in the back stack after starting SiteCreationActivity, we could have
         // used a TaskStackBuilder to do so. However, since we want to handle the SiteCreationActivity result in
         // WPMainActivity, we must start it this way.
-        final Intent intent = new Intent(activity, WPMainActivity.class);
+        final Intent intent = createMainActivityAndSiteCreationActivityIntent(activity);
+        activity.startActivity(intent);
+    }
+
+    @NonNull
+    public static Intent createMainActivityAndSiteCreationActivityIntent(Context context) {
+        final Intent intent = new Intent(context, WPMainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
         intent.putExtra(WPMainActivity.ARG_SHOW_SITE_CREATION, true);
-        activity.startActivity(intent);
+        return intent;
     }
 
     public static void showSignInForResult(Activity activity) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -141,6 +141,7 @@ import org.wordpress.android.viewmodel.main.WPMainActivityViewModel.FocusPointIn
 import org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel;
 import org.wordpress.android.widgets.AppRatingDialog;
 import org.wordpress.android.widgets.WPDialogSnackbar;
+import org.wordpress.android.workers.CreateSiteNotificationScheduler;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -232,6 +233,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Inject QuickStartRepository mQuickStartRepository;
     @Inject QuickStartUtilsWrapper mQuickStartUtilsWrapper;
     @Inject AnalyticsTrackerWrapper mAnalyticsTrackerWrapper;
+    @Inject CreateSiteNotificationScheduler mCreateSiteNotificationScheduler;
 
     /*
      * fragments implement this if their contents can be scrolled, called when user
@@ -405,6 +407,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (canShowAppRatingPrompt) {
             AppRatingDialog.INSTANCE.showRateDialogIfNeeded(getFragmentManager());
         }
+
+        mCreateSiteNotificationScheduler.scheduleCreateSiteNotification();
 
         initViewModel();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -408,7 +408,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
             AppRatingDialog.INSTANCE.showRateDialogIfNeeded(getFragmentManager());
         }
 
-        mCreateSiteNotificationScheduler.scheduleCreateSiteNotification();
+        mCreateSiteNotificationScheduler.scheduleCreateSiteNotificationIfNeeded();
 
         initViewModel();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -157,7 +157,8 @@ public class AppPrefs {
         SITE_JETPACK_CAPABILITIES,
         REMOVED_QUICK_START_CARD_TYPE,
         PINNED_DYNAMIC_CARD,
-        BLOGGING_REMINDERS_SHOWN
+        BLOGGING_REMINDERS_SHOWN,
+        SHOULD_SCHEDULE_CREATE_SITE_NOTIFICATION
     }
 
     /**
@@ -1253,6 +1254,14 @@ public class AppPrefs {
 
     @NonNull private static String getBloggingRemindersConfigKey(int siteId) {
         return DeletablePrefKey.BLOGGING_REMINDERS_SHOWN.name() + siteId;
+    }
+
+    public static void setShouldScheduleCreateSiteNotification(boolean shouldSchedule) {
+        setBoolean(DeletablePrefKey.SHOULD_SCHEDULE_CREATE_SITE_NOTIFICATION, shouldSchedule);
+    }
+
+    public static boolean shouldScheduleCreateSiteNotification() {
+        return getBoolean(DeletablePrefKey.SHOULD_SCHEDULE_CREATE_SITE_NOTIFICATION, true);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -77,6 +77,10 @@ class AppPrefsWrapper @Inject constructor() {
         get() = AppPrefs.shouldShowStoriesIntro()
         set(shouldShow) = AppPrefs.setShouldShowStoriesIntro(shouldShow)
 
+    var shouldScheduleCreateSiteNotification: Boolean
+        get() = AppPrefs.shouldScheduleCreateSiteNotification()
+        set(shouldSchedule) = AppPrefs.setShouldScheduleCreateSiteNotification(shouldSchedule)
+
     fun getAppWidgetSiteId(appWidgetId: Int) = AppPrefs.getStatsWidgetSelectedSiteId(appWidgetId)
     fun setAppWidgetSiteId(siteId: Long, appWidgetId: Int) = AppPrefs.setStatsWidgetSelectedSiteId(siteId, appWidgetId)
     fun removeAppWidgetSiteId(appWidgetId: Int) = AppPrefs.removeStatsWidgetSelectedSiteId(appWidgetId)

--- a/WordPress/src/main/java/org/wordpress/android/workers/CreateSiteNotificationHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/CreateSiteNotificationHandler.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.ActivityLauncher
 import javax.inject.Inject
 
 class CreateSiteNotificationHandler @Inject constructor(
@@ -15,6 +16,6 @@ class CreateSiteNotificationHandler @Inject constructor(
     }
 
     override fun buildIntent(context: Context): Intent {
-        return Intent() // TODO: Replace this with respective intent in ActivityLauncher
+        return ActivityLauncher.createMainActivityAndSiteCreationActivityIntent(context)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/workers/CreateSiteNotificationScheduler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/CreateSiteNotificationScheduler.kt
@@ -1,26 +1,36 @@
 package org.wordpress.android.workers
 
 import org.wordpress.android.R
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.workers.LocalNotification.Type.CREATE_SITE
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 class CreateSiteNotificationScheduler
 @Inject constructor(
-    private val localNotificationScheduler: LocalNotificationScheduler
+    private val localNotificationScheduler: LocalNotificationScheduler,
+    private val createSiteNotificationHandler: CreateSiteNotificationHandler,
+    private val appsPrefs: AppPrefsWrapper
 ) {
     fun scheduleCreateSiteNotification() {
-        val createSiteNotification = LocalNotification(
-                type = CREATE_SITE,
-                delay = 10,
-                delayUnits = TimeUnit.SECONDS,
-                title = R.string.create_site_notification_title,
-                text = R.string.create_site_notification_text,
-                icon = R.drawable.ic_wordpress_white_24dp,
-                actionIcon = -1,
-                actionTitle = R.string.create_site_notification_create_site_action
-        )
-        localNotificationScheduler.scheduleOneTimeNotification(createSiteNotification)
+        if (createSiteNotificationHandler.shouldShowNotification() && appsPrefs.shouldScheduleCreateSiteNotification) {
+            val firstNotification = LocalNotification(
+                    type = CREATE_SITE,
+                    delay = 1, // 1 day from now
+                    delayUnits = TimeUnit.DAYS,
+                    title = R.string.create_site_notification_title,
+                    text = R.string.create_site_notification_text,
+                    icon = R.drawable.ic_wordpress_white_24dp,
+                    actionIcon = -1,
+                    actionTitle = R.string.create_site_notification_create_site_action
+            )
+            val secondNotification = firstNotification.copy(
+                    delay = 8 // 1 week after first notification
+            )
+            localNotificationScheduler.scheduleOneTimeNotification(firstNotification, secondNotification)
+
+            appsPrefs.shouldScheduleCreateSiteNotification = false
+        }
     }
 
     fun cancelCreateSiteNotification() {

--- a/WordPress/src/main/java/org/wordpress/android/workers/CreateSiteNotificationScheduler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/CreateSiteNotificationScheduler.kt
@@ -12,7 +12,7 @@ class CreateSiteNotificationScheduler
     private val createSiteNotificationHandler: CreateSiteNotificationHandler,
     private val appsPrefs: AppPrefsWrapper
 ) {
-    fun scheduleCreateSiteNotification() {
+    fun scheduleCreateSiteNotificationIfNeeded() {
         if (createSiteNotificationHandler.shouldShowNotification() && appsPrefs.shouldScheduleCreateSiteNotification) {
             val firstNotification = LocalNotification(
                     type = CREATE_SITE,

--- a/WordPress/src/main/java/org/wordpress/android/workers/CreateSiteNotificationScheduler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/CreateSiteNotificationScheduler.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.workers
+
+import org.wordpress.android.R
+import org.wordpress.android.workers.LocalNotification.Type.CREATE_SITE
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+class CreateSiteNotificationScheduler
+@Inject constructor(
+    private val localNotificationScheduler: LocalNotificationScheduler
+) {
+    fun scheduleCreateSiteNotification() {
+        val createSiteNotification = LocalNotification(
+                type = CREATE_SITE,
+                delay = 10,
+                delayUnits = TimeUnit.SECONDS,
+                title = R.string.create_site_notification_title,
+                text = R.string.create_site_notification_text,
+                icon = R.drawable.ic_wordpress_white_24dp,
+                actionIcon = -1,
+                actionTitle = R.string.create_site_notification_create_site_action
+        )
+        localNotificationScheduler.scheduleOneTimeNotification(createSiteNotification)
+    }
+
+    fun cancelCreateSiteNotification() {
+        localNotificationScheduler.cancelScheduledNotification(CREATE_SITE)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationScheduler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationScheduler.kt
@@ -8,29 +8,18 @@ import org.wordpress.android.workers.LocalNotification.Type
 import javax.inject.Inject
 
 class LocalNotificationScheduler @Inject constructor(
-    private val contextProvider: ContextProvider,
-    private val localNotificationHandlerFactory: LocalNotificationHandlerFactory
+    private val contextProvider: ContextProvider
 ) {
     private val workManager = WorkManager.getInstance(contextProvider.getContext())
-    
-    fun scheduleOneTimeNotification(localNotification: LocalNotification): Boolean {
-        val localPushHandler = localNotificationHandlerFactory.buildLocalNotificationHandler(localNotification.type)
-        if (localPushHandler.shouldShowNotification()) {
-            val work = OneTimeWorkRequestBuilder<LocalNotificationWorker>()
-                    .setInitialDelay(localNotification.delay, localNotification.delayUnits)
-                    .addTag(localNotification.type.tag)
-                    .setInputData(
-                            LocalNotificationWorker.buildData(
-                                    localNotification
-                            )
-                    )
-                    .build()
 
-            workManager.enqueue(work)
-            return true
-        } else {
-            return false
-        }
+    fun scheduleOneTimeNotification(localNotification: LocalNotification) {
+        val work = OneTimeWorkRequestBuilder<LocalNotificationWorker>()
+                .setInitialDelay(localNotification.delay, localNotification.delayUnits)
+                .addTag(localNotification.type.tag)
+                .setInputData(LocalNotificationWorker.buildData(localNotification))
+                .build()
+
+        workManager.enqueue(work)
     }
 
     fun cancelScheduledNotification(notificationType: Type) {

--- a/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationScheduler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationScheduler.kt
@@ -9,17 +9,18 @@ import javax.inject.Inject
 class LocalNotificationScheduler(private val workManager: WorkManager) {
     @Inject constructor(context: Context) : this(WorkManager.getInstance(context))
 
-    fun scheduleOneTimeNotification(localNotification: LocalNotification) {
-        val work = OneTimeWorkRequestBuilder<LocalNotificationWorker>()
-                .setInitialDelay(localNotification.delay, localNotification.delayUnits)
-                .addTag(localNotification.type.tag)
-                .setInputData(LocalNotificationWorker.buildData(localNotification))
-                .build()
-
-        workManager.enqueue(work)
+    fun scheduleOneTimeNotification(vararg localNotifications: LocalNotification) {
+        workManager.enqueue(localNotifications.map { buildOneTimeWorkRequest(it) })
     }
 
     fun cancelScheduledNotification(notificationType: Type) {
         workManager.cancelAllWorkByTag(notificationType.tag)
     }
+
+    private fun buildOneTimeWorkRequest(localNotification: LocalNotification) =
+            OneTimeWorkRequestBuilder<LocalNotificationWorker>()
+                    .setInitialDelay(localNotification.delay, localNotification.delayUnits)
+                    .addTag(localNotification.type.tag)
+                    .setInputData(LocalNotificationWorker.buildData(localNotification))
+                    .build()
 }

--- a/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationScheduler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationScheduler.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.workers
 
-import androidx.core.app.NotificationManagerCompat
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import org.wordpress.android.viewmodel.ContextProvider
@@ -8,7 +7,7 @@ import org.wordpress.android.workers.LocalNotification.Type
 import javax.inject.Inject
 
 class LocalNotificationScheduler @Inject constructor(
-    private val contextProvider: ContextProvider
+    contextProvider: ContextProvider
 ) {
     private val workManager = WorkManager.getInstance(contextProvider.getContext())
 
@@ -24,13 +23,5 @@ class LocalNotificationScheduler @Inject constructor(
 
     fun cancelScheduledNotification(notificationType: Type) {
         workManager.cancelAllWorkByTag(notificationType.tag)
-    }
-
-    fun cancelNotification(pushId: Int) {
-        if (pushId != -1) {
-            with(NotificationManagerCompat.from(contextProvider.getContext())) {
-                cancel(pushId)
-            }
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationScheduler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationScheduler.kt
@@ -1,15 +1,13 @@
 package org.wordpress.android.workers
 
+import android.content.Context
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
-import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.workers.LocalNotification.Type
 import javax.inject.Inject
 
-class LocalNotificationScheduler @Inject constructor(
-    contextProvider: ContextProvider
-) {
-    private val workManager = WorkManager.getInstance(contextProvider.getContext())
+class LocalNotificationScheduler(private val workManager: WorkManager) {
+    @Inject constructor(context: Context) : this(WorkManager.getInstance(context))
 
     fun scheduleOneTimeNotification(localNotification: LocalNotification) {
         val work = OneTimeWorkRequestBuilder<LocalNotificationWorker>()

--- a/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationScheduler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationScheduler.kt
@@ -11,6 +11,8 @@ class LocalNotificationScheduler @Inject constructor(
     private val contextProvider: ContextProvider,
     private val localNotificationHandlerFactory: LocalNotificationHandlerFactory
 ) {
+    private val workManager = WorkManager.getInstance(contextProvider.getContext())
+    
     fun scheduleOneTimeNotification(localNotification: LocalNotification): Boolean {
         val localPushHandler = localNotificationHandlerFactory.buildLocalNotificationHandler(localNotification.type)
         if (localPushHandler.shouldShowNotification()) {
@@ -24,9 +26,7 @@ class LocalNotificationScheduler @Inject constructor(
                     )
                     .build()
 
-            WorkManager.getInstance(contextProvider.getContext()).enqueue(
-                    work
-            )
+            workManager.enqueue(work)
             return true
         } else {
             return false
@@ -34,7 +34,7 @@ class LocalNotificationScheduler @Inject constructor(
     }
 
     fun cancelScheduledNotification(notificationType: Type) {
-        WorkManager.getInstance(contextProvider.getContext()).cancelAllWorkByTag(notificationType.tag)
+        workManager.cancelAllWorkByTag(notificationType.tag)
     }
 
     fun cancelNotification(pushId: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationWorker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationWorker.kt
@@ -21,10 +21,9 @@ class LocalNotificationWorker(
 ) : CoroutineWorker(context, params) {
     override suspend fun doWork(): Result {
         val id = inputData.getInt(ID, -1)
-        if (id == -1) return Result.failure()
+        val type = Type.fromTag(inputData.getString(TYPE))
 
-        val typeTag = inputData.getString(TYPE)
-        val type = Type.fromTag(typeTag) ?: return Result.failure()
+        if (id == -1 || type == null) return Result.failure()
 
         val localNotificationHandler = localNotificationHandlerFactory.buildLocalNotificationHandler(type)
         if (localNotificationHandler.shouldShowNotification()) {

--- a/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationWorker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationWorker.kt
@@ -19,7 +19,6 @@ class LocalNotificationWorker(
     params: WorkerParameters,
     private val localNotificationHandlerFactory: LocalNotificationHandlerFactory
 ) : CoroutineWorker(context, params) {
-    @Suppress("TooGenericExceptionCaught")
     override suspend fun doWork(): Result {
         val id = inputData.getInt(ID, -1)
         if (id == -1) return Result.failure()

--- a/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationWorker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/LocalNotificationWorker.kt
@@ -22,11 +22,14 @@ class LocalNotificationWorker(
     @Suppress("TooGenericExceptionCaught")
     override suspend fun doWork(): Result {
         val id = inputData.getInt(ID, -1)
-
         if (id == -1) return Result.failure()
 
-        with(NotificationManagerCompat.from(context)) {
-            notify(id, localNotificationBuilder().build())
+        val typeTag = inputData.getString(TYPE)
+        val type = Type.fromTag(typeTag) ?: return Result.failure()
+
+        val localNotificationHandler = localNotificationHandlerFactory.buildLocalNotificationHandler(type)
+        if (localNotificationHandler.shouldShowNotification()) {
+            NotificationManagerCompat.from(context).notify(id, localNotificationBuilder().build())
         }
 
         return Result.success()

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3696,4 +3696,9 @@
     <string name="stats_disabled_subtitle">Enable site stats to see detailed information about your traffic, likes, comments, and subscribers.</string>
     <string name="stats_disabled_enable_stats_button">Enable site stats</string>
     <string name="stats_disabled_enable_stats_error_message">Unable to activate site stats</string>
+
+    <!-- Create Site Notification -->
+    <string name="create_site_notification_title">Create your WordPress website</string>
+    <string name="create_site_notification_text">Get your site up and running in just a few quick steps</string>
+    <string name="create_site_notification_create_site_action">Create site</string>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/workers/CreateSiteNotificationHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/CreateSiteNotificationHandlerTest.kt
@@ -1,40 +1,50 @@
 package org.wordpress.android.workers
 
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 
 @RunWith(MockitoJUnitRunner::class)
 class CreateSiteNotificationHandlerTest {
-    @Mock
-    lateinit var accountStore: AccountStore
-    @Mock
-    lateinit var siteStore: SiteStore
+    private lateinit var createSiteNotificationHandler: CreateSiteNotificationHandler
+
+    private val accountStore: AccountStore = mock()
+    private val siteStore: SiteStore = mock()
 
     @Before
     fun setUp() {
+        createSiteNotificationHandler = CreateSiteNotificationHandler(
+                accountStore,
+                siteStore
+        )
+    }
+
+    @Test
+    fun `should not show notification when the user is logged out`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+
+        assertThat(createSiteNotificationHandler.shouldShowNotification()).isFalse
+    }
+
+    @Test
+    fun `should not show notification when the user has sites`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(siteStore.hasSite()).thenReturn(true)
+
+        assertThat(createSiteNotificationHandler.shouldShowNotification()).isFalse
+    }
+
+    @Test
+    fun `should show notification when the user is logged in and has no sites`() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(siteStore.hasSite()).thenReturn(false)
-    }
 
-    @Test
-    fun verifyShouldShowNotification() {
-        assertThat(accountStore.hasAccessToken() && !siteStore.hasSite()).isTrue
-    }
-
-    @Test
-    fun verifyShouldNotShowNotification() {
-        assertThat(accountStore.hasAccessToken() && siteStore.hasSite()).isFalse
-    }
-
-    @Test
-    fun verifyDoesNotShowNotification() {
-        assertThat(!accountStore.hasAccessToken() && !siteStore.hasSite()).isFalse
+        assertThat(createSiteNotificationHandler.shouldShowNotification()).isTrue
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/workers/CreateSiteNotificationSchedulerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/CreateSiteNotificationSchedulerTest.kt
@@ -1,0 +1,79 @@
+package org.wordpress.android.workers
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.workers.LocalNotification.Type.CREATE_SITE
+
+@RunWith(MockitoJUnitRunner::class)
+class CreateSiteNotificationSchedulerTest {
+    private lateinit var createSiteNotificationScheduler: CreateSiteNotificationScheduler
+
+    private val localNotificationScheduler: LocalNotificationScheduler = mock()
+    private val createSiteNotificationHandler: CreateSiteNotificationHandler = mock()
+    private val appsPrefs: AppPrefsWrapper = mock()
+
+    @Before
+    fun setUp() {
+        createSiteNotificationScheduler = CreateSiteNotificationScheduler(
+                localNotificationScheduler,
+                createSiteNotificationHandler,
+                appsPrefs
+        )
+    }
+
+    @Test
+    fun `notification isn't scheduled when shouldShowNotification is false`() {
+        whenever(createSiteNotificationHandler.shouldShowNotification()).thenReturn(false)
+
+        createSiteNotificationScheduler.scheduleCreateSiteNotificationIfNeeded()
+
+        verifyZeroInteractions(localNotificationScheduler)
+        verifyZeroInteractions(appsPrefs)
+    }
+
+    @Test
+    fun `notification isn't scheduled when shouldScheduleCreateSiteNotification is false`() {
+        whenever(createSiteNotificationHandler.shouldShowNotification()).thenReturn(true)
+        whenever(appsPrefs.shouldScheduleCreateSiteNotification).thenReturn(false)
+
+        createSiteNotificationScheduler.scheduleCreateSiteNotificationIfNeeded()
+
+        verifyZeroInteractions(localNotificationScheduler)
+        verify(appsPrefs, never()).shouldScheduleCreateSiteNotification = any()
+    }
+
+    @Test
+    fun `notifications are scheduled when shouldShowNotification and shouldScheduleCreateSiteNotification are true`() {
+        whenever(createSiteNotificationHandler.shouldShowNotification()).thenReturn(true)
+        whenever(appsPrefs.shouldScheduleCreateSiteNotification).thenReturn(true)
+
+        createSiteNotificationScheduler.scheduleCreateSiteNotificationIfNeeded()
+
+        argumentCaptor<LocalNotification>().apply {
+            verify(localNotificationScheduler).scheduleOneTimeNotification(capture(), capture())
+
+            assertThat(firstValue.delay).isEqualTo(1)
+            assertThat(secondValue.delay).isEqualTo(8)
+            assertThat(allValues).allMatch { it.type == CREATE_SITE }
+        }
+        verify(appsPrefs).shouldScheduleCreateSiteNotification = false
+    }
+
+    @Test
+    fun `cancel calls LocalNotificationScheduler with correct type`() {
+        createSiteNotificationScheduler.cancelCreateSiteNotification()
+        verify(localNotificationScheduler).cancelScheduledNotification(argThat { this == CREATE_SITE })
+    }
+}


### PR DESCRIPTION
Fixes #14639

This PR builds on top of the work done in #14681 and #14691 to implement the remaining parts of the Create Site notification. I think the changes are pretty straightforward, but let me know if you have any questions.

A few improvements were made to make sure we stick to the following requirements:

1. The notification is only scheduled when the user is logged in and doesn't have any sites.
1. Once it's scheduled, two notifications are shown. The first one is shown a day after the user opened the app and the second one a week after the first.
1. If the user creates a site or logs out after the notification has been scheduled, the notification isn't shown.

In the future, it would be good to combine the implementation here with the one we used for Blogging Reminders.

### To test

Run the new unit tests. Additionally:

#### 1. Notification is scheduled

1. Clear app data.
1. Login with an account that **doesn't have any sites**.
1. Notice the main screen.
1. On `logcat`, notice a message like this, indicating both notifications were scheduled:

```
WM-SystemJobScheduler: Scheduling work ID 1182934f-f3fc-41f1-954a-43cd9eb3f626 Job ID 1
WM-SystemJobScheduler: Scheduling work ID aa8ae790-4fc1-497e-b4db-62141fa94ddd Job ID 2
```

5. Close the app and open it again.
6. Make sure you **don't see** any new scheduling message on `logcat`.

#### 2. Notification is not scheduled

1. Clear app data.
1. Login with an account that **has at least one site**.
1. Notice the main screen.
1. On `logcat`, make sure you **don't see** any scheduling message.

#### 3. Notification is shown

To test if the notification is shown, I recommend changing the following line from `DAYS` to `MINUTES`.

https://github.com/wordpress-mobile/WordPress-Android/blob/6e70206072d0eb7a300b6267713d29c29b21595a/WordPress/src/main/java/org/wordpress/android/workers/CreateSiteNotificationScheduler.kt#L20

1. Clear app data and run the steps from test 1.
1. Verify that both notifications appear after the initial delay.
1. After the notifications are shown, click on them.
1. Notice the site creation flow.
1. On `logcat`, make sure you **don't see** any scheduling message.

#### 4. Notification is not shown

1. Clear app data and run the steps from test 1.
1. Logout from the app or create a new site.
1. Verify that the notifications **don't appear** after the initial delay.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
Unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
