### PR TITLE
Use single string with placeholder for likes string localisation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/TrainOfFacesItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/TrainOfFacesItem.kt
@@ -4,7 +4,7 @@ import androidx.annotation.DimenRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.reader.adapters.TrainOfFacesViewType.BLOGGERS_LIKING_TEXT
 import org.wordpress.android.ui.reader.adapters.TrainOfFacesViewType.FACE
-import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
 
 @DimenRes const val FACE_ITEM_LEFT_OFFSET_DIMEN = R.dimen.margin_small_medium
 @DimenRes const val FACE_ITEM_AVATAR_SIZE_DIMEN = R.dimen.avatar_sz_small
@@ -12,7 +12,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 sealed class TrainOfFacesItem(val type: TrainOfFacesViewType) {
     data class FaceItem(val userId: Long, val userAvatarUrl: String) : TrainOfFacesItem(FACE)
     data class BloggersLikingTextItem(
-        val textWithParams: UiStringResWithParams
+        val text: UiStringText
     ) : TrainOfFacesItem(BLOGGERS_LIKING_TEXT)
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/TrainOfFacesItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/TrainOfFacesItem.kt
@@ -4,7 +4,6 @@ import androidx.annotation.DimenRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.reader.adapters.TrainOfFacesViewType.BLOGGERS_LIKING_TEXT
 import org.wordpress.android.ui.reader.adapters.TrainOfFacesViewType.FACE
-import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 
 @DimenRes const val FACE_ITEM_LEFT_OFFSET_DIMEN = R.dimen.margin_small_medium
@@ -13,8 +12,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 sealed class TrainOfFacesItem(val type: TrainOfFacesViewType) {
     data class FaceItem(val userId: Long, val userAvatarUrl: String) : TrainOfFacesItem(FACE)
     data class BloggersLikingTextItem(
-        val textWithParams: UiStringResWithParams,
-        val underlineDelimiterClosure: UiStringRes
+        val textWithParams: UiStringResWithParams
     ) : TrainOfFacesItem(BLOGGERS_LIKING_TEXT)
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/BloggingLikersTextViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/BloggingLikersTextViewHolder.kt
@@ -1,10 +1,5 @@
 package org.wordpress.android.ui.reader.viewholders
 
-import android.content.Context
-import android.text.Spannable
-import android.text.SpannableString
-import android.text.TextPaint
-import android.text.style.UnderlineSpan
 import android.view.ViewGroup
 import org.wordpress.android.R
 import org.wordpress.android.databinding.BloggerLikersTextItemBinding
@@ -13,7 +8,6 @@ import org.wordpress.android.ui.reader.adapters.FACE_ITEM_LEFT_OFFSET_DIMEN
 import org.wordpress.android.ui.reader.adapters.TrainOfFacesItem.BloggersLikingTextItem
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
-import org.wordpress.android.util.getColorFromAttribute
 import org.wordpress.android.util.viewBinding
 
 class BloggingLikersTextViewHolder(
@@ -34,36 +28,7 @@ class BloggingLikersTextViewHolder(
         }
 
         numBloggers.text = with(bloggersTextItem) {
-            val fullText = uiHelpers.getTextOfUiString(itemView.context, textWithParams)
-            formatWithSpan(itemView.context, fullText)
-        }
-    }
-
-    private fun formatWithSpan(context: Context, text: CharSequence): Spannable {
-        val fullText = StringBuffer(text).toString()
-        val start = fullText.indexOf("_")
-        val end = fullText.lastIndexOf("_") - 1
-        val fullTextSanitized = fullText.replace("_", "")
-
-        val underscoresFound = end >= 0 && start >= 0
-        val underscoresInString = start < end && end <= fullTextSanitized.length - 1
-
-        return if (underscoresFound && underscoresInString) {
-            SpannableString(fullTextSanitized).apply {
-                setSpan(
-                        object : UnderlineSpan() {
-                            override fun updateDrawState(ds: TextPaint) {
-                                ds.isUnderlineText = true
-                                ds.color = context.getColorFromAttribute(R.attr.colorPrimary)
-                            }
-                        },
-                        start,
-                        end,
-                        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-                )
-            }
-        } else {
-            SpannableString(fullTextSanitized)
+            uiHelpers.getTextOfUiString(itemView.context, text)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/BloggingLikersTextViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/BloggingLikersTextViewHolder.kt
@@ -45,9 +45,10 @@ class BloggingLikersTextViewHolder(
         val end = fullText.lastIndexOf("_") - 1
         val fullTextSanitized = fullText.replace("_", "")
 
-        return if (end < 0 || start < 0 || end <= start || end >= fullTextSanitized.length - 1) {
-            SpannableString(fullTextSanitized)
-        } else {
+        val underscoresFound = end >= 0 && start >= 0
+        val underscoresInString = start < end && end <= fullTextSanitized.length - 1
+
+        return if (underscoresFound && underscoresInString) {
             SpannableString(fullTextSanitized).apply {
                 setSpan(
                         object : UnderlineSpan() {
@@ -61,6 +62,8 @@ class BloggingLikersTextViewHolder(
                         Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
                 )
             }
+        } else {
+            SpannableString(fullTextSanitized)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/BloggingLikersTextViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/BloggingLikersTextViewHolder.kt
@@ -41,15 +41,11 @@ class BloggingLikersTextViewHolder(
 
     private fun formatWithSpan(context: Context, text: CharSequence): Spannable {
         val fullText = StringBuffer(text).toString()
-        val underlineEnd = fullText.lastIndexOf("_")
-
-        if (underlineEnd < 0) return SpannableString(fullText)
-
-        val closureString = fullText.substring(underlineEnd).replace("_", "")
+        val start = fullText.indexOf("_")
+        val end = fullText.lastIndexOf("_") - 1
         val fullTextSanitized = fullText.replace("_", "")
-        val start = 0
-        val end = fullTextSanitized.lastIndexOf(closureString)
-        return if (end <= start || end >= text.length - 1) {
+
+        return if (end < 0 || start < 0 || end <= start || end >= fullTextSanitized.length - 1) {
             SpannableString(fullTextSanitized)
         } else {
             SpannableString(fullTextSanitized).apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/BloggingLikersTextViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/BloggingLikersTextViewHolder.kt
@@ -35,20 +35,24 @@ class BloggingLikersTextViewHolder(
 
         numBloggers.text = with(bloggersTextItem) {
             val fullText = uiHelpers.getTextOfUiString(itemView.context, textWithParams)
-            val closure = uiHelpers.getTextOfUiString(itemView.context, underlineDelimiterClosure)
-            SpannableString(fullText).formatWithSpan(itemView.context, fullText, closure)
+            formatWithSpan(itemView.context, fullText)
         }
     }
 
-    private fun SpannableString.formatWithSpan(context: Context, text: CharSequence, closure: CharSequence): Spannable {
-        val textString = StringBuffer(text).toString()
-        val closureString = StringBuffer(closure).toString()
+    private fun formatWithSpan(context: Context, text: CharSequence): Spannable {
+        val fullText = StringBuffer(text).toString()
+        val underlineEnd = fullText.lastIndexOf("_")
+
+        if (underlineEnd < 0) return SpannableString(fullText)
+
+        val closureString = fullText.substring(underlineEnd).replace("_", "")
+        val fullTextSanitized = fullText.replace("_", "")
         val start = 0
-        val end = textString.lastIndexOf(closureString) - 1
+        val end = fullTextSanitized.lastIndexOf(closureString)
         return if (end <= start || end >= text.length - 1) {
-            this
+            SpannableString(fullTextSanitized)
         } else {
-            this.apply {
+            SpannableString(fullTextSanitized).apply {
                 setSpan(
                         object : UnderlineSpan() {
                             override fun updateDrawState(ds: TextPaint) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -615,31 +615,31 @@ class ReaderPostDetailViewModel @Inject constructor(
             }
             numLikes == 1 && iLiked -> {
                 BloggersLikingTextItem(
-                        UiStringResWithParams(R.string.like_faces_you_text, listOf())
+                        UiStringResWithParams(R.string.like_faces_you_like_text, listOf())
                 ).toList()
             }
             numLikes == 2 && iLiked -> {
                 BloggersLikingTextItem(
-                        UiStringResWithParams(R.string.like_faces_you_plus_one_text, listOf())
+                        UiStringResWithParams(R.string.like_faces_you_plus_one_like_text, listOf())
                 ).toList()
             }
             numLikes > 2 && iLiked -> {
                 BloggersLikingTextItem(
                         UiStringResWithParams(
-                                R.string.like_faces_plural_with_you_text,
+                                R.string.like_faces_you_plus_others_like_text,
                                 listOf(UiStringText((numLikes - 1).toString()))
                         )
                 ).toList()
             }
             numLikes == 1 && !iLiked -> {
                 BloggersLikingTextItem(
-                        UiStringResWithParams(R.string.like_faces_one_blogger_text, listOf())
+                        UiStringResWithParams(R.string.like_faces_one_blogger_likes_text, listOf())
                 ).toList()
             }
             numLikes > 1 && !iLiked -> {
                 BloggersLikingTextItem(
                         UiStringResWithParams(
-                                R.string.like_faces_more_bloggers_text,
+                                R.string.like_faces_others_like_text,
                                 listOf(UiStringText(numLikes.toString()))
                         )
                 ).toList()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -609,47 +609,39 @@ class ReaderPostDetailViewModel @Inject constructor(
     }
 
     private fun getLikersFacesText(showEmptyState: Boolean, numLikes: Int, iLiked: Boolean): List<TrainOfFacesItem> {
-        val likeThisResString = UiStringRes(R.string.like_this)
-        val likesThisResString = UiStringRes(R.string.likes_this)
-
         return when {
             showEmptyState -> {
                 listOf()
             }
             numLikes == 1 && iLiked -> {
                 BloggersLikingTextItem(
-                        UiStringResWithParams(R.string.like_faces_you_text, listOf(likeThisResString)),
-                        likeThisResString
+                        UiStringResWithParams(R.string.like_faces_you_text, listOf())
                 ).toList()
             }
             numLikes == 2 && iLiked -> {
                 BloggersLikingTextItem(
-                        UiStringResWithParams(R.string.like_faces_you_plus_one_text, listOf(likeThisResString)),
-                        likeThisResString
+                        UiStringResWithParams(R.string.like_faces_you_plus_one_text, listOf())
                 ).toList()
             }
             numLikes > 2 && iLiked -> {
                 BloggersLikingTextItem(
                         UiStringResWithParams(
                                 R.string.like_faces_plural_with_you_text,
-                                listOf(UiStringText((numLikes - 1).toString()), likeThisResString)
-                        ),
-                        likeThisResString
+                                listOf(UiStringText((numLikes - 1).toString()))
+                        )
                 ).toList()
             }
             numLikes == 1 && !iLiked -> {
                 BloggersLikingTextItem(
-                        UiStringResWithParams(R.string.like_faces_one_blogger_text, listOf(likesThisResString)),
-                        likesThisResString
+                        UiStringResWithParams(R.string.like_faces_one_blogger_text, listOf())
                 ).toList()
             }
             numLikes > 1 && !iLiked -> {
                 BloggersLikingTextItem(
                         UiStringResWithParams(
                                 R.string.like_faces_more_bloggers_text,
-                                listOf(UiStringText(numLikes.toString()), likeThisResString)
-                        ),
-                        likeThisResString
+                                listOf(UiStringText(numLikes.toString()))
+                        )
                 ).toList()
             }
             else -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -57,10 +57,10 @@ import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiSt
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.LoadingUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState
 import org.wordpress.android.ui.reader.views.uistates.ReaderPostDetailsHeaderViewUiState.ReaderPostDetailsHeaderUiState
+import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiDimen
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -93,7 +93,8 @@ class ReaderPostDetailViewModel @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val getLikesHandler: GetLikesHandler,
     private val likesEnhancementsFeatureConfig: LikesEnhancementsFeatureConfig,
-    private val engagementUtils: EngagementUtils
+    private val engagementUtils: EngagementUtils,
+    private val htmlMessageUtils: HtmlMessageUtils
 ) : ScopedViewModel(mainDispatcher) {
     private var getLikesJob: Job? = null
 
@@ -601,7 +602,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         items: List<TrainOfFacesItem>
     ) = if (goingToShowFaces) {
         when (val lastItem = items.lastOrNull()) {
-            is BloggersLikingTextItem -> lastItem.textWithParams
+            is BloggersLikingTextItem -> lastItem.text
             is FaceItem, null -> UiStringText("")
         }
     } else {
@@ -615,32 +616,46 @@ class ReaderPostDetailViewModel @Inject constructor(
             }
             numLikes == 1 && iLiked -> {
                 BloggersLikingTextItem(
-                        UiStringResWithParams(R.string.like_faces_you_like_text, listOf())
+                        UiStringText(
+                                htmlMessageUtils.getHtmlMessageFromStringFormatResId(R.string.like_faces_you_like_text)
+                        )
                 ).toList()
             }
             numLikes == 2 && iLiked -> {
                 BloggersLikingTextItem(
-                        UiStringResWithParams(R.string.like_faces_you_plus_one_like_text, listOf())
+                        UiStringText(
+                                htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                                        R.string.like_faces_you_plus_one_like_text
+                                )
+                        )
                 ).toList()
             }
             numLikes > 2 && iLiked -> {
                 BloggersLikingTextItem(
-                        UiStringResWithParams(
-                                R.string.like_faces_you_plus_others_like_text,
-                                listOf(UiStringText((numLikes - 1).toString()))
+                        UiStringText(
+                                htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                                        R.string.like_faces_you_plus_others_like_text,
+                                        numLikes - 1
+                                )
                         )
                 ).toList()
             }
             numLikes == 1 && !iLiked -> {
                 BloggersLikingTextItem(
-                        UiStringResWithParams(R.string.like_faces_one_blogger_likes_text, listOf())
+                        UiStringText(
+                                htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                                        R.string.like_faces_one_blogger_likes_text
+                                )
+                        )
                 ).toList()
             }
             numLikes > 1 && !iLiked -> {
                 BloggersLikingTextItem(
-                        UiStringResWithParams(
-                                R.string.like_faces_others_like_text,
-                                listOf(UiStringText(numLikes.toString()))
+                        UiStringText(
+                                htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                                        R.string.like_faces_others_like_text,
+                                        numLikes
+                                )
                         )
                 ).toList()
             }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1506,14 +1506,14 @@
     <string name="like_title_singular">1 Like</string>
     <string name="like_title_plural">%d Likes</string>
     <string name="like_faces_error_loading_message">Error loading like data. %s.</string>
-    <!-- Note for translators: the underscores in the like_faces_* strings below are used
-    to mark the end of underlined text; it is not displayed in final string but must be kept
+    <!-- Note for translators: the underscores in the strings below are used to mark the start
+    and the end of underlined text; it is not displayed in final string but must be kept
     there for coding purposes (code ref: BloggingLikersTextViewHolder.formatWithSpan function) -->
-    <string name="like_faces_you_like_text">You_ like this.</string>
-    <string name="like_faces_you_plus_one_like_text">You and 1 blogger_ like this.</string>
-    <string name="like_faces_you_plus_others_like_text">You and %1$s bloggers_ like this.</string>
-    <string name="like_faces_one_blogger_likes_text">1 blogger_ likes this.</string>
-    <string name="like_faces_others_like_text">%1$s bloggers_ like this.</string>
+    <string name="like_faces_you_like_text">_You_ like this.</string>
+    <string name="like_faces_you_plus_one_like_text">_You and 1 blogger_ like this.</string>
+    <string name="like_faces_you_plus_others_like_text">_You and %1$s bloggers_ like this.</string>
+    <string name="like_faces_one_blogger_likes_text">_1 blogger_ likes this.</string>
+    <string name="like_faces_others_like_text">_%1$s bloggers_ like this.</string>
 
     <!-- reader -->
     <string name="reader">Reader</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1506,14 +1506,14 @@
     <string name="like_title_singular">1 Like</string>
     <string name="like_title_plural">%d Likes</string>
     <string name="like_faces_error_loading_message">Error loading like data. %s.</string>
-    <!-- Note for translators: the underscores in the strings below are used to mark the start
-    and the end of underlined text; it is not displayed in final string but must be kept
-    there for coding purposes (code ref: BloggingLikersTextViewHolder.formatWithSpan function) -->
-    <string name="like_faces_you_like_text">_You_ like this.</string>
-    <string name="like_faces_you_plus_one_like_text">_You and 1 blogger_ like this.</string>
-    <string name="like_faces_you_plus_others_like_text">_You and %1$s bloggers_ like this.</string>
-    <string name="like_faces_one_blogger_likes_text">_1 blogger_ likes this.</string>
-    <string name="like_faces_others_like_text">_%1$s bloggers_ like this.</string>
+    <!-- Note for translators: the '&lt;a href=""&gt;' and '&lt;/a&gt;' must be kept without
+    translations/modifications and are used to enclose the portion of the text
+    that will be rendered as underlined. -->
+    <string name="like_faces_you_like_text">&lt;a href=""&gt;You&lt;/a&gt; like this.</string>
+    <string name="like_faces_you_plus_one_like_text">&lt;a href=""&gt;You and 1 blogger&lt;/a&gt; like this.</string>
+    <string name="like_faces_you_plus_others_like_text">&lt;a href=""&gt;You and %1$s bloggers&lt;/a&gt; like this.</string>
+    <string name="like_faces_one_blogger_likes_text">&lt;a href=""&gt;1 blogger&lt;/a&gt; likes this.</string>
+    <string name="like_faces_others_like_text">&lt;a href=""&gt;%1$s bloggers&lt;/a&gt; like this.</string>
 
     <!-- reader -->
     <string name="reader">Reader</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1505,15 +1505,15 @@
     <string name="get_likes_empty_state_title">An error occurred while getting likes data</string>
     <string name="like_title_singular">1 Like</string>
     <string name="like_title_plural">%d Likes</string>
+    <string name="like_faces_error_loading_message">Error loading like data. %s.</string>
     <!-- Note for translators: the underscores in the like_faces_* strings below are used
     to mark the end of underlined text; it is not displayed in final string but must be kept
     there for coding purposes (code ref: BloggingLikersTextViewHolder.formatWithSpan function) -->
-    <string name="like_faces_you_text">You_ like this.</string>
-    <string name="like_faces_you_plus_one_text">You and 1 blogger_ like this.</string>
-    <string name="like_faces_plural_with_you_text">You and %1$s bloggers_ like this.</string>
-    <string name="like_faces_one_blogger_text">1 blogger_ likes this.</string>
-    <string name="like_faces_more_bloggers_text">%1$s bloggers_ like this.</string>
-    <string name="like_faces_error_loading_message">Error loading like data. %s.</string>
+    <string name="like_faces_you_like_text">You_ like this.</string>
+    <string name="like_faces_you_plus_one_like_text">You and 1 blogger_ like this.</string>
+    <string name="like_faces_you_plus_others_like_text">You and %1$s bloggers_ like this.</string>
+    <string name="like_faces_one_blogger_likes_text">1 blogger_ likes this.</string>
+    <string name="like_faces_others_like_text">%1$s bloggers_ like this.</string>
 
     <!-- reader -->
     <string name="reader">Reader</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1505,13 +1505,14 @@
     <string name="get_likes_empty_state_title">An error occurred while getting likes data</string>
     <string name="like_title_singular">1 Like</string>
     <string name="like_title_plural">%d Likes</string>
-    <string name="like_this">like this</string>
-    <string name="likes_this">likes this</string>
-    <string name="like_faces_you_text">You %1$s.</string>
-    <string name="like_faces_you_plus_one_text">You and 1 blogger %1$s.</string>
-    <string name="like_faces_plural_with_you_text">You and %1$s bloggers %2$s.</string>
-    <string name="like_faces_one_blogger_text">1 blogger %1$s.</string>
-    <string name="like_faces_more_bloggers_text">%1$s bloggers %2$s.</string>
+    <!-- Note for translators: the underscores in the like_faces_* strings below are used
+    to mark the end of underlined text; it is not displayed in final string but must be kept
+    there for coding purposes (code ref: BloggingLikersTextViewHolder.formatWithSpan function) -->
+    <string name="like_faces_you_text">You_ like this.</string>
+    <string name="like_faces_you_plus_one_text">You and 1 blogger_ like this.</string>
+    <string name="like_faces_plural_with_you_text">You and %1$s bloggers_ like this.</string>
+    <string name="like_faces_one_blogger_text">1 blogger_ likes this.</string>
+    <string name="like_faces_more_bloggers_text">%1$s bloggers_ like this.</string>
     <string name="like_faces_error_loading_message">Error loading like data. %s.</string>
 
     <!-- reader -->

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -866,9 +866,8 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
                     likers + BloggersLikingTextItem(
                             textWithParams = UiStringResWithParams(
                                     stringRes = R.string.like_faces_more_bloggers_text,
-                                    params = listOf(UiStringText("10"), UiStringRes(R.string.like_this))
-                            ),
-                            underlineDelimiterClosure = UiStringRes(R.string.like_this)
+                                    params = listOf(UiStringText("10"))
+                            )
                     )
             )
             assertThat(showEmptyState).isFalse

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -865,7 +865,7 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
             assertThat(engageItemsList).isEqualTo(
                     likers + BloggersLikingTextItem(
                             textWithParams = UiStringResWithParams(
-                                    stringRes = R.string.like_faces_more_bloggers_text,
+                                    stringRes = R.string.like_faces_others_like_text,
                                     params = listOf(UiStringText("10"))
                             )
                     )

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -91,9 +91,9 @@ import org.wordpress.android.ui.reader.views.uistates.FollowButtonUiState
 import org.wordpress.android.ui.reader.views.uistates.ReaderBlogSectionUiState
 import org.wordpress.android.ui.reader.views.uistates.ReaderBlogSectionUiState.ReaderBlogSectionClickData
 import org.wordpress.android.ui.reader.views.uistates.ReaderPostDetailsHeaderViewUiState.ReaderPostDetailsHeaderUiState
+import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiDimen.UIDimenRes
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.WpUrlUtilsWrapper
@@ -136,6 +136,7 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
     @Mock private lateinit var likesEnhancementsFeatureConfig: LikesEnhancementsFeatureConfig
     @Mock private lateinit var contextProvider: ContextProvider
     @Mock private lateinit var engagementUtils: EngagementUtils
+    @Mock private lateinit var htmlMessageUtils: HtmlMessageUtils
 
     private val fakePostFollowStatusChangedFeed = MutableLiveData<FollowStatusChanged>()
     private val fakeRefreshPostFeed = MutableLiveData<Event<Unit>>()
@@ -174,7 +175,8 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
                 TEST_DISPATCHER,
                 getLikesHandler,
                 likesEnhancementsFeatureConfig,
-                engagementUtils
+                engagementUtils,
+                htmlMessageUtils
         )
         whenever(readerGetPostUseCase.get(any(), any(), any())).thenReturn(Pair(readerPost, false))
         whenever(readerPostCardActionsHandler.followStatusUpdated).thenReturn(fakePostFollowStatusChangedFeed)
@@ -848,10 +850,12 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
     fun `ui state show likers faces when data available`() {
         val likesState = getGetLikesState(TEST_CONFIG_1) as LikesData
         val likers = MutableList(5) { mock<FaceItem>() }
+        val testTextString = "10 bloggers like this."
 
         getLikesState.value = likesState
         whenever(accountStore.account).thenReturn(AccountModel().apply { userId = -1 })
         whenever(engagementUtils.likesToTrainOfFaces(anyList())).thenReturn(likers)
+        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), anyInt())).thenReturn(testTextString)
         val post = mock<ReaderPost>()
         whenever(post.isWP).thenReturn(true)
         viewModel.post = post
@@ -862,14 +866,7 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
         assertThat(likeObserver).isNotEmpty
         with(likeObserver.first()) {
             assertThat(showLoading).isFalse
-            assertThat(engageItemsList).isEqualTo(
-                    likers + BloggersLikingTextItem(
-                            textWithParams = UiStringResWithParams(
-                                    stringRes = R.string.like_faces_others_like_text,
-                                    params = listOf(UiStringText("10"))
-                            )
-                    )
-            )
+            assertThat(engageItemsList).isEqualTo(likers + BloggersLikingTextItem(UiStringText(testTextString)))
             assertThat(showEmptyState).isFalse
             assertThat(emptyStateTitle).isNull()
         }


### PR DESCRIPTION
Fixes #15330

We were keeping the closure strings `likes this` and `like this` as separate resources to detect the last part of the string and match the text position we need to not underline. We are here using two "_" to mark the start and end of the underline text keeping all the text (including the `likes this` and `like this`) in each resource string directly. Also the approach is pretty similar to what was already done in iOS [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/16965).

cc @AliSoftware  

## To test
Reporting below the same test steps from #15248 ; visually nothing should change from there.

- Open a post with 0 likes.
   - Verify the likes view is shown when the post is liked.
   - Verify the likes view is hidden when the post is unliked.
- Open a post where you're the only one liking the post.
   - Verify the likes view is hidden when the post is unliked.
   - Verify the likes view is shown when the post is liked.
- Open a post with more than 5 likes from other people.
   - Verify that it shows 6 avatars when the post is liked.
   - Verify that it shows 5 avatars when the post is unliked.
- Verify that the animation works fine when the post is liked and unliked.
- Verify that the animation direction is correct in RTL language.
- Smoke test likers list by tapping on the train of faces and accessing from Notifications > Likes

## Regression Notes
1. Potential unintended areas of impact
Train of likes in reader details

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + already available unit testing

3. What automated tests I added (or what prevented me from doing so)
already available unit testing.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
