### PR TITLE
Block editor: Fixes bug preventing button block gradient background from being updated in the editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 18.3
 -----
 * [**] Media: Fix Atomic sites video not playing issue. (https://github.com/wordpress-mobile/WordPress-Android/pull/15285)
+* [*] Block editor: Fixes bug preventing button block gradient background from being updated in the editor [https://github.com/wordpress-mobile/WordPress-Android/pull/15312]
 
 18.2
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.61.0'
+    ext.gutenbergMobileVersion = '2112-00c20ed9f7324968b46a162a679f8c7358d53b8e'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '2112-00c20ed9f7324968b46a162a679f8c7358d53b8e'
+    ext.gutenbergMobileVersion = 'v1.61.0'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '2112-00c20ed9f7324968b46a162a679f8c7358d53b8e'
+    fluxCVersion = 'develop-beb2db2dac770e17e28bf1e0c36edc1e794498aa'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.25.1'
+    fluxCVersion = '2112-00c20ed9f7324968b46a162a679f8c7358d53b8e'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/3936

**Depends on:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2112

### Description
Fixes bug preventing button block gradient background from being updated in the editor by [passing](https://github.com/WordPress/gutenberg/blob/4fc1b6f1b16a032d4e732519074973cb3292f757/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt#L41) the `null` values of `rawStyles` down to the editor.

To test:
1. Open the editor
2. Add a button block
3. Open the editor settings
4. Open the background color
5. Set a gradient background from the predefined list
6. **Verify** that the change is reflected in the editor

## Regression Notes
1. Potential unintended areas of impact
Functionality based on Global styles and features

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Relied on [existing tests](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_EditorThemeStoreTest.kt)

3. What automated tests I added (or what prevented me from doing so)
Relied on [existing tests](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_EditorThemeStoreTest.kt)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
