### PR TITLE
Update Buildkite Docker image to fix lint task

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 docker-container: &docker-container
   plugins:
     - docker#v3.8.0:
-        image: "public.ecr.aws/m4u4m2y0/android-build-image:latest"
+        image: "public.ecr.aws/automattic/android-build-image:311ab824e9fd33ebb71de83c3fd1c328ea84443b"
         environment:
           - "CI=true"
 


### PR DESCRIPTION
This PR updates the Docker image used for the Buildkite jobs. The new Docker image has some of the dependencies cached, so it doesn't need to download them from remote which fixes the issue with `groovy-all` dependency not being able to be downloaded in current `develop`.

Note that this is a temporary solution. Even if we cache the dependencies in Docker image, which we were planning to test, we probably wouldn't do it in the way I've done it for today. However, the priority right now is to fix the current `develop`, so it doesn't block developers. I'll follow up with this soon.

**To test:**
* Nothing to test, as long as CI is green, we are good to merge this

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
