### PR TITLE
Issue/uc show retry button in footer after timeout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/usecases/PaginateCommentsResourceProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/usecases/PaginateCommentsResourceProvider.kt
@@ -3,10 +3,14 @@ package org.wordpress.android.models.usecases
 import dagger.Reusable
 import org.wordpress.android.fluxc.store.CommentsStore
 import org.wordpress.android.ui.comments.unified.UnrepliedCommentsUtils
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
 @Reusable
 class PaginateCommentsResourceProvider @Inject constructor(
     val commentsStore: CommentsStore,
-    val unrepliedCommentsUtils: UnrepliedCommentsUtils
+    val unrepliedCommentsUtils: UnrepliedCommentsUtils,
+    val networkUtilsWrapper: NetworkUtilsWrapper,
+    val resourceProvider: ResourceProvider
 )

--- a/WordPress/src/main/java/org/wordpress/android/models/usecases/PaginateCommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/usecases/PaginateCommentsUseCase.kt
@@ -47,8 +47,10 @@ class PaginateCommentsUseCase @Inject constructor(
                     is OnGetPage -> {
                         val parameters = action.parameters
                         val commentsStore = utilsProvider.commentsStore
-                        if (parameters.offset == 0) flowChannel.emit(Loading(PAGINATE_USE_CASE))
-                        delay(LOADING_STATE_DELAY)
+                        if (parameters.offset == 0) {
+                            flowChannel.emit(Loading(PAGINATE_USE_CASE))
+                            delay(LOADING_STATE_DELAY)
+                        }
                         val result = if (!utilsProvider.networkUtilsWrapper.isNetworkAvailable()) {
                             val cachedComments = if (parameters.offset > 0) {
                                 commentsStore.getCommentsForSite(

--- a/WordPress/src/main/java/org/wordpress/android/models/usecases/PaginateCommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/usecases/PaginateCommentsUseCase.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.models.usecases
 
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
@@ -30,6 +31,7 @@ class PaginateCommentsUseCase @Inject constructor(
         resourceProvider = paginateCommentsResourceProvider,
         initialState = Idle
 ) {
+    @Suppress("LongMethod") // temporary suppress until we come up with better architecture for use cases
     sealed class PaginateCommentsState : StateInterface<PaginateCommentsResourceProvider, PaginateCommentsAction,
             PagingData, CommentsUseCaseType,
             CommentError> {
@@ -46,7 +48,7 @@ class PaginateCommentsUseCase @Inject constructor(
                         val parameters = action.parameters
                         val commentsStore = utilsProvider.commentsStore
                         if (parameters.offset == 0) flowChannel.emit(Loading(PAGINATE_USE_CASE))
-
+                        delay(LOADING_STATE_DELAY)
                         val result = if (!utilsProvider.networkUtilsWrapper.isNetworkAvailable()) {
                             val cachedComments = if (parameters.offset > 0) {
                                 commentsStore.getCommentsForSite(
@@ -142,5 +144,9 @@ class PaginateCommentsUseCase @Inject constructor(
             val pagingParameters: GetPageParameters,
             val hasMore: Boolean
         ) : Parameters()
+    }
+
+    companion object {
+        const val LOADING_STATE_DELAY = 500L
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
@@ -142,12 +142,6 @@ class UnifiedCommentListViewModel @Inject constructor(
 
     private fun requestNextPage(offset: Int) {
         launch(bgDispatcher) {
-            if (!networkUtilsWrapper.isNetworkAvailable()) {
-                launch(bgDispatcher) {
-                    _onSnackbarMessage.emit(SnackbarMessageHolder(UiStringRes(string.no_network_message)))
-                }
-                return@launch
-            }
             unifiedCommentsListHandler.requestPage(
                     GetPageParameters(
                             site = selectedSiteRepository.getSelectedSite()!!,

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
@@ -142,6 +142,11 @@ class UnifiedCommentListViewModel @Inject constructor(
 
     private fun requestNextPage(offset: Int) {
         launch(bgDispatcher) {
+            if (!networkUtilsWrapper.isNetworkAvailable()) {
+                launch(bgDispatcher) {
+                    _onSnackbarMessage.emit(SnackbarMessageHolder(UiStringRes(string.no_network_message)))
+                }
+            }
             unifiedCommentsListHandler.requestPage(
                     GetPageParameters(
                             site = selectedSiteRepository.getSelectedSite()!!,

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
@@ -142,11 +142,6 @@ class UnifiedCommentListViewModel @Inject constructor(
 
     private fun requestNextPage(offset: Int) {
         launch(bgDispatcher) {
-            if (!networkUtilsWrapper.isNetworkAvailable()) {
-                launch(bgDispatcher) {
-                    _onSnackbarMessage.emit(SnackbarMessageHolder(UiStringRes(string.no_network_message)))
-                }
-            }
             unifiedCommentsListHandler.requestPage(
                     GetPageParameters(
                             site = selectedSiteRepository.getSelectedSite()!!,

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/PaginateCommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/PaginateCommentsUseCaseTest.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.ui.comments.utils.testCommentsPayload30
 import org.wordpress.android.ui.comments.utils.testCommentsPayload60
 import org.wordpress.android.ui.comments.utils.testCommentsPayloadLastPage
 import org.wordpress.android.usecase.UseCaseResult
+import org.wordpress.android.util.NetworkUtilsWrapper
 
 @ExperimentalCoroutinesApi
 class PaginateCommentsUseCaseTest : BaseUnitTest() {
@@ -49,6 +50,7 @@ class PaginateCommentsUseCaseTest : BaseUnitTest() {
     @Mock private lateinit var commentStore: CommentsStore
     @Mock private lateinit var paginateCommentsResourceProvider: PaginateCommentsResourceProvider
     @Mock private lateinit var unrepliedCommentsUtils: UnrepliedCommentsUtils
+    @Mock private lateinit var networkUtilsWrapper: NetworkUtilsWrapper
 
     private lateinit var paginateCommentsUseCase: PaginateCommentsUseCase
 
@@ -56,8 +58,10 @@ class PaginateCommentsUseCaseTest : BaseUnitTest() {
 
     @Before
     fun setup() {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
         whenever(paginateCommentsResourceProvider.commentsStore).thenReturn(commentStore)
         whenever(paginateCommentsResourceProvider.unrepliedCommentsUtils).thenReturn(unrepliedCommentsUtils)
+        whenever(paginateCommentsResourceProvider.networkUtilsWrapper).thenReturn(networkUtilsWrapper)
 
         runBlocking {
             Mockito.`when`(commentStore.fetchCommentsPage(eq(site), any(), eq(0), any(), any()))

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/comments/UnifiedCommentListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/comments/UnifiedCommentListViewModelTest.kt
@@ -87,7 +87,10 @@ class UnifiedCommentListViewModelTest : BaseUnitTest() {
         whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(anyOrNull())).thenReturn("Apr 19")
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
         whenever(paginateCommentsResourceProvider.commentsStore).thenReturn(commentStore)
+        whenever(paginateCommentsResourceProvider.networkUtilsWrapper).thenReturn(networkUtilsWrapper)
+        whenever(paginateCommentsResourceProvider.resourceProvider).thenReturn(resourceProvider)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(resourceProvider.getString(string.no_network_message)).thenReturn("No network")
 
         batchModerateCommentsUseCase = BatchModerateCommentsUseCase(moderateCommentsResourceProvider)
         moderationWithUndoUseCase = ModerateCommentWithUndoUseCase(moderateCommentsResourceProvider)
@@ -315,6 +318,9 @@ class UnifiedCommentListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `tapping retry button in footer shows error snackbar when there is no internet`() = runBlockingTest {
+        whenever(commentStore.getCommentsForSite(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()))
+                .thenReturn(testComments.take(30))
+
         val result = mutableListOf<CommentsUiModel>()
         val job = launch {
             viewModel.uiState.collectLatest {
@@ -360,7 +366,7 @@ class UnifiedCommentListViewModelTest : BaseUnitTest() {
 
         val noInternetSnackbar = snackbarResults[1] // first one is test error snackabr
 
-        assertThat(noInternetSnackbar.message).isEqualTo(UiStringRes(string.no_network_message))
+        assertThat(noInternetSnackbar.message).isEqualTo(UiStringText("No network"))
 
         job.cancel()
         snackbarJob.cancel()


### PR DESCRIPTION
This PR shows Retry button in the comment list footer when there is no internet connection.

To test:
- Open comment list with more then one page of comments.
- Turn on airplane mode and scroll the list to the bottom.
- Confirm that the "no internet" snackbar appears when bottom loader view becomes visible.
- Confirm that the "Retry" button becomes visible.