### PR TITLE
Feature/15234 domains dashboard

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -686,6 +686,11 @@
 
         <!--Domain Registration-->
         <activity
+            android:name=".ui.domains.DomainsDashboardActivity"
+            android:label="@string/site_settings_site_domains_title"
+            android:theme="@style/WordPress.NoActionBar" />
+
+        <activity
             android:name=".ui.domains.DomainRegistrationActivity"
             android:label="@string/register_domain"
             android:theme="@style/WordPress.NoActionBar"/>

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -52,6 +52,7 @@ import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment;
 import org.wordpress.android.ui.domains.DomainSuggestionsFragment;
+import org.wordpress.android.ui.domains.DomainsDashboardFragment;
 import org.wordpress.android.ui.engagement.EngagedPeopleListActivity;
 import org.wordpress.android.ui.engagement.EngagedPeopleListFragment;
 import org.wordpress.android.ui.engagement.UserProfileBottomSheetFragment;
@@ -540,6 +541,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PlansListAdapter object);
 
     void inject(PlanDetailsFragment object);
+
+    void inject(DomainsDashboardFragment object);
 
     void inject(DomainSuggestionsFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.debug.DebugSettingsViewModel;
 import org.wordpress.android.ui.debug.cookies.DebugCookiesViewModel;
 import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverViewModel;
 import org.wordpress.android.ui.domains.DomainRegistrationMainViewModel;
+import org.wordpress.android.ui.domains.DomainsDashboardViewModel;
 import org.wordpress.android.ui.engagement.EngagedPeopleListViewModel;
 import org.wordpress.android.ui.engagement.UserProfileViewModel;
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel;
@@ -273,6 +274,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(PlansViewModel.class)
     abstract ViewModel plansViewModel(PlansViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(DomainsDashboardViewModel.class)
+    abstract ViewModel domainsDashboardViewModel(DomainsDashboardViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -48,6 +48,7 @@ import org.wordpress.android.ui.comments.unified.UnifiedCommentsActivity;
 import org.wordpress.android.ui.debug.cookies.DebugCookiesActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose;
+import org.wordpress.android.ui.domains.DomainsDashboardActivity;
 import org.wordpress.android.ui.engagement.EngagedPeopleListActivity;
 import org.wordpress.android.ui.engagement.EngagementNavigationSource;
 import org.wordpress.android.ui.engagement.HeaderData;
@@ -672,6 +673,14 @@ public class ActivityLauncher {
             intent.putExtra(PluginDetailActivity.KEY_PLUGIN_SLUG, slug);
             context.startActivity(intent);
         }
+    }
+
+    public static void viewDomainsDashboardActivityForResult(Activity activity, SiteModel site,
+                                            @NonNull DomainRegistrationPurpose purpose) {
+        Intent intent = new Intent(activity, DomainsDashboardActivity.class);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(DomainRegistrationActivity.DOMAIN_REGISTRATION_PURPOSE_KEY, purpose);
+        activity.startActivityForResult(intent, RequestCodes.DOMAIN_REGISTRATION);
     }
 
     public static void viewDomainRegistrationActivityForResult(Activity activity, SiteModel site,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardActivity.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.ui.domains
+
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.R
+import org.wordpress.android.databinding.ActivityDomainsDashboardBinding
+import org.wordpress.android.ui.LocaleAwareActivity
+import javax.inject.Inject
+
+class DomainsDashboardActivity : LocaleAwareActivity() {
+    @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: DomainsDashboardViewModel
+    private lateinit var binding: ActivityDomainsDashboardBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        with(ActivityDomainsDashboardBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            binding = this
+
+            setSupportActionBar(toolbarDomains)
+            supportActionBar?.let {
+                it.setHomeButtonEnabled(true)
+                it.setDisplayHomeAsUpEnabled(true)
+            }
+
+            val fm = supportFragmentManager
+            var domainsDashboardFragment =
+                    fm.findFragmentByTag(DomainsDashboardFragment.TAG) as? DomainsDashboardFragment
+
+            if (domainsDashboardFragment == null) {
+                domainsDashboardFragment = DomainsDashboardFragment.newInstance()
+                fm.beginTransaction()
+                        .add(R.id.fragment_container, domainsDashboardFragment, DomainsDashboardFragment.TAG)
+                        .commit()
+            }
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.ui.domains
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.FragmentDomainsDashboardBinding
+import javax.inject.Inject
+
+class DomainsDashboardFragment : Fragment() {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: DomainsDashboardViewModel
+    private var binding: FragmentDomainsDashboardBinding? = null
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val nonNullActivity = requireActivity()
+        (nonNullActivity.application as WordPress).component()?.inject(this)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_domains_dashboard, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel = ViewModelProvider(this, viewModelFactory).get(DomainsDashboardViewModel::class.java)
+        with(FragmentDomainsDashboardBinding.bind(view)) {
+            binding = this
+        }
+    }
+
+    companion object {
+        const val TAG = "DOMAINS_DASHBOARD_FRAGMENT"
+        @JvmStatic fun newInstance() = DomainsDashboardFragment()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
@@ -33,7 +33,8 @@ class DomainsDashboardFragment : Fragment() {
     }
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
@@ -31,8 +32,9 @@ class DomainsDashboardViewModel @Inject constructor(
     private val _uiModel = MutableLiveData<List<MySiteItem>>()
     val uiModel = _uiModel
 
-    val siteUrl = selectedSiteRepository.selectedSiteChange.value?.url.toString()
+    val siteUrl: String = SiteUtils.getHomeURLOrHostName(selectedSiteRepository.selectedSiteChange.value)
 
+    // TODO: UI and logic is work in progress.  Will be revamped once design is ready
     private fun buildPrimarySiteAddressUiItems(onClick: (ListItemAction) -> Unit): List<MySiteItem> {
         val listItems = mutableListOf<MySiteItem>()
         listItems += CategoryHeader(UiStringRes(string.domains_primary_domain))

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.ui.domains
+
+import androidx.lifecycle.ViewModel
+import javax.inject.Inject
+
+class DomainsDashboardViewModel @Inject constructor() : ViewModel() {
+    private var isStarted: Boolean = false
+    fun start() {
+        if (isStarted) {
+            return
+        }
+
+        isStarted = true
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -23,7 +23,7 @@ import javax.inject.Inject
 
 class DomainsDashboardViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val selectedSiteRepository: SelectedSiteRepository,
+    private val selectedSiteRepository: SelectedSiteRepository
 ) : ViewModel() {
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation
@@ -35,8 +35,8 @@ class DomainsDashboardViewModel @Inject constructor(
 
     private fun buildPrimarySiteAddressUiItems(onClick: (ListItemAction) -> Unit): List<MySiteItem> {
         val listItems = mutableListOf<MySiteItem>()
-        listItems +=  CategoryHeader(UiStringRes(string.domains_primary_domain))
-        listItems +=  ListItem(
+        listItems += CategoryHeader(UiStringRes(string.domains_primary_domain))
+        listItems += ListItem(
                         R.drawable.ic_domains_white_24dp,
                         primaryText = UiStringResWithParams(
                                 string.domains_primary_domain_address,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -1,15 +1,76 @@
 package org.wordpress.android.ui.domains
 
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED
+import org.wordpress.android.ui.mysite.ListItemAction
+import org.wordpress.android.ui.mysite.MySiteItem
+import org.wordpress.android.ui.mysite.MySiteItem.CategoryHeader
+import org.wordpress.android.ui.mysite.MySiteItem.DomainRegistrationBlock
+import org.wordpress.android.ui.mysite.MySiteItem.ListItem
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomainRegistration
+import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
-class DomainsDashboardViewModel @Inject constructor() : ViewModel() {
+class DomainsDashboardViewModel @Inject constructor(
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val selectedSiteRepository: SelectedSiteRepository,
+) : ViewModel() {
+    private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
+    val onNavigation = _onNavigation
+
+    private val _uiModel = MutableLiveData<List<MySiteItem>>()
+    val uiModel = _uiModel
+
+    val siteUrl = selectedSiteRepository.selectedSiteChange.value?.url.toString()
+
+    private fun buildPrimarySiteAddressUiItems(onClick: (ListItemAction) -> Unit): List<MySiteItem> {
+        val listItems = mutableListOf<MySiteItem>()
+        listItems +=  CategoryHeader(UiStringRes(string.domains_primary_domain))
+        listItems +=  ListItem(
+                        R.drawable.ic_domains_white_24dp,
+                        primaryText = UiStringResWithParams(
+                                string.domains_primary_domain_address,
+                                listOf(UiStringText(siteUrl))),
+                        onClick = ListItemInteraction.create(ListItemAction.POSTS, onClick)
+                )
+
+        if (selectedSiteRepository.getSelectedSite()?.hasFreePlan == true) {
+            listItems += ListItem(
+                    R.drawable.ic_domains_white_24dp,
+                    primaryText = UiStringRes(string.domains_free_plan_get_your_domain_title),
+                    onClick = ListItemInteraction.create(this::domainRegistrationClick))
+        } else {
+            DomainRegistrationBlock(ListItemInteraction.create(this::domainRegistrationClick))
+        }
+        return listItems
+    }
+
     private var isStarted: Boolean = false
     fun start() {
         if (isStarted) {
             return
         }
-
         isStarted = true
+        _uiModel.value = buildPrimarySiteAddressUiItems { onItemClick() }
+    }
+
+    private fun onItemClick() {
+        // TODO
+    }
+
+    private fun domainRegistrationClick() {
+        val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
+        analyticsTrackerWrapper.track(DOMAIN_CREDIT_REDEMPTION_TAPPED, selectedSite)
+        _onNavigation.value = Event(OpenDomainRegistration(selectedSite))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -47,6 +47,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenBackup
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenComments
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenCropActivity
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomainRegistration
+import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomains
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenJetpackSettings
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMeScreen
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMedia
@@ -289,6 +290,11 @@ class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
                 action.site,
                 action.source,
                 action.mediaUris.toTypedArray()
+        )
+        is OpenDomains -> ActivityLauncher.viewDomainsDashboardActivityForResult(
+                activity,
+                action.site,
+                CTA_DOMAIN_CREDIT_REDEMPTION // TODO: replace with correct CTA
         )
         is OpenDomainRegistration -> ActivityLauncher.viewDomainRegistrationActivityForResult(
                 activity,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ListItemAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ListItemAction.kt
@@ -11,6 +11,7 @@ enum class ListItemAction {
     ADMIN,
     PEOPLE,
     SHARING,
+    DOMAINS,
     SITE_SETTINGS,
     THEMES,
     PLUGINS,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -49,6 +49,7 @@ import org.wordpress.android.ui.mysite.ListItemAction.ACTIVITY_LOG
 import org.wordpress.android.ui.mysite.ListItemAction.ADMIN
 import org.wordpress.android.ui.mysite.ListItemAction.BACKUP
 import org.wordpress.android.ui.mysite.ListItemAction.COMMENTS
+import org.wordpress.android.ui.mysite.ListItemAction.DOMAINS
 import org.wordpress.android.ui.mysite.ListItemAction.JETPACK_SETTINGS
 import org.wordpress.android.ui.mysite.ListItemAction.MEDIA
 import org.wordpress.android.ui.mysite.ListItemAction.PAGES
@@ -76,6 +77,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenBackup
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenComments
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenCropActivity
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomainRegistration
+import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomains
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenJetpackSettings
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMeScreen
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMedia
@@ -332,6 +334,7 @@ class MySiteViewModel
                     quickStartRepository.requestNextStepOfTask(ENABLE_POST_SHARING)
                     OpenSharing(selectedSite)
                 }
+                DOMAINS -> OpenDomains(selectedSite)
                 SITE_SETTINGS -> OpenSiteSettings(selectedSite)
                 THEMES -> OpenThemes(selectedSite)
                 PLUGINS -> OpenPlugins(selectedSite)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteItemsBuilder.kt
@@ -58,6 +58,7 @@ class SiteItemsBuilder
                 siteListItemBuilder.buildPeopleItemIfAvailable(site, onClick),
                 siteListItemBuilder.buildPluginItemIfAvailable(site, onClick),
                 siteListItemBuilder.buildShareItemIfAvailable(site, onClick, showEnablePostSharingFocusPoint),
+                siteListItemBuilder.buildDomainsItemIfAvailable(site, onClick),
                 siteListItemBuilder.buildSiteSettingsItemIfAvailable(site, onClick),
                 CategoryHeader(UiStringRes(R.string.my_site_header_external)),
                 ListItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.SiteUtilsWrapper
+import org.wordpress.android.util.config.SiteDomainsFeatureConfig
 import java.util.GregorianCalendar
 import java.util.TimeZone
 import javax.inject.Inject
@@ -22,7 +23,8 @@ class SiteListItemBuilder
     private val accountStore: AccountStore,
     private val pluginUtilsWrapper: PluginUtilsWrapper,
     private val siteUtilsWrapper: SiteUtilsWrapper,
-    private val themeBrowserUtils: ThemeBrowserUtils
+    private val themeBrowserUtils: ThemeBrowserUtils,
+    private val siteDomainsFeatureConfig: SiteDomainsFeatureConfig
 ) {
     fun buildActivityLogItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         val isWpComOrJetpack = siteUtilsWrapper.isAccessedViaWPComRest(
@@ -143,6 +145,18 @@ class SiteListItemBuilder
                     UiStringRes(R.string.my_site_btn_sharing),
                     showFocusPoint = showFocusPoint,
                     onClick = ListItemInteraction.create(ListItemAction.SHARING, onClick)
+            )
+        } else null
+    }
+
+    fun buildDomainsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
+        return if (siteDomainsFeatureConfig.isEnabled()
+                && site.hasCapabilityManageOptions
+                || !siteUtilsWrapper.isAccessedViaWPComRest(site)) {
+            ListItem(
+                    R.drawable.ic_domains_white_24dp,
+                    UiStringRes(R.string.my_site_btn_domains),
+                    onClick = ListItemInteraction.create(ListItemAction.DOMAINS, onClick)
             )
         } else null
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
@@ -150,9 +150,9 @@ class SiteListItemBuilder
     }
 
     fun buildDomainsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
-        return if (siteDomainsFeatureConfig.isEnabled()
-                && site.hasCapabilityManageOptions
-                || !siteUtilsWrapper.isAccessedViaWPComRest(site)) {
+        return if (siteDomainsFeatureConfig.isEnabled() &&
+                site.hasCapabilityManageOptions ||
+                !siteUtilsWrapper.isAccessedViaWPComRest(site)) {
             ListItem(
                     R.drawable.ic_domains_white_24dp,
                     UiStringRes(R.string.my_site_btn_domains),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -22,6 +22,7 @@ sealed class SiteNavigationAction {
     data class OpenAdmin(val site: SiteModel) : SiteNavigationAction()
     data class OpenPeople(val site: SiteModel) : SiteNavigationAction()
     data class OpenSharing(val site: SiteModel) : SiteNavigationAction()
+    data class OpenDomains(val site: SiteModel) : SiteNavigationAction()
     data class OpenSiteSettings(val site: SiteModel) : SiteNavigationAction()
     data class OpenThemes(val site: SiteModel) : SiteNavigationAction()
     data class OpenPlugins(val site: SiteModel) : SiteNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -86,7 +86,6 @@ import org.wordpress.android.ui.prefs.homepage.HomepageSettingsDialog;
 import org.wordpress.android.ui.prefs.timezone.SiteSettingsTimezoneBottomSheet;
 import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ContextExtensionsKt;
 import org.wordpress.android.util.ContextUtilsKt;
 import org.wordpress.android.util.HtmlUtils;
@@ -103,7 +102,6 @@ import org.wordpress.android.util.WPPrefUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
 import org.wordpress.android.util.config.BloggingRemindersFeatureConfig;
-import org.wordpress.android.util.config.SiteDomainsFeatureConfig;
 import org.wordpress.android.util.config.ManageCategoriesFeatureConfig;
 import org.wordpress.android.widgets.WPSnackbar;
 
@@ -186,7 +184,6 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Inject ZendeskHelper mZendeskHelper;
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject BloggingRemindersFeatureConfig mBloggingRemindersFeatureConfig;
-    @Inject SiteDomainsFeatureConfig mSiteDomainsFeatureConfig;
     @Inject ManageCategoriesFeatureConfig mManageCategoriesFeatureConfig;
     @Inject UiHelpers mUiHelpers;
 
@@ -209,7 +206,6 @@ public class SiteSettingsFragment extends PreferenceFragment
     private EditTextPreference mAddressPref;
     private DetailListPreference mPrivacyPref;
     private DetailListPreference mLanguagePref;
-    private Preference mSiteDomainsPref;
 
     // Homepage settings
     private WPPreference mHomepagePref;
@@ -502,7 +498,6 @@ public class SiteSettingsFragment extends PreferenceFragment
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         initBloggingReminders();
-        setupSiteDomainsSetting();
     }
 
     private AppCompatActivity getAppCompatActivity() {
@@ -581,8 +576,6 @@ public class SiteSettingsFragment extends PreferenceFragment
             setupTimezoneBottomSheet();
         } else if (preference == mBloggingRemindersPref) {
             setupBloggingRemindersBottomSheet();
-        } else if (preference == mSiteDomainsPref) {
-            startSiteDomainsFlow();
         } else if (preference == mHomepagePref) {
             showHomepageSettings();
         }
@@ -979,7 +972,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         mPostsPerPagePref = getClickPref(R.string.pref_key_site_posts_per_page);
         mTimezonePref = getClickPref(R.string.pref_key_site_timezone);
         mBloggingRemindersPref = getClickPref(R.string.pref_key_blogging_reminders);
-        mSiteDomainsPref = getClickPref(R.string.pref_key_site_domains);
         mHomepagePref = (WPPreference) getChangePref(R.string.pref_key_homepage_settings);
         updateHomepageSummary();
         mAmpPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_amp);
@@ -1097,7 +1089,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                 mDateFormatPref, mTimeFormatPref, mTimezonePref, mBloggingRemindersPref, mPostsPerPagePref, mAmpPref,
                 mDeleteSitePref, mJpMonitorActivePref, mJpMonitorEmailNotesPref, mJpSsoPref,
                 mJpMonitorWpNotesPref, mJpBruteForcePref, mJpAllowlistPref, mJpMatchEmailPref, mJpUseTwoFactorPref,
-                mGutenbergDefaultForNewPosts, mHomepagePref, mSiteDomainsPref
+                mGutenbergDefaultForNewPosts, mHomepagePref
         };
 
         for (Preference preference : editablePreference) {
@@ -1236,28 +1228,6 @@ public class SiteSettingsFragment extends PreferenceFragment
             return;
         }
         mBloggingRemindersViewModel.onSettingsItemClicked(mSite.getId());
-    }
-
-    private void setupSiteDomainsSetting() {
-        if (mSiteDomainsPref == null || !isAdded()) {
-            return;
-        }
-
-        if (!mSiteDomainsFeatureConfig.isEnabled()) {
-            removeSiteDomainsPref();
-        } else {
-            if (mSiteDomainsPref != null) {
-                mSiteDomainsPref.setSummary(R.string.register_domain); // TODO: Use the correct title here
-            }
-        }
-    }
-
-    private void startSiteDomainsFlow() {
-        if (mSiteDomainsPref == null || !isAdded()) {
-            return;
-        }
-        // TODO: Launch Domian purchase flow
-        AppLog.d(T.SETTINGS, "Site domains flow");
     }
 
     private void showHomepageSettings() {

--- a/WordPress/src/main/res/layout/activity_domains_dashboard.xml
+++ b/WordPress/src/main/res/layout/activity_domains_dashboard.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_domains"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/fragment_domains_dashboard.xml
+++ b/WordPress/src/main/res/layout/fragment_domains_dashboard.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.domains.DomainsDashboardFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/register_domain" />
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/fragment_domains_dashboard.xml
+++ b/WordPress/src/main/res/layout/fragment_domains_dashboard.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.domains.DomainsDashboardFragment">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/content_recycler_view"
+        android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/register_domain" />
+        android:clipToPadding="false"
+        android:descendantFocusability="beforeDescendants"
+        android:scrollbars="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintTop_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </FrameLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2138,6 +2138,7 @@
     <string name="my_site_btn_site_pages">Site Pages</string>
     <string name="my_site_btn_blog_posts">Blog Posts</string>
     <string name="my_site_btn_sharing">Sharing</string>
+    <string name="my_site_btn_domains">Domains</string>
     <string name="my_site_btn_site_settings">Site Settings</string>
     <string name="my_site_btn_comments" translatable="false">@string/comments</string>
     <string name="my_site_btn_switch_site">Switch Site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2433,15 +2433,15 @@
 
     <string name="domains_primary_domain">PRIMARY SITE ADDRESS</string>
     <string name="domains_primary_domain_address">%s</string>
-    <string name="domains_primary_domain_blurb">Your primary site address is what visitors will see in browser address bar when they visit your website.</string>
-    <string name="domains_redirected_domains">REDIRECTED DOMAINS</string>
-    <string name="domains_redirected_domains_blurb">Redirected domains are domains that you own and redirect to your site at %s. Anyone visiting your redirected domains will land on your site. Learn more.</string>
-    <string name="domains_manage_domains">Manage Domains</string>
-    <string name="domains_paid_plan_claim_your_domain_title">Claim your free domain</string>
-    <string name="domains_paid_plan_claim_your_domain_caption">You have a free one-year domain registration included with your domain</string>
+<!--    <string name="domains_primary_domain_blurb">Your primary site address is what visitors will see in browser address bar when they visit your website.</string>-->
+<!--    <string name="domains_redirected_domains">REDIRECTED DOMAINS</string>-->
+<!--    <string name="domains_redirected_domains_blurb">Redirected domains are domains that you own and redirect to your site at %s. Anyone visiting your redirected domains will land on your site. Learn more.</string>-->
+<!--    <string name="domains_manage_domains">Manage Domains</string>-->
+<!--    <string name="domains_paid_plan_claim_your_domain_title">Claim your free domain</string>-->
+<!--    <string name="domains_paid_plan_claim_your_domain_caption">You have a free one-year domain registration included with your domain</string>-->
     <string name="domains_free_plan_get_your_domain_title">Get your domain</string>
-    <string name="domains_free_plan_get_your_domain_caption">Redirect a custom domain to your site at %s</string>
-    <string name="domains_free_plan_redirect_learn_more">Learn more about domain redirects</string>
+<!--    <string name="domains_free_plan_get_your_domain_caption">Redirect a custom domain to your site at %s</string>-->
+<!--    <string name="domains_free_plan_redirect_learn_more">Learn more about domain redirects</string>-->
 
     <!-- Automated Transfer Eligibility Errors -->
     <string name="plugin_install_site_ineligible_default_error">If you just registered a domain name, please wait until we finish setting it up and try again.\n\nIf not, looks like something went wrong and plugin feature might not be available for this site.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2431,6 +2431,18 @@
     <string name="domain_registration_state_picker_dialog_title">Select State</string>
     <string name="domain_registration_registering_domain_name_progress_dialog_message">Registering domain name…</string>
 
+    <string name="domains_primary_domain">PRIMARY SITE ADDRESS</string>
+    <string name="domains_primary_domain_address">%s</string>
+    <string name="domains_primary_domain_blurb">Your primary site address is what visitors will see in browser address bar when they visit your website.</string>
+    <string name="domains_redirected_domains">REDIRECTED DOMAINS</string>
+    <string name="domains_redirected_domains_blurb">Redirected domains are domains that you own and redirect to your site at %s. Anyone visiting your redirected domains will land on your site. Learn more.</string>
+    <string name="domains_manage_domains">Manage Domains</string>
+    <string name="domains_paid_plan_claim_your_domain_title">Claim your free domain</string>
+    <string name="domains_paid_plan_claim_your_domain_caption">You have a free one-year domain registration included with your domain</string>
+    <string name="domains_free_plan_get_your_domain_title">Get your domain</string>
+    <string name="domains_free_plan_get_your_domain_caption">Redirect a custom domain to your site at %s</string>
+    <string name="domains_free_plan_redirect_learn_more">Learn more about domain redirects</string>
+
     <!-- Automated Transfer Eligibility Errors -->
     <string name="plugin_install_site_ineligible_default_error">If you just registered a domain name, please wait until we finish setting it up and try again.\n\nIf not, looks like something went wrong and plugin feature might not be available for this site.</string>
     <string name="plugin_install_site_ineligible_not_using_custom_domain">Plugin feature requires a custom domain.</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -59,11 +59,6 @@
             android:title="@string/site_settings_timezone_title" />
 
         <org.wordpress.android.ui.prefs.WPPreference
-            android:id="@+id/pref_site_domains"
-            android:key="@string/pref_key_site_domains"
-            android:title="@string/site_settings_site_domains_title" />
-
-        <org.wordpress.android.ui.prefs.WPPreference
             android:id="@+id/pref_blogging_reminders"
             android:key="@string/pref_key_blogging_reminders"
             android:title="@string/site_settings_blogging_reminders_title" />

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteListItemBuilderTest.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.plugins.PluginUtilsWrapper
 import org.wordpress.android.ui.themes.ThemeBrowserUtils
 import org.wordpress.android.util.SiteUtilsWrapper
+import org.wordpress.android.util.config.SiteDomainsFeatureConfig
 
 @RunWith(MockitoJUnitRunner::class)
 class SiteListItemBuilderTest {
@@ -21,6 +22,7 @@ class SiteListItemBuilderTest {
     @Mock lateinit var siteUtilsWrapper: SiteUtilsWrapper
     @Mock lateinit var themeBrowserUtils: ThemeBrowserUtils
     @Mock lateinit var siteModel: SiteModel
+    @Mock lateinit var siteDomainsFeatureConfig: SiteDomainsFeatureConfig
     private lateinit var siteListItemBuilder: SiteListItemBuilder
 
     @Before
@@ -29,7 +31,8 @@ class SiteListItemBuilderTest {
                 accountStore,
                 pluginUtilsWrapper,
                 siteUtilsWrapper,
-                themeBrowserUtils
+                themeBrowserUtils,
+                siteDomainsFeatureConfig
         )
     }
 


### PR DESCRIPTION
Fixes #15234 

Adds **Domains** entry point on Site dashboard and adds a new **domains dashboard**

<img width=320 src="https://user-images.githubusercontent.com/990349/130933051-68e9251b-bb6e-4a2e-a1ab-3c9610358f18.png" />


To test:

1. Turn on **SiteDomainsFeatureConfig** and  **MySiteImprovementsFeatureConfig** from App Settings -> Debug settings 
2. Find new Domains item under Configuration on My Site dashboard
3. Tapping on Domains should launch Site domains dashboard with temporary UI
4. Click on Get your domain to launch Register Domain 

## Regression Notes
1. Potential unintended areas of impact
Site dashboard

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Unit testing

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
