### PR TITLE
Issue/uc remove feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -102,7 +102,7 @@ android {
         buildConfigField "boolean", "IS_JETPACK_APP", "false"
         buildConfigField "String", "TRACKS_EVENT_PREFIX", '"wpandroid_"'
         buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"org.wordpress.android"'
-        buildConfigField "boolean", "UNIFIED_COMMENTS_LIST", "true"
+        buildConfigField "boolean", "UNIFIED_COMMENTS_LIST", "false"
         buildConfigField "boolean", "MP4_COMPOSER_VIDEO_OPTIMIZATION", "false"
         buildConfigField "boolean", "BLOGGING_REMINDERS", "false"
         buildConfigField "boolean", "MANAGE_CATEGORIES", "false"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -102,7 +102,7 @@ android {
         buildConfigField "boolean", "IS_JETPACK_APP", "false"
         buildConfigField "String", "TRACKS_EVENT_PREFIX", '"wpandroid_"'
         buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"org.wordpress.android"'
-        buildConfigField "boolean", "UNIFIED_COMMENTS_LIST", "false"
+        buildConfigField "boolean", "UNIFIED_COMMENTS_LIST", "true"
         buildConfigField "boolean", "MP4_COMPOSER_VIDEO_OPTIMIZATION", "false"
         buildConfigField "boolean", "BLOGGING_REMINDERS", "false"
         buildConfigField "boolean", "MANAGE_CATEGORIES", "false"
@@ -165,7 +165,6 @@ android {
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationIdSuffix ".beta"
             dimension "buildType"
-            buildConfigField "boolean", "UNIFIED_COMMENTS_LIST", "true"
         }
 
         jalapeno { // Pre-Alpha version, used for PR builds, can be installed along release, alpha, beta, dev versions

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
@@ -293,16 +293,6 @@ class UnifiedCommentListViewModel @Inject constructor(
                 )
             }
         }
-        //        else {
-//            launch {
-//                _onCommentDetailsRequested.emit(
-//                        SelectedComment(
-//                                comment.remoteCommentId,
-//                                CommentStatus.fromString(comment.status)
-//                        )
-//                )
-//            }
-//        }
     }
 
     fun clearActionModeSelection() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.comments.unified
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.MenuItem
@@ -54,7 +55,11 @@ class UnifiedCommentsActivity : LocaleAwareActivity() {
         }
     }
 
