### PR TITLE
My Site Dashboard: Phase 1 - Quick Start finetune UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
@@ -56,7 +56,6 @@ sealed class MySiteItem(open val type: Type, open val activeQuickStartItem: Bool
     data class DomainRegistrationBlock(val onClick: ListItemInteraction) : MySiteItem(DOMAIN_REGISTRATION_BLOCK)
 
     data class QuickStartBlock(
-        @DrawableRes val icon: Int,
         val title: UiString,
         val onRemoveMenuItemClick: ListItemInteraction,
         val taskTypeItems: List<QuickStartTaskTypeItem>

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilder.kt
@@ -18,7 +18,6 @@ class QuickStartBlockBuilder @Inject constructor() {
         onRemoveMenuItemClick: () -> Unit,
         onItemClick: (QuickStartTaskType) -> Unit
     ) = QuickStartBlock(
-            icon = R.drawable.ic_list_checkmark_white_24dp,
             title = UiStringRes(R.string.quick_start_sites),
             onRemoveMenuItemClick = ListItemInteraction.create { onRemoveMenuItemClick.invoke() },
             taskTypeItems = categories.map { buildQuickStartTaskTypeItem(it, onItemClick) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.ui.mysite.MySiteItem.QuickStartBlock.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteItemViewHolder
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.util.ColorUtils
 import org.wordpress.android.util.viewBinding
 
 class QuickStartBlockViewHolder(
@@ -73,8 +72,6 @@ class QuickStartBlockViewHolder(
         ObjectAnimator.ofInt(this, PROGRESS, item.progress).setDuration(PROGRESS_ANIMATION_DURATION).start()
 
         val progressIndicatorColor = ContextCompat.getColor(itemView.context, item.progressColor)
-        val progressTrackColor = ColorUtils.applyEmphasisToColor(progressIndicatorColor, lowEmphasisAlpha)
-        progressBackgroundTintList = ColorStateList.valueOf(progressTrackColor)
         progressTintList = ColorStateList.valueOf(progressIndicatorColor)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockViewHolder.kt
@@ -36,7 +36,6 @@ class QuickStartBlockViewHolder(
     }
 
     private fun QuickStartToolbarBinding.update(block: QuickStartBlock) {
-        quickStartIcon.setBackgroundResource(block.icon)
         quickStartTitle.text = uiHelpers.getTextOfUiString(itemView.context, block.title)
         quickStartMore.setOnClickListener { showQuickStartCardMenu(block.onRemoveMenuItemClick) }
     }

--- a/WordPress/src/main/res/drawable/ic_list_checkmark_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_list_checkmark_white_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:fillColor="@android:color/white"
-      android:pathData="M9.5,15.5L5,20l-2.5,-2.5 1.06,-1.06L5,17.88l3.44,-3.44L9.5,15.5zM10,5v2h11L21,5L10,5zM10,19h11v-2L10,17v2zM10,13h11v-2L10,11v2zM8.44,8.44L5,11.88l-1.44,-1.44L2.5,11.5 5,14l4.5,-4.5 -1.06,-1.06zM8.44,2.44L5,5.88 3.56,4.44 2.5,5.5 5,8l4.5,-4.5 -1.06,-1.06z"/>
-</vector>

--- a/WordPress/src/main/res/drawable/quick_start_card_progress_drawable.xml
+++ b/WordPress/src/main/res/drawable/quick_start_card_progress_drawable.xml
@@ -3,7 +3,7 @@
     <item android:id="@android:id/background">
         <shape
             android:shape="ring"
-            android:thicknessRatio="8"
+            android:thicknessRatio="10"
             android:useLevel="false">
             <solid android:color="@color/on_surface_divider" />
         </shape>
@@ -14,7 +14,7 @@
             android:toDegrees="270">
             <shape
                 android:shape="ring"
-                android:thicknessRatio="6"
+                android:thicknessRatio="8"
                 android:useLevel="true">
                 <solid android:color="?colorPrimary" />
             </shape>

--- a/WordPress/src/main/res/drawable/quick_start_card_progress_drawable.xml
+++ b/WordPress/src/main/res/drawable/quick_start_card_progress_drawable.xml
@@ -3,8 +3,9 @@
     <item android:id="@android:id/background">
         <shape
             android:shape="ring"
+            android:thicknessRatio="8"
             android:useLevel="false">
-            <solid android:color="?colorSurface" />
+            <solid android:color="@color/on_surface_divider" />
         </shape>
     </item>
     <item android:id="@android:id/progress">
@@ -13,6 +14,7 @@
             android:toDegrees="270">
             <shape
                 android:shape="ring"
+                android:thicknessRatio="6"
                 android:useLevel="true">
                 <solid android:color="?colorPrimary" />
             </shape>

--- a/WordPress/src/main/res/layout/quick_start_block.xml
+++ b/WordPress/src/main/res/layout/quick_start_block.xml
@@ -2,9 +2,10 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/quick_start"
+    style="@style/WordPress.CardView.Unelevated"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="@dimen/margin_large">
+    android:layout_margin="@dimen/margin_medium">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/quick_start_task_type_item.xml
+++ b/WordPress/src/main/res/layout/quick_start_task_type_item.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/item_root"
     style="@style/QuickStartTypeRow"
-    android:paddingEnd="@dimen/my_site_card_row_padding"
-    android:paddingStart="@dimen/my_site_card_row_padding">
+    android:padding="@dimen/my_site_card_row_padding">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/item_title"

--- a/WordPress/src/main/res/layout/quick_start_task_type_item.xml
+++ b/WordPress/src/main/res/layout/quick_start_task_type_item.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/item_root"
     style="@style/QuickStartTypeRow"
-    android:paddingEnd="@dimen/content_margin_site_row_start"
-    android:paddingStart="@dimen/content_margin_site_row_start">
+    android:paddingEnd="@dimen/my_site_card_row_padding"
+    android:paddingStart="@dimen/my_site_card_row_padding">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/item_title"

--- a/WordPress/src/main/res/layout/quick_start_toolbar.xml
+++ b/WordPress/src/main/res/layout/quick_start_toolbar.xml
@@ -6,8 +6,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?attr/listPreferredItemHeightSmall"
-    android:paddingEnd="@dimen/content_margin_site_row_start"
-    android:paddingStart="@dimen/content_margin_site_row_start"
+    android:paddingEnd="@dimen/my_site_card_row_padding"
+    android:paddingStart="@dimen/my_site_card_row_padding"
     tools:showIn="@layout/quick_start_block">
 
     <com.google.android.material.textview.MaterialTextView

--- a/WordPress/src/main/res/layout/quick_start_toolbar.xml
+++ b/WordPress/src/main/res/layout/quick_start_toolbar.xml
@@ -7,7 +7,7 @@
     android:layout_height="wrap_content"
     android:paddingEnd="@dimen/my_site_card_row_padding"
     android:paddingStart="@dimen/my_site_card_row_padding"
-    android:paddingTop="@dimen/my_site_card_row_padding"
+    android:paddingTop="@dimen/my_site_card_row_top_padding"
     tools:showIn="@layout/quick_start_block">
 
     <com.google.android.material.textview.MaterialTextView

--- a/WordPress/src/main/res/layout/quick_start_toolbar.xml
+++ b/WordPress/src/main/res/layout/quick_start_toolbar.xml
@@ -14,7 +14,6 @@
         android:id="@+id/quick_start_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_extra_large"
         android:ellipsize="end"
         android:maxLines="1"
         android:textAlignment="viewStart"

--- a/WordPress/src/main/res/layout/quick_start_toolbar.xml
+++ b/WordPress/src/main/res/layout/quick_start_toolbar.xml
@@ -5,9 +5,9 @@
     android:id="@+id/quick_start_toolbar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?attr/listPreferredItemHeightSmall"
     android:paddingEnd="@dimen/my_site_card_row_padding"
     android:paddingStart="@dimen/my_site_card_row_padding"
+    android:paddingTop="@dimen/my_site_card_row_padding"
     tools:showIn="@layout/quick_start_block">
 
     <com.google.android.material.textview.MaterialTextView

--- a/WordPress/src/main/res/layout/quick_start_toolbar.xml
+++ b/WordPress/src/main/res/layout/quick_start_toolbar.xml
@@ -18,7 +18,7 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:textAlignment="viewStart"
-        android:textAppearance="?attr/textAppearanceSubtitle1"
+        android:textAppearance="?attr/textAppearanceBody2"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/quick_start_more"
         app:layout_constraintStart_toStartOf="parent"

--- a/WordPress/src/main/res/layout/quick_start_toolbar.xml
+++ b/WordPress/src/main/res/layout/quick_start_toolbar.xml
@@ -10,18 +10,6 @@
     android:paddingStart="@dimen/content_margin_site_row_start"
     tools:showIn="@layout/quick_start_block">
 
-    <ImageView
-        android:id="@+id/quick_start_icon"
-        android:layout_width="@dimen/my_site_list_row_icon_size"
-        android:layout_height="@dimen/my_site_list_row_icon_size"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:importantForAccessibility="no"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:tint="?attr/wpColorOnSurfaceMedium"
-        tools:src="@drawable/ic_list_checkmark_white_24dp" />
-
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/quick_start_title"
         android:layout_width="0dp"
@@ -33,7 +21,7 @@
         android:textAppearance="?attr/textAppearanceSubtitle1"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/quick_start_more"
-        app:layout_constraintStart_toEndOf="@+id/quick_start_icon"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="@string/quick_start_sites" />
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -314,6 +314,7 @@
     <dimen name="my_site_content_area">500dp</dimen>
     <dimen name="my_site_quick_action_button_container_width">64dp</dimen>
     <dimen name="my_site_quick_action_button_text_max_width">84dp</dimen>
+    <dimen name="my_site_card_row_padding">16dp</dimen>
 
     <!--me-->
     <dimen name="me_list_row_icon_size">24dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -315,6 +315,7 @@
     <dimen name="my_site_quick_action_button_container_width">64dp</dimen>
     <dimen name="my_site_quick_action_button_text_max_width">84dp</dimen>
     <dimen name="my_site_card_row_padding">16dp</dimen>
+    <dimen name="my_site_card_row_top_padding">12dp</dimen>
 
     <!--me-->
     <dimen name="me_list_row_icon_size">24dp</dimen>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -762,7 +762,7 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:maxLines">1</item>
         <item name="android:paddingEnd">@dimen/content_margin</item>
-        <item name="android:textAppearance">?attr/textAppearanceBody2</item>
+        <item name="android:textAppearance">?attr/textAppearanceCaption</item>
         <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>
     </style>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -752,7 +752,7 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:maxLines">1</item>
         <item name="android:paddingEnd">@dimen/content_margin</item>
-        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
+        <item name="android:textAppearance">?attr/textAppearanceBody2</item>
     </style>
 
     <style name="QuickStartTypeSubtitle">

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -201,7 +201,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         )
     private val quickStartBlock: QuickStartBlock
         get() = QuickStartBlock(
-                icon = 0,
                 title = UiStringText(""),
                 onRemoveMenuItemClick = ListItemInteraction.create { removeMenuItemClickAction },
                 taskTypeItems = listOf(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/quickstart/QuickStartBlockBuilderTest.kt
@@ -29,15 +29,6 @@ class QuickStartBlockBuilderTest : BaseUnitTest() {
         builder = QuickStartBlockBuilder()
     }
 
-    /* ICON */
-
-    @Test
-    fun `when block is built, then icon exists`() {
-        val quickStartBlock = buildQuickStartBlock()
-
-        assertThat(quickStartBlock.icon).isEqualTo(R.drawable.ic_list_checkmark_white_24dp)
-    }
-
     /* TITLE */
 
     @Test


### PR DESCRIPTION
Parent #15189

This PR adjusts the UI based upon the latest design iteration. Included are margin/padding changes, progress circle background color. size ratios, card frame, and font sizes for titles and text.


Dark | Light
-- | --
<img width="250" height="500" alt="Quick Start Dark" src="https://user-images.githubusercontent.com/506707/130638913-5f235d3f-c06a-493c-b67c-64bc3e3a7f54.png"> | <img width="250" height="500" alt="Quick Start Light" src="https://user-images.githubusercontent.com/506707/130638902-d0fc1a88-3db1-488b-b67c-ecffbf03a656.png">


**To test:**
- Launch the app 
- Navigate to My Site -> App Settings -> Test feature configuration
- Enable the `MySiteImprovementsFeatureConfig` and tap the button to restart the app (I also like to swipe the app closed after that and then reopen - sometimes weird behavior happens)
- Log out of the app
- Log in to the app
- When the Quick Start Prompt is shown, tap the "Show me around" option

## Regression Notes
1. Potential unintended areas of impact N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A
3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
