### PR TITLE
Remove build_for_translation_review lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -941,36 +941,6 @@ REPOSITORY_NAME="WordPress-Android"
   end
 
   #####################################################################################
-  # build_for_translation_review
-  # -----------------------------------------------------------------------------------
-  # This lane builds an app bundle with pending translations
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane build_for_translation_review [custom_version:<custom_version>]
-  #####################################################################################
-  desc "Builds an app bundle"
-  lane :build_for_translation_review do | options |
-
-    translator_locales = %w[de es fr id it ja ko nl ru sv zh-cn zh-tw tr he pt ar pl th sr vi]
-    translator_locales_map = ALL_LOCALES.select { translator_locales.include?(h[:glotpress]) }
-
-    android_download_translations(
-      glotpress_url: 'https://translate.wordpress.com/projects/wporg/apps/android',
-      status_filter: ['current', 'waiting', 'fuzzy'],
-      locales: translator_locales_map,
-      lint_task: nil, skip_commit: true
-    )
-
-    cmd_params = ""
-    unless options[:custom_version].nil?
-      UI.message("Building custom version: #{options[:custom_version]}")
-      cmd_params=" -PversionName=\"#{options[:custom_version]}\""
-    end
-
-    sh("export SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD=1 && cd .. && ./gradlew --stacktrace assembleJalapenoRelease #{cmd_params}")
-  end
-
-  #####################################################################################
   # trigger_ci
   # -----------------------------------------------------------------------------------
   # This lane triggers a CircleCI build on demand, with custom parameters


### PR DESCRIPTION
In https://github.com/wordpress-mobile/WordPress-Android/pull/15216 we removed the support for Translations Reviewers builds, but I forgot to remove the related lane in `Fastfile`.

This PR fixes my mistake and completes the clean-up 😀.

To test:
- Check that CI is green.


## Regression Notes
1. Potential unintended areas of impact
-

2. What I did to test those areas of impact (or what existing automated tests I relied on)
-

3. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