+    // for some reason lint is not happy about VIEW_PAGER_OFFSCREEN_PAGE_LIMIT, even through it's a valid constant
+    @SuppressLint("WrongConstant")
     private fun UnifiedCommentActivityBinding.setupContent() {
+        viewPager.offscreenPageLimit = VIEW_PAGER_OFFSCREEN_PAGE_LIMIT
+
         pagerAdapter = UnifiedCommentListPagerAdapter(commentListFilters, this@UnifiedCommentsActivity)
         viewPager.adapter = pagerAdapter
 
@@ -103,5 +108,9 @@ class UnifiedCommentsActivity : LocaleAwareActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    companion object {
+        private const val VIEW_PAGER_OFFSCREEN_PAGE_LIMIT = 1
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -402,10 +402,11 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         rowBlogPosts.setOnClickListener { viewPosts() }
         rowMedia.setOnClickListener { viewMedia() }
         rowPages.setOnClickListener { viewPages() }
-        rowComments.setOnClickListener { ActivityLauncher.viewCurrentBlogComments(activity, selectedSite) }
-        rowUnifiedComments.setOnClickListener {
+        rowComments.setOnClickListener {
             if (unifiedCommentsListFeatureConfig.isEnabled()) {
                 ActivityLauncher.viewUnifiedComments(activity, selectedSite)
+            } else {
+                ActivityLauncher.viewCurrentBlogComments(activity, selectedSite)
             }
         }
         rowThemes.setOnClickListener {
@@ -607,12 +608,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         selectedSiteRepository.showSiteIconProgressBar.observe(viewLifecycleOwner, {
             showSiteIconProgressBar(it == true)
         })
-
-        rowUnifiedComments.visibility = if (unifiedCommentsListFeatureConfig.isEnabled()) {
-            View.VISIBLE
-        } else {
-            View.GONE
-        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ListItemAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ListItemAction.kt
@@ -17,6 +17,5 @@ enum class ListItemAction {
     STATS,
     MEDIA,
     COMMENTS,
-    UNIFIED_COMMENTS,
     VIEW_SITE
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -55,7 +55,6 @@ import org.wordpress.android.ui.mysite.ListItemAction.SHARING
 import org.wordpress.android.ui.mysite.ListItemAction.SITE_SETTINGS
 import org.wordpress.android.ui.mysite.ListItemAction.STATS
 import org.wordpress.android.ui.mysite.ListItemAction.THEMES
-import org.wordpress.android.ui.mysite.ListItemAction.UNIFIED_COMMENTS
 import org.wordpress.android.ui.mysite.ListItemAction.VIEW_SITE
 import org.wordpress.android.ui.mysite.MySiteItem.DomainRegistrationBlock
 import org.wordpress.android.ui.mysite.MySiteItem.DynamicCard
@@ -254,8 +253,7 @@ class MySiteViewModel
                             scanAvailable,
                             activeTask == QuickStartTask.VIEW_SITE,
                             activeTask == ENABLE_POST_SHARING,
-                            activeTask == EXPLORE_PLANS,
-                            unifiedCommentsListFeatureConfig.isEnabled()
+                            activeTask == EXPLORE_PLANS
                     )
             )
             scrollToQuickStartTaskIfNecessary(
@@ -310,8 +308,13 @@ class MySiteViewModel
                     getStatsNavigationActionForSite(site)
                 }
                 MEDIA -> OpenMedia(site)
-                COMMENTS -> OpenComments(site)
-                UNIFIED_COMMENTS -> OpenUnifiedComments(site)
+                COMMENTS -> {
+                    if (unifiedCommentsListFeatureConfig.isEnabled()) {
+                        OpenUnifiedComments(site)
+                    } else {
+                        OpenComments(site)
+                    }
+                }
                 VIEW_SITE -> {
                     quickStartRepository.completeTask(QuickStartTask.VIEW_SITE)
                     OpenSite(site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteItemsBuilder.kt
@@ -21,8 +21,7 @@ class SiteItemsBuilder
         isScanAvailable: Boolean = false,
         showViewSiteFocusPoint: Boolean = false,
         showEnablePostSharingFocusPoint: Boolean = false,
-        showExplorePlansFocusPoint: Boolean = false,
-        isUnifiedCommentsFeatureEnabled: Boolean = false
+        showExplorePlansFocusPoint: Boolean = false
     ): List<MySiteItem> {
         return listOfNotNull(
                 siteListItemBuilder.buildPlanItemIfAvailable(site, showExplorePlansFocusPoint, onClick),
@@ -52,10 +51,6 @@ class SiteItemsBuilder
                         R.drawable.ic_comment_white_24dp,
                         UiStringRes(R.string.my_site_btn_comments),
                         onClick = ListItemInteraction.create(ListItemAction.COMMENTS, onClick)
-                ),
-                siteListItemBuilder.buildUnifiedCommentsItemIfAvailable(
-                        onClick,
-                        isUnifiedCommentsFeatureEnabled
                 ),
                 siteCategoryItemBuilder.buildLookAndFeelHeaderIfAvailable(site),
                 siteListItemBuilder.buildThemesItemIfAvailable(site, onClick),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
@@ -101,19 +101,6 @@ class SiteListItemBuilder
         } else null
     }
 
-    fun buildUnifiedCommentsItemIfAvailable(
-        onClick: (ListItemAction) -> Unit,
-        isUnifiedCommentsAvailable: Boolean = false
-    ): ListItem? {
-        return if (isUnifiedCommentsAvailable) {
-            ListItem(
-                    R.drawable.ic_comment_white_24dp,
-                    UiStringRes(R.string.my_site_btn_unified_comments),
-                    onClick = ListItemInteraction.create(ListItemAction.UNIFIED_COMMENTS, onClick)
-            )
-        } else null
-    }
-
     fun buildAdminItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (shouldShowWPAdmin(site)) {
             ListItem(

--- a/WordPress/src/main/java/org/wordpress/android/util/config/UnifiedCommentsListFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/UnifiedCommentsListFeatureConfig.kt
@@ -1,17 +1,23 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.UnifiedCommentsListFeatureConfig.Companion.UNIFIED_COMMENTS_LIST_REMOTE_FIELD
 import javax.inject.Inject
 
 /**
- * Configuration of the Unified Comments improvements
+ * Configuration of the Unified Comments list improvements
  */
-@FeatureInDevelopment
+@Feature(UNIFIED_COMMENTS_LIST_REMOTE_FIELD, true)
 class UnifiedCommentsListFeatureConfig
 @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
         appConfig,
-        BuildConfig.UNIFIED_COMMENTS_LIST
-)
+        BuildConfig.UNIFIED_COMMENTS_LIST,
+        UNIFIED_COMMENTS_LIST_REMOTE_FIELD
+) {
+    companion object {
+        const val UNIFIED_COMMENTS_LIST_REMOTE_FIELD = "unified_comment_list_remote_field"
+    }
+}

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -578,24 +578,6 @@
 
                     </LinearLayout>
 
-                    <!--Unified Comments -->
-                    <LinearLayout
-                        android:id="@+id/row_unified_comments"
-                        style="@style/MySiteListRowLayout">
-
-                        <ImageView
-                            android:id="@+id/my_site_unified_comments_icon"
-                            style="@style/MySiteListRowIcon"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_comment_white_24dp" />
-
-                        <org.wordpress.android.widgets.WPTextView
-                            android:id="@+id/my_site_unified_comments_text_view"
-                            style="@style/MySiteListRowTextView"
-                            android:text="@string/my_site_btn_unified_comments" />
-
-                    </LinearLayout>
-
                     <!--Look and Feel-->
                     <org.wordpress.android.widgets.WPTextView
                         android:id="@+id/my_site_look_and_feel_header"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2131,7 +2131,6 @@
     <string name="my_site_btn_sharing">Sharing</string>
     <string name="my_site_btn_site_settings">Settings</string>
     <string name="my_site_btn_comments" translatable="false">@string/comments</string>
-    <string name="my_site_btn_unified_comments" translatable="false">Unified Comments</string>
     <string name="my_site_btn_switch_site">Switch Site</string>
     <string name="my_site_btn_view_admin">View Admin</string>
     <string name="my_site_btn_view_site">View Site</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -914,40 +914,6 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `unified comment menu item is visible, when unifiedCommentsListFeatureConfig is enabled`() = test {
-        whenever(unifiedCommentsListFeatureConfig.isEnabled()).thenReturn(true)
-
-        initSelectedSite()
-
-        verify(siteItemsBuilder).buildSiteItems(
-                site = eq(site),
-                onClick = any(),
-                isBackupAvailable = any(),
-                isScanAvailable = any(),
-                showViewSiteFocusPoint = any(),
-                showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any()
-        )
-    }
-
-    @Test
-    fun `unified comment menu item is NOT visible, when unifiedCommentsListFeatureConfig is disabled`() = test {
-        whenever(unifiedCommentsListFeatureConfig.isEnabled()).thenReturn(false)
-
-        initSelectedSite()
-
-        verify(siteItemsBuilder).buildSiteItems(
-                site = eq(site),
-                onClick = any(),
-                isBackupAvailable = any(),
-                isScanAvailable = any(),
-                showViewSiteFocusPoint = any(),
-                showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any()
-        )
-    }
-
-    @Test
     fun `when no site is selected and screen height is higher than 600 pixels, show empty view image`() {
         whenever(displayUtilsWrapper.getDisplayPixelHeight()).thenReturn(600)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -858,8 +858,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 isScanAvailable = any(),
                 showViewSiteFocusPoint = eq(false),
                 showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any(),
-                isUnifiedCommentsFeatureEnabled = any()
+                showExplorePlansFocusPoint = any()
         )
     }
 
@@ -876,8 +875,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 isScanAvailable = eq(false),
                 showViewSiteFocusPoint = any(),
                 showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any(),
-                isUnifiedCommentsFeatureEnabled = any()
+                showExplorePlansFocusPoint = any()
         )
     }
 
@@ -894,8 +892,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 isScanAvailable = eq(true),
                 showViewSiteFocusPoint = eq(false),
                 showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any(),
-                isUnifiedCommentsFeatureEnabled = any()
+                showExplorePlansFocusPoint = any()
         )
     }
 
