### PR TITLE
Site domains setting

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -108,7 +108,7 @@ android {
         buildConfigField "boolean", "GLOBAL_STYLE_SUPPORT", "true"
         buildConfigField "boolean", "ONBOARDING_IMPROVEMENTS", "false"
         buildConfigField "boolean", "QUICK_START_DYNAMIC_CARDS", "false"
-        buildConfigField "boolean", "DOMAIN_PURCHASE", "false"
+        buildConfigField "boolean", "SITE_DOMAINS", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -86,6 +86,7 @@ import org.wordpress.android.ui.prefs.homepage.HomepageSettingsDialog;
 import org.wordpress.android.ui.prefs.timezone.SiteSettingsTimezoneBottomSheet;
 import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ContextExtensionsKt;
 import org.wordpress.android.util.ContextUtilsKt;
 import org.wordpress.android.util.HtmlUtils;
@@ -102,6 +103,7 @@ import org.wordpress.android.util.WPPrefUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
 import org.wordpress.android.util.config.BloggingRemindersFeatureConfig;
+import org.wordpress.android.util.config.SiteDomainsFeatureConfig;
 import org.wordpress.android.util.config.ManageCategoriesFeatureConfig;
 import org.wordpress.android.widgets.WPSnackbar;
 
@@ -184,6 +186,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Inject ZendeskHelper mZendeskHelper;
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject BloggingRemindersFeatureConfig mBloggingRemindersFeatureConfig;
+    @Inject SiteDomainsFeatureConfig mSiteDomainsFeatureConfig;
     @Inject ManageCategoriesFeatureConfig mManageCategoriesFeatureConfig;
     @Inject UiHelpers mUiHelpers;
 
@@ -206,6 +209,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     private EditTextPreference mAddressPref;
     private DetailListPreference mPrivacyPref;
     private DetailListPreference mLanguagePref;
+    private Preference mSiteDomainsPref;
 
     // Homepage settings
     private WPPreference mHomepagePref;
@@ -498,6 +502,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         initBloggingReminders();
+        setupSiteDomainsSetting();
     }
 
     private AppCompatActivity getAppCompatActivity() {
@@ -576,6 +581,8 @@ public class SiteSettingsFragment extends PreferenceFragment
             setupTimezoneBottomSheet();
         } else if (preference == mBloggingRemindersPref) {
             setupBloggingRemindersBottomSheet();
+        } else if (preference == mSiteDomainsPref) {
+            startSiteDomainsFlow();
         } else if (preference == mHomepagePref) {
             showHomepageSettings();
         }
@@ -972,6 +979,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         mPostsPerPagePref = getClickPref(R.string.pref_key_site_posts_per_page);
         mTimezonePref = getClickPref(R.string.pref_key_site_timezone);
         mBloggingRemindersPref = getClickPref(R.string.pref_key_blogging_reminders);
+        mSiteDomainsPref = getClickPref(R.string.pref_key_site_domains);
         mHomepagePref = (WPPreference) getChangePref(R.string.pref_key_homepage_settings);
         updateHomepageSummary();
         mAmpPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_amp);
@@ -1089,7 +1097,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                 mDateFormatPref, mTimeFormatPref, mTimezonePref, mBloggingRemindersPref, mPostsPerPagePref, mAmpPref,
                 mDeleteSitePref, mJpMonitorActivePref, mJpMonitorEmailNotesPref, mJpSsoPref,
                 mJpMonitorWpNotesPref, mJpBruteForcePref, mJpAllowlistPref, mJpMatchEmailPref, mJpUseTwoFactorPref,
-                mGutenbergDefaultForNewPosts, mHomepagePref
+                mGutenbergDefaultForNewPosts, mHomepagePref, mSiteDomainsPref
         };
 
         for (Preference preference : editablePreference) {
@@ -1228,6 +1236,28 @@ public class SiteSettingsFragment extends PreferenceFragment
             return;
         }
         mBloggingRemindersViewModel.onSettingsItemClicked(mSite.getId());
