### PR TITLE
[Tooling] Create a Single, Unified GitHub Releases for WP Alpha, WP Beta & JP Beta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
                 name: Build << parameters.app >> Zalpha
                 command: |
                   if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-                    bundle exec fastlane build_alpha app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+                    bundle exec fastlane build_alpha app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:true
                   fi
                 no_output_timeout: 15m
       - unless:
@@ -134,15 +134,18 @@ jobs:
                 name: Build << parameters.app >> Vanilla
                 command: |
                   if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-                    bundle exec fastlane build_beta app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+                    bundle exec fastlane build_beta app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:true
                   else
-                    bundle exec fastlane build_and_upload_release app:<< parameters.app >> skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+                    bundle exec fastlane build_and_upload_release app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:true
                   fi
                 no_output_timeout: 15m
       - android/save-gradle-cache
       - store_artifacts:
           path: build
           destination: Artifacts
+      - persist_to_workspace:
+          root: .
+          paths: ['build/*.aab', 'WordPress/*metadata/release_notes.txt']
       - slack/status:
           include_job_number_field: false
           include_project_field: false
@@ -150,6 +153,18 @@ jobs:
           webhook: '${SLACK_BUILD_WEBHOOK}'
           failure_message: '${SLACK_FAILURE_MESSAGE}'
           success_message: '${SLACK_SUCCESS_MESSAGE}'
+  Create GitHub Release:
+    executor:
+      name: android/default
+      api-version: "29"
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Create GitHub Release
+          command: |
+            bundle exec fastlane create_gh_release
+
 
   Connected Tests:
     parameters:
@@ -405,3 +420,5 @@ workflows:
           name: "Release: JP Beta"
           app: jetpack
           alpha: false
