### PR TITLE
Fixes typo in site created screen subtitle

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3104,7 +3104,7 @@
     <string name="new_site_creation_screen_title_general">Create Site</string>
     <string name="new_site_creation_screen_title_step_count">%1$d of %2$d</string>
     <string name="new_site_creation_preview_title">Your site has been created!</string>
-    <string name="new_site_creation_preview_subtitle">You\'ll be able to customize look and feel of your site later</string>
+    <string name="new_site_creation_preview_subtitle">You\'ll be able to customize the look and feel of your site later</string>
     <string name="site_creation_fetch_suggestions_error_unknown">There was a problem</string>
     <string name="site_creation_error_generic_title">There was a problem</string>
     <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>


### PR DESCRIPTION
### Description
Fixes a small typo on the “Your site has been created” screen. We should add a “the” to: “You’ll be a able to customize **the** look and feel of your site later”
_internal ref: `p5T066-2Dl-p2#comment-9888`_

To test:
1. Create a site
2. Verify that the new wording is included in the “Your site has been created” screen

|Before|After|
|---|---|
|![device-2021-09-09-100226](https://user-images.githubusercontent.com/304044/132639180-c499d0d5-9821-4438-8772-1e1a81910090.png)|![device-2021-09-09-100658](https://user-images.githubusercontent.com/304044/132639172-bebbdeb4-e419-4354-9664-b4bc74dea9e7.png)|

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
