### PR TITLE
[TEST][DO NOT MERGE] Add string that use other string without translatable to test peril warnings

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -26,6 +26,9 @@
     <string name="video_quality">Video Quality</string>
     <string name="password">Password</string>
 
+    <!-- test peril -->
+    <string name="test_resource">@string/save</string>
+
     <!-- comment form labels -->
     <string name="anonymous">Anonymous</string>
 


### PR DESCRIPTION
Fixes #

To test:

Add string that use other string without translatable to test peril warnings

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
