### PR TITLE
Migrate `Quick Start - List Item` refresh logic to `ImprovedMySiteFragment`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -22,9 +22,11 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.databinding.NewMySiteFragmentBinding
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.FullScreenDialogFragment
 import org.wordpress.android.ui.FullScreenDialogFragment.Builder
+import org.wordpress.android.ui.FullScreenDialogFragment.OnConfirmListener
 import org.wordpress.android.ui.FullScreenDialogFragment.OnDismissListener
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.TextInputDialogFragment
@@ -103,6 +105,7 @@ import javax.inject.Inject
 class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
         TextInputDialogFragment.Callback,
         QuickStartPromptClickInterface,
+        OnConfirmListener,
         OnDismissListener {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var imageManager: ImageManager
@@ -308,6 +311,7 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
         val bundle = QuickStartFullScreenDialogFragment.newBundle(action.type)
         Builder(requireContext())
                 .setTitle(action.title)
+                .setOnConfirmListener(this)
                 .setOnDismissListener(this)
                 .setContent(QuickStartFullScreenDialogFragment::class.java, bundle)
                 .build()
@@ -542,6 +546,13 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
 
     override fun onNeutralClicked(instanceTag: String) {
         Toast.makeText(context, "QS - Neutral Clicked", Toast.LENGTH_LONG).show()
+    }
+
+    override fun onConfirm(result: Bundle?) {
+        if (result != null) {
+            val task = result.getSerializable(QuickStartFullScreenDialogFragment.RESULT_TASK) as? QuickStartTask
+            viewModel.onQuickStartFullScreenDialogConfirm(task)
+        }
     }
 
     override fun onDismiss() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.databinding.NewMySiteFragmentBinding
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.FullScreenDialogFragment
 import org.wordpress.android.ui.FullScreenDialogFragment.Builder
+import org.wordpress.android.ui.FullScreenDialogFragment.OnDismissListener
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.TextInputDialogFragment
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
@@ -101,7 +102,8 @@ import javax.inject.Inject
 @Suppress("TooManyFunctions")
 class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
         TextInputDialogFragment.Callback,
-        QuickStartPromptClickInterface {
+        QuickStartPromptClickInterface,
+        OnDismissListener {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var uiHelpers: UiHelpers
@@ -306,6 +308,7 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
         val bundle = QuickStartFullScreenDialogFragment.newBundle(action.type)
         Builder(requireContext())
                 .setTitle(action.title)
+                .setOnDismissListener(this)
                 .setContent(QuickStartFullScreenDialogFragment::class.java, bundle)
                 .build()
                 .show(requireActivity().supportFragmentManager, FullScreenDialogFragment.TAG)
@@ -539,5 +542,9 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
 
     override fun onNeutralClicked(instanceTag: String) {
         Toast.makeText(context, "QS - Neutral Clicked", Toast.LENGTH_LONG).show()
+    }
+
+    override fun onDismiss() {
+        viewModel.onQuickStartFullScreenDialogDismiss()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -550,8 +550,9 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
 
     override fun onConfirm(result: Bundle?) {
         if (result != null) {
-            val task = result.getSerializable(QuickStartFullScreenDialogFragment.RESULT_TASK) as? QuickStartTask
-            viewModel.onQuickStartFullScreenDialogConfirm(task)
+            viewModel.onQuickStartFullScreenDialogConfirm(
+                    task = result.getSerializable(QuickStartFullScreenDialogFragment.RESULT_TASK) as? QuickStartTask
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -259,7 +259,14 @@ class MySiteViewModel
 
             if (!quickStartDynamicCardsFeatureConfig.isEnabled() &&
                     quickStartUtilsWrapper.isQuickStartInProgress(appPrefsWrapper.getSelectedSite())) {
-                siteItems.add(quickStartBlockBuilder.build(this::onQuickStartTaskTypeItemClick))
+                quickStartCategories.takeIf { it.isNotEmpty() }?.let {
+                    siteItems.add(
+                            quickStartBlockBuilder.build(
+                                    quickStartCategories,
+                                    this::onQuickStartTaskTypeItemClick
+                            )
+                    )
+                }
             }
 
             siteItems.addAll(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -366,6 +366,10 @@ class MySiteViewModel
         quickStartRepository.setActiveTask(task)
     }
 
+    fun onQuickStartFullScreenDialogConfirm(task: QuickStartTask?) {
+        task?.let { onQuickStartTaskCardClick(it) }
+    }
+
     fun onQuickStartFullScreenDialogDismiss() {
         quickStartRepository.refresh()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -366,6 +366,10 @@ class MySiteViewModel
         quickStartRepository.setActiveTask(task)
     }
 
+    fun onQuickStartFullScreenDialogDismiss() {
+        quickStartRepository.refresh()
+    }
+
     private fun titleClick() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
         if (!networkUtilsWrapper.isNetworkAvailable()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -192,9 +192,9 @@ class QuickStartRepository
     }
 
     private suspend fun onCategoryCompleted(siteId: Int, categoryType: QuickStartTaskType) {
-        val completionMessage = getCategoryCompletionMessage(categoryType)
-        _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(completionMessage.asHtml()))))
         if (quickStartDynamicCardsFeatureConfig.isEnabled()) {
+            val completionMessage = getCategoryCompletionMessage(categoryType)
+            _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(completionMessage.asHtml()))))
             dynamicCardStore.removeCard(siteId, categoryType.toDynamicCardType())
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -95,8 +95,7 @@ class QuickStartRepository
             refresh()
         }
         val quickStartTaskTypes = refresh.mapAsync(coroutineScope) {
-            val quickStartTaskTypes = getQuickStartTaskTypes(siteId)
-            quickStartTaskTypes.onEach { taskType ->
+            getQuickStartTaskTypes(siteId).onEach { taskType ->
                 if (quickStartUtils.isEveryQuickStartTaskDoneForType(siteId, taskType)) {
                     onCategoryCompleted(siteId, taskType)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
@@ -1,39 +1,36 @@
 package org.wordpress.android.ui.mysite.quickstart
 
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.MySiteItem.QuickStartBlock
 import org.wordpress.android.ui.mysite.MySiteItem.QuickStartBlock.QuickStartTaskTypeItem
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.mysite.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import javax.inject.Inject
 
-class QuickStartBlockBuilder
-@Inject constructor(
-    private val appPrefsWrapper: AppPrefsWrapper,
-    private val quickStartStore: QuickStartStore
-) {
-    fun build(onItemClick: (QuickStartTaskType) -> Unit): QuickStartBlock {
-        val localSiteId = appPrefsWrapper.getSelectedSite().toLong()
-
+class QuickStartBlockBuilder @Inject constructor() {
+    fun build(
+        categories: List<QuickStartCategory>,
+        onItemClick: (QuickStartTaskType) -> Unit
+    ): QuickStartBlock {
         val taskTypeItems = mutableListOf<QuickStartTaskTypeItem>()
-        taskTypeItems.add(buildQuickStartTaskTypeItem(localSiteId, QuickStartTaskType.CUSTOMIZE, onItemClick))
-        taskTypeItems.add(buildQuickStartTaskTypeItem(localSiteId, QuickStartTaskType.GROW, onItemClick))
+        categories.forEach { category ->
+            taskTypeItems.add(buildQuickStartTaskTypeItem(category, onItemClick))
+        }
 
         return QuickStartBlock(taskTypeItems = taskTypeItems)
     }
 
     private fun buildQuickStartTaskTypeItem(
-        localSiteId: Long,
-        quickStartTaskType: QuickStartTaskType,
+        category: QuickStartCategory,
         onItemClick: (QuickStartTaskType) -> Unit
     ): QuickStartTaskTypeItem {
-        val countCompleted = quickStartStore.getCompletedTasksByType(localSiteId, quickStartTaskType).size
-        val countUncompleted = quickStartStore.getUncompletedTasksByType(localSiteId, quickStartTaskType).size
+        val quickStartTaskType = category.taskType
+        val countCompleted = category.completedTasks.size
+        val countUncompleted = category.uncompletedTasks.size
 
         return QuickStartTaskTypeItem(
                 quickStartTaskType = quickStartTaskType,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
@@ -15,14 +15,9 @@ class QuickStartBlockBuilder @Inject constructor() {
     fun build(
         categories: List<QuickStartCategory>,
         onItemClick: (QuickStartTaskType) -> Unit
-    ): QuickStartBlock {
-        val taskTypeItems = mutableListOf<QuickStartTaskTypeItem>()
-        categories.forEach { category ->
-            taskTypeItems.add(buildQuickStartTaskTypeItem(category, onItemClick))
-        }
-
-        return QuickStartBlock(taskTypeItems = taskTypeItems)
-    }
+    ) = QuickStartBlock(
+            taskTypeItems = categories.map { buildQuickStartTaskTypeItem(it, onItemClick) }
+    )
 
     private fun buildQuickStartTaskTypeItem(
         category: QuickStartCategory,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1041,6 +1041,18 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when QS full screen dialog confirm is triggered on task tap, then task is set as active task`() {
+        val task = QuickStartTask.VIEW_SITE
+        initSelectedSite(
+                isQuickStartDynamicCardEnabled = false,
+                isQuickStartInProgress = true
+        )
+        viewModel.onQuickStartFullScreenDialogConfirm(task)
+
+        verify(quickStartRepository).setActiveTask(task)
+    }
+
+    @Test
     fun `when build is Jetpack, then quick action block is not built`() {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1030,6 +1030,17 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when QS fullscreen dialog dismiss is triggered, then quick start repository is refreshed`() {
+        initSelectedSite(
+                isQuickStartDynamicCardEnabled = false,
+                isQuickStartInProgress = true
+        )
+        viewModel.onQuickStartFullScreenDialogDismiss()
+
+        verify(quickStartRepository).refresh()
+    }
+
+    @Test
     fun `when build is Jetpack, then quick action block is not built`() {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1199,7 +1199,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                                 )
                         )
                 )
-            }.whenever(quickStartBlockBuilder).build(any())
+            }.whenever(quickStartBlockBuilder).build(any(), any())
         } else {
             whenever(quickStartUtilsWrapper.isQuickStartInProgress(siteId)).thenReturn(false)
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -73,6 +73,7 @@ import org.wordpress.android.ui.mysite.MySiteViewModelTest.SiteInfoBlockAction.I
 import org.wordpress.android.ui.mysite.MySiteViewModelTest.SiteInfoBlockAction.SWITCH_SITE_CLICK
 import org.wordpress.android.ui.mysite.MySiteViewModelTest.SiteInfoBlockAction.TITLE_CLICK
 import org.wordpress.android.ui.mysite.MySiteViewModelTest.SiteInfoBlockAction.URL_CLICK
+import org.wordpress.android.ui.mysite.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ChangeSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteNavigationAction.AddNewSite
@@ -102,6 +103,7 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsSource
 import org.wordpress.android.ui.mysite.quickstart.QuickStartBlockBuilder
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
@@ -1181,7 +1183,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         if (isQuickStartInProgress) {
             whenever(quickStartUtilsWrapper.isQuickStartInProgress(siteId)).thenReturn(true)
             doAnswer {
-                quickStartTaskTypeItemClickAction = (it.getArgument(0) as (QuickStartTaskType) -> Unit)
+                quickStartTaskTypeItemClickAction = (it.getArgument(1) as (QuickStartTaskType) -> Unit)
                 QuickStartBlock(
                         taskTypeItems = listOf(
                                 QuickStartTaskTypeItem(
@@ -1200,6 +1202,15 @@ class MySiteViewModelTest : BaseUnitTest() {
                         )
                 )
             }.whenever(quickStartBlockBuilder).build(any(), any())
+            quickStartUpdate.value = QuickStartUpdate(
+                    categories = listOf(
+                            QuickStartCategory(
+                                    taskType = QuickStartTaskType.CUSTOMIZE,
+                                    uncompletedTasks = listOf(QuickStartTaskDetails.UPDATE_SITE_TITLE),
+                                    completedTasks = emptyList()
+                            )
+                    )
+            )
         } else {
             whenever(quickStartUtilsWrapper.isQuickStartInProgress(siteId)).thenReturn(false)
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -110,13 +110,25 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given same type tasks done, when refresh started, then completion message shown `() = test {
-        initStore()
+    fun `given dynamic card enabled + same type tasks done, when refresh started, then completion msg shown`() =
+            test {
+                whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(true)
+                initStore()
 
-        triggerQSRefreshAfterSameTypeTasksAreComplete()
+                triggerQSRefreshAfterSameTypeTasksAreComplete()
 
-        assertThat(snackbars).containsOnly(SnackbarMessageHolder(UiStringText(ALL_TASKS_COMPLETED_MESSAGE)))
-    }
+                assertThat(snackbars).containsOnly(SnackbarMessageHolder(UiStringText(ALL_TASKS_COMPLETED_MESSAGE)))
+            }
+
+    @Test
+    fun `given dynamic card disabled + same type tasks done, when refresh started, then completion msg not shown`() =
+            test {
+                initStore()
+
+                triggerQSRefreshAfterSameTypeTasksAreComplete()
+
+                assertThat(snackbars).doesNotContain(SnackbarMessageHolder(UiStringText(ALL_TASKS_COMPLETED_MESSAGE)))
+            }
 
     @Test
     fun `given dynamic card enabled + same type tasks done, when refresh started, then dynamic card removed`() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -123,6 +123,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     @Test
     fun `given dynamic card disabled + same type tasks done, when refresh started, then completion msg not shown`() =
             test {
+                whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
                 initStore()
 
                 triggerQSRefreshAfterSameTypeTasksAreComplete()
@@ -143,6 +144,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     @Test
     fun `given dynamic card disabled + same type tasks done, when refresh started, then dynamic card not removed`() =
             test {
+                whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
                 initStore()
 
                 triggerQSRefreshAfterSameTypeTasksAreComplete()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -129,6 +129,29 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given dynamic card disabled + same type tasks done, when refresh started, then dynamic card not removed`() =
+            test {
+                initStore()
+
+                triggerQSRefreshAfterSameTypeTasksAreComplete()
+
+                verify(dynamicCardStore, never()).removeCard(siteId, GROW_QUICK_START)
+            }
+
+    @Test
+    fun `given dynamic card disabled + same type tasks done, when refresh started, then both task types exists`() =
+            test {
+                whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
+                initStore()
+
+                triggerQSRefreshAfterSameTypeTasksAreComplete()
+                var result: QuickStartUpdate? = null
+                quickStartRepository.buildSource(testScope(), siteId).observeForever { result = it }
+
+                assertThat(result?.categories?.map { it.taskType }).isEqualTo(listOf(CUSTOMIZE, GROW))
+            }
+
+    @Test
     fun `refresh does not show completion message if not all tasks of a same type have been completed`() = test {
         initStore()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -159,10 +159,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 initStore()
 
                 triggerQSRefreshAfterSameTypeTasksAreComplete()
-                var result: QuickStartUpdate? = null
-                quickStartRepository.buildSource(testScope(), siteId).observeForever { result = it }
 
-                assertThat(result?.categories?.map { it.taskType }).isEqualTo(listOf(CUSTOMIZE, GROW))
+                assertThat(result.last().categories.map { it.taskType }).isEqualTo(listOf(CUSTOMIZE, GROW))
             }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -44,6 +44,7 @@ import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteImprovementsFeatureConfig
+import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 
 class QuickStartRepositoryTest : BaseUnitTest() {
@@ -57,6 +58,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     @Mock lateinit var dynamicCardStore: DynamicCardStore
     @Mock lateinit var htmlCompat: HtmlCompatWrapper
     @Mock lateinit var mySiteImprovementsFeatureConfig: MySiteImprovementsFeatureConfig
+    @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
     private lateinit var site: SiteModel
     private lateinit var quickStartRepository: QuickStartRepository
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -78,7 +80,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 eventBus,
                 dynamicCardStore,
                 htmlCompat,
-                mySiteImprovementsFeatureConfig
+                mySiteImprovementsFeatureConfig,
+                quickStartDynamicCardsFeatureConfig
         )
         snackbars = mutableListOf()
         quickStartPrompts = mutableListOf()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
@@ -1,20 +1,15 @@
 package org.wordpress.android.ui.mysite.quickstart
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyLong
-import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.store.QuickStartStore
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.MySiteItem.QuickStartBlock
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.mysite.QuickStartRepository.QuickStartCategory
+import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
@@ -24,18 +19,13 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 class QuickStartBlockBuilderTest : BaseUnitTest() {
     private lateinit var builder: QuickStartBlockBuilder
 
-    @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
-    @Mock lateinit var quickStartStore: QuickStartStore
-
-    private val siteId = 1
-    private val completedTasks: List<QuickStartTask> = listOf(QuickStartTask.UPDATE_SITE_TITLE)
-    private val uncompletedTasks: List<QuickStartTask> = listOf(QuickStartTask.VIEW_SITE)
+    private val completedTasks: List<QuickStartTaskDetails> = listOf(QuickStartTaskDetails.UPDATE_SITE_TITLE)
+    private val uncompletedTasks: List<QuickStartTaskDetails> = listOf(QuickStartTaskDetails.VIEW_SITE_TUTORIAL)
     private val onItemClick: (QuickStartTaskType) -> Unit = {}
 
     @Before
     fun setUp() {
-        builder = QuickStartBlockBuilder(appPrefsWrapper, quickStartStore)
-        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
+        builder = QuickStartBlockBuilder()
     }
 
     @Test
@@ -168,14 +158,24 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
     }
 
     private fun buildQuickStartBlock(
-        completedTasks: List<QuickStartTask>? = null,
-        uncompletedTasks: List<QuickStartTask>? = null
+        completedTasks: List<QuickStartTaskDetails>? = null,
+        uncompletedTasks: List<QuickStartTaskDetails>? = null
     ): QuickStartBlock {
-        whenever(quickStartStore.getCompletedTasksByType(anyLong(), any()))
-                .thenReturn(completedTasks ?: this.completedTasks)
-        whenever(quickStartStore.getUncompletedTasksByType(anyLong(), any()))
-                .thenReturn(uncompletedTasks ?: this.uncompletedTasks)
-        return builder.build(onItemClick)
+        val customizeCategory = buildQuickStartCategory(QuickStartTaskType.CUSTOMIZE, completedTasks, uncompletedTasks)
+        val growCategory = buildQuickStartCategory(QuickStartTaskType.GROW, completedTasks, uncompletedTasks)
+        return builder.build(listOf(customizeCategory, growCategory), onItemClick)
+    }
+
+    private fun buildQuickStartCategory(
+        taskType: QuickStartTaskType,
+        completedTasks: List<QuickStartTaskDetails>?,
+        uncompletedTasks: List<QuickStartTaskDetails>?
+    ): QuickStartCategory {
+        return QuickStartCategory(
+                taskType = taskType,
+                completedTasks = completedTasks ?: this.completedTasks,
+                uncompletedTasks = uncompletedTasks ?: this.uncompletedTasks
+        )
     }
 
     private fun getQuickStartTaskTypeItem(


### PR DESCRIPTION
Issue #15127

This PR 
- builds `Quick Start - List Item` in `ImprovedMySiteFragment` using the QS repository's categories. This is done so that the list item can be refreshed every time the categories are refreshed from the QS repository.
- refreshes the `Quick Start - List Item` in `ImprovedMySiteFragment` when the `QuickStartFullScreenDialogFragment` is dismissed.
- handles `QuickStartFullScreenDialogFragment`'s confirm action which is triggered when a [quick start task is tapped from this fragment](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFullScreenDialogFragment.java#L157) by calling the QS repository's `onQuickStartTaskCardClick` via the VM. QS focus points and snack bars are taken care of automatically (note that existing snack bars from `ImprovedMySiteFragment` are reused). 

To test:

1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Disable `QuickStartDynamicCardsFeatureConfig`, enable `MySiteImprovementsFeatureConfig`
3. Restart the app
4. Select a site with quick start in progress 
5. Click quick start task type list item
6. Notice that `QuickStartFullScreenDialogFragment` gets opened
7. Select a task from the `QuickStartFullScreenDialogFragment`
8. Notice that when `QuickStartFullScreenDialogFragment` is dismissed, the appropriate QS focus point and snack bar get displayed based on the chosen task, and the completed tasks count is updated on the task type list item when that task is completed 
9. Repeat steps 5-8 till all tasks for a task type are complete
10. Notice that the task type is struck-through on `ImprovedMySiteFragment` once the `QuickStartFullScreenDialogFragment` is dismissed

## Regression Notes
1. Potential unintended areas of impact
    - `ImprovedMySiteFragment` -> `Quick Start - Dynamic Card` (`MySiteImprovementsFeatureConfig` - ON, `QuickStartDynamicCardsFeatureConfig` - ON )
    - `MySiteFragment` -> `Quick Start` (`MySiteImprovementsFeatureConfig` - OFF)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for actions intercepted in `ImprovedMySiteFragment` from `QuickStartFullScreenDialogFragment`. `QuickStartFullScreenDialogFragment` is shown in `MySiteImprovementsFeatureConfig` only when `QuickStartDynamicCardsFeatureConfig` - OFF.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
