### PR TITLE
Unit tests for Quick Start Dynamic Card vs Block display

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1041,6 +1041,13 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given quick start is not in progress, when site is selected, then QS dynamic card not built`() {
+        initSelectedSite(isQuickStartInProgress = false)
+
+        assertThat(findQuickStartDynamicCard()).isNull()
+    }
+
+    @Test
     fun `given dynamic card disabled + quick start in progress, when site is selected, then dynamic card not built`() {
         initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1048,14 +1048,14 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given dynamic card disabled + quick start in progress, when site is selected, then dynamic card not built`() {
+    fun `given dynamic card disabled + QS in progress, when site is selected, then QS dynamic card not built`() {
         initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
 
         assertThat(findQuickStartDynamicCard()).isNull()
     }
 
     @Test
-    fun `given dynamic card enabled + quick start in progress, when site is selected, then dynamic card built`() {
+    fun `given dynamic card enabled + quick start in progress, when site is selected, then QS dynamic card built`() {
         initSelectedSite(isQuickStartDynamicCardEnabled = true, isQuickStartInProgress = true)
 
         assertThat(findQuickStartDynamicCard()).isNotNull

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -193,7 +193,6 @@ class MySiteViewModelTest : BaseUnitTest() {
     private var removeMenuItemClickAction: (() -> Unit)? = null
     private var quickStartTaskTypeItemClickAction: ((QuickStartTaskType) -> Unit)? = null
     private var dynamicCardMoreClick: ((DynamicCardMenuModel) -> Unit)? = null
-    private var dynamicCardMenuModel = DynamicCardMenuModel(CUSTOMIZE_QUICK_START, true)
     private val quickStartCategory: QuickStartCategory
         get() = QuickStartCategory(
                 taskType = QuickStartTaskType.CUSTOMIZE,
@@ -219,14 +218,17 @@ class MySiteViewModelTest : BaseUnitTest() {
                         )
                 )
         )
-    private val quickStartTaskCard: QuickStartCard
+    private val dynamicQuickStartTaskCard: QuickStartCard
         get() = QuickStartCard(
                 CUSTOMIZE_QUICK_START,
                 UiStringRes(0),
                 emptyList(),
                 0,
                 0,
-                ListItemInteraction.create(dynamicCardMenuModel, dynamicCardMoreClick as (DynamicCardMenuModel) -> Unit)
+                ListItemInteraction.create(
+                        DynamicCardMenuModel(CUSTOMIZE_QUICK_START, true),
+                        dynamicCardMoreClick as (DynamicCardMenuModel) -> Unit
+                )
         )
 
     @InternalCoroutinesApi
@@ -1367,7 +1369,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         }.whenever(quickStartBlockBuilder).build(any(), any(), any())
         doAnswer {
             dynamicCardMoreClick = (it.getArgument(2) as (DynamicCardMenuModel) -> Unit)
-            quickStartTaskCard
+            dynamicQuickStartTaskCard
         }.whenever(quickStartItemBuilder).build(any(), anyOrNull(), any(), any())
 
         quickStartUpdate.value = QuickStartUpdate(


### PR DESCRIPTION
Issue #15127

Related PR: #15162

This PR updates/ adds unit tests for `Quick Start Dynamic Card` vs `Quick Start Block` display so that both of them do not appear together as noticed in https://github.com/wordpress-mobile/WordPress-Android/pull/15162#pullrequestreview-728239536.

### To test
That the tests cover different possibilities for `Quick Start Dynamic Card` or `Quick Start Block` display.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
