### PR TITLE
Update minSdk to 24

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartCardViewHolder.kt
@@ -2,16 +2,12 @@ package org.wordpress.android.ui.mysite
 
 import android.animation.ObjectAnimator
 import android.content.res.ColorStateList
-import android.graphics.drawable.LayerDrawable
-import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.ViewGroup
 import androidx.appcompat.widget.TooltipCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
-import androidx.core.graphics.BlendModeColorFilterCompat.createBlendModeColorFilterCompat
-import androidx.core.graphics.BlendModeCompat.SRC_IN
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager.HORIZONTAL
 import androidx.recyclerview.widget.RecyclerView

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartCardViewHolder.kt
@@ -64,18 +64,8 @@ class QuickStartCardViewHolder(
 
         val progressIndicatorColor = ContextCompat.getColor(root.context, item.accentColor)
         val progressTrackColor = ColorUtils.applyEmphasisToColor(progressIndicatorColor, lowEmphasisAlpha)
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
-            quickStartCardProgress.progressBackgroundTintList = ColorStateList.valueOf(progressTrackColor)
-            quickStartCardProgress.progressTintList = ColorStateList.valueOf(progressIndicatorColor)
-        } else {
-            // Workaround for Lollipop
-            val progressDrawable = quickStartCardProgress.progressDrawable.mutate() as LayerDrawable
-            val backgroundLayer = progressDrawable.findDrawableByLayerId(android.R.id.background)
-            val progressLayer = progressDrawable.findDrawableByLayerId(android.R.id.progress)
-            backgroundLayer.colorFilter = createBlendModeColorFilterCompat(progressTrackColor, SRC_IN)
-            progressLayer.colorFilter = createBlendModeColorFilterCompat(progressIndicatorColor, SRC_IN)
-            quickStartCardProgress.progressDrawable = progressDrawable
-        }
+        quickStartCardProgress.progressBackgroundTintList = ColorStateList.valueOf(progressTrackColor)
+        quickStartCardProgress.progressTintList = ColorStateList.valueOf(progressIndicatorColor)
 
         quickStartCardTitle.text = uiHelpers.getTextOfUiString(root.context, item.title)
         (quickStartCardRecyclerView.adapter as? QuickStartTaskCardAdapter)?.loadData(item.taskCards)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
-import android.os.Build;
 import android.os.Bundle;
 import android.preference.EditTextPreference;
 import android.text.TextUtils;
@@ -167,11 +166,6 @@ public class SummaryEditTextPreference extends EditTextPreference implements Pre
         ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) message.getLayoutParams();
         int leftMargin = 0;
         int bottomMargin = view.getResources().getDimensionPixelSize(R.dimen.margin_small);
-        // Different versions handle the message view's margin differently
-        // This is a small hack to try to make it align with the input for earlier versions
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1) {
-            leftMargin = view.getResources().getDimensionPixelSize(R.dimen.margin_small);
-        }
         layoutParams.setMargins(0, layoutParams.topMargin, 0, bottomMargin);
         MarginLayoutParamsCompat.setMarginStart(layoutParams, leftMargin);
         MarginLayoutParamsCompat.setMarginEnd(layoutParams, layoutParams.rightMargin);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPSwitchPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPSwitchPreference.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
