### PR TITLE
Jetpack Screenshot Test Updates

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.screenshots;
 
 import android.provider.Settings;
 
+import androidx.test.espresso.DataInteraction;
+import androidx.test.espresso.ViewInteraction;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import androidx.test.rule.ActivityTestRule;
@@ -20,15 +22,19 @@ import org.wordpress.android.support.BaseTest;
 import org.wordpress.android.support.DemoModeEnabler;
 import org.wordpress.android.ui.WPLaunchActivity;
 
+import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
+import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.is;
+import static org.wordpress.android.support.WPSupportUtils.childAtPosition;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 import static org.wordpress.android.support.WPSupportUtils.getCurrentActivity;
 import static org.wordpress.android.support.WPSupportUtils.idleFor;
@@ -113,14 +119,24 @@ public class JPScreenshotTest extends BaseTest {
     private void navigateBackupDownload() {
         moveToBackup();
 
-        onView(withId(R.id.log_list_view))
-                .check(matches(hasDescendant(withText(containsString("plugins"))))).perform(click());
+        ViewInteraction appCompatImageButton = onView(
+                allOf(withId(R.id.action_button), withContentDescription("Activity Log action button"),
+                        childAtPosition(
+                                allOf(withId(R.id.activity_content_container),
+                                        childAtPosition(
+                                                withId(R.id.log_list_view),
+                                                1)),
+                                1),
+                        isDisplayed()));
+        appCompatImageButton.perform(click());
 
-        waitForElementToBeDisplayedWithoutFailure(R.id.activityDownloadBackupButton);
+        DataInteraction linearLayout = onData(anything())
+                .inAdapterView(childAtPosition(
+                        withClassName(is("android.widget.PopupWindow$PopupBackgroundView")),
+                        0))
+                .atPosition(1);
+        linearLayout.perform(click());
 
-        if (isElementDisplayed(R.id.activityDownloadBackupButton)) {
-            clickOn(R.id.activityDownloadBackupButton);
-        }
 
         setNightModeAndWait(false);
         takeScreenshot("4-back-up-your-site-at-any-moment");

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/activity/wpcom_v2_site_activity.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/activity/wpcom_v2_site_activity.json
@@ -170,7 +170,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{fnow offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -213,7 +213,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{fnow offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -259,7 +259,7 @@
               "role": "administrator"
             },
             "type": "Update",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{fnow offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -317,7 +317,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{fnow offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -376,7 +376,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{fnow offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -428,7 +428,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{fnow offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -476,7 +476,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{fnow offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -531,7 +531,7 @@
               "role": "administrator"
             },
             "type": "Join",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{fnow offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -560,7 +560,7 @@
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{fnow offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -590,7 +590,7 @@
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -620,7 +620,7 @@
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{fnow offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -673,7 +673,7 @@
               "role": ""
             },
             "type": "Update",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{fnow offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -706,7 +706,7 @@
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
+            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/activity/wpcom_v2_site_activity.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/activity/wpcom_v2_site_activity.json
@@ -38,7 +38,7 @@
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "2021-05-06T06:23:10.798+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -79,7 +79,7 @@
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "2021-05-06T06:23:05.356+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -120,7 +120,7 @@
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "2021-05-06T06:22:58.776+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -170,7 +170,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "2021-05-05T15:59:23.139+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -213,7 +213,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "2021-05-05T14:52:03.207+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -259,7 +259,7 @@
               "role": "administrator"
             },
             "type": "Update",
-            "published": "2021-05-05T14:52:03.207+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -317,7 +317,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "2021-05-05T14:51:27.222+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -376,7 +376,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "2021-05-05T14:51:27.222+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -428,7 +428,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "2021-05-05T14:51:27.222+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -476,7 +476,7 @@
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "2021-05-05T14:51:16.865+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -531,7 +531,7 @@
               "role": "administrator"
             },
             "type": "Join",
-            "published": "2021-05-05T14:50:55.428+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -560,7 +560,7 @@
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "2021-05-05T13:58:59.141+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -590,7 +590,7 @@
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "2021-05-05T13:58:32.797+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -620,7 +620,7 @@
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "2021-05-05T13:58:02.881+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -673,7 +673,7 @@
               "role": ""
             },
             "type": "Update",
-            "published": "2021-05-05T14:26:16.327+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945
@@ -706,7 +706,7 @@
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "2021-05-05T13:55:44.830+00:00",
+            "published": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
             "generator": {
               "jetpack_version": 9.7,
               "blog_id": 185124945

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/scan/wpcom_v2_sites_185124945_scan.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/scan/wpcom_v2_sites_185124945_scan.json
@@ -16,7 +16,7 @@
       }],
       "most_recent": {
         "is_initial": false,
-        "timestamp": "2021-05-18T06:20:06+00:00",
+        "timestamp": "{{fnow format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
         "duration": 17,
         "progress": 100,
         "error": false


### PR DESCRIPTION
Parent #14633

This PR updates the following:
- Changes the interaction of the Backup Download test within `JPScreenshotTest`
- Updates `wpcom_v2_site_activity.json` and `wpcom_v2_sites_185124945_scan.json` mocks to use dynamic dates

NOTE: These changes were extracted from the fastlane Screenshots PR #14744, as I am going to streamline that PR in prep to handover to P9 for directory/file name restructuring.

**To test:**
- Check out this branch (you can not use the APK)
- Change the build variant to a Jetpack debug variant
- Build the app
- Run JPScreenshotTest.jPScreenshotTest
Results: 1 test should pass

## Regression Notes
1. Potential unintended areas of impact
  JPScreenshot Connected tests
2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Ran JPSreenshotTest manually
3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
