### PR TITLE
Comment details like status on background. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'develop-b82b3393b340141183eaa734085e83d5c8652f77'
+    fluxCVersion = '2104-f31799545d7a558f4615d3b6344ce5ecd19fcddd'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '2104-f31799545d7a558f4615d3b6344ce5ecd19fcddd'
+    fluxCVersion = 'develop-d48bc00c18ec086acca6252ac3a376a6d2e38d84'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #15171

Fluxc companion PR is [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2104) and contains some more details about the issue.

### To test

1. Copy/pasted from linked issue for convenience, check the like status is now preserved:
    - Tap on comment in comments list to open the Comment detail view
    - Tap Like icon and note that it highlights
    - Tap More → Copy Link Address → Snackbar → Share
    - Share with an app outside of WP (For example: slack or messages)
    - Return to app
    - Note that the Like icon is no longer highlighted on the detail view
    - Tap the ← button to return to the comments list
    - Tap the same comment to open the detail view
    - Note the Like icon is highlighted

2. Smoke test:
    - Comment details
    - Comments list in My Site
    - Comments Notifications

## Regression Notes
1. Potential unintended areas of impact
Comment interaction from Comment Details screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
CommentDetailFragment is being refactored soon as part of the phase 2 of the Comments Unification project; currently logic is inside a fragment and not straightforward  to test before the afore mentioned refactor.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
