### PR TITLE
Add debug cookies feature – Part 2

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -625,9 +625,14 @@
             android:name=".ui.stockmedia.StockMediaPickerActivity"
             android:label=""
             android:theme="@style/WordPress.NoActionBar" />
+
         <activity
             android:name="org.wordpress.android.ui.debug.DebugSettingsActivity"
             android:launchMode="singleTop"
+            android:theme="@style/WordPress.NoActionBar" />
+
+        <activity
+            android:name=".ui.debug.cookies.DebugCookiesActivity"
             android:theme="@style/WordPress.NoActionBar" />
 
         <!-- Notifications activities -->

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -82,6 +82,7 @@ import org.wordpress.android.push.GCMRegistrationIntentService;
 import org.wordpress.android.push.NotificationType;
 import org.wordpress.android.support.ZendeskHelper;
 import org.wordpress.android.ui.ActivityId;
+import org.wordpress.android.ui.debug.cookies.DebugCookieManager;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
@@ -184,6 +185,7 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
     @Inject ImageEditorFileUtils mImageEditorFileUtils;
     @Inject ExPlat mExPlat;
     @Inject WordPressWorkersFactory mWordPressWorkerFactory;
+    @Inject DebugCookieManager mDebugCookieManager;
     @Inject @Named(APPLICATION_SCOPE) CoroutineScope mAppScope;
 
     // For development and production `AnalyticsTrackerNosara`, for testing a mocked `Tracker` will be injected.
@@ -367,6 +369,8 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
         ProcessLifecycleOwner.get().getLifecycle().addObserver(mStoryMediaSaveUploadBridge);
 
         mExPlat.forceRefresh();
