### PR TITLE
Update My Site menu wording

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [**] Media: Fix Atomic sites video not playing issue. (https://github.com/wordpress-mobile/WordPress-Android/pull/15285)
 * [*] Block editor: Fixes bug preventing button block gradient background from being updated in the editor [https://github.com/wordpress-mobile/WordPress-Android/pull/15312]
+* [*] Updated the wording for the "Posts" and "Pages" entries in My Site screen [https://github.com/wordpress-mobile/WordPress-Android/pull/15327]
 
 18.2
 -----

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2140,7 +2140,7 @@
     <string name="my_site_header_jetpack">Jetpack</string>
     <string name="my_site_header_publish">Publish</string>
     <string name="my_site_btn_jetpack_settings">Jetpack Settings</string>
-    <string name="my_site_btn_site_pages">Site Pages</string>
+    <string name="my_site_btn_site_pages">Pages</string>
     <string name="my_site_btn_blog_posts">Posts</string>
     <string name="my_site_btn_sharing">Sharing</string>
     <string name="my_site_btn_domains">Domains</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2141,7 +2141,7 @@
     <string name="my_site_header_publish">Publish</string>
     <string name="my_site_btn_jetpack_settings">Jetpack Settings</string>
     <string name="my_site_btn_site_pages">Site Pages</string>
-    <string name="my_site_btn_blog_posts">Blog Posts</string>
+    <string name="my_site_btn_blog_posts">Posts</string>
     <string name="my_site_btn_sharing">Sharing</string>
     <string name="my_site_btn_domains">Domains</string>
     <string name="my_site_btn_site_settings">Site Settings</string>


### PR DESCRIPTION
Fixes #14570
Equivalent PR in WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/17156

## What this does

This PR is part of HACK week item p7cLQ7-1H5-p2#comment-3181.

 - Updates the "Blog Posts" to "Posts" in the "My Site" screen – as well as in the related screens pushed on tap of those items, for consistency
 - Updates the "Site Pages" to "Pages" in that same screen, for consistency – even if that wasn't part of the original issue and request; I took the liberty to update that too as I felt it made sense, but **we might want @eduardozulian's confirmation about this one** first (see p7cLQ7-1H5-p2#comment-3248)

## Screenshots

<details><summary>🖼 "My Site" Screen</summary>
<table><tr><th>Before</th><th>After</th></tr><tr>
<td><img alt="15327-MySite-Before" src="https://user-images.githubusercontent.com/216089/133419743-40fe36ea-7759-479e-b55d-2713a1a71413.png" /></td>
<td><img alt="15327-MySite-After" src="https://user-images.githubusercontent.com/216089/133419210-a757f38a-af0c-4145-97e4-fc8c269a2bfa.png" /></td>
</tr></table></details>

<details><summary>🖼 "Posts" Screen</summary>
<table><tr><th>Before</th><th>After</th></tr><tr>
<td><img alt="15327-Posts-Before" src="https://user-images.githubusercontent.com/216089/133419809-a86bf833-9637-4183-b41d-3220acdde852.png" /></td>
<td><img alt="15327-Posts-After" src="https://user-images.githubusercontent.com/216089/133419260-ced1b6df-503e-437d-b187-2220ad97d408.png" /></td>
</tr></table></details>

<details><summary>🖼 "Pages" Screen</summary>
<table><tr><th>Before</th><th>After</th></tr><tr>
<td><img alt="15327-Pages-Before" src="https://user-images.githubusercontent.com/216089/133419852-1584f9c6-7b0f-4bee-b5e6-ae0b2adb3e03.png" /></td>
<td><img alt="15327-Pages-After" src="https://user-images.githubusercontent.com/216089/133419320-74eba429-77e1-4be8-9f3c-2e5e435f7f10.png" /></td>
</tr></table></details>

## To Test

1. Open the app
2. Tap on My Site
3. Check the titles in the menu are "Posts" and "Pages" (not "Blog Posts" nor "Site Pages")
4. Tap on "Posts" and check the title of the screen matches.
5. Go back to "My Sites", then Tap on "Pages" and check the title of the screen matches.

_Note: Unlike for the [corresponding iOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/17156), there's no real need to test the Quick Tour feature for this diff, because on WPAndroid this step of the tour highlights the round "Pages" button in "Quick Links" section – which was already named just "Pages" (as opposed to the iOS app which highlights the "Pages" row whose copy was changed in the menu/list)_

## Regression Notes

#### 1. Potential unintended areas of impact

_None_

#### 2. What I did to test those areas of impact (or what existing automated tests I relied on)

_None_

####  3. What automated tests I added (or what prevented me from doing so)

I've run the UI tests and ensured that change in wording didn't break them.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.