### PR TITLE
Issue/uc list check empty site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/usecases/BatchModerateCommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/usecases/BatchModerateCommentsUseCase.kt
@@ -11,7 +11,6 @@ import org.wordpress.android.fluxc.store.CommentStore.CommentError
 import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.INVALID_RESPONSE
 import org.wordpress.android.fluxc.store.CommentsStore.CommentsActionPayload
-import org.wordpress.android.fluxc.store.CommentsStore.CommentsData.CommentsActionData
 import org.wordpress.android.fluxc.store.CommentsStore.CommentsData.DoNotCare
 import org.wordpress.android.models.usecases.BatchModerateCommentsUseCase.ModerateCommentsAction
 import org.wordpress.android.models.usecases.BatchModerateCommentsUseCase.ModerateCommentsAction.OnModerateComments
@@ -57,12 +56,6 @@ class BatchModerateCommentsUseCase @Inject constructor(
                                                     "Comment not found"
                                             )
                                     )
-
-                                    // emit success if the comment already have desired state
-                                    if (commentBeforeModeration.status == parameters.newStatus.toString()) {
-                                        val result = listOf(commentBeforeModeration)
-                                        return@async CommentsActionPayload(CommentsActionData(result, result.size))
-                                    }
 
                                     val localModerationResult = commentsStore.moderateCommentLocally(
                                             site = parameters.site,

--- a/WordPress/src/main/java/org/wordpress/android/models/usecases/BatchModerateCommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/usecases/BatchModerateCommentsUseCase.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.store.CommentStore.CommentError
 import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.INVALID_RESPONSE
 import org.wordpress.android.fluxc.store.CommentsStore.CommentsActionPayload
+import org.wordpress.android.fluxc.store.CommentsStore.CommentsData.CommentsActionData
 import org.wordpress.android.fluxc.store.CommentsStore.CommentsData.DoNotCare
 import org.wordpress.android.models.usecases.BatchModerateCommentsUseCase.ModerateCommentsAction
 import org.wordpress.android.models.usecases.BatchModerateCommentsUseCase.ModerateCommentsAction.OnModerateComments
@@ -56,6 +57,12 @@ class BatchModerateCommentsUseCase @Inject constructor(
                                                     "Comment not found"
                                             )
                                     )
+
+                                    // emit success if the comment already have desired state
+                                    if (commentBeforeModeration.status == parameters.newStatus.toString()) {
+                                        val result = listOf(commentBeforeModeration)
+                                        return@async CommentsActionPayload(CommentsActionData(result, result.size))
+                                    }
 
                                     val localModerationResult = commentsStore.moderateCommentLocally(
                                             site = parameters.site,

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
@@ -7,8 +7,10 @@ import android.view.MenuItem
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayoutMediator
 import kotlinx.coroutines.flow.collect
+import org.wordpress.android.R
 import org.wordpress.android.R.dimen
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -21,13 +23,17 @@ import org.wordpress.android.ui.comments.unified.CommentFilter.PENDING
 import org.wordpress.android.ui.comments.unified.CommentFilter.SPAM
 import org.wordpress.android.ui.comments.unified.CommentFilter.TRASHED
 import org.wordpress.android.ui.comments.unified.CommentFilter.UNREPLIED
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.widgets.WPSnackbarWrapper
 import java.util.HashMap
 import javax.inject.Inject
 
 class UnifiedCommentsActivity : LocaleAwareActivity() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Inject lateinit var selectedSiteRepository: SelectedSiteRepository
+    @Inject lateinit var snackbarWrapper: WPSnackbarWrapper
     private lateinit var viewModel: UnifiedCommentActivityViewModel
 
     private val commentListFilters = listOf(ALL, PENDING, UNREPLIED, APPROVED, SPAM, TRASHED)
@@ -46,6 +52,15 @@ class UnifiedCommentsActivity : LocaleAwareActivity() {
         val disabledAlpha = TypedValue()
         resources.getValue(dimen.material_emphasis_disabled, disabledAlpha, true)
         disabledTabsOpacity = disabledAlpha.float
+
+        if (selectedSiteRepository.getSelectedSite() == null) {
+            snackbarWrapper.make(
+                    findViewById(R.id.coordinator_layout),
+                    getString(R.string.blog_not_found),
+                    Snackbar.LENGTH_SHORT
+            ).show()
+            finish()
+        }
 
         binding = UnifiedCommentActivityBinding.inflate(layoutInflater).apply {
             setContentView(root)

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
@@ -7,7 +7,6 @@ import android.view.MenuItem
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
-import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayoutMediator
 import kotlinx.coroutines.flow.collect
 import org.wordpress.android.R
@@ -24,8 +23,8 @@ import org.wordpress.android.ui.comments.unified.CommentFilter.SPAM
 import org.wordpress.android.ui.comments.unified.CommentFilter.TRASHED
 import org.wordpress.android.ui.comments.unified.CommentFilter.UNREPLIED
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.widgets.WPSnackbarWrapper
 import java.util.HashMap
 import javax.inject.Inject
 
@@ -33,7 +32,6 @@ class UnifiedCommentsActivity : LocaleAwareActivity() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
     @Inject lateinit var selectedSiteRepository: SelectedSiteRepository
-    @Inject lateinit var snackbarWrapper: WPSnackbarWrapper
     private lateinit var viewModel: UnifiedCommentActivityViewModel
 
     private val commentListFilters = listOf(ALL, PENDING, UNREPLIED, APPROVED, SPAM, TRASHED)
@@ -54,11 +52,7 @@ class UnifiedCommentsActivity : LocaleAwareActivity() {
         disabledTabsOpacity = disabledAlpha.float
 
         if (selectedSiteRepository.getSelectedSite() == null) {
-            snackbarWrapper.make(
-                    findViewById(R.id.coordinator_layout),
-                    getString(R.string.blog_not_found),
-                    Snackbar.LENGTH_SHORT
-            ).show()
+            ToastUtils.showToast(this@UnifiedCommentsActivity, R.string.blog_not_found, ToastUtils.Duration.SHORT)
             finish()
         }
 


### PR DESCRIPTION
This is a fix for Unified Comments List.

This PR adds a check for a missing selected site when opening Comments Activity.

To test:
- The issue is hard to reproduce, but try opening comments after switching between self-hosted and wpcom sites.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
