### PR TITLE
Migrate `Quick Start - More Menu` to `ImprovedMySiteFragment`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
@@ -55,7 +55,10 @@ sealed class MySiteItem(open val type: Type, open val activeQuickStartItem: Bool
 
     data class DomainRegistrationBlock(val onClick: ListItemInteraction) : MySiteItem(DOMAIN_REGISTRATION_BLOCK)
 
-    data class QuickStartBlock(val taskTypeItems: List<QuickStartTaskTypeItem>) : MySiteItem(QUICK_START_BLOCK) {
+    data class QuickStartBlock(
+        val onRemoveMenuItemClick: ListItemInteraction,
+        val taskTypeItems: List<QuickStartTaskTypeItem>
+    ) : MySiteItem(QUICK_START_BLOCK) {
         data class QuickStartTaskTypeItem(
             val quickStartTaskType: QuickStartTaskType,
             @DrawableRes val icon: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -263,6 +263,7 @@ class MySiteViewModel
                     siteItems.add(
                             quickStartBlockBuilder.build(
                                     quickStartCategories,
+                                    this::onQuickStartBlockRemoveMenuItemClick,
                                     this::onQuickStartTaskTypeItemClick
                             )
                     )
@@ -355,6 +356,9 @@ class MySiteViewModel
 
     private fun onDynamicCardMoreClick(model: DynamicCardMenuModel) {
         _onDynamicCardMenuShown.postValue(Event(model))
+    }
+
+    private fun onQuickStartBlockRemoveMenuItemClick() {
     }
 
     private fun onQuickStartTaskTypeItemClick(type: QuickStartTaskType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -24,6 +24,8 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_ACTION_POSTS_
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_ACTION_STATS_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_HIDE_CARD_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REMOVE_CARD_TAPPED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REMOVE_DIALOG_NEGATIVE_TAPPED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REMOVE_DIALOG_POSITIVE_TAPPED
 import org.wordpress.android.fluxc.model.DynamicCardType
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -506,6 +508,7 @@ class MySiteViewModel
                             Event(OpenMediaPicker(requireNotNull(selectedSiteRepository.getSelectedSite())))
                     )
                 }
+                TAG_REMOVE_NEXT_STEPS_DIALOG -> onRemoveNextStepsDialogPositiveButtonClicked()
             }
             is Negative -> when (interaction.tag) {
                 TAG_ADD_SITE_ICON_DIALOG -> {
@@ -516,6 +519,7 @@ class MySiteViewModel
                     quickStartRepository.completeTask(UPLOAD_SITE_ICON, true)
                     selectedSiteRepository.updateSiteIconMediaId(0, true)
                 }
+                TAG_REMOVE_NEXT_STEPS_DIALOG -> onRemoveNextStepsDialogNegativeButtonClicked()
             }
             is Dismissed -> when (interaction.tag) {
                 TAG_ADD_SITE_ICON_DIALOG, TAG_CHANGE_SITE_ICON_DIALOG -> {
@@ -523,6 +527,17 @@ class MySiteViewModel
                 }
             }
         }
+    }
+
+    private fun onRemoveNextStepsDialogPositiveButtonClicked() {
+        analyticsTrackerWrapper.track(QUICK_START_REMOVE_DIALOG_POSITIVE_TAPPED)
+        quickStartRepository.skipQuickStart()
+        refresh()
+        clearActiveQuickStartTask()
+    }
+
+    private fun onRemoveNextStepsDialogNegativeButtonClicked() {
+        analyticsTrackerWrapper.track(QUICK_START_REMOVE_DIALOG_NEGATIVE_TAPPED)
     }
 
     fun handleTakenSiteIcon(iconUrl: String?, source: PhotoPickerMediaSource?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -62,6 +62,7 @@ import org.wordpress.android.ui.mysite.MySiteItem.DynamicCard
 import org.wordpress.android.ui.mysite.MySiteItem.QuickActionsBlock
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ChangeSiteIconDialogModel
+import org.wordpress.android.ui.mysite.SiteDialogModel.ShowRemoveNextStepsDialog
 import org.wordpress.android.ui.mysite.SiteNavigationAction.AddNewSite
 import org.wordpress.android.ui.mysite.SiteNavigationAction.ConnectJetpackForStats
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenActivityLog
@@ -359,6 +360,7 @@ class MySiteViewModel
     }
 
     private fun onQuickStartBlockRemoveMenuItemClick() {
+        _onBasicDialogShown.value = Event(ShowRemoveNextStepsDialog)
     }
 
     private fun onQuickStartTaskTypeItemClick(type: QuickStartTaskType) {
@@ -712,6 +714,7 @@ class MySiteViewModel
     companion object {
         const val TAG_ADD_SITE_ICON_DIALOG = "TAG_ADD_SITE_ICON_DIALOG"
         const val TAG_CHANGE_SITE_ICON_DIALOG = "TAG_CHANGE_SITE_ICON_DIALOG"
+        const val TAG_REMOVE_NEXT_STEPS_DIALOG = "TAG_REMOVE_NEXT_STEPS_DIALOG"
         const val SITE_NAME_CHANGE_CALLBACK_ID = 1
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -132,9 +132,7 @@ class QuickStartRepository
     fun skipQuickStart() {
         selectedSiteRepository.getSelectedSite()?.let { site ->
             val siteLocalId = site.id.toLong()
-            for (quickStartTask in QuickStartTask.values()) {
-                quickStartStore.setDoneTask(siteLocalId, quickStartTask, true)
-            }
+            QuickStartTask.values().forEach { quickStartStore.setDoneTask(siteLocalId, it, true) }
             quickStartStore.setQuickStartCompleted(siteLocalId, true)
             // skipping all tasks means no achievement notification, so we mark it as received
             quickStartStore.setQuickStartNotificationReceived(siteLocalId, true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -131,13 +131,13 @@ class QuickStartRepository
 
     fun skipQuickStart() {
         selectedSiteRepository.getSelectedSite()?.let { site ->
-            val siteId = site.id.toLong()
+            val siteLocalId = site.id.toLong()
             for (quickStartTask in QuickStartTask.values()) {
-                quickStartStore.setDoneTask(siteId, quickStartTask, true)
+                quickStartStore.setDoneTask(siteLocalId, quickStartTask, true)
             }
-            quickStartStore.setQuickStartCompleted(siteId, true)
+            quickStartStore.setQuickStartCompleted(siteLocalId, true)
             // skipping all tasks means no achievement notification, so we mark it as received
-            quickStartStore.setQuickStartNotificationReceived(siteId, true)
+            quickStartStore.setQuickStartNotificationReceived(siteLocalId, true)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -126,6 +126,18 @@ class QuickStartRepository
         }
     }
 
+    fun skipQuickStart() {
+        selectedSiteRepository.getSelectedSite()?.let { site ->
+            val siteId = site.id.toLong()
+            for (quickStartTask in QuickStartTask.values()) {
+                quickStartStore.setDoneTask(siteId, quickStartTask, true)
+            }
+            quickStartStore.setQuickStartCompleted(siteId, true)
+            // skipping all tasks means no achievement notification, so we mark it as received
+            quickStartStore.setQuickStartNotificationReceived(siteId, true)
+        }
+    }
+
     fun refresh() {
         refresh.postValue(true)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteDialogModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteDialogModel.kt
@@ -28,4 +28,12 @@ sealed class SiteDialogModel(
             R.string.my_site_icon_dialog_remove_button,
             R.string.my_site_icon_dialog_cancel_button
     )
+
+    object ShowRemoveNextStepsDialog : SiteDialogModel(
+            MySiteViewModel.TAG_REMOVE_NEXT_STEPS_DIALOG,
+            R.string.quick_start_dialog_remove_next_steps_title,
+            R.string.quick_start_dialog_remove_next_steps_message,
+            R.string.remove,
+            R.string.cancel
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
@@ -14,8 +14,10 @@ import javax.inject.Inject
 class QuickStartBlockBuilder @Inject constructor() {
     fun build(
         categories: List<QuickStartCategory>,
+        onRemoveMenuItemClick: () -> Unit,
         onItemClick: (QuickStartTaskType) -> Unit
     ) = QuickStartBlock(
+            onRemoveMenuItemClick = ListItemInteraction.create { onRemoveMenuItemClick.invoke() },
             taskTypeItems = categories.map { buildQuickStartTaskTypeItem(it, onItemClick) }
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
 import org.wordpress.android.ui.mysite.MySiteItem.QuickStartBlock
 import org.wordpress.android.ui.mysite.MySiteItem.QuickStartBlock.QuickStartTaskTypeItem
 import org.wordpress.android.ui.mysite.MySiteItemViewHolder
+import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.viewBinding
 
@@ -19,13 +20,17 @@ class QuickStartBlockViewHolder(
     private val uiHelpers: UiHelpers
 ) : MySiteItemViewHolder<QuickStartBlockBinding>(parent.viewBinding(QuickStartBlockBinding::inflate)) {
     fun bind(block: QuickStartBlock) = with(binding) {
-        quickStartMore.setOnClickListener { showQuickStartCardMenu() }
+        quickStartMore.setOnClickListener { showQuickStartCardMenu(block.onRemoveMenuItemClick) }
         updateQuickStartCustomizeContainer(block.taskTypeItems.first { it.quickStartTaskType == CUSTOMIZE })
         updateQuickStartGrowContainer(block.taskTypeItems.first { it.quickStartTaskType == GROW })
     }
 
-    private fun QuickStartBlockBinding.showQuickStartCardMenu() {
+    private fun QuickStartBlockBinding.showQuickStartCardMenu(onRemoveMenuItemClick: ListItemInteraction) {
         val quickStartPopupMenu = PopupMenu(itemView.context, quickStartMore)
+        quickStartPopupMenu.setOnMenuItemClickListener {
+            onRemoveMenuItemClick.click()
+            return@setOnMenuItemClickListener true
+        }
         quickStartPopupMenu.inflate(R.menu.quick_start_card_menu)
         quickStartPopupMenu.show()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
@@ -2,7 +2,9 @@ package org.wordpress.android.ui.mysite.quickstart
 
 import android.graphics.Paint
 import android.view.ViewGroup
+import androidx.appcompat.widget.PopupMenu
 import com.google.android.material.textview.MaterialTextView
+import org.wordpress.android.R
 import org.wordpress.android.databinding.QuickStartBlockBinding
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CUSTOMIZE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
@@ -17,8 +19,15 @@ class QuickStartBlockViewHolder(
     private val uiHelpers: UiHelpers
 ) : MySiteItemViewHolder<QuickStartBlockBinding>(parent.viewBinding(QuickStartBlockBinding::inflate)) {
     fun bind(block: QuickStartBlock) = with(binding) {
+        quickStartMore.setOnClickListener { showQuickStartCardMenu() }
         updateQuickStartCustomizeContainer(block.taskTypeItems.first { it.quickStartTaskType == CUSTOMIZE })
         updateQuickStartGrowContainer(block.taskTypeItems.first { it.quickStartTaskType == GROW })
+    }
+
+    private fun QuickStartBlockBinding.showQuickStartCardMenu() {
+        val quickStartPopupMenu = PopupMenu(itemView.context, quickStartMore)
+        quickStartPopupMenu.inflate(R.menu.quick_start_card_menu)
+        quickStartPopupMenu.show()
     }
 
     private fun QuickStartBlockBinding.updateQuickStartCustomizeContainer(item: QuickStartTaskTypeItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1010,10 +1010,8 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when quick start task type item is clicked, then quick start full screen dialog is opened`() {
-        initSelectedSite(
-                isQuickStartDynamicCardEnabled = false,
-                isQuickStartInProgress = true
-        )
+        initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
+
         requireNotNull(quickStartTaskTypeItemClickAction).invoke(QuickStartTaskType.CUSTOMIZE)
 
         assertThat(navigationActions.last()).isInstanceOf(OpenQuickStartFullScreenDialog::class.java)
@@ -1021,10 +1019,8 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when quick start task type item is clicked, then quick start active task is cleared`() {
-        initSelectedSite(
-                isQuickStartDynamicCardEnabled = false,
-                isQuickStartInProgress = true
-        )
+        initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
+
         requireNotNull(quickStartTaskTypeItemClickAction).invoke(QuickStartTaskType.CUSTOMIZE)
 
         verify(quickStartRepository).clearActiveTask()
@@ -1032,10 +1028,8 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when QS fullscreen dialog dismiss is triggered, then quick start repository is refreshed`() {
-        initSelectedSite(
-                isQuickStartDynamicCardEnabled = false,
-                isQuickStartInProgress = true
-        )
+        initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
+
         viewModel.onQuickStartFullScreenDialogDismiss()
 
         verify(quickStartRepository).refresh()
@@ -1044,10 +1038,8 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Test
     fun `when QS full screen dialog confirm is triggered on task tap, then task is set as active task`() {
         val task = QuickStartTask.VIEW_SITE
-        initSelectedSite(
-                isQuickStartDynamicCardEnabled = false,
-                isQuickStartInProgress = true
-        )
+        initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
+
         viewModel.onQuickStartFullScreenDialogConfirm(task)
 
         verify(quickStartRepository).setActiveTask(task)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -103,6 +103,7 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.Dyn
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsSource
 import org.wordpress.android.ui.mysite.quickstart.QuickStartBlockBuilder
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.utils.ListItemInteraction
@@ -1034,6 +1035,42 @@ class MySiteViewModelTest : BaseUnitTest() {
         requireNotNull(removeMenuItemClickAction).invoke()
 
         assertThat(dialogModels.last()).isEqualTo(ShowRemoveNextStepsDialog)
+    }
+
+    @Test
+    fun `when remove next steps dialog negative btn clicked, then QS is not skipped`() {
+        initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
+
+        viewModel.onDialogInteraction(DialogInteraction.Negative(MySiteViewModel.TAG_REMOVE_NEXT_STEPS_DIALOG))
+
+        verify(quickStartRepository, never()).skipQuickStart()
+    }
+
+    @Test
+    fun `when remove next steps dialog positive btn clicked, then QS is skipped`() {
+        initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
+
+        viewModel.onDialogInteraction(DialogInteraction.Positive(MySiteViewModel.TAG_REMOVE_NEXT_STEPS_DIALOG))
+
+        verify(quickStartRepository).skipQuickStart()
+    }
+
+    @Test
+    fun `when remove next steps dialog positive btn clicked, then QS repo refreshed`() {
+        initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
+
+        viewModel.onDialogInteraction(DialogInteraction.Positive(MySiteViewModel.TAG_REMOVE_NEXT_STEPS_DIALOG))
+
+        verify(quickStartRepository).refresh()
+    }
+
+    @Test
+    fun `when remove next steps dialog positive btn clicked, then QS active task cleared`() {
+        initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
+
+        viewModel.onDialogInteraction(DialogInteraction.Positive(MySiteViewModel.TAG_REMOVE_NEXT_STEPS_DIALOG))
+
+        verify(quickStartRepository).clearActiveTask()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -180,6 +180,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                     )
             )
     )
+    private var removeMenuItemClickAction: (() -> Unit)? = null
     private var quickStartTaskTypeItemClickAction: ((QuickStartTaskType) -> Unit)? = null
 
     @InternalCoroutinesApi
@@ -1206,8 +1207,9 @@ class MySiteViewModelTest : BaseUnitTest() {
         if (isQuickStartInProgress) {
             whenever(quickStartUtilsWrapper.isQuickStartInProgress(siteId)).thenReturn(true)
             doAnswer {
-                quickStartTaskTypeItemClickAction = (it.getArgument(1) as (QuickStartTaskType) -> Unit)
+                quickStartTaskTypeItemClickAction = (it.getArgument(2) as (QuickStartTaskType) -> Unit)
                 QuickStartBlock(
+                        onRemoveMenuItemClick = ListItemInteraction.create { removeMenuItemClickAction },
                         taskTypeItems = listOf(
                                 QuickStartTaskTypeItem(
                                         quickStartTaskType = QuickStartTaskType.CUSTOMIZE,
@@ -1224,7 +1226,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                                 )
                         )
                 )
-            }.whenever(quickStartBlockBuilder).build(any(), any())
+            }.whenever(quickStartBlockBuilder).build(any(), any(), any())
             quickStartUpdate.value = QuickStartUpdate(
                     categories = listOf(
                             QuickStartCategory(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -76,6 +76,7 @@ import org.wordpress.android.ui.mysite.MySiteViewModelTest.SiteInfoBlockAction.U
 import org.wordpress.android.ui.mysite.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ChangeSiteIconDialogModel
+import org.wordpress.android.ui.mysite.SiteDialogModel.ShowRemoveNextStepsDialog
 import org.wordpress.android.ui.mysite.SiteNavigationAction.AddNewSite
 import org.wordpress.android.ui.mysite.SiteNavigationAction.ConnectJetpackForStats
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenActivityLog
@@ -1027,6 +1028,15 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given dynamic card disabled, when QS remove menu item is clicked, then remove next steps dialog shown`() {
+        initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
+
+        requireNotNull(removeMenuItemClickAction).invoke()
+
+        assertThat(dialogModels.last()).isEqualTo(ShowRemoveNextStepsDialog)
+    }
+
+    @Test
     fun `when QS fullscreen dialog dismiss is triggered, then quick start repository is refreshed`() {
         initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
 
@@ -1199,7 +1209,9 @@ class MySiteViewModelTest : BaseUnitTest() {
         if (isQuickStartInProgress) {
             whenever(quickStartUtilsWrapper.isQuickStartInProgress(siteId)).thenReturn(true)
             doAnswer {
+                removeMenuItemClickAction = (it.getArgument(1) as () -> Unit)
                 quickStartTaskTypeItemClickAction = (it.getArgument(2) as (QuickStartTaskType) -> Unit)
+
                 QuickStartBlock(
                         onRemoveMenuItemClick = ListItemInteraction.create { removeMenuItemClickAction },
                         taskTypeItems = listOf(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -189,9 +189,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
 
         quickStartRepository.skipQuickStart()
 
-        for (quickStartTask in QuickStartTask.values()) {
-            verify(quickStartStore).setDoneTask(siteId.toLong(), quickStartTask, true)
-        }
+        QuickStartTask.values().forEach { verify(quickStartStore).setDoneTask(siteId.toLong(), it, true) }
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.model.SiteHomepageSettings.ShowOnFront
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.DynamicCardStore
 import org.wordpress.android.fluxc.store.QuickStartStore
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CREATE_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_POST_SHARING
@@ -177,6 +178,39 @@ class QuickStartRepositoryTest : BaseUnitTest() {
 
         assertThat(snackbars).isEmpty()
     }
+
+    @Test
+    fun `when quick start is skipped, then all quick start tasks for the selected site are set to done`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        initStore()
+
+        quickStartRepository.skipQuickStart()
+
+        for (quickStartTask in QuickStartTask.values()) {
+            verify(quickStartStore).setDoneTask(siteId.toLong(), quickStartTask, true)
+        }
+    }
+
+    @Test
+    fun `when quick start is skipped, then quick start is marked complete for the selected site`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        initStore()
+
+        quickStartRepository.skipQuickStart()
+
+        verify(quickStartStore).setQuickStartCompleted(siteId.toLong(), true)
+    }
+
+    @Test
+    fun `when quick start is skipped, then quick start notifications for the selected site are marked received`() =
+            test {
+                whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+                initStore()
+
+                quickStartRepository.skipQuickStart()
+
+                verify(quickStartStore).setQuickStartNotificationReceived(siteId.toLong(), true)
+            }
 
     @Test
     fun `start marks CREATE_SITE as done and loads model`() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
@@ -158,6 +158,15 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
                 .isEqualTo(ListItemInteraction.create(taskTypeItem.quickStartTaskType, onItemClick))
     }
 
+    /* REMOVE MENU ITEM */
+
+    @Test
+    fun `when block is built, then remove menu item click is set on the block`() {
+        val quickStartBlock = buildQuickStartBlock()
+
+        assertThat(quickStartBlock.onRemoveMenuItemClick).isNotNull
+    }
+
     private fun buildQuickStartBlock(
         completedTasks: List<QuickStartTaskDetails>? = null,
         uncompletedTasks: List<QuickStartTaskDetails>? = null

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
@@ -22,6 +22,7 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
     private val completedTasks: List<QuickStartTaskDetails> = listOf(QuickStartTaskDetails.UPDATE_SITE_TITLE)
     private val uncompletedTasks: List<QuickStartTaskDetails> = listOf(QuickStartTaskDetails.VIEW_SITE_TUTORIAL)
     private val onItemClick: (QuickStartTaskType) -> Unit = {}
+    private val onRemoveMenuItemClick: () -> Unit = {}
 
     @Before
     fun setUp() {
@@ -163,7 +164,7 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
     ): QuickStartBlock {
         val customizeCategory = buildQuickStartCategory(QuickStartTaskType.CUSTOMIZE, completedTasks, uncompletedTasks)
         val growCategory = buildQuickStartCategory(QuickStartTaskType.GROW, completedTasks, uncompletedTasks)
-        return builder.build(listOf(customizeCategory, growCategory), onItemClick)
+        return builder.build(listOf(customizeCategory, growCategory), onRemoveMenuItemClick, onItemClick)
     }
 
     private fun buildQuickStartCategory(


### PR DESCRIPTION
Issue #15127 

This PR migrates more menu display + remove menu item action from the `MySiteFragment` to the `ImprovedMySiteFragment`.

As discussed, used `SiteDialogModel` for displaying the remove next steps dialog on remove menu item click in 1a2d314.

To test:

Prerequisite: 

1. Go to `My Site` -> `App Settings` -> `Test feature configuration`
2. Disable `QuickStartDynamicCardsFeatureConfig`, enable `MySiteImprovementsFeatureConfig`
3. Restart the app

##### Test 1 (Remove Menu Item)

1. Select a site with `Quick Start` in progress
2. Click more menu in the `Next Steps` section
3. Notice that more menu -> `Remove` menu item is shown
4. Click `Remove` menu item
5. Notice that "Remove Next Steps" dialog is shown with "Remove" and "Cancel" buttons
6. Click "Cancel" button
7. Notice that dialog is dismissed
8. Repeat steps 2-5
9. Click "Remove" button
5. Notice that the `Next Steps` section is removed 

##### Test 2  (Notifications/ Reminders after Quick Start or "Next Steps" section is removed)

 "Remind next task" notifications/ reminders are migrated to `ImprovedMySiteFragment` in #15163 and merged with this PR in d4d774d. This test tests that  "remind next task" notifications are not shown once the quick start (or "Next Steps")  section is removed.

1. Create a new site
2. When the Quick Start Prompt is shown, tap the "Show me around" option
3. Tap the Customize your site row to launch the QS dialog
4. Tap on Check your site title (the dialog will close and you'll be brought back to My Site)
5. Tap on the blue flashing icon on site title and change the text so that the task gets completed
6. Click more menu -> "Remove" menu item -> "Remove" button in the "Remove Next Steps" dialog so that Quick Start or" Next Steps" section is removed
7. Navigate out of the app to the Settings area of your device and locate the area that manages the time.
8. Disable the "use network-provided time"
9. Manually set the date/time for 2 days and 2 minutes from now (as the notifications are set for 2 day in future)
10. Wait for a couple of minutes and note that the notification does NOT arrive at the device
11. Once testing is complete, enable "use network-provided time"

![device-2021-08-12-153957](https://user-images.githubusercontent.com/1405144/129179602-cce308bd-961a-4b1f-943e-1beaa22473a8.png)

## Regression Notes
1. Potential unintended areas of impact
    More menu functionality on 
    - `ImprovedMySiteFragment` -> `Quick Start - Dynamic Card` (`MySiteImprovementsFeatureConfig` - ON, `QuickStartDynamicCardsFeatureConfig` - ON )
    - `MySiteFragment` -> `Quick Start` (`MySiteImprovementsFeatureConfig` - OFF)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Added tests for the more menu -> `Remove` menu item action.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
