### PR TITLE
Update CI Workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,13 @@ jobs:
           path: Artifacts
           destination: Artifacts
   Release Build:
+    parameters:
+      alpha:
+        description: If true, builds the Zalpha, otherwise builds the beta
+        type: boolean
+      app:
+        description: The app to build, should be either 'wordpress' or 'jetpack'
+        type: string
     executor:
       name: android/default
       api-version: "29"
@@ -89,7 +96,7 @@ jobs:
       - run:
           name: Init messages
           command: |
-            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress/Jetpack Android failed!'" >> $BASH_ENV
+            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for << parameters.app >> Android failed!'" >> $BASH_ENV
       - git/shallow-checkout:
           init-submodules: true
       - checkout-submodules
@@ -105,36 +112,33 @@ jobs:
           command: |
             APP_VERSION=$(./gradlew -q printVersionName | tail -1)
             echo "export APP_VERSION=${APP_VERSION}" >> $BASH_ENV
-            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress/Jetpack Android $APP_VERSION failed!'" >> $BASH_ENV
-            echo "export SLACK_SUCCESS_MESSAGE=':tada: WordPress/Jetpack Android $APP_VERSION has been deployed!'" >> $BASH_ENV
+            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for << parameters.app >> Android $APP_VERSION failed!'" >> $BASH_ENV
+            echo "export SLACK_SUCCESS_MESSAGE=':tada: << parameters.app >> Android $APP_VERSION has been deployed!'" >> $BASH_ENV
             # Prevent fastlane from checking for updates, also removing the verbose fastlane changelog at the end of each invocation.
             echo "export FASTLANE_SKIP_UPDATE_CHECK=1" >> $BASH_ENV
             bundle check
-      - run:
-          name: Build WordPress Zalpha
-          command: |
-            if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-              bundle exec fastlane build_alpha app:wordpress skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
-            fi
-          no_output_timeout: 15m
-      - run:
-          name: Build WordPress Vanilla
-          command: |
-            if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-              bundle exec fastlane build_beta app:wordpress skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
-            else
-              bundle exec fastlane build_and_upload_release app:wordpress skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
-            fi
-          no_output_timeout: 15m
-      - run:
-          name: Build Jetpack Vanilla
-          command: |
-            if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-              bundle exec fastlane build_beta app:jetpack skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
-            else
-              bundle exec fastlane build_and_upload_release app:jetpack skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
-            fi
-          no_output_timeout: 15m
+      - when:
+          condition: << parameters.alpha >>
+          steps:
+            - run:
+                name: Build << parameters.app >> Zalpha
+                command: |
+                  if [[ ${APP_VERSION} == *"-rc-"* ]]; then
+                    bundle exec fastlane build_alpha app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+                  fi
+                no_output_timeout: 15m
+      - unless:
+          condition: << parameters.alpha >>
+          steps:
+            - run:
+                name: Build << parameters.app >> Vanilla
+                command: |
+                  if [[ ${APP_VERSION} == *"-rc-"* ]]; then
+                    bundle exec fastlane build_beta app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+                  else
+                    bundle exec fastlane build_and_upload_release app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+                  fi
+                no_output_timeout: 15m
       - android/save-gradle-cache
       - store_artifacts:
           path: build
@@ -389,5 +393,15 @@ workflows:
   Release Build:
     when: << pipeline.parameters.release_build >>
     jobs:
-      - Release Build
-
+      - Release Build:
+          name: "Release: WP Alpha"
+          app: wordpress
+          alpha: true
+      - Release Build:
+          name: "Release: WP Beta"
+          app: wordpress
+          alpha: false
+      - Release Build:
+          name: "Release: JP Beta"
+          app: jetpack
+          alpha: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
                 name: Build << parameters.app >> Zalpha
                 command: |
                   if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-                    bundle exec fastlane build_alpha app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+                    bundle exec fastlane build_alpha app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:false upload_to_play_store:false
                   fi
                 no_output_timeout: 15m
       - unless:
@@ -134,9 +134,9 @@ jobs:
                 name: Build << parameters.app >> Vanilla
                 command: |
                   if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-                    bundle exec fastlane build_beta app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+                    bundle exec fastlane build_beta app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:false upload_to_play_store:false
                   else
