### PR TITLE
Introduce `Quick Start - Dynamic Cards` feature flag and guard the feature

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -108,6 +108,7 @@ android {
         buildConfigField "boolean", "MANAGE_CATEGORIES", "false"
         buildConfigField "boolean", "GLOBAL_STYLE_SUPPORT", "false"
         buildConfigField "boolean", "ONBOARDING_IMPROVEMENTS", "false"
+        buildConfigField "boolean", "QUICK_START_DYNAMIC_CARDS", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -230,12 +230,12 @@ class MySiteViewModel
                 analyticsTrackerWrapper.track(DOMAIN_CREDIT_PROMPT_SHOWN)
                 siteItems.add(DomainRegistrationBlock(ListItemInteraction.create(this::domainRegistrationClick)))
             }
-            if (quickStartDynamicCardsFeatureConfig.isEnabled()) {
-                val dynamicCards: Map<DynamicCardType, DynamicCard> = mutableListOf<DynamicCard>().also { list ->
-                    // Add all possible future dynamic cards here. If we ever have a remote source of dynamic cards, we'd
-                    // need to implement a smarter solution where we'd build the sources based on the dynamic cards.
-                    // This means that the stream of dynamic cards would emit a new stream for each of the cards. The
-                    // current solution is good enough for a few sources.
+            val dynamicCards: Map<DynamicCardType, DynamicCard> = mutableListOf<DynamicCard>().also { list ->
+                // Add all possible future dynamic cards here. If we ever have a remote source of dynamic cards, we'd
+                // need to implement a smarter solution where we'd build the sources based on the dynamic cards.
+                // This means that the stream of dynamic cards would emit a new stream for each of the cards. The
+                // current solution is good enough for a few sources.
+                if (quickStartDynamicCardsFeatureConfig.isEnabled()) {
                     list.addAll(quickStartCategories.map { category ->
                         quickStartItemBuilder.build(
                                 category,
@@ -244,11 +244,12 @@ class MySiteViewModel
                                 this::onQuickStartTaskCardClick
                         )
                     })
-                }.associateBy { it.dynamicCardType }
-                siteItems.addAll(
-                        visibleDynamicCards.mapNotNull { dynamicCardType -> dynamicCards[dynamicCardType] }
-                )
-            }
+                }
+            }.associateBy { it.dynamicCardType }
+
+            siteItems.addAll(
+                    visibleDynamicCards.mapNotNull { dynamicCardType -> dynamicCards[dynamicCardType] }
+            )
 
             siteItems.addAll(
                     siteItemsBuilder.buildSiteItems(

--- a/WordPress/src/main/java/org/wordpress/android/util/config/QuickStartDynamicCardsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/QuickStartDynamicCardsFeatureConfig.kt
@@ -15,4 +15,3 @@ class QuickStartDynamicCardsFeatureConfig
         appConfig,
         BuildConfig.QUICK_START_DYNAMIC_CARDS
 )
-

--- a/WordPress/src/main/java/org/wordpress/android/util/config/QuickStartDynamicCardsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/QuickStartDynamicCardsFeatureConfig.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration of the Quick Start Dynamic cards within the My Site improvements
+ */
+@FeatureInDevelopment
+class QuickStartDynamicCardsFeatureConfig
+@Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.QUICK_START_DYNAMIC_CARDS
+)
+

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -106,6 +106,7 @@ import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.util.config.UnifiedCommentsListFeatureConfig
 import org.wordpress.android.viewmodel.ContextProvider
 
@@ -133,6 +134,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var dynamicCardsSource: DynamicCardsSource
     @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var unifiedCommentsListFeatureConfig: UnifiedCommentsListFeatureConfig
+    @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<UiModel>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -203,7 +205,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 currentAvatarSource,
                 dynamicCardsSource,
                 buildConfigWrapper,
-                unifiedCommentsListFeatureConfig
+                unifiedCommentsListFeatureConfig,
+                quickStartDynamicCardsFeatureConfig
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()


### PR DESCRIPTION
This PR introduces a feature flag for Quick Start Dynamic Cards within the Improved My Site flow. 

When the  `MySiteImprovementsFeatureConfig` is enabled, then enabling the `QuickStartDynamicCardsFeatureFlag` feature flag will show the Customize your site and Grow your audience dynamic cards. Enabling/disabling the `QuickStartDynamicCardsFeatureFlag` without enabling the `MySiteImprovementsFeatureConfig` will have no effect on the My Site view.

The driver for this PR was to separate the work done for the Quick Start dynamic cards from the other improvements made to My Site, so that we can eventually release `ImprovedMySiteFragment`.

**To Test**
1. Launch the app & log in
2. Select a Site from the list
3. Chose “Show me around” from the quick prompt view
4. **Note**: The Next Steps (quick start) rows are visible
5. Go to Me -> App Settings -> Test Feature Configuration
6. Enable `MySiteImprovementFeatureConfig` and restart the app
7. Swipe the app closed and reopen
8. When the app relaunches, My Site is shown
9. **Note**: The Next Steps (quick start) rows are not visible
10. Go to Me -> App Settings -> Test Feature Configuration
11. Enable `QuickStartDynamicCardsFeatureConfig` and restart the app
12. Navigate back to the MySite view 
13. **Note**: The Customize your site and Grow your audience dynamic cards are shown

## Regression Notes
1. Potential unintended areas of impact 
The quick start dynamic cards are shown when the flag is off.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual test
3. What automated tests I added (or what prevented me from doing so)
Updated `MySIteViewModelTest` to mock the new config feature flag.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
