### PR TITLE
Fluxc from s3

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -450,6 +450,9 @@ dependencies {
 
     implementation ("$gradle.ext.loginFlowBinaryPath:$wordPressLoginVersion") {
         exclude group: "com.github.wordpress-mobile.WordPress-FluxC-Android", module: "fluxc"
+        exclude group: "org.wordpress", module: "fluxc"
+        exclude group: "org.wordpress.fluxc"
+        exclude group: "org.wordpress.fluxc.plugins"
         exclude group: 'com.github.bumptech.glide'
         exclude group: 'org.wordpress', module: 'utils'
     }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -17,6 +17,7 @@ repositories {
         url "https://a8c-libs.s3.amazonaws.com/android"
         content {
             includeGroup "org.wordpress"
+            includeGroup "org.wordpress.fluxc"
             includeGroup "org.wordpress-mobile.gutenberg-mobile"
         }
     }
@@ -426,7 +427,7 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
-    implementation("$gradle.ext.fluxCBinaryPath:fluxc:$fluxCVersion") {
+    implementation("$gradle.ext.fluxCBinaryPath:$fluxCVersion") {
         exclude group: "com.android.volley"
         exclude group: 'org.wordpress', module: 'utils'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '2083-0712ed7d457e7a34c2d9d1951e95cf6ee3170c52'
+    fluxCVersion = 'develop-0193e64889a94b44c507c6aba5b83ce0fc96bc61'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '2083-327d81ba2b334df14e3ee0862956b7b77af16d11'
+    fluxCVersion = '2083-0712ed7d457e7a34c2d9d1951e95cf6ee3170c52'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.22.0'
+    fluxCVersion = '2083-327d81ba2b334df14e3ee0862956b7b77af16d11'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ include ':libs:WordPressAnnotations'
 include ':WordPressMocks'
 project(':WordPressMocks').projectDir = new File(rootProject.projectDir, properties.getOrDefault('wp.wordpress_mocks_path', 'libs/mocks') + '/WordPressMocks')
 
-gradle.ext.fluxCBinaryPath = "com.github.wordpress-mobile.WordPress-FluxC-Android"
+gradle.ext.fluxCBinaryPath = "org.wordpress:fluxc"
 gradle.ext.wputilsBinaryPath = "org.wordpress:utils"
 gradle.ext.gutenbergMobileBinaryPath = "org.wordpress-mobile.gutenberg-mobile:react-native-gutenberg-bridge"
 gradle.ext.loginFlowBinaryPath = "org.wordpress:login"
@@ -45,7 +45,7 @@ if (localBuilds.exists()) {
         includeBuild(ext.localFluxCPath) {
             dependencySubstitution {
                 println "Substituting fluxc with the local build"
-                substitute module("$gradle.ext.fluxCBinaryPath:fluxc") with project(':fluxc')
+                substitute module("$gradle.ext.fluxCBinaryPath") with project(':fluxc')
             }
         }
     }


### PR DESCRIPTION
Updates FluxC dependency to be fetched from S3: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2083

Note that fluxc version needs to be updated before this can be merged.

**To test:**
* Smoke test the app
* Verify that composite build works for FluxC

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
