### PR TITLE
Feature/15214 blogging reminders add time on epilogue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/EpilogueBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/EpilogueBuilder.kt
@@ -38,7 +38,8 @@ class EpilogueBuilder @Inject constructor(
             ZERO -> UiStringRes(string.blogging_reminders_epilogue_body_no_reminders)
             SEVEN_DAYS -> UiStringText(
                     htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                            string.blogging_reminders_epilogue_body_everyday
+                            string.blogging_reminders_epilogue_body_everyday_with_time,
+                            bloggingRemindersModel?.getNotificationTime()
                     )
             )
             else -> {
@@ -48,9 +49,10 @@ class EpilogueBuilder @Inject constructor(
 
                 UiStringText(
                         htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                                string.blogging_reminders_epilogue_body_days,
+                                string.blogging_reminders_epilogue_body_days_with_time,
                                 numberOfTimes,
-                                selectedDays
+                                selectedDays,
+                                bloggingRemindersModel?.getNotificationTime().toString().toBold()
                         )
                 )
             }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3719,8 +3719,8 @@ translators: Block name. %s: The localized block name -->
     <string name="blogging_reminders_done">Done</string>
     <string name="blogging_reminders_epilogue_title">All set!</string>
     <string name="blogging_reminders_epilogue_not_set_title">Reminders removed!</string>
-    <string name="blogging_reminders_epilogue_body_days">You\'ll get reminders to blog %1$s a week on %2$s.</string>
-    <string name="blogging_reminders_epilogue_body_everyday">You\'ll get reminders to blog &lt;b&gt;everyday&lt;/b&gt;.</string>
+    <string name="blogging_reminders_epilogue_body_days_with_time">You\'ll get reminders to blog %1$s a week on %2$s at %3$s.</string>
+    <string name="blogging_reminders_epilogue_body_everyday_with_time">You\'ll get reminders to blog &lt;b&gt;everyday&lt;/b&gt; at &lt;b&gt;%s&lt;/b&gt;.</string>
     <string name="blogging_reminders_epilogue_body_no_reminders">You have no reminders set.</string>
     <string name="blogging_reminders_epilogue_caption">You can update this anytime via My Site &gt; Settings &gt; Blogging reminders.</string>
     <string name="blogging_reminders_select_days">Select the days you want to blog on</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/EpilogueBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/EpilogueBuilderTest.kt
@@ -65,12 +65,15 @@ class EpilogueBuilderTest {
                 .thenReturn(dayLabel)
         val selectedDays = "<b>Wednesday</b>, <b>Sunday</b>"
         whenever(listFormatterUtils.formatList(listOf("<b>Wednesday</b>", "<b>Sunday</b>"))).thenReturn(selectedDays)
-        val message = "You'll get reminders to blog <b>$dayLabel</b> a week on $selectedDays."
+        val selectedTime = bloggingRemindersModel.getNotificationTime()
+        val message = "You'll get reminders to blog <b>$dayLabel</b> a week on $selectedDays at <b>$selectedTime</b>."
         whenever(
                 htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                        string.blogging_reminders_epilogue_body_days,
+                        string.blogging_reminders_epilogue_body_days_with_time,
                         "<b>$dayLabel</b>",
-                        selectedDays
+                        selectedDays,
+                        "<b>$selectedTime</b>"
+
                 )
         ).thenReturn(message)
 
@@ -87,10 +90,11 @@ class EpilogueBuilderTest {
                 hour,
                 minute
         )
-        val message = "You'll get reminders to blog <b>everyday</b>."
+        val message = "You'll get reminders to blog <b>everyday</b> at <b>10:00 am</b>."
         whenever(
                 htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                        string.blogging_reminders_epilogue_body_everyday
+                        string.blogging_reminders_epilogue_body_everyday_with_time,
+                        bloggingRemindersModel.getNotificationTime()
                 )
         ).thenReturn(
                 message


### PR DESCRIPTION
Adds time to epilogue screen summary in Blogging Reminders flow

Fixes #15214 

<img width=320 src="https://user-images.githubusercontent.com/990349/129882226-fb85a234-9314-4d3c-9333-069fcc27d614.png" />


To test:

1. Go to Site settings
2. Open blogging reminder setting
3. Select days if not already selected
4. Select a time other than default time
5. Update
6. Check the summary on epilogue screen shows time as well

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
NA

3. What automated tests I added (or what prevented me from doing so)
Unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