-                    bundle exec fastlane build_and_upload_release app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+                    bundle exec fastlane build_and_upload_release app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:false upload_to_play_store:false
                   fi
                 no_output_timeout: 15m
       - android/save-gradle-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,10 +65,10 @@ jobs:
             echo "export VERSION_NAME=$VERSION_NAME" >> $BASH_ENV
       - run:
           name: Build WordPress APK
-          command: ./gradlew --stacktrace assembleWordpressJalapenoDebug -PversionName="$VERSION_NAME"
+          command: ./gradlew --stacktrace assembleWordpressJalapenoDebug -PinstallableBuildVersionName="$VERSION_NAME"
       - run:
           name: Build Jetpack APK
-          command: ./gradlew --stacktrace assembleJetpackJalapenoDebug -PversionName="$VERSION_NAME"
+          command: ./gradlew --stacktrace assembleJetpackJalapenoDebug -PinstallableBuildVersionName="$VERSION_NAME"
       - android/save-gradle-cache
       - run:
           name: Prepare APK

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,6 @@ parameters:
   release_build:
     type: boolean
     default: false
-  # Display name of the app and should match the usual public facing name (e.g. WordPress, Jetpack)
-  app_name:
-    type: string
-    default: "WordPress"
-  # The key used to reference the app in the Fastfile
-  product_key:
-    type: string
-    default: "wordpress"
 
 commands:
   copy-gradle-properties:
@@ -97,7 +89,7 @@ jobs:
       - run:
           name: Init messages
           command: |
-            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for << pipeline.parameters.app_name >> Android failed!'" >> $BASH_ENV
+            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress/Jetpack Android failed!'" >> $BASH_ENV
       - git/shallow-checkout:
           init-submodules: true
       - checkout-submodules
@@ -111,27 +103,36 @@ jobs:
       - run:
           name: Prepare build
           command: |
-            echo "export APP_VERSION=$(./gradlew -q printVersionName -PproductKey='<< pipeline.parameters.product_key >>' | tail -1)" >> $BASH_ENV
-            SLACK_MESSAGE_VERSION=$(./gradlew -q printVersionName -PproductKey="<< pipeline.parameters.product_key >>" | tail -1)
-            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for << pipeline.parameters.app_name >> Android $SLACK_MESSAGE_VERSION failed!'" >> $BASH_ENV
-            echo "export SLACK_SUCCESS_MESSAGE=':tada: << pipeline.parameters.app_name >> Android $SLACK_MESSAGE_VERSION has been deployed!'" >> $BASH_ENV
+            APP_VERSION=$(./gradlew -q printVersionName | tail -1)
+            echo "export APP_VERSION=${APP_VERSION}" >> $BASH_ENV
+            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress/Jetpack Android $APP_VERSION failed!'" >> $BASH_ENV
+            echo "export SLACK_SUCCESS_MESSAGE=':tada: WordPress/Jetpack Android $APP_VERSION has been deployed!'" >> $BASH_ENV
             # Prevent fastlane from checking for updates, also removing the verbose fastlane changelog at the end of each invocation.
             echo "export FASTLANE_SKIP_UPDATE_CHECK=1" >> $BASH_ENV
             bundle check
       - run:
-          name: Build Zalpha
+          name: Build WordPress Zalpha
           command: |
             if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-              bundle exec fastlane build_alpha app:"<< pipeline.parameters.product_key >>" skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+              bundle exec fastlane build_alpha app:wordpress skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
             fi
           no_output_timeout: 15m
       - run:
-          name: Build Vanilla
+          name: Build WordPress Vanilla
           command: |
             if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-              bundle exec fastlane build_beta app:"<< pipeline.parameters.product_key >>" skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+              bundle exec fastlane build_beta app:wordpress skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
             else
