### PR TITLE
Remove unneeded todos

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
@@ -90,7 +90,7 @@ public class JPScreenshotTest extends BaseTest {
         clickOn(R.id.switch_site);
 
         (new SitePickerPage()).chooseSiteWithURL("yourjetpack.blog");
-        // todo: annmarie
+
         waitForElementToBeDisplayedWithoutFailure(R.id.recycler_view);
 
         setNightModeAndWait(false);

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -216,7 +216,6 @@ public class WPScreenshotTest extends BaseTest {
 
         (new SitePickerPage()).chooseSiteWithURL("tricountyrealestate.wordpress.com");
 
-        // todo: annmarie
         waitForElementToBeDisplayedWithoutFailure(R.id.recycler_view);
 
         if (isElementDisplayed(R.id.tooltip_message)) {


### PR DESCRIPTION
This PR removes to unneeded `todo` statements that were inadvertently pushed to develop.

To test: N/A 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
