### PR TITLE
Fixes 13644 NullPointerException updatedSite must not be null

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
@@ -174,11 +174,13 @@ class PageListEventListener(
     @Subscribe(threadMode = MAIN)
     fun onSiteChanged(event: OnSiteChanged) {
         if (!event.isError) {
-            siteStore.getSiteByLocalId(site.id)?.let { updatedSite ->
-                if (updatedSite.showOnFront != site.showOnFront ||
-                        updatedSite.pageForPosts != site.pageForPosts ||
-                        updatedSite.pageOnFront != site.pageForPosts) {
-                    handleHomepageSettingsChange(updatedSite)
+            if (siteStore.hasSiteWithLocalId(site.id)) {
+                siteStore.getSiteByLocalId(site.id)?.let { updatedSite ->
+                    if (updatedSite.showOnFront != site.showOnFront ||
+                            updatedSite.pageForPosts != site.pageForPosts ||
+                            updatedSite.pageOnFront != site.pageForPosts) {
+                        handleHomepageSettingsChange(updatedSite)
+                    }
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
@@ -173,14 +173,12 @@ class PageListEventListener(
     @SuppressWarnings("unused")
     @Subscribe(threadMode = MAIN)
     fun onSiteChanged(event: OnSiteChanged) {
-        if (!event.isError) {
-            if (siteStore.hasSiteWithLocalId(site.id)) {
-                siteStore.getSiteByLocalId(site.id)?.let { updatedSite ->
-                    if (updatedSite.showOnFront != site.showOnFront ||
-                            updatedSite.pageForPosts != site.pageForPosts ||
-                            updatedSite.pageOnFront != site.pageForPosts) {
-                        handleHomepageSettingsChange(updatedSite)
-                    }
+        if (!event.isError && siteStore.hasSiteWithLocalId(site.id)) {
+            siteStore.getSiteByLocalId(site.id)?.let { updatedSite ->
+                if (updatedSite.showOnFront != site.showOnFront ||
+                        updatedSite.pageForPosts != site.pageForPosts ||
+                        updatedSite.pageOnFront != site.pageForPosts) {
+                    handleHomepageSettingsChange(updatedSite)
                 }
             }
         }


### PR DESCRIPTION
checks for site existence, just in case if it doesn't exist due to deletion or some other action

Fixes #13664 

To test:
Try the following actions to see it doesn't result in **NullPointerException**: updatedSite must not be null

- site creation 
- changing the homepage, and 
- deleting a site 
- try deleting a site on the web and then try to add pages and changing homepage via the app

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Unit tests

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
