### PR TITLE
My Site Dashboard - Phase 1: Address connected tests issues

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -19,7 +19,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
-import static org.wordpress.android.support.BetterScrollToAction.scrollTo;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.longClickOn;
@@ -86,9 +85,6 @@ public class MySitesPage {
             // If My Site Improvements are enabled, we reach the item in a different way
             onView(withId(R.id.recycler_view))
                     .perform(actionOnItem(hasDescendant(withText(R.string.stats)), click()));
-        } else {
-            onView(allOf(withId(R.id.my_site_stats_text_view), withText(R.string.stats)))
-                    .perform(scrollTo(), click());
         }
     }
 
@@ -101,9 +97,6 @@ public class MySitesPage {
             // If My Site Improvements are enabled, we reach the item in a different way
             onView(withId(R.id.recycler_view))
                     .perform(actionOnItem(hasDescendant(itemViewMatcher), click()));
-        } else {
-            onView(itemViewMatcher)
-                    .perform(scrollTo(), click());
         }
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
@@ -90,7 +90,8 @@ public class JPScreenshotTest extends BaseTest {
         clickOn(R.id.switch_site);
 
         (new SitePickerPage()).chooseSiteWithURL("yourjetpack.blog");
-        waitForElementToBeDisplayedWithoutFailure(R.id.row_blog_posts);
+        // todo: annmarie
+        waitForElementToBeDisplayedWithoutFailure(R.id.recycler_view);
 
         setNightModeAndWait(false);
         takeScreenshot("1-bring-your-jetpack-with-you");

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -216,7 +216,8 @@ public class WPScreenshotTest extends BaseTest {
 
         (new SitePickerPage()).chooseSiteWithURL("tricountyrealestate.wordpress.com");
 
-        waitForElementToBeDisplayedWithoutFailure(R.id.row_blog_posts);
+        // todo: annmarie
+        waitForElementToBeDisplayedWithoutFailure(R.id.recycler_view);
 
         if (isElementDisplayed(R.id.tooltip_message)) {
             clickOn(R.id.tooltip_message);


### PR DESCRIPTION
Parent #15252 

This PR fixes connected tests compile issues due to removal of elements from the `my_site_fragment.xml`

To test:
Compile connected tests locally
./gradlew WordPress:assembleWordPressVanillaDebugAndroidTest --stacktrace

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Compiled connected tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
