### PR TITLE
Add prices to search suggestions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.domains
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.Adapter
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
 
 class DomainSuggestionsAdapter(
@@ -9,6 +10,7 @@ class DomainSuggestionsAdapter(
 ) : Adapter<DomainSuggestionsViewHolder>() {
     private val list = mutableListOf<DomainSuggestionResponse>()
     var selectedPosition = -1
+    lateinit var siteModel: SiteModel
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DomainSuggestionsViewHolder {
         return DomainSuggestionsViewHolder(
@@ -22,7 +24,7 @@ class DomainSuggestionsAdapter(
     }
 
     override fun onBindViewHolder(holder: DomainSuggestionsViewHolder, position: Int) {
-        holder.bind(list[position], position, selectedPosition == position)
+        holder.bind(list[position], position, selectedPosition == position, siteModel)
     }
 
     private fun onDomainSuggestionSelected(suggestion: DomainSuggestionResponse?, position: Int) {
@@ -35,7 +37,8 @@ class DomainSuggestionsAdapter(
         itemSelectionListener(suggestion, position)
     }
 
-    internal fun updateSuggestionsList(items: List<DomainSuggestionResponse>) {
+    internal fun updateSuggestionsList(items: List<DomainSuggestionResponse>, site: SiteModel) {
+        siteModel = site
         list.clear()
         list.addAll(items)
         notifyDataSetChanged()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.domains
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.Adapter
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
 
 class DomainSuggestionsAdapter(
@@ -10,7 +9,7 @@ class DomainSuggestionsAdapter(
 ) : Adapter<DomainSuggestionsViewHolder>() {
     private val list = mutableListOf<DomainSuggestionResponse>()
     var selectedPosition = -1
-    lateinit var siteModel: SiteModel
+    var isDomainCreditAvailable: Boolean = false
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DomainSuggestionsViewHolder {
         return DomainSuggestionsViewHolder(
@@ -24,7 +23,7 @@ class DomainSuggestionsAdapter(
     }
 
     override fun onBindViewHolder(holder: DomainSuggestionsViewHolder, position: Int) {
-        holder.bind(list[position], position, selectedPosition == position, siteModel)
+        holder.bind(list[position], position, selectedPosition == position, isDomainCreditAvailable)
     }
 
     private fun onDomainSuggestionSelected(suggestion: DomainSuggestionResponse?, position: Int) {
@@ -37,8 +36,8 @@ class DomainSuggestionsAdapter(
         itemSelectionListener(suggestion, position)
     }
 
-    internal fun updateSuggestionsList(items: List<DomainSuggestionResponse>, site: SiteModel) {
-        siteModel = site
+    internal fun updateSuggestionsList(items: List<DomainSuggestionResponse>, isDomainCreditAvailable: Boolean) {
+        this.isDomainCreditAvailable = isDomainCreditAvailable
         list.clear()
         list.addAll(items)
         notifyDataSetChanged()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -119,7 +119,7 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
     private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionResponse>) {
         val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
         adapter.selectedPosition = viewModel.selectedPosition.value ?: -1
-        adapter.updateSuggestionsList(domainSuggestions, viewModel.site)
+        adapter.updateSuggestionsList(domainSuggestions, viewModel.isDomainCreditAvailable)
     }
 
     private fun onDomainSuggestionSelected(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -119,7 +119,7 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
     private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionResponse>) {
         val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
         adapter.selectedPosition = viewModel.selectedPosition.value ?: -1
-        adapter.updateSuggestionsList(domainSuggestions)
+        adapter.updateSuggestionsList(domainSuggestions, viewModel.site)
     }
 
     private fun onDomainSuggestionSelected(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.domains
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,9 +8,7 @@ import android.widget.TextView
 import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
-import org.wordpress.android.util.SiteUtils
 
 class DomainSuggestionsViewHolder(
     parent: ViewGroup,
@@ -24,9 +21,14 @@ class DomainSuggestionsViewHolder(
     private val selectionRadioButton: RadioButton = itemView.findViewById(R.id.domain_selection_radio_button)
     private val container: View = itemView.findViewById(R.id.domain_suggestions_container)
 
-    fun bind(suggestion: DomainSuggestionResponse, position: Int, isSelectedPosition: Boolean, site: SiteModel) {
+    fun bind(
+        suggestion: DomainSuggestionResponse,
+        position: Int,
+        isSelectedPosition: Boolean,
+        isDomainCreditAvailable: Boolean
+    ) {
         domainName.text = suggestion.domain_name
-        domainCost.text = getFormattedCost(suggestion, site)
+        domainCost.text = getFormattedCost(suggestion, isDomainCreditAvailable)
         selectionRadioButton.isChecked = isSelectedPosition
 
         container.setOnClickListener {
@@ -40,28 +42,29 @@ class DomainSuggestionsViewHolder(
         }
     }
 
-    private fun getFormattedCost(suggestion: DomainSuggestionResponse, site: SiteModel) = when {
+    private fun getFormattedCost(
+        suggestion: DomainSuggestionResponse,
+        isDomainCreditAvailable: Boolean
+    ) = when {
         suggestion.is_free -> {
             suggestion.cost
         }
-        SiteUtils.onFreePlan(site) -> {
-            Log.d(suggestion.product_id.toString(), suggestion.product_slug)
-
+        isDomainCreditAvailable -> {
             HtmlCompat.fromHtml(
                     String.format(
                             container.context.getString(
-                                    R.string.domain_suggestions_list_item_cost
+                                    R.string.domain_suggestions_list_item_cost_free
                             ),
                             suggestion.cost
                     ),
                     HtmlCompat.FROM_HTML_MODE_LEGACY
             )
         }
-        else -> { // on paid plan
+        else -> { // on free plan
             HtmlCompat.fromHtml(
                     String.format(
                             container.context.getString(
-                                    R.string.domain_suggestions_list_item_cost_free
+                                    R.string.domain_suggestions_list_item_cost
                             ),
                             suggestion.cost
                     ),

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
@@ -1,13 +1,17 @@
 package org.wordpress.android.ui.domains
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.RadioButton
 import android.widget.TextView
+import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
+import org.wordpress.android.util.SiteUtils
 
 class DomainSuggestionsViewHolder(
     parent: ViewGroup,
@@ -16,11 +20,13 @@ class DomainSuggestionsViewHolder(
         LayoutInflater.from(parent.context).inflate(R.layout.domain_suggestion_list_item, parent, false)
 ) {
     private val domainName: TextView = itemView.findViewById(R.id.domain_name)
+    private val domainCost: TextView = itemView.findViewById(R.id.domain_cost)
     private val selectionRadioButton: RadioButton = itemView.findViewById(R.id.domain_selection_radio_button)
     private val container: View = itemView.findViewById(R.id.domain_suggestions_container)
 
-    fun bind(suggestion: DomainSuggestionResponse, position: Int, isSelectedPosition: Boolean) {
+    fun bind(suggestion: DomainSuggestionResponse, position: Int, isSelectedPosition: Boolean, site: SiteModel) {
         domainName.text = suggestion.domain_name
+        domainCost.text = getFormattedCost(suggestion, site)
         selectionRadioButton.isChecked = isSelectedPosition
 
         container.setOnClickListener {
@@ -31,6 +37,36 @@ class DomainSuggestionsViewHolder(
             } else {
                 itemSelectionListener(null, -1)
             }
+        }
+    }
+
+    private fun getFormattedCost(suggestion: DomainSuggestionResponse, site: SiteModel) = when {
+        suggestion.is_free -> {
+            suggestion.cost
+        }
+        SiteUtils.onFreePlan(site) -> {
+            Log.d(suggestion.product_id.toString(), suggestion.product_slug)
+
+            HtmlCompat.fromHtml(
+                    String.format(
+                            container.context.getString(
+                                    R.string.domain_suggestions_list_item_cost
+                            ),
+                            suggestion.cost
+                    ),
+                    HtmlCompat.FROM_HTML_MODE_LEGACY
+            )
+        }
+        else -> { // on paid plan
+            HtmlCompat.fromHtml(
+                    String.format(
+                            container.context.getString(
+                                    R.string.domain_suggestions_list_item_cost_free
+                            ),
+                            suggestion.cost
+                    ),
+                    HtmlCompat.FROM_HTML_MODE_LEGACY
+            )
         }
     }
 }

--- a/WordPress/src/main/res/layout/domain_suggestion_list_item.xml
+++ b/WordPress/src/main/res/layout/domain_suggestion_list_item.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/domain_suggestions_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:selectableItemBackground"
     android:gravity="center_vertical"
+    android:layout_marginStart="@dimen/margin_extra_large"
+    android:layout_marginEnd="@dimen/margin_extra_large"
+    android:layout_marginBottom="@dimen/margin_medium"
     android:minHeight="@dimen/min_touch_target_sz"
     android:orientation="horizontal">
 
@@ -12,15 +17,32 @@
         android:id="@+id/domain_selection_radio_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_medium_large"
-        android:layout_marginEnd="@dimen/margin_small_medium"
-        android:clickable="false" />
+        android:clickable="false"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/domain_name"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_extra_medium_large"
-        android:textAppearance="?attr/textAppearanceSubtitle1" />
+        android:layout_marginStart="@dimen/margin_medium"
+        android:textAppearance="?attr/textAppearanceListItem"
+        app:layout_constraintStart_toEndOf="@id/domain_selection_radio_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="travelwithkids.com"/>
 
-</LinearLayout>
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/domain_cost"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_medium"
+        android:textAppearance="?attr/textAppearanceListItemSecondary"
+        app:layout_constraintStart_toEndOf="@id/domain_selection_radio_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/domain_name"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:text="Free for the first year US$18.99/year"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2414,6 +2414,8 @@
     <string name="domains_suggestions_intro_title">Choose a premium domain name</string>
     <string name="domains_suggestions_intro_description">This is where people will find you on the internet.</string>
     <string name="domain_suggestions_search_hint">Type a keyword for more ideas</string>
+    <string name="domain_suggestions_list_item_cost">&lt;b&gt;%s&lt;/b&gt;/year</string>
+    <string name="domain_suggestions_list_item_cost_free">&lt;strong&gt;&lt;span style="color:#008000;"&gt;Free for the first yea&lt;span&gt;r&lt;/strong&gt; &lt;s&gt; &lt;b&gt;%s&lt;/b&gt;/year &lt;/s&gt;</string>
     <string name="domain_suggestions_fetch_error">Domain suggestions couldn\'t be loaded</string>
     <string name="domain_registration_contact_form_input_error">Please enter a valid %s</string>
     <string name="domain_registration_privacy_protection_title">Privacy Protection</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2414,8 +2414,8 @@
     <string name="domains_suggestions_intro_title">Choose a premium domain name</string>
     <string name="domains_suggestions_intro_description">This is where people will find you on the internet.</string>
     <string name="domain_suggestions_search_hint">Type a keyword for more ideas</string>
-    <string name="domain_suggestions_list_item_cost">&lt;b&gt;%s&lt;/b&gt;/year</string>
-    <string name="domain_suggestions_list_item_cost_free">&lt;strong&gt;&lt;span style="color:#008000;"&gt;Free for the first yea&lt;span&gt;r&lt;/strong&gt; &lt;s&gt; &lt;b&gt;%s&lt;/b&gt;/year &lt;/s&gt;</string>
+    <string name="domain_suggestions_list_item_cost">%s&lt;span style="color:#50575e;"&gt; /year&lt;span&gt;</string>
+    <string name="domain_suggestions_list_item_cost_free">&lt;strong&gt;&lt;span style="color:#008000;"&gt;Free for the first year &lt;span&gt;&lt;/strong&gt;&lt;span style="color:#50575e;"&gt;&lt;s&gt;%s /year&lt;/s&gt;&lt;span&gt;</string>
     <string name="domain_suggestions_fetch_error">Domain suggestions couldn\'t be loaded</string>
     <string name="domain_registration_contact_form_input_error">Please enter a valid %s</string>
     <string name="domain_registration_privacy_protection_title">Privacy Protection</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
+import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrationHandler
 import org.wordpress.android.ui.plans.PlansConstants
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.helpers.Debouncer
@@ -25,6 +26,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Mock lateinit var dispatcher: Dispatcher
     @Mock lateinit var debouncer: Debouncer
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
+    @Mock lateinit var domainRegistrationHandler: DomainRegistrationHandler
 
     private lateinit var site: SiteModel
     private lateinit var viewModel: DomainSuggestionsViewModel
@@ -32,7 +34,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Before
     fun setUp() {
         site = SiteModel().also { it.name = "Test Site" }
-        viewModel = DomainSuggestionsViewModel(tracker, dispatcher, debouncer)
+        viewModel = DomainSuggestionsViewModel(tracker, dispatcher, debouncer, domainRegistrationHandler)
 
         whenever(debouncer.debounce(any(), any(), any(), any())).thenAnswer { invocation ->
             val delayedRunnable = invocation.arguments[1] as Runnable


### PR DESCRIPTION
Updated search suggestions with pricing

Fixes #15315 

<table><tr><td><img width=320 src="https://user-images.githubusercontent.com/990349/134106774-8bd92550-6e88-4698-9f53-d8c11fa20dbb.png"</td><td><img width=320 src="https://user-images.githubusercontent.com/990349/134106810-fc05157c-866a-473a-849d-910b9c99a8d3.png"</td></tr></table>

To test:

Wait for this [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/15305) merge before testing this for better interface

1. Enable AppSettings -> Debug settings -> SiteDomainsFeatureConfig ✅
2. Return to My Site, Notice there's a new item under Configuration -> 🌐 Domains
3. Click on Domains, takes your Site Domains Screen
4. Click on Search for a domain.  Notice the domain search suggestions now show prices
5. Test with a free plan and paid plan to to see the above screens


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