-import android.os.Build;
 import android.preference.SwitchPreference;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -72,12 +71,10 @@ public class WPSwitchPreference extends SwitchPreference implements PreferenceHi
         }
 
         // style custom switch preference
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            Switch switchControl = getSwitch((ViewGroup) view);
-            if (switchControl != null) {
-                if (mThumbTint != null) {
-                    switchControl.setThumbTintList(mThumbTint);
-                }
+        Switch switchControl = getSwitch((ViewGroup) view);
+        if (switchControl != null) {
+            if (mThumbTint != null) {
+                switchControl.setThumbTintList(mThumbTint);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.stories.intro
 
 import android.app.Dialog
 import android.content.Context
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -50,14 +48,12 @@ class StoriesIntroDialogFragment : DialogFragment() {
         viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(StoriesIntroViewModel::class.java)
 
-        if (VERSION.SDK_INT >= VERSION_CODES.M) {
-            val window: Window? = dialog.window
-            window?.let {
-                window.statusBarColor = dialog.context.getColorFromAttribute(attr.colorSurface)
-                if (!resources.configuration.isDarkTheme()) {
-                    window.decorView.systemUiVisibility = window.decorView
-                            .systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-                }
+        val window: Window? = dialog.window
+        window?.let {
+            window.statusBarColor = dialog.context.getColorFromAttribute(attr.colorSurface)
+            if (!resources.configuration.isDarkTheme()) {
+                window.decorView.systemUiVisibility = window.decorView
+                        .systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
             }
         }
         return dialog

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.whatsnew
 
 import android.app.Dialog
 import android.content.Context
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -40,14 +38,12 @@ class FeatureAnnouncementDialogFragment : DialogFragment() {
         viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(FeatureAnnouncementViewModel::class.java)
 
-        if (VERSION.SDK_INT >= VERSION_CODES.M) {
-            val window: Window? = dialog.window
-            window?.let {
-                window.statusBarColor = dialog.context.getColorFromAttribute(attr.colorSurface)
-                if (!resources.configuration.isDarkTheme()) {
-                    window.decorView.systemUiVisibility = window.decorView
-                            .systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-                }
+        val window: Window? = dialog.window
+        window?.let {
+            window.statusBarColor = dialog.context.getColorFromAttribute(attr.colorSurface)
+            if (!resources.configuration.isDarkTheme()) {
+                window.decorView.systemUiVisibility = window.decorView
+                        .systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
             }
         }
         return dialog

--- a/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
@@ -2,8 +2,6 @@ package org.wordpress.android.util
 
 import android.content.Context
 import android.graphics.Rect
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import android.view.TouchDelegate
 import android.view.View
 import android.view.ViewTreeObserver
@@ -17,9 +15,7 @@ fun View.setVisible(visible: Boolean) {
 }
 
 fun View.redirectContextClickToLongPressListener() {
-    if (VERSION.SDK_INT >= VERSION_CODES.M) {
-        this.setOnContextClickListener { it.performLongClick() }
-    }
+    this.setOnContextClickListener { it.performLongClick() }
 }
 
 fun View.expandTouchTargetArea(@DimenRes dimenRes: Int, heightOnly: Boolean = false) {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -173,12 +173,10 @@ public class WPActivityUtils {
         Context context = window.getContext();
         boolean isDarkTheme = ConfigurationExtensionsKt.isDarkTheme(context.getResources().getConfiguration());
         if (!isDarkTheme) {
-            if (VERSION.SDK_INT >= VERSION_CODES.M) {
-                int systemVisibility = window.getDecorView().getSystemUiVisibility();
-                int newSystemVisibility = showInLightMode ? systemVisibility | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-                        : systemVisibility & ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-                window.getDecorView().setSystemUiVisibility(newSystemVisibility);
-            }
+            int systemVisibility = window.getDecorView().getSystemUiVisibility();
+            int newSystemVisibility = showInLightMode ? systemVisibility | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                    : systemVisibility & ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            window.getDecorView().setSystemUiVisibility(newSystemVisibility);
         }
     }
 

--- a/WordPress/src/main/res/values-v23/styles.xml
+++ b/WordPress/src/main/res/values-v23/styles.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="WordPress.NoActionBar.TranslucentStatus" parent="WordPress.NoActionBar">
-        <item name="android:statusBarColor">@android:color/white</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowTranslucentStatus">true</item>
-    </style>
-</resources>

--- a/WordPress/src/main/res/values-v23/styles_login.xml
+++ b/WordPress/src/main/res/values-v23/styles_login.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="LoginTheme.TransparentStatusBar" parent="LoginTheme">
-        <item name="android:statusBarColor">@android:color/transparent</item>
-    </style>
-</resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -382,6 +382,8 @@
 
     <style name="WordPress.NoActionBar.TranslucentStatus" parent="WordPress.NoActionBar">
         <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:statusBarColor">@android:color/white</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 
     <style name="MediaSettings.Divider">

--- a/WordPress/src/main/res/values/styles_login.xml
+++ b/WordPress/src/main/res/values/styles_login.xml
@@ -8,7 +8,9 @@
         <item name="colorSecondaryVariant">@color/colorSecondaryVariant</item>
     </style>
 
-    <style name="LoginTheme.TransparentStatusBar" parent="LoginTheme" />
+    <style name="LoginTheme.TransparentStatusBar" parent="LoginTheme">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
 
     <style name="Login.EmptyView.TextView.Username" parent="android:Widget.TextView">
         <item name="android:textSize">@null</item>

--- a/WordPress/src/test/java/org/wordpress/android/RobolectricSetupTest.java
+++ b/WordPress/src/test/java/org/wordpress/android/RobolectricSetupTest.java
@@ -14,7 +14,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(application = TestApplication.class, sdk = VERSION_CODES.LOLLIPOP)
+@Config(application = TestApplication.class, sdk = VERSION_CODES.N)
 public class RobolectricSetupTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/reactnative/ReactNativeRequestHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/reactnative/ReactNativeRequestHandlerTest.kt
@@ -25,7 +25,7 @@ import org.wordpress.android.fluxc.store.ReactNativeStore
 import org.wordpress.android.test
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
 
-@Config(application = TestApplication::class, sdk = [VERSION_CODES.LOLLIPOP])
+@Config(application = TestApplication::class, sdk = [VERSION_CODES.N])
 @RunWith(RobolectricTestRunner::class)
 class ReactNativeRequestHandlerTest {
     private val reactNativeStore = mock<ReactNativeStore>()

--- a/WordPress/src/wordpress/java/org.wordpress.android.ui.accounts.login/LoginPrologueFragment.kt
+++ b/WordPress/src/wordpress/java/org.wordpress.android.ui.accounts.login/LoginPrologueFragment.kt
@@ -1,8 +1,6 @@
 package org.wordpress.android.ui.accounts.login
 
 import android.content.Context
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.view.View
 import androidx.annotation.FloatRange
@@ -45,12 +43,10 @@ class LoginPrologueFragment : Fragment(R.layout.login_signup_screen) {
 
         // setting up a full screen flags for the decor view of this fragment,
         // that will work with transparent status bar
-        if (VERSION.SDK_INT >= VERSION_CODES.M) {
-            val decorView: View = view
-            var flags = decorView.systemUiVisibility
-            flags = flags or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-            decorView.systemUiVisibility = flags
-        }
+        val decorView: View = view
+        var flags = decorView.systemUiVisibility
+        flags = flags or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+        decorView.systemUiVisibility = flags
         val binding = LoginSignupScreenBinding.bind(view)
 
         with(binding.bottomButtonsContainer) {

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ ext {
     compileSdkVersion = 29
     buildToolVersion = '29.0.2'
 
-    minSdkVersion = 21
+    minSdkVersion = 24
     targetSdkVersion = 29
 
     coroutinesVersion = '1.3.9'

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -20,8 +20,8 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
     }
 }
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -36,10 +36,8 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        versionCode 13
-        versionName "1.3"
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
     }
     compileOptions {
         sourceCompatibility 1.8

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
@@ -7,7 +7,6 @@ import android.graphics.Point;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.VectorDrawable;
-import android.os.Build;
 import android.util.DisplayMetrics;
 
 import androidx.annotation.DrawableRes;
@@ -31,7 +30,7 @@ public class EditorMediaUtils {
         if (drawable instanceof BitmapDrawable) {
             bitmap = ((BitmapDrawable) drawable).getBitmap();
             bitmap = ImageUtils.getScaledBitmapAtLongestSide(bitmap, maxImageSizeForVisualEditor);
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && drawable instanceof VectorDrawable) {
+        } else if (drawable instanceof VectorDrawable) {
             bitmap = Bitmap.createBitmap(maxImageSizeForVisualEditor, maxImageSizeForVisualEditor,
                                          Bitmap.Config.ARGB_8888);
             Canvas canvas = new Canvas(bitmap);

--- a/libs/editor/example/build.gradle
+++ b/libs/editor/example/build.gradle
@@ -17,10 +17,8 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.editorexample"
-        minSdkVersion 21
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
     }
     buildTypes {
         release {

--- a/libs/mocks/WordPressMocks/build.gradle
+++ b/libs/mocks/WordPressMocks/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 29
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
     }
 }
 

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -4,8 +4,8 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 29
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
     }
 }
 


### PR DESCRIPTION
Fixes #15077 in combination with #15085 & #15138.

After an internal discussion, we decided to upgrade `minSdk` to 24 as we have less than 5% of our users on the earlier versions of Android.

I've also taken the opportunity to remove the `versionName` and `versionCode` values there were outdated.
Besides upgrading the `minSdk`, it removes obsolete checks for the earlier versions of sdk. I suggest turning on the `hide whitespaces` option to review these changes.

The only change that should be given extra attention to is 90ccc1ad048719ae851222e5d9655d52d698ae77 which merges `values-v23` into `values` since these values will always be available. This is also what the lint task recommended to do.

~**Note that https://github.com/Automattic/stories-android/pull/711 needs to be merged and the `libs/stories-android` submodule needs to be updated before this can be merged.**~

**To test:**
* Verify the app still works 🤷 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