@@ -912,8 +909,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 isScanAvailable = any(),
                 showViewSiteFocusPoint = any(),
                 showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any(),
-                isUnifiedCommentsFeatureEnabled = any()
+                showExplorePlansFocusPoint = any()
         )
     }
 
@@ -930,8 +926,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 isScanAvailable = any(),
                 showViewSiteFocusPoint = any(),
                 showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any(),
-                isUnifiedCommentsFeatureEnabled = eq(true)
+                showExplorePlansFocusPoint = any()
         )
     }
 
@@ -948,8 +943,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 isScanAvailable = any(),
                 showViewSiteFocusPoint = any(),
                 showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any(),
-                isUnifiedCommentsFeatureEnabled = eq(false)
+                showExplorePlansFocusPoint = any()
         )
     }
 
@@ -1054,7 +1048,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         doAnswer {
             clickAction = it.getArgument(1)
             listOf<MySiteItem>()
-        }.whenever(siteItemsBuilder).buildSiteItems(eq(site), any(), any(), any(), any(), any(), any(), any())
+        }.whenever(siteItemsBuilder).buildSiteItems(eq(site), any(), any(), any(), any(), any(), any())
 
         initSelectedSite()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemFixtures.kt
@@ -71,11 +71,6 @@ val COMMENTS_ITEM = ListItem(
         UiStringRes(R.string.my_site_btn_comments),
         onClick = ListItemInteraction.create(ListItemAction.COMMENTS, SITE_ITEM_ACTION)
 )
