### PR TITLE
Enable editor help menu for eligible users

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1271,7 +1271,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
         if (helpMenuItem != null) {
             if (mEditorFragment instanceof GutenbergEditorFragment
-                && BuildConfig.DEBUG
+                && canViewEditorOnboarding()
                 && showMenuItems
             ) {
                 helpMenuItem.setVisible(true);

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3824-5e258538499d216ecdcea31257d8210b4e70f351'
+    ext.gutenbergMobileVersion = '3824-836174f0e711c1e98b4bfe231c536851ee0440c5'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.60.0-alpha1'
+    ext.gutenbergMobileVersion = '3824-5e258538499d216ecdcea31257d8210b4e70f351'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3824-836174f0e711c1e98b4bfe231c536851ee0440c5'
+    ext.gutenbergMobileVersion = 'v1.60.0-alpha2'
 
     repositories {
         maven {


### PR DESCRIPTION
## Related PRs
* https://github.com/WordPress/gutenberg/pull/34018
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/3824
* https://github.com/wordpress-mobile/WordPress-iOS/pull/17008

To test: See https://github.com/WordPress/gutenberg/pull/34018. 

## Regression Notes
1. Potential unintended areas of impact
    Changes to the feature flag could disrupted existing flagged features. 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Tested a few of the feature flag feature to ensure they functioned as expected. 
3. What automated tests I added (or what prevented me from doing so)
    Decided automated tests in this repository were not valuable for this Gutenberg-centric change. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
