### PR TITLE
Stripping HTML tags from post titles in Stats\Insights

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapper.kt
@@ -1,16 +1,17 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 
 import org.apache.commons.text.StringEscapeUtils
+import org.jsoup.Jsoup
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.InsightsLatestPostModel
 import org.wordpress.android.ui.stats.StatsUtilsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem
-import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text.Clickable
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.LatestPostSummaryUseCase.LinkClickParams
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
+import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
@@ -30,7 +31,7 @@ class LatestPostSummaryMapper
         }
         val sinceLabel = statsUtilsWrapper.getSinceLabelLowerCase(model.postDate)
         val postTitle = if (model.postTitle.isNotBlank()) {
-            StringEscapeUtils.unescapeHtml4(model.postTitle)
+            StringEscapeUtils.unescapeHtml4(model.postTitle).let { Jsoup.parse(it).text() }
         } else {
             resourceProvider.getString(R.string.untitled_in_parentheses)
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapperTest.kt
@@ -1,11 +1,13 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
@@ -136,5 +138,28 @@ class LatestPostSummaryMapperTest {
         barChartItem.entries.apply {
             assertThat(this).hasSize(30)
         }
+    }
+
+    @Test
+    fun `strips HTML from post title in latest post summary`() {
+        val postTitleWithHtml = "<b>Title</b> with <font color=\"red\">HTML</color>"
+
+        val viewCount = 0
+        val model = InsightsLatestPostModel(siteId, postTitleWithHtml, postURL, date, postId, viewCount, 0, 0, listOf())
+
+        val sinceTimeLabel = "10 mins"
+        whenever(statsUtilsWrapper.getSinceLabelLowerCase(date)).thenReturn(sinceTimeLabel)
+
+        whenever(
+                resourceProvider.getString(
+                        eq(R.string.stats_insights_latest_post_with_no_engagement),
+                        eq(sinceTimeLabel),
+                        anyString()
+                )
+        ).thenAnswer { "message with no engagement for post ${it.getArgument<String>(2)}" }
+
+        val result = mapper.buildMessageItem(model) {}
+
+        assertThat(result.text).isEqualTo("message with no engagement for post Title with HTML")
     }
 }


### PR DESCRIPTION
Fixes #15176

**N.B. This time I used the JSoup parser so that the fix doesn't rely on android libraries (unlike HtmlUtils.stripHtml) and can be verified with java unit test.**

To test:
- Create a post that contains HTML tags in its title (e.g. My <b>Test</b> Post)
- Go to My Site\Stats, notice the post in Latest Post Summary section of Insights tab, and make sure HTML tags are stripped

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added a unit test to LatestPostSummaryMapperTest

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