-              bundle exec fastlane build_and_upload_release app:"<< pipeline.parameters.product_key >>" skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+              bundle exec fastlane build_and_upload_release app:wordpress skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+            fi
+          no_output_timeout: 15m
+      - run:
+          name: Build Jetpack Vanilla
+          command: |
+            if [[ ${APP_VERSION} == *"-rc-"* ]]; then
+              bundle exec fastlane build_beta app:jetpack skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+            else
+              bundle exec fastlane build_and_upload_release app:jetpack skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
             fi
           no_output_timeout: 15m
       - android/save-gradle-cache

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -184,8 +184,8 @@ android {
             applicationIdSuffix ".prealpha"
             dimension "buildType"
 
-            versionName versionProperties.getProperty("alpha.versionName")
-            versionCode versionProperties.getProperty("alpha.versionCode").toInteger()
+            versionName project.findProperty("installableBuildVersionName") ?: versionProperties.getProperty("alpha.versionName")
+            versionCode 1 // Fixed versionCode because those builds are not meant to be uploaded to the PlayStore.
         }
 
         // Also dynamically add additional `buildConfigFields` to our app flavors from any `wp.`/`jp.`-prefixed property in `gradle.properties`

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -266,7 +266,6 @@ static def addBuildConfigFieldsFromPrefixedProperties(variant, properties, prefi
     }
 
     // Then define the found properties as buildConfigFields
-    // Also define found properties that started with `res.` (`res_*` keys once in the `fields_map`) as resValues
     fields_map.each {
         variant.buildConfigField "String", it.key.toUpperCase(), "\"${it.value}\""
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -372,7 +372,7 @@ REPOSITORY_NAME="WordPress-Android"
   desc "Updates store metadata and runs the release checks"
   lane :finalize_release do | options |
     # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
-    UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix(app: '')
+    UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix(app: 'wp_jp')
 
     android_finalize_prechecks(options)
     configure_apply(force: is_ci)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -139,10 +139,11 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Creates a new release branch from the current develop"
   lane :code_freeze do | options |
-    old_version = android_codefreeze_prechecks(options)
+    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
+    old_version = android_codefreeze_prechecks(options.merge({app: 'wp_jp'}))
 
-    android_bump_version_release(app: 'wordpress')
-    new_version = android_get_app_version(app: 'wordpress')
+    android_bump_version_release(app: 'wp_jp')
+    new_version = android_get_app_version(app: 'wp_jp')
 
     # need to get prs list before version update to frozen tag
     get_prs_list(repository: GHHELPER_REPO, milestone: new_version, report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{new_version}.txt")
@@ -179,16 +180,17 @@ REPOSITORY_NAME="WordPress-Android"
   # This lane executes the initial steps planned on code freeze
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane complete_code_freeze app:<wordpress|jetpack> [skip_confirm:<skip confirm>]
+  # bundle exec fastlane complete_code_freeze [skip_confirm:<skip confirm>]
   #
   # Example:
-  # bundle exec fastlane complete_code_freeze app:wordpress
-  # bundle exec fastlane complete_code_freeze app:jetpack skip_confirm:true
+  # bundle exec fastlane complete_code_freeze
+  # bundle exec fastlane complete_code_freeze skip_confirm:true
   #####################################################################################
   desc "Trigger a release build for a given app after code freeze"
   lane :complete_code_freeze do | options |
-    android_completecodefreeze_prechecks(options)
-    new_version = android_get_app_version(app: options[:app])
+    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
+    android_completecodefreeze_prechecks(options.merge({app: 'wp_jp'}))
+    new_version = android_get_app_version(app: 'wp_jp')
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 
@@ -308,13 +310,13 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane new_beta_release base_version:10.6.1
   #####################################################################################
   desc "Updates a release branch for a new beta release"
-  lane :new_beta_release do | options |
-    app = options[:app]
-    android_betabuild_prechecks(options)
+  lane :new_beta_release do |options|
+    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
+    android_betabuild_prechecks(options.merge({app: 'wp_jp'}))
     send_strings_for_translation()
     download_translations()
-    android_bump_version_beta(app: app)
-    new_version = android_get_app_version(app: app)
+    android_bump_version_beta(app: 'wp_jp')
+    new_version = android_get_app_version(app: 'wp_jp')
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 
@@ -333,8 +335,8 @@ REPOSITORY_NAME="WordPress-Android"
   lane :new_hotfix_release do |options|
     hotfix_version = options[:version_name] || UI.input('Version number for the new hotfix?')
     previous_tag = android_hotfix_prechecks(version_name: hotfix_version, skip_confirm: options[:skip_confirm])
-    # FIXME: get rid of the `app:`` parameter once Jetpack refactoring gets done
-    android_bump_version_hotfix(previous_version_name: previous_tag, version_name: hotfix_version, version_code: options[:version_code], app: options[:app])
+    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
+    android_bump_version_hotfix(previous_version_name: previous_tag, version_name: hotfix_version, version_code: options[:version_code], app: 'wp_jp')
   end
 
   #####################################################################################
@@ -350,7 +352,8 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Finalizes a hotfix release by triggering a release build"
   lane :finalize_hotfix_release do |options|
-    new_version = android_get_app_version(app: options[:app])
+    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
+    new_version = android_get_app_version(app: 'wp_jp')
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 
@@ -368,37 +371,41 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Updates store metadata and runs the release checks"
   lane :finalize_release do | options |
-    app = options[:app] || 'wordpress'
-    UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix(app: app)
+    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
+    UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix(app: '')
 
     android_finalize_prechecks(options)
     configure_apply(force: is_ci)
+
     UI.message('Checking app strings translation status...')
     check_translation_progress(
       glotpress_url: 'https://translate.wordpress.org/projects/apps/android/dev/',
       abort_on_violations: false
     )
 
-    UI.message("Checking #{app} release notes strings translation status...")
-    paths = APP_SPECIFIC_VALUES[app.to_sym]
+    UI.message("Checking WordPress release notes strings translation status...")
     check_translation_progress(
-      glotpress_url: paths[:gp_url],
+      glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:gp_url],
+      abort_on_violations: false
+    )
+
+    UI.message("Checking Jetpack release notes strings translation status...")
+    check_translation_progress(
+      glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:gp_url],
       abort_on_violations: false
     )
 
     download_translations()
 
