### PR TITLE
Handles exception thrown when the theme has not been initialised yet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2325,6 +2325,20 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     /**
+     * Checks if the theme supports the new gallery block with image blocks.
+     * Note that if the editor theme has not been initialized (usually on the first app run)
+     * the value returned is null and the `unstable_gallery_with_image_blocks` analytics property will not be reported.
+     * @return true if the the supports the new gallery block with image blocks or null if the theme is not initialized.
+     */
+    private Boolean themeSupportsGalleryWithImageBlocks() {
+        EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);
+        if (editorTheme == null) {
+            return null;
+        }
+        return editorTheme.getThemeSupport().getGalleryWithImageBlocks();
+    }
+
+    /**
      * Temporary method for the Editor Onboarding project to control the percentage
      * of users able to use this new editor onboarding tooltip feature. This will eventually
      * be removed when the functionality is opened to all users.
@@ -3301,9 +3315,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 ((GutenbergEditorFragment) mEditorFragment).resetUploadingMediaToFailed(mediaIds);
             }
         } else if (mShowAztecEditor && mEditorFragment instanceof AztecEditorFragment) {
-            EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);
-            Boolean supportsGalleryWithImageBlocks = editorTheme.getThemeSupport().getGalleryWithImageBlocks();
-            mPostEditorAnalyticsSession.start(null, canViewEditorOnboarding(), supportsGalleryWithImageBlocks);
+            mPostEditorAnalyticsSession.start(null, canViewEditorOnboarding(), themeSupportsGalleryWithImageBlocks());
         }
     }
 
@@ -3316,15 +3328,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
         // It assumes this is being called when the editor has finished loading
         // If you need to refactor this, please ensure that the startup_time_ms property
         // is still reflecting the actual startup time of the editor
-        EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);
-        Boolean supportsGalleryWithImageBlocks = null;
-        if (editorTheme != null) {
-            // Note that if the editor theme has not been initialized (usually on the first app run) the
-            // `unstable_gallery_with_image_blocks` analytics property will not be reported
-            supportsGalleryWithImageBlocks = editorTheme.getThemeSupport().getGalleryWithImageBlocks();
-        }
         mPostEditorAnalyticsSession
-                .start(unsupportedBlocksList, canViewEditorOnboarding(), supportsGalleryWithImageBlocks);
+                .start(unsupportedBlocksList, canViewEditorOnboarding(), themeSupportsGalleryWithImageBlocks());
         presentNewPageNoticeIfNeeded();
 
         // don't start listening for Story events just now if we're waiting for a block to be replaced,


### PR DESCRIPTION
Fixes #15300

**Based on** https://github.com/wordpress-mobile/WordPress-Android/pull/15308 and targeting `release/18.2`

## Description
This PR fixes a `NullPointerException` introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/15134

To test:
I was not able to reproduce the conditions that lead to a crash. Thus I only validated the fix by triggering a `null` value for the `editorTheme` at debug time.

A few edge cases I tested include:
* Starting the editor quickly after a clean install of the app
* Starting the editor quickly in offline mode after a clean install of the app

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
The complexity of `EditPostActivity` makes it hard to add an automated tests for this part of the code.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
