### PR TITLE
Fix/15184 domain results hidden in landscape

### DIFF
--- a/WordPress/src/main/res/layout/site_creation_search_input_item.xml
+++ b/WordPress/src/main/res/layout/site_creation_search_input_item.xml
@@ -24,7 +24,7 @@
             android:layout_marginStart="@dimen/margin_small"
             android:drawablePadding="@dimen/margin_extra_large"
             android:background="@android:color/transparent"
-            android:imeOptions="actionSearch"
+            android:imeOptions="actionSearch|flagNoExtractUi"
             android:importantForAutofill="noExcludeDescendants"
             android:inputType="text"
             android:singleLine="true"


### PR DESCRIPTION
Fixes #15184 


https://user-images.githubusercontent.com/990349/129650908-ba786695-7871-4807-880e-cf329f52d788.mp4



To test:

1.     Create a new site
2.     Select a theme
3.     During domain selection, type part of a domain you want to search for
4.     Turn your device to move to landscape mode.
5.     Note the search results appearing same as portrait mode


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
NA

3. What automated tests I added (or what prevented me from doing so)
NA

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