+      - Create GitHub Release:
+          requires: ["Release: WP Alpha", "Release: WP Beta", "Release: JP Beta"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
                 name: Build << parameters.app >> Zalpha
                 command: |
                   if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-                    bundle exec fastlane build_alpha app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:false
+                    bundle exec fastlane build_alpha app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:true
                   fi
                 no_output_timeout: 15m
       - unless:
@@ -134,9 +134,9 @@ jobs:
                 name: Build << parameters.app >> Vanilla
                 command: |
                   if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-                    bundle exec fastlane build_beta app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:false
+                    bundle exec fastlane build_beta app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:true
                   else
-                    bundle exec fastlane build_and_upload_release app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:false
+                    bundle exec fastlane build_and_upload_release app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:true
                   fi
                 no_output_timeout: 15m
       - android/save-gradle-cache
@@ -146,13 +146,13 @@ jobs:
       - persist_to_workspace:
           root: build
           paths: ['*.aab'] # So they are made available for the "Create GitHub Release" job
-      # - slack/status:
-      #     include_job_number_field: false
-      #     include_project_field: false
-      #     include_visit_job_action: false
-      #     webhook: '${SLACK_BUILD_WEBHOOK}'
-      #     failure_message: '${SLACK_FAILURE_MESSAGE}'
-      #     success_message: '${SLACK_SUCCESS_MESSAGE}'
+      - slack/status:
+          include_job_number_field: false
+          include_project_field: false
+          include_visit_job_action: false
+          webhook: '${SLACK_BUILD_WEBHOOK}'
+          failure_message: '${SLACK_FAILURE_MESSAGE}'
+          success_message: '${SLACK_SUCCESS_MESSAGE}'
   Create GitHub Release:
     executor:
       name: android/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,8 @@ jobs:
           path: build
           destination: Artifacts
       - persist_to_workspace:
-          root: .
-          paths: ['build/*.aab'] # So they are made available for the "Create GitHub Release" job
+          root: build
+          paths: ['*.aab'] # So they are made available for the "Create GitHub Release" job
       - slack/status:
           include_job_number_field: false
           include_project_field: false
@@ -158,12 +158,12 @@ jobs:
       name: android/default
       api-version: "29"
     steps:
-      - attach_workspace:
-          at: .
       - git/shallow-checkout:
           init-submodules: false
       - bundle-install/bundle-install:
           cache_key_prefix: *release-build-cache-key
+      - attach_workspace:
+          at: build # Restore *.aab files built from "Release Build" jobs so we can attach them to the GitHub release
       - run:
           name: Create GitHub Release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
                 name: Build << parameters.app >> Zalpha
                 command: |
                   if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-                    bundle exec fastlane build_alpha app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:true
+                    bundle exec fastlane build_alpha app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:false
                   fi
                 no_output_timeout: 15m
       - unless:
@@ -134,9 +134,9 @@ jobs:
                 name: Build << parameters.app >> Vanilla
                 command: |
                   if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-                    bundle exec fastlane build_beta app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:true
+                    bundle exec fastlane build_beta app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:false
                   else
-                    bundle exec fastlane build_and_upload_release app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:true
+                    bundle exec fastlane build_and_upload_release app:<< parameters.app >> skip_confirm:true skip_prechecks:true upload_to_play_store:false
                   fi
                 no_output_timeout: 15m
       - android/save-gradle-cache
@@ -146,13 +146,13 @@ jobs:
       - persist_to_workspace:
           root: build
           paths: ['*.aab'] # So they are made available for the "Create GitHub Release" job
-      - slack/status:
-          include_job_number_field: false
-          include_project_field: false
-          include_visit_job_action: false
-          webhook: '${SLACK_BUILD_WEBHOOK}'
-          failure_message: '${SLACK_FAILURE_MESSAGE}'
-          success_message: '${SLACK_SUCCESS_MESSAGE}'
+      # - slack/status:
+      #     include_job_number_field: false
+      #     include_project_field: false
+      #     include_visit_job_action: false
+      #     webhook: '${SLACK_BUILD_WEBHOOK}'
+      #     failure_message: '${SLACK_FAILURE_MESSAGE}'
+      #     success_message: '${SLACK_SUCCESS_MESSAGE}'
   Create GitHub Release:
     executor:
       name: android/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
           init-submodules: true
       - checkout-submodules
       - bundle-install/bundle-install:
-          cache_key_prefix: release-build-v2
+          cache_key_prefix: &release-build-cache-key release-build-v2
       - run:
           name: Copy Secrets
           command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane run configure_apply
@@ -145,7 +145,7 @@ jobs:
           destination: Artifacts
       - persist_to_workspace:
           root: .
-          paths: ['build/*.aab', 'WordPress/*metadata/release_notes.txt']
+          paths: ['build/*.aab'] # So they are made available for the "Create GitHub Release" job
       - slack/status:
           include_job_number_field: false
           include_project_field: false
@@ -160,6 +160,10 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - git/shallow-checkout:
+          init-submodules: false
+      - bundle-install/bundle-install:
+          cache_key_prefix: *release-build-cache-key
       - run:
           name: Create GitHub Release
           command: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -941,6 +941,59 @@ REPOSITORY_NAME="WordPress-Android"
   end
 
   #####################################################################################
+  # create_gh_release
+  # -----------------------------------------------------------------------------------
+  # This lane creates a GitHub release for the current version
+  #   - attaching the existing .aab files in `build/` as the release assets
+  #   - using the WP & JP release_notes.txt as description
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane create_gh_release [app:<wordpress|jetpack>] [version:<Hash{name,code}>] [prerelease:true]
+  #
+  # Examples:
+  # bundle exec fastlane create_gh_release prerelease:true  # Includes existing assets for WPAlpha+WPBeta+JPBeta
+  # bundle exec fastlane create_gh_release app:wordpress prerelease:true # Includes existing assets for WPAlpha+WPBeta
+  # bundle exec fastlane create_gh_release version:{name:12.3-rc-4} prerelease:true # Includes existing assets for WPAlpha+WPBeta+JPBeta 12.3-rc-4
+  # bundle exec fastlane create_gh_release app:jetpack version:{name:12.3-rc-4} prerelease:true # Includes only existing asset for JPBeta 12.3-rc-4
+  #####################################################################################
+  lane :create_gh_release do |options|
+    set_prerelease_flag = options[:prerelease].nil? ? false : options[:prerelease]
+
+    apps = options[:app].nil? ? ['wordpress', 'jetpack'] : [options[:app]]
+    versions = options[:version].nil? ? [android_get_alpha_version(app: 'wp_jp'), android_get_release_version(app: 'wp_jp')] : [options[:version]]
+
+    release_assets = apps.flat_map do |app|
+      versions.flat_map { |vers| bundle_file_path(app, vers) }
+    end.select { |f| File.exist?(f) }
+
+    release_title = versions.last['name']
+
+    UI.message("Creating release for #{release_title} with the following assets: #{release_assets.inspect}")
+
+    require 'tempfile'
+    Tempfile.create('unified-release-notes') do |tmp_file|
+      app_titles = { 'wordpress' => 'WordPress', 'jetpack' => 'Jetpack' }
+      unified_notes = apps.map do |app|
+        notes = File.read(release_notes_path(app))
+        "\#\# #{app_titles[app]}\n\n#{notes}"
+      end.join("\n\n")
+      tmp_file.write(unified_notes)
+
+      create_release(
+        repository: GHHELPER_REPO,
+        version: release_title,
+        release_notes_file_path: tmp_file.path,
+        prerelease: set_prerelease_flag,
+        release_assets: release_assets.join(',')
+      )
+    end
+  end
+
+#####################################################################################
+# Private lanes
+#####################################################################################
+
+  #####################################################################################
   # trigger_ci
   # -----------------------------------------------------------------------------------
   # This lane triggers a CircleCI build on demand, with custom parameters
@@ -983,37 +1036,12 @@ REPOSITORY_NAME="WordPress-Android"
     end
   end
 
-#####################################################################################
-# Private lanes
-#####################################################################################
   private_lane :delete_old_changelogs do |options|
     app = options[:app] || 'wordpress'
     app_values = APP_SPECIFIC_VALUES[app.to_sym]
     Dir.glob(File.join(app_values[:metadata_dir], 'android', '*', 'changelogs', '*')).each do |file|
       File.delete(file) if Integer(File.basename(file, ".*")) < Integer(options[:build]) rescue puts "Cannot delete file #{file}"
     end
-  end
-
-  private_lane :create_gh_release do | options |
-    set_prerelease_flag = options[:prerelease].nil? ? false : options[:prerelease]
-    version = options[:version]
-
-    if version.nil?
-      UI.message("Ignoring request to create GH version since version specified is nil")
-      next
-    end
-
-    apk_file_path = universal_apk_file_path(options[:app], version)
-    aab_file_path = bundle_file_path(options[:app], version)
-    # APKs built on CI are unsigned, so don't upload them until we have a fix
-    release_assets = [aab_file_path]
-    release_assets.append(apk_file_path) unless is_ci
-    create_release(repository:GHHELPER_REPO,
-      version: version["name"],
-      release_notes_file_path: release_notes_path(options[:app]),
-      prerelease: set_prerelease_flag,
-      release_assets: release_assets.join(',')
-    )
   end
 
   private_lane :cleanup_release_files do | options |
@@ -1046,20 +1074,9 @@ REPOSITORY_NAME="WordPress-Android"
     ]
   end
 
