### PR TITLE
Fix editor_session_start event customer property key

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3320,7 +3320,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         Boolean supportsGalleryWithImageBlocks = null;
         if (editorTheme != null) {
             // Note that if the editor theme has not been initialized (usually on the first app run) the
-            // `unstableGalleryWithImageBlocks` analytics property will not be reported
+            // `unstable_gallery_with_image_blocks` analytics property will not be reported
             supportsGalleryWithImageBlocks = editorTheme.getThemeSupport().getGalleryWithImageBlocks();
         }
         mPostEditorAnalyticsSession

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -24,7 +24,7 @@ public class PostEditorAnalyticsSession implements Serializable {
     private static final String KEY_HAS_UNSUPPORTED_BLOCKS = "has_unsupported_blocks";
     private static final String KEY_UNSUPPORTED_BLOCKS = "unsupported_blocks";
     private static final String KEY_CAN_VIEW_EDITOR_ONBOARDING = "can_view_editor_onboarding";
-    private static final String KEY_GALLERY_WITH_IMAGE_BLOCKS = "unstableGalleryWithImageBlocks";
+    private static final String KEY_GALLERY_WITH_IMAGE_BLOCKS = "unstable_gallery_with_image_blocks";
     private static final String KEY_POST_TYPE = "post_type";
     private static final String KEY_OUTCOME = "outcome";
     private static final String KEY_SESSION_ID = "session_id";


### PR DESCRIPTION
Prior to this change, `wpandroid_editor_session_start` events were not sent to Tracks, as they were marked as invalid with the following error. This relates to changes made in #15134 and aligns with the fix applied to iOS with https://github.com/wordpress-mobile/WordPress-iOS/pull/17130


```
Custom properties dictionary keys must contain alpha characters and underscores only.
```

To test: 

1. Install `18.2` beta build. 
2. Launch post editor. 
3. ⚠️ Verify `wpandroid_editor_session_start` event _does not_ arrive to Tracks. 
4. Install build from this PR. 
5. Launch post editor. 
6. ✅ Verify `wpandroid_editor_session_start` event arrives to Tracks with expected properties. 

## Regression Notes
1. Potential unintended areas of impact
Custom properties for the event are missing.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified custom properties arrived with the event in Tracks.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
