### PR TITLE
My Site Dashboard - Phase 1 - Fix QSP for the Site Picker and Login Epilogue Screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -84,6 +84,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment;
+import org.wordpress.android.ui.mysite.ImprovedMySiteFragment;
 import org.wordpress.android.ui.mysite.QuickStartRepository;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.notifications.NotificationEvents;
@@ -1280,6 +1281,15 @@ public class WPMainActivity extends LocaleAwareActivity implements
         return null;
     }
 
+    private ImprovedMySiteFragment getImprovedMySiteFragment() {
+        Fragment fragment = mBottomNav.getFragment(PageType.MY_SITE);
+        if (fragment instanceof ImprovedMySiteFragment) {
+            return (ImprovedMySiteFragment) fragment;
+        }
+
+        return null;
+    }
+
     private void passOnActivityResultToMySiteFragment(int requestCode, int resultCode, Intent data) {
         Fragment fragment = mBottomNav.getFragment(PageType.MY_SITE);
         if (fragment != null) {
@@ -1660,25 +1670,34 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
     @Override
     public void onPositiveClicked(@NonNull String instanceTag) {
-        MySiteFragment fragment = getMySiteFragment();
-        if (fragment != null) {
-            fragment.onPositiveClicked(instanceTag);
+        MySiteFragment mySiteFragment = getMySiteFragment();
+        ImprovedMySiteFragment improvedMySiteFragment = getImprovedMySiteFragment();
+        if (mySiteFragment != null) {
+            mySiteFragment.onPositiveClicked(instanceTag);
+        } else if (improvedMySiteFragment != null) {
+            improvedMySiteFragment.onPositiveClicked(instanceTag);
         }
     }
 
     @Override
     public void onNegativeClicked(@NonNull String instanceTag) {
-        MySiteFragment fragment = getMySiteFragment();
-        if (fragment != null) {
-            fragment.onNegativeClicked(instanceTag);
+        MySiteFragment mySiteFragment = getMySiteFragment();
+        ImprovedMySiteFragment improvedMySiteFragment = getImprovedMySiteFragment();
+        if (mySiteFragment != null) {
+            mySiteFragment.onNegativeClicked(instanceTag);
+        } else if (improvedMySiteFragment != null) {
+            improvedMySiteFragment.onNegativeClicked(instanceTag);
         }
     }
 
     @Override
     public void onNeutralClicked(@NonNull String instanceTag) {
-        MySiteFragment fragment = getMySiteFragment();
-        if (fragment != null) {
-            fragment.onNeutralClicked(instanceTag);
+        MySiteFragment mySiteFragment = getMySiteFragment();
+        ImprovedMySiteFragment improvedMySiteFragment = getImprovedMySiteFragment();
+        if (mySiteFragment != null) {
+            mySiteFragment.onNeutralClicked(instanceTag);
+        } else if (improvedMySiteFragment != null) {
+            improvedMySiteFragment.onNeutralClicked(instanceTag);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1158,7 +1158,11 @@ public class WPMainActivity extends LocaleAwareActivity implements
             case RequestCodes.LOGIN_EPILOGUE:
                 if (resultCode == RESULT_OK) {
                     setSite(data);
-                    showQuickStartDialog();
+                    if (getMySiteFragment() != null) {
+                        showQuickStartDialog();
+                    } else {
+                        passOnActivityResultToMySiteFragment(requestCode, resultCode, data);
+                    }
                 }
                 break;
             case RequestCodes.SITE_PICKER:

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -61,8 +61,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenStats
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenStories
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenThemes
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenUnifiedComments
-import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialogNew
-import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialogOld
+import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialog
 import org.wordpress.android.ui.mysite.SiteNavigationAction.StartWPComLoginForJetpackStats
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel
@@ -289,18 +288,12 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
                 CTA_DOMAIN_CREDIT_REDEMPTION
         )
         is AddNewSite -> SitePickerActivity.addSite(activity, action.isSignedInWpCom)
-        is ShowQuickStartDialogOld -> showQuickStartDialog(
-                R.string.quick_start_dialog_need_help_title,
-                R.string.quick_start_dialog_need_help_message,
-                R.string.quick_start_dialog_need_help_button_positive,
-                R.string.quick_start_dialog_need_help_manage_site_button_negative,
-                R.string.quick_start_dialog_need_help_button_neutral
-        )
-        is ShowQuickStartDialogNew -> showQuickStartDialog(
-                R.string.quick_start_dialog_need_help_manage_site_title,
-                R.string.quick_start_dialog_need_help_manage_site_message,
-                R.string.quick_start_dialog_need_help_manage_site_button_positive,
-                R.string.quick_start_dialog_need_help_button_negative
+        is ShowQuickStartDialog -> showQuickStartDialog(
+                action.title,
+                action.message,
+                action.positiveButtonLabel,
+                action.negativeButtonLabel,
+                action.neutralButtonLabel
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -437,6 +437,7 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
             RequestCodes.DOMAIN_REGISTRATION -> if (resultCode == Activity.RESULT_OK) {
                 viewModel.handleSuccessfulDomainRegistrationResult(data.getStringExtra(RESULT_REGISTERED_DOMAIN_EMAIL))
             }
+            RequestCodes.LOGIN_EPILOGUE,
             RequestCodes.CREATE_SITE -> {
                 viewModel.startQuickStart(data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -17,7 +17,6 @@ import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity
 import org.wordpress.android.R
-import org.wordpress.android.R.attr
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.NewMySiteFragmentBinding
 import org.wordpress.android.ui.ActivityLauncher
@@ -317,7 +316,7 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
         options.setShowCropGrid(false)
         options.setStatusBarColor(context.getColorFromAttribute(android.R.attr.statusBarColor))
         options.setToolbarColor(context.getColorFromAttribute(R.attr.wpColorAppBar))
-        options.setToolbarWidgetColor(context.getColorFromAttribute(attr.colorOnSurface))
+        options.setToolbarWidgetColor(context.getColorFromAttribute(R.attr.colorOnSurface))
         options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.NONE)
         options.setHideBottomControls(true)
         UCrop.of(imageUri.uri, Uri.fromFile(File(context.cacheDir, "cropped_for_site_icon.jpg")))

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -59,6 +59,8 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenStats
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenStories
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenThemes
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenUnifiedComments
+import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialogNew
+import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialogOld
 import org.wordpress.android.ui.mysite.SiteNavigationAction.StartWPComLoginForJetpackStats
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel
@@ -281,6 +283,8 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
                 CTA_DOMAIN_CREDIT_REDEMPTION
         )
         is AddNewSite -> SitePickerActivity.addSite(activity, action.isSignedInWpCom)
+        is ShowQuickStartDialogOld -> TODO("Show old quick start dialog.")
+        is ShowQuickStartDialogNew -> TODO("Show new quick start dialog.")
     }
 
     private fun handleUploadedItem(itemUploadedModel: ItemUploadedModel) = when (itemUploadedModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -95,6 +95,7 @@ import org.wordpress.android.viewmodel.observeEvent
 import java.io.File
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
         TextInputDialogFragment.Callback,
         QuickStartPromptClickInterface {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
 import android.widget.ImageView
+import androidx.annotation.StringRes
 import androidx.appcompat.widget.TooltipCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -18,6 +19,7 @@ import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.databinding.NewMySiteFragmentBinding
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
@@ -69,6 +71,7 @@ import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource
 import org.wordpress.android.ui.posts.BasicDialogViewModel
 import org.wordpress.android.ui.posts.BasicDialogViewModel.BasicDialogModel
+import org.wordpress.android.ui.posts.QuickStartPromptDialogFragment
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
@@ -282,8 +285,19 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
                 CTA_DOMAIN_CREDIT_REDEMPTION
         )
         is AddNewSite -> SitePickerActivity.addSite(activity, action.isSignedInWpCom)
-        is ShowQuickStartDialogOld -> TODO("Show old quick start dialog.")
-        is ShowQuickStartDialogNew -> TODO("Show new quick start dialog.")
+        is ShowQuickStartDialogOld -> showQuickStartDialog(
+                R.string.quick_start_dialog_need_help_title,
+                R.string.quick_start_dialog_need_help_message,
+                R.string.quick_start_dialog_need_help_button_positive,
+                R.string.quick_start_dialog_need_help_manage_site_button_negative,
+                R.string.quick_start_dialog_need_help_button_neutral
+        )
+        is ShowQuickStartDialogNew -> showQuickStartDialog(
+                R.string.quick_start_dialog_need_help_manage_site_title,
+                R.string.quick_start_dialog_need_help_manage_site_message,
+                R.string.quick_start_dialog_need_help_manage_site_button_positive,
+                R.string.quick_start_dialog_need_help_button_negative
+        )
     }
 
     private fun handleUploadedItem(itemUploadedModel: ItemUploadedModel) = when (itemUploadedModel) {
@@ -431,6 +445,28 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
         }
     }
 
+    private fun showQuickStartDialog(
+        @StringRes title: Int,
+        @StringRes message: Int,
+        @StringRes positiveButtonLabel: Int,
+        @StringRes negativeButtonLabel: Int,
+        @StringRes neutralButtonLabel: Int? = null
+    ) {
+        val tag = TAG_QUICK_START_DIALOG
+        val quickStartPromptDialogFragment = QuickStartPromptDialogFragment()
+        quickStartPromptDialogFragment.initialize(
+                tag,
+                getString(title),
+                getString(message),
+                getString(positiveButtonLabel),
+                R.drawable.img_illustration_site_about_280dp,
+                getString(negativeButtonLabel),
+                neutralButtonLabel?.let { getString(it) } ?: ""
+        )
+        quickStartPromptDialogFragment.show(parentFragmentManager, tag)
+        AnalyticsTracker.track(AnalyticsTracker.Stat.QUICK_START_REQUEST_VIEWED)
+    }
+
     private fun NewMySiteFragmentBinding.loadData(items: List<MySiteItem>) {
         recyclerView.setVisible(true)
         actionableEmptyView.setVisible(false)
@@ -467,6 +503,7 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
     companion object {
         private const val KEY_LIST_STATE = "key_list_state"
         private const val KEY_NESTED_LISTS_STATES = "key_nested_lists_states"
+        private const val TAG_QUICK_START_DIALOG = "TAG_QUICK_START_DIALOG"
         fun newInstance(): ImprovedMySiteFragment {
             return ImprovedMySiteFragment()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
 import android.widget.ImageView
+import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.appcompat.widget.TooltipCompat
 import androidx.fragment.app.Fragment
@@ -72,6 +73,7 @@ import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMedia
 import org.wordpress.android.ui.posts.BasicDialogViewModel
 import org.wordpress.android.ui.posts.BasicDialogViewModel.BasicDialogModel
 import org.wordpress.android.ui.posts.QuickStartPromptDialogFragment
+import org.wordpress.android.ui.posts.QuickStartPromptDialogFragment.QuickStartPromptClickInterface
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
@@ -94,7 +96,8 @@ import java.io.File
 import javax.inject.Inject
 
 class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
-        TextInputDialogFragment.Callback {
+        TextInputDialogFragment.Callback,
+        QuickStartPromptClickInterface {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var uiHelpers: UiHelpers
@@ -515,5 +518,17 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
 
     override fun onTextInputDialogDismissed(callbackId: Int) {
         viewModel.onSiteNameChooserDismissed()
+    }
+
+    override fun onPositiveClicked(instanceTag: String) {
+        Toast.makeText(context, "QS - Positive Clicked", Toast.LENGTH_LONG).show()
+    }
+
+    override fun onNegativeClicked(instanceTag: String) {
+        Toast.makeText(context, "QS - Negative Clicked", Toast.LENGTH_LONG).show()
+    }
+
+    override fun onNeutralClicked(instanceTag: String) {
+        Toast.makeText(context, "QS - Neutral Clicked", Toast.LENGTH_LONG).show()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -86,6 +86,8 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenSiteSettings
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenStats
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenThemes
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenUnifiedComments
+import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialogNew
+import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialogOld
 import org.wordpress.android.ui.mysite.SiteNavigationAction.StartWPComLoginForJetpackStats
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment.DynamicCardMenuModel
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction
@@ -606,7 +608,11 @@ class MySiteViewModel
     }
 
     fun startQuickStart(newSiteLocalID: Int) {
-        quickStartRepository.startQuickStart(newSiteLocalID)
+        if (quickStartDynamicCardsFeatureConfig.isEnabled()) {
+            quickStartRepository.startQuickStart(newSiteLocalID)
+        } else {
+            showQuickStartDialog(selectedSiteRepository.getSelectedSite())
+        }
     }
 
     fun onQuickStartMenuInteraction(interaction: DynamicCardMenuInteraction) {
@@ -623,6 +629,18 @@ class MySiteViewModel
                     analyticsTrackerWrapper.track(QUICK_START_HIDE_CARD_TAPPED)
                     dynamicCardsSource.hideItem(interaction.cardType)
                     quickStartRepository.refresh()
+                }
+            }
+        }
+    }
+
+    private fun showQuickStartDialog(siteModel: SiteModel?) {
+        if (siteModel != null && quickStartUtilsWrapper.isQuickStartAvailableForTheSite(siteModel)) {
+            if (onboardingImprovementsFeatureConfig.isEnabled()) {
+                _onNavigation.postValue(Event(ShowQuickStartDialogNew))
+            } else {
+                if (appPrefsWrapper.isQuickStartEnabled()) {
+                    _onNavigation.postValue(Event(ShowQuickStartDialogOld))
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -86,8 +86,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenSiteSettings
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenStats
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenThemes
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenUnifiedComments
-import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialogNew
-import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialogOld
+import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialog
 import org.wordpress.android.ui.mysite.SiteNavigationAction.StartWPComLoginForJetpackStats
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment.DynamicCardMenuModel
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction
@@ -637,10 +636,29 @@ class MySiteViewModel
     private fun showQuickStartDialog(siteModel: SiteModel?) {
         if (siteModel != null && quickStartUtilsWrapper.isQuickStartAvailableForTheSite(siteModel)) {
             if (onboardingImprovementsFeatureConfig.isEnabled()) {
-                _onNavigation.postValue(Event(ShowQuickStartDialogNew))
+                _onNavigation.postValue(
+                        Event(
+                                ShowQuickStartDialog(
+                                        R.string.quick_start_dialog_need_help_manage_site_title,
+                                        R.string.quick_start_dialog_need_help_manage_site_message,
+                                        R.string.quick_start_dialog_need_help_manage_site_button_positive,
+                                        R.string.quick_start_dialog_need_help_button_negative
+                                )
+                        )
+                )
             } else {
                 if (appPrefsWrapper.isQuickStartEnabled()) {
-                    _onNavigation.postValue(Event(ShowQuickStartDialogOld))
+                    _onNavigation.postValue(
+                            Event(
+                                    ShowQuickStartDialog(
+                                            R.string.quick_start_dialog_need_help_title,
+                                            R.string.quick_start_dialog_need_help_message,
+                                            R.string.quick_start_dialog_need_help_button_positive,
+                                            R.string.quick_start_dialog_need_help_manage_site_button_negative,
+                                            R.string.quick_start_dialog_need_help_button_neutral
+                                    )
+                            )
+                    )
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -114,6 +114,7 @@ import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.OnboardingImprovementsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.util.config.UnifiedCommentsListFeatureConfig
 import org.wordpress.android.util.getEmailValidationMessage
@@ -154,6 +155,7 @@ class MySiteViewModel
     private val buildConfigWrapper: BuildConfigWrapper,
     private val unifiedCommentsListFeatureConfig: UnifiedCommentsListFeatureConfig,
     private val quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig,
+    private val onboardingImprovementsFeatureConfig: OnboardingImprovementsFeatureConfig,
     private val quickStartUtilsWrapper: QuickStartUtilsWrapper,
     private val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(mainDispatcher) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -47,6 +47,9 @@ sealed class SiteNavigationAction {
         val source: PagePostCreationSourcesDetail,
         val mediaUris: List<String>
     ) : SiteNavigationAction()
+
     data class OpenDomainRegistration(val site: SiteModel) : SiteNavigationAction()
     data class AddNewSite(val isSignedInWpCom: Boolean) : SiteNavigationAction()
+    object ShowQuickStartDialogOld : SiteNavigationAction()
+    object ShowQuickStartDialogNew : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mysite
 
+import androidx.annotation.StringRes
 import com.wordpress.stories.compose.frame.StorySaveEvents.StorySaveResult
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
@@ -50,6 +51,11 @@ sealed class SiteNavigationAction {
 
     data class OpenDomainRegistration(val site: SiteModel) : SiteNavigationAction()
     data class AddNewSite(val isSignedInWpCom: Boolean) : SiteNavigationAction()
-    object ShowQuickStartDialogOld : SiteNavigationAction()
-    object ShowQuickStartDialogNew : SiteNavigationAction()
+    data class ShowQuickStartDialog(
+        @StringRes val title: Int,
+        @StringRes val message: Int,
+        @StringRes val positiveButtonLabel: Int,
+        @StringRes val negativeButtonLabel: Int,
+        @StringRes val neutralButtonLabel: Int? = null
+    ) : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -195,6 +195,8 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun setMainPageIndex(index: Int) = AppPrefs.setMainPageIndex(index)
 
+    fun isQuickStartEnabled() = !AppPrefs.isQuickStartDisabled()
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
@@ -30,6 +30,10 @@ class QuickStartUtilsWrapper
         return QuickStartUtils.isQuickStartInProgress(quickStartStore, siteId)
     }
 
+    fun isQuickStartAvailableForTheSite(siteModel: SiteModel): Boolean {
+        return QuickStartUtils.isQuickStartAvailableForTheSite(siteModel)
+    }
+
     @JvmOverloads
     fun stylizeQuickStartPrompt(
         activityContext: Context,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1043,7 +1043,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given QS is not available for the site, when quick start start is triggered, then QSP is not shown`() {
+    fun `given QS is not available for the site, when start quick start is triggered, then QSP is not shown`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(false)
@@ -1054,7 +1054,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given onboarding improvements feature is on, when quick start start is triggered, then new QSP is shown`() {
+    fun `given onboarding improvements feature is on, when start quick start is triggered, then new QSP is shown`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(true)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -92,8 +92,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenSitePicker
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenSiteSettings
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenStats
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenThemes
-import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialogNew
-import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialogOld
+import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialog
 import org.wordpress.android.ui.mysite.SiteNavigationAction.StartWPComLoginForJetpackStats
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsSource
@@ -1063,7 +1062,14 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         viewModel.startQuickStart(siteId)
 
-        assertThat(navigationActions).containsExactly(ShowQuickStartDialogNew)
+        assertThat(navigationActions).containsExactly(
+                ShowQuickStartDialog(
+                        R.string.quick_start_dialog_need_help_manage_site_title,
+                        R.string.quick_start_dialog_need_help_manage_site_message,
+                        R.string.quick_start_dialog_need_help_manage_site_button_positive,
+                        R.string.quick_start_dialog_need_help_button_negative
+                )
+        )
     }
 
     @Test
@@ -1089,7 +1095,15 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         viewModel.startQuickStart(siteId)
 
-        assertThat(navigationActions).containsExactly(ShowQuickStartDialogOld)
+        assertThat(navigationActions).containsExactly(
+                ShowQuickStartDialog(
+                        R.string.quick_start_dialog_need_help_title,
+                        R.string.quick_start_dialog_need_help_message,
+                        R.string.quick_start_dialog_need_help_button_positive,
+                        R.string.quick_start_dialog_need_help_manage_site_button_negative,
+                        R.string.quick_start_dialog_need_help_button_neutral
+                )
+        )
     }
 
     private fun findQuickActionsBlock() = getLastItems().find { it is QuickActionsBlock } as QuickActionsBlock?


### PR DESCRIPTION
Parent #15130 

This PR fixes QSP for the `Site Picker` and `Login Epilogue` screens, in terms of:
- `Site Picker` screen:
  - Making sure that the QSP* is shown at the end of the flow.
  - Making sure that the new QSP* actions, like `Show me around` and `No thanks` are connected to the `Improved My Site` screen. At this point a toast is shown to verify that connection.
- `Login Epilogue` screen:
  - Making sure that when selecting a site, the new `QSP*` actions, like `Show me around` and `No thanks` are connected to the `Improved My Site` screen. At this point a toast is shown to verify that connection.
  - Making sure that when clicking the `Create New Site` button and going through the flow, the new `QSP*` actions, like `Show me around` and `No thanks` are connected to the `Improved My Site` screen. At this point a toast is shown to verify that connection.

PS: In a subsequent PR, the toast functionality will be replaced with the actual implementation, that is the showing or hiding of the `QS*` within the `Improved My Site` screen.

`QS* -> Quick Start`
`QSP* -> Quick Start Prompt`

-----

To test:

Scenario: `Site Picker - Create New Site`
1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Enable the `MySiteImprovementsFeatureConfig` feature flag.
3. Go to the `Site Picker` screen and add a new `wp.com` site.
4. Go through the flow and at the end of it make sure the new `QSP*` is shown.
5. Click the `Show me around` button.
6. Make sure the `Improved My Site` screen is shown and that the `QS - Positive Clicked` toast is shown.
7. Try the same flow, but this time click the `No thanks` button, then make sure the `QS - Negative Clicked` toast is shown.

Scenario: `Login Epilogue - Select Site`
1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Enable the `MySiteImprovementsFeatureConfig` feature flag.
3. Log-out and log-in to the app again.
4. When on the `Login Epilogue` screen, select a site from the list of sites.
5. Make sure the new `QSP*` is shown.
6. Click the `Show me around` button.
7. Make sure the `Improved My Site` screen is shown and that the `QS - Positive Clicked` toast is shown.
8. Try the same flow, but this time click the `No thanks` button, then make sure the `QS - Negative Clicked` toast is shown.

Scenario: `Login Epilogue - Create New Site`
1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Enable the `MySiteImprovementsFeatureConfig` feature flag.
3. Log-out and log-in to the app again.
4. When on the `Login Epilogue` screen, click on the `Create New Site` button.
5. Go through the flow and at the end of it make sure the new `QSP*` is shown.
6. Click the `Show me around` button.
7. Make sure the `Improved My Site` screen is shown and that the `QS - Positive Clicked` toast is shown.
8. Try the same flow, but this time click the `No thanks` button, then make sure the `QS - Negative Clicked` toast is shown.

-----

## Regression Notes
1. Potential unintended areas of impact

The existing `Quick Start` logic (old or/and new) might be somehow affected by all the changes in this PR since there has been some updates to all that.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
