### PR TITLE
Onboarding Improvements: Epilogue Screen Alternative Flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1332,11 +1332,11 @@ public class ActivityLauncher {
         }
     }
 
-    public static void showLoginEpilogueForResult(Activity activity, boolean showAndReturn,
+    public static void showLoginEpilogueForResult(Activity activity,
                                                   ArrayList<Integer> oldSitesIds, boolean doLoginUpdate) {
         Intent intent = new Intent(activity, LoginEpilogueActivity.class);
         intent.putExtra(LoginEpilogueActivity.EXTRA_DO_LOGIN_UPDATE, doLoginUpdate);
-        intent.putExtra(LoginEpilogueActivity.EXTRA_SHOW_AND_RETURN, showAndReturn);
+        intent.putExtra(LoginEpilogueActivity.EXTRA_SHOW_AND_RETURN, true);
         intent.putIntegerArrayListExtra(LoginEpilogueActivity.ARG_OLD_SITES_IDS, oldSitesIds);
         activity.startActivityForResult(intent, RequestCodes.SHOW_LOGIN_EPILOGUE_AND_RETURN);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -324,11 +324,11 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                 finish();
                 break;
             case JETPACK_STATS:
-                ActivityLauncher.showLoginEpilogueForResult(this, true, oldSitesIds, true);
+                ActivityLauncher.showLoginEpilogueForResult(this, oldSitesIds, true);
                 break;
             case WPCOM_LOGIN_DEEPLINK:
             case WPCOM_REAUTHENTICATE:
-                ActivityLauncher.showLoginEpilogueForResult(this, true, oldSitesIds, false);
+                ActivityLauncher.showLoginEpilogueForResult(this, oldSitesIds, false);
                 break;
             case SHARE_INTENT:
             case SELFHOSTED_ONLY:

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -118,7 +118,9 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     }
 
     private boolean isNewLoginEpilogueScreenEnabled() {
-        return mOnboardingImprovementsFeatureConfig.isEnabled() && !mBuildConfigWrapper.isJetpackApp();
+        return mOnboardingImprovementsFeatureConfig.isEnabled()
+               && !mBuildConfigWrapper.isJetpackApp()
+               && !mShowAndReturn;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -188,7 +188,8 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
                 headerHandler(),
                 footerHandler(),
                 mOldSitesIds,
-                SitePickerMode.DEFAULT_MODE
+                SitePickerMode.DEFAULT_MODE,
+                mShowAndReturn
         );
         setOnSiteClickListener();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -464,14 +464,17 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     private boolean isValidPosition(int position) {
-        if (mOnboardingImprovementsFeatureConfig.isEnabled()
-            && !mBuildConfigWrapper.isJetpackApp()
-            && !mShowAndReturn
-        ) {
+        if (isNewLoginEpilogueScreenEnabled()) {
             return (position >= 0 && position <= mSites.size());
         } else {
             return (position >= 0 && position < mSites.size());
         }
+    }
+
+    private boolean isNewLoginEpilogueScreenEnabled() {
+        return mOnboardingImprovementsFeatureConfig.isEnabled()
+               && !mBuildConfigWrapper.isJetpackApp()
+               && !mShowAndReturn;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -101,6 +101,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private boolean mIsMultiSelectEnabled;
     private final boolean mIsInSearchMode;
     private boolean mShowHiddenSites = false;
+    private final boolean mShowAndReturn;
     private boolean mShowSelfHostedSites = true;
     private String mLastSearch;
     private SiteList mAllSites;
@@ -161,7 +162,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              boolean isInEditMode
     ) {
         this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener,
-                null, null, null, sitePickerMode, isInEditMode);
+                null, null, null, sitePickerMode, isInEditMode, false);
     }
 
     public SitePickerAdapter(Context context,
@@ -174,7 +175,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              @Nullable ArrayList<Integer> ignoreSitesIds
     ) {
         this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener,
-                headerHandler, null, ignoreSitesIds, SitePickerMode.DEFAULT_MODE, false);
+                headerHandler, null, ignoreSitesIds, SitePickerMode.DEFAULT_MODE, false, false);
     }
 
     public SitePickerAdapter(Context context,
@@ -186,10 +187,11 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              @NonNull ViewHolderHandler<?> headerHandler,
                              @Nullable ViewHolderHandler<?> footerHandler,
                              ArrayList<Integer> ignoreSitesIds,
-                             SitePickerMode sitePickerMode
+                             SitePickerMode sitePickerMode,
+                             boolean showAndReturn
     ) {
         this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener,
-                headerHandler, footerHandler, ignoreSitesIds, sitePickerMode, false);
+                headerHandler, footerHandler, ignoreSitesIds, sitePickerMode, false, showAndReturn);
     }
 
     public SitePickerAdapter(Context context,
@@ -202,7 +204,8 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              @Nullable ViewHolderHandler<?> footerHandler,
                              @Nullable ArrayList<Integer> ignoreSitesIds,
                              SitePickerMode sitePickerMode,
-                             boolean isInEditMode
+                             boolean isInEditMode,
+                             boolean showAndReturn
     ) {
         super();
         ((WordPress) context.getApplicationContext()).component().inject(this);
@@ -236,6 +239,8 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mSitePickerMode = sitePickerMode;
 
         mShowHiddenSites = isInEditMode; // If site picker is in edit mode, show hidden sites.
+
+        mShowAndReturn = showAndReturn;
 
         loadSites();
     }
