### PR TITLE
Changed the vertical alignment of "No comments yet" placeholder to ce…

### DIFF
--- a/WordPress/src/main/res/layout/reader_activity_comment_list.xml
+++ b/WordPress/src/main/res/layout/reader_activity_comment_list.xml
@@ -28,7 +28,7 @@
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/text_empty"
             style="@style/ReaderTextView.EmptyList"
-            android:layout_above="@+id/layout_bottom"
+            android:layout_centerInParent="true"
             android:text="@string/reader_empty_comments"
             android:textColor="?attr/wpColorOnSurfaceMedium"
             android:visibility="gone"


### PR DESCRIPTION
…nter it in the screen (matching the progress indicator vertical alignment)

Fixes #13536

To test:
1. Go to Reader.
2. Tap the comment icon for any post with comments enabled but doesn't have any comments yet.
3. Observe "No comments yet" placeholder text nicely centered.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
