### PR TITLE
Hide keyboard on prologue screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginProloguePageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginProloguePageFragment.kt
@@ -11,6 +11,7 @@ import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import org.wordpress.android.R
 import org.wordpress.android.databinding.LoginIntroTemplateViewBinding
+import org.wordpress.android.util.ActivityUtils
 import kotlin.math.min
 
 class LoginProloguePageFragment : Fragment(R.layout.login_intro_template_view) {
@@ -94,5 +95,10 @@ class LoginProloguePageFragment : Fragment(R.layout.login_intro_template_view) {
         promoBackgroundId?.let {
             inflater.inflate(it, binding.promoBackgroundContainer, true)
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        activity?.let { ActivityUtils.hideKeyboard(it) }
     }
 }


### PR DESCRIPTION
Fixes #15168

This PR hides the keyboard on the prologue screen as noticed in issue #15168. 

To test:

1. Tap Login in or sign up with WordPress.com button
2. Tap into the email address field
3. Tap the back arrow button
4. 👀 Keyboard is dismissed

https://user-images.githubusercontent.com/1405144/129319921-6ed72876-f963-491d-9dd5-84c3d6a0887a.mp4

## Regression Notes
1. Potential unintended areas of impact
Jetpack app - prologue screen 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested Jetpack app (production version) manually, this issue doesn't exist there and doesn't need any fix.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
