### PR TITLE
My Site Dashboard - Phase 1 - Quick Start

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
@@ -61,8 +61,6 @@ sealed class MySiteItem(open val type: Type, open val activeQuickStartItem: Bool
     ) : MySiteItem(QUICK_START_BLOCK) {
         data class QuickStartTaskTypeItem(
             val quickStartTaskType: QuickStartTaskType,
-            @DrawableRes val icon: Int,
-            val iconEnabled: Boolean,
             val title: UiString,
             val titleEnabled: Boolean,
             val subtitle: UiString,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
@@ -67,6 +67,8 @@ sealed class MySiteItem(open val type: Type, open val activeQuickStartItem: Bool
             val titleEnabled: Boolean,
             val subtitle: UiString,
             val strikeThroughTitle: Boolean,
+            @ColorRes val progressColor: Int,
+            val progress: Int,
             val onClick: ListItemInteraction
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
@@ -56,6 +56,8 @@ sealed class MySiteItem(open val type: Type, open val activeQuickStartItem: Bool
     data class DomainRegistrationBlock(val onClick: ListItemInteraction) : MySiteItem(DOMAIN_REGISTRATION_BLOCK)
 
     data class QuickStartBlock(
+        @DrawableRes val icon: Int,
+        val title: UiString,
         val onRemoveMenuItemClick: ListItemInteraction,
         val taskTypeItems: List<QuickStartTaskTypeItem>
     ) : MySiteItem(QUICK_START_BLOCK) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
@@ -59,9 +59,10 @@ class QuickStartBlockBuilder @Inject constructor() {
     }
 
     private fun getProgress(countCompleted: Int, totalCount: Int) =
-            if (totalCount > 0) ((countCompleted / totalCount.toFloat()) * 100).roundToInt() else 0
+            if (totalCount > 0) ((countCompleted / totalCount.toFloat()) * PERCENT_HUNDRED).roundToInt() else 0
 
     companion object {
         private const val UNEXPECTED_QUICK_START_TYPE = "Unexpected quick start type"
+        private const val PERCENT_HUNDRED = 100
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
@@ -32,8 +32,6 @@ class QuickStartBlockBuilder @Inject constructor() {
 
         return QuickStartTaskTypeItem(
                 quickStartTaskType = quickStartTaskType,
-                icon = getIcon(taskType = quickStartTaskType, isCompleted = countUncompleted == 0),
-                iconEnabled = countUncompleted > 0,
                 title = UiStringRes(getTitle(quickStartTaskType)),
                 titleEnabled = countUncompleted > 0,
                 subtitle = UiStringResWithParams(
@@ -54,18 +52,6 @@ class QuickStartBlockBuilder @Inject constructor() {
         return when (taskType) {
             QuickStartTaskType.CUSTOMIZE -> R.string.quick_start_sites_type_customize
             QuickStartTaskType.GROW -> R.string.quick_start_sites_type_grow
-            QuickStartTaskType.UNKNOWN -> throw IllegalArgumentException(UNEXPECTED_QUICK_START_TYPE)
-        }
-    }
-
-    private fun getIcon(taskType: QuickStartTaskType, isCompleted: Boolean): Int {
-        return when (taskType) {
-            QuickStartTaskType.CUSTOMIZE -> R.drawable.bg_oval_primary_40_customize_white_40dp_selector
-            QuickStartTaskType.GROW -> if (isCompleted) {
-                R.drawable.bg_oval_neutral_30_multiple_users_white_40dp
-            } else {
-                R.drawable.bg_oval_blue_50_multiple_users_white_40dp
-            }
             QuickStartTaskType.UNKNOWN -> throw IllegalArgumentException(UNEXPECTED_QUICK_START_TYPE)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import javax.inject.Inject
+import kotlin.math.roundToInt
 
 class QuickStartBlockBuilder @Inject constructor() {
     fun build(
@@ -43,6 +44,8 @@ class QuickStartBlockBuilder @Inject constructor() {
                         )
                 ),
                 strikeThroughTitle = countUncompleted == 0,
+                progressColor = R.color.colorPrimary,
+                progress = getProgress(countCompleted, countCompleted + countUncompleted),
                 onClick = ListItemInteraction.create(quickStartTaskType, onItemClick)
         )
     }
@@ -51,7 +54,7 @@ class QuickStartBlockBuilder @Inject constructor() {
         return when (taskType) {
             QuickStartTaskType.CUSTOMIZE -> R.string.quick_start_sites_type_customize
             QuickStartTaskType.GROW -> R.string.quick_start_sites_type_grow
-            QuickStartTaskType.UNKNOWN -> throw IllegalArgumentException("Unexpected quick start type")
+            QuickStartTaskType.UNKNOWN -> throw IllegalArgumentException(UNEXPECTED_QUICK_START_TYPE)
         }
     }
 
@@ -63,7 +66,14 @@ class QuickStartBlockBuilder @Inject constructor() {
             } else {
                 R.drawable.bg_oval_blue_50_multiple_users_white_40dp
             }
-            QuickStartTaskType.UNKNOWN -> throw IllegalArgumentException("Unexpected quick start type")
+            QuickStartTaskType.UNKNOWN -> throw IllegalArgumentException(UNEXPECTED_QUICK_START_TYPE)
         }
+    }
+
+    private fun getProgress(countCompleted: Int, totalCount: Int) =
+            if (totalCount > 0) ((countCompleted / totalCount.toFloat()) * 100).roundToInt() else 0
+
+    companion object {
+        private const val UNEXPECTED_QUICK_START_TYPE = "Unexpected quick start type"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
@@ -18,6 +18,8 @@ class QuickStartBlockBuilder @Inject constructor() {
         onRemoveMenuItemClick: () -> Unit,
         onItemClick: (QuickStartTaskType) -> Unit
     ) = QuickStartBlock(
+            icon = R.drawable.ic_list_checkmark_white_24dp,
+            title = UiStringRes(R.string.quick_start_sites),
             onRemoveMenuItemClick = ListItemInteraction.create { onRemoveMenuItemClick.invoke() },
             taskTypeItems = categories.map { buildQuickStartTaskTypeItem(it, onItemClick) }
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
@@ -1,8 +1,13 @@
 package org.wordpress.android.ui.mysite.quickstart
 
+import android.animation.ObjectAnimator
+import android.content.res.ColorStateList
 import android.graphics.Paint
 import android.view.ViewGroup
+import android.widget.ProgressBar
 import androidx.appcompat.widget.PopupMenu
+import androidx.core.content.ContextCompat
+import androidx.core.content.res.ResourcesCompat
 import com.google.android.material.textview.MaterialTextView
 import org.wordpress.android.R
 import org.wordpress.android.databinding.QuickStartBlockBinding
@@ -14,12 +19,15 @@ import org.wordpress.android.ui.mysite.MySiteItem.QuickStartBlock.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteItemViewHolder
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.ColorUtils
 import org.wordpress.android.util.viewBinding
 
 class QuickStartBlockViewHolder(
     parent: ViewGroup,
     private val uiHelpers: UiHelpers
 ) : MySiteItemViewHolder<QuickStartBlockBinding>(parent.viewBinding(QuickStartBlockBinding::inflate)) {
+    private val lowEmphasisAlpha = ResourcesCompat.getFloat(itemView.resources, R.dimen.emphasis_low)
+
     fun bind(block: QuickStartBlock) = with(binding) {
         quickStartMore.setOnClickListener { showQuickStartCardMenu(block.onRemoveMenuItemClick) }
         quickStartCustomize.update(block.taskTypeItems.first { it.quickStartTaskType == CUSTOMIZE })
@@ -47,6 +55,7 @@ class QuickStartBlockViewHolder(
             paintFlags(item)
         }
         itemSubtitle.text = uiHelpers.getTextOfUiString(itemView.context, item.subtitle)
+        itemProgress.update(item)
         itemRoot.setOnClickListener { item.onClick.click() }
     }
 
@@ -56,5 +65,18 @@ class QuickStartBlockViewHolder(
         } else {
             paintFlags and Paint.STRIKE_THRU_TEXT_FLAG.inv()
         }
+    }
+
+    private fun ProgressBar.update(item: QuickStartTaskTypeItem) {
+        ObjectAnimator.ofInt(this, PROGRESS, item.progress).setDuration(600).start()
+
+        val progressIndicatorColor = ContextCompat.getColor(itemView.context, item.progressColor)
+        val progressTrackColor = ColorUtils.applyEmphasisToColor(progressIndicatorColor, lowEmphasisAlpha)
+        progressBackgroundTintList = ColorStateList.valueOf(progressTrackColor)
+        progressTintList = ColorStateList.valueOf(progressIndicatorColor)
+    }
+
+    companion object {
+        private const val PROGRESS = "progress"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
@@ -71,7 +71,7 @@ class QuickStartBlockViewHolder(
     }
 
     private fun ProgressBar.update(item: QuickStartTaskTypeItem) {
-        ObjectAnimator.ofInt(this, PROGRESS, item.progress).setDuration(600).start()
+        ObjectAnimator.ofInt(this, PROGRESS, item.progress).setDuration(PROGRESS_ANIMATION_DURATION).start()
 
         val progressIndicatorColor = ContextCompat.getColor(itemView.context, item.progressColor)
         val progressTrackColor = ColorUtils.applyEmphasisToColor(progressIndicatorColor, lowEmphasisAlpha)
@@ -81,5 +81,6 @@ class QuickStartBlockViewHolder(
 
     companion object {
         private const val PROGRESS = "progress"
+        private const val PROGRESS_ANIMATION_DURATION = 600L
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.widget.PopupMenu
 import com.google.android.material.textview.MaterialTextView
 import org.wordpress.android.R
 import org.wordpress.android.databinding.QuickStartBlockBinding
+import org.wordpress.android.databinding.QuickStartTaskTypeItemBinding
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CUSTOMIZE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
 import org.wordpress.android.ui.mysite.MySiteItem.QuickStartBlock
@@ -21,8 +22,8 @@ class QuickStartBlockViewHolder(
 ) : MySiteItemViewHolder<QuickStartBlockBinding>(parent.viewBinding(QuickStartBlockBinding::inflate)) {
     fun bind(block: QuickStartBlock) = with(binding) {
         quickStartMore.setOnClickListener { showQuickStartCardMenu(block.onRemoveMenuItemClick) }
-        updateQuickStartCustomizeContainer(block.taskTypeItems.first { it.quickStartTaskType == CUSTOMIZE })
-        updateQuickStartGrowContainer(block.taskTypeItems.first { it.quickStartTaskType == GROW })
+        quickStartCustomize.update(block.taskTypeItems.first { it.quickStartTaskType == CUSTOMIZE })
+        quickStartGrow.update(block.taskTypeItems.first { it.quickStartTaskType == GROW })
     }
 
     private fun QuickStartBlockBinding.showQuickStartCardMenu(onRemoveMenuItemClick: ListItemInteraction) {
@@ -35,30 +36,18 @@ class QuickStartBlockViewHolder(
         quickStartPopupMenu.show()
     }
 
-    private fun QuickStartBlockBinding.updateQuickStartCustomizeContainer(item: QuickStartTaskTypeItem) {
-        quickStartCustomizeIcon.setBackgroundResource(item.icon)
-        quickStartCustomizeIcon.isEnabled = item.iconEnabled
-
-        quickStartCustomizeTitle.text = uiHelpers.getTextOfUiString(itemView.context, item.title)
-        quickStartCustomizeTitle.isEnabled = item.titleEnabled
-        quickStartCustomizeTitle.paintFlags(item)
-
-        quickStartCustomizeSubtitle.text = uiHelpers.getTextOfUiString(itemView.context, item.subtitle)
-
-        quickStartCustomize.setOnClickListener { item.onClick.click() }
-    }
-
-    private fun QuickStartBlockBinding.updateQuickStartGrowContainer(item: QuickStartTaskTypeItem) {
-        quickStartGrowIcon.setBackgroundResource(item.icon)
-        quickStartGrowIcon.isEnabled = item.iconEnabled
-
-        quickStartGrowTitle.text = uiHelpers.getTextOfUiString(itemView.context, item.title)
-        quickStartGrowTitle.isEnabled = item.titleEnabled
-        quickStartGrowTitle.paintFlags(item)
-
-        quickStartGrowSubtitle.text = uiHelpers.getTextOfUiString(itemView.context, item.subtitle)
-
-        quickStartGrow.setOnClickListener { item.onClick.click() }
+    private fun QuickStartTaskTypeItemBinding.update(item: QuickStartTaskTypeItem) {
+        with(itemIcon) {
+            setBackgroundResource(item.icon)
+            isEnabled = item.iconEnabled
+        }
+        with(itemTitle) {
+            text = uiHelpers.getTextOfUiString(itemView.context, item.title)
+            isEnabled = item.titleEnabled
+            paintFlags(item)
+        }
+        itemSubtitle.text = uiHelpers.getTextOfUiString(itemView.context, item.subtitle)
+        itemRoot.setOnClickListener { item.onClick.click() }
     }
 
     private fun MaterialTextView.paintFlags(item: QuickStartTaskTypeItem) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
@@ -36,6 +36,8 @@ class QuickStartBlockViewHolder(
     }
 
     private fun QuickStartToolbarBinding.update(block: QuickStartBlock) {
+        quickStartIcon.setBackgroundResource(block.icon)
+        quickStartTitle.text = uiHelpers.getTextOfUiString(itemView.context, block.title)
         quickStartMore.setOnClickListener { showQuickStartCardMenu(block.onRemoveMenuItemClick) }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
@@ -50,10 +50,6 @@ class QuickStartBlockViewHolder(
     }
 
     private fun QuickStartTaskTypeItemBinding.update(item: QuickStartTaskTypeItem) {
-        with(itemIcon) {
-            setBackgroundResource(item.icon)
-            isEnabled = item.iconEnabled
-        }
         with(itemTitle) {
             text = uiHelpers.getTextOfUiString(itemView.context, item.title)
             isEnabled = item.titleEnabled

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
@@ -12,6 +12,7 @@ import com.google.android.material.textview.MaterialTextView
 import org.wordpress.android.R
 import org.wordpress.android.databinding.QuickStartBlockBinding
 import org.wordpress.android.databinding.QuickStartTaskTypeItemBinding
+import org.wordpress.android.databinding.QuickStartToolbarBinding
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CUSTOMIZE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
 import org.wordpress.android.ui.mysite.MySiteItem.QuickStartBlock
@@ -29,12 +30,16 @@ class QuickStartBlockViewHolder(
     private val lowEmphasisAlpha = ResourcesCompat.getFloat(itemView.resources, R.dimen.emphasis_low)
 
     fun bind(block: QuickStartBlock) = with(binding) {
-        quickStartMore.setOnClickListener { showQuickStartCardMenu(block.onRemoveMenuItemClick) }
+        quickStartToolbar.update(block)
         quickStartCustomize.update(block.taskTypeItems.first { it.quickStartTaskType == CUSTOMIZE })
         quickStartGrow.update(block.taskTypeItems.first { it.quickStartTaskType == GROW })
     }
 
-    private fun QuickStartBlockBinding.showQuickStartCardMenu(onRemoveMenuItemClick: ListItemInteraction) {
+    private fun QuickStartToolbarBinding.update(block: QuickStartBlock) {
+        quickStartMore.setOnClickListener { showQuickStartCardMenu(block.onRemoveMenuItemClick) }
+    }
+
+    private fun QuickStartToolbarBinding.showQuickStartCardMenu(onRemoveMenuItemClick: ListItemInteraction) {
         val quickStartPopupMenu = PopupMenu(itemView.context, quickStartMore)
         quickStartPopupMenu.setOnMenuItemClickListener {
             onRemoveMenuItemClick.click()

--- a/WordPress/src/main/res/drawable/ic_list_checkmark_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_list_checkmark_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M9.5,15.5L5,20l-2.5,-2.5 1.06,-1.06L5,17.88l3.44,-3.44L9.5,15.5zM10,5v2h11L21,5L10,5zM10,19h11v-2L10,17v2zM10,13h11v-2L10,11v2zM8.44,8.44L5,11.88l-1.44,-1.44L2.5,11.5 5,14l4.5,-4.5 -1.06,-1.06zM8.44,2.44L5,5.88 3.56,4.44 2.5,5.5 5,8l4.5,-4.5 -1.06,-1.06z"/>
+</vector>

--- a/WordPress/src/main/res/layout/quick_start_block.xml
+++ b/WordPress/src/main/res/layout/quick_start_block.xml
@@ -1,40 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/quick_start"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/margin_large">
 
-    <RelativeLayout
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
         <include
             android:id="@+id/quick_start_toolbar"
-            layout="@layout/quick_start_toolbar" />
+            layout="@layout/quick_start_toolbar"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <include
             android:id="@+id/quick_start_customize"
             layout="@layout/quick_start_task_type_item"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/quick_start_toolbar" />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/quick_start_toolbar" />
 
         <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/divider_size"
-            android:layout_below="@+id/quick_start_customize"
-            android:layout_marginStart="@dimen/content_margin_site_row_start"
-            android:background="?android:attr/listDivider" />
+            android:id="@+id/divider"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/listDivider"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/quick_start_customize" />
 
         <include
             android:id="@+id/quick_start_grow"
             layout="@layout/quick_start_task_type_item"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/quick_start_customize"/>
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider" />
 
-    </RelativeLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/layout/quick_start_block.xml
+++ b/WordPress/src/main/res/layout/quick_start_block.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/quick_start"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -13,41 +12,9 @@
         android:paddingStart="@dimen/content_margin_site_row_start"
         android:paddingEnd="@dimen/content_margin_site_row_start">
 
-        <RelativeLayout
+        <include
             android:id="@+id/quick_start_toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="?attr/listPreferredItemHeightSmall"
-            android:paddingStart="@dimen/content_margin_site_row_start"
-            android:paddingEnd="@dimen/content_margin_site_row_start">
-
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/quick_start_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_centerVertical="true"
-                android:layout_toStartOf="@+id/quick_start_more"
-                android:ellipsize="end"
-                android:maxLines="1"
-                android:text="@string/quick_start_sites"
-                android:textAlignment="viewStart"
-                android:textAppearance="?attr/textAppearanceSubtitle1" />
-
-            <ImageView
-                android:id="@+id/quick_start_more"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_centerVertical="true"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:clickable="true"
-                android:contentDescription="@string/content_description_more"
-                android:focusable="true"
-                android:src="@drawable/ic_more_vert_white_24dp"
-                app:tint="?attr/wpColorOnSurfaceMedium" />
-
-        </RelativeLayout>
+            layout="@layout/quick_start_toolbar" />
 
         <include
             android:id="@+id/quick_start_customize"

--- a/WordPress/src/main/res/layout/quick_start_block.xml
+++ b/WordPress/src/main/res/layout/quick_start_block.xml
@@ -2,7 +2,6 @@
 <com.google.android.material.card.MaterialCardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/quick_start"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -18,7 +17,9 @@
             android:id="@+id/quick_start_toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:minHeight="?attr/listPreferredItemHeightSmall">
+            android:minHeight="?attr/listPreferredItemHeightSmall"
+            android:paddingStart="@dimen/content_margin_site_row_start"
+            android:paddingEnd="@dimen/content_margin_site_row_start">
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/quick_start_title"
@@ -48,31 +49,12 @@
 
         </RelativeLayout>
 
-        <RelativeLayout
+        <include
             android:id="@+id/quick_start_customize"
-            style="@style/QuickStartTypeRow"
-            android:layout_below="@+id/quick_start_toolbar">
-
-            <ImageView
-                android:id="@+id/quick_start_customize_icon"
-                style="@style/QuickStartTypeIcon"
-                android:background="@drawable/bg_oval_primary_40_customize_white_40dp_selector"
-                android:importantForAccessibility="no" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/quick_start_customize_title"
-                style="@style/QuickStartTypeTitle"
-                android:layout_toEndOf="@+id/quick_start_customize_icon"
-                android:text="@string/quick_start_sites_type_customize" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/quick_start_customize_subtitle"
-                style="@style/QuickStartTypeSubtitle"
-                android:layout_below="@+id/quick_start_customize_title"
-                android:layout_toEndOf="@+id/quick_start_customize_icon"
-                tools:text="1 of 6 complete" />
-
-        </RelativeLayout>
+            layout="@layout/quick_start_task_type_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/quick_start_toolbar" />
 
         <View
             android:layout_width="match_parent"
@@ -81,31 +63,12 @@
             android:layout_marginStart="@dimen/quick_start_type_divider_margin_start"
             android:background="?android:attr/listDivider" />
 
-        <RelativeLayout
+        <include
             android:id="@+id/quick_start_grow"
-            style="@style/QuickStartTypeRow"
-            android:layout_below="@+id/quick_start_customize">
-
-            <ImageView
-                android:id="@+id/quick_start_grow_icon"
-                style="@style/QuickStartTypeIcon"
-                android:background="@drawable/bg_oval_blue_50_multiple_users_white_40dp_selector"
-                android:importantForAccessibility="no" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/quick_start_grow_title"
-                style="@style/QuickStartTypeTitle"
-                android:layout_toEndOf="@+id/quick_start_grow_icon"
-                android:text="@string/quick_start_sites_type_grow" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/quick_start_grow_subtitle"
-                style="@style/QuickStartTypeSubtitle"
-                android:layout_below="@+id/quick_start_grow_title"
-                android:layout_toEndOf="@+id/quick_start_grow_icon"
-                tools:text="0 of 5 complete" />
-
-        </RelativeLayout>
+            layout="@layout/quick_start_task_type_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/quick_start_customize"/>
 
     </RelativeLayout>
 

--- a/WordPress/src/main/res/layout/quick_start_block.xml
+++ b/WordPress/src/main/res/layout/quick_start_block.xml
@@ -27,7 +27,6 @@
             android:layout_width="match_parent"
             android:layout_height="@dimen/divider_size"
             android:layout_below="@+id/quick_start_customize"
-            android:layout_marginStart="@dimen/quick_start_type_divider_margin_start"
             android:background="?android:attr/listDivider" />
 
         <include

--- a/WordPress/src/main/res/layout/quick_start_block.xml
+++ b/WordPress/src/main/res/layout/quick_start_block.xml
@@ -8,9 +8,7 @@
 
     <RelativeLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingStart="@dimen/content_margin_site_row_start"
-        android:paddingEnd="@dimen/content_margin_site_row_start">
+        android:layout_height="wrap_content">
 
         <include
             android:id="@+id/quick_start_toolbar"
@@ -27,6 +25,7 @@
             android:layout_width="match_parent"
             android:layout_height="@dimen/divider_size"
             android:layout_below="@+id/quick_start_customize"
+            android:layout_marginStart="@dimen/content_margin_site_row_start"
             android:background="?android:attr/listDivider" />
 
         <include

--- a/WordPress/src/main/res/layout/quick_start_task_type_item.xml
+++ b/WordPress/src/main/res/layout/quick_start_task_type_item.xml
@@ -15,6 +15,7 @@
             android:id="@+id/item_title"
             style="@style/QuickStartTypeTitle"
             android:layout_toEndOf="@+id/item_icon"
+            android:layout_toStartOf="@+id/item_progress"
             android:text="@string/quick_start_sites_type_customize" />
 
         <com.google.android.material.textview.MaterialTextView
@@ -22,6 +23,23 @@
             style="@style/QuickStartTypeSubtitle"
             android:layout_below="@+id/item_title"
             android:layout_toEndOf="@+id/item_icon"
+            android:layout_toStartOf="@+id/item_progress"
             tools:text="1 of 6 complete" />
+
+        <!-- The ProgressBar component does not support determinate mode when using a
+            circular progress bar style. To work around this, we set a horizontal style
+            coupled with a custom circular drawable that has an equivalent structure,
+            which allow us to tint both its background and foreground layers programmatically. -->
+        <ProgressBar
+            android:id="@+id/item_progress"
+            style="?android:progressBarStyleHorizontal"
+            android:layout_width="@dimen/quick_start_card_progress_indicator_size"
+            android:layout_height="@dimen/quick_start_card_progress_indicator_size"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:indeterminate="false"
+            android:progressDrawable="@drawable/quick_start_card_progress_drawable"
+            tools:progress="75"
+            tools:progressTint="@color/colorPrimary" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/quick_start_task_type_item.xml
+++ b/WordPress/src/main/res/layout/quick_start_task_type_item.xml
@@ -34,6 +34,7 @@
             android:indeterminate="false"
             android:progressDrawable="@drawable/quick_start_card_progress_drawable"
             tools:progress="75"
-            tools:progressTint="@color/colorPrimary" />
+            tools:progressTint="@color/colorPrimary"
+            tools:progressBackgroundTint="@color/primary_0" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/quick_start_task_type_item.xml
+++ b/WordPress/src/main/res/layout/quick_start_task_type_item.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    android:id="@+id/item_root"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/QuickStartTypeRow">
+
+        <ImageView
+            android:id="@+id/item_icon"
+            style="@style/QuickStartTypeIcon"
+            android:background="@drawable/bg_oval_primary_40_customize_white_40dp_selector"
+            android:importantForAccessibility="no" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/item_title"
+            style="@style/QuickStartTypeTitle"
+            android:layout_toEndOf="@+id/item_icon"
+            android:text="@string/quick_start_sites_type_customize" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/item_subtitle"
+            style="@style/QuickStartTypeSubtitle"
+            android:layout_below="@+id/item_title"
+            android:layout_toEndOf="@+id/item_icon"
+            tools:text="1 of 6 complete" />
+
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/quick_start_task_type_item.xml
+++ b/WordPress/src/main/res/layout/quick_start_task_type_item.xml
@@ -3,7 +3,9 @@
     android:id="@+id/item_root"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/QuickStartTypeRow">
+    style="@style/QuickStartTypeRow"
+    android:paddingStart="@dimen/content_margin_site_row_start"
+    android:paddingEnd="@dimen/content_margin_site_row_start">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/item_title"

--- a/WordPress/src/main/res/layout/quick_start_task_type_item.xml
+++ b/WordPress/src/main/res/layout/quick_start_task_type_item.xml
@@ -1,40 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    android:id="@+id/item_root"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/item_root"
     style="@style/QuickStartTypeRow"
-    android:paddingStart="@dimen/content_margin_site_row_start"
-    android:paddingEnd="@dimen/content_margin_site_row_start">
+    android:paddingEnd="@dimen/content_margin_site_row_start"
+    android:paddingStart="@dimen/content_margin_site_row_start">
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/item_title"
-            style="@style/QuickStartTypeTitle"
-            android:layout_toStartOf="@+id/item_progress"
-            android:text="@string/quick_start_sites_type_customize" />
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/item_title"
+        style="@style/QuickStartTypeTitle"
+        android:text="@string/quick_start_sites_type_customize"
+        app:layout_constraintEnd_toStartOf="@+id/item_progress"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/item_subtitle"
-            style="@style/QuickStartTypeSubtitle"
-            android:layout_below="@+id/item_title"
-            android:layout_toStartOf="@+id/item_progress"
-            tools:text="1 of 6 complete" />
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/item_subtitle"
+        style="@style/QuickStartTypeSubtitle"
+        app:layout_constraintEnd_toStartOf="@+id/item_progress"
+        app:layout_constraintTop_toBottomOf="@+id/item_title"
+        tools:text="1 of 6 complete" />
 
-        <!-- The ProgressBar component does not support determinate mode when using a
-            circular progress bar style. To work around this, we set a horizontal style
-            coupled with a custom circular drawable that has an equivalent structure,
-            which allow us to tint both its background and foreground layers programmatically. -->
-        <ProgressBar
-            android:id="@+id/item_progress"
-            style="?android:progressBarStyleHorizontal"
-            android:layout_width="@dimen/quick_start_card_progress_indicator_size"
-            android:layout_height="@dimen/quick_start_card_progress_indicator_size"
-            android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true"
-            android:indeterminate="false"
-            android:progressDrawable="@drawable/quick_start_card_progress_drawable"
-            tools:progress="75"
-            tools:progressTint="@color/colorPrimary"
-            tools:progressBackgroundTint="@color/primary_0" />
+    <!-- The ProgressBar component does not support determinate mode when using a
+        circular progress bar style. To work around this, we set a horizontal style
+        coupled with a custom circular drawable that has an equivalent structure,
+        which allow us to tint both its background and foreground layers programmatically. -->
+    <ProgressBar
+        android:id="@+id/item_progress"
+        style="?android:progressBarStyleHorizontal"
+        android:layout_width="@dimen/quick_start_card_progress_indicator_size"
+        android:layout_height="@dimen/quick_start_card_progress_indicator_size"
+        android:indeterminate="false"
+        android:progressDrawable="@drawable/quick_start_card_progress_drawable"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:progress="75"
+        tools:progressBackgroundTint="@color/primary_0"
+        tools:progressTint="@color/colorPrimary" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/quick_start_task_type_item.xml
+++ b/WordPress/src/main/res/layout/quick_start_task_type_item.xml
@@ -5,16 +5,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/QuickStartTypeRow">
 
-        <ImageView
-            android:id="@+id/item_icon"
-            style="@style/QuickStartTypeIcon"
-            android:background="@drawable/bg_oval_primary_40_customize_white_40dp_selector"
-            android:importantForAccessibility="no" />
-
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/item_title"
             style="@style/QuickStartTypeTitle"
-            android:layout_toEndOf="@+id/item_icon"
             android:layout_toStartOf="@+id/item_progress"
             android:text="@string/quick_start_sites_type_customize" />
 
@@ -22,7 +15,6 @@
             android:id="@+id/item_subtitle"
             style="@style/QuickStartTypeSubtitle"
             android:layout_below="@+id/item_title"
-            android:layout_toEndOf="@+id/item_icon"
             android:layout_toStartOf="@+id/item_progress"
             tools:text="1 of 6 complete" />
 

--- a/WordPress/src/main/res/layout/quick_start_toolbar.xml
+++ b/WordPress/src/main/res/layout/quick_start_toolbar.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/quick_start_toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?attr/listPreferredItemHeightSmall"
+    tools:showIn="@layout/quick_start_block">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/quick_start_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:layout_toStartOf="@+id/quick_start_more"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:text="@string/quick_start_sites"
+        android:textAlignment="viewStart"
+        android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+    <ImageView
+        android:id="@+id/quick_start_more"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:clickable="true"
+        android:contentDescription="@string/content_description_more"
+        android:focusable="true"
+        android:src="@drawable/ic_more_vert_white_24dp"
+        app:tint="?attr/wpColorOnSurfaceMedium" />
+
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/quick_start_toolbar.xml
+++ b/WordPress/src/main/res/layout/quick_start_toolbar.xml
@@ -1,50 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/quick_start_toolbar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?attr/listPreferredItemHeightSmall"
-    tools:showIn="@layout/quick_start_block"
+    android:paddingEnd="@dimen/content_margin_site_row_start"
     android:paddingStart="@dimen/content_margin_site_row_start"
-    android:paddingEnd="@dimen/content_margin_site_row_start">
+    tools:showIn="@layout/quick_start_block">
 
     <ImageView
         android:id="@+id/quick_start_icon"
         android:layout_width="@dimen/my_site_list_row_icon_size"
         android:layout_height="@dimen/my_site_list_row_icon_size"
-        android:layout_alignParentStart="true"
-        android:layout_centerVertical="true"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:importantForAccessibility="no"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:tint="?attr/wpColorOnSurfaceMedium"
-        tools:src="@drawable/ic_list_checkmark_white_24dp"/>
+        tools:src="@drawable/ic_list_checkmark_white_24dp" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/quick_start_title"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_toEndOf="@+id/quick_start_icon"
-        android:layout_centerVertical="true"
-        android:layout_toStartOf="@+id/quick_start_more"
+        android:layout_marginStart="@dimen/margin_extra_large"
         android:ellipsize="end"
         android:maxLines="1"
         android:textAlignment="viewStart"
         android:textAppearance="?attr/textAppearanceSubtitle1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/quick_start_more"
+        app:layout_constraintStart_toEndOf="@+id/quick_start_icon"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="@string/quick_start_sites" />
 
     <ImageView
         android:id="@+id/quick_start_more"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_centerVertical="true"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:clickable="true"
         android:contentDescription="@string/content_description_more"
         android:focusable="true"
         android:src="@drawable/ic_more_vert_white_24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:tint="?attr/wpColorOnSurfaceMedium" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/quick_start_toolbar.xml
+++ b/WordPress/src/main/res/layout/quick_start_toolbar.xml
@@ -17,9 +17,9 @@
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
         android:layout_marginEnd="@dimen/margin_extra_large"
-        android:src="@drawable/ic_list_checkmark_white_24dp"
         android:importantForAccessibility="no"
-        app:tint="?attr/wpColorOnSurfaceMedium" />
+        app:tint="?attr/wpColorOnSurfaceMedium"
+        tools:src="@drawable/ic_list_checkmark_white_24dp"/>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/quick_start_title"
@@ -30,9 +30,9 @@
         android:layout_toStartOf="@+id/quick_start_more"
         android:ellipsize="end"
         android:maxLines="1"
-        android:text="@string/quick_start_sites"
         android:textAlignment="viewStart"
-        android:textAppearance="?attr/textAppearanceSubtitle1" />
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        tools:text="@string/quick_start_sites" />
 
     <ImageView
         android:id="@+id/quick_start_more"

--- a/WordPress/src/main/res/layout/quick_start_toolbar.xml
+++ b/WordPress/src/main/res/layout/quick_start_toolbar.xml
@@ -6,7 +6,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?attr/listPreferredItemHeightSmall"
-    tools:showIn="@layout/quick_start_block">
+    tools:showIn="@layout/quick_start_block"
+    android:paddingStart="@dimen/content_margin_site_row_start"
+    android:paddingEnd="@dimen/content_margin_site_row_start">
 
     <ImageView
         android:id="@+id/quick_start_icon"

--- a/WordPress/src/main/res/layout/quick_start_toolbar.xml
+++ b/WordPress/src/main/res/layout/quick_start_toolbar.xml
@@ -8,11 +8,22 @@
     android:minHeight="?attr/listPreferredItemHeightSmall"
     tools:showIn="@layout/quick_start_block">
 
+    <ImageView
+        android:id="@+id/quick_start_icon"
+        android:layout_width="@dimen/my_site_list_row_icon_size"
+        android:layout_height="@dimen/my_site_list_row_icon_size"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:src="@drawable/ic_list_checkmark_white_24dp"
+        android:importantForAccessibility="no"
+        app:tint="?attr/wpColorOnSurfaceMedium" />
+
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/quick_start_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
+        android:layout_toEndOf="@+id/quick_start_icon"
         android:layout_centerVertical="true"
         android:layout_toStartOf="@+id/quick_start_more"
         android:ellipsize="end"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2963,7 +2963,7 @@
     <string name="quick_start_sites_type_customize">Customize your site</string>
     <string name="quick_start_sites_type_grow">Grow your audience</string>
     <string name="quick_start_sites_type_subtitle">%1$d of %2$d complete</string>
-    <string name="quick_start_sites_type_tasks_completed">%1$s of %2$s complete</string>
+    <string name="quick_start_sites_type_tasks_completed">%1$s out of %2$s complete</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
     <string name="quick_start_span_start" translatable="false">&lt;span&gt;</string>
     <string name="quick_start_focus_point_description">tap here</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -211,6 +211,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                                 titleEnabled = true,
                                 subtitle = UiStringText(""),
                                 strikeThroughTitle = false,
+                                progressColor = 0,
+                                progress = 0,
                                 onClick = ListItemInteraction.create(
                                         QuickStartTaskType.CUSTOMIZE,
                                         { quickStartTaskTypeItemClickAction }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -201,12 +201,12 @@ class MySiteViewModelTest : BaseUnitTest() {
         )
     private val quickStartBlock: QuickStartBlock
         get() = QuickStartBlock(
+                icon = 0,
+                title = UiStringText(""),
                 onRemoveMenuItemClick = ListItemInteraction.create { removeMenuItemClickAction },
                 taskTypeItems = listOf(
                         QuickStartTaskTypeItem(
                                 quickStartTaskType = QuickStartTaskType.CUSTOMIZE,
-                                icon = 0,
-                                iconEnabled = true,
                                 title = UiStringText(""),
                                 titleEnabled = true,
                                 subtitle = UiStringText(""),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
-import kotlin.math.roundToInt
 
 @InternalCoroutinesApi
 class QuickStartBlockBuilderTest : BaseUnitTest() {
@@ -134,9 +133,8 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
     fun `given non zero completed tasks, when block is built, then completed tasks progress is non zero`() {
         val quickStartBlock = buildQuickStartBlock()
 
-        assertThat(getQuickStartTaskTypeItem(quickStartBlock).progress)
-                .isEqualTo(((completedTasks.size / (completedTasks.size + uncompletedTasks.size.toFloat())) * 100)
-                        .roundToInt())
+        val percentCompleted = 50
+        assertThat(getQuickStartTaskTypeItem(quickStartBlock).progress).isEqualTo(percentCompleted)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
@@ -30,6 +30,24 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
         builder = QuickStartBlockBuilder()
     }
 
+    /* ICON */
+
+    @Test
+    fun `when block is built, then icon exists`() {
+        val quickStartBlock = buildQuickStartBlock()
+
+        assertThat(quickStartBlock.icon).isEqualTo(R.drawable.ic_list_checkmark_white_24dp)
+    }
+
+    /* TITLE */
+
+    @Test
+    fun `when block is built, then title exists`() {
+        val quickStartBlock = buildQuickStartBlock()
+
+        assertThat(quickStartBlock.title).isEqualTo(UiStringRes(R.string.quick_start_sites))
+    }
+
     /* TASK TYPE ITEM */
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import kotlin.math.roundToInt
 
 @InternalCoroutinesApi
 class QuickStartBlockBuilderTest : BaseUnitTest() {
@@ -145,6 +146,31 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
                                 )
                         )
                 )
+    }
+
+    /* PROGRESS BAR */
+
+    @Test
+    fun `given non zero completed tasks, when block is built, then completed tasks progress is non zero`() {
+        val quickStartBlock = buildQuickStartBlock()
+
+        assertThat(getQuickStartTaskTypeItem(quickStartBlock).progress)
+                .isEqualTo(((completedTasks.size / (completedTasks.size + uncompletedTasks.size.toFloat())) * 100)
+                        .roundToInt())
+    }
+
+    @Test
+    fun `given zero completed tasks, when block is built, then completed tasks progress is zero`() {
+        val quickStartBlock = buildQuickStartBlock(emptyList())
+
+        assertThat(getQuickStartTaskTypeItem(quickStartBlock).progress).isEqualTo(0)
+    }
+
+    @Test
+    fun `when block is built, then progress color equals primary color`() {
+        val quickStartBlock = buildQuickStartBlock(emptyList())
+
+        assertThat(getQuickStartTaskTypeItem(quickStartBlock).progressColor).isEqualTo(R.color.colorPrimary)
     }
 
     /* ITEM CLICK */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
@@ -44,46 +44,6 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
         assertThat(quickStartBlock.taskTypeItems.map { it.quickStartTaskType }).contains(QuickStartTaskType.GROW)
     }
 
-    /* ICON */
-
-    @Test
-    fun `given uncompleted tasks exist, when block is built, then icon is enabled`() {
-        val quickStartBlock = buildQuickStartBlock()
-
-        assertThat(getQuickStartTaskTypeItem(quickStartBlock).iconEnabled).isTrue
-    }
-
-    @Test
-    fun `given uncompleted tasks do not exist, when block is built, then icon is disabled`() {
-        val quickStartBlock = buildQuickStartBlock(uncompletedTasks = emptyList())
-
-        assertThat(getQuickStartTaskTypeItem(quickStartBlock).iconEnabled).isFalse
-    }
-
-    @Test
-    fun `when customize task type item is built, then customize icon exists`() {
-        val quickStartBlock = buildQuickStartBlock()
-
-        assertThat(getQuickStartTaskTypeItem(quickStartBlock, QuickStartTaskType.CUSTOMIZE).icon)
-                .isEqualTo(R.drawable.bg_oval_primary_40_customize_white_40dp_selector)
-    }
-
-    @Test
-    fun `given uncompleted tasks exist, when grow task type item is built, then grow icon exists`() {
-        val quickStartBlock = buildQuickStartBlock()
-
-        assertThat(getQuickStartTaskTypeItem(quickStartBlock, QuickStartTaskType.GROW).icon)
-                .isEqualTo(R.drawable.bg_oval_blue_50_multiple_users_white_40dp)
-    }
-
-    @Test
-    fun `given uncompleted tasks do not exist, when grow task type item is built, then grow icon exists`() {
-        val quickStartBlock = buildQuickStartBlock(uncompletedTasks = emptyList())
-
-        assertThat(getQuickStartTaskTypeItem(quickStartBlock, QuickStartTaskType.GROW).icon)
-                .isEqualTo(R.drawable.bg_oval_neutral_30_multiple_users_white_40dp)
-    }
-
     /* TITLE */
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
@@ -30,6 +30,8 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
         builder = QuickStartBlockBuilder()
     }
 
+    /* TASK TYPE ITEM */
+
     @Test
     fun `when block is built, then customise quick start task type item exists`() {
         val quickStartBlock = buildQuickStartBlock()
@@ -44,7 +46,7 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
         assertThat(quickStartBlock.taskTypeItems.map { it.quickStartTaskType }).contains(QuickStartTaskType.GROW)
     }
 
-    /* TITLE */
+    /* TASK TYPE ITEM TITLE */
 
     @Test
     fun `given uncompleted tasks exist, when block is built, then title is enabled`() {
@@ -90,7 +92,7 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
         assertThat(getQuickStartTaskTypeItem(quickStartBlock).strikeThroughTitle).isTrue
     }
 
-    /* SUBTITLE */
+    /* TASK TYPE ITEM SUBTITLE */
 
     @Test
     fun `when block is built, then task type item subtitle contains completed amd uncompleted count`() {
@@ -108,7 +110,7 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
                 )
     }
 
-    /* PROGRESS BAR */
+    /* TASK TYPE ITEM PROGRESS BAR */
 
     @Test
     fun `given non zero completed tasks, when block is built, then completed tasks progress is non zero`() {


### PR DESCRIPTION
Issue #15189

Based on the Quick Start Phase 1 design, this PR 
- Adds progress indicator 
- Adds a header icon
- Removes row icons
 
in the quick start block. 

To test:

1. Go to My Site -> App Settings -> Test feature configuration.
2. Disable `QuickStartDynamicCardsFeatureConfig`, enable `MySiteImprovementsFeatureConfig`
3. Restart the app
4. Select a site with quick start in progress
5. Notice that the quick start block contains the following updates:
   - ✅  progress indicator is copied from the [dynamic quick start VH](https://github.com/wordpress-mobile/WordPress-Android/blob/9088afbcfe30b71bbb1974eaf728e0cbe802932f/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartCardViewHolder.kt#L61-L64). It gets updated based on the completed tasks count. 
   - ✅  header icon is present before the title
   - ✅  row icons are removed
   - ✅  subtitle is renamed from `$completedCount of $total` to `$completed out of $total` (this will be reflected in the old my site fragment as well on `develop`)

<img src=https://user-images.githubusercontent.com/1405144/129565101-5577f871-349b-403e-b8d9-d8e746fa636c.jpg  width=500>

Note:
This PR is still in draft as I need to fine-tune the UI based on the final design to be provided in Zeplin.

## Regression Notes
1. Potential unintended areas of impact
    - `ImprovedMySiteFragment` -> `Quick Start - Dynamic Card` (`MySiteImprovementsFeatureConfig` - ON, `QuickStartDynamicCardsFeatureConfig` - ON )
    - `MySiteFragment` -> `Quick Start` (`MySiteImprovementsFeatureConfig` - OFF)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for the updated UI elements

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
