### PR TITLE
Add tracking for time selection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
@@ -55,9 +55,9 @@ class BloggingRemindersAnalyticsTracker @Inject constructor(
 
     fun trackFlowCompleted() = track(BLOGGING_REMINDERS_FLOW_COMPLETED)
 
-    fun trackRemindersScheduled(daysCount: Int) = track(
+    fun trackRemindersScheduled(daysCount: Int, timeSelected: CharSequence) = track(
             BLOGGING_REMINDERS_SCHEDULED,
-            mapOf(DAYS_OF_WEEK_COUNT_KEY to daysCount)
+            mapOf(DAYS_OF_WEEK_COUNT_KEY to daysCount, SELECTED_TIME to timeSelected)
     )
 
     fun trackRemindersCancelled() = track(BLOGGING_REMINDERS_CANCELLED)
@@ -90,5 +90,6 @@ class BloggingRemindersAnalyticsTracker @Inject constructor(
         private const val BUTTON_KEY = "button"
         private const val SOURCE_KEY = "source"
         private const val DAYS_OF_WEEK_COUNT_KEY = "days_of_week_count"
+        private const val SELECTED_TIME = "selected_time"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
@@ -57,7 +57,7 @@ class BloggingRemindersAnalyticsTracker @Inject constructor(
 
     fun trackRemindersScheduled(daysCount: Int, timeSelected: CharSequence) = track(
             BLOGGING_REMINDERS_SCHEDULED,
-            mapOf(DAYS_OF_WEEK_COUNT_KEY to daysCount, SELECTED_TIME to timeSelected)
+            mapOf(DAYS_OF_WEEK_COUNT_KEY to daysCount, SELECTED_TIME_KEY to timeSelected)
     )
 
     fun trackRemindersCancelled() = track(BLOGGING_REMINDERS_CANCELLED)
@@ -90,6 +90,6 @@ class BloggingRemindersAnalyticsTracker @Inject constructor(
         private const val BUTTON_KEY = "button"
         private const val SOURCE_KEY = "source"
         private const val DAYS_OF_WEEK_COUNT_KEY = "days_of_week_count"
-        private const val SELECTED_TIME = "selected_time"
+        private const val SELECTED_TIME_KEY = "selected_time"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
@@ -4,6 +4,7 @@ import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+import java.util.Locale
 
 data class BloggingRemindersUiModel(
     val siteId: Int,
@@ -13,4 +14,7 @@ data class BloggingRemindersUiModel(
 ) {
     fun getNotificationTime(): CharSequence =
             LocalTime.of(hour, minute).format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
+
+    fun getNotificationTime24hour(): CharSequence =
+            LocalTime.of(hour, minute).format(DateTimeFormatter.ofPattern("HH:mm", Locale.ROOT))
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -167,7 +167,8 @@ class BloggingRemindersViewModel @Inject constructor(
                             bloggingRemindersModel.hour,
                             bloggingRemindersModel.minute,
                             bloggingRemindersModel.toReminderConfig())
-                    analyticsTracker.trackRemindersScheduled(daysCount, bloggingRemindersModel.getNotificationTime24hour())
+                    analyticsTracker.trackRemindersScheduled(
+                            daysCount, bloggingRemindersModel.getNotificationTime24hour())
                 } else {
                     reminderScheduler.cancelBySiteId(bloggingRemindersModel.siteId)
                     analyticsTracker.trackRemindersCancelled()

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -167,7 +167,7 @@ class BloggingRemindersViewModel @Inject constructor(
                             bloggingRemindersModel.hour,
                             bloggingRemindersModel.minute,
                             bloggingRemindersModel.toReminderConfig())
-                    analyticsTracker.trackRemindersScheduled(daysCount, bloggingRemindersModel.getNotificationTime())
+                    analyticsTracker.trackRemindersScheduled(daysCount, bloggingRemindersModel.getNotificationTime24hour())
                 } else {
                     reminderScheduler.cancelBySiteId(bloggingRemindersModel.siteId)
                     analyticsTracker.trackRemindersCancelled()

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -167,7 +167,7 @@ class BloggingRemindersViewModel @Inject constructor(
                             bloggingRemindersModel.hour,
                             bloggingRemindersModel.minute,
                             bloggingRemindersModel.toReminderConfig())
-                    analyticsTracker.trackRemindersScheduled(daysCount)
+                    analyticsTracker.trackRemindersScheduled(daysCount, bloggingRemindersModel.getNotificationTime())
                 } else {
                     reminderScheduler.cancelBySiteId(bloggingRemindersModel.siteId)
                     analyticsTracker.trackRemindersCancelled()

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTrackerTest.kt
@@ -130,9 +130,10 @@ class BloggingRemindersAnalyticsTrackerTest {
 
     @Test
     fun `trackRemindersScheduled tracks correct event and properties`() {
-        bloggingRemindersAnalyticsTracker.trackRemindersScheduled(3)
+        bloggingRemindersAnalyticsTracker.trackRemindersScheduled(3, "10:30 am")
         verify(analyticsTracker).track(eq(BLOGGING_REMINDERS_SCHEDULED), checkMap {
             assertThat(it).containsEntry("days_of_week_count", 3)
+            assertThat(it).containsEntry("selected_time", "10:30 am")
             assertThat(it).containsKey("blog_type")
         })
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTrackerTest.kt
@@ -28,10 +28,14 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Scr
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Screen.PROLOGUE
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Screen.SELECTION
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import java.time.DayOfWeek.FRIDAY
+import java.time.DayOfWeek.MONDAY
+import java.time.DayOfWeek.THURSDAY
 
 @RunWith(MockitoJUnitRunner::class)
 class BloggingRemindersAnalyticsTrackerTest {
     lateinit var bloggingRemindersAnalyticsTracker: BloggingRemindersAnalyticsTracker
+    lateinit var bloggingRemindersUiModel: BloggingRemindersUiModel
 
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private val siteStore: SiteStore = mock {
@@ -130,10 +134,13 @@ class BloggingRemindersAnalyticsTrackerTest {
 
     @Test
     fun `trackRemindersScheduled tracks correct event and properties`() {
-        bloggingRemindersAnalyticsTracker.trackRemindersScheduled(3, "10:30 am")
+        bloggingRemindersUiModel = BloggingRemindersUiModel(
+                1, setOf(MONDAY, THURSDAY, FRIDAY), 14, 30)
+        bloggingRemindersAnalyticsTracker.trackRemindersScheduled(
+                bloggingRemindersUiModel.enabledDays.size, bloggingRemindersUiModel.getNotificationTime24hour())
         verify(analyticsTracker).track(eq(BLOGGING_REMINDERS_SCHEDULED), checkMap {
             assertThat(it).containsEntry("days_of_week_count", 3)
-            assertThat(it).containsEntry("selected_time", "10:30 am")
+            assertThat(it).containsEntry("selected_time", "14:30")
             assertThat(it).containsKey("blog_type")
         })
     }


### PR DESCRIPTION
Track time selection feature by adding a selected_time property to the blogging_reminders_scheduled event

Fixes #15177 

To test:
- Go to Site settings
- Open blogging reminder setting
- Select days if not already selected
- Select a time other than default time
- Update
- Notice that the log shows tracking event 
WordPress-STATS: 🔵 Tracked: blogging_reminders_scheduled, Properties: {"days_of_week_count":2,"selected_time":"14:30","blog_type":"wpcom"}

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Feature tests 

3. What automated tests I added (or what prevented me from doing so) 
Unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