-  def universal_apk_name(app, version)
-    basenames = { wordpress: 'wpandroid', jetpack: 'jpandroid' }
-    basename = basenames[app.to_sym] || basenames[:wordpress]
-    "#{basename}-#{version["name"]}-universal.apk"
-  end
-
   def bundle_file_path(app, version)
     prefix = app.downcase == "jetpack" ? JP_PREFIX : WP_PREFIX
     project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
-    File.join(project_root, "build", "#{prefix}-#{ version["name"] }.aab")
-  end
-
-  def universal_apk_file_path(app, version)
-    project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
-    File.join(project_root, "build", universal_apk_name(app, version))
+    File.join(project_root, "build", "#{prefix}-#{version["name"]}.aab")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -970,23 +970,23 @@ REPOSITORY_NAME="WordPress-Android"
 
     UI.message("Creating release for #{release_title} with the following assets: #{release_assets.inspect}")
 
-    require 'tempfile'
-    Tempfile.create('unified-release-notes') do |tmp_file|
-      app_titles = { 'wordpress' => 'WordPress', 'jetpack' => 'Jetpack' }
-      unified_notes = apps.map do |app|
-        notes = File.read(release_notes_path(app))
-        "\#\# #{app_titles[app]}\n\n#{notes}"
-      end.join("\n\n")
-      tmp_file.write(unified_notes)
+    app_titles = { 'wordpress' => 'WordPress', 'jetpack' => 'Jetpack' }
+    tmp_file_file = File.absolute_path('unified-release-notes.txt')
+    unified_notes = apps.map do |app|
+      notes = File.read(release_notes_path(app))
+      "\#\# #{app_titles[app]}\n\n#{notes}"
+    end.join("\n\n")
+    File.write(tmp_file_file, unified_notes)
 
