### PR TITLE
Fix reader post details crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -112,8 +112,8 @@ class ReaderPostDetailViewModel @Inject constructor(
     val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
     private val _updateLikesState = MediatorLiveData<GetLikesState>()
-    val likesUiState: LiveData<EngagedPeopleListUiState> = _updateLikesState.map {
-        state -> buildLikersUiState(state)
+    val likesUiState: LiveData<EngagedPeopleListUiState> = _updateLikesState.map { state ->
+        buildLikersUiState(state)
     }
 
     /**
@@ -136,6 +136,7 @@ class ReaderPostDetailViewModel @Inject constructor(
             return blogId != post.blogId || postId != post.postId || numLikes != post.numLikes
         }
     }
+
     private var lastRenderedLikesData: RenderedLikesData? = null
 
     private val shouldOfferSignIn: Boolean
@@ -590,19 +591,21 @@ class ReaderPostDetailViewModel @Inject constructor(
 
     fun onLikeFacesClicked() {
         post?.let { readerPost ->
-            _navigationEvents.value = Event(ShowEngagedPeopleList(
-                    readerPost.blogId,
-                    readerPost.postId,
-                    HeaderData(
-                            AuthorNameString(readerPost.authorName),
-                            readerPost.title,
-                            readerPost.postAvatar,
-                            readerPost.authorId,
-                            readerPost.authorBlogId,
-                            readerPost.authorBlogUrl,
-                            lastRenderedLikesData?.numLikes ?: readerPost.numLikes
+            _navigationEvents.value = Event(
+                    ShowEngagedPeopleList(
+                            readerPost.blogId,
+                            readerPost.postId,
+                            HeaderData(
+                                    AuthorNameString(readerPost.authorName),
+                                    readerPost.title,
+                                    readerPost.postAvatar,
+                                    readerPost.authorId,
+                                    readerPost.authorBlogId,
+                                    readerPost.authorBlogUrl,
+                                    lastRenderedLikesData?.numLikes ?: readerPost.numLikes
+                            )
                     )
-            ))
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -246,10 +246,9 @@ class ReaderPostDetailViewModel @Inject constructor(
     }
 
     private suspend fun getOrFetchReaderPost(blogId: Long, postId: Long) {
-        _uiState.value = LoadingUiState
-
         getReaderPostFromDb(blogId = blogId, postId = postId)
         if (post == null) {
+            _uiState.value = LoadingUiState
             when (readerFetchPostUseCase.fetchPost(blogId = blogId, postId = postId, isFeed = isFeed)) {
                 FetchReaderPostState.Success -> {
                     getReaderPostFromDb(blogId, postId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -467,27 +467,31 @@ class ReaderPostDetailViewModel @Inject constructor(
     }
 
     private fun updatePostActions(post: ReaderPost) {
-        _uiState.value = (_uiState.value as? ReaderPostDetailsUiState)?.copy(
-                actions = postDetailUiStateBuilder.buildPostActions(
-                        post,
-                        this@ReaderPostDetailViewModel::onButtonClicked
-                )
-        )
+        (_uiState.value as? ReaderPostDetailsUiState)?.let {
+            _uiState.value = it.copy(
+                    actions = postDetailUiStateBuilder.buildPostActions(
+                            post,
+                            this@ReaderPostDetailViewModel::onButtonClicked
+                    )
+            )
+        }
     }
 
     private fun updateRelatedPostsUiState(sourcePost: ReaderPost, state: FetchRelatedPostsState.Success) {
-        _uiState.value = (_uiState.value as? ReaderPostDetailsUiState)?.copy(
-                localRelatedPosts = convertRelatedPostsToUiState(
-                        sourcePost = sourcePost,
-                        relatedPosts = state.localRelatedPosts,
-                        isGlobal = false
-                ),
-                globalRelatedPosts = convertRelatedPostsToUiState(
-                        sourcePost = sourcePost,
-                        relatedPosts = state.globalRelatedPosts,
-                        isGlobal = true
-                )
-        )
+        (_uiState.value as? ReaderPostDetailsUiState)?.let {
+            _uiState.value = it.copy(
+                    localRelatedPosts = convertRelatedPostsToUiState(
+                            sourcePost = sourcePost,
+                            relatedPosts = state.localRelatedPosts,
+                            isGlobal = false
+                    ),
+                    globalRelatedPosts = convertRelatedPostsToUiState(
+                            sourcePost = sourcePost,
+                            relatedPosts = state.globalRelatedPosts,
+                            isGlobal = true
+                    )
+            )
+        }
     }
 
     private fun trackAndUpdateNotAuthorisedErrorState() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -238,14 +238,14 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
 
     /* SHOW POST - LOADING */
     @Test
-    fun `when show post is triggered, then loading state is shown`() = test {
-        val observers = init(showPost = false)
-        whenever(readerGetPostUseCase.get(anyLong(), anyLong(), anyBoolean())).thenReturn(Pair(readerPost, false))
+    fun `given local post not found, when show post is triggered, then loading state is shown`() =
+            testWithoutLocalPost {
+                val observers = init(showPost = false)
 
-        viewModel.onShowPost(blogId = readerPost.blogId, postId = readerPost.postId)
+                viewModel.onShowPost(blogId = readerPost.blogId, postId = readerPost.postId)
 
-        assertThat(observers.uiStates.first()).isEqualTo(LoadingUiState)
-    }
+                assertThat(observers.uiStates.first()).isEqualTo(LoadingUiState)
+            }
 
     /* SHOW POST - GET LOCAL POST */
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -247,6 +247,16 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
                 assertThat(observers.uiStates.first()).isEqualTo(LoadingUiState)
             }
 
+    @Test
+    fun `given local post found, when show post is triggered, then loading state is not shown`() = test {
+        val observers = init(showPost = false)
+        whenever(readerGetPostUseCase.get(anyLong(), anyLong(), anyBoolean())).thenReturn(Pair(readerPost, false))
+
+        viewModel.onShowPost(blogId = readerPost.blogId, postId = readerPost.postId)
+
+        assertThat(observers.uiStates.first()).isNotInstanceOf(LoadingUiState::class.java)
+    }
+
     /* SHOW POST - GET LOCAL POST */
     @Test
     fun `given local post is found, when show post is triggered, then ui is updated`() = test {


### PR DESCRIPTION
Fixes #15070

I was sometimes able to reproduce this crash on the Reader post details screen on rotating the device.

### Observations

`_uiState.value` is sometimes set to `LoadingUiState` when checked inside `updateRelatedPostsUiState`.
In this case,  `(_uiState.value as? ReaderPostDetailsUiState)` converts to null and `_uiState` is updated with a null value causing a crash in the `initViewModel$1.onChanged` where it is not expected to be null. 

   ```
   E: _uiState.value: 
   org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel$UiState$LoadingUiState@eed3862
   E: FATAL EXCEPTION: main
    Process: org.wordpress.android.prealpha, PID: 8564
    java.lang.NullPointerException: Attempt to invoke virtual method 'boolean org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel$UiState.getErrorVisible()' on a null object reference
        at org.wordpress.android.ui.reader.ReaderPostDetailFragment$initViewModel$1.onChanged(ReaderPostDetailFragment.kt:443)
        at org.wordpress.android.ui.reader.ReaderPostDetailFragment$initViewModel$1.onChanged(ReaderPostDetailFragment.kt:133)
        at androidx.lifecycle.LiveData.considerNotify(LiveData.java:133)
        at androidx.lifecycle.LiveData.dispatchingValue(LiveData.java:151)
        at androidx.lifecycle.LiveData.setValue(LiveData.java:309)
        at androidx.lifecycle.MutableLiveData.setValue(MutableLiveData.java:50)
        at org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.updateRelatedPostsUiState(ReaderPostDetailViewModel.kt:483)
   ```

### Solution

As `onRelatedPostsRequested` is called [only when the post is available in the VM](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt#L1282-L1287), `_uiState` is now updated with `LoadingUiState` only when the post is fetched from the server and not when the post exists in the DB (see 3aeee11) so that the above scenario doesn't happen.

Also, in 08e4395, `_uiState` is updated only when the current UI state is `ReaderPostDetailsUiState` inside `updateRelatedPostsUiState` and `updatePostActions` as related posts and actions UI should be displayed only when the selected post is available and already laid on the screen. If UI is in any other state at this time, it should be an invalid state and the UI should not be updated.

### Merge Notes

I'm a bit surprised why this issue started appearing in `17.7-rc-2`, considering refactoring for reader post details was done in a much earlier release `17.0`. Considering rising numbers in Sentry, targeting `release/17.9` as a beta fix.

### To test

1. Go to Reader. 
2. Tap a reader post.
3. Rotate the device 2-3 times.
4. Go back and repeat steps 2, 3 for few more random posts.
5. Note that the app doesn't crash.

## Regression Notes
1. Potential unintended areas of impact
None, changes have minimal impact. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
NA

3. What automated tests I added (or what prevented me from doing so)
Updated existing UI tests for the loading state.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.