### PR TITLE
Quick Start: Remove if conditions in the VM to display the quick start block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -260,6 +260,8 @@ class MySiteViewModel
                 }
             }.associateBy { it.dynamicCardType }
 
+            siteItems.addAll(visibleDynamicCards.mapNotNull { dynamicCardType -> dynamicCards[dynamicCardType] })
+
             if (!quickStartDynamicCardsFeatureConfig.isEnabled()) {
                 quickStartCategories.takeIf { it.isNotEmpty() }?.let {
                     siteItems.add(
@@ -270,10 +272,6 @@ class MySiteViewModel
                     )
                 }
             }
-
-            siteItems.addAll(
-                    visibleDynamicCards.mapNotNull { dynamicCardType -> dynamicCards[dynamicCardType] }
-            )
 
             siteItems.addAll(
                     siteItemsBuilder.buildSiteItems(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -260,8 +260,15 @@ class MySiteViewModel
                 }
             }.associateBy { it.dynamicCardType }
 
-            quickStartCategories.takeIf { it.isNotEmpty() }?.let {
-                siteItems.add(quickStartBlockBuilder.build(quickStartCategories, this::onQuickStartTaskTypeItemClick))
+            if (!quickStartDynamicCardsFeatureConfig.isEnabled()) {
+                quickStartCategories.takeIf { it.isNotEmpty() }?.let {
+                    siteItems.add(
+                            quickStartBlockBuilder.build(
+                                    quickStartCategories,
+                                    this::onQuickStartTaskTypeItemClick
+                            )
+                    )
+                }
             }
 
             siteItems.addAll(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -257,16 +257,8 @@ class MySiteViewModel
                 }
             }.associateBy { it.dynamicCardType }
 
-            if (!quickStartDynamicCardsFeatureConfig.isEnabled() &&
-                    quickStartUtilsWrapper.isQuickStartInProgress(appPrefsWrapper.getSelectedSite())) {
-                quickStartCategories.takeIf { it.isNotEmpty() }?.let {
-                    siteItems.add(
-                            quickStartBlockBuilder.build(
-                                    quickStartCategories,
-                                    this::onQuickStartTaskTypeItemClick
-                            )
-                    )
-                }
+            quickStartCategories.takeIf { it.isNotEmpty() }?.let {
+                siteItems.add(quickStartBlockBuilder.build(quickStartCategories, this::onQuickStartTaskTypeItemClick))
             }
 
             siteItems.addAll(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1202,9 +1202,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         isQuickStartInProgress: Boolean = false
     ) {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(isQuickStartDynamicCardEnabled)
-        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
-        if (isQuickStartInProgress) {
-            whenever(quickStartUtilsWrapper.isQuickStartInProgress(siteId)).thenReturn(true)
+        if (!isQuickStartDynamicCardEnabled && isQuickStartInProgress) {
             doAnswer {
                 quickStartTaskTypeItemClickAction = (it.getArgument(1) as (QuickStartTaskType) -> Unit)
                 QuickStartBlock(
@@ -1234,8 +1232,6 @@ class MySiteViewModelTest : BaseUnitTest() {
                             )
                     )
             )
-        } else {
-            whenever(quickStartUtilsWrapper.isQuickStartInProgress(siteId)).thenReturn(false)
         }
         onSiteSelected.value = siteId
         onSiteChange.value = site


### PR DESCRIPTION
Issue #15127

This PR removes the if conditions added during the old quick start section migration to the `ImprovedMySiteFragment` in [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/15141). 

Quick start categories received from the repository have already gone through these checks [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt#L115) and [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt#L105), so these duplicate checks are not required. 

Note that there's a difference in the site ids used to check the quick start progress in the VM and the repository. As discussed, it will be taken care of in a separate PR where we plan to start using the selected site repository site id instead of the AppPref's site id.

To test:
Changes being simple, it should be sufficient to just code review the change.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