-      create_release(
-        repository: GHHELPER_REPO,
-        version: release_title,
-        release_notes_file_path: tmp_file.path,
-        prerelease: set_prerelease_flag,
-        release_assets: release_assets.join(',')
-      )
-    end
+    create_release(
+      repository: GHHELPER_REPO,
+      version: release_title,
+      release_notes_file_path: tmp_file_file,
+      prerelease: set_prerelease_flag,
+      release_assets: release_assets.join(',')
+    )
+
+    FileUtils.rm(tmp_file_file)
   end
 
 #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -417,13 +417,13 @@ REPOSITORY_NAME="WordPress-Android"
   # This lane builds the final release of the app and uploads it
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>] [skip_prechecks:<skip prechecks>] [create_release:<Create release on GH> ]
+  # bundle exec fastlane build_and_upload_release app:<wordpress|jetpack> [skip_confirm:<skip confirm>] [skip_prechecks:<skip prechecks>] [create_release:<Create release on GH> ]
   #
   # Example:
-  # bundle exec fastlane build_and_upload_release
-  # bundle exec fastlane build_and_upload_release skip_confirm:true
-  # bundle exec fastlane build_and_upload_release skip_prechecks:true
-  # bundle exec fastlane build_and_upload_release create_release:true
+  # bundle exec fastlane build_and_upload_release app:wordpress
+  # bundle exec fastlane build_and_upload_release app:wordpress skip_confirm:true
+  # bundle exec fastlane build_and_upload_release app:jetpack skip_prechecks:true
+  # bundle exec fastlane build_and_upload_release app:wordpress create_release:true
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_and_upload_release do |options|
@@ -445,7 +445,7 @@ REPOSITORY_NAME="WordPress-Android"
     upload_build_to_play_store(version: version, track: "production", app: app)
 
     if (options[:create_release])
-      create_gh_release(version: version, app: app)
+      create_gh_release(app: app, version: version)
     end
   end
 
@@ -483,12 +483,12 @@ REPOSITORY_NAME="WordPress-Android"
   # This lane builds the app it for internal testing and optionally uploads it
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_alpha [skip_confirm:<skip confirm>] [upload_to_play_store:<upload to play store>] [create_release:<Create release on GH> ]
+  # bundle exec fastlane build_alpha app:<wordpress|jetpack> [skip_confirm:<true|false>] [upload_to_play_store:<true|false>] [create_release:<true|false>]
   #
   # Example:
-  # bundle exec fastlane build_alpha
-  # bundle exec fastlane build_alpha skip_confirm:true upload_to_play_store:true
-  # bundle exec fastlane build_alpha create_release:true
+  # bundle exec fastlane build_alpha app:wordpress create_release:true
+  # bundle exec fastlane build_alpha app:wordpress skip_confirm:true upload_to_play_store:true
+  # bundle exec fastlane build_alpha app:jetpack
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_alpha do |options|
@@ -506,7 +506,7 @@ REPOSITORY_NAME="WordPress-Android"
     end
 
     if (options[:create_release])
-      create_gh_release(version: version, prerelease: true, app: app)
+      create_gh_release(app: app, version: version, prerelease: true)
     end
   end
 
@@ -516,12 +516,12 @@ REPOSITORY_NAME="WordPress-Android"
   # This lane builds the app it for internal testing and optionally uploads it
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_beta [skip_confirm:<skip confirm>] [upload_to_play_store:<upload to play store>] [create_release:<Create release on GH> ]
+  # bundle exec fastlane build_beta app:<wordpress|jetpack> [skip_confirm:<true|false>] [upload_to_play_store:<true|false>] [create_release:<true|false>]
   #
   # Example:
