### PR TITLE
Change reader post list background from #101517 to #121212

### DIFF
--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -48,7 +48,7 @@
     <color name="reader_following_empty_view_background">@color/transparent</color>
 
     <!-- Reader Post Card -->
-    <color name="reader_post_list_background">@color/gray_100</color>
+    <color name="reader_post_list_background">@color/background_dark</color>
     <color name="reader_welcome_card_background">@color/background_dark</color>
     <color name="reader_welcome_card_text">@color/white</color>
 


### PR DESCRIPTION
Fixes #14842

To test:

1. Turn on dark mode.
2. Go to Reader.
3. Find a tab where you have no content.
4. See empty state.
5. Confirm background color is now the standard #121212.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
