### PR TITLE
Migrate Snackbar Reminders to ImprovedMySiteFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
@@ -127,9 +127,9 @@ class UnifiedCommentListFragment : Fragment(R.layout.unified_comment_list_fragme
                                             clickListener = { snackbarMessage.buttonAction() }
                                     )
                                 },
-                                dismissCallback = { _, _ ->
+                                dismissCallback = { _, event ->
                                     currentSnackbar = null
-                                    snackbarMessage.onDismissAction()
+                                    snackbarMessage.onDismissAction(event)
                                 },
                                 showCallback = { snackbar -> currentSnackbar = snackbar }
                         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
@@ -229,7 +229,7 @@ class UnifiedCommentListViewModel @Inject constructor(
                                             )
                                         }
                                     },
-                                    onDismissAction = {
+                                    onDismissAction = { _ ->
                                         launch(bgDispatcher) {
                                             if (commentInModeration.contains(it.data.remoteCommentId)) {
                                                 commentInModeration.remove(it.data.remoteCommentId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
@@ -249,7 +249,7 @@ class EngagedPeopleListFragment : Fragment() {
                                     clickListener = { holder.buttonAction() }
                             )
                         },
-                        dismissCallback = { _, _ -> holder.onDismissAction() }
+                        dismissCallback = { _, event -> holder.onDismissAction(event) }
                 )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -327,7 +327,10 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                 !AppPrefs.isQuickStartNoticeRequired()) {
             return
         }
-        val taskToPrompt = getNextUncompletedQuickStartTask(quickStartStore, AppPrefs.getSelectedSite().toLong())
+        val taskToPrompt = QuickStartUtils.getNextUncompletedQuickStartTask(
+                quickStartStore,
+                AppPrefs.getSelectedSite().toLong()
+        )
         if (taskToPrompt != null) {
             quickStartSnackBarHandler.removeCallbacksAndMessages(null)
             quickStartSnackBarHandler.postDelayed({

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -325,10 +325,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         if (!isQuickStartInProgress(quickStartStore) || !AppPrefs.isQuickStartNoticeRequired()) {
             return
         }
-        val taskToPrompt = getNextUncompletedQuickStartTask(
-                quickStartStore,
-                AppPrefs.getSelectedSite().toLong(), CUSTOMIZE
-        ) // CUSTOMIZE is default type
+        val taskToPrompt = getNextUncompletedQuickStartTask(quickStartStore, AppPrefs.getSelectedSite().toLong())
         if (taskToPrompt != null) {
             quickStartSnackBarHandler.removeCallbacksAndMessages(null)
             quickStartSnackBarHandler.postDelayed({

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -575,7 +575,7 @@ class MediaPickerFragment : Fragment() {
                                     clickListener = View.OnClickListener { holder.buttonAction() }
                             )
                         },
-                        dismissCallback = { _, _ -> holder.onDismissAction() }
+                        dismissCallback = { _, event -> holder.onDismissAction(event) }
                 )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -366,6 +366,7 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
         activity?.let {
             if (!it.isChangingConfigurations) {
                 viewModel.clearActiveQuickStartTask()
+                viewModel.dismissQuickStartNotice()
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -501,12 +501,12 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
         activity?.let { parent ->
             snackbarSequencer.enqueue(
                     SnackbarItem(
-                            Info(
+                            info = Info(
                                     view = parent.findViewById(R.id.coordinator),
                                     textRes = holder.message,
                                     duration = Snackbar.LENGTH_LONG
                             ),
-                            holder.buttonTitle?.let {
+                            action = holder.buttonTitle?.let {
                                 Action(
                                         textRes = holder.buttonTitle,
                                         clickListener = { holder.buttonAction() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -13,7 +13,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener
-import com.google.android.material.snackbar.Snackbar
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity
@@ -505,7 +504,7 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
                             info = Info(
                                     view = parent.findViewById(R.id.coordinator),
                                     textRes = holder.message,
-                                    duration = Snackbar.LENGTH_LONG
+                                    duration = holder.duration
                             ),
                             action = holder.buttonTitle?.let {
                                 Action(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -548,11 +548,8 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
     }
 
     override fun onConfirm(result: Bundle?) {
-        if (result != null) {
-            viewModel.onQuickStartFullScreenDialogConfirm(
-                    task = result.getSerializable(QuickStartFullScreenDialogFragment.RESULT_TASK) as? QuickStartTask
-            )
-        }
+        val task = result?.getSerializable(QuickStartFullScreenDialogFragment.RESULT_TASK) as? QuickStartTask
+        task?.let { viewModel.onQuickStartTaskCardClick(it) }
     }
 
     override fun onDismiss() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -512,7 +512,7 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
                                         clickListener = { holder.buttonAction() }
                                 )
                             },
-                            dismissCallback = { _, _ -> holder.onDismissAction() }
+                            dismissCallback = { _, event -> holder.onDismissAction(event) }
                     )
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -359,6 +359,7 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
     override fun onResume() {
         super.onResume()
         viewModel.refresh()
+        viewModel.checkAndShowQuickStartNotice()
     }
 
     override fun onPause() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -120,6 +120,7 @@ import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -166,7 +167,8 @@ class MySiteViewModel
     private val quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig,
     private val onboardingImprovementsFeatureConfig: OnboardingImprovementsFeatureConfig,
     private val quickStartUtilsWrapper: QuickStartUtilsWrapper,
-    private val appPrefsWrapper: AppPrefsWrapper
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val snackbarSequencer: SnackbarSequencer
 ) : ScopedViewModel(mainDispatcher) {
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val _onTechInputDialogShown = MutableLiveData<Event<TextInputDialogModel>>()
@@ -481,6 +483,10 @@ class MySiteViewModel
 
     fun checkAndShowQuickStartNotice() {
         quickStartRepository.checkAndShowQuickStartNotice()
+    }
+
+    fun dismissQuickStartNotice() {
+        if (quickStartRepository.isQuickStartNoticeShown) snackbarSequencer.dismissLastSnackbar()
     }
 
     fun onSiteNameChosen(input: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -479,6 +479,10 @@ class MySiteViewModel
         quickStartRepository.clearActiveTask()
     }
 
+    fun checkAndShowQuickStartNotice() {
+        quickStartRepository.checkAndShowQuickStartNotice()
+    }
+
     fun onSiteNameChosen(input: String) {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             _onSnackbarMessage.postValue(
@@ -493,6 +497,7 @@ class MySiteViewModel
         // This callback is called even when the dialog interaction is positive,
         // otherwise we would need to call 'completeTask' on 'onSiteNameChosen' as well.
         quickStartRepository.completeTask(UPDATE_SITE_TITLE, true)
+        quickStartRepository.checkAndShowQuickStartNotice()
     }
 
     fun onDialogInteraction(interaction: DialogInteraction) {
@@ -509,10 +514,12 @@ class MySiteViewModel
             is Negative -> when (interaction.tag) {
                 TAG_ADD_SITE_ICON_DIALOG -> {
                     quickStartRepository.completeTask(UPLOAD_SITE_ICON, true)
+                    quickStartRepository.checkAndShowQuickStartNotice()
                 }
                 TAG_CHANGE_SITE_ICON_DIALOG -> {
                     analyticsTrackerWrapper.track(MY_SITE_ICON_REMOVED)
                     quickStartRepository.completeTask(UPLOAD_SITE_ICON, true)
+                    quickStartRepository.checkAndShowQuickStartNotice()
                     selectedSiteRepository.updateSiteIconMediaId(0, true)
                 }
                 TAG_REMOVE_NEXT_STEPS_DIALOG -> onRemoveNextStepsDialogNegativeButtonClicked()
@@ -520,6 +527,7 @@ class MySiteViewModel
             is Dismissed -> when (interaction.tag) {
                 TAG_ADD_SITE_ICON_DIALOG, TAG_CHANGE_SITE_ICON_DIALOG -> {
                     quickStartRepository.completeTask(UPLOAD_SITE_ICON, true)
+                    quickStartRepository.checkAndShowQuickStartNotice()
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -370,12 +370,8 @@ class MySiteViewModel
         _onNavigation.value = Event(OpenQuickStartFullScreenDialog(type, quickStartBlockBuilder.getTitle(type)))
     }
 
-    private fun onQuickStartTaskCardClick(task: QuickStartTask) {
+    fun onQuickStartTaskCardClick(task: QuickStartTask) {
         quickStartRepository.setActiveTask(task)
-    }
-
-    fun onQuickStartFullScreenDialogConfirm(task: QuickStartTask?) {
-        task?.let { onQuickStartTaskCardClick(it) }
     }
 
     fun onQuickStartFullScreenDialogDismiss() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts
 import org.wordpress.android.ui.quickstart.QuickStartNoticeDetails
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
+import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.EventBusWrapper
@@ -73,7 +74,8 @@ class QuickStartRepository
     private val htmlCompat: HtmlCompatWrapper,
     private val mySiteImprovementsFeatureConfig: MySiteImprovementsFeatureConfig,
     private val quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig,
-    private val contextProvider: ContextProvider
+    private val contextProvider: ContextProvider,
+    private val htmlMessageUtils: HtmlMessageUtils
 ) : CoroutineScope, MySiteSource<QuickStartUpdate> {
     private val job: Job = Job()
     override val coroutineContext: CoroutineContext
@@ -264,9 +266,14 @@ class QuickStartRepository
         if (taskToPrompt != null) {
             analyticsTrackerWrapper.track(QUICK_START_TASK_DIALOG_VIEWED)
             appPrefsWrapper.setQuickStartNoticeRequired(false)
+            val taskNoticeDetails = QuickStartNoticeDetails.getNoticeForTask(taskToPrompt)
+            val message = htmlMessageUtils.getHtmlMessageFromStringFormat(
+                    "<b>${resourceProvider.getString(taskNoticeDetails.titleResId)}</b>:" +
+                            " ${resourceProvider.getString(taskNoticeDetails.messageResId)}"
+            )
             _onSnackbar.value = Event(
                     SnackbarMessageHolder(
-                            message = UiStringRes(QuickStartNoticeDetails.getNoticeForTask(taskToPrompt).titleResId),
+                            message = UiStringText(message),
                             buttonTitle = UiStringRes(string.quick_start_button_positive),
                             buttonAction = { onQuickStartNoticeButtonAction(taskToPrompt) },
                             onDismissAction = { event ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -278,7 +278,8 @@ class QuickStartRepository
                             buttonAction = { onQuickStartNoticeButtonAction(taskToPrompt) },
                             onDismissAction = { event ->
                                 if (event == DISMISS_EVENT_SWIPE) onQuickStartNoticeNegativeAction(taskToPrompt)
-                            }
+                            },
+                            duration = QUICK_START_NOTICE_DURATION
                     )
             )
         }
@@ -299,4 +300,8 @@ class QuickStartRepository
         val uncompletedTasks: List<QuickStartTaskDetails>,
         val completedTasks: List<QuickStartTaskDetails>
     )
+
+    companion object {
+        private const val QUICK_START_NOTICE_DURATION = 7000
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -2,12 +2,14 @@ package org.wordpress.android.ui.mysite
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import com.google.android.material.snackbar.Snackbar.Callback.DISMISS_EVENT_SWIPE
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_TASK_DIALOG_NEGATIVE_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_TASK_DIALOG_POSITIVE_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_TASK_DIALOG_VIEWED
 import org.wordpress.android.fluxc.Dispatcher
@@ -266,7 +268,10 @@ class QuickStartRepository
                     SnackbarMessageHolder(
                             message = UiStringRes(QuickStartNoticeDetails.getNoticeForTask(taskToPrompt).titleResId),
                             buttonTitle = UiStringRes(string.quick_start_button_positive),
-                            buttonAction = { onQuickStartNoticeButtonAction(taskToPrompt) }
+                            buttonAction = { onQuickStartNoticeButtonAction(taskToPrompt) },
+                            onDismissAction = { event ->
+                                if (event == DISMISS_EVENT_SWIPE) onQuickStartNoticeNegativeAction(taskToPrompt)
+                            }
                     )
             )
         }
@@ -275,6 +280,11 @@ class QuickStartRepository
     private fun onQuickStartNoticeButtonAction(task: QuickStartTask) {
         analyticsTrackerWrapper.track(QUICK_START_TASK_DIALOG_POSITIVE_TAPPED)
         setActiveTask(task)
+    }
+
+    private fun onQuickStartNoticeNegativeAction(task: QuickStartTask) {
+        analyticsTrackerWrapper.track(QUICK_START_TASK_DIALOG_NEGATIVE_TAPPED)
+        appPrefsWrapper.setLastSkippedQuickStartTask(task)
     }
 
     data class QuickStartCategory(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -86,6 +86,7 @@ class QuickStartRepository
     val onSnackbar = _onSnackbar as LiveData<Event<SnackbarMessageHolder>>
     val onQuickStartMySitePrompts = _onQuickStartMySitePrompts as LiveData<Event<QuickStartMySitePrompts>>
     val activeTask = _activeTask as LiveData<QuickStartTask?>
+    var isQuickStartNoticeShown: Boolean = false
 
     private var pendingTask: QuickStartTask? = null
 
@@ -267,12 +268,14 @@ class QuickStartRepository
                     "<b>${resourceProvider.getString(taskNoticeDetails.titleResId)}</b>:" +
                             " ${resourceProvider.getString(taskNoticeDetails.messageResId)}"
             )
+            isQuickStartNoticeShown = true
             _onSnackbar.value = Event(
                     SnackbarMessageHolder(
                             message = UiStringText(message),
                             buttonTitle = UiStringRes(R.string.quick_start_button_positive),
                             buttonAction = { onQuickStartNoticeButtonAction(taskToPrompt) },
                             onDismissAction = { event ->
+                                isQuickStartNoticeShown = false
                                 if (event == DISMISS_EVENT_SWIPE) onQuickStartNoticeNegativeAction(taskToPrompt)
                             },
                             duration = QUICK_START_NOTICE_DURATION

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Job
 import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_TASK_DIALOG_POSITIVE_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_TASK_DIALOG_VIEWED
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
@@ -264,10 +265,16 @@ class QuickStartRepository
             _onSnackbar.value = Event(
                     SnackbarMessageHolder(
                             message = UiStringRes(QuickStartNoticeDetails.getNoticeForTask(taskToPrompt).titleResId),
-                            buttonTitle = UiStringRes(string.quick_start_button_positive)
+                            buttonTitle = UiStringRes(string.quick_start_button_positive),
+                            buttonAction = { onQuickStartNoticeButtonAction(taskToPrompt) }
                     )
             )
         }
+    }
+
+    private fun onQuickStartNoticeButtonAction(task: QuickStartTask) {
+        analyticsTrackerWrapper.track(QUICK_START_TASK_DIALOG_POSITIVE_TAPPED)
+        setActiveTask(task)
     }
 
     data class QuickStartCategory(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -175,7 +175,12 @@ class QuickStartRepository
             _activeTask.value = null
             pendingTask = null
             if (quickStartStore.hasDoneTask(site.id.toLong(), task)) return
-            quickStartUtilsWrapper.completeTaskAndRemindNextOne(task, site, null, contextProvider.getContext())
+            quickStartUtilsWrapper.completeTaskAndRemindNextOne(
+                    task,
+                    site,
+                    QuickStartEvent(task),
+                    contextProvider.getContext()
+            )
             setTaskDoneAndTrack(task, site.id)
             // We need to refresh immediately. This is useful for tasks that are completed on the My Site screen.
             if (refreshImmediately) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
@@ -1,10 +1,12 @@
 package org.wordpress.android.ui.pages
 
+import com.google.android.material.snackbar.Snackbar
 import org.wordpress.android.ui.utils.UiString
 
 data class SnackbarMessageHolder(
     val message: UiString,
     val buttonTitle: UiString? = null,
     val buttonAction: () -> Unit = {},
-    val onDismissAction: (event: Int) -> Unit = {}
+    val onDismissAction: (event: Int) -> Unit = {},
+    val duration: Int = Snackbar.LENGTH_LONG
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
@@ -6,5 +6,5 @@ data class SnackbarMessageHolder(
     val message: UiString,
     val buttonTitle: UiString? = null,
     val buttonAction: () -> Unit = {},
-    val onDismissAction: () -> Unit = {}
+    val onDismissAction: (event: Int) -> Unit = {}
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
@@ -64,7 +64,7 @@ class PostConflictResolver(
             invalidateList.invoke()
         }
 
-        val onDismissAction = {
+        val onDismissAction = { _: Int ->
             if (!isUndoed) {
                 localPostIdForFetchingRemoteVersionOfConflictedPost = null
                 PostUtils.trackSavePostAnalytics(post, site)
@@ -108,7 +108,7 @@ class PostConflictResolver(
                 dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(originalPostCopyForConflictUndo))
             }
         }
-        val onDismissAction = {
+        val onDismissAction = { _: Int ->
             originalPostCopyForConflictUndo = null
         }
         val snackBarHolder = SnackbarMessageHolder(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -431,7 +431,7 @@ class PostsListActivity : LocaleAwareActivity(),
                                         clickListener = { holder.buttonAction() }
                                 )
                             },
-                            dismissCallback = { _, _ -> holder.onDismissAction() }
+                            dismissCallback = { _, event -> holder.onDismissAction(event) }
                     )
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -199,6 +199,10 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun setQuickStartDisabled(isDisabled: Boolean) = AppPrefs.setQuickStartDisabled(isDisabled)
 
+    fun isQuickStartNoticeRequired() = AppPrefs.isQuickStartNoticeRequired()
+
+    fun setQuickStartNoticeRequired(shown: Boolean) = AppPrefs.setQuickStartNoticeRequired(shown)
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.prefs
 
 import org.wordpress.android.fluxc.model.JetpackCapability
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.PostListViewLayoutType
@@ -202,6 +203,8 @@ class AppPrefsWrapper @Inject constructor() {
     fun isQuickStartNoticeRequired() = AppPrefs.isQuickStartNoticeRequired()
 
     fun setQuickStartNoticeRequired(shown: Boolean) = AppPrefs.setQuickStartNoticeRequired(shown)
+
+    fun setLastSkippedQuickStartTask(task: QuickStartTask) = AppPrefs.setLastSkippedQuickStartTask(task)
 
     companion object {
         private const val LIGHT_MODE_ID = 0

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -350,8 +350,7 @@ class QuickStartUtils {
         @JvmStatic
         fun getNextUncompletedQuickStartTask(
             quickStartStore: QuickStartStore,
-            siteId: Long,
-            taskType: QuickStartTaskType
+            siteId: Long
         ): QuickStartTask? {
             // get all the uncompleted tasks for all task types
             val uncompletedTasks = ArrayList<QuickStartTask>()

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
@@ -131,4 +131,7 @@ class QuickStartUtilsWrapper
         quickStartStore.setDoneTask(siteId.toLong(), CREATE_SITE, true)
         analyticsTrackerWrapper.track(QUICK_START_STARTED, mySiteImprovementsFeatureConfig)
     }
+
+    fun getNextUncompletedQuickStartTask(siteLocalId: Long) =
+            QuickStartUtils.getNextUncompletedQuickStartTask(quickStartStore, siteLocalId)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteImprovementsFeatureConfig
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 class QuickStartUtilsWrapper
 @Inject constructor(
     private val quickStartStore: QuickStartStore,

--- a/WordPress/src/main/java/org/wordpress/android/util/SnackbarSequencer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SnackbarSequencer.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.widgets.WPSnackbarWrapper
+import java.lang.ref.SoftReference
 import java.util.LinkedList
 import java.util.Queue
 import javax.inject.Inject
@@ -30,6 +31,8 @@ class SnackbarSequencer @Inject constructor(
     private var job: Job = Job()
 
     private val snackBarQueue: Queue<SnackbarItem> = LinkedList()
+
+    private var lastSnackBarReference: SoftReference<Snackbar?>? = null
 
     override val coroutineContext: CoroutineContext
         get() = mainDispatcher + job
@@ -83,6 +86,8 @@ class SnackbarSequencer @Inject constructor(
 
             val snackbar = wpSnackbarWrapper.make(view, message, item.info.duration)
 
+            lastSnackBarReference = SoftReference(snackbar)
+
             item.action?.let { actionInfo ->
                 snackbar.setAction(
                         uiHelper.getTextOfUiString(context, actionInfo.textRes),
@@ -100,5 +105,9 @@ class SnackbarSequencer @Inject constructor(
         } ?: null.also {
             AppLog.e(T.UTILS, "SnackbarSequencer > prepareSnackBar Unexpected null view")
         }
+    }
+
+    fun dismissLastSnackbar() {
+        lastSnackBarReference?.get()?.dismiss()
     }
 }

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -360,6 +360,7 @@
 
     <style name="WordPress.SnackbarText" parent="@style/Widget.MaterialComponents.Snackbar.TextView">
         <item name="actionTextColorAlpha">1.0</item>
+        <item name="android:maxLines">5</item>
     </style>
 
     <style name="WordPress.TabLayout" parent="Widget.MaterialComponents.TabLayout">

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -125,6 +125,7 @@ import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
+import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.OnboardingImprovementsFeatureConfig
@@ -161,6 +162,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var onboardingImprovementsFeatureConfig: OnboardingImprovementsFeatureConfig
     @Mock lateinit var quickStartUtilsWrapper: QuickStartUtilsWrapper
     @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock lateinit var snackbarSequencer: SnackbarSequencer
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<UiModel>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -278,7 +280,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 quickStartDynamicCardsFeatureConfig,
                 onboardingImprovementsFeatureConfig,
                 quickStartUtilsWrapper,
-                appPrefsWrapper
+                appPrefsWrapper,
+                snackbarSequencer
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1152,11 +1152,11 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when QS full screen dialog confirm is triggered on task tap, then task is set as active task`() {
+    fun `when quick start task is clicked, then task is set as active task`() {
         val task = QuickStartTask.VIEW_SITE
         initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
 
-        viewModel.onQuickStartFullScreenDialogConfirm(task)
+        viewModel.onQuickStartTaskCardClick(task)
 
         verify(quickStartRepository).setActiveTask(task)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1317,6 +1317,48 @@ class MySiteViewModelTest : BaseUnitTest() {
         verify(appPrefsWrapper).setQuickStartDisabled(true)
     }
 
+    @Test
+    fun `when check and show quick start notice is triggered, then check and show quick start notice`() {
+        viewModel.checkAndShowQuickStartNotice()
+
+        verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    @Test
+    fun `when add site icon dialog negative button is clicked, then check and show quick start notice`() {
+        viewModel.onDialogInteraction(DialogInteraction.Negative(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG))
+
+        verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    @Test
+    fun `when change site icon dialog negative button is clicked, then check and show quick start notice`() {
+        viewModel.onDialogInteraction(DialogInteraction.Negative(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG))
+
+        verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    @Test
+    fun `when add site icon dialog is dismissed, then check and show quick start notice`() {
+        viewModel.onDialogInteraction(DialogInteraction.Dismissed(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG))
+
+        verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    @Test
+    fun `when change site icon dialog is dismissed, then check and show quick start notice`() {
+        viewModel.onDialogInteraction(DialogInteraction.Dismissed(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG))
+
+        verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    @Test
+    fun `when site chooser is dismissed, then check and show quick start notice`() {
+        viewModel.onSiteNameChooserDismissed()
+
+        verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
     private fun findQuickActionsBlock() = getLastItems().find { it is QuickActionsBlock } as QuickActionsBlock?
 
     private fun findQuickStartBlock() = getLastItems().find { it is QuickStartBlock } as QuickStartBlock?

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -92,6 +92,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenComments
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomainRegistration
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMeScreen
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMedia
+import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMediaPicker
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenPages
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenPlan
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenPlugins
@@ -1350,6 +1351,59 @@ class MySiteViewModelTest : BaseUnitTest() {
         viewModel.checkAndShowQuickStartNotice()
 
         verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    @Test
+    fun `when add site icon dialog +ve btn is clicked, then upload site icon task marked complete without refresh`() {
+        viewModel.onDialogInteraction(DialogInteraction.Positive(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG))
+
+        verify(quickStartRepository).completeTask(task = UPLOAD_SITE_ICON, refreshImmediately = false)
+    }
+
+    @Test
+    fun `when change site icon dialog +ve btn clicked, then upload site icon task marked complete without refresh`() {
+        viewModel.onDialogInteraction(DialogInteraction.Positive(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG))
+
+        verify(quickStartRepository).completeTask(task = UPLOAD_SITE_ICON, refreshImmediately = false)
+    }
+
+    @Test
+    fun `when add site icon dialog -ve btn is clicked, then upload site icon task marked complete with refresh`() {
+        viewModel.onDialogInteraction(DialogInteraction.Negative(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG))
+
+        verify(quickStartRepository).completeTask(task = UPLOAD_SITE_ICON, refreshImmediately = true)
+    }
+
+    @Test
+    fun `when change site icon dialog -ve btn is clicked, then upload site icon task marked complete with refresh`() {
+        viewModel.onDialogInteraction(DialogInteraction.Negative(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG))
+
+        verify(quickStartRepository).completeTask(task = UPLOAD_SITE_ICON, refreshImmediately = true)
+    }
+
+    @Test
+    fun `when site icon dialog is dismissed, then upload site icon task is marked complete with refresh`() {
+        viewModel.onDialogInteraction(DialogInteraction.Dismissed(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG))
+
+        verify(quickStartRepository).completeTask(task = UPLOAD_SITE_ICON, refreshImmediately = true)
+    }
+
+    @Test
+    fun `when add site icon dialog positive button is clicked, then media picker is opened`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+
+        viewModel.onDialogInteraction(DialogInteraction.Positive(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG))
+
+        assertThat(navigationActions).containsExactly(OpenMediaPicker(site))
+    }
+
+    @Test
+    fun `when change site icon dialog positive button is clicked, then media picker is opened`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+
+        viewModel.onDialogInteraction(DialogInteraction.Positive(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG))
+
+        assertThat(navigationActions).containsExactly(OpenMediaPicker(site))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1318,6 +1318,34 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when refresh is triggered, then update site settings if necessary`() {
+        viewModel.refresh()
+
+        verify(selectedSiteRepository).updateSiteSettingsIfNecessary()
+    }
+
+    @Test
+    fun `when refresh is triggered, then refresh quick start`() {
+        viewModel.refresh()
+
+        verify(quickStartRepository).refresh()
+    }
+
+    @Test
+    fun `when refresh is triggered, then refresh current avatar`() {
+        viewModel.refresh()
+
+        verify(currentAvatarSource).refresh()
+    }
+
+    @Test
+    fun `when clear active quick start task is triggered, then clear active quick start task`() {
+        viewModel.clearActiveQuickStartTask()
+
+        verify(quickStartRepository).clearActiveTask()
+    }
+
+    @Test
     fun `when check and show quick start notice is triggered, then check and show quick start notice`() {
         viewModel.checkAndShowQuickStartNotice()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.test
 import org.wordpress.android.testScope
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.QuickStartUpdate
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
@@ -54,6 +55,7 @@ private const val ALL_TASKS_COMPLETED_MESSAGE = "All tasks completed!"
 class QuickStartRepositoryTest : BaseUnitTest() {
     @Mock lateinit var quickStartStore: QuickStartStore
     @Mock lateinit var quickStartUtilsWrapper: QuickStartUtilsWrapper
+    @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
@@ -78,6 +80,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 TEST_DISPATCHER,
                 quickStartStore,
                 quickStartUtilsWrapper,
+                appPrefsWrapper,
                 selectedSiteRepository,
                 resourceProvider,
                 analyticsTrackerWrapper,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mysite
 
+import com.google.android.material.snackbar.Snackbar.Callback
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
@@ -412,6 +413,27 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 snackbars.last().buttonAction.invoke()
 
                 assertThat(result.last().activeTask).isEqualTo(PUBLISH_POST)
+            }
+
+    @Test
+    fun `when show quick start notice dismissed using swipe-to-dismiss action, then the task is skipped`() = test {
+        initStore(nextUncompletedTask = PUBLISH_POST)
+        quickStartRepository.checkAndShowQuickStartNotice()
+
+        snackbars.last().onDismissAction.invoke(Callback.DISMISS_EVENT_SWIPE)
+
+        verify(appPrefsWrapper).setLastSkippedQuickStartTask(PUBLISH_POST)
+    }
+
+    @Test
+    fun `when show quick start notice dismissed using non swipe-to-dismiss action, then the task is not skipped`() =
+            test {
+                initStore(nextUncompletedTask = PUBLISH_POST)
+                quickStartRepository.checkAndShowQuickStartNotice()
+
+                snackbars.last().onDismissAction.invoke(Callback.DISMISS_EVENT_ACTION)
+
+                verify(appPrefsWrapper, never()).setLastSkippedQuickStartTask(PUBLISH_POST)
             }
 
     private fun triggerQSRefreshAfterSameTypeTasksAreComplete() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -384,6 +384,25 @@ class QuickStartRepositoryTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `given uncompleted task exists, when show quick start notice is triggered, then snackbar is shown`() = test {
+        initStore(nextUncompletedTask = PUBLISH_POST)
+
+        quickStartRepository.checkAndShowQuickStartNotice()
+
+        assertThat(snackbars).isNotEmpty
+    }
+
+    @Test
+    fun `given uncompleted task not exists, when show quick start notice is triggered, then snackbar not shown`() =
+            test {
+                initStore(nextUncompletedTask = null)
+
+                quickStartRepository.checkAndShowQuickStartNotice()
+
+                assertThat(snackbars).isEmpty()
+            }
+
     private fun triggerQSRefreshAfterSameTypeTasksAreComplete() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isEveryQuickStartTaskDoneForType(siteId, GROW)).thenReturn(true)
@@ -401,7 +420,10 @@ class QuickStartRepositoryTest : BaseUnitTest() {
         quickStartRepository.refresh()
     }
 
-    private suspend fun initStore() {
+    private suspend fun initStore(
+        nextUncompletedTask: QuickStartTask? = null
+    ) {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(dynamicCardStore.getCards(siteId)).thenReturn(
                 DynamicCardsModel(
                         dynamicCardTypes = listOf(
@@ -411,6 +433,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 )
         )
         whenever(quickStartUtilsWrapper.isQuickStartInProgress(site.id)).thenReturn(true)
+        whenever(appPrefsWrapper.isQuickStartNoticeRequired()).thenReturn(true)
         whenever(quickStartStore.getUncompletedTasksByType(siteId.toLong(), CUSTOMIZE)).thenReturn(listOf(CREATE_SITE))
         whenever(quickStartStore.getCompletedTasksByType(siteId.toLong(), CUSTOMIZE)).thenReturn(
                 listOf(
@@ -424,6 +447,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 )
         ).thenReturn(listOf(ENABLE_POST_SHARING))
         whenever(quickStartStore.getCompletedTasksByType(siteId.toLong(), GROW)).thenReturn(listOf(PUBLISH_POST))
+        whenever(quickStartUtilsWrapper.getNextUncompletedQuickStartTask(siteId.toLong()))
+                .thenReturn(nextUncompletedTask)
     }
 
     private fun assertModel() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.mysite
 
 import com.google.android.material.snackbar.Snackbar.Callback
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
@@ -41,6 +42,7 @@ import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails.CREATE_SITE_TUTORIAL
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails.PUBLISH_POST_TUTORIAL
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails.SHARE_SITE_TUTORIAL
+import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.HtmlCompatWrapper
@@ -65,8 +67,9 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     @Mock lateinit var dynamicCardStore: DynamicCardStore
     @Mock lateinit var htmlCompat: HtmlCompatWrapper
     @Mock lateinit var mySiteImprovementsFeatureConfig: MySiteImprovementsFeatureConfig
-    @Mock lateinit var contextProvider: ContextProvider
     @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
+    @Mock lateinit var contextProvider: ContextProvider
+    @Mock lateinit var htmlMessageUtils: HtmlMessageUtils
     private lateinit var site: SiteModel
     private lateinit var quickStartRepository: QuickStartRepository
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -91,7 +94,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 htmlCompat,
                 mySiteImprovementsFeatureConfig,
                 quickStartDynamicCardsFeatureConfig,
-                contextProvider
+                contextProvider,
+                htmlMessageUtils
         )
         snackbars = mutableListOf()
         quickStartPrompts = mutableListOf()
@@ -380,7 +384,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
         verify(quickStartUtilsWrapper).completeTaskAndRemindNextOne(
                 PUBLISH_POST,
                 site,
-                null,
+                QuickStartEvent(PUBLISH_POST),
                 contextProvider.getContext()
         )
     }
@@ -482,6 +486,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
         whenever(quickStartStore.getCompletedTasksByType(siteId.toLong(), GROW)).thenReturn(listOf(PUBLISH_POST))
         whenever(quickStartUtilsWrapper.getNextUncompletedQuickStartTask(siteId.toLong()))
                 .thenReturn(nextUncompletedTask)
+        whenever(htmlMessageUtils.getHtmlMessageFromStringFormat(anyOrNull())).thenReturn("")
     }
 
     private fun assertModel() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -403,6 +403,17 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 assertThat(snackbars).isEmpty()
             }
 
+    @Test
+    fun `given uncompleted task, when quick start notice button action is clicked, then the task is marked active`() =
+            test {
+                initStore(nextUncompletedTask = PUBLISH_POST)
+                quickStartRepository.checkAndShowQuickStartNotice()
+
+                snackbars.last().buttonAction.invoke()
+
+                assertThat(result.last().activeTask).isEqualTo(PUBLISH_POST)
+            }
+
     private fun triggerQSRefreshAfterSameTypeTasksAreComplete() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isEveryQuickStartTaskDoneForType(siteId, GROW)).thenReturn(true)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -45,15 +45,15 @@ import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteImprovementsFeatureConfig
-import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
+import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
 
 private const val ALL_TASKS_COMPLETED_MESSAGE = "All tasks completed!"
 
 class QuickStartRepositoryTest : BaseUnitTest() {
     @Mock lateinit var quickStartStore: QuickStartStore
-    @Mock lateinit var quickStartUtils: QuickStartUtilsWrapper
+    @Mock lateinit var quickStartUtilsWrapper: QuickStartUtilsWrapper
     @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
@@ -77,7 +77,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
         quickStartRepository = QuickStartRepository(
                 TEST_DISPATCHER,
                 quickStartStore,
-                quickStartUtils,
+                quickStartUtilsWrapper,
                 selectedSiteRepository,
                 resourceProvider,
                 analyticsTrackerWrapper,
@@ -172,7 +172,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
         initStore()
 
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        whenever(quickStartUtils.isEveryQuickStartTaskDoneForType(siteId, GROW)).thenReturn(false)
+        whenever(quickStartUtilsWrapper.isEveryQuickStartTaskDoneForType(siteId, GROW)).thenReturn(false)
 
         val task = PUBLISH_POST
         quickStartRepository.setActiveTask(task)
@@ -219,7 +219,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
 
         quickStartRepository.startQuickStart(siteId)
 
-        verify(quickStartUtils).startQuickStart(siteId)
+        verify(quickStartUtilsWrapper).startQuickStart(siteId)
         assertModel()
     }
 
@@ -361,7 +361,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
 
         quickStartRepository.completeTask(UPDATE_SITE_TITLE)
 
-        verify(quickStartUtils, never()).completeTaskAndRemindNextOne(any(), any(), any(), any())
+        verify(quickStartUtilsWrapper, never()).completeTaskAndRemindNextOne(any(), any(), any(), any())
     }
 
     @Test
@@ -373,12 +373,17 @@ class QuickStartRepositoryTest : BaseUnitTest() {
 
         quickStartRepository.completeTask(PUBLISH_POST)
 
-        verify(quickStartUtils).completeTaskAndRemindNextOne(PUBLISH_POST, site, null, contextProvider.getContext())
+        verify(quickStartUtilsWrapper).completeTaskAndRemindNextOne(
+                PUBLISH_POST,
+                site,
+                null,
+                contextProvider.getContext()
+        )
     }
 
     private fun triggerQSRefreshAfterSameTypeTasksAreComplete() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        whenever(quickStartUtils.isEveryQuickStartTaskDoneForType(siteId, GROW)).thenReturn(true)
+        whenever(quickStartUtilsWrapper.isEveryQuickStartTaskDoneForType(siteId, GROW)).thenReturn(true)
         whenever(resourceProvider.getString(any())).thenReturn(ALL_TASKS_COMPLETED_MESSAGE)
         whenever(htmlCompat.fromHtml(ALL_TASKS_COMPLETED_MESSAGE)).thenReturn(ALL_TASKS_COMPLETED_MESSAGE)
 
@@ -402,7 +407,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                         )
                 )
         )
-        whenever(quickStartUtils.isQuickStartInProgress(site.id)).thenReturn(true)
+        whenever(quickStartUtilsWrapper.isQuickStartInProgress(site.id)).thenReturn(true)
         whenever(quickStartStore.getUncompletedTasksByType(siteId.toLong(), CUSTOMIZE)).thenReturn(listOf(CREATE_SITE))
         whenever(quickStartStore.getCompletedTasksByType(siteId.toLong(), CUSTOMIZE)).thenReturn(
                 listOf(


### PR DESCRIPTION
Fixes #15187

## Description

This PR migrates quick start notices (for the next task to be completed) to `ImprovedMySiteFragment`. 

The snackbar that was used in deprecated `MySiteFragment` had few style issues (see https://github.com/wordpress-mobile/WordPress-Android/issues/15187#issuecomment-899550641), which were resolved in the existing snackbar available in `ImprovedMySiteFragment`. The PR continued using this `ImprovedMySiteFragment`  snackbar with  few design modifications (see  p1629720041003300-slack-C0290FLA0RM).

## To test

##### Prequisite

1. Go to `My Site` -> `App Settings` -> `Test feature configuration`.
2. Disable `QuickStartDynamicCardsFeatureConfig`, enable `MySiteImprovementsFeatureConfig`
3. Restart the app

##### Quick start notice display 

4. Select a site with quick start in progress 
5. Click quick start task type list item
6. Notice that `QuickStartFullScreenDialogFragment` gets opened
7. Select a task from the `QuickStartFullScreenDialogFragment`
8. Notice that when `QuickStartFullScreenDialogFragment` is dismissed, the appropriate QS focus point and snack bar get displayed based on the chosen task
9. Perform the task so that it gets completed
10. Notice that quick start notice is displayed for the next task 

![qsn-prompt](https://user-images.githubusercontent.com/1405144/130617834-85f67554-87ca-4e4e-b7e6-f8f3adbdcba6.png)

##### Positive button action 

11. Click "Go" button in the quick start notice
12. Notice that appropriate QS focus point and snack bar get displayed based for this next task

##### Negative action (triggered by user using swipe-to-dismiss action)

13. Add a breakpoint on `QuickStartRepository.onQuickStartNoticeNegativeAction` and enable debugging
14. Repeat steps 5-10
15. Swipe-to-dismiss the quick start notice for the next task 
16. Notice that breakpoint added on 13. gets hit

##### Auto Dismiss 

17. Resume from debugging 
18. Repeat steps 5-10
19. Wait for snackbar to dismiss by itself (after timeout)
20. Notice that breakpoint added on 13. is not hit

## Regression Notes
1. Potential unintended areas of impact
    - `ImprovedMySiteFragment` -> `Quick Start - Dynamic Card` (`MySiteImprovementsFeatureConfig` - ON, `QuickStartDynamicCardsFeatureConfig` - ON ) - new quick start notice will appear 
    - `MySiteFragment` -> `Quick Start` (`MySiteImprovementsFeatureConfig` - OFF) - old quick start notice will appear

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually 

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for the migrated functionality in `ImprovedMySiteFragment`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.