@@ -459,7 +464,10 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     private boolean isValidPosition(int position) {
-        if (mOnboardingImprovementsFeatureConfig.isEnabled() && !mBuildConfigWrapper.isJetpackApp()) {
+        if (mOnboardingImprovementsFeatureConfig.isEnabled()
+            && !mBuildConfigWrapper.isJetpackApp()
+            && !mShowAndReturn
+        ) {
             return (position >= 0 && position <= mSites.size());
         } else {
             return (position >= 0 && position < mSites.size());


### PR DESCRIPTION
Parent #14990

This PR makes sure that the existing `Login Epilogue` screen is show for the `Alternative Flow`*, irrespective of the `Onboarding Improvements` feature flag. As such, below is a table based on which the new `Login Epilogue` screen is to be shown:

(*) Alternative flow == Login mode of `JETPACK_STATS`, `WPCOM_LOGIN_DEEPLINK` or `WPCOM_REAUTHENTICATE`

Flow | Onboarding Improvements Feature Flag | Login Epilogue Screen
-----|-----|-----
Normal | Off | Existing
Normal | On | New
Alternative | Off | Existing
Alternative | On | Existing

-----

To test:

#### Scenario: `Normal Flow - Onboarding Improvements Feature Flag - OFF`
1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Disable the `OnboardingImprovementsFeatureConfig` feature flag.
3. Log-out and log-in to the app again.
4. Make sure the **EXISTING** `Login Epilogue` screen is shown and works as expected.

#### Scenario: `Normal Flow - Onboarding Improvements Feature Flag - ON`
1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Enable the `OnboardingImprovementsFeatureConfig` feature flag.
3. Log-out and log-in to the app again.
4. Make sure the **NEW** `Login Epilogue` screen is shown and works as expected.

#### Scenario: `Alternative Flow - Onboarding Improvements Feature Flag - OFF`
1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Disable the `OnboardingImprovementsFeatureConfig` feature flag.
3. Log-out and log-in to the app again, but this time try to enter through the `JETPACK_STATS`, `WPCOM_LOGIN_DEEPLINK` or `WPCOM_REAUTHENTICATE` login mode.
4. If you can't figure out how to enter through those alternative login modes, you can manually comment out lines `308 to 315` and lines `318 to `325` within the `LoginActivity` class to force the `Login Epilogue` screen to launch for the alternative flow.
5. Make sure the **EXISTING** `Login Epilogue` screen is shown and works as expected.

#### Scenario: `Alternative Flow - Onboarding Improvements Feature Flag - ON`
1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Enable the `OnboardingImprovementsFeatureConfig` feature flag.
3. Log-out and log-in to the app again, but this time try to enter through the `JETPACK_STATS`, `WPCOM_LOGIN_DEEPLINK` or `WPCOM_REAUTHENTICATE` login mode.
4. If you can't figure out how to enter through those alternative login modes, you can manually comment out lines `308 to 315` and lines `318 to `325` within the `LoginActivity` class to force the `Login Epilogue` screen to launch for the alternative flow.
5. Make sure the **EXISTING** `Login Epilogue` screen is shown and works as expected.

-----

## Regression Notes
1. Potential unintended areas of impact

The existing `Login Epilogue` screen might be somehow affected by all the changes in this PR since all 3 screen are sharing all the logic, that is code-wise.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
