### PR TITLE
Moves windowLayoutInDisplayCutoutMode & windowLightNavigationBar usage to API 27

### DIFF
--- a/WordPress/src/main/res/values-v27/styles.xml
+++ b/WordPress/src/main/res/values-v27/styles.xml
@@ -5,4 +5,21 @@
         <item name="android:windowLightNavigationBar">true</item>
     </style>
 
+    <style name="WordPress.Stories.Immersive" parent="WordPress.NoActionBar">
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:immersive">true</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+
+    <style name="WordPress.NoActionBar.DarkNavbar" parent="WordPress.NoActionBar">
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:statusBarColor">?attr/colorPrimarySurface</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="toolbarNavigationButtonStyle">
+            @style/Widget.AppCompat.Toolbar.Button.Navigation
+        </item>
+    </style>
+
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -218,11 +218,9 @@
         <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:immersive">true</item>
         <item name="android:windowFullscreen">true</item>
-        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 
     <style name="WordPress.NoActionBar.DarkNavbar" parent="WordPress.NoActionBar">
-        <item name="android:windowLightNavigationBar">false</item>
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:statusBarColor">?attr/colorPrimarySurface</item>
         <item name="android:navigationBarColor">@android:color/black</item>


### PR DESCRIPTION
Fixes #15077 in combination with #15085 & #15135.

`windowLayoutInDisplayCutoutMode` & `windowLightNavigationBar` properties are only available in API >= 27, so this PR adds the styles that use this property to `values-v27/styles.xml` and removes the unavailable property from the default `values/styles.xml` file.

**To test:**

This PR doesn't have any impact on the current UI, but there are a couple things the reviewer can check if they want to be extra sure.

1. In current `develop` go into `values/styles.xml` and find the usages for these properties. Android Studio will complain about them not being available before API 27 and offer to add the values to `values-v27` which results in this diff. (it won't remove the properties from `values/styles.xml`, that needs to be done manually)
2. For the more paranoid, which I kind of was because I wasn't sure how the resources were merged (if at all), one can open two emulators one for API < 27 and one for API >= 27, run the app, select dark mode, go to about page and verify they look correct. Then, to see the different values in play, one can change `WordPress.NoActionBar.DarkNavbar`'s `android:navigationBarColor` in these two different places to different colors. This color will show up at the bottom navigation bar in the about page. Note that, if the `values-v27` color is completely removed, but the `values` one is assigned to something like orange, the emulator with API >= 27 will still show it as black. This tells me that styles with the same name for different apis are **not** merged. They instead get assigned directly.

The second test is really unnecessary, but I just wanted share what I did to understand the behavior.

## Regression Notes
1. Potential unintended areas of impact
Incorrect styling for the changed `WordPress.Stories.Immersive` and `WordPress.NoActionBar.DarkNavbar` styles

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the UI as described in the testing steps

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
