### PR TITLE
Quick Start - Grow List: Fix Text wrapping

### DIFF
--- a/WordPress/src/main/res/layout/quick_start_list_item.xml
+++ b/WordPress/src/main/res/layout/quick_start_list_item.xml
@@ -30,7 +30,6 @@
         style="@style/QuickStartSubtitle"
         android:layout_below="@+id/title"
         android:layout_toEndOf="@+id/icon"
-        app:fixWidowWords="true"
         tools:text="@string/quick_start_list_create_site_subtitle" />
 
     <View


### PR DESCRIPTION
Fixes #15182

This PR allows [widow words](https://www.proofreadingacademy.com/advice/editing-tips-widows-and-orphans-explained/) or the "dangling one word" for quick start subtitles to fix visually off text-wrapping.

To test:

1. Create a new site.
2. Choose "Show me around" on the Quick Start prompt.
3. Tap "Grow your audience" to open the list of tasks.
4. Compare the subtext under "Check your stats" 

Before | After
-------|------
![widow-word-fix](https://user-images.githubusercontent.com/1405144/133390041-5ad03bc8-3001-439c-ba8b-e327eee24a78.png) | ![widow-word-fix-removed](https://user-images.githubusercontent.com/1405144/133390154-7120dde2-0a65-413b-8357-5329dd2cbc2b.png)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