+
+        mDebugCookieManager.sync();
     }
 
     protected void initWorkManager() {

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -46,6 +46,7 @@ import org.wordpress.android.ui.comments.EditCommentActivity;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentListAdapter;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentListFragment;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsActivity;
+import org.wordpress.android.ui.debug.cookies.DebugCookiesFragment;
 import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment;
@@ -690,6 +691,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(LayoutPreviewFragment object);
 
     void inject(QuickStartPromptDialogFragment object);
+
+    void inject(DebugCookiesFragment object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -13,7 +13,6 @@ import org.wordpress.android.BuildConfig;
 import org.wordpress.android.ui.CommentFullScreenDialogFragment;
 import org.wordpress.android.ui.accounts.signup.SettingsUsernameChangerFragment;
 import org.wordpress.android.ui.accounts.signup.UsernameChangerFullScreenDialogFragment;
-import org.wordpress.android.ui.debug.cookies.DebugCookiesFragment;
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment.CountryPickerDialogFragment;
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment.StatePickerDialogFragment;
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep;
@@ -105,9 +104,6 @@ public abstract class ApplicationModule {
 
     @ContributesAndroidInjector
     abstract DebugSettingsFragment contributeDebugSettingsFragment();
-
-    @ContributesAndroidInjector
-    abstract DebugCookiesFragment contributeDebugCookiesFragment();
 
     @ContributesAndroidInjector
     abstract BasicDialog contributeBasicDialog();

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -13,6 +13,7 @@ import org.wordpress.android.BuildConfig;
 import org.wordpress.android.ui.CommentFullScreenDialogFragment;
 import org.wordpress.android.ui.accounts.signup.SettingsUsernameChangerFragment;
 import org.wordpress.android.ui.accounts.signup.UsernameChangerFullScreenDialogFragment;
+import org.wordpress.android.ui.debug.cookies.DebugCookiesFragment;
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment.CountryPickerDialogFragment;
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment.StatePickerDialogFragment;
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep;
@@ -104,6 +105,9 @@ public abstract class ApplicationModule {
 
     @ContributesAndroidInjector
     abstract DebugSettingsFragment contributeDebugSettingsFragment();
+
+    @ContributesAndroidInjector
+    abstract DebugCookiesFragment contributeDebugCookiesFragment();
 
     @ContributesAndroidInjector
     abstract BasicDialog contributeBasicDialog();

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.accounts.LoginEpilogueViewModel;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginSiteCheckErrorViewModel;
 import org.wordpress.android.ui.accounts.login.LoginPrologueViewModel;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentListViewModel;
+import org.wordpress.android.ui.debug.cookies.DebugCookiesViewModel;
 import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverViewModel;
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel;
 import org.wordpress.android.ui.accounts.LoginViewModel;
@@ -554,4 +555,9 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(CategoriesListViewModel.class)
     abstract ViewModel categoriesViewModel(CategoriesListViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(DebugCookiesViewModel.class)
+    abstract ViewModel debugCookiesViewModel(DebugCookiesViewModel viewModel);
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -43,6 +43,7 @@ import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailActivity;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
 import org.wordpress.android.ui.comments.CommentsActivity;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsActivity;
+import org.wordpress.android.ui.debug.cookies.DebugCookiesActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose;
 import org.wordpress.android.ui.engagement.EngagedPeopleListActivity;
@@ -1558,5 +1559,9 @@ public class ActivityLauncher {
         Intent intent = new Intent(context, CategoriesListActivity.class);
         intent.putExtra(WordPress.SITE, site);
         context.startActivity(intent);
+    }
+
+    public static void viewDebugCookies(@NonNull Context context) {
+        context.startActivity(new Intent(context, DebugCookiesActivity.class));
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsFragment.kt
@@ -9,7 +9,10 @@ import androidx.recyclerview.widget.RecyclerView
 import dagger.android.support.DaggerFragment
 import org.wordpress.android.R
 import org.wordpress.android.databinding.DebugSettingsFragmentBinding
+import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.debug.DebugSettingsViewModel.NavigationAction.DebugCookies
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
 
@@ -48,6 +51,11 @@ class DebugSettingsFragment : DaggerFragment(R.layout.debug_settings_fragment) {
                     layoutManager?.onRestoreInstanceState(recyclerViewState)
                 }
             })
+            viewModel.onNavigation.observeEvent(viewLifecycleOwner) {
+                when (it) {
+                    DebugCookies -> ActivityLauncher.viewDebugCookies(requireContext())
+                }
+            }
             viewModel.start()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsViewModel.kt
@@ -5,12 +5,14 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.debug.DebugSettingsViewModel.NavigationAction.DebugCookies
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Button
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Feature
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Feature.State.DISABLED
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Feature.State.ENABLED
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Feature.State.UNKNOWN
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Header
+import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Row
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.ToggleAction
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Type.BUTTON
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Type.FEATURE
@@ -22,6 +24,7 @@ import org.wordpress.android.util.config.FeaturesInDevelopment
 import org.wordpress.android.util.config.ManualFeatureConfig
 import org.wordpress.android.util.config.RemoteConfig
 import org.wordpress.android.util.config.RemoteConfigDefaults
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -35,6 +38,8 @@ class DebugSettingsViewModel
 ) : ScopedViewModel(mainDispatcher) {
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
+    private val _onNavigation = MutableLiveData<Event<NavigationAction>>()
+    val onNavigation: LiveData<Event<NavigationAction>> = _onNavigation
     private var hasChange: Boolean = false
 
     fun start() {
@@ -60,7 +65,12 @@ class DebugSettingsViewModel
             uiItems.add(Button(R.string.debug_settings_restart_app, debugUtils::restartApp))
         }
         uiItems.add(Header(R.string.debug_settings_tools))
+        uiItems.add(Row(R.string.debug_cookies_title, ListItemInteraction.create(this::onDebugCookiesClick)))
         _uiState.value = UiState(uiItems)
+    }
+
+    private fun onDebugCookiesClick() {
+        _onNavigation.value = Event(DebugCookies)
     }
 
     private fun buildDevelopedFeatures(): List<Feature> {
@@ -131,5 +141,9 @@ class DebugSettingsViewModel
         enum class Type {
             HEADER, FEATURE, BUTTON, ROW
         }
+    }
+
+    sealed class NavigationAction {
+        object DebugCookies : NavigationAction()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookie.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookie.kt
@@ -1,0 +1,30 @@
+package org.wordpress.android.ui.debug.cookies
+
+import com.google.gson.Gson
+import java.net.HttpCookie
+import java.net.URI
+
+data class DebugCookie(
+    val domain: String,
+    val name: String,
+    val value: String?,
+    val scheme: String = "https",
+    val path: String = "/",
+    val version: Int = 0
+) {
+    val key = domain + "_" + name
+
+    fun toURI(): URI = URI(scheme, domain, path, null)
+
+    fun toHttpCookie(): HttpCookie = HttpCookie(name, value).apply {
+        version = this@DebugCookie.version
+        domain = this@DebugCookie.domain
+        path = this@DebugCookie.path
+    }
+
+    fun encode(gson: Gson): String = gson.toJson(this)
+
+    companion object {
+        fun decode(gson: Gson, encoded: String?): DebugCookie? = gson.fromJson(encoded, DebugCookie::class.java)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookieManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookieManager.kt
@@ -1,0 +1,62 @@
+package org.wordpress.android.ui.debug.cookies
+
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+import androidx.core.content.edit
+import com.google.gson.GsonBuilder
+import org.wordpress.android.util.BuildConfigWrapper
+import java.net.CookieManager
+import javax.inject.Inject
+
+/**
+ * This class wraps a [CookieStore][java.net.CookieStore] and a [SharedPreferences][android.content.SharedPreferences],
+ * and syncs [DebugCookie]s between them.
+ *
+ * Note: this class was not designed with production use in mind, and because of that, it makes several assumptions
+ * about the format of the cookies. If we ever need to use this for anything other than manually setting debug cookies,
+ * then we should consider introducing our own [CookieStore][java.net.CookieStore] implementation instead.
+ *
+ * @param context The [Context][android.content.Context] from which the
+ * [SharedPreferences][android.content.SharedPreferences] will be built.
+ * @param cookieManager The [CookieManager][java.net.CookieManager] from which the [CookieStore][java.net.CookieStore]
+ * will be retrieved.
+ */
+class DebugCookieManager @Inject constructor(
+    context: Context,
+    cookieManager: CookieManager,
+    private val buildConfig: BuildConfigWrapper
+) {
+    private val preferences = context.getSharedPreferences(DEBUG_COOKIE_PREFERENCES, MODE_PRIVATE)
+    private val store = cookieManager.cookieStore
+    private val gson = GsonBuilder().serializeNulls().create()
+
+    fun sync() {
+        if (buildConfig.isDebugSettingsEnabled()) {
+            getAll().forEach { addToStore(it) }
+        }
+    }
+
+    fun getAll() = preferences.all.values.mapNotNull { DebugCookie.decode(gson, it as? String?) }
+
+    fun add(cookie: DebugCookie) {
+        addToStore(cookie)
+        addToPreferences(cookie)
+    }
+
+    fun remove(cookie: DebugCookie) {
+        removeFromStore(cookie)
+        removeFromPreferences(cookie)
+    }
+
+    private fun addToStore(cookie: DebugCookie) = store.add(cookie.toURI(), cookie.toHttpCookie())
+
+    private fun removeFromStore(cookie: DebugCookie) = store.remove(cookie.toURI(), cookie.toHttpCookie())
+
+    private fun addToPreferences(cookie: DebugCookie) = preferences.edit { putString(cookie.key, cookie.encode(gson)) }
+
+    private fun removeFromPreferences(cookie: DebugCookie) = preferences.edit { remove(cookie.key) }
+
+    companion object {
+        private const val DEBUG_COOKIE_PREFERENCES = "debug-cookie-preferences"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesActivity.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.ui.debug.cookies
+
+import android.os.Bundle
+import android.view.MenuItem
+import org.wordpress.android.databinding.DebugCookiesActivityBinding
+import org.wordpress.android.ui.LocaleAwareActivity
+
+class DebugCookiesActivity : LocaleAwareActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(DebugCookiesActivityBinding.inflate(layoutInflater).root)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
+        android.R.id.home -> {
+            onBackPressed()
+            true
+        }
+        else -> super.onOptionsItemSelected(item)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesAdapter.kt
@@ -1,32 +1,22 @@
 package org.wordpress.android.ui.debug.cookies
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.DiffUtil.Callback
-import androidx.recyclerview.widget.RecyclerView.Adapter
+import androidx.recyclerview.widget.DiffUtil.ItemCallback
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.databinding.DebugCookieItemBinding
+import org.wordpress.android.ui.debug.cookies.DebugCookiesAdapter.DebugCookieItem
 import org.wordpress.android.ui.debug.cookies.DebugCookiesAdapter.DebugCookieItemViewHolder
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.viewBinding
 
-class DebugCookiesAdapter : Adapter<DebugCookieItemViewHolder>() {
-    private var items: List<DebugCookieItem> = listOf()
-
-    fun update(newItems: List<DebugCookieItem>) {
-        val diffResult = DiffUtil.calculateDiff(DebugCookiesDiffCallback(items, newItems))
-        items = newItems
-        diffResult.dispatchUpdatesTo(this)
-    }
-
+class DebugCookiesAdapter : ListAdapter<DebugCookieItem, DebugCookieItemViewHolder>(DebugCookiesDiffCallback()) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
             DebugCookieItemViewHolder(parent.viewBinding(DebugCookieItemBinding::inflate))
 
     override fun onBindViewHolder(holder: DebugCookieItemViewHolder, position: Int) {
-        holder.onBind(items[position])
+        holder.onBind(getItem(position))
     }
-
-    override fun getItemCount() = items.size
 
     class DebugCookieItemViewHolder(private val binding: DebugCookieItemBinding) : ViewHolder(binding.root) {
         fun onBind(item: DebugCookieItem) = with(binding) {
@@ -39,14 +29,9 @@ class DebugCookiesAdapter : Adapter<DebugCookieItemViewHolder>() {
         }
     }
 
-    class DebugCookiesDiffCallback(
-        private val oldList: List<DebugCookieItem>,
-        private val newList: List<DebugCookieItem>
-    ) : Callback() {
-        override fun getOldListSize() = oldList.size
-        override fun getNewListSize() = newList.size
-        override fun areItemsTheSame(old: Int, new: Int) = oldList[old].key == newList[new].key
-        override fun areContentsTheSame(old: Int, new: Int) = oldList[old] == newList[new]
+    class DebugCookiesDiffCallback : ItemCallback<DebugCookieItem>() {
+        override fun areItemsTheSame(oldItem: DebugCookieItem, newItem: DebugCookieItem) = oldItem.key == newItem.key
+        override fun areContentsTheSame(oldItem: DebugCookieItem, newItem: DebugCookieItem) = oldItem == newItem
     }
 
     data class DebugCookieItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesAdapter.kt
@@ -1,0 +1,60 @@
+package org.wordpress.android.ui.debug.cookies
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.DiffUtil.Callback
+import androidx.recyclerview.widget.RecyclerView.Adapter
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import org.wordpress.android.databinding.DebugCookieItemBinding
+import org.wordpress.android.ui.debug.cookies.DebugCookiesAdapter.DebugCookieItemViewHolder
+import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.util.viewBinding
+
+class DebugCookiesAdapter : Adapter<DebugCookieItemViewHolder>() {
+    private var items: List<DebugCookieItem> = listOf()
+
+    fun update(newItems: List<DebugCookieItem>) {
+        val diffResult = DiffUtil.calculateDiff(DebugCookiesDiffCallback(items, newItems))
+        items = newItems
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+            DebugCookieItemViewHolder(parent.viewBinding(DebugCookieItemBinding::inflate))
+
+    override fun onBindViewHolder(holder: DebugCookieItemViewHolder, position: Int) {
+        holder.onBind(items[position])
+    }
+
+    override fun getItemCount() = items.size
+
+    class DebugCookieItemViewHolder(private val binding: DebugCookieItemBinding) : ViewHolder(binding.root) {
+        fun onBind(item: DebugCookieItem) = with(binding) {
+            cookieDomain.text = item.domain
+            cookieName.text = item.name
+            cookieValue.text = item.value
+
+            root.setOnClickListener { item.onClick.click() }
+            deleteCookieButton.setOnClickListener { item.onDeleteClick.click() }
+        }
+    }
+
+    class DebugCookiesDiffCallback(
+        private val oldList: List<DebugCookieItem>,
+        private val newList: List<DebugCookieItem>
+    ) : Callback() {
+        override fun getOldListSize() = oldList.size
+        override fun getNewListSize() = newList.size
+        override fun areItemsTheSame(old: Int, new: Int) = oldList[old].key == newList[new].key
+        override fun areContentsTheSame(old: Int, new: Int) = oldList[old] == newList[new]
+    }
+
+    data class DebugCookieItem(
+        val key: String,
+        val domain: String,
+        val name: String,
+        val value: String?,
+        val onClick: ListItemInteraction,
+        val onDeleteClick: ListItemInteraction
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
@@ -1,19 +1,26 @@
 package org.wordpress.android.ui.debug.cookies
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
-import dagger.android.support.DaggerFragment
 import org.wordpress.android.R
+import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.DebugCookiesFragmentBinding
 import javax.inject.Inject
 
-class DebugCookiesFragment : DaggerFragment(R.layout.debug_cookies_fragment) {
+class DebugCookiesFragment : Fragment(R.layout.debug_cookies_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: DebugCookiesViewModel
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        (requireActivity().application as WordPress).component().inject(this)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
@@ -3,14 +3,21 @@ package org.wordpress.android.ui.debug.cookies
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.android.support.DaggerFragment
 import org.wordpress.android.R
 import org.wordpress.android.databinding.DebugCookiesFragmentBinding
+import javax.inject.Inject
 
 class DebugCookiesFragment : DaggerFragment(R.layout.debug_cookies_fragment) {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: DebugCookiesViewModel
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(DebugCookiesViewModel::class.java)
+
         with(DebugCookiesFragmentBinding.bind(view)) {
             setupToolbar()
             setupViews()

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
@@ -1,0 +1,31 @@
+package org.wordpress.android.ui.debug.cookies
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import dagger.android.support.DaggerFragment
+import org.wordpress.android.R
+import org.wordpress.android.databinding.DebugCookiesFragmentBinding
+
+class DebugCookiesFragment : DaggerFragment(R.layout.debug_cookies_fragment) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        with(DebugCookiesFragmentBinding.bind(view)) {
+            setupToolbar()
+        }
+    }
+
+    private fun DebugCookiesFragmentBinding.setupToolbar() {
+        with(requireActivity() as AppCompatActivity) {
+            setSupportActionBar(toolbar)
+            supportActionBar?.let {
+                it.setHomeButtonEnabled(true)
+                it.setDisplayHomeAsUpEnabled(true)
+            }
+        }
+    }
+
+    companion object {
+        fun newInstance() = DebugCookiesFragment()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
@@ -53,7 +53,7 @@ class DebugCookiesFragment : DaggerFragment(R.layout.debug_cookies_fragment) {
 
     private fun DebugCookiesFragmentBinding.setupObservers() {
         viewModel.uiState.observe(viewLifecycleOwner) { uiState ->
-            (recyclerView.adapter as? DebugCookiesAdapter)?.update(uiState.items)
+            (recyclerView.adapter as? DebugCookiesAdapter)?.submitList(uiState.items)
             uiState.domainInputText?.let { domainInput.setTextAndMoveCursor(it) }
             uiState.nameInputText?.let { nameInput.setTextAndMoveCursor(it) }
             uiState.valueInputText?.let { valueInput.setTextAndMoveCursor(it) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.debug.cookies
 
 import android.os.Bundle
 import android.view.View
+import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -21,6 +22,7 @@ class DebugCookiesFragment : DaggerFragment(R.layout.debug_cookies_fragment) {
         with(DebugCookiesFragmentBinding.bind(view)) {
             setupToolbar()
             setupViews()
+            setupObservers()
         }
     }
 
@@ -39,6 +41,28 @@ class DebugCookiesFragment : DaggerFragment(R.layout.debug_cookies_fragment) {
             layoutManager = LinearLayoutManager(context)
             adapter = DebugCookiesAdapter()
         }
+
+        setCookieButton.setOnClickListener {
+            viewModel.setCookie(
+                    domainInput.text.toString(),
+                    nameInput.text.toString(),
+                    valueInput.text.toString()
+            )
+        }
+    }
+
+    private fun DebugCookiesFragmentBinding.setupObservers() {
+        viewModel.uiState.observe(viewLifecycleOwner) { uiState ->
+            (recyclerView.adapter as? DebugCookiesAdapter)?.update(uiState.items)
+            uiState.domainInputText?.let { domainInput.setTextAndMoveCursor(it) }
+            uiState.nameInputText?.let { nameInput.setTextAndMoveCursor(it) }
+            uiState.valueInputText?.let { valueInput.setTextAndMoveCursor(it) }
+        }
+    }
+
+    private fun EditText.setTextAndMoveCursor(text: String) {
+        this.setText(text)
+        this.setSelection(text.length)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.debug.cookies
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.android.support.DaggerFragment
 import org.wordpress.android.R
 import org.wordpress.android.databinding.DebugCookiesFragmentBinding
@@ -12,6 +13,7 @@ class DebugCookiesFragment : DaggerFragment(R.layout.debug_cookies_fragment) {
         super.onViewCreated(view, savedInstanceState)
         with(DebugCookiesFragmentBinding.bind(view)) {
             setupToolbar()
+            setupViews()
         }
     }
 
@@ -22,6 +24,13 @@ class DebugCookiesFragment : DaggerFragment(R.layout.debug_cookies_fragment) {
                 it.setHomeButtonEnabled(true)
                 it.setDisplayHomeAsUpEnabled(true)
             }
+        }
+    }
+
+    private fun DebugCookiesFragmentBinding.setupViews() {
+        recyclerView.apply {
+            layoutManager = LinearLayoutManager(context)
+            adapter = DebugCookiesAdapter()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesViewModel.kt
@@ -1,8 +1,60 @@
 package org.wordpress.android.ui.debug.cookies
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.ui.debug.cookies.DebugCookiesAdapter.DebugCookieItem
+import org.wordpress.android.ui.utils.ListItemInteraction
 import javax.inject.Inject
 
-class DebugCookiesViewModel @Inject constructor() : ViewModel() {
-    // TODO
+class DebugCookiesViewModel @Inject constructor(
+    private val debugCookieManager: DebugCookieManager
+) : ViewModel() {
+    private val _uiState = MutableLiveData(UiState(getUpdatedItems()))
+    val uiState: LiveData<UiState> = _uiState
+
+    fun setCookie(domain: String?, name: String?, value: String?) {
+        if (!domain.isNullOrBlank() && !name.isNullOrBlank()) {
+            debugCookieManager.add(DebugCookie(domain, name, value))
+            _uiState.value = UiState(
+                    items = getUpdatedItems(),
+                    domainInputText = domain,
+                    nameInputText = name,
+                    valueInputText = value
+            )
+        }
+    }
+
+    private fun onItemClick(debugCookie: DebugCookie) {
+        _uiState.value = _uiState.value?.copy(
+                domainInputText = debugCookie.domain,
+                nameInputText = debugCookie.name,
+                valueInputText = debugCookie.value
+        )
+    }
+
+    private fun onDeleteClick(debugCookie: DebugCookie) {
+        debugCookieManager.remove(debugCookie)
+        _uiState.value = _uiState.value?.copy(
+                items = getUpdatedItems()
+        )
+    }
+
+    private fun getUpdatedItems() = debugCookieManager.getAll().sortedBy { it.key }.map {
+        DebugCookieItem(
+                it.key,
+                it.domain,
+                it.name,
+                it.value,
+                ListItemInteraction.create(it, ::onItemClick),
+                ListItemInteraction.create(it, ::onDeleteClick)
+        )
+    }
+
+    data class UiState(
+        val items: List<DebugCookieItem>,
+        val domainInputText: String? = null,
+        val nameInputText: String? = null,
+        val valueInputText: String? = null
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesViewModel.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.ui.debug.cookies
+
+import androidx.lifecycle.ViewModel
+import javax.inject.Inject
+
+class DebugCookiesViewModel @Inject constructor() : ViewModel() {
+    // TODO
+}

--- a/WordPress/src/main/res/layout/debug_cookie_item.xml
+++ b/WordPress/src/main/res/layout/debug_cookie_item.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/linearLayout2"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:paddingEnd="@dimen/margin_medium"
+    android:paddingStart="@dimen/margin_medium">
+
+    <TextView
+        android:id="@+id/cookie_domain"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_medium"
+        android:textAppearance="?attr/textAppearanceCaption"
+        app:layout_constraintEnd_toStartOf="@+id/delete_cookie_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="wordpress.com" />
+
+    <TextView
+        android:id="@+id/cookie_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_medium"
+        android:textAppearance="?attr/textAppearanceCaption"
+        app:layout_constraintEnd_toStartOf="@+id/delete_cookie_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/cookie_domain"
+        tools:text="cookie_name" />
+
+    <TextView
+        android:id="@+id/cookie_value"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_medium"
+        android:textAppearance="?attr/textAppearanceCaption"
+        app:layout_constraintEnd_toStartOf="@+id/delete_cookie_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/cookie_name"
+        tools:text="cookie_value" />
+
+    <ImageButton
+        android:id="@+id/delete_cookie_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:padding="@dimen/margin_medium"
+        android:src="@drawable/ic_delete_black_24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="?attr/wpColorOnSurfaceMedium"
+        tools:ignore="ContentDescription" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/debug_cookies_activity.xml
+++ b/WordPress/src/main/res/layout/debug_cookies_activity.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/WordPress/src/main/res/layout/debug_cookies_activity.xml
+++ b/WordPress/src/main/res/layout/debug_cookies_activity.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/fragment_container"
+    android:name="org.wordpress.android.ui.debug.cookies.DebugCookiesFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />

--- a/WordPress/src/main/res/layout/debug_cookies_fragment.xml
+++ b/WordPress/src/main/res/layout/debug_cookies_fragment.xml
@@ -25,11 +25,87 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler_view"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:background="@color/divider" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:layout_marginEnd="@dimen/margin_medium"
+            android:layout_marginStart="@dimen/margin_medium"
+            app:hintEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/domain_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/debug_cookies_cookie_domain_hint"
+                android:inputType="textUri"
+                android:text="@string/debug_cookies_cookie_domain_hint" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:layout_marginEnd="@dimen/margin_medium"
+            android:layout_marginStart="@dimen/margin_medium"
+            app:hintEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/name_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/debug_cookies_cookie_name_hint"
+                android:inputType="text" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:layout_marginEnd="@dimen/margin_medium"
+            android:layout_marginStart="@dimen/margin_medium"
+            app:hintEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/value_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/debug_cookies_cookie_value_hint"
+                android:inputType="text" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/set_cookie_button"
+            style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:layout_marginEnd="@dimen/margin_medium"
+            android:layout_marginStart="@dimen/margin_medium"
+            android:text="@string/debug_cookies_set_cookie" />
+
+    </LinearLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/debug_cookies_fragment.xml
+++ b/WordPress/src/main/res/layout/debug_cookies_fragment.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.debug.cookies.DebugCookiesFragment">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        android:fitsSystemWindows="true">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_scrollFlags="noScroll"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+            app:theme="@style/WordPress.ActionBar"
+            app:title="@string/debug_cookies_title" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -912,6 +912,9 @@
     <string name="debug_settings_missing_developed_feature" translatable="false">Don\'t see a feature you\'re working on? Check that your feature config file is annotated with the FeatureInDevelopment annotation.</string>
     <string name="debug_settings_tools" translatable="false">Tools</string>
 
+    <!-- Debug cookies -->
+    <string name="debug_cookies_title" translatable="false">Debug cookies</string>
+
     <!-- stats -->
     <string name="stats">Stats</string>
     <string name="stats_jetpack_connection_setup_info">To use Stats on your WordPress site, you\'ll need to install the Jetpack plugin.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -914,6 +914,10 @@
 
     <!-- Debug cookies -->
     <string name="debug_cookies_title" translatable="false">Debug cookies</string>
+    <string name="debug_cookies_set_cookie" translatable="false">Set cookie</string>
+    <string name="debug_cookies_cookie_domain_hint" translatable="false">wordpress.com</string>
+    <string name="debug_cookies_cookie_name_hint" translatable="false">cookie_name</string>
+    <string name="debug_cookies_cookie_value_hint" translatable="false">cookie_value</string>
 
     <!-- stats -->
     <string name="stats">Stats</string>

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'develop-0193e64889a94b44c507c6aba5b83ce0fc96bc61'
+    fluxCVersion = 'develop-76106a2176a4d12f39f22c8d41eb35b1df8fd46e'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
This PR adds a "Debug cookies" option to the Debug Settings screen. It basically allows us to add and remove any cookie value to be used on our app requests for testing purposes:


https://user-images.githubusercontent.com/830056/128933846-cdd386ae-d049-41f7-b5d0-3133e392a06c.mp4




### To test

Notes: 
- You'll need a tool like Charles so you can verify that the cookies are being added to the requests.

1. Open the app.
1. Tap the Me button.
1. On the Me screen, go to App Settings > Debug settings > Debug cookies.
1. On the Debug Cookies screen, add any kind of cookie name and cookie value combination (ex: `my_cookie_name` and `my_cookie_value`).
1. Tap "Set cookie".
1. Go back to My Site screen.
1. On Charles, verify that new API requests have the new cookie added to them:

<img width="769" src="https://user-images.githubusercontent.com/830056/128933088-0beb32ad-a219-4a4c-8e82-13951476f8fb.png">

## Regression Notes
1. Potential unintended areas of impact
None that I can think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
