### PR TITLE
Onboarding Improvements: Fix E2E UI Tests

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -36,7 +36,7 @@ public class LoginTests extends BaseTest {
         new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword(E2E_WP_COM_USER_PASSWORD)
-                       .confirmLogin();
+                       .confirmLogin(false);
     }
 
     @Test
@@ -44,7 +44,7 @@ public class LoginTests extends BaseTest {
         new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress(E2E_WP_COM_PASSWORDLESS_USER_EMAIL)
                        .openMagicLink(mMagicLinkActivityTestRule)
-                       .confirmLogin();
+                       .confirmLogin(false);
     }
 
     @Test
@@ -53,7 +53,7 @@ public class LoginTests extends BaseTest {
                        .enterSiteAddress(E2E_WP_COM_USER_SITE_ADDRESS)
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword(E2E_WP_COM_USER_PASSWORD)
-                       .confirmLogin();
+                       .confirmLogin(false);
     }
 
     @Test
@@ -62,7 +62,7 @@ public class LoginTests extends BaseTest {
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .chooseMagicLink()
                        .openMagicLink(mMagicLinkActivityTestRule)
-                       .confirmLogin();
+                       .confirmLogin(false);
     }
 
     @Test
@@ -70,7 +70,7 @@ public class LoginTests extends BaseTest {
         new LoginFlow().chooseEnterYourSiteAddress()
                        .enterSiteAddress(E2E_SELF_HOSTED_USER_SITE_ADDRESS)
                        .enterUsernameAndPassword(E2E_SELF_HOSTED_USER_USERNAME, E2E_SELF_HOSTED_USER_PASSWORD)
-                       .confirmLogin();
+                       .confirmLogin(true);
     }
 
     @After

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -115,7 +115,7 @@ public class BaseTest {
         new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword(E2E_WP_COM_USER_PASSWORD)
-                       .confirmLogin();
+                       .confirmLogin(false);
     }
 
     private void wpLogout() {


### PR DESCRIPTION
Parent #14989

This PR fixes the failing e2e UI tests after having the `Onboarding Improvements: Existing Users` feature being enabled.

Since the `Onboarding Improvements` feature flag has been turned on and merged into `develop`, these `LoginTests` have been started to fail. This is expected since all the login tests were not being built to interact with the new `Login Epilogue` screen.

This commit updates the `Login Flow` and more specifically the `confirmLogin(...)` functionality so that it respects the new `Login
Epilogue` screen. As such:
- For the WordPress app and a wp.com site, the new `Login Epilogue` and the `Quick Start Prompt` are being asserted.
- For the WordPress app and a self-hosted site, the new `Login Epilogue` is being asserted but the `Quick Start Prompt` is excluded from it.
- For the Jetpack app, the existing `Login Epilogue` is asserted.

-----

To test:
1. Fin the `LoginTests.java` e2e test suite within the `androidTest` source set and run it.
2. Verify that all the 5 tests within this test suite pass successfully:
    - `loginWithEmailPassword`
    - `loginWithPasswordlessAccount`
    - `loginWithSiteAddress`
    - `loginWithMagicLink`
    - `loginWithSelfHostedAccount`

PS: Also, wait for CI to run the `WordPress Connected Tests`, which are to be triggered manually and verify that CI  completes successfully on those as well.

-----

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
