### PR TITLE
Update time for Blogging Reminders Site Settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -104,7 +104,7 @@ class BloggingRemindersViewModel @Inject constructor(
 
     fun getSettingsState(siteId: Int): LiveData<UiString> {
         return bloggingRemindersStore.bloggingRemindersModel(siteId).map {
-            mapper.toUiModel(it).let { uiModel -> dayLabelUtils.buildNTimesLabel(uiModel) }
+            mapper.toUiModel(it).let { uiModel -> dayLabelUtils.buildSiteSettingsLabel(uiModel) }
         }.asLiveData(mainDispatcher)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DayLabelUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DayLabelUtils.kt
@@ -31,4 +31,17 @@ class DayLabelUtils
         val size = bloggingRemindersModel?.enabledDays?.size ?: 0
         return counts.getOrNull(size - 1)
     }
+
+    fun buildSiteSettingsLabel(bloggingRemindersModel: BloggingRemindersUiModel?): UiString {
+        val counts = resourceProvider.getStringArray(R.array.blogging_reminders_count)
+        val size = bloggingRemindersModel?.enabledDays?.size ?: 0
+        return if (size > 0) {
+            UiStringResWithParams(R.string.blogging_reminders_site_settings_label, listOf(
+                    UiStringText(counts[size - 1]),
+                    UiStringText(bloggingRemindersModel?.getNotificationTime().toString()))
+            )
+        } else {
+            UiStringRes(R.string.blogging_reminders_not_set)
+        }
+    }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3703,6 +3703,7 @@ translators: Block name. %s: The localized block name -->
     <string name="post_publishing_set_up_blogging_reminders_message">Your post is publishing… in the meantime, you can set up blogging reminders on days you want to post.</string>
     <string name="set_up_blogging_reminders_message">Set up blogging reminders on days you want to post.</string>
     <string name="set_your_blogging_reminders_button">Set reminders</string>
+    <string name="blogging_reminders_site_settings_label">%1$s a week at %2$s</string>
     <string name="blogging_reminders_n_a_week">%s a week</string>
     <string-array name="blogging_reminders_count">
         <item>Once</item>

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
@@ -152,9 +152,9 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
                         model
                 )
         )
-        val dayLabel = UiStringText("Blogging reminders 2 times a week")
+        val dayLabel = UiStringText("Blogging reminders 2 times a week at 10:00 am")
         whenever(
-                dayLabelUtils.buildNTimesLabel(
+                dayLabelUtils.buildSiteSettingsLabel(
                         BloggingRemindersUiModel(
                                 siteId,
                                 setOf(DayOfWeek.MONDAY, DayOfWeek.SUNDAY),


### PR DESCRIPTION
Add time after n times a week
fix test

Fixes #15220 

<img width=320 src="https://user-images.githubusercontent.com/990349/129994404-73eb4a06-c4f7-430d-b406-409f3b874b0b.png" />


To test:

1. Go to Site settings
2. Scroll to **Blogging reminders** setting
3. Notice that it displays time along with frequency, otherwise
4. Select days if not already selected
5. Select a time other than default time
6. Update
7. Notice that it displays time along with frequency


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
NA

3. What automated tests I added (or what prevented me from doing so)
Unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
