### PR TITLE
Fix featured image landscape mode display on Pixel 5

### DIFF
--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -165,7 +165,7 @@
     <!-- reader more menu spacer height -->
     <dimen name="reader_more_menu_spacer_height">16dp</dimen>
     <!-- collapsing toolbar scrim visible height trigger -->
-    <dimen name="scrim_visible_height_trigger">150dp</dimen>
+    <dimen name="scrim_visible_height_trigger">130dp</dimen>
 
     <item name="expandable_chips_view_chip_alpha" format="float" type="dimen">
         @dimen/emphasis_extra_extra_low


### PR DESCRIPTION
Fixes #15084

To test:

Prerequisite: Pixel5 device

1. Go to Reader.
2. Tap a post with a featured image.
3. Rotate the device to landscape mode.
4. Notice that the featured image is visible.


![device-2021-07-28-120059](https://user-images.githubusercontent.com/1405144/127274936-92181768-1045-4d89-8f0e-c0e7f87bbc8f.png)


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
