### PR TITLE
[WP Stories] Make sure to recreate StoryFrameItems from the remote url when local file not available

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/LoadStoryFromStoriesPrefsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/LoadStoryFromStoriesPrefsUseCase.kt
@@ -2,9 +2,6 @@ package org.wordpress.android.ui.stories.usecase
 
 import android.net.Uri
 import com.wordpress.stories.compose.story.StoryFrameItem
-import com.wordpress.stories.compose.story.StoryFrameItem.BackgroundSource.FileBackgroundSource
-import com.wordpress.stories.compose.story.StoryFrameItem.BackgroundSource.UriBackgroundSource
-import com.wordpress.stories.compose.story.StoryFrameItemType
 import com.wordpress.stories.compose.story.StoryIndex
 import com.wordpress.stories.compose.story.StoryRepository
 import dagger.Reusable

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/LoadStoryFromStoriesPrefsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/LoadStoryFromStoriesPrefsUseCase.kt
@@ -2,6 +2,9 @@ package org.wordpress.android.ui.stories.usecase
 
 import android.net.Uri
 import com.wordpress.stories.compose.story.StoryFrameItem
+import com.wordpress.stories.compose.story.StoryFrameItem.BackgroundSource.FileBackgroundSource
+import com.wordpress.stories.compose.story.StoryFrameItem.BackgroundSource.UriBackgroundSource
+import com.wordpress.stories.compose.story.StoryFrameItemType
 import com.wordpress.stories.compose.story.StoryIndex
 import com.wordpress.stories.compose.story.StoryRepository
 import dagger.Reusable
