### PR TITLE
Add content description to FAB

### DIFF
--- a/WordPress/src/main/res/layout/media_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/media_picker_fragment.xml
@@ -13,6 +13,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
         android:layout_margin="@dimen/fab_margin"
+        android:contentDescription="@string/photo_picker_camera_desc"
         android:src="@drawable/ic_photo_camera_24px"
         android:visibility="gone"
         tools:ignore="InconsistentLayout" />

--- a/WordPress/src/main/res/layout/photo_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/photo_picker_fragment.xml
@@ -12,11 +12,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
-        android:visibility="gone"
-        android:src="@drawable/ic_photo_camera_24px"
-        android:layout_marginEnd="@dimen/fab_margin"
         android:layout_marginBottom="@dimen/fab_margin_stories"
-        tools:ignore="InconsistentLayout"/>
+        android:layout_marginEnd="@dimen/fab_margin"
+        android:contentDescription="@string/photo_picker_camera_desc"
+        android:src="@drawable/ic_photo_camera_24px"
+        android:visibility="gone"
+        tools:ignore="InconsistentLayout" />
 
     <RelativeLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Parent #15077 

This PR fixes lint error by adding content description to:
`media_picker_fragment.xml`
`photo_picker_fragment.xml`

For more details see: paqN3M-mc

To test:
- Open your device's Settings app.
- Navigate to Accessibility and select TalkBack.
- At the top of the TalkBack screen, press On/Off to turn on TalkBack.
- In the confirmation dialog, select OK to confirm permissions.
- Navigate to stories and tap the FAB
- Listen for the content description 'Open Camera'
- Navigate to media picker and tap the FAB
- Listen for the content description 'Open Camera'

## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 
3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
