### PR TITLE
Fixes crash appearing when the site software version is null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '2109-6fa16d2cea0c38381a6fc68f5337114870a3b318'
+    fluxCVersion = '1.25.1'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '2109-9d135cabe9b2d3fc8dbc8e778d3215b0d874b687'
+    fluxCVersion = '2109-6fa16d2cea0c38381a6fc68f5337114870a3b318'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'develop-a471f6245ea15181c3463a1892a3a586ac546c83'
+    fluxCVersion = '2109-9d135cabe9b2d3fc8dbc8e778d3215b0d874b687'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #15278

#### Depends on:
* https://github.com/wordpress-mobile/WordPress-Android/pull/15287
* https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/90
* https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2109

#### Description
This PR fixes a crash appearing when the site software version is null by reusing the existing `VersionUtils` [code](https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/90) that performs a `null` check.

To test:
Reproducing the initial [issue](https://github.com/wordpress-mobile/WordPress-Android/issues/15278) is not possible without using the debugger (or tweaking a WordPress installation to not provide the software version). Thus we relied on [unit tests](https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/90/files#diff-f3effa178b391d32530469b7869104f8018c4eaf06c1e24beabfad6d59ff578a) to cover this [case](https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/90/files#diff-f3effa178b391d32530469b7869104f8018c4eaf06c1e24beabfad6d59ff578aR127).
As a minimum sanity test **verify that the editor opens without a crash**.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Relied on [existing tests](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/895de9fc5110af9bac99e214ce4fd5f5fece742f/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_EditorThemeStoreTest.kt)

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
