### PR TITLE
Introduce support contact form basic implementation

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -635,6 +635,10 @@
             android:name=".ui.debug.cookies.DebugCookiesActivity"
             android:theme="@style/WordPress.NoActionBar" />
 
+        <activity
+            android:name=".ui.support.SupportFormActivity"
+            android:theme="@style/WordPress.NoActionBar" />
+
         <!-- Notifications activities -->
         <activity
             android:name=".ui.notifications.NotificationsDetailActivity"

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -217,6 +217,7 @@ import org.wordpress.android.ui.stories.intro.StoriesIntroDialogFragment;
 import org.wordpress.android.ui.suggestion.SuggestionActivity;
 import org.wordpress.android.ui.suggestion.SuggestionSourceSubcomponent.SuggestionSourceModule;
 import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter;
+import org.wordpress.android.ui.support.SupportFormFragment;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.ui.themes.ThemeBrowserFragment;
 import org.wordpress.android.ui.uploads.MediaUploadHandler;
@@ -696,6 +697,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(BloggingReminderTimePicker object);
 
     void inject(DebugCookiesFragment object);
+
+    void inject(SupportFormFragment object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -75,6 +75,7 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifie
 import org.wordpress.android.ui.stories.StoryComposerViewModel;
 import org.wordpress.android.ui.stories.intro.StoriesIntroViewModel;
 import org.wordpress.android.ui.suggestion.SuggestionViewModel;
+import org.wordpress.android.ui.support.SupportFormViewModel;
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementViewModel;
 import org.wordpress.android.viewmodel.ViewModelFactory;
 import org.wordpress.android.viewmodel.ViewModelKey;
@@ -572,4 +573,9 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(DebugCookiesViewModel.class)
     abstract ViewModel debugCookiesViewModel(DebugCookiesViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(SupportFormViewModel.class)
+    abstract ViewModel supportFormViewModel(SupportFormViewModel viewModel);
 }

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -55,6 +55,9 @@ class ZendeskHelper(
     private val zendeskInstance: Zendesk
         get() = Zendesk.INSTANCE
 
+    private val supportInstance: Support
+        get() = Support.INSTANCE
+
     private val isZendeskEnabled: Boolean
         get() = zendeskInstance.isInitialized
 
@@ -106,7 +109,7 @@ class ZendeskHelper(
         }
         zendeskInstance.init(context, zendeskUrl, applicationId, oauthClientId)
         Logger.setLoggable(enableLogs)
-        Support.INSTANCE.init(zendeskInstance)
+        supportInstance.init(zendeskInstance)
         refreshIdentity()
     }
 
@@ -194,7 +197,7 @@ class ZendeskHelper(
      * it's successful. We'll use the return value to decide whether to show a push notification or not.
      */
     fun refreshRequest(context: Context, requestId: String?): Boolean =
-            Support.INSTANCE.refreshRequest(requestId, context)
+            supportInstance.refreshRequest(requestId, context)
 
     /**
      * This function should be called when the user logs out of WordPress.com. Push notifications are only available

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.login.BuildConfig
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.accounts.HelpActivity.Origin
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils
 import org.wordpress.android.ui.prefs.AppPrefs
@@ -138,6 +139,22 @@ class ZendeskHelper(
                         buildConfigWrapper
                     )
                 )
+        }
+    }
+
+    // TODO Add documentation
+    @JvmOverloads
+    fun showSupportForm(
+        context: Context,
+        origin: Origin?,
+        selectedSite: SiteModel?,
+        extraTags: List<String>? = null
+    ) {
+        require(isZendeskEnabled) {
+            zendeskNeedsToBeEnabledError
+        }
+        requireIdentity(context, selectedSite) {
+            ActivityLauncher.viewSupportForm(context, origin, selectedSite, extraTags)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -202,6 +202,21 @@ class ZendeskHelper(
     }
 
     // TODO Add documentation
+    fun showTicket(
+        context: Context,
+        request: Request,
+        selectedSite: SiteModel?
+    ) {
+        require(isZendeskEnabled) {
+            zendeskNeedsToBeEnabledError
+        }
+        requireIdentity(context, selectedSite) {
+            // TODO Add tracking
+            RequestActivity.builder().withRequest(request).show(context)
+        }
+    }
+
+    // TODO Add documentation
     fun createRequest(
         context: Context,
         origin: Origin?,

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -105,6 +105,7 @@ import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
 import org.wordpress.android.ui.stories.StoryComposerActivity;
 import org.wordpress.android.ui.suggestion.SuggestionActivity;
 import org.wordpress.android.ui.suggestion.SuggestionType;
+import org.wordpress.android.ui.support.SupportFormActivity;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -1288,6 +1289,15 @@ public class ActivityLauncher {
     public static void viewZendeskTickets(@NonNull Context context,
                                           @Nullable SiteModel selectedSite) {
         viewHelpAndSupportInNewStack(context, Origin.ZENDESK_NOTIFICATION, selectedSite, null);
+    }
+
+    public static void viewSupportForm(@NonNull Context context, @Nullable Origin origin,
+                                       @Nullable SiteModel selectedSite, @Nullable List<String> extraSupportTags) {
+        // TODO Add tracking
+        // Map<String, String> properties = new HashMap<>();
+        // properties.put("origin", origin.name());
+        // AnalyticsTracker.track(Stat.SUPPORT_FORM_OPENED, properties);
+        context.startActivity(SupportFormActivity.createIntent(context, origin, selectedSite, extraSupportTags));
     }
 
     public static void viewSSLCerts(Context context, String certificateString) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -56,7 +56,7 @@ class HelpActivity : LocaleAwareActivity() {
                 actionBar.elevation = 0f // remove shadow
             }
 
-            contactUsButton.setOnClickListener { createNewZendeskTicket() }
+            contactUsButton.setOnClickListener { showSupportForm() }
             faqButton.setOnClickListener { showFaq() }
             myTicketsButton.setOnClickListener { showZendeskTickets() }
             applicationVersion.text = getString(R.string.version_with_name_param, WordPress.versionName)
@@ -109,6 +109,15 @@ class HelpActivity : LocaleAwareActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    private fun showSupportForm() {
+        zendeskHelper.showSupportForm(
+                this,
+                originFromExtras,
+                selectedSiteFromExtras,
+                extraTagsFromExtras
+        )
     }
 
     private fun createNewZendeskTicket() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/support/SupportFormActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/support/SupportFormActivity.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.ui.support
+
+import android.os.Bundle
+import android.view.MenuItem
+import org.wordpress.android.databinding.SupportFormActivityBinding
+import org.wordpress.android.ui.LocaleAwareActivity
+
+class SupportFormActivity : LocaleAwareActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(SupportFormActivityBinding.inflate(layoutInflater).root)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
+        android.R.id.home -> {
+            onBackPressed()
+            true
+        }
+        else -> super.onOptionsItemSelected(item)
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/support/SupportFormActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/support/SupportFormActivity.kt
@@ -1,9 +1,16 @@
 package org.wordpress.android.ui.support
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
+import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SupportFormActivityBinding
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.support.ZendeskExtraTags
 import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.ui.accounts.HelpActivity.Origin
+import org.wordpress.android.util.SiteUtils
 
 class SupportFormActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -18,5 +25,38 @@ class SupportFormActivity : LocaleAwareActivity() {
         }
         else -> super.onOptionsItemSelected(item)
     }
-}
 
+    companion object {
+        const val ORIGIN_KEY = "ORIGIN_KEY"
+        const val EXTRA_TAGS_KEY = "EXTRA_TAGS_KEY"
+
+        @JvmStatic
+        fun createIntent(
+            context: Context,
+            origin: Origin?,
+            selectedSite: SiteModel?,
+            extraSupportTags: List<String>?
+        ) = Intent(context, SupportFormActivity::class.java).apply {
+            putExtra(ORIGIN_KEY, origin)
+
+            selectedSite?.let {
+                putExtra(WordPress.SITE, it)
+            }
+
+            // construct a mutable list to add the related and extra tags
+            val tagsList = arrayListOf<String>().apply {
+                // add the provided list of tags if any
+                extraSupportTags?.let { addAll(it) }
+
+                // Append the "mobile_gutenberg_is_default" tag if gutenberg is set to default for new posts
+                if (SiteUtils.isBlockEditorDefaultForNewPost(selectedSite)) {
+                    add(ZendeskExtraTags.gutenbergIsDefault)
+                }
+            }
+
+            if (tagsList.isNotEmpty()) {
+                putStringArrayListExtra(EXTRA_TAGS_KEY, tagsList)
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/support/SupportFormFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/support/SupportFormFragment.kt
@@ -3,17 +3,28 @@ package org.wordpress.android.ui.support
 import android.content.Context
 import android.os.Bundle
 import android.view.View
+import android.widget.ArrayAdapter
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SupportFormFragmentBinding
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.util.SiteUtils
 import javax.inject.Inject
 
 class SupportFormFragment : Fragment(R.layout.support_form_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: SupportFormViewModel
+
+    @Inject lateinit var siteStore: SiteStore
+
+    private val selectedSiteFromExtras by lazy { activity?.intent?.extras?.get(WordPress.SITE) as SiteModel? }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -26,6 +37,7 @@ class SupportFormFragment : Fragment(R.layout.support_form_fragment) {
 
         with(SupportFormFragmentBinding.bind(view)) {
             setupToolbar()
+            setupViews()
         }
     }
 
@@ -37,5 +49,51 @@ class SupportFormFragment : Fragment(R.layout.support_form_fragment) {
                 it.setDisplayHomeAsUpEnabled(true)
             }
         }
+    }
+
+    private fun SupportFormFragmentBinding.setupViews() {
+        val reasonForContactItems = resources.getStringArray(R.array.support_form_reason_for_contact_array)
+        val reasonForContactAdapter = ArrayAdapter(
+                requireContext(),
+                R.layout.support_form_simple_list_item,
+                reasonForContactItems
+        )
+        reasonForContactTextView.setAdapter(reasonForContactAdapter)
+        reasonForContactTextView.setText(reasonForContactItems.first(), false)
+
+        val feelingItems = resources.getStringArray(R.array.support_form_feeling_array)
+        val feelingAdapter = ArrayAdapter(requireContext(), R.layout.support_form_simple_list_item, feelingItems)
+        feelingTextView.setAdapter(feelingAdapter)
+        feelingTextView.setText(feelingItems.first(), false)
+
+        val allSites = siteStore.sites
+        val siteItems = allSites.map { SiteUtils.getHomeURLOrHostName(it) }
+        val siteAdapter = ArrayAdapter(requireContext(), R.layout.support_form_simple_list_item, siteItems)
+        siteTextView.setAdapter(siteAdapter)
+        siteTextView.setText(SiteUtils.getHomeURLOrHostName(selectedSiteFromExtras ?: allSites.first()), false)
+
+        messageEditText.doAfterTextChanged {
+            sendMessageButton.isEnabled = it?.isNotBlank() == true
+        }
+
+        sendMessageButton.setOnClickListener {
+            showProgress(true)
+
+            val message = "How you can help: ${reasonForContactTextView.text}\n" +
+                    "How I feel: ${feelingTextView.text}\n" +
+                    "Site I need help with: ${siteTextView.text}\n\n" +
+                    messageEditText.text
+
+            Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun SupportFormFragmentBinding.showProgress(show: Boolean) {
+        sendMessageButtonProgress.isVisible = show
+        reasonForContactInputLayout.isEnabled = !show
+        feelingInputLayout.isEnabled = !show
+        siteInputLayout.isEnabled = !show
+        messageInputLayout.isEnabled = !show
+        sendMessageButton.isEnabled = !show
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/support/SupportFormFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/support/SupportFormFragment.kt
@@ -1,0 +1,41 @@
+package org.wordpress.android.ui.support
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.SupportFormFragmentBinding
+import javax.inject.Inject
+
+class SupportFormFragment : Fragment(R.layout.support_form_fragment) {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: SupportFormViewModel
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        (requireActivity().application as WordPress).component().inject(this)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(SupportFormViewModel::class.java)
+
+        with(SupportFormFragmentBinding.bind(view)) {
+            setupToolbar()
+        }
+    }
+
+    private fun SupportFormFragmentBinding.setupToolbar() {
+        with(requireActivity() as AppCompatActivity) {
+            setSupportActionBar(toolbar)
+            supportActionBar?.let {
+                it.setHomeButtonEnabled(true)
+                it.setDisplayHomeAsUpEnabled(true)
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/support/SupportFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/support/SupportFormViewModel.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.ui.support
+
+import androidx.lifecycle.ViewModel
+import javax.inject.Inject
+
+class SupportFormViewModel @Inject constructor() : ViewModel() {
+    // TODO: Implement the ViewModel
+}

--- a/WordPress/src/main/res/layout/support_form_activity.xml
+++ b/WordPress/src/main/res/layout/support_form_activity.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_container"
+    android:name="org.wordpress.android.ui.support.SupportFormFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/WordPress/src/main/res/layout/support_form_fragment.xml
+++ b/WordPress/src/main/res/layout/support_form_fragment.xml
@@ -29,17 +29,103 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingStart="@dimen/margin_extra_large"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <TextView
-            android:id="@+id/message"
-            android:layout_width="wrap_content"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/reason_for_contact_input_layout"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/help_screen_title"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-    </LinearLayout>
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:hint="@string/support_form_reason_for_contact_hint">
 
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                android:id="@+id/reason_for_contact_text_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/feeling_input_layout"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:hint="@string/support_form_feeling_hint">
+
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                android:id="@+id/feeling_text_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/site_input_layout"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:hint="@string/support_form_site_hint">
+
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                android:id="@+id/site_text_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/message_input_layout"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:hint="@string/support_form_message_hint"
+            app:helperText="@string/support_form_message_helper_text"
+            app:helperTextEnabled="true">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/message_edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="top"
+                android:inputType="textCapSentences|textAutoCorrect|textMultiLine"
+                android:minLines="8" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:layout_weight="1" />
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_extra_large">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/send_message_button"
+                style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:enabled="false"
+                android:text="@string/support_form_send_message_action"
+                android:textAllCaps="false"
+                tools:enabled="true" />
+
+            <ProgressBar
+                android:id="@+id/send_message_button_progress"
+                android:layout_width="@dimen/support_form_button_progress_size"
+                android:layout_height="@dimen/support_form_button_progress_size"
+                android:layout_gravity="center"
+                android:indeterminate="true"
+                android:visibility="gone" />
+        </FrameLayout>
+
+    </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/support_form_fragment.xml
+++ b/WordPress/src/main/res/layout/support_form_fragment.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.support.SupportFormFragment">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        android:fitsSystemWindows="true">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_scrollFlags="noScroll"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+            app:theme="@style/WordPress.ActionBar"
+            app:title="@string/help_screen_title" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <TextView
+            android:id="@+id/message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/help_screen_title"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/support_form_simple_list_item.xml
+++ b/WordPress/src/main/res/layout/support_form_simple_list_item.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:ellipsize="end"
+    android:maxLines="1"
+    android:padding="16dp"
+    android:textAppearance="?attr/textAppearanceSubtitle1" />

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -670,4 +670,7 @@
 
     <dimen name="blogging_reminders_days_top_margin">42dp</dimen>
     <dimen name="blogging_reminders_days_middle_margin">7dp</dimen>
+
+    <!-- Support form -->
+    <dimen name="support_form_button_progress_size">32dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3789,4 +3789,38 @@ translators: Block name. %s: The localized block name -->
     <!-- Weekly Roundup Notification -->
     <string name="weekly_roundup_notification_title">Weekly Roundup: %s</string>
     <string name="weekly_roundup_notification_text">Your site got %1$d views, %2$d likes, %3$d comments.</string>
+
+    <!-- Support Form -->
+    <string name="support_form_reason_for_contact_hint">You\'re reaching out to…</string>
+    <string name="support_form_feeling_hint">Mind sharing how you feel?</string>
+    <string name="support_form_site_hint">Which site do you need help with?</string>
+    <string name="support_form_message_hint">How can we help?</string>
+    <string name="support_form_message_helper_text">Tip: the more details you can share, the sooner we can get back to you!</string>
+    <string name="support_form_send_message_action">Send message</string>
+
+    <string name="support_form_reason_for_contact_get_started">Get started</string>
+    <string name="support_form_reason_for_contact_report_bug">Report something isn\'t working</string>
+    <string name="support_form_reason_for_contact_make_suggestion">Make a suggestion</string>
+
+    <string-array name="support_form_reason_for_contact_array" translatable="false">
+        <item>@string/support_form_reason_for_contact_get_started</item>
+        <item>@string/support_form_reason_for_contact_report_bug</item>
+        <item>@string/support_form_reason_for_contact_make_suggestion</item>
+    </string-array>
+
+    <string name="support_form_feeling_rather_not">I\'d rather not</string>
+    <string name="support_form_feeling_happy">Happy</string>
+    <string name="support_form_feeling_confused">Confused</string>
+    <string name="support_form_feeling_discouraged">Discouraged</string>
+    <string name="support_form_feeling_upset">Upset</string>
+    <string name="support_form_feeling_panicked">Panicked</string>
+
+    <string-array name="support_form_feeling_array" translatable="false">
+        <item>@string/support_form_feeling_rather_not</item>
+        <item>@string/support_form_feeling_happy</item>
+        <item>@string/support_form_feeling_confused</item>
+        <item>@string/support_form_feeling_discouraged</item>
+        <item>@string/support_form_feeling_upset</item>
+        <item>@string/support_form_feeling_panicked</item>
+    </string-array>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3823,4 +3823,6 @@ translators: Block name. %s: The localized block name -->
         <item>@string/support_form_feeling_upset</item>
         <item>@string/support_form_feeling_panicked</item>
     </string-array>
+
+    <string name="support_form_request_creation_error">Something went wrong. Try again later.</string>
 </resources>


### PR DESCRIPTION
This PR introduces a basic contact form implementation to the support flow. It's just a POC and should not be merged for now. Please check #15365 and this internal ref pbArwn-2Wq-p2 for more info.

<img width=300 src="https://user-images.githubusercontent.com/830056/134413633-a9b4d5f9-1d93-4fe4-97b1-09b66159b3c4.png"/>

Besides adding the screen above and its related classes, this PR also adds two methods to `ZendeskHelper`:
- `createRequest` creates a new request using Zendesk's [`RequestProvider`](https://zendesk.github.io/mobile_sdk_javadocs/supportv2/v301/index.html?zendesk/support/RequestProvider.html). It reuses a good part of the logic that was already being used by `createNewTicket`.
- `showTicket` starts a `RequestActivity` with an existing `Request`.

### To test

1. Open the app.
1. On the Main screen, tap the Me button.
1. From the Me screen, navigate to Help & Support > Contact Support.
1. Notice the new contact form screen.
1. Fill in all fields.
1. Tap the Send Message button.
1. Notice the progress bar.
1. Wait for a while.
1. Notice the chat screen.
1. Verify that there's already a message in the chat with the info that was entered in the form.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
