### PR TITLE
Integrate gutenberg-mobile release 1.58.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.58.1'
+    ext.gutenbergMobileVersion = '3795-e3ba0b6a93b4de1c90ebb989d4f1dc4dd0894333'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3795-e3ba0b6a93b4de1c90ebb989d4f1dc4dd0894333'
+    ext.gutenbergMobileVersion = '3795-48bd31f057df2b4f6c7a0ba0773e81a816190b98'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3795-48bd31f057df2b4f6c7a0ba0773e81a816190b98'
+    ext.gutenbergMobileVersion = 'v1.58.2'
 
     repositories {
         maven {


### PR DESCRIPTION
## Description
This PR incorporates the 1.58.2 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3795

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.