### PR TITLE
Update need help message copy for quick start prompt

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2881,7 +2881,7 @@
 
     <!-- Quick Start Promo Dialog (New) -->
     <string name="quick_start_dialog_need_help_manage_site_title">Want a little help managing this site with the app?</string>
-    <string name="quick_start_dialog_need_help_manage_site_message">We\'ll walk you through the basics of managing your site with the app.</string>
+    <string name="quick_start_dialog_need_help_manage_site_message">Learn the basics with a quick walkthrough.</string>
     <string name="quick_start_dialog_need_help_manage_site_button_positive">Show me around</string>
     <string name="quick_start_dialog_need_help_manage_site_button_negative" translatable="false">@string/quick_start_dialog_need_help_button_negative</string>
 


### PR DESCRIPTION
Fixes #15081

To test:

Since the changes are very simple, it is sufficient to just compare the updated message in the `strings.xml` with the one provided in the linked task. 


![copy_update](https://user-images.githubusercontent.com/1405144/127278407-62a5e60c-1b6e-4648-9f70-5ce3894411e8.png)


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
