### PR TITLE
Integrate gutenberg-mobile release 1.59.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3830-accc4d3843291c9fe27425cfea36ac2c55c5d465'
+    ext.gutenbergMobileVersion = '3830-7724f8412b57ac264c46bb89f94afd503bcb57ec'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.59.0'
+    ext.gutenbergMobileVersion = '3830-accc4d3843291c9fe27425cfea36ac2c55c5d465'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
     ext.wordPressLoginVersion = '0.0.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3830-7724f8412b57ac264c46bb89f94afd503bcb57ec'
+    ext.gutenbergMobileVersion = 'v1.59.1'
 
     repositories {
         maven {


### PR DESCRIPTION
## Description
This PR incorporates the 1.59.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3830

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.