### PR TITLE
Force FluxC version to be strict and update it to the latest

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -423,7 +423,10 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
-    implementation("$gradle.ext.fluxCBinaryPath:$fluxCVersion") {
+    implementation("$gradle.ext.fluxCBinaryPath") {
+        version {
+            strictly fluxCVersion
+        }
         exclude group: "com.android.volley"
         exclude group: 'org.wordpress', module: 'utils'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '2085-6413bc370255bfebde6e386a05d004cecc81372e'
+    fluxCVersion = 'develop-b82b3393b340141183eaa734085e83d5c8652f77'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
In https://github.com/wordpress-mobile/WordPress-Android/pull/15174 we stopped excluding the FluxC dependency for login library because we expected Gradle to be able to pick the right version - which is always the client one for us. However, that doesn't seem to be the case, because in current develop if `fluxCVersion` is changed to `develop-b82b3393b340141183eaa734085e83d5c8652f77`, it'll resolve to `1.23.0` the version login library is requesting.

This PR tells Gradle to always pick the fluxC version that's set from the client.

**To test:**

* Run `./gradlew assembleWordPressVanillaDebug --scan` and open the Gradle scan
* Go to dependencies section and search for `fluxc`
* Verify that the version picked is `develop-b82b3393b340141183eaa734085e83d5c8652f77`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
