### PR TITLE
Remove media file extension from the media file title

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -122,6 +122,12 @@ public class FluxCUtils {
             }
         }
 
+        String title = filename;
+        // Remove extension from title
+        if (fileExtension != null && title.contains("." + fileExtension)) {
+            title = title.substring(0, title.lastIndexOf(fileExtension) - 1);
+        }
+
         // If file extension is null, upload won't work on wordpress.com
         if (fileExtension == null) {
             fileExtension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
@@ -129,7 +135,7 @@ public class FluxCUtils {
         }
 
         media.setFileName(filename);
-        media.setTitle(filename);
+        media.setTitle(title);
         media.setFilePath(path);
         media.setLocalSiteId(localSiteId);
         media.setFileExtension(fileExtension);

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -109,6 +109,7 @@ public class FluxCUtils {
 
         MediaModel media = mediaStore.instantiateMediaModel();
         String filename = org.wordpress.android.fluxc.utils.MediaUtils.getFileName(path);
+        if (filename == null) filename = "";
         String fileExtension = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(path);
 
         if (TextUtils.isEmpty(mimeType)) {


### PR DESCRIPTION
Fixes #15108 

This PR removes file extension from the local media title before upoad. 

To test:

1. Go to "My Site" tab
2. Click "Media" from "Quick Links"
3. Click + button on the media grid screen
4. Click "Take photo" from the menu
5. Wait for the upload to complete
6. Click the newly uploaded photo
7. Notice that the photo title does not contain a file extension
8. Repeat above steps for "Choose from device" and "Take video" menu options 
9. Notice that the media title still does not contain a file extension

## Regression Notes
1. Potential unintended areas of impact
Minimal changes are applied to just update the title,  should not affect the rest of the code.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
See above

3. What automated tests I added (or what prevented me from doing so)
None. `FluxCUtils` is a legacy class accessing static methods from classes like `MediaUtils`, `TextUtils`, `UrlUtils` and refactoring it to support tests is currently out of scope of this PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
