### PR TITLE
Removes kotlin-gradle-plugin dependency from WordPressEditor

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,13 +1,5 @@
 buildscript {
     ext.aztecVersion = 'v1.3.45'
-
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-    }
 }
 
 repositories {


### PR DESCRIPTION
This PR removes the `kotlin-gradle-plugin` dependency from `WordPressEditor` because it's already added in the root `build.gradle` file. This change fixes the following error while running `./gradlew :WordPress:dependencies`:

```
* Where:
Build file '/Users/leweo/Developer/Projects/WordPress-Android/libs/editor/WordPressEditor/build.gradle' line: 9

* What went wrong:
A problem occurred evaluating project ':libs:editor:WordPressEditor'.
> Cannot change dependencies of dependency configuration ':libs:editor:WordPressEditor:classpath' after it has been resolved.
```

Note that this shouldn't be an issue once we switch to Plugin DSL and we can once again apply the plugin directly in the module if necessary.

**To test:**
* Run `./gradlew :WordPress:dependencies` in current `develop` and verify the above error
* Run the same command in this branch and verify the issue is fixed

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
