### PR TITLE
My Site Dashboard: Phase 1 - Reminder Notifications Fix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
@@ -100,9 +100,9 @@ class QuickStartUtilsWrapper
             analyticsTrackerWrapper.track(Stat.QUICK_START_ALL_TASKS_COMPLETED, mySiteImprovementsFeatureConfig)
             val payload = CompleteQuickStartPayload(site, NEXT_STEPS.toString())
             dispatcher.dispatch(SiteActionBuilder.newCompleteQuickStartAction(payload))
-        } else if (quickStartEvent?.task == task) {
-            AppPrefs.setQuickStartNoticeRequired(true)
         } else {
+            if (quickStartEvent?.task == task) AppPrefs.setQuickStartNoticeRequired(true)
+
             if (context != null && quickStartStore.hasDoneTask(siteLocalId, CREATE_SITE)) {
                 val nextTask =
                         QuickStartUtils.getNextUncompletedQuickStartTaskForReminderNotification(


### PR DESCRIPTION
Parent #15126 

This PR fixes reminder notifications not showing when the quick start event task was equal to the QuickStartTask. By combining the if statement, we ensure that the show reminder check is hit.

**To test:**
- Launch the app 
- Navigate to My Site -> App Settings -> Test feature configuration
- Enable the `MySiteImprovementsFeatureConfig` and tap the button to restart the app
- Logout, then login
- Select a site from the prologue view
- When the Quick Start Prompt is shown, tap the "Show me around" option
- Tap the `Customize your site` row to launch the QS dialog
- Tap on `Check your site title` (the dialog will close and you'll be brought back to My Site)
- Tap on the blue flashing icon on site title and change the text
***Notifications are set for two days in the future, so you have to change the date/time on the device for testing***
- Navigate out of the app to the Settings area of your device and locate the area that manages the time.
- Disable the "use network-provided time" 
- Manually set the date/time for 2 days and 2 minutes from now
- NOTE: The notification should arrive at the device within a couple of minutes
- After the notification is shown - **don't forget to enable "use network-provided time"**

## Regression Notes
1. Potential unintended areas of impact
Quick start doesn't show reminders or notifications

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tested and ran test suite

3. What automated tests I added (or what prevented me from doing so)
4. N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
