### PR TITLE
Integrate gutenberg-mobile release 1.61.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3970-a886a1493ef95e420957e760488b47e68a611610'
+    ext.gutenbergMobileVersion = 'v1.61.1'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.61.0'
+    ext.gutenbergMobileVersion = '3970-a886a1493ef95e420957e760488b47e68a611610'
 
     repositories {
         maven {


### PR DESCRIPTION
## Description
This PR incorporates the 1.61.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3970

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.