@@ -63,11 +66,13 @@ class LoadStoryFromStoriesPrefsUseCase @Inject constructor(
     private fun loadOrReCreateStoryFromStoriesPrefs(site: SiteModel, mediaIds: ArrayList<String>): ReCreateStoryResult {
         // the StoryRepository didn't have it but we have editable serialized slides so,
         // create a new Story from scratch with these deserialized StoryFrameItems
-        var allStorySlidesAreEditable: Boolean = true
-        var noSlidesLoaded = false
         var storyIndex = StoryRepository.DEFAULT_NONE_SELECTED
         storyRepositoryWrapper.loadStory(storyIndex)
         storyIndex = storyRepositoryWrapper.getCurrentStoryIndex()
+
+        // hold media that we'll need to retrieve from Site's media to use its remote url (flattened media)
+        val tmpMediaIdsLong = ArrayList<Long>()
+
         for (mediaId in mediaIds) {
             // let's check if this is a temporary id
             if (mediaId.startsWith(TEMPORARY_ID_PREFIX)) {
@@ -82,36 +87,52 @@ class LoadStoryFromStoriesPrefsUseCase @Inject constructor(
                         site.getId().toLong(),
                         RemoteId(mediaId.toLong())
                 )?.let {
-                    storyRepositoryWrapper.addStoryFrameItemToCurrentStory(it)
-                } ?: run {
-                    allStorySlidesAreEditable = false
-
-                    // for this missing frame we'll create a new frame using the actual uploaded flattened media
-                    val tmpMediaIdsLong = ArrayList<Long>()
-                    tmpMediaIdsLong.add(mediaId.toLong())
-                    val mediaModelList: List<MediaModel> = mediaStore.getSiteMediaWithIds(
-                            site,
-                            tmpMediaIdsLong
-                    )
-                    if (mediaModelList.isEmpty()) {
-                        noSlidesLoaded = true
+                    // verify the background media referenced here is still valid for editing, otherwise
+                    // use the actual uploaded flattened media for safety
+                    if (storiesPrefs.isValidSlide(site.getId().toLong(), RemoteId(mediaId.toLong()))) {
+                        // just add the deserialized slide, given it's perfectly valid
+                        storyRepositoryWrapper.addStoryFrameItemToCurrentStory(it)
                     } else {
-                        for (mediaModel in mediaModelList) {
-                            val storyFrameItem = StoryFrameItem.getNewStoryFrameItemFromUri(
-                                    Uri.parse(mediaModel.url),
-                                    mediaModel.isVideo
-                            )
-                            storyFrameItem.id = mediaModel.mediaId.toString()
-                            storyRepositoryWrapper.addStoryFrameItemToCurrentStory(storyFrameItem)
-                        }
+                        // add to the list of slides we need to retrieve a flattened media url for
+                        tmpMediaIdsLong.add(mediaId.toLong())
                     }
-                }
+                } ?: tmpMediaIdsLong.add(mediaId.toLong())
             }
         }
 
-        noSlidesLoaded = storyRepositoryWrapper.getStoryAtIndex(storyIndex).frames.size == 0
+        // if we collected media that we couldn't find locally, let's retrieve the remote urls for these all in one go
+        val result: ReCreateStoryResult
+        if (!tmpMediaIdsLong.isEmpty()) {
+            result = recreateStoryFrameItemsFromRemoteSiteFlattenedMediaUrls(storyIndex, site, tmpMediaIdsLong)
+        } else {
+            val noSlidesLoaded = storyRepositoryWrapper.getStoryAtIndex(storyIndex).frames.size == 0
+            result = ReCreateStoryResult(storyIndex, allStorySlidesAreEditable = true, noSlidesLoaded)
+        }
+        return result
+    }
 
-        return ReCreateStoryResult(storyIndex, allStorySlidesAreEditable, noSlidesLoaded)
+    private fun recreateStoryFrameItemsFromRemoteSiteFlattenedMediaUrls(
+        storyIndex: StoryIndex,
+        site: SiteModel,
+        mediaIds: ArrayList<Long>
+    ): ReCreateStoryResult {
+        // for this missing frame we'll create a new frame using the actual uploaded flattened media
+        val mediaModelList: List<MediaModel> = mediaStore.getSiteMediaWithIds(
+                site,
+                mediaIds
+        )
+
+        for (mediaModel in mediaModelList) {
+            val storyFrameItem = StoryFrameItem.getNewStoryFrameItemFromUri(
+                    Uri.parse(mediaModel.url),
+                    mediaModel.isVideo
+            )
+            storyFrameItem.id = mediaModel.mediaId.toString()
+            storyRepositoryWrapper.addStoryFrameItemToCurrentStory(storyFrameItem)
+        }
+
+        val noSlidesLoaded = storyRepositoryWrapper.getStoryAtIndex(storyIndex).frames.size == 0
+        return ReCreateStoryResult(storyIndex, allStorySlidesAreEditable = false, noSlidesLoaded)
     }
 
     fun loadStoryFromMemoryOrRecreateFromPrefs(site: SiteModel, mediaFiles: ArrayList<Any>): ReCreateStoryResult {
@@ -124,7 +145,7 @@ class LoadStoryFromStoriesPrefsUseCase @Inject constructor(
         )
 
         // now look for a Story in the StoryRepository that has all these frames and, if not found, let's
-        // just build the Story object ourselves to match the order in which the media files were passed. 
+        // just build the Story object ourselves to match the order in which the media files were passed.
         var storyIndex = storyRepositoryWrapper.findStoryContainingStoryFrameItemsByIds(mediaIds)
         if (storyIndex == StoryRepository.DEFAULT_NONE_SELECTED) {
             // the StoryRepository didn't have it but we have editable serialized slides so,


### PR DESCRIPTION

Fixes #15096 

To test:
1. add a Story with an image from the media picker
2. publish the GB post
3. erase the app cache
4. open the app again and edit the story Post in Gutenberg
5. tap on the Story block twice to edit
6. observe the app does not crash, and the "Limited Story Editing" dialog is shown. Tapping OK will let you proceed to the Story composer using the flattened media as a background.

### Background

We load serialized Stories so these can be populated back in the StoryComposer and as such, the user can edit Stories that were created on the same device.

The problem was that the code assumed that, when we'd find a serialized `StoryFrameItem` in our StoriesPrefs storage, the background media originally used referenced to by the `BackgroundSource` component for a given Story slide (StoryFrameItem) would still be accessible, even when it was checked with the safeguard made previously in LoadStoryFromStoriesPrefsUseCase, as follows:

1. the user taps on the Story block inside a Gutenberg Post and this triggers the bridge to open the StoryComposer
2. first, we check whether the story slides are editable, this is done by the following call stack in LoadStoryFromStoriesPrefsUseCase:

- `areAllStorySlidesEditable()` makes sure that we have all background images / videos for all of this story's slides so we can load them up for editing in the Story Composer
- for each of them we check this with `isValidSlide()`, which verifies both that a) the slide Id is real with `checkSlideIdExists` and b) `checkSlideOriginalBackgroundMediaExists`.
- this last check makes sure the background media, as stated above, is accessible and openable.

The specific problem would appear a few moments later, when we re-created the Story to be loaded in the StoryRepository with the actual StoryFrameItem with the remote Id (as previously uploaded) would not be checked for its referenced background media URI to be actually accessible. This check was missing in [this part of code](https://github.com/wordpress-mobile/WordPress-Android/blob/70ce7de8817020d29768074bb408688436320220/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/LoadStoryFromStoriesPrefsUseCase.kt#L81-L86).

### Solution

In this PR, I take care of this and also refactored things a bit just to make sure that the StoryFrameItems get their flattened media URLs loaded correctly for both cases (covering the new case of a serialized item existing but the media is no longer available, and the other more obvious and already covered case where the serialized slide was  missing entirely).

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
