### PR TITLE
Integrate gutenberg-mobile release 1.62.0-alpha

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.61.0'
+    ext.gutenbergMobileVersion = '3976-0dca2c2a7ee9cc2c2bc01c31fe56db34e9684096'
 
     repositories {
         maven {


### PR DESCRIPTION
## Description
This PR incorporates the 1.62.0-alpha release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3976

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.