-  # bundle exec fastlane build_beta
-  # bundle exec fastlane build_beta skip_confirm:true upload_to_play_store:true
-  # bundle exec fastlane build_beta create_release:true
+  # bundle exec fastlane build_beta app:wordpress create_release:true
+  # bundle exec fastlane build_beta app:wordpress skip_confirm:true upload_to_play_store:true
+  # bundle exec fastlane build_beta app:jetpack create_release:true
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_beta do |options|
@@ -539,7 +539,7 @@ REPOSITORY_NAME="WordPress-Android"
     end
 
     if (options[:create_release])
-      create_gh_release(version: version, prerelease: true, app: app)
+      create_gh_release(app: app, version: version, prerelease: true)
     end
   end
 
@@ -549,12 +549,12 @@ REPOSITORY_NAME="WordPress-Android"
   # This lane builds the app for restricted internal testing, and optionally uploads it to PlayStore's Internal track
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_internal [app:<name of app>] [skip_confirm:<skip confirm>] [upload_to_play_store:<upload to play store>] [create_release:<Create release on GH> ]
+  # bundle exec fastlane build_internal app:<wordpress|jetpack>] [skip_confirm:<true|false>] [upload_to_play_store:<true|false>] [create_release:<true|false>]
   #
   # Example:
-  # bundle exec fastlane build_internal
-  # bundle exec fastlane build_internal skip_confirm:true upload_to_play_store:true
-  # bundle exec fastlane build_internal create_release:true
+  # bundle exec fastlane build_internal app:wordpress
+  # bundle exec fastlane build_internal app:wordpress skip_confirm:true upload_to_play_store:true
+  # bundle exec fastlane build_internal app:jetpack create_release:true
   #####################################################################################
   desc "Builds and updates for internal testing"
   lane :build_internal do |options|
@@ -572,7 +572,7 @@ REPOSITORY_NAME="WordPress-Android"
     end
 
     if (options[:create_release])
-      create_gh_release(version: version, prerelease: true, app: app)
+      create_gh_release(app: app, version: version, prerelease: true)
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -954,7 +954,7 @@ REPOSITORY_NAME="WordPress-Android"
   # Examples:
   # bundle exec fastlane create_gh_release     # Guesses prerelease status based on version name. Includes existing assets for WPAlpha+WPBeta+JPBeta
   # bundle exec fastlane create_gh_release app:wordpress prerelease:true                        # Includes existing assets for WPAlpha+WPBeta
-  # bundle exec fastlane create_gh_release version:{name:12.3-rc-4} prerelease:true             # Includes existing assets for WPAlpha+WPBeta+JPBeta 12.3-rc-4
+  # bundle exec fastlane create_gh_release version:{name:12.3-rc-4} prerelease:true             # Includes existing assets for WPBeta+JPBeta 12.3-rc-4
   # bundle exec fastlane create_gh_release app:jetpack version:{name:12.3-rc-4} prerelease:true # Includes only existing asset for JPBeta 12.3-rc-4
   #####################################################################################
   lane :create_gh_release do |options|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -993,49 +993,6 @@ REPOSITORY_NAME="WordPress-Android"
 # Private lanes
 #####################################################################################
 
-  #####################################################################################
-  # trigger_ci
-  # -----------------------------------------------------------------------------------
-  # This lane triggers a CircleCI build on demand, with custom parameters
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  #   trigger_ci(
-  #     [token:<circleci_token>,]
-  #     [fork:<github_fork_name>,]
-  #     [branch:<git branch>,]
-  #     [parameters:<CircleCI pipeline parameters>]
-  #   )
-  # -----------------------------------------------------------------------------------
-  # Notes:
-  #   - The CircleCI token can be passed via the CIRCLECI_TOKEN env var instead of as a parameter to the lane call
-  #   - The fork parameter allows us to trigger a build on a fork of WPAndroid instead of the default repo on `wordpress-mobile` org.
-  #####################################################################################
-  desc "Trigger a CircleCI Build"
-  private_lane :trigger_ci do |options|
-    token = options[:token] || ENV['CIRCLECI_TOKEN']
-    UI.user_error!("You need to provide a CircleCI token either via the token: option or CIRCLECI_TOKEN env var") if token.nil?
-
-    require 'net/http'
-    require 'uri'
-    require 'json'
-
-    fork = options[:fork] || 'wordpress-mobile'
-    uri = URI.parse("https://circleci.com/api/v2/project/github/#{fork}/WordPress-Android/pipeline")
-    headers = {
-      'Content-Type' => 'application/json',
-      'Accept' => 'application/json',
-      "Circle-Token" => token
-    }
-
-    Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
-      request = Net::HTTP::Post.new(uri.request_uri, headers)
-      body = { "branch": options[:branch], "parameters": options[:parameters] }
-      request.body = body.to_json
-      response = http.request(request)
-      UI.message(response.body)
-    end
-  end
-
   private_lane :delete_old_changelogs do |options|
     app = options[:app] || 'wordpress'
     app_values = APP_SPECIFIC_VALUES[app.to_sym]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -946,7 +946,7 @@ REPOSITORY_NAME="WordPress-Android"
   # This lane creates a GitHub release for the current version
   #   - Attaching the existing .aab files in `build/` as the release assets
   #   - Using the WP & JP release_notes.txt as description
