### PR TITLE
Fix crash when initializing `PagesActivity` from upload notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -128,7 +128,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
                 }
             }
             initializeViews(nonNullActivity)
-            initializeViewModels(nonNullActivity, savedInstanceState)
+            initializeViewModelObservers(nonNullActivity, savedInstanceState)
         }
     }
 
@@ -283,7 +283,10 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         })
     }
 
-    private fun PagesFragmentBinding.initializeViewModels(activity: FragmentActivity, savedInstanceState: Bundle?) {
+    private fun PagesFragmentBinding.initializeViewModelObservers(
+        activity: FragmentActivity,
+        savedInstanceState: Bundle?
+    ) {
         setupObservers(activity)
         setupActions(activity)
         setupMlpObservers(activity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -106,13 +106,18 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
+
+        val nonNullActivity = requireActivity()
+        (nonNullActivity.application as? WordPress)?.component()?.inject(this)
+
+        viewModel = ViewModelProvider(nonNullActivity, viewModelFactory).get(PagesViewModel::class.java)
+        mlpViewModel = ViewModelProvider(nonNullActivity, viewModelFactory).get(ModalLayoutPickerViewModel::class.java)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val nonNullActivity = requireActivity()
-        (nonNullActivity.application as? WordPress)?.component()?.inject(this)
         with(PagesFragmentBinding.bind(view)) {
             binding = this
             with(nonNullActivity as AppCompatActivity) {
@@ -279,9 +284,6 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
     }
 
     private fun PagesFragmentBinding.initializeViewModels(activity: FragmentActivity, savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(activity, viewModelFactory).get(PagesViewModel::class.java)
-        mlpViewModel = ViewModelProvider(activity, viewModelFactory).get(ModalLayoutPickerViewModel::class.java)
-
         setupObservers(activity)
         setupActions(activity)
         setupMlpObservers(activity)


### PR DESCRIPTION
Fixes #15015

When the Pages screen is opened from the notification shown after a successful page upload, we call the `PagesFragment::onSpecificPageRequested` method, which was calling the `ViewModel` before it had been initialized. This PR moves that logic to `onCreate` and renames the method where it was before, to indicate the `ViewModel`s are not being initialized there anymore.

To test:

1. Open the app.
1. On the My Site screen, tap "Pages".
1. On the Pages screen, tap the FAB.
1. Select a layout for the page and tap "Create Page".
1. On the Editor, wait until the page is loaded and tap "Publish".
1. On the bottom sheet, tap "Publish now".
1. Press back until you have exited the app. (In my experience, this has to be done really quickly!)
1. Notice a notification indicating the page upload status.
1. Notice a second notification indicating the page was uploaded successfully.
1. Tap the notification.
1. Notice the Pages screen is opened again, without crashing.

Note: If you don't see the second notification, try exiting the app faster. It won't show up if the app is in the foreground.

## Regression Notes
1. Potential unintended areas of impact
Nothing that I can of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
None, since this is happening at the Activity/Fragment level.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
