### PR TITLE
Onboarding Improvements: Epilogue Screen Create New Site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.LocaleAwareActivity;
+import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.CloseWithResultOk;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.CreateNewSite;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.SelectSite;
@@ -121,7 +122,7 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
     }
 
     private void createNewSite() {
-        // TODO: Trigger create new site action.
+        ActivityLauncher.newBlogForResult(this);
     }
 
     private void closeWithResultOk() {
@@ -143,5 +144,18 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
         }
         fragmentTransaction.replace(R.id.fragment_container, fragment, tag);
         fragmentTransaction.commit();
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == RequestCodes.CREATE_SITE
+            && resultCode == RESULT_OK
+            && data != null
+        ) {
+            int newSiteLocalID = data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1);
+            setResult(RESULT_OK, new Intent().putExtra(SitePickerActivity.KEY_LOCAL_ID, newSiteLocalID));
+            finish();
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -88,6 +88,11 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
     }
 
     @Override
+    public void onCreateNewSite() {
+        // TODO: Trigger view model call.
+    }
+
+    @Override
     public void onConnectAnotherSite() {
         if (mAccountStore.hasAccessToken()) {
             ActivityLauncher.addSelfHostedSiteForResult(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.CloseWithResultOk;
+import org.wordpress.android.ui.accounts.LoginNavigationEvents.CreateNewSite;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.SelectSite;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowNoJetpackSites;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowPostSignupInterstitialScreen;
@@ -68,6 +69,8 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
                 showPostSignupInterstitialScreen();
             } else if (loginEvent instanceof SelectSite) {
                 selectSite(((SelectSite) loginEvent).getLocalId());
+            } else if (loginEvent instanceof CreateNewSite) {
+                createNewSite();
             } else if (loginEvent instanceof CloseWithResultOk) {
                 closeWithResultOk();
             } else if (loginEvent instanceof ShowNoJetpackSites) {
@@ -89,7 +92,7 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
 
     @Override
     public void onCreateNewSite() {
-        // TODO: Trigger view model call.
+        mViewModel.onCreateNewSite();
     }
 
     @Override
@@ -115,6 +118,10 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
     private void selectSite(int localId) {
         setResult(RESULT_OK, new Intent().putExtra(SitePickerActivity.KEY_LOCAL_ID, localId));
         finish();
+    }
+
+    private void createNewSite() {
+        // TODO: Trigger create new site action.
     }
 
     private void closeWithResultOk() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
@@ -23,7 +23,7 @@ class LoginEpilogueViewModel @Inject constructor(
     }
 
     fun onCreateNewSite() {
-        // TODO: Post navigation event.
+        _navigationEvents.postValue(Event(LoginNavigationEvents.CreateNewSite))
     }
 
     fun onContinue() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
@@ -22,6 +22,10 @@ class LoginEpilogueViewModel @Inject constructor(
         _navigationEvents.postValue(Event(LoginNavigationEvents.SelectSite(localId)))
     }
 
+    fun onCreateNewSite() {
+        // TODO: Post navigation event.
+    }
+
     fun onContinue() {
         if (!siteStore.hasSite()) handleNoSitesFound() else handleSitesFound()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginNavigationEvents.kt
@@ -9,6 +9,7 @@ sealed class LoginNavigationEvents {
     data class ShowInstructions(val url: String = INSTRUCTIONS_URL) : LoginNavigationEvents()
     object ShowPostSignupInterstitialScreen : LoginNavigationEvents()
     data class SelectSite(val localId: Int) : LoginNavigationEvents()
+    object CreateNewSite : LoginNavigationEvents()
     object CloseWithResultOk : LoginNavigationEvents()
     object ShowEmailLoginScreen : LoginNavigationEvents()
     object ShowLoginViaSiteAddressScreen : LoginNavigationEvents()

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -131,7 +131,11 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         button.setOnClickListener(v -> {
             mUnifiedLoginTracker.trackClick(Click.CONTINUE);
             if (mLoginEpilogueListener != null) {
-                mLoginEpilogueListener.onContinue();
+                if (mOnboardingImprovementsFeatureConfig.isEnabled()) {
+                    mLoginEpilogueListener.onCreateNewSite();
+                } else {
+                    mLoginEpilogueListener.onContinue();
+                }
             }
         });
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueListener.java
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.accounts.login;
 public interface LoginEpilogueListener {
     void onSiteClick(int localId);
 
+    void onCreateNewSite();
+
     void onConnectAnotherSite();
 
     void onContinue();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1151,8 +1151,10 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 }
                 break;
             case RequestCodes.LOGIN_EPILOGUE:
-                setSite(data);
-                showQuickStartDialog();
+                if (resultCode == RESULT_OK) {
+                    setSite(data);
+                    showQuickStartDialog();
+                }
                 break;
             case RequestCodes.SITE_PICKER:
                 if (getMySiteFragment() != null) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
@@ -34,6 +34,15 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
         assertThat(navigationEvent.localId).isEqualTo(localId)
     }
 
+    @Test
+    fun `when create new site is triggered, then launch create new site flow`() {
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onCreateNewSite()
+
+        assertThat(navigationEvents.first()).isInstanceOf(LoginNavigationEvents.CreateNewSite::class.java)
+    }
+
     /* WordPress app - Post Signup Interstitial Screen */
     @Test
     fun `given wp app with no sites, when continued from epilogue first time, then signup interstitial shown`() {


### PR DESCRIPTION
Parent #14990

This PR enabled creating a new site from within the newly designed `Login Epilogue` screen.

NOTE:  Dismissing the `Your site has been created!` screen, instead of clicking the `OK` button shows the previous underlying screen (instead of the expected My Site screen). This is expected and working exactly as is with the `Site Picker` screen as well. A nice to have task was added to the parent issue which will aim to deal with that, if the ends up being decided as important to have.

-----

To test:
1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Enable the `OnboardingImprovementsFeatureConfig` feature flag.
3. Log-out and log-in to the app again.
4. When on the `Login Epilogue` screen, click on the `Create New Site` button.
5. Make sure the `Choose a design` site creation screen is shown.
6. Pick a design, click preview or skip and in general verify everything works as expected. Then progress with the `Choose a domain`
7. Pick a name for your site and create a site. The `Your site has been created!` screen will be shown. Click `OK`. Note, you can also dismiss this screen, but it will navigate you back to the `Login Epilogue` screen as per the **NOTE** above.
8. Make sure the new `Quick Start Prompt` is shown.
9. Dismiss, click the `No thanks` or the `Show me around` button and make sure the `My Site` screen is shown with or without showing the `Quick Start` section, with its `Next Steps` and all, according to your action.

-----

## Regression Notes
1. Potential unintended areas of impact

The `Site Creation` flow might not work as expected when that flow is triggered from within the `Login Epilogue` screen and based on the base input that it was given.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