-  #   - If prerelease:<true|false> is not provided, the pre-release status will be guessed from the version name
+  #   - If `prerelease:<true|false>`` is not provided, the pre-release status will be inferred from the version name
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane create_gh_release [app:<wordpress|jetpack>] [version:<Hash{name,code}>] [prerelease:<true|false>]
@@ -971,22 +971,22 @@ REPOSITORY_NAME="WordPress-Android"
     UI.message("Creating release for #{release_title} with the following assets: #{release_assets.inspect}")
 
     app_titles = { 'wordpress' => 'WordPress', 'jetpack' => 'Jetpack' }
-    tmp_file_file = File.absolute_path('unified-release-notes.txt')
+    tmp_file = File.absolute_path('unified-release-notes.txt')
     unified_notes = apps.map do |app|
       notes = File.read(release_notes_path(app))
       "\#\# #{app_titles[app]}\n\n#{notes}"
     end.join("\n\n")
-    File.write(tmp_file_file, unified_notes)
+    File.write(tmp_file, unified_notes)
 
     create_release(
       repository: GHHELPER_REPO,
       version: release_title,
-      release_notes_file_path: tmp_file_file,
+      release_notes_file_path: tmp_file,
       prerelease: set_prerelease_flag,
       release_assets: release_assets.join(',')
     )
 
-    FileUtils.rm(tmp_file_file)
+    FileUtils.rm(tmp_file)
   end
 
 #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -944,21 +944,20 @@ REPOSITORY_NAME="WordPress-Android"
   # create_gh_release
   # -----------------------------------------------------------------------------------
   # This lane creates a GitHub release for the current version
-  #   - attaching the existing .aab files in `build/` as the release assets
-  #   - using the WP & JP release_notes.txt as description
+  #   - Attaching the existing .aab files in `build/` as the release assets
+  #   - Using the WP & JP release_notes.txt as description
+  #   - If prerelease:<true|false> is not provided, the pre-release status will be guessed from the version name
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane create_gh_release [app:<wordpress|jetpack>] [version:<Hash{name,code}>] [prerelease:true]
+  # bundle exec fastlane create_gh_release [app:<wordpress|jetpack>] [version:<Hash{name,code}>] [prerelease:<true|false>]
   #
   # Examples:
-  # bundle exec fastlane create_gh_release prerelease:true  # Includes existing assets for WPAlpha+WPBeta+JPBeta
-  # bundle exec fastlane create_gh_release app:wordpress prerelease:true # Includes existing assets for WPAlpha+WPBeta
-  # bundle exec fastlane create_gh_release version:{name:12.3-rc-4} prerelease:true # Includes existing assets for WPAlpha+WPBeta+JPBeta 12.3-rc-4
+  # bundle exec fastlane create_gh_release     # Guesses prerelease status based on version name. Includes existing assets for WPAlpha+WPBeta+JPBeta
+  # bundle exec fastlane create_gh_release app:wordpress prerelease:true                        # Includes existing assets for WPAlpha+WPBeta
+  # bundle exec fastlane create_gh_release version:{name:12.3-rc-4} prerelease:true             # Includes existing assets for WPAlpha+WPBeta+JPBeta 12.3-rc-4
   # bundle exec fastlane create_gh_release app:jetpack version:{name:12.3-rc-4} prerelease:true # Includes only existing asset for JPBeta 12.3-rc-4
   #####################################################################################
   lane :create_gh_release do |options|
