### PR TITLE
Recommend the app

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -109,6 +109,7 @@ android {
         buildConfigField "boolean", "ONBOARDING_IMPROVEMENTS", "false"
         buildConfigField "boolean", "QUICK_START_DYNAMIC_CARDS", "false"
         buildConfigField "boolean", "SITE_DOMAINS", "false"
+        buildConfigField "boolean", "RECOMMEND_THE_APP", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -164,6 +165,8 @@ android {
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationIdSuffix ".beta"
             dimension "buildType"
+
+            buildConfigField "boolean", "RECOMMEND_THE_APP", "true"
         }
 
         jalapeno { // Pre-Alpha version, used for PR builds, can be installed along release, alpha, beta, dev versions

--- a/WordPress/src/main/java/org/wordpress/android/models/recommend/RecommendApiCallsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/recommend/RecommendApiCallsProvider.kt
@@ -53,7 +53,8 @@ class RecommendApiCallsProvider @Inject constructor(
                     val template = gson.fromJson<RecommendTemplateData>(it.toString(), mapType)
                     AppLog.d(
                             T.API,
-                            "getTemplateFromJson > name[${template.name}], link[${template.link}], message[${template.message}]"
+                            "getTemplateFromJson > name[${template.name}], " +
+                                    "link[${template.link}], message[${template.message}]"
                     )
                     Success(template)
                 } catch (jsonEx: JsonParseException) {

--- a/WordPress/src/main/java/org/wordpress/android/models/recommend/RecommendApiCallsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/recommend/RecommendApiCallsProvider.kt
@@ -1,0 +1,107 @@
+package org.wordpress.android.models.recommend
+
+import com.android.volley.VolleyError
+import com.google.gson.Gson
+import com.google.gson.JsonParseException
+import com.google.gson.reflect.TypeToken
+import com.wordpress.rest.RestRequest.ErrorListener
+import com.wordpress.rest.RestRequest.Listener
+import org.json.JSONObject
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendCallResult.Failure
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendCallResult.Success
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.LocaleManager
+import org.wordpress.android.util.VolleyUtils
+import org.wordpress.android.viewmodel.ContextProvider
+import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+class RecommendApiCallsProvider @Inject constructor(
+    private val contextProvider: ContextProvider
+) {
+    suspend fun getRecommendTemplate(appName: String): RecommendCallResult = suspendCoroutine { cont ->
+        val language = LocaleManager.getLanguage(contextProvider.getContext())
+        val endPointPath = "/mobile/share-app-link?app=$appName&locale=$language"
+
+        val listener = Listener { jsonObject ->
+            val result = getTemplateFromJson(jsonObject, appName)
+            cont.resume(result)
+        }
+        val errorListener = ErrorListener { volleyError ->
+            val error = getErrorStringAndLog("getRecommendTemplate", volleyError)
+            cont.resume(Failure(error))
+        }
+
+        WordPress.getRestClientUtilsV2().get(
+                endPointPath,
+                listener,
+                errorListener
+        )
+    }
+
+    private fun getTemplateFromJson(json: JSONObject?, appName: String): RecommendCallResult {
+        return json?.let {
+            val name = it.optString("name")
+            if (name == appName) {
+                try {
+                    val gson = Gson()
+                    val mapType = object : TypeToken<RecommendTemplateData>() {}.type
+                    val template = gson.fromJson<RecommendTemplateData>(it.toString(), mapType)
+                    AppLog.d(
+                            T.API,
+                            "getTemplateFromJson > name[${template.name}], link[${template.link}], message[${template.message}]"
+                    )
+                    Success(template)
+                } catch (jsonEx: JsonParseException) {
+                    AppLog.d(
+                            T.API,
+                            "getTemplateFromJson > Error parsing server API response: error[{${jsonEx.message}}]"
+                    )
+                    Failure(
+                            contextProvider.getContext()
+                                    .getString((R.string.recommend_app_bad_format_response))
+                    )
+                }
+            } else {
+                AppLog.d(T.API, "getTemplateFromJson > wrong app name received: expected[$appName] got[$name]")
+                Failure(contextProvider.getContext().getString(R.string.recommend_app_bad_format_response))
+            }
+        } ?: Failure(contextProvider.getContext().getString(R.string.recommend_app_null_response))
+    }
+
+    private fun getErrorStringAndLog(
+        functionName: String,
+        volleyError: VolleyError?
+    ): String {
+        val error = VolleyUtils.errStringFromVolleyError(volleyError)
+        return if (error.isNullOrEmpty()) {
+            AppLog.d(
+                    T.API,
+                    "$functionName > Failed with empty string [volleyError = $volleyError]"
+            )
+            contextProvider.getContext().getString(R.string.recommend_app_generic_get_template_error)
+        } else {
+            AppLog.d(
+                    T.API,
+                    "$functionName > Failed [error = $error]"
+            )
+            error
+        }
+    }
+
+    sealed class RecommendCallResult {
+        data class Success(val templateData: RecommendTemplateData) : RecommendCallResult()
+        data class Failure(val error: String) : RecommendCallResult()
+    }
+
+    data class RecommendTemplateData(val name: String, val message: String, val link: String)
+
+    enum class RecommendAppName(val appName: String) {
+        WordPress("wordpress"),
+        Jetpack("jetpack")
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -186,12 +186,12 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         // Limiting the feature to WordPress only in this v1
         if (recommendTheAppFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
             setRecommendLoadingState(false)
-            rowRecommendTheApp.visibility = View.VISIBLE
+            recommendTheAppContainer.visibility = View.VISIBLE
             rowRecommendTheApp.setOnClickListener {
                 viewModel.onRecommendTheApp()
             }
         } else {
-            rowRecommendTheApp.visibility = View.GONE
+            recommendTheAppContainer.visibility = View.GONE
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -183,7 +183,8 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     }
 
     private fun MeFragmentBinding.initRecommendUiState() {
-        if (recommendTheAppFeatureConfig.isEnabled()) {
+        // Limiting the feature to WordPress only in this v1
+        if (recommendTheAppFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
             setRecommendLoadingState(false)
             rowRecommendTheApp.visibility = View.VISIBLE
             rowRecommendTheApp.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
@@ -48,12 +48,12 @@ class MeViewModel
         val message: String,
         val link: String
     ) {
-        constructor(showLoading: Boolean): this(
+        constructor(showLoading: Boolean) : this(
                 showLoading = showLoading,
                 message = "",
                 link = ""
         )
-        constructor(error: String): this(
+        constructor(error: String) : this(
                 error = error,
                 message = "",
                 link = ""
@@ -78,7 +78,7 @@ class MeViewModel
     fun getSite() = selectedSiteRepository.getSelectedSite()
 
     fun onRecommendTheApp() {
-        when(val state = _recommendUiState.value) {
+        when (val state = _recommendUiState.value) {
             is ApiFetchedResult -> {
                 if (state.isError()) {
                     getRecommendTemplate()
@@ -121,7 +121,7 @@ class MeViewModel
     }
 
     private fun RecommendCallResult.toFetchedResult(): ApiFetchedResult {
-        return when(this) {
+        return when (this) {
             is Failure -> ApiFetchedResult(error = this.error)
             is Success -> ApiFetchedResult(
                     message = this.templateData.message,
@@ -131,7 +131,7 @@ class MeViewModel
     }
 
     private fun RecommendAppState.toUiState(): Event<RecommendAppUiState> {
-        return Event(when(this) {
+        return Event(when (this) {
             is ApiFetchedResult -> if (this.isError()) {
                 RecommendAppUiState(this.error!!)
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
@@ -2,12 +2,26 @@ package org.wordpress.android.ui.main
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.map
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendAppName
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendCallResult
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendCallResult.Failure
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendCallResult.Success
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.recommend.RecommendAppState
+import org.wordpress.android.ui.recommend.RecommendAppState.ApiFetchedResult
+import org.wordpress.android.ui.recommend.RecommendAppState.FetchingApi
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -17,10 +31,35 @@ class MeViewModel
 @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) val bgDispatcher: CoroutineDispatcher,
-    private val selectedSiteRepository: SelectedSiteRepository
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val recommendApiCallsProvider: RecommendApiCallsProvider,
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val contextProvider: ContextProvider
 ) : ScopedViewModel(mainDispatcher) {
     private val _showDisconnectDialog = MutableLiveData<Event<Boolean>>()
     val showDisconnectDialog: LiveData<Event<Boolean>> = _showDisconnectDialog
+
+    private val _recommendUiState = MutableLiveData<RecommendAppState>()
+    val recommendUiState: LiveData<Event<RecommendAppUiState>> = _recommendUiState.map { it.toUiState() }
+
+    data class RecommendAppUiState(
+        val showLoading: Boolean = false,
+        val error: String? = null,
+        val message: String,
+        val link: String
+    ) {
+        constructor(showLoading: Boolean): this(
+                showLoading = showLoading,
+                message = "",
+                link = ""
+        )
+        constructor(error: String): this(
+                error = error,
+                message = "",
+                link = ""
+        )
+        fun isError() = error != null
+    }
 
     fun signOutWordPress(application: WordPress) {
         launch {
@@ -37,4 +76,75 @@ class MeViewModel
     }
 
     fun getSite() = selectedSiteRepository.getSelectedSite()
+
+    fun onRecommendTheApp() {
+        when(val state = _recommendUiState.value) {
+            is ApiFetchedResult -> {
+                if (state.isError()) {
+                    getRecommendTemplate()
+                } else {
+                    _recommendUiState.value = state
+                }
+            }
+            FetchingApi -> {
+                return
+            }
+            null -> {
+                getRecommendTemplate()
+            }
+        }
+    }
+
+    private fun getRecommendTemplate() {
+        launch {
+            _recommendUiState.value = FetchingApi
+            withContext(bgDispatcher) {
+                delay(SHOW_LOADING_DELAY)
+
+                if (!networkUtilsWrapper.isNetworkAvailable()) {
+                    _recommendUiState.postValue(
+                            ApiFetchedResult(contextProvider.getContext().getString(R.string.no_network_message))
+                    )
+                } else {
+                    val fetchedResult = recommendApiCallsProvider.getRecommendTemplate(
+                            if (BuildConfig.IS_JETPACK_APP) {
+                                RecommendAppName.Jetpack.appName
+                            } else {
+                                RecommendAppName.WordPress.appName
+                            }
+                    ).toFetchedResult()
+
+                    _recommendUiState.postValue(fetchedResult)
+                }
+            }
+        }
+    }
+
+    private fun RecommendCallResult.toFetchedResult(): ApiFetchedResult {
+        return when(this) {
+            is Failure -> ApiFetchedResult(error = this.error)
+            is Success -> ApiFetchedResult(
+                    message = this.templateData.message,
+                    link = this.templateData.link
+            )
+        }
+    }
+
+    private fun RecommendAppState.toUiState(): Event<RecommendAppUiState> {
+        return Event(when(this) {
+            is ApiFetchedResult -> if (this.isError()) {
+                RecommendAppUiState(this.error!!)
+            } else {
+                RecommendAppUiState(
+                        link = this.link,
+                        message = this.message
+                )
+            }
+            FetchingApi -> RecommendAppUiState(showLoading = true)
+        })
+    }
+
+    companion object {
+        private const val SHOW_LOADING_DELAY = 300L
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/recommend/RecommendAppState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/recommend/RecommendAppState.kt
@@ -7,7 +7,7 @@ sealed class RecommendAppState {
         val message: String,
         val link: String
     ) : RecommendAppState() {
-        constructor(error: String): this(error, "", "")
+        constructor(error: String) : this(error, "", "")
         fun isError() = error != null
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/recommend/RecommendAppState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/recommend/RecommendAppState.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.ui.recommend
+
+sealed class RecommendAppState {
+    object FetchingApi : RecommendAppState()
+    data class ApiFetchedResult(
+        val error: String? = null,
+        val message: String,
+        val link: String
+    ) : RecommendAppState() {
+        constructor(error: String): this(error, "", "")
+        fun isError() = error != null
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/RecommendTheAppFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/RecommendTheAppFeatureConfig.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+@FeatureInDevelopment
+class RecommendTheAppFeatureConfig @Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.RECOMMEND_THE_APP
+)

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -200,6 +200,32 @@
 
             <View style="@style/MeListSectionDividerView" />
 
+            <com.facebook.shimmer.ShimmerFrameLayout
+                android:id="@+id/recommend_the_app_shimmer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:shimmer_auto_start="false">
+
+                <LinearLayout
+                    android:id="@+id/row_recommend_the_app"
+                    style="@style/MeListRowLayout">
+
+                    <ImageView
+                        android:id="@+id/me_share_icon"
+                        style="@style/MeListRowIcon"
+                        android:contentDescription="@null"
+                        android:src="@drawable/ic_share_white_24dp" />
+
+                    <org.wordpress.android.util.widgets.AutoResizeTextView
+                        android:id="@+id/me_share_text_view"
+                        style="@style/MeListRowTextView"
+                        android:text="@string/me_btn_share" />
+
+                </LinearLayout>
+            </com.facebook.shimmer.ShimmerFrameLayout>
+
+            <View style="@style/MeListSectionDividerView" />
+
             <LinearLayout
                 android:id="@+id/row_logout"
                 style="@style/MeListRowLayout">

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -200,31 +200,38 @@
 
             <View style="@style/MeListSectionDividerView" />
 
-            <com.facebook.shimmer.ShimmerFrameLayout
-                android:id="@+id/recommend_the_app_shimmer"
+            <LinearLayout
+                android:id="@+id/recommend_the_app_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:shimmer_auto_start="false">
+                android:orientation="vertical">
 
-                <LinearLayout
-                    android:id="@+id/row_recommend_the_app"
-                    style="@style/MeListRowLayout">
+                <com.facebook.shimmer.ShimmerFrameLayout
+                    android:id="@+id/recommend_the_app_shimmer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:shimmer_auto_start="false">
 
-                    <ImageView
-                        android:id="@+id/me_share_icon"
-                        style="@style/MeListRowIcon"
-                        android:contentDescription="@null"
-                        android:src="@drawable/ic_share_white_24dp" />
+                    <LinearLayout
+                        android:id="@+id/row_recommend_the_app"
+                        style="@style/MeListRowLayout">
 
-                    <org.wordpress.android.util.widgets.AutoResizeTextView
-                        android:id="@+id/me_share_text_view"
-                        style="@style/MeListRowTextView"
-                        android:text="@string/me_btn_share" />
+                        <ImageView
+                            android:id="@+id/me_share_icon"
+                            style="@style/MeListRowIcon"
+                            android:contentDescription="@null"
+                            android:src="@drawable/ic_share_white_24dp" />
 
-                </LinearLayout>
-            </com.facebook.shimmer.ShimmerFrameLayout>
+                        <org.wordpress.android.util.widgets.AutoResizeTextView
+                            android:id="@+id/me_share_text_view"
+                            style="@style/MeListRowTextView"
+                            android:text="@string/me_btn_share" />
 
-            <View style="@style/MeListSectionDividerView" />
+                    </LinearLayout>
+                </com.facebook.shimmer.ShimmerFrameLayout>
+
+                <View style="@style/MeListSectionDividerView" />
+            </LinearLayout>
 
             <LinearLayout
                 android:id="@+id/row_logout"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1769,6 +1769,7 @@
     <string name="version_with_name_param">Version %s</string>
     <string name="tos">Terms of Service</string>
     <string name="privacy_policy">Privacy policy</string>
+    <string name="share_the_app">@string/me_btn_share</string>
 
     <!-- Remote Post&Page has conflicts with local post -->
     <string name="local_post_is_conflicted">Version conflict</string>
@@ -2201,6 +2202,7 @@
     <string name="me_profile_photo">Profile Photo</string>
     <string name="me_btn_app_settings">App Settings</string>
     <string name="me_btn_support">Help &amp; Support</string>
+    <string name="me_btn_share">Share WordPress with a friend</string>
     <string name="me_btn_login_logout">Login/Logout</string>
     <string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
     <string name="me_disconnect_from_wordpress_com">Log out of WordPress.com</string>
@@ -2357,6 +2359,12 @@
     <string name="invite_links_bad_format_response">Invalid response received</string>
     <string name="invite_links_disable_dialog_title">Disable invite link</string>
     <string name="invite_links_disable_dialog_message">Once this invite link is disabled, nobody will be able to use it to join your team. Are you sure?</string>
+
+    <!--Recommend the app-->
+    <string name="recommend_app_subject">WordPress Apps - Apps for any screen</string>
+    <string name="recommend_app_null_response">No response received</string>
+    <string name="recommend_app_bad_format_response">Invalid response received</string>
+    <string name="recommend_app_generic_get_template_error">Unknown error fetching recommend app template</string>
 
     <!--Plugins-->
     <string name="plugins">Plugins</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1769,7 +1769,6 @@
     <string name="version_with_name_param">Version %s</string>
     <string name="tos">Terms of Service</string>
     <string name="privacy_policy">Privacy policy</string>
-    <string name="share_the_app">@string/me_btn_share</string>
 
     <!-- Remote Post&Page has conflicts with local post -->
     <string name="local_post_is_conflicted">Version conflict</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
@@ -1,15 +1,28 @@
 package org.wordpress.android.ui.main
 
+import android.content.Context
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.WordPress
 import org.wordpress.android.models.recommend.RecommendApiCallsProvider
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendAppName
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendCallResult.Failure
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendCallResult.Success
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendTemplateData
+import org.wordpress.android.test
+import org.wordpress.android.ui.main.MeViewModel.RecommendAppUiState
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.ContextProvider
@@ -22,10 +35,17 @@ class MeViewModelTest : BaseUnitTest() {
     @Mock lateinit var recommendApiCallsProvider: RecommendApiCallsProvider
     @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
     @Mock lateinit var contextProvider: ContextProvider
+    @Mock lateinit var context: Context
+
     private lateinit var viewModel: MeViewModel
+
+    private val recommendUiState: MutableList<RecommendAppUiState> = mutableListOf()
 
     @Before
     fun setUp() {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(contextProvider.getContext()).thenReturn(context)
+
         viewModel = MeViewModel(
                 TEST_DISPATCHER,
                 TEST_DISPATCHER,
@@ -34,6 +54,8 @@ class MeViewModelTest : BaseUnitTest() {
                 networkUtilsWrapper,
                 contextProvider
         )
+
+        setupObservers()
     }
 
     @Test
@@ -56,5 +78,93 @@ class MeViewModelTest : BaseUnitTest() {
         viewModel.openDisconnectDialog()
 
         assertThat(events[0].getContentIfNotHandled()).isTrue()
+    }
+
+    @Test
+    fun `recommend template is recovered on first call`() = test {
+        whenever(recommendApiCallsProvider.getRecommendTemplate(anyString())).thenReturn(DEFAULT_SUCCESS_API_RESPONSE)
+
+        viewModel.onRecommendTheApp()
+
+        verify(recommendApiCallsProvider, times(1)).getRecommendTemplate(anyString())
+
+        assertThat(recommendUiState).isEqualTo(listOf(
+                RecommendAppUiState(showLoading = true),
+                RecommendAppUiState(
+                    message = DEFAULT_SUCCESS_API_RESPONSE.templateData.message,
+                    link = DEFAULT_SUCCESS_API_RESPONSE.templateData.link)
+                )
+        )
+    }
+
+    @Test
+    fun `recommend triggers an error when no network`() {
+        val noNetError = "No Network Error"
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+        whenever(context.getString(R.string.no_network_message)).thenReturn(noNetError)
+
+        viewModel.onRecommendTheApp()
+
+        assertThat(recommendUiState).isEqualTo(listOf(
+                RecommendAppUiState(showLoading = true),
+                RecommendAppUiState(noNetError)
+        ))
+    }
+
+    @Test
+    fun `recommend triggers an error on api call error`() = test {
+        whenever(recommendApiCallsProvider.getRecommendTemplate(anyString())).thenReturn(DEFAULT_FAILURE_API_RESPONSE)
+
+        viewModel.onRecommendTheApp()
+
+        assertThat(recommendUiState).isEqualTo(listOf(
+                RecommendAppUiState(showLoading = true),
+                RecommendAppUiState(DEFAULT_FAILURE_API_RESPONSE.error)
+        ))
+    }
+
+    @Test
+    fun `recommend use already fetched template when available`() = test {
+        whenever(recommendApiCallsProvider.getRecommendTemplate(anyString())).thenReturn(DEFAULT_SUCCESS_API_RESPONSE)
+
+        // first call successfully gets the template
+        viewModel.onRecommendTheApp()
+        // second call should use the already available template
+        viewModel.onRecommendTheApp()
+
+        assertThat(recommendUiState).isEqualTo(listOf(
+                RecommendAppUiState(showLoading = true),
+                RecommendAppUiState(
+                        message = DEFAULT_SUCCESS_API_RESPONSE.templateData.message,
+                        link = DEFAULT_SUCCESS_API_RESPONSE.templateData.link
+                ),
+                RecommendAppUiState(
+                        message = DEFAULT_SUCCESS_API_RESPONSE.templateData.message,
+                        link = DEFAULT_SUCCESS_API_RESPONSE.templateData.link
+                )
+        ))
+
+        verify(recommendApiCallsProvider, times(1)).getRecommendTemplate(anyString())
+    }
+
+    private fun setupObservers() {
+        recommendUiState.clear()
+
+        viewModel.recommendUiState.observeForever {
+            it.applyIfNotHandled {
+                recommendUiState.add(this)
+            }
+        }
+    }
+
+    companion object {
+        private val DEFAULT_SUCCESS_API_RESPONSE = Success(
+                templateData = RecommendTemplateData(
+                        name = RecommendAppName.WordPress.appName,
+                        message = "sharing message",
+                        link = "https://sharinglink.org"
+                )
+        )
+        private val DEFAULT_FAILURE_API_RESPONSE = Failure("API call Error")
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
@@ -9,18 +9,31 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.WordPress
+import org.wordpress.android.models.recommend.RecommendApiCallsProvider
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.Event
 
 @InternalCoroutinesApi
 class MeViewModelTest : BaseUnitTest() {
     @Mock lateinit var wordPress: WordPress
     @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
+    @Mock lateinit var recommendApiCallsProvider: RecommendApiCallsProvider
+    @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    @Mock lateinit var contextProvider: ContextProvider
     private lateinit var viewModel: MeViewModel
 
     @Before
     fun setUp() {
-        viewModel = MeViewModel(TEST_DISPATCHER, TEST_DISPATCHER, selectedSiteRepository)
+        viewModel = MeViewModel(
+                TEST_DISPATCHER,
+                TEST_DISPATCHER,
+                selectedSiteRepository,
+                recommendApiCallsProvider,
+                networkUtilsWrapper,
+                contextProvider
+        )
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
@@ -1,8 +1,6 @@
 package org.wordpress.android.ui.main
 
 import android.content.Context
-import com.nhaarman.mockitokotlin2.KArgumentCaptor
-import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever


### PR DESCRIPTION
Fixes #15269 

https://user-images.githubusercontent.com/47797566/131883329-eb8aaaf7-a08a-450d-9f02-eba86671cf78.mov

The output as per the above has been already checked with @mattmiklic but cc-ing you fyi 🙇 . Note also that final implementation will add a share button to the about screen as well, but there has been already a discussion on slack (p1630508255058500?thread_ts=1630499387.055200&cid=C01CW1VMLAF-slack-hummingbird) and given the about screen is going to be reviewed soon we will insert the sharing option there.

This PR introduce (behind a feature flag for now) a `recommend the app` feature. When the feature flag is active, you get a `Share WordPress with a friend`menu item in the `Me Screen`. Tapping on the menu item an Android Share Sheet is opened that allows to copy the link or share with the apps that can intercept the ACTION_SEND in your device.

**Note 1:** the text and share link template is recovered from a dedicated API endpoint. The subject (where applicable) is currently hard coded as a string resource. Endpoint logic mimic iOS already deployed implementation, for this simple implementation we didn't create a store but implemented a Api calls provider. We can revisit this in a v2 in case we decide to add more fields and cache the template.

**Note 2:** the template is recovered only when the VM has not recovered it yet; in the video above for example you can see the first time the shimmer effect on the button is shown (fetching the API) but the second time being the VM still there the shimmer is not shown (using the already fetched template).

**Note 3:** the endpoint is not authenticated so everything should work also for pure self-hosted sites.

Below a few examples of the sharing operation result:

| Message | ![image](https://user-images.githubusercontent.com/47797566/131881133-9984aed4-823f-4c93-ba0a-053f5f21d796.png) |
|---|---|
| Mail | ![image](https://user-images.githubusercontent.com/47797566/131880898-ea792bd6-7483-4967-9635-e1b29f332684.png) |
| Twitter | ![image](https://user-images.githubusercontent.com/47797566/131885900-e40d5876-698c-4a51-b633-911ad37172c9.png) |

## To test
- Enable the feature flag is not active
- Go to Me screen and check the menu is there
- Set airplane mode ON and check that tapping the share menu returns a snackbar for no network
- Set airplane mode OFF and check that now the share sheet is shown and you can share the link with text (and subject if using the email to share)
- Repeat the above configuring only a self-hosted site in the app, everything should work the same.
- Smoke test the me screen

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
No impact expected but did some manual smoke testing regardless.

3. What automated tests I added (or what prevented me from doing so)
Added a unit tests to the MeViewModel.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