-    android_bump_version_final_release(app: app)
-    version = android_get_release_version(app: app)
-    download_metadata_strings(app: app, version: version["name"], build_number: version["code"])
+    android_bump_version_final_release(app: 'wp_jp')
+    version = android_get_release_version(app: 'wp_jp')
+    download_metadata_strings(version: version["name"], build_number: version["code"])
 
     # Wrap up
-    if UI.confirm('Do you want to remove branch protection and frozen tag? You should ideally only do so once _both_ JP and WP have been released')
-      removebranchprotection(repository:GHHELPER_REPO, branch: "release/#{version["name"]}")
-      setfrozentag(repository:GHHELPER_REPO, milestone: version["name"], freeze: false)
-      create_new_milestone(repository: GHHELPER_REPO)
-      close_milestone(repository:GHHELPER_REPO, milestone: version["name"])
-    end
+    removebranchprotection(repository:GHHELPER_REPO, branch: "release/#{version["name"]}")
+    setfrozentag(repository:GHHELPER_REPO, milestone: version["name"], freeze: false)
+    create_new_milestone(repository: GHHELPER_REPO)
+    close_milestone(repository:GHHELPER_REPO, milestone: version["name"])
 
     # Trigger release build
     trigger_release_build(branch_to_build: "release/#{version["name"]}")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -89,11 +89,9 @@ APP_SPECIFIC_VALUES = {
 
 WP_PACKAGE_NAME = "org.wordpress.android"
 WP_PREFIX = "wpandroid"
-WP_APP_NAME = "WordPress"
 
 JP_PACKAGE_NAME = "com.jetpack.android"
 JP_PREFIX = "jpandroid"
-JP_APP_NAME = "Jetpack"
 
 UPLOAD_TO_PLAY_STORE_JSON_KEY = File.join(Dir.home, '.configure', 'wordpress-android', 'secrets', 'google-upload-credentials.json')
 
@@ -191,7 +189,7 @@ REPOSITORY_NAME="WordPress-Android"
   lane :complete_code_freeze do | options |
     android_completecodefreeze_prechecks(options)
     new_version = android_get_app_version(app: options[:app])
-    trigger_release_build(branch_to_build: "release/#{new_version}", app: options[:app])
+    trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 
   #####################################################################################
@@ -317,7 +315,7 @@ REPOSITORY_NAME="WordPress-Android"
     download_translations(app: app)
     android_bump_version_beta(app: app)
     new_version = android_get_app_version(app: app)
-    trigger_release_build(branch_to_build: "release/#{new_version}", app: app)
+    trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 
   #####################################################################################
@@ -349,10 +347,11 @@ REPOSITORY_NAME="WordPress-Android"
   #
   # Example:
   # bundle exec fastlane finalize_hotfix_release
+  #####################################################################################
   desc "Finalizes a hotfix release by triggering a release build"
   lane :finalize_hotfix_release do |options|
     new_version = android_get_app_version(app: options[:app])
-    trigger_release_build(branch_to_build: "release/#{new_version}", app: options[:app])
+    trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 
   #####################################################################################
@@ -402,7 +401,7 @@ REPOSITORY_NAME="WordPress-Android"
     end
 
     # Trigger release build
-    trigger_release_build(branch_to_build: "release/#{version["name"]}", app: options[:app])
+    trigger_release_build(branch_to_build: "release/#{version["name"]}")
   end
 
   #####################################################################################
@@ -620,12 +619,11 @@ REPOSITORY_NAME="WordPress-Android"
   #
   #####################################################################################
   lane :trigger_release_build do | options |
-    app_name = options[:app].downcase == "jetpack" ? JP_APP_NAME : WP_APP_NAME
     circleci_trigger_job(
       circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"],
       repository: REPOSITORY_NAME,
       branch: options[:branch_to_build],
-      job_params: {"release_build" => true, "app_name" => app_name, "product_key" =>  options[:app] }
+      job_params: { "release_build" => true }
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -426,19 +426,20 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane build_and_upload_release create_release:true
   #####################################################################################
   desc "Builds and updates for distribution"
-  lane :build_and_upload_release do | options |
+  lane :build_and_upload_release do |options|
+    # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
     android_build_prechecks(
       skip_confirm: options[:skip_confirm],
       alpha: false,
       beta: false,
       final: true,
-      app: options[:app]
+      app: 'wp_jp'
     )
     android_build_preflight() unless options[:skip_prechecks]
 
     # Create the file names
     app = options[:app]
-    version=android_get_release_version(app: app)
+    version = android_get_release_version(app: 'wp_jp')
     build_bundle(version: version, app: app, flavor:"Vanilla", buildType: "Release")
 
     upload_build_to_play_store(version: version, track: "production", app: app)
@@ -462,13 +463,14 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane build_and_upload_beta create_release:true
   #####################################################################################
   desc "Builds and updates for distribution"
-  lane :build_and_upload_pre_releases do | options |
+  lane :build_and_upload_pre_releases do |options|
+    # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
     android_build_prechecks(
       skip_confirm: options[:skip_confirm],
       alpha: true,
       beta: true,
       final: false,
-      app: options[:app]
+      app: 'wp_jp'
     )
     android_build_preflight() unless (options[:skip_prechecks])
     build_alpha(skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release], app: options[:app])
@@ -489,14 +491,15 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane build_alpha create_release:true
   #####################################################################################
   desc "Builds and updates for distribution"
-  lane :build_alpha do | options |
-    android_build_prechecks(skip_confirm: options[:skip_confirm], alpha: true, app: options[:app]) unless (options[:skip_prechecks])
+  lane :build_alpha do |options|
+    # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
+    android_build_prechecks(skip_confirm: options[:skip_confirm], alpha: true, app: 'wp_jp') unless (options[:skip_prechecks])
     android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names
     app = options[:app]
-    version=android_get_alpha_version(app: app)
-    build_bundle(version: version, app:app, flavor:"Zalpha", buildType: "Release")
+    version = android_get_alpha_version(app: 'wp_jp')
+    build_bundle(version: version, app: app, flavor:"Zalpha", buildType: "Release")
 
     if (options[:upload_to_play_store]) then
        upload_build_to_play_store(version: version, track: "alpha", app: app)
@@ -521,13 +524,14 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane build_beta create_release:true
   #####################################################################################
   desc "Builds and updates for distribution"
-  lane :build_beta do | options |
-    android_build_prechecks(skip_confirm: options[:skip_confirm], beta: true, app: options[:app]) unless (options[:skip_prechecks])
+  lane :build_beta do |options|
+    # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
+    android_build_prechecks(skip_confirm: options[:skip_confirm], beta: true, app: 'wp_jp') unless (options[:skip_prechecks])
     android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names
     app = options[:app]
-    version=android_get_release_version(app: app)
+    version = android_get_release_version(app: 'wp_jp')
     build_bundle(version: version, app: app, flavor:"Vanilla", buildType: "Release")
 
     if (options[:upload_to_play_store]) then
@@ -553,13 +557,14 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane build_internal create_release:true
   #####################################################################################
   desc "Builds and updates for internal testing"
-  lane :build_internal do | options |
-    android_build_prechecks(skip_confirm: options[:skip_confirm], app: options[:app]) unless (options[:skip_prechecks])
+  lane :build_internal do |options|
+    # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
+    android_build_prechecks(skip_confirm: options[:skip_confirm], app: 'wp_jp') unless (options[:skip_prechecks])
     android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names
     app = options[:app]
-    version=android_get_release_version(app: app)
+    version = android_get_release_version(app: 'wp_jp')
     build_bundle(version: version, app: app, flavor:"Zalpha", buildType: "Debug")
 
     if (options[:upload_to_play_store]) then
@@ -585,12 +590,12 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane upload_build_to_play_store version:15.0-rc-1 track:beta
   #####################################################################################
   desc "Upload Build to Play Store"
-  lane :upload_build_to_play_store do | options |
+  lane :upload_build_to_play_store do |options|
 
     app = options[:app]
     package_name = app.downcase == "jetpack" ? JP_PACKAGE_NAME : WP_PACKAGE_NAME
 
-    version=options[:version]
+    version = options[:version]
 
     if version.nil?
       UI.message("No version available for #{options[:track]} track for #{app}")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -312,7 +312,7 @@ REPOSITORY_NAME="WordPress-Android"
     app = options[:app]
     android_betabuild_prechecks(options)
     send_strings_for_translation()
-    download_translations(app: app)
+    download_translations()
     android_bump_version_beta(app: app)
     new_version = android_get_app_version(app: app)
     trigger_release_build(branch_to_build: "release/#{new_version}")
@@ -386,7 +386,7 @@ REPOSITORY_NAME="WordPress-Android"
       abort_on_violations: false
     )
 
