### PR TITLE
My Site Dashboard - Phase 1 - Connect QSP with QS for the Improved My Site Screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -534,7 +534,7 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
     }
 
     override fun onNegativeClicked(instanceTag: String) {
-        Toast.makeText(context, "QS - Negative Clicked", Toast.LENGTH_LONG).show()
+        viewModel.ignoreQuickStart()
     }
 
     override fun onNeutralClicked(instanceTag: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -447,11 +447,11 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
             }
             RequestCodes.LOGIN_EPILOGUE,
             RequestCodes.CREATE_SITE -> {
-                viewModel.startQuickStart(data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1))
+                viewModel.checkAndStartQuickStart(data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1))
             }
             RequestCodes.SITE_PICKER -> {
                 if (data.getIntExtra(WPMainActivity.ARG_CREATE_SITE, 0) == RequestCodes.CREATE_SITE) {
-                    viewModel.startQuickStart(data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1))
+                    viewModel.checkAndStartQuickStart(data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1))
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
 import android.widget.ImageView
-import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.appcompat.widget.TooltipCompat
 import androidx.fragment.app.Fragment
@@ -538,6 +537,6 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
     }
 
     override fun onNeutralClicked(instanceTag: String) {
-        Toast.makeText(context, "QS - Neutral Clicked", Toast.LENGTH_LONG).show()
+        viewModel.disableQuickStart()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -530,7 +530,7 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
     }
 
     override fun onPositiveClicked(instanceTag: String) {
-        Toast.makeText(context, "QS - Positive Clicked", Toast.LENGTH_LONG).show()
+        viewModel.startQuickStart()
     }
 
     override fun onNegativeClicked(instanceTag: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_ACTION_STATS_
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_HIDE_CARD_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REMOVE_CARD_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_NEUTRAL_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED
 import org.wordpress.android.fluxc.model.DynamicCardType
 import org.wordpress.android.fluxc.model.MediaModel
@@ -683,7 +684,10 @@ class MySiteViewModel
     }
 
     fun disableQuickStart() {
-        // TODO: Disable quick start.
+        if (!onboardingImprovementsFeatureConfig.isEnabled()) {
+            analyticsTrackerWrapper.track(QUICK_START_REQUEST_DIALOG_NEUTRAL_TAPPED)
+            appPrefsWrapper.setQuickStartDisabled(true)
+        }
     }
 
     data class UiModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -613,7 +613,7 @@ class MySiteViewModel
         }
     }
 
