### PR TITLE
[WP Stories] fix stories editor session start

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -128,6 +128,14 @@ public class PostEditorAnalyticsSession implements Serializable {
         }
     }
 
+    public void resetStartTime() {
+        if (!mStarted) {
+            mStartTime = System.currentTimeMillis();
+        } else {
+            AppLog.w(T.EDITOR, "An editor session start time cannot be reset once it's started");
+        }
+    }
+
     public void switchEditor(Editor editor) {
         mCurrentEditor = editor;
         Map<String, Object> properties = getCommonProperties();

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -292,6 +292,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        viewModel.onStoryComposerAnalyticsSessionStartTimeReset()
         super.onActivityResult(requestCode, resultCode, data)
         data?.let {
             when (requestCode) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -223,6 +223,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             if (filteredList.isNotEmpty()) {
                 addFramesToStoryFromMediaUriList(filteredList)
                 setDefaultSelectionAndUpdateBackgroundSurfaceUI(filteredList)
+                viewModel.onStoryComposerFinishedAddingMedia()
             }
 
             // finally if any of the files was a gif, warn the user

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -23,6 +23,7 @@ import com.wordpress.stories.compose.PermanentPermissionDenialDialogProvider
 import com.wordpress.stories.compose.PrepublishingEventProvider
 import com.wordpress.stories.compose.SnackbarProvider
 import com.wordpress.stories.compose.StoryDiscardListener
+import com.wordpress.stories.compose.frame.StoryLoadEvents.StoryLoadEnd
 import com.wordpress.stories.compose.frame.StorySaveEvents.StorySaveResult
 import com.wordpress.stories.compose.story.StoryFrameItem
 import com.wordpress.stories.compose.story.StoryFrameItem.BackgroundSource.FileBackgroundSource
@@ -33,6 +34,8 @@ import com.wordpress.stories.compose.story.StoryRepository.DEFAULT_NONE_SELECTED
 import com.wordpress.stories.util.KEY_STORY_EDIT_MODE
 import com.wordpress.stories.util.KEY_STORY_INDEX
 import com.wordpress.stories.util.KEY_STORY_SAVE_RESULT
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -656,5 +659,12 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                 ).show(supportFragmentManager, FRAGMENT_ANNOUNCEMENT_DIALOG)
             }
         }
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onStoryLoadEnd(event: StoryLoadEnd) {
+        // once the Story has been loaded by the Composer, we should mark the composing session start as the
+        // UI is ready to receive user's input
+        viewModel.onStoryComposerStartAnalyticsSession()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -223,7 +223,11 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             if (filteredList.isNotEmpty()) {
                 addFramesToStoryFromMediaUriList(filteredList)
                 setDefaultSelectionAndUpdateBackgroundSurfaceUI(filteredList)
-                viewModel.onStoryComposerFinishedAddingMedia()
+                // generally speaking, adding media will happen at the beginning of loading the StoryComposer, so once
+                // it's done adding media the StoryComposer will be ready to render the newly loaded / created Story.
+                // Hence, it makes sense to start the editor session tracking at this point - note subsequent calls
+                // will have no effect, given PostEditorAnalyticsSession has a flag so it can only be started once.
+                viewModel.onStoryComposerStartAnalyticsSession()
             }
 
             // finally if any of the files was a gif, warn the user
@@ -378,6 +382,9 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                 return
             }
             storyEditorMedia.addExistingMediaToEditorAsync(WP_MEDIA_LIBRARY, ids)