-    download_translations(app: app)
+    download_translations()
 
     android_bump_version_final_release(app: app)
     version = android_get_release_version(app: app)
@@ -912,19 +912,19 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   # download_translations
   # -----------------------------------------------------------------------------------
-  # This lane download the string translations from GlotPress
+  # This lane downloads the string translations from GlotPress
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane download_translations [app:<wordpress|jetpack>]
+  # bundle exec fastlane download_translations
   #####################################################################################
-  lane :download_translations do |options|
+  lane :download_translations do
     # For now WordPress and Jetpack use the same GlotPress project and share the same `strings.xml`
     # (the Jetpack-dedicated one, https://translate.wordpress.com/projects/jetpack/apps/android/, is empty anyway for now).
     android_download_translations(
       res_dir: File.join('WordPress', 'src', 'main', 'res'),
       glotpress_url: 'https://translate.wordpress.org/projects/apps/android/dev/',
       locales: ALL_LOCALES,
-      lint_task: "lint#{options[:app]}VanillaRelease" # TODO: Should we adapt this
+      lint_task: "lintWordpressVanillaRelease" # TODO: Should we adapt this?
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -673,15 +673,15 @@ REPOSITORY_NAME="WordPress-Android"
   # from GlotPress and updates the local files
   # -----------------------------------------------------------------------------------
   # Usage:
-  # fastlane download_metadata_strings app:<wordpress|jetpack> build_number:<build_number> version:<version>
+  # fastlane download_metadata_strings build_number:<build_number> version:<version>
   #
   # Example:
-  # fastlane download_metadata_strings app:jetpack build_number:573 version:10.3
+  # fastlane download_metadata_strings build_number:573 version:10.3
   #####################################################################################
   desc "Downloads translated metadata from GlotPress"
   lane :download_metadata_strings do |options|
-    download_wordpress_metadata_strings(options) unless options[:app] != 'wordpress'
-    download_jetpack_metadata_strings(options) unless options[:app] != 'jetpack'
+    download_wordpress_metadata_strings(options)
+    download_jetpack_metadata_strings(options)
   end
 
   desc "Downloads WordPress's translated metadata from GlotPress"


### PR DESCRIPTION
This is part of project paaHJt-2s8-p2

ℹ️ This PR targets release/18.2. I've made this choice so that it gives me the opportunity to use it for the current release cycle (and test it in real conditions ASAP), assuming it's approved and merged before the end of Sprint.

## What it does

 - Update the `.circleci/config.yml` to build Jetpack Vanilla in the same workflow (and single API trigger) that it builds Wordpress Zalpha and WordPress Vanilla
 - Update the `Fastfile` to adapt the `trigger_release_build` lane accordingly
 - Update other lanes of the `Fastfile` to stop requiring passing the `app:` parameter when using lanes for usual release duties (`code_freeze`, `new_beta_release`, etc)
 - Update the `app:` parameter of version-management-related actions called from `Fastlane` to a dummy value `wp_jp`
   - This is a way for me to check that the `app:` param for those actions don't have any impact anymore, as per https://github.com/wordpress-mobile/release-toolkit/pull/298 changes. If we confirm after this PR that things continue working, that would confirm we can delete the `app:` param completely for those actions in the release-toolkit during next iteration.
   - The `app:` param is still present and used for some other lanes, like `build_bundle` and friends, as it is used by the `.circleci/config.yml` to know which app to build; so that param will stay even after the refactor. This is why not all `app:` params have been changed to dummy values, but only the relevant ones
 - Now builds WP WP Alpha, WP Vanilla and JP Vanilla all in parallel instead of series (see full thread in p1630938604091100-slack-CC7L49W13, summary in Slack comment p1631035688017600-slack-C020B5ME5L0, and https://github.com/wordpress-mobile/WordPress-Android/pull/15273#issuecomment-914591201)

## What it does not (yet)

 - It still generates a GitHub release for each of the 3 builds; I plan to unify that to generate a single GH release for the 3 soon (we will need to wait on other jobs and pass artefacts around to collect them for the release draft)

This will be addressed in a subsequent PR, as it feels safer to do those kind of changes incrementally – especially to the lack of type-checking in the Fastfile and toolkit there makes me be quite cautious 😉 . 

## To test

 - Run `bundle exec fastlane new_beta_release` and check that it updates the translations, bumps the version correctly in the `version.properties` with a single common value for JP and WP, lint the project only for WP (since both are using same strings), then trigger a release build on CI
 - Cancel the build on CI, since that build will be triggered on the `release/18.2` branch on CI, which doesn't have the changes in the `Fastfile` nor `.circleci/config.yml`
 - Cut a new branch from this `jetpack-infra/ci` branch, and cherry-pick the version bump that was made in the last step in `release/18.2` branch, and push it to the remote.
 - Trigger a release build on this new branch using `bundle exec fastlane trigger_release_build branch_to_build:<your-branch-name>`
 - Check that the CI builds WordPress Zalpha, WordPress Vanilla and Jetpack Vanilla all in parallel, and succeeds the builds(†), then uploads to PlayStore, and creates the GitHub Release for each(‡)
 - Verify that Installable Builds for both WP and JP are still properly built and created with the expected version.

#### Notes

(†) Given p1631035422011900-slack-C020B5ME5L0, there is a chance that one of the 3 jobs in the workflow will fail with an Out of Memory (Gradle Daemon Disappeared) issue, and you will have to restart just the failed job ("Restart from failed") to finally get it green. This is a known issue, that was deemed acceptable to live with until we find time for the BuildKite migration (and not doing parallelization led to the recent `aapt2` crash anyway, so at least it's still better)

(‡) Last commit bebbe1b disables the upload to PlayStore and GitHub Release creation, in order to facilitate testing (allowing you to trigger release builds using API multiple times without risking the duplicate versionCode issue or spamming GH releases while testing). I intend to revert bebbe1b before merging that PR.

#### Cleanup

 - Revert the last 2 commits (translations update and **version bump**) from the release branch
 - Delete your temporary branch you cut from this one, both locally and from remote.
 - Delete the 3 GitHub release drafts that were created during those tests
 - Go to the PlayStore for WordPress, delete the 2 `.aab` (alpha and beta) in "App Bundler Explorer" tab, and also discard the 2 release drafts (alpha and beta)
 - Do the same for the PlayStore for Jetpack – delete the single `.aab` for beta and the beta release draft