-    set_prerelease_flag = options[:prerelease].nil? ? false : options[:prerelease]
-
     apps = options[:app].nil? ? ['wordpress', 'jetpack'] : [options[:app]]
     versions = options[:version].nil? ? [android_get_alpha_version(app: 'wp_jp'), android_get_release_version(app: 'wp_jp')] : [options[:version]]
 
@@ -967,6 +966,7 @@ REPOSITORY_NAME="WordPress-Android"
     end.select { |f| File.exist?(f) }
 
     release_title = versions.last['name']
+    set_prerelease_flag = options[:prerelease].nil? ? /-rc-|alpha-/.match?(release_title) : options[:prerelease]
 
     UI.message("Creating release for #{release_title} with the following assets: #{release_assets.inspect}")
 

--- a/version.properties
+++ b/version.properties
@@ -1,9 +1,9 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=18.2-rc-3
+versionName=18.2-rc-999
 versionCode=1108
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
-alpha.versionName=alpha-319
+alpha.versionName=alpha-999
 alpha.versionCode=1109

--- a/version.properties
+++ b/version.properties
@@ -1,9 +1,9 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=18.2-rc-999
+versionName=18.2-rc-3
 versionCode=1108
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
-alpha.versionName=alpha-999
+alpha.versionName=alpha-319
 alpha.versionCode=1109


### PR DESCRIPTION
This is part of project paaHJt-2s9-p2

ℹ️  This PR targets `release/18.2` in the hope I get the occasion to use it in this release in case it's merged in time.

## What it does

Now that https://github.com/wordpress-mobile/WordPress-Android/pull/15273 has been merged and the 3 Release Builds (WP Alpha, WP Beta, JP Beta) are done in parallel, this PR is now able to **create a single GitHub Release for all 3 builds**, instead of creating one GitHub Release for each like before.

## How

 - Refactor the `create_gh_release` lane to be able to include multiple assets for multiple apps and versions at once, merging release notes as necessary into one description.
 - Update the YARD doc of `build_*` lanes to mention the `app:` parameters and update their call to `create_gh_release`
 - Update the `.circleci/config.yml` file to call `create_gh_release` with the 3 build artifacts only created once the 3 parallel builds have finished.

## To Test

* Run `git checkout -b ci-test/pr15319 origin/jetpack-infra/unified-gh-release^1` to cut a new branch from the commit **before the tip of this one**.
  * This will include the debug commit 1e5c7795f269cb7e340bb9405dadd11839d59b4f – which changes the `versionName` to a dummy `18.2-rc-999`, and disables `upload_to_playstore:true` and the `slack` action – but not include the last commit of this branch which reverts those debug changes.
   * This is done to avoid noise during testing, but also to ensure the test GitHub Release gets a new name (instead of being auto-matched with existing tag `18.2-rc-3`), and so that the builds won't fail with "versionCode already exists in PlayStore"
* Push your new test branch to origin: `git push -u origin ci-test/pr15319`
* Trigger a release build: `bundle exec fastlane trigger_release_build branch_to_build:ci-test/pr15319`
* Wait for the CI workflow to finish, then check that a single, unified [GitHub Release](https://github.com/wordpress-mobile/WordPress-Android/releases) draft has been created.

The generated GitHub Release draft should:
 - Point to the commit sha1 of your `ci-test/pr15319` branch, which should be `1e5c7795f269cb7e340bb9405dadd11839d59b4f`
 - Be titled `"18.2-rc-999"`
 - Contain BOTH the WordPress and Jetpack release notes or 18.2 – as found in `WordPress/{metadata,jetpack_metadata}/release_notes.txt` files
 - Contain the 3 `.aab` artefacts (WP Alpha, WP Beta, JP Beta)
 - Be marked as "This is a pre-release"

<details><summary>Screenshot of the expected GitHub Release draft</summary>
<img src="https://user-images.githubusercontent.com/216089/133105573-30b7ed96-95c1-44e3-ac90-c1683277f862.png" />
</details>

#### Cleanup

* Delete your `ci-test/pr15319` branch from origin.
* Delete the draft GitHub Release named `18.2-rc-999`.
