### PR TITLE
issue/15172-Mysite-url-cutoff

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/MySiteTitleAndSubtitleLabelView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/MySiteTitleAndSubtitleLabelView.kt
@@ -36,7 +36,7 @@ class MySiteTitleAndSubtitleLabelView @JvmOverloads constructor(
                 constraintSet.clone(this@MySiteTitleAndSubtitleLabelView)
                 constraintSet.connect(title.id, ConstraintSet.BOTTOM, guideline.id, ConstraintSet.TOP, 0)
                 constraintSet.applyTo(this@MySiteTitleAndSubtitleLabelView)
-            } else if (title.lineCount == 2 && (title.layoutParams as LayoutParams).bottomToTop == guideline.id) {
+            } else if (title.lineCount  >    1 && (title.layoutParams as LayoutParams).bottomToTop == guideline.id) {
                 val constraintSet = ConstraintSet()
                 constraintSet.clone(this@MySiteTitleAndSubtitleLabelView)
                 constraintSet.clear(title.id, ConstraintSet.BOTTOM)

--- a/WordPress/src/main/java/org/wordpress/android/widgets/MySiteTitleAndSubtitleLabelView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/MySiteTitleAndSubtitleLabelView.kt
@@ -36,7 +36,7 @@ class MySiteTitleAndSubtitleLabelView @JvmOverloads constructor(
                 constraintSet.clone(this@MySiteTitleAndSubtitleLabelView)
                 constraintSet.connect(title.id, ConstraintSet.BOTTOM, guideline.id, ConstraintSet.TOP, 0)
                 constraintSet.applyTo(this@MySiteTitleAndSubtitleLabelView)
-            } else if (title.lineCount  >    1 && (title.layoutParams as LayoutParams).bottomToTop == guideline.id) {
+            } else if (title.lineCount > 1 && (title.layoutParams as LayoutParams).bottomToTop == guideline.id) {
                 val constraintSet = ConstraintSet()
                 constraintSet.clone(this@MySiteTitleAndSubtitleLabelView)
                 constraintSet.clear(title.id, ConstraintSet.BOTTOM)


### PR DESCRIPTION
Fixes #15172  

**Description:** When the font is set to maximum and your site title is more than 1 line, the URL of the site gets hidden. 
 This was because the Title and URL section was bound to the lower edge of the image.
I removed the restraint and made the widget accommodate for more than 2 lines as well.

**To test:** Set the font to the largest setting and open the app.

**Before:**
![129197683-10e1ed47-2183-4a1a-a514-26a76698b902](https://user-images.githubusercontent.com/47075510/132035574-2766d59d-210f-4779-9f20-7c7e05e1c370.png)

**After:**
![WhatsApp Image 2021-09-03 at 19 04 23](https://user-images.githubusercontent.com/47075510/132035620-6f7ccf7f-f952-4b1a-9147-f7f00694749a.jpeg)






## Regression Notes
1. Potential unintended areas of impact
  None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  None

3. What automated tests I added (or what prevented me from doing so)
  None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
