### PR TITLE
Update login library to 0.0.4

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -449,10 +449,6 @@ dependencies {
     }
 
     implementation ("$gradle.ext.loginFlowBinaryPath:$wordPressLoginVersion") {
-        exclude group: "com.github.wordpress-mobile.WordPress-FluxC-Android", module: "fluxc"
-        exclude group: "org.wordpress", module: "fluxc"
-        exclude group: "org.wordpress.fluxc"
-        exclude group: "org.wordpress.fluxc.plugins"
         exclude group: 'com.github.bumptech.glide'
         exclude group: 'org.wordpress', module: 'utils'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = 'develop-f98c841225fbc61031f32426aaef4e347b34f717'
-    ext.wordPressLoginVersion = '0.0.3'
+    ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.59.0'
 


### PR DESCRIPTION
This update brings in changes from https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/62 which should not have any impact on the app since the FluxC version is added as a dependency in the main module.

**To test:**
* Smoke test login(?)

## Regression Notes
**1. Potential unintended areas of impact**

Duplicate class error for FluxC classes. This is due to the removal of the `exclude` statement. However, if this is going to happen, it should happen in CI, so as long as CI is green, we should be fine.

**2. What I did to test those areas of impact (or what existing automated tests I relied on)**

N/A

**3. What automated tests I added (or what prevented me from doing so)**

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
