### PR TITLE
Stripping HTML tags from post titles in Blog Posts page tabs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.POSTS
+import org.wordpress.android.util.HtmlUtils
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.NothingToUpload
@@ -200,7 +201,7 @@ class PostListItemUiStateHelper @Inject constructor(
 
     private fun getTitle(post: PostModel): UiString {
         return if (post.title.isNotBlank()) {
-            UiStringText(StringEscapeUtils.unescapeHtml4(post.title))
+            UiStringText(StringEscapeUtils.unescapeHtml4(post.title).let { HtmlUtils.stripHtml(it) })
         } else UiStringRes(R.string.untitled_in_parentheses)
     }
 


### PR DESCRIPTION
Fixes #15158

To test:
- Create a post that contains HTML tags in its title (e.g. My <b>Test</b> Post)
- Go to My Site\Posts, locate the post, and make sure HTML tags are stripped
- Applies to posts displayed in different tabs (i.e. Published, Drafts, etc.)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
None :(
I attempted to add unit tests under org.wordpress.android.viewmodel.posts.PostListItemUiStateHelperTest, but HtmlUtils.stripHtml relies on Html.fromHtml, which requires an instrumented test environment. Creating an instrumented test for PostListItemUiStateHelper turned out to be problematic, because of its dependencies on final classes, which cannot be mocked in instrumented test environment.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