-    fun startQuickStart(newSiteLocalID: Int) {
+    fun checkAndStartQuickStart(newSiteLocalID: Int) {
         if (quickStartDynamicCardsFeatureConfig.isEnabled()) {
             quickStartRepository.startQuickStart(newSiteLocalID)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -682,6 +682,10 @@ class MySiteViewModel
         analyticsTrackerWrapper.track(QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
     }
 
+    fun disableQuickStart() {
+        // TODO: Disable quick start.
+    }
+
     data class UiModel(
         val accountAvatarUrl: String,
         val state: State

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -671,6 +671,10 @@ class MySiteViewModel
         }
     }
 
+    fun startQuickStart() {
+        // TODO: Start quick start.
+    }
+
     data class UiModel(
         val accountAvatarUrl: String,
         val state: State

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -677,6 +677,10 @@ class MySiteViewModel
         selectedSiteRepository.getSelectedSite()?.id?.let { quickStartRepository.startQuickStart(it) }
     }
 
+    fun ignoreQuickStart() {
+        // TODO: Ignore quick start.
+    }
+
     data class UiModel(
         val accountAvatarUrl: String,
         val state: State

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_ACTION_POSTS_
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_ACTION_STATS_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_HIDE_CARD_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REMOVE_CARD_TAPPED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED
 import org.wordpress.android.fluxc.model.DynamicCardType
 import org.wordpress.android.fluxc.model.MediaModel
@@ -678,7 +679,7 @@ class MySiteViewModel
     }
 
     fun ignoreQuickStart() {
-        // TODO: Ignore quick start.
+        analyticsTrackerWrapper.track(QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
     }
 
     data class UiModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_ACTION_POSTS_
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_ACTION_STATS_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_HIDE_CARD_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REMOVE_CARD_TAPPED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED
 import org.wordpress.android.fluxc.model.DynamicCardType
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -672,7 +673,8 @@ class MySiteViewModel
     }
 
     fun startQuickStart() {
-        // TODO: Start quick start.
+        analyticsTrackerWrapper.track(QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED)
+        selectedSiteRepository.getSelectedSite()?.id?.let { quickStartRepository.startQuickStart(it) }
     }
 
     data class UiModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -197,6 +197,8 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun isQuickStartEnabled() = !AppPrefs.isQuickStartDisabled()
 
+    fun setQuickStartDisabled(isDisabled: Boolean) = AppPrefs.setQuickStartDisabled(isDisabled)
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1050,43 +1050,43 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given QS dynamic cards cards feature is on, when start quick start is triggered, then QS starts`() {
+    fun `given QS dynamic cards cards feature is on, when check and start QS is triggered, then QS starts`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(true)
 
-        viewModel.startQuickStart(siteId)
+        viewModel.checkAndStartQuickStart(siteId)
 
         verify(quickStartRepository).startQuickStart(siteId)
     }
 
     @Test
-    fun `given no selected site, when start quick start is triggered, then QSP is not shown`() {
+    fun `given no selected site, when check and start QS is triggered, then QSP is not shown`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
 
-        viewModel.startQuickStart(siteId)
+        viewModel.checkAndStartQuickStart(siteId)
 
         assertThat(navigationActions).isEmpty()
     }
 
     @Test
-    fun `given QS is not available for the site, when start quick start is triggered, then QSP is not shown`() {
+    fun `given QS is not available for the site, when check and start QS is triggered, then QSP is not shown`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(false)
 
-        viewModel.startQuickStart(siteId)
+        viewModel.checkAndStartQuickStart(siteId)
 
         assertThat(navigationActions).isEmpty()
     }
 
     @Test
-    fun `given onboarding improvements feature is on, when start quick start is triggered, then new QSP is shown`() {
+    fun `given onboarding improvements feature is on, when check and start QS is triggered, then new QSP is shown`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(true)
         whenever(onboardingImprovementsFeatureConfig.isEnabled()).thenReturn(true)
 
-        viewModel.startQuickStart(siteId)
+        viewModel.checkAndStartQuickStart(siteId)
 
         assertThat(navigationActions).containsExactly(
                 ShowQuickStartDialog(
@@ -1099,27 +1099,27 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given QS is disabled, when start quick start is triggered, then old QSP is not shown`() {
+    fun `given QS is disabled, when check and start QS is triggered, then old QSP is not shown`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(true)
         whenever(onboardingImprovementsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(appPrefsWrapper.isQuickStartEnabled()).thenReturn(false)
 
-        viewModel.startQuickStart(siteId)
+        viewModel.checkAndStartQuickStart(siteId)
 
         assertThat(navigationActions).isEmpty()
     }
 
     @Test
-    fun `given QS is enabled, when start quick start is triggered, then old QSP is shown`() {
+    fun `given QS is enabled, when check and start QS is triggered, then old QSP is shown`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(true)
         whenever(onboardingImprovementsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(appPrefsWrapper.isQuickStartEnabled()).thenReturn(true)
 
-        viewModel.startQuickStart(siteId)
+        viewModel.checkAndStartQuickStart(siteId)
 
         assertThat(navigationActions).containsExactly(
                 ShowQuickStartDialog(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -8,6 +8,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -28,6 +29,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMP
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_NEUTRAL_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED
 import org.wordpress.android.fluxc.model.DynamicCardType.CUSTOMIZE_QUICK_START
 import org.wordpress.android.fluxc.model.DynamicCardType.GROW_QUICK_START
@@ -1155,6 +1157,34 @@ class MySiteViewModelTest : BaseUnitTest() {
         viewModel.ignoreQuickStart()
 
         verify(analyticsTrackerWrapper).track(QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
+    }
+
+    @Test
+    fun `given onboarding improvements feature is on, when disable QS is triggered, then do nothing`() {
+        whenever(onboardingImprovementsFeatureConfig.isEnabled()).thenReturn(true)
+
+        viewModel.disableQuickStart()
+
+        verifyZeroInteractions(analyticsTrackerWrapper)
+        verifyZeroInteractions(appPrefsWrapper)
+    }
+
+    @Test
+    fun `when disable QS is triggered, then QS request dialog neutral tapped is tracked`() {
+        whenever(onboardingImprovementsFeatureConfig.isEnabled()).thenReturn(false)
+
+        viewModel.disableQuickStart()
+
+        verify(analyticsTrackerWrapper).track(QUICK_START_REQUEST_DIALOG_NEUTRAL_TAPPED)
+    }
+
+    @Test
+    fun `when disable QS is triggered, then disable QS`() {
+        whenever(onboardingImprovementsFeatureConfig.isEnabled()).thenReturn(false)
+
+        viewModel.disableQuickStart()
+
+        verify(appPrefsWrapper).setQuickStartDisabled(true)
     }
 
     private fun findQuickActionsBlock() = getLastItems().find { it is QuickActionsBlock } as QuickActionsBlock?

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED
 import org.wordpress.android.fluxc.model.DynamicCardType.CUSTOMIZE_QUICK_START
 import org.wordpress.android.fluxc.model.DynamicCardType.GROW_QUICK_START
@@ -1147,6 +1148,13 @@ class MySiteViewModelTest : BaseUnitTest() {
         viewModel.startQuickStart()
 
         verify(quickStartRepository).startQuickStart(site.id)
+    }
+
+    @Test
+    fun `when ignore QS is triggered, then QS request dialog negative tapped is tracked`() {
+        viewModel.ignoreQuickStart()
+
+        verify(analyticsTrackerWrapper).track(QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
     }
 
     private fun findQuickActionsBlock() = getLastItems().find { it is QuickActionsBlock } as QuickActionsBlock?

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED
 import org.wordpress.android.fluxc.model.DynamicCardType.CUSTOMIZE_QUICK_START
 import org.wordpress.android.fluxc.model.DynamicCardType.GROW_QUICK_START
 import org.wordpress.android.fluxc.model.SiteModel
@@ -1130,6 +1131,22 @@ class MySiteViewModelTest : BaseUnitTest() {
                         R.string.quick_start_dialog_need_help_button_neutral
                 )
         )
+    }
+
+    @Test
+    fun `when start QS is triggered, then QS request dialog positive tapped is tracked`() {
+        viewModel.startQuickStart()
+
+        verify(analyticsTrackerWrapper).track(QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED)
+    }
+
+    @Test
+    fun `when start QS is triggered, then QS starts`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+
+        viewModel.startQuickStart()
+
+        verify(quickStartRepository).startQuickStart(site.id)
     }
 
     private fun findQuickActionsBlock() = getLastItems().find { it is QuickActionsBlock } as QuickActionsBlock?


### PR DESCRIPTION
Parent #15130

This PR connects `QSP*` with `QS*` for the `Improved My Site` screen. This means that this PR enables the below `QSP*` actions, when that dialog is shown from within the `Improved My Site` screen:
- Positive: `Show me around` for both the old and new flow (see `Onboarding Improvements` project).
- Negative: `No thanks` for both the old and new flow (see `Onboarding Improvements` project).
- Neutral: `Never` only for the old flow (see `Onboarding Improvements` project).

Note: The logic for all actions was copy-pasted from within `MySiteFragment`, based on the `TAG_QUICK_START_DIALOG` instance tag.

`QS* -> Quick Start`
`QSP* -> Quick Start Prompt`

-----

To test:

Scenario: `Show me around`
1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Enable the `MySiteImprovementsFeatureConfig` feature flag.
3. Trigger showing the `QSP*` either through the `Site Picker` or the `Login Epilogue` screens and flows. Preferable from both screen and all 3 flows.
4. Click the `Show me around` button.
5. Make sure the `Improved My Site` screen is shown and that the `QS*` is shown.

Scenario: `No thanks`
1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Enable the `MySiteImprovementsFeatureConfig` feature flag.
3. Trigger showing the `QSP*` either through the `Site Picker` or the `Login Epilogue` screens and flows. Preferable from both screen and all 3 flows.
4. Click the `No thanks` button.
5. Make sure the `Improved My Site` screen is shown and that the `QS*` is not shown.

-----

## Regression Notes
1. Potential unintended areas of impact

The existing `Quick Start` logic (old or/and new) might be somehow affected by all the changes in this PR since there has been some updates to all that.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