+    }
+
+    private void setupSiteDomainsSetting() {
+        if (mSiteDomainsPref == null || !isAdded()) {
+            return;
+        }
+
+        if (!mSiteDomainsFeatureConfig.isEnabled()) {
+            removeSiteDomainsPref();
+        } else {
+            if (mSiteDomainsPref != null) {
+                mSiteDomainsPref.setSummary(R.string.register_domain); // TODO: Use the correct title here
+            }
+        }
+    }
+
+    private void startSiteDomainsFlow() {
+        if (mSiteDomainsPref == null || !isAdded()) {
+            return;
+        }
+        // TODO: Launch Domian purchase flow
+        AppLog.d(T.SETTINGS, "Site domains flow");
     }
 
     private void showHomepageSettings() {
@@ -1980,6 +2010,10 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void removeBloggingRemindersSettings() {
         WPPrefUtils.removePreference(this, R.string.pref_key_site_general, R.string.pref_key_blogging_reminders);
+    }
+
+    private void removeSiteDomainsPref() {
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_general, R.string.pref_key_site_domains);
     }
 
     private void removePrivateOptionFromPrivacySetting() {

--- a/WordPress/src/main/java/org/wordpress/android/util/config/SiteDomainsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/SiteDomainsFeatureConfig.kt
@@ -5,15 +5,15 @@ import org.wordpress.android.annotation.FeatureInDevelopment
 import javax.inject.Inject
 
 // TODO: Uncomment the lines 9 and 13 when remote field is configured and remove line 10 and this to-do
-// @Feature(DomainPurchaseFeatureConfig.DOMAIN_PURCHASE_REMOTE_FIELD, false)
+// @Feature(SiteDomainsFeatureConfig.SITE_DOMAINS_REMOTE_FIELD, false)
 @FeatureInDevelopment
-class DomainPurchaseFeatureConfig
+class SiteDomainsFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.DOMAIN_PURCHASE
-//        DOMAINS_PURCHASE_REMOTE_FIELD
+        BuildConfig.SITE_DOMAINS
+//        SITE_DOMAINS_REMOTE_FIELD
 ) {
     companion object {
-        const val DOMAIN_PURCHASE_REMOTE_FIELD = "domain_purchase_remote_field"
+        const val SITE_DOMAINS_REMOTE_FIELD = "site_domains_remote_field"
     }
 }

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -50,6 +50,7 @@
     <string name="pref_key_site_time_format" translatable="false">wp_pref_site_time_format</string>
     <string name="pref_key_site_timezone" translatable="false">wp_pref_site_timezone</string>
     <string name="pref_key_blogging_reminders" translatable="false">wp_pref_blogging_reminders</string>
+    <string name="pref_key_site_domains" translatable="false">wp_pref_site_domains</string>
     <string name="pref_key_site_posts_per_page" translatable="false">wp_pref_site_post_per_page</string>
     <string name="pref_key_site_amp" translatable="false">wp_pref_site_amp</string>
     <string name="pref_key_site_traffic" translatable="false">wp_pref_site_traffic</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -607,6 +607,7 @@
     <string name="site_settings_time_format_title">Time Format</string>
     <string name="site_settings_timezone_title">Timezone</string>
     <string name="site_settings_timezone_subtitle">Choose a city in your timezone</string>
+    <string name="site_settings_site_domains_title">Site domains</string>
     <string name="site_settings_blogging_reminders_title">Blogging reminders</string>
     <string name="site_settings_posts_per_page_title">Posts per page</string>
     <string name="site_settings_format_entry_custom">Custom</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -59,6 +59,11 @@
             android:title="@string/site_settings_timezone_title" />
 
         <org.wordpress.android.ui.prefs.WPPreference
+            android:id="@+id/pref_site_domains"
+            android:key="@string/pref_key_site_domains"
+            android:title="@string/site_settings_site_domains_title" />
+
+        <org.wordpress.android.ui.prefs.WPPreference
             android:id="@+id/pref_blogging_reminders"
             android:key="@string/pref_key_blogging_reminders"
             android:title="@string/site_settings_blogging_reminders_title" />


### PR DESCRIPTION
Introducing a static entry point for site domains in Site settings

Fixes #15222 

<img width=320 src="https://user-images.githubusercontent.com/990349/130416600-23469f19-421d-47d7-9e83-8c7faf0c0632.png" />


To test:

1. Go to App Settings -> Debug Settings -> enable **SiteDomainsFeatureConfig**
2. Return to My Site -> Go to **Settings** under _Configuration_
3. Find **Site domains** setting under _General_

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