+        } else if (data.hasExtra(MediaPickerConstants.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED)) {
+            // when coming from this entry point, we can start the analytics session
+            viewModel.onStoryComposerStartAnalyticsSession()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -130,6 +130,10 @@ class StoryComposerViewModel @Inject constructor(
         this.postEditorAnalyticsSession?.start(null, null, null)
     }
 
+    fun onStoryComposerAnalyticsSessionStartTimeReset() {
+        this.postEditorAnalyticsSession?.resetStartTime()
+    }
+
     fun writeToBundle(outState: Bundle) {
         outState.putSerializable(WordPress.SITE, site)
         outState.putInt(StoryComposerActivity.STATE_KEY_POST_LOCAL_ID, editPostRepository.id)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -126,11 +126,7 @@ class StoryComposerViewModel @Inject constructor(
         )
     }
 
-    fun onStoryComposerFinishedAddingMedia() {
-        // generally speaking, adding media will happen at the beginning of loading the StoryComposer, so once
-        // it's done adding media the StoryComposer will be ready to render the newly loaded / created Story.
-        // Hence, it makes sense to start the editor session tracking at this point - note subsequent calls
-        // will have no effect, given PostEditorAnalyticsSession has a flag so it can only be started once.
+    fun onStoryComposerStartAnalyticsSession() {
         this.postEditorAnalyticsSession?.start(null, null, null)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -114,7 +114,6 @@ class StoryComposerViewModel @Inject constructor(
                 editPostRepository.getPost(),
                 site
         )
-        this.postEditorAnalyticsSession?.start(null, null, null)
     }
 
     private fun createPostEditorAnalyticsSessionTracker(
@@ -125,6 +124,14 @@ class StoryComposerViewModel @Inject constructor(
                 PostEditorAnalyticsSession.Editor.WP_STORIES_CREATOR,
                 post, site, true
         )
+    }
+
+    fun onStoryComposerFinishedAddingMedia() {
+        // generally speaking, adding media will happen at the beginning of loading the StoryComposer, so once
+        // it's done adding media the StoryComposer will be ready to render the newly loaded / created Story.
+        // Hence, it makes sense to start the editor session tracking at this point - note subsequent calls
+        // will have no effect, given PostEditorAnalyticsSession has a flag so it can only be started once.
+        this.postEditorAnalyticsSession?.start(null, null, null)
     }
 
     fun writeToBundle(outState: Bundle) {


### PR DESCRIPTION
Fixes #15291 

See accompanying stories library PR https://github.com/Automattic/stories-android/pull/714

**tl;dr** the session was being marked as started right after having created the `PostEditorAnalyticsSession` object, which invariably meant an elapsed startup time of 0 to 1 milliseconds when looking into Tracks.

This PR aims at fixing this by adding a few methods and making the calls at the right moments, which are after having loaded a Story and the composer is about to show it on the screen.

### Description

Following up on this [comment](https://github.com/wordpress-mobile/WordPress-Android/issues/15291#issuecomment-915257034), the moments in which Story frames are loaded onto the Story composer can be roughly grouped as follows:

#### MediaPicker
Using the **MediaPicker**. The `EditorMediaListener`'s `appendMediaFiles` is the last entry point to adding Story slides once the media has been obtained from the media picker and passed on to the Story Composer.  In the StoryComposerActivity, we have an observer on `mediaFilesUris` object which is ultimately reponsible for adding the media items as slides, via the `addFramesToStoryFromMediaUriList()` method:

```
    private fun setupViewModelObservers() {
        viewModel.mediaFilesUris.observe(this, { uriList ->
            val filteredList = uriList.filterNot { MediaUtils.isGif(it.toString()) }
            if (filteredList.isNotEmpty()) {
                addFramesToStoryFromMediaUriList(filteredList)
                setDefaultSelectionAndUpdateBackgroundSurfaceUI(filteredList)
            }
```

So, adding a call at that point to signal the session start (or what is the same, readiness of the editor for user interaction) is the right way to measure it (added [here](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/15291-stories-editor-session-start?expand=1#diff-32ef15fee2cf2c96f64279e6c70d35a31552e6508585386c60e57ef2dd19b21dR229-R233)).
This part is executed for any media items chosen with the media picker (local to the device,  from other apps, from the free photo library, or from the WordPress site's media).

_This part covers most of the use cases that are of interest or are comparable to the time-to-start being measured for Aztec or Gutenberg._

#### Starting the composer on live camera preview mode
If the user chooses to tap on the camera FAB presented on the picker, which triggers the live preview mode of the Story Composer, then things get a bit trickier. In reality, the moment when things are ready to be presented in this mode is detected either in [`BackgroundSurfaceManagerReadyListener`](https://github.com/Automattic/stories-android/blob/develop/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt#L504-L518) or within `launchCameraPreviewWithSurfaceSafeguard`, both internal to ComposeLoopFrameActivity in the Stories library.

I'd argue this second moment is essentially not as important, given this is very specific to the Story composer, so in this case I'd stick to something simpler at the client app level (StoryComposerActivity), and just check whether we've been passed the `requestCodes.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED  in `handleMediaPickerIntentData`. This is done [here](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/15291-stories-editor-session-start?expand=1#diff-32ef15fee2cf2c96f64279e6c70d35a31552e6508585386c60e57ef2dd19b21dR389-R391).

#### Loading an existing Story
When the user loads an existing Story (by tapping on a Story block in GB mobile that was already created on this very device), then we have a slightly different situation, in which the actual loading is taken care of via Intent and handled internally by ComposeLoopFrameActivity's `onLoadFromIntent()`. For this then, we added `StoryLoadStart` and `StoryLoadEnd` events in the stories library in https://github.com/Automattic/stories-android/pull/714; that can be listened to from the client app in order to do whatever is needed (in this case, to mark the start of the user editing session once we get a `StoryLoadEnd` event - see https://github.com/wordpress-mobile/WordPress-Android/commit/2132127d12d3aa43f5e93bd7e61a99a19ec3424a).

#### Special case: editing an empty Story block
If the user adds an empty Story block to a Gutenberg post and then taps on ADD MEDIA, or edits an existing block ~things work the same here.~ things are a bit different: 
- The StoryComposerActivity gets launched, and it realizes it needs to show the provided Media Picker so to allow the user to add media
- so now the MediaPicker is shown, waiting for the user's pick results
- finally, we get a call in `onActivityResult`, and only at this point and after adding the media slides (see the section above called MediaPicker, which covered how this part of the flow works) we know how much time it took for the StoryComposer to set itself up with the media it was passed along from the Media Picker.

Given this, we added a new method to PostEditorAnalyticsSession in order to [reset the `mStartTime`](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/15291-stories-editor-session-start?expand=1#diff-471b17a541b67be8b228ee74e749614c81c28bed72dad82663e442b19d876c5eR131-R138) to current time when we come back from the media picker, given we really want to measure the StoryComposer start up time since getting the media items until after these have been added as media slides (otherwise, we'd be counting also all the time spent by the user choosing media items in the MediaPicker).

#### Final note
It's worth noting that the session's object `start()` method may be called more than once when you keep adding slides to a Story at different moments (by tapping the "+" button on the StoryFrameSelector at the bottom-right of the screen). Fortunately there's a [safeguard within the method itself,](https://github.com/wordpress-mobile/WordPress-Android/blob/daecb9589521445025ee3b66e5636cd1ecee1aad/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java#L125-L128) that doesn't allow that to happen and gets an entry on the application's log with a warning. This is fine and I'm relying on this behavior to avoid having more complicated checks at the client app level that would make things only more complex.

### To test:

**TEST CASE A: Select media from media picker**
1. create a new story
2. when the media picker appears, select one or more media items
3. Observe the media items get added, and the logs show an entry such as this:
```
2021-09-08 19:50:10.787 29365-29365/org.wordpress.android I/WordPress-STATS: 🔵 Tracked: editor_session_start, Properties: {"has_unsupported_blocks":"0","editor":"wp_stories_creator","content_type":"new","startup_time_ms":1054,"session_id":"e9df54a2-1e1b-4fa5-8078-04edf0892f46","post_type":"post","blog_type":"wpcom","editor_has_hw_disabled":"0","unsupported_blocks":[]}
```

4. tap on the "+" button on the story composer's story frame selector to add more media items
5. pick one or more media items
6. observe the new item(s) get added as slides, and the following entry is observed in the log:

```
2021-09-08 19:51:22.062 29365-29365/org.wordpress.android W/WordPress-EDITOR: An editor session cannot be attempted to be started more than once, unless it's due to rotation or Editor switch
```

(that's expected)

7. once more, tap on the "+" button on the story composer's story frame selector to add more media items
8. when the media picker appears, cancel it (tap on the back arrow)
9. observe the following log entry:

```
2021-09-08 19:52:23.574 29365-29365/org.wordpress.android W/WordPress-EDITOR: An editor session start time cannot be reset once it's started
```

That's expected, since the session has already been started the first time we added media items.

**TEST CASE B:** 
- repeat case A, but in step 2 try choosing media from the local device, free photo library, and the site's WP Media.

Picking pictures that are not local to the device (for example, from Google Photos or other apps) may take a while, but this time is not considered as part of the StoryComposer load time. So, when adding media items like this, the logs should show something like:

```
2021-09-08 19:58:31.935 29365-29365/org.wordpress.android I/WordPress-STATS: 🔵 Tracked: editor_session_start, Properties: {"has_unsupported_blocks":"0","editor":"wp_stories_creator","content_type":"new","startup_time_ms":647,"session_id":"7230c859-4c9a-4745-a52e-a50f25c5ff1f","post_type":"post","blog_type":"wpcom","editor_has_hw_disabled":"0","unsupported_blocks":[]}
```


**TEST CASE C: existing empty block**
1. create a new post in GB mobile, and add a Story block
2. tap on ADD MEDIA on the Story block.
3. when the media picker appears, select one or more media items to add
4. observe these get added, and a log entry such as this appears:

```
2021-09-08 20:01:49.164 29365-29365/org.wordpress.android I/WordPress-STATS: 🔵 Tracked: editor_session_start, Properties: {"has_unsupported_blocks":"0","editor":"wp_stories_creator","content_type":"new","startup_time_ms":503,"session_id":"c08cd534-c9a2-4a53-910a-2e0e80ad9cf0","post_type":"post","blog_type":"wpcom","editor_has_hw_disabled":"0","unsupported_blocks":[]}
```
5. Save the Story and verify the Story Block gets populated in GB.


**TEST CASE D:** editing existing non-empty Story block, that was created on this device
1. create a block post with a story block with some slides in it
2. open the post and tap on the Story block twice to edit the Story block
3. observe the StoryComposer fires up and shows your slides, and a line appears in the log as well.


## Regression Notes
1. Potential unintended areas of impact
None, this is only related to how we track editor sessions startup timing, and is only restricted to the StoryComposer

2. What I did to test those areas of impact (or what existing automated tests I relied on)
See manual testing paths above

3. What automated tests I added (or what prevented me from doing so)
The nature of startup time is dependant on various entry points which are tightly coupled with the Media Picker and other sources to load Story slides from. The easiest way to test each path is described above.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