-val UNIFIED_COMMENTS_ITEM = ListItem(
-        R.drawable.ic_comment_white_24dp,
-        UiStringRes(R.string.my_site_btn_unified_comments),
-        onClick = ListItemInteraction.create(ListItemAction.UNIFIED_COMMENTS, SITE_ITEM_ACTION)
-)
 val ADMIN_ITEM = ListItem(
         R.drawable.ic_wordpress_white_24dp,
         UiStringRes(R.string.my_site_btn_view_admin),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemsBuilderTest.kt
@@ -55,8 +55,7 @@ class SiteItemsBuilderTest {
                 addSiteSettingsItem = true,
                 addThemesItem = true,
                 addBackupItem = true,
-                addScanItem = true,
-                addUnifiedComments = true
+                addScanItem = true
         )
 
         val buildSiteItems = siteItemsBuilder.buildSiteItems(siteModel, SITE_ITEM_ACTION)
@@ -74,7 +73,6 @@ class SiteItemsBuilderTest {
                 MEDIA_ITEM,
                 PAGES_ITEM,
                 COMMENTS_ITEM,
-                UNIFIED_COMMENTS_ITEM,
                 LOOK_AND_FEEL_HEADER,
                 THEMES_ITEM,
                 CONFIGURATION_HEADER,
@@ -118,8 +116,7 @@ class SiteItemsBuilderTest {
         addThemesItem: Boolean = false,
         addBackupItem: Boolean = false,
         addScanItem: Boolean = false,
-        showPlansFocusPoint: Boolean = false,
-        addUnifiedComments: Boolean = false
+        showPlansFocusPoint: Boolean = false
     ) {
         if (addJetpackHeader) {
             whenever(siteCategoryItemBuilder.buildJetpackCategoryIfAvailable(siteModel)).thenReturn(
@@ -200,11 +197,6 @@ class SiteItemsBuilderTest {
         if (addThemesItem) {
             whenever(siteListItemBuilder.buildThemesItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
                     THEMES_ITEM
-            )
-        }
-        if (addUnifiedComments) {
-            whenever(siteListItemBuilder.buildUnifiedCommentsItemIfAvailable(SITE_ITEM_ACTION)).thenReturn(
-                    UNIFIED_COMMENTS_ITEM
             )
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteListItemBuilderTest.kt
@@ -430,30 +430,6 @@ class SiteListItemBuilderTest {
         assertThat(item).isNull()
     }
 
-    @Test
-    fun `unified comments item built if the feature flag is enabled`() {
-        val isUnifiedCommentFeatureAvailable = true
-
-        val item = siteListItemBuilder.buildUnifiedCommentsItemIfAvailable(
-                SITE_ITEM_ACTION,
-                isUnifiedCommentFeatureAvailable
-        )
-
-        assertThat(item).isEqualTo(UNIFIED_COMMENTS_ITEM)
-    }
-
-    @Test
-    fun `unified comments item not built if the feature flag is not enabled`() {
-        val isUnifiedCommentFeatureAvailable = false
-
-        val item = siteListItemBuilder.buildUnifiedCommentsItemIfAvailable(
-                SITE_ITEM_ACTION,
-                isUnifiedCommentFeatureAvailable
-        )
-
-        assertThat(item).isNull()
-    }
-
     private fun setupSiteSettings(canManageOptions: Boolean = false, isAccessedViaWPComRest: Boolean = true) {
         whenever(siteModel.hasCapabilityManageOptions).thenReturn(canManageOptions)
         whenever(siteUtilsWrapper.isAccessedViaWPComRest(siteModel)).thenReturn(isAccessedViaWPComRest)


### PR DESCRIPTION
Part of #15101

This PR sets the feature flag for unified comments to ON, and adds remote capabilities.


To test:
- Using the vanilla version open Comments and confirm that you are using Unified Comments.


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
