### PR TITLE
Enable webp format image

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 17.9
 -----
 * [***] Block editor: New Block: Embed block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3727]
+* [*] Added webp image format support [https://github.com/wordpress-mobile/WordPress-Android/pull/15068]
 
 17.8
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_coroutines_version = '1.3.9'
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
-    ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
+    ext.wordPressUtilsVersion = 'e65ea637'
     ext.wordPressLoginVersion = 'develop-5007ecf737918be639e1d80ff2c6e07fd73f64cf'
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.58.0'
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.22.0-beta-5'
+    fluxCVersion = '3aacdea9'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_coroutines_version = '1.3.9'
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
-    ext.wordPressUtilsVersion = '89-e65ea63707ba04d7719d35b6f02bd65ad4757994'
+    ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = 'develop-5007ecf737918be639e1d80ff2c6e07fd73f64cf'
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.58.0'
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '3aacdea9'
+    fluxCVersion = '1.22.0-beta-6'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_coroutines_version = '1.3.9'
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
-    ext.wordPressUtilsVersion = 'e65ea637'
+    ext.wordPressUtilsVersion = '89-e65ea63707ba04d7719d35b6f02bd65ad4757994'
     ext.wordPressLoginVersion = 'develop-5007ecf737918be639e1d80ff2c6e07fd73f64cf'
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.58.0'


### PR DESCRIPTION
Fixes #2885

This PR enables `webp` format image display and upload in the WPAndroid app.

**Related PRs**

FluxC: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2070
WordPress-Utils-Android:  https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/89

**To test**

1. Go to My Site -> Media
2. Click + button to add an image from device
3. Upload a `webp` format image
4. Notice that the image is uploaded without issues
5. Click the image from the media grid
6. Notice that the image loads fine on the file details screen

https://user-images.githubusercontent.com/1405144/126902849-12ce1433-83aa-487a-ab45-b0e10d79a288.mp4

**Merge Instructions**

- Targets 18.0, can be (preferably) merged with 17.9.

- Only 1 reviewer is sufficient.

1. Wait for the corresponding `WordPress-Utils-Android` and `FluxC` PRs to be merged to develop
2. Create FluxC tag 
3. Replace `WordPress-Utils-Android` and `FluxC` tags in `build.gradle`
4. Wait for release notes to be updated
5. Remove `Not Ready for Merge` label
6. Merge the PR

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
