### PR TITLE
Merge release/18.2 into develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+18.3
+-----
+
+
 18.2
 -----
 * [*] When you like a post from the reader post details, your avatar is gracefully added to the list of people who liked that post through an animation [https://github.com/wordpress-mobile/WordPress-Android/pull/15248]

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,3 +1,5 @@
--A Weekly Roundup: a summary of activity (views, likes, comments) on your most-used sites, sent to you each Monday.
--A toggle option in the Embed block to resize embedded content, like videos and other media, on smaller devices.
--A time selection feature that lets you choose a specific time to receive a Blogging Reminder.
+* [*] When you like a post from the reader post details, your avatar is gracefully added to the list of people who liked that post through an animation [https://github.com/wordpress-mobile/WordPress-Android/pull/15248]
+* [*] Users can now share the WordPress app with their friends from the Me screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/15279]
+* [***] Block editor: Inserter: Add Inserter Block Search [https://github.com/WordPress/gutenberg/pull/33237]
+* [**] Block editor: Enable embed preview for a list of providers (for now only YouTube and Twitter) [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3900]
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,3 +1,5 @@
--A Weekly Roundup: a summary of activity (views, likes, comments) on your most-used sites, sent to you each Monday.
--A toggle option in the Embed block to resize embedded content, like videos and other media, on smaller devices.
--A time selection feature that lets you choose a specific time to receive a Blogging Reminder.
+* [*] When you like a post from the reader post details, your avatar is gracefully added to the list of people who liked that post through an animation [https://github.com/wordpress-mobile/WordPress-Android/pull/15248]
+* [*] Users can now share the WordPress app with their friends from the Me screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/15279]
+* [***] Block editor: Inserter: Add Inserter Block Search [https://github.com/WordPress/gutenberg/pull/33237]
+* [**] Block editor: Enable embed preview for a list of providers (for now only YouTube and Twitter) [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3900]
+

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3416,14 +3416,12 @@
     <string name="gutenberg_native_edit_video" tools:ignore="UnusedResources">Edit video</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_and" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for Android</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_ios" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for iOS</string>
-    <string name="gutenberg_native_embed_block_previews_are_coming_soon" tools:ignore="UnusedResources">Embed block previews are coming soon</string>
     <!-- translators: accessibility text. Empty Embed caption. -->
     <string name="gutenberg_native_embed_caption_empty" tools:ignore="UnusedResources">Embed caption. Empty</string>
     <!-- translators: accessibility text. %s: Embed caption. -->
     <string name="gutenberg_native_embed_caption_s" tools:ignore="UnusedResources">Embed caption. %s</string>
     <string name="gutenberg_native_embed_link" tools:ignore="UnusedResources">Embed link</string>
     <string name="gutenberg_native_embed_media" tools:ignore="UnusedResources">Embed media</string>
-    <string name="gutenberg_native_embed_previews_not_yet_available" tools:ignore="UnusedResources">Embed previews not yet available</string>
     <string name="gutenberg_native_error" tools:ignore="UnusedResources">Error</string>
     <string name="gutenberg_native_excerpt_length_words" tools:ignore="UnusedResources">Excerpt length (words)</string>
     <string name="gutenberg_native_failed_to_insert_audio_file" tools:ignore="UnusedResources">Failed to insert audio file.</string>
@@ -3455,6 +3453,7 @@
     <string name="gutenberg_native_inside" tools:ignore="UnusedResources">Inside</string>
     <string name="gutenberg_native_invalid_url_audio_file_not_found" tools:ignore="UnusedResources">Invalid URL. Audio file not found.</string>
     <string name="gutenberg_native_invalid_url_please_enter_a_valid_url" tools:ignore="UnusedResources">Invalid URL. Please enter a valid URL.</string>
+    <string name="gutenberg_native_line_height" tools:ignore="UnusedResources">Line Height</string>
     <string name="gutenberg_native_link_inserted" tools:ignore="UnusedResources">Link inserted</string>
     <string name="gutenberg_native_link_settings" tools:ignore="UnusedResources">Link Settings</string>
     <string name="gutenberg_native_link_text" tools:ignore="UnusedResources">Link text</string>
@@ -3485,7 +3484,6 @@
     <string name="gutenberg_native_navigate_up" tools:ignore="UnusedResources">Navigate Up</string>
     <string name="gutenberg_native_navigates_to_custom_color_picker" tools:ignore="UnusedResources">Navigates to custom color picker</string>
     <string name="gutenberg_native_navigates_to_customize_the_gradient" tools:ignore="UnusedResources">Navigates to customize the gradient</string>
-    <!-- translators: %s: Select control button label e.g. "Button width" -->
     <string name="gutenberg_native_navigates_to_select_s" tools:ignore="UnusedResources">Navigates to select %s</string>
     <string name="gutenberg_native_navigates_to_the_previous_content_sheet" tools:ignore="UnusedResources">Navigates to the previous content sheet</string>
     <string name="gutenberg_native_no_application_can_handle_this_request" tools:ignore="UnusedResources">No application can handle this request.</string>
@@ -3536,6 +3534,8 @@ translators: Block name. %s: The localized block name -->
     <string name="gutenberg_native_s_block_newly_available" tools:ignore="UnusedResources">%s block, newly available</string>
     <!-- translators: %s: block title e.g: "Paragraph". -->
     <string name="gutenberg_native_s_block_options" tools:ignore="UnusedResources">%s block options</string>
+    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
+    <string name="gutenberg_native_s_block_previews_are_coming_soon" tools:ignore="UnusedResources">%s block previews are coming soon</string>
     <!-- translators: accessibility text for blocks with invalid content. %d: localized block title -->
     <string name="gutenberg_native_s_block_this_block_has_invalid_content" tools:ignore="UnusedResources">%s block. This block has invalid content</string>
     <!-- translators: %s: name of the reusable block -->
@@ -3546,6 +3546,8 @@ translators: Block name. %s: The localized block name -->
     <string name="gutenberg_native_s_has_url_set" tools:ignore="UnusedResources">%s has URL set</string>
     <!-- translators: Missing block alert title. %s: The localized block name -->
     <string name="gutenberg_native_s_is_not_fully_supported" tools:ignore="UnusedResources">\'%s\' is not fully–supported</string>
+    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
+    <string name="gutenberg_native_s_previews_not_yet_available" tools:ignore="UnusedResources">%s previews not yet available</string>
     <!-- translators: %s: social link name e.g: "Instagram". -->
     <string name="gutenberg_native_s_social_icon" tools:ignore="UnusedResources">%s social icon</string>
     <string name="gutenberg_native_scrollable_block_menu_closed" tools:ignore="UnusedResources">Scrollable block menu closed.</string>
@@ -3559,7 +3561,6 @@ translators: Block name. %s: The localized block name -->
     <string name="gutenberg_native_select_a_color" tools:ignore="UnusedResources">Select a color</string>
     <string name="gutenberg_native_select_a_color_above" tools:ignore="UnusedResources">Select a color above</string>
     <string name="gutenberg_native_select_a_layout" tools:ignore="UnusedResources">Select a layout</string>
-    <!-- translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="gutenberg_native_selected_s" tools:ignore="UnusedResources">Selected: %s</string>
     <string name="gutenberg_native_set_as_featured_image" tools:ignore="UnusedResources">Set as Featured Image </string>
     <string name="gutenberg_native_show_post_content" tools:ignore="UnusedResources">Show post content</string>
@@ -3592,8 +3593,10 @@ translators: Block name. %s: The localized block name -->
     <!-- translators: accessibility text. %s: video caption. -->
     <string name="gutenberg_native_video_caption_s" tools:ignore="UnusedResources">Video caption. %s</string>
     <string name="gutenberg_native_we_are_working_hard_to_add_more_blocks_with_each_release" tools:ignore="UnusedResources">We are working hard to add more blocks with each release.</string>
-    <string name="gutenberg_native_we_re_working_hard_on_adding_support_for_embed_previews_in_the_me" tools:ignore="UnusedResources">We’re working hard on adding support for embed previews. In the meantime, you can preview the embedded content on the page.</string>
-    <string name="gutenberg_native_we_re_working_hard_on_adding_support_for_embed_previews_in_the_me_7978045c" tools:ignore="UnusedResources">We’re working hard on adding support for embed previews. In the meantime, you can preview the embedded content on the post.</string>
+    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
+    <string name="gutenberg_native_we_re_working_hard_on_adding_support_for_s_previews_in_the_meanti" tools:ignore="UnusedResources">We’re working hard on adding support for %s previews. In the meantime, you can preview the embedded content on the page.</string>
+    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
+    <string name="gutenberg_native_we_re_working_hard_on_adding_support_for_s_previews_in_the_meanti_d8f5837e" tools:ignore="UnusedResources">We’re working hard on adding support for %s previews. In the meantime, you can preview the embedded content on the post.</string>
     <string name="gutenberg_native_welcome_to_the_world_of_blocks" tools:ignore="UnusedResources">Welcome to the world of blocks</string>
     <string name="gutenberg_native_what_is_a_block" tools:ignore="UnusedResources">What is a block?</string>
     <string name="gutenberg_native_what_is_alt_text" tools:ignore="UnusedResources">What is alt text?</string>

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'develop-a471f6245ea15181c3463a1892a3a586ac546c83'
+    fluxCVersion = '1.25.0'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -607,6 +607,7 @@
     <string name="site_settings_time_format_title">Time Format</string>
     <string name="site_settings_timezone_title">Timezone</string>
     <string name="site_settings_timezone_subtitle">Choose a city in your timezone</string>
+    <string name="site_settings_site_domains_title">Site domains</string>
     <string name="site_settings_blogging_reminders_title">Blogging reminders</string>
     <string name="site_settings_posts_per_page_title">Posts per page</string>
     <string name="site_settings_format_entry_custom">Custom</string>
@@ -1504,8 +1505,13 @@
     <string name="get_likes_empty_state_title">An error occurred while getting likes data</string>
     <string name="like_title_singular">1 Like</string>
     <string name="like_title_plural">%d Likes</string>
-    <string name="like_faces_singular_text">1 blogger likes this.</string>
-    <string name="like_faces_plural_text">%d bloggers like this.</string>
+    <string name="like_this">like this</string>
+    <string name="likes_this">likes this</string>
+    <string name="like_faces_you_text">You %1$s.</string>
+    <string name="like_faces_you_plus_one_text">You and 1 blogger %1$s.</string>
+    <string name="like_faces_plural_with_you_text">You and %1$s bloggers %2$s.</string>
+    <string name="like_faces_one_blogger_text">1 blogger %1$s.</string>
+    <string name="like_faces_more_bloggers_text">%1$s bloggers %2$s.</string>
     <string name="like_faces_error_loading_message">Error loading like data. %s.</string>
 
     <!-- reader -->
@@ -2137,6 +2143,7 @@
     <string name="my_site_btn_site_pages">Site Pages</string>
     <string name="my_site_btn_blog_posts">Blog Posts</string>
     <string name="my_site_btn_sharing">Sharing</string>
+    <string name="my_site_btn_domains">Domains</string>
     <string name="my_site_btn_site_settings">Site Settings</string>
     <string name="my_site_btn_comments" translatable="false">@string/comments</string>
     <string name="my_site_btn_switch_site">Switch Site</string>
@@ -2167,6 +2174,7 @@
     <string name="my_site_bottom_sheet_add_post">Blog post</string>
     <string name="my_site_bottom_sheet_add_page">Site page</string>
     <string name="my_site_bottom_sheet_add_story">Story post</string>
+    <string name="my_site_quick_actions_title">Quick Links</string>
 
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>
@@ -2193,6 +2201,7 @@
     <string name="me_profile_photo">Profile Photo</string>
     <string name="me_btn_app_settings">App Settings</string>
     <string name="me_btn_support">Help &amp; Support</string>
+    <string name="me_btn_share">Share WordPress with a friend</string>
     <string name="me_btn_login_logout">Login/Logout</string>
     <string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
     <string name="me_disconnect_from_wordpress_com">Log out of WordPress.com</string>
@@ -2350,6 +2359,12 @@
     <string name="invite_links_disable_dialog_title">Disable invite link</string>
     <string name="invite_links_disable_dialog_message">Once this invite link is disabled, nobody will be able to use it to join your team. Are you sure?</string>
 
+    <!--Recommend the app-->
+    <string name="recommend_app_subject">WordPress Apps - Apps for any screen</string>
+    <string name="recommend_app_null_response">No response received</string>
+    <string name="recommend_app_bad_format_response">Invalid response received</string>
+    <string name="recommend_app_generic_get_template_error">Unknown error fetching recommend app template</string>
+
     <!--Plugins-->
     <string name="plugins">Plugins</string>
     <string name="plugin_byline">by %s</string>
@@ -2428,6 +2443,18 @@
     <string name="domain_registration_country_picker_dialog_title">Select Country</string>
     <string name="domain_registration_state_picker_dialog_title">Select State</string>
     <string name="domain_registration_registering_domain_name_progress_dialog_message">Registering domain name…</string>
+
+    <string name="domains_primary_domain">PRIMARY SITE ADDRESS</string>
+    <string name="domains_primary_domain_address">%s</string>
+<!--    <string name="domains_primary_domain_blurb">Your primary site address is what visitors will see in browser address bar when they visit your website.</string>-->
+<!--    <string name="domains_redirected_domains">REDIRECTED DOMAINS</string>-->
+<!--    <string name="domains_redirected_domains_blurb">Redirected domains are domains that you own and redirect to your site at %s. Anyone visiting your redirected domains will land on your site. Learn more.</string>-->
+<!--    <string name="domains_manage_domains">Manage Domains</string>-->
+<!--    <string name="domains_paid_plan_claim_your_domain_title">Claim your free domain</string>-->
+<!--    <string name="domains_paid_plan_claim_your_domain_caption">You have a free one-year domain registration included with your domain</string>-->
+    <string name="domains_free_plan_get_your_domain_title">Get your domain</string>
+<!--    <string name="domains_free_plan_get_your_domain_caption">Redirect a custom domain to your site at %s</string>-->
+<!--    <string name="domains_free_plan_redirect_learn_more">Learn more about domain redirects</string>-->
 
     <!-- Automated Transfer Eligibility Errors -->
     <string name="plugin_install_site_ineligible_default_error">If you just registered a domain name, please wait until we finish setting it up and try again.\n\nIf not, looks like something went wrong and plugin feature might not be available for this site.</string>
@@ -2962,7 +2989,6 @@
     <string name="quick_start_sites">Next Steps</string>
     <string name="quick_start_sites_type_customize">Customize your site</string>
     <string name="quick_start_sites_type_grow">Grow your audience</string>
-    <string name="quick_start_sites_type_subtitle">%1$d of %2$d complete</string>
     <string name="quick_start_sites_type_tasks_completed">%1$s out of %2$s complete</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
     <string name="quick_start_span_start" translatable="false">&lt;span&gt;</string>
@@ -3390,14 +3416,12 @@
     <string name="gutenberg_native_edit_video" tools:ignore="UnusedResources">Edit video</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_and" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for Android</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_ios" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for iOS</string>
-    <string name="gutenberg_native_embed_block_previews_are_coming_soon" tools:ignore="UnusedResources">Embed block previews are coming soon</string>
     <!-- translators: accessibility text. Empty Embed caption. -->
     <string name="gutenberg_native_embed_caption_empty" tools:ignore="UnusedResources">Embed caption. Empty</string>
     <!-- translators: accessibility text. %s: Embed caption. -->
     <string name="gutenberg_native_embed_caption_s" tools:ignore="UnusedResources">Embed caption. %s</string>
     <string name="gutenberg_native_embed_link" tools:ignore="UnusedResources">Embed link</string>
     <string name="gutenberg_native_embed_media" tools:ignore="UnusedResources">Embed media</string>
-    <string name="gutenberg_native_embed_previews_not_yet_available" tools:ignore="UnusedResources">Embed previews not yet available</string>
     <string name="gutenberg_native_error" tools:ignore="UnusedResources">Error</string>
     <string name="gutenberg_native_excerpt_length_words" tools:ignore="UnusedResources">Excerpt length (words)</string>
     <string name="gutenberg_native_failed_to_insert_audio_file" tools:ignore="UnusedResources">Failed to insert audio file.</string>
@@ -3429,6 +3453,7 @@
     <string name="gutenberg_native_inside" tools:ignore="UnusedResources">Inside</string>
     <string name="gutenberg_native_invalid_url_audio_file_not_found" tools:ignore="UnusedResources">Invalid URL. Audio file not found.</string>
     <string name="gutenberg_native_invalid_url_please_enter_a_valid_url" tools:ignore="UnusedResources">Invalid URL. Please enter a valid URL.</string>
+    <string name="gutenberg_native_line_height" tools:ignore="UnusedResources">Line Height</string>
     <string name="gutenberg_native_link_inserted" tools:ignore="UnusedResources">Link inserted</string>
     <string name="gutenberg_native_link_settings" tools:ignore="UnusedResources">Link Settings</string>
     <string name="gutenberg_native_link_text" tools:ignore="UnusedResources">Link text</string>
@@ -3459,7 +3484,6 @@
     <string name="gutenberg_native_navigate_up" tools:ignore="UnusedResources">Navigate Up</string>
     <string name="gutenberg_native_navigates_to_custom_color_picker" tools:ignore="UnusedResources">Navigates to custom color picker</string>
     <string name="gutenberg_native_navigates_to_customize_the_gradient" tools:ignore="UnusedResources">Navigates to customize the gradient</string>
-    <!-- translators: %s: Select control button label e.g. "Button width" -->
     <string name="gutenberg_native_navigates_to_select_s" tools:ignore="UnusedResources">Navigates to select %s</string>
     <string name="gutenberg_native_navigates_to_the_previous_content_sheet" tools:ignore="UnusedResources">Navigates to the previous content sheet</string>
     <string name="gutenberg_native_no_application_can_handle_this_request" tools:ignore="UnusedResources">No application can handle this request.</string>
@@ -3510,6 +3534,8 @@ translators: Block name. %s: The localized block name -->
     <string name="gutenberg_native_s_block_newly_available" tools:ignore="UnusedResources">%s block, newly available</string>
     <!-- translators: %s: block title e.g: "Paragraph". -->
     <string name="gutenberg_native_s_block_options" tools:ignore="UnusedResources">%s block options</string>
+    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
+    <string name="gutenberg_native_s_block_previews_are_coming_soon" tools:ignore="UnusedResources">%s block previews are coming soon</string>
     <!-- translators: accessibility text for blocks with invalid content. %d: localized block title -->
     <string name="gutenberg_native_s_block_this_block_has_invalid_content" tools:ignore="UnusedResources">%s block. This block has invalid content</string>
     <!-- translators: %s: name of the reusable block -->
@@ -3520,6 +3546,8 @@ translators: Block name. %s: The localized block name -->
     <string name="gutenberg_native_s_has_url_set" tools:ignore="UnusedResources">%s has URL set</string>
     <!-- translators: Missing block alert title. %s: The localized block name -->
     <string name="gutenberg_native_s_is_not_fully_supported" tools:ignore="UnusedResources">\'%s\' is not fully–supported</string>
+    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
+    <string name="gutenberg_native_s_previews_not_yet_available" tools:ignore="UnusedResources">%s previews not yet available</string>
     <!-- translators: %s: social link name e.g: "Instagram". -->
     <string name="gutenberg_native_s_social_icon" tools:ignore="UnusedResources">%s social icon</string>
     <string name="gutenberg_native_scrollable_block_menu_closed" tools:ignore="UnusedResources">Scrollable block menu closed.</string>
@@ -3533,7 +3561,6 @@ translators: Block name. %s: The localized block name -->
     <string name="gutenberg_native_select_a_color" tools:ignore="UnusedResources">Select a color</string>
     <string name="gutenberg_native_select_a_color_above" tools:ignore="UnusedResources">Select a color above</string>
     <string name="gutenberg_native_select_a_layout" tools:ignore="UnusedResources">Select a layout</string>
-    <!-- translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="gutenberg_native_selected_s" tools:ignore="UnusedResources">Selected: %s</string>
     <string name="gutenberg_native_set_as_featured_image" tools:ignore="UnusedResources">Set as Featured Image </string>
     <string name="gutenberg_native_show_post_content" tools:ignore="UnusedResources">Show post content</string>
@@ -3566,8 +3593,10 @@ translators: Block name. %s: The localized block name -->
     <!-- translators: accessibility text. %s: video caption. -->
     <string name="gutenberg_native_video_caption_s" tools:ignore="UnusedResources">Video caption. %s</string>
     <string name="gutenberg_native_we_are_working_hard_to_add_more_blocks_with_each_release" tools:ignore="UnusedResources">We are working hard to add more blocks with each release.</string>
-    <string name="gutenberg_native_we_re_working_hard_on_adding_support_for_embed_previews_in_the_me" tools:ignore="UnusedResources">We’re working hard on adding support for embed previews. In the meantime, you can preview the embedded content on the page.</string>
-    <string name="gutenberg_native_we_re_working_hard_on_adding_support_for_embed_previews_in_the_me_7978045c" tools:ignore="UnusedResources">We’re working hard on adding support for embed previews. In the meantime, you can preview the embedded content on the post.</string>
+    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
+    <string name="gutenberg_native_we_re_working_hard_on_adding_support_for_s_previews_in_the_meanti" tools:ignore="UnusedResources">We’re working hard on adding support for %s previews. In the meantime, you can preview the embedded content on the page.</string>
+    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
+    <string name="gutenberg_native_we_re_working_hard_on_adding_support_for_s_previews_in_the_meanti_d8f5837e" tools:ignore="UnusedResources">We’re working hard on adding support for %s previews. In the meantime, you can preview the embedded content on the post.</string>
     <string name="gutenberg_native_welcome_to_the_world_of_blocks" tools:ignore="UnusedResources">Welcome to the world of blocks</string>
     <string name="gutenberg_native_what_is_a_block" tools:ignore="UnusedResources">What is a block?</string>
     <string name="gutenberg_native_what_is_alt_text" tools:ignore="UnusedResources">What is alt text?</string>

--- a/version.properties
+++ b/version.properties
@@ -1,9 +1,9 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=18.1
-versionCode=1103
+versionName=18.2-rc-1
+versionCode=1104
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
-alpha.versionName=alpha-316
-alpha.versionCode=1102
+alpha.versionName=alpha-317
+alpha.versionCode=1105


### PR DESCRIPTION
- [x] WordPress 18.2-rc-1 submitted to Google (*)
- [x] Jetpack 18.2-rc-1 submitted to Google

(*) CI seems to fail building the `Vanilla` flavor (p1630938604091100-slack-CC7L49W13), while it succeeds to build `zalpha` and while building `Vanilla` locally on my Mac works.

I've thus built and uploaded this 18.2-rc-1 aab locally (`fastlane build_beta`) instead of from CI to avoid delaying the beta testing too much, until I get to fix the CI issue. I'll continue to investigate the CI failure tomorrow, and plan to do a separate PR if I find a fix, to not block this PR.