### PR TITLE
Merge release/18.3 into develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+18.4
+-----
+
+
 18.3
 -----
 * [**] Media: Fix Atomic sites video not playing issue. (https://github.com/wordpress-mobile/WordPress-Android/pull/15285)

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,1 +1,12 @@
-We have made a couple of handy tweaks to the Block editor: The Embed block now gives you a sneak preview when you add something from YouTube or Twitter (more providers to come); and when you go to insert a block and nothing is found, there is now a no results view.
+* [**] Media: Fix Atomic sites video not playing issue. (https://github.com/wordpress-mobile/WordPress-Android/pull/15285)
+* [*] Block editor: Fixes bug preventing button block gradient background from being updated in the editor [https://github.com/wordpress-mobile/WordPress-Android/pull/15312]
+* [*] Updated the wording for the "Posts" and "Pages" entries in My Site screen [https://github.com/wordpress-mobile/WordPress-Android/pull/15327]
+* [**] Block editor: Embed block: Enable WordPress embed preview [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3853]
+* [**] Block editor: Embed block: Add error bottom sheet with retry and convert to link actions. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3921]
+* [**] Block editor: Embed block: Implemented the No Preview UI when an embed is successful, but we're unable to show an inline preview [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3927]
+* [**] Block editor: Fix issue of main toolbar initial position being wrong when RTL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3923]
+* [*] Block editor: Embed block: Add device's locale to preview content [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3788]
+* [*] Block editor: Embed block: Fix content disappearing when switching light/dark mode [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3859]
+* [*] Block editor: Column block: Translate column width's control labels [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3952]
+* [**] Block editor: Embed block: Enable embed preview for Instagram and Vimeo providers. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3918]
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,4 +1,12 @@
-- The Embed block now gives a preview when you add from YouTube or Twitter. 
-- If nothing is found in a block inserter search a “no results” view appears. 
-- The Me screen has a new “Share WordPress with a friend” button, allowing you to share a WordPress app link. 
-- Liking a post in the Reader also adds your avatar to the like.
+* [**] Media: Fix Atomic sites video not playing issue. (https://github.com/wordpress-mobile/WordPress-Android/pull/15285)
+* [*] Block editor: Fixes bug preventing button block gradient background from being updated in the editor [https://github.com/wordpress-mobile/WordPress-Android/pull/15312]
+* [*] Updated the wording for the "Posts" and "Pages" entries in My Site screen [https://github.com/wordpress-mobile/WordPress-Android/pull/15327]
+* [**] Block editor: Embed block: Enable WordPress embed preview [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3853]
+* [**] Block editor: Embed block: Add error bottom sheet with retry and convert to link actions. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3921]
+* [**] Block editor: Embed block: Implemented the No Preview UI when an embed is successful, but we're unable to show an inline preview [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3927]
+* [**] Block editor: Fix issue of main toolbar initial position being wrong when RTL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3923]
+* [*] Block editor: Embed block: Add device's locale to preview content [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3788]
+* [*] Block editor: Embed block: Fix content disappearing when switching light/dark mode [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3859]
+* [*] Block editor: Column block: Translate column width's control labels [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3952]
+* [**] Block editor: Embed block: Enable embed preview for Instagram and Vimeo providers. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3918]
+

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3356,7 +3356,10 @@
     <string name="gutenberg_native_choose_images" tools:ignore="UnusedResources">Choose images</string>
     <string name="gutenberg_native_choose_video" tools:ignore="UnusedResources">Choose video</string>
     <string name="gutenberg_native_clear_search" tools:ignore="UnusedResources">Clear search</string>
+    <!-- translators: %d: column index. -->
+    <string name="gutenberg_native_column_d" tools:ignore="UnusedResources">Column %d</string>
     <string name="gutenberg_native_columns_settings" tools:ignore="UnusedResources">Columns Settings</string>
+    <string name="gutenberg_native_convert_to_link" tools:ignore="UnusedResources">Convert to link</string>
     <string name="gutenberg_native_copied_block" tools:ignore="UnusedResources">Copied block</string>
     <string name="gutenberg_native_copy_block" tools:ignore="UnusedResources">Copy block</string>
     <string name="gutenberg_native_copy_file_url" tools:ignore="UnusedResources">Copy file URL</string>
@@ -3407,6 +3410,7 @@
     <!-- translators: accessibility text (hint for switches) -->
     <string name="gutenberg_native_double_tap_to_toggle_setting" tools:ignore="UnusedResources">Double tap to toggle setting</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change" tools:ignore="UnusedResources">Double tap to undo last change</string>
+    <string name="gutenberg_native_double_tap_to_view_embed_options" tools:ignore="UnusedResources">Double tap to view embed options.</string>
     <string name="gutenberg_native_drag_to_adjust_focal_point" tools:ignore="UnusedResources">Drag to adjust focal point</string>
     <string name="gutenberg_native_duplicate_block" tools:ignore="UnusedResources">Duplicate block</string>
     <string name="gutenberg_native_each_block_has_its_own_settings_to_find_them_tap_on_a_block_its_s" tools:ignore="UnusedResources">Each block has its own settings. To find them, tap on a block. Its settings will appear on the toolbar at the bottom of the screen.</string>
@@ -3419,12 +3423,14 @@
     <string name="gutenberg_native_edit_video" tools:ignore="UnusedResources">Edit video</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_and" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for Android</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_ios" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for iOS</string>
+    <string name="gutenberg_native_embed_block_previews_are_coming_soon" tools:ignore="UnusedResources">Embed block previews are coming soon</string>
     <!-- translators: accessibility text. Empty Embed caption. -->
     <string name="gutenberg_native_embed_caption_empty" tools:ignore="UnusedResources">Embed caption. Empty</string>
     <!-- translators: accessibility text. %s: Embed caption. -->
     <string name="gutenberg_native_embed_caption_s" tools:ignore="UnusedResources">Embed caption. %s</string>
     <string name="gutenberg_native_embed_link" tools:ignore="UnusedResources">Embed link</string>
     <string name="gutenberg_native_embed_media" tools:ignore="UnusedResources">Embed media</string>
+    <string name="gutenberg_native_embed_options" tools:ignore="UnusedResources">Embed options</string>
     <string name="gutenberg_native_error" tools:ignore="UnusedResources">Error</string>
     <string name="gutenberg_native_excerpt_length_words" tools:ignore="UnusedResources">Excerpt length (words)</string>
     <string name="gutenberg_native_failed_to_insert_audio_file" tools:ignore="UnusedResources">Failed to insert audio file.</string>
@@ -3493,6 +3499,8 @@
     <string name="gutenberg_native_no_application_can_handle_this_request_please_install_a_web_brows" tools:ignore="UnusedResources">No application can handle this request. Please install a Web browser.</string>
     <string name="gutenberg_native_no_blocks_found" tools:ignore="UnusedResources">No blocks found</string>
     <string name="gutenberg_native_no_custom_placeholder_set" tools:ignore="UnusedResources">No custom placeholder set</string>
+    <string name="gutenberg_native_no_preview_available" tools:ignore="UnusedResources">No preview available</string>
+    <string name="gutenberg_native_none" tools:ignore="UnusedResources">None</string>
     <string name="gutenberg_native_note_column_layout_may_vary_between_themes_and_screen_sizes" tools:ignore="UnusedResources">Note: Column layout may vary between themes and screen sizes</string>
     <string name="gutenberg_native_number_of_columns" tools:ignore="UnusedResources">Number of columns</string>
     <string name="gutenberg_native_once_you_become_familiar_with_the_names_of_different_blocks_you_c" tools:ignore="UnusedResources">Once you become familiar with the names of different blocks, you can add a block by typing a forward slash followed by the block name — for example, /image or /heading.</string>
@@ -3527,6 +3535,7 @@
     <string name="gutenberg_native_replace_file" tools:ignore="UnusedResources">Replace file</string>
     <string name="gutenberg_native_replace_image_or_video" tools:ignore="UnusedResources">Replace image or video</string>
     <string name="gutenberg_native_replace_video" tools:ignore="UnusedResources">Replace video</string>
+    <string name="gutenberg_native_retry" tools:ignore="UnusedResources">Retry</string>
     <string name="gutenberg_native_rich_text_editing" tools:ignore="UnusedResources">Rich text editing</string>
     <!-- translators: %s: Block name e.g. "Image block"
 translators: Block name. %s: The localized block name -->
@@ -3537,12 +3546,12 @@ translators: Block name. %s: The localized block name -->
     <string name="gutenberg_native_s_block_newly_available" tools:ignore="UnusedResources">%s block, newly available</string>
     <!-- translators: %s: block title e.g: "Paragraph". -->
     <string name="gutenberg_native_s_block_options" tools:ignore="UnusedResources">%s block options</string>
-    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
-    <string name="gutenberg_native_s_block_previews_are_coming_soon" tools:ignore="UnusedResources">%s block previews are coming soon</string>
     <!-- translators: accessibility text for blocks with invalid content. %d: localized block title -->
     <string name="gutenberg_native_s_block_this_block_has_invalid_content" tools:ignore="UnusedResources">%s block. This block has invalid content</string>
     <!-- translators: %s: name of the reusable block -->
     <string name="gutenberg_native_s_converted_to_regular_blocks" tools:ignore="UnusedResources">%s converted to regular blocks</string>
+    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
+    <string name="gutenberg_native_s_embed_block_previews_are_coming_soon" tools:ignore="UnusedResources">%s embed block previews are coming soon</string>
     <!-- translators: %s: social link name e.g: "Instagram". -->
     <string name="gutenberg_native_s_has_no_url_set" tools:ignore="UnusedResources">%s has no URL set</string>
     <!-- translators: %s: social link name e.g: "Instagram". -->

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'develop-beb2db2dac770e17e28bf1e0c36edc1e794498aa'
+    fluxCVersion = '1.26.0'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -913,6 +913,7 @@
     <string name="debug_settings_restart_app" translatable="false">Restart the app</string>
     <string name="debug_settings_missing_developed_feature" translatable="false">Don\'t see a feature you\'re working on? Check that your feature config file is annotated with the FeatureInDevelopment annotation.</string>
     <string name="debug_settings_tools" translatable="false">Tools</string>
+    <string name="debug_settings_force_show_weekly_roundup" translatable="false">Force show Weekly Roundup notification</string>
 
     <!-- Debug cookies -->
     <string name="debug_cookies_title" translatable="false">Debug cookies</string>
@@ -1505,14 +1506,15 @@
     <string name="get_likes_empty_state_title">An error occurred while getting likes data</string>
     <string name="like_title_singular">1 Like</string>
     <string name="like_title_plural">%d Likes</string>
-    <string name="like_this">like this</string>
-    <string name="likes_this">likes this</string>
-    <string name="like_faces_you_text">You %1$s.</string>
-    <string name="like_faces_you_plus_one_text">You and 1 blogger %1$s.</string>
-    <string name="like_faces_plural_with_you_text">You and %1$s bloggers %2$s.</string>
-    <string name="like_faces_one_blogger_text">1 blogger %1$s.</string>
-    <string name="like_faces_more_bloggers_text">%1$s bloggers %2$s.</string>
     <string name="like_faces_error_loading_message">Error loading like data. %s.</string>
+    <!-- Note for translators: the '&lt;a href=""&gt;' and '&lt;/a&gt;' must be kept without
+    translations/modifications and are used to enclose the portion of the text
+    that will be rendered as underlined. -->
+    <string name="like_faces_you_like_text">&lt;a href=""&gt;You&lt;/a&gt; like this.</string>
+    <string name="like_faces_you_plus_one_like_text">&lt;a href=""&gt;You and 1 blogger&lt;/a&gt; like this.</string>
+    <string name="like_faces_you_plus_others_like_text">&lt;a href=""&gt;You and %1$s bloggers&lt;/a&gt; like this.</string>
+    <string name="like_faces_one_blogger_likes_text">&lt;a href=""&gt;1 blogger&lt;/a&gt; likes this.</string>
+    <string name="like_faces_others_like_text">&lt;a href=""&gt;%1$s bloggers&lt;/a&gt; like this.</string>
 
     <!-- reader -->
     <string name="reader">Reader</string>
@@ -2140,8 +2142,8 @@
     <string name="my_site_header_jetpack">Jetpack</string>
     <string name="my_site_header_publish">Publish</string>
     <string name="my_site_btn_jetpack_settings">Jetpack Settings</string>
-    <string name="my_site_btn_site_pages">Site Pages</string>
-    <string name="my_site_btn_blog_posts">Blog Posts</string>
+    <string name="my_site_btn_site_pages">Pages</string>
+    <string name="my_site_btn_blog_posts">Posts</string>
     <string name="my_site_btn_sharing">Sharing</string>
     <string name="my_site_btn_domains">Domains</string>
     <string name="my_site_btn_site_settings">Site Settings</string>
@@ -2968,6 +2970,7 @@
     <string name="quick_start_list_check_stats_title">Check your stats</string>
     <string name="quick_start_list_create_site_subtitle">Get your site up and running.</string>
     <string name="quick_start_list_create_site_title">Create your site</string>
+    <string name="quick_start_list_create_site_message">Site created! Complete another task.</string>
     <string name="quick_start_list_update_site_title_title">Check your site title</string>
     <string name="quick_start_list_update_site_title_subtitle">Give your site a name that reflects its personality and topic.</string>
     <string name="quick_start_list_enable_sharing_subtitle">Automatically share new posts to your social media.</string>
@@ -3104,7 +3107,7 @@
     <string name="new_site_creation_screen_title_general">Create Site</string>
     <string name="new_site_creation_screen_title_step_count">%1$d of %2$d</string>
     <string name="new_site_creation_preview_title">Your site has been created!</string>
-    <string name="new_site_creation_preview_subtitle">You\'ll be able to customize look and feel of your site later</string>
+    <string name="new_site_creation_preview_subtitle">You\'ll be able to customize the look and feel of your site later</string>
     <string name="site_creation_fetch_suggestions_error_unknown">There was a problem</string>
     <string name="site_creation_error_generic_title">There was a problem</string>
     <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>
@@ -3353,7 +3356,10 @@
     <string name="gutenberg_native_choose_images" tools:ignore="UnusedResources">Choose images</string>
     <string name="gutenberg_native_choose_video" tools:ignore="UnusedResources">Choose video</string>
     <string name="gutenberg_native_clear_search" tools:ignore="UnusedResources">Clear search</string>
+    <!-- translators: %d: column index. -->
+    <string name="gutenberg_native_column_d" tools:ignore="UnusedResources">Column %d</string>
     <string name="gutenberg_native_columns_settings" tools:ignore="UnusedResources">Columns Settings</string>
+    <string name="gutenberg_native_convert_to_link" tools:ignore="UnusedResources">Convert to link</string>
     <string name="gutenberg_native_copied_block" tools:ignore="UnusedResources">Copied block</string>
     <string name="gutenberg_native_copy_block" tools:ignore="UnusedResources">Copy block</string>
     <string name="gutenberg_native_copy_file_url" tools:ignore="UnusedResources">Copy file URL</string>
@@ -3404,6 +3410,7 @@
     <!-- translators: accessibility text (hint for switches) -->
     <string name="gutenberg_native_double_tap_to_toggle_setting" tools:ignore="UnusedResources">Double tap to toggle setting</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change" tools:ignore="UnusedResources">Double tap to undo last change</string>
+    <string name="gutenberg_native_double_tap_to_view_embed_options" tools:ignore="UnusedResources">Double tap to view embed options.</string>
     <string name="gutenberg_native_drag_to_adjust_focal_point" tools:ignore="UnusedResources">Drag to adjust focal point</string>
     <string name="gutenberg_native_duplicate_block" tools:ignore="UnusedResources">Duplicate block</string>
     <string name="gutenberg_native_each_block_has_its_own_settings_to_find_them_tap_on_a_block_its_s" tools:ignore="UnusedResources">Each block has its own settings. To find them, tap on a block. Its settings will appear on the toolbar at the bottom of the screen.</string>
@@ -3416,12 +3423,14 @@
     <string name="gutenberg_native_edit_video" tools:ignore="UnusedResources">Edit video</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_and" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for Android</string>
     <string name="gutenberg_native_editing_reusable_blocks_is_not_yet_supported_on_wordpress_for_ios" tools:ignore="UnusedResources">Editing reusable blocks is not yet supported on WordPress for iOS</string>
+    <string name="gutenberg_native_embed_block_previews_are_coming_soon" tools:ignore="UnusedResources">Embed block previews are coming soon</string>
     <!-- translators: accessibility text. Empty Embed caption. -->
     <string name="gutenberg_native_embed_caption_empty" tools:ignore="UnusedResources">Embed caption. Empty</string>
     <!-- translators: accessibility text. %s: Embed caption. -->
     <string name="gutenberg_native_embed_caption_s" tools:ignore="UnusedResources">Embed caption. %s</string>
     <string name="gutenberg_native_embed_link" tools:ignore="UnusedResources">Embed link</string>
     <string name="gutenberg_native_embed_media" tools:ignore="UnusedResources">Embed media</string>
+    <string name="gutenberg_native_embed_options" tools:ignore="UnusedResources">Embed options</string>
     <string name="gutenberg_native_error" tools:ignore="UnusedResources">Error</string>
     <string name="gutenberg_native_excerpt_length_words" tools:ignore="UnusedResources">Excerpt length (words)</string>
     <string name="gutenberg_native_failed_to_insert_audio_file" tools:ignore="UnusedResources">Failed to insert audio file.</string>
@@ -3490,6 +3499,8 @@
     <string name="gutenberg_native_no_application_can_handle_this_request_please_install_a_web_brows" tools:ignore="UnusedResources">No application can handle this request. Please install a Web browser.</string>
     <string name="gutenberg_native_no_blocks_found" tools:ignore="UnusedResources">No blocks found</string>
     <string name="gutenberg_native_no_custom_placeholder_set" tools:ignore="UnusedResources">No custom placeholder set</string>
+    <string name="gutenberg_native_no_preview_available" tools:ignore="UnusedResources">No preview available</string>
+    <string name="gutenberg_native_none" tools:ignore="UnusedResources">None</string>
     <string name="gutenberg_native_note_column_layout_may_vary_between_themes_and_screen_sizes" tools:ignore="UnusedResources">Note: Column layout may vary between themes and screen sizes</string>
     <string name="gutenberg_native_number_of_columns" tools:ignore="UnusedResources">Number of columns</string>
     <string name="gutenberg_native_once_you_become_familiar_with_the_names_of_different_blocks_you_c" tools:ignore="UnusedResources">Once you become familiar with the names of different blocks, you can add a block by typing a forward slash followed by the block name — for example, /image or /heading.</string>
@@ -3524,6 +3535,7 @@
     <string name="gutenberg_native_replace_file" tools:ignore="UnusedResources">Replace file</string>
     <string name="gutenberg_native_replace_image_or_video" tools:ignore="UnusedResources">Replace image or video</string>
     <string name="gutenberg_native_replace_video" tools:ignore="UnusedResources">Replace video</string>
+    <string name="gutenberg_native_retry" tools:ignore="UnusedResources">Retry</string>
     <string name="gutenberg_native_rich_text_editing" tools:ignore="UnusedResources">Rich text editing</string>
     <!-- translators: %s: Block name e.g. "Image block"
 translators: Block name. %s: The localized block name -->
@@ -3534,12 +3546,12 @@ translators: Block name. %s: The localized block name -->
     <string name="gutenberg_native_s_block_newly_available" tools:ignore="UnusedResources">%s block, newly available</string>
     <!-- translators: %s: block title e.g: "Paragraph". -->
     <string name="gutenberg_native_s_block_options" tools:ignore="UnusedResources">%s block options</string>
-    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
-    <string name="gutenberg_native_s_block_previews_are_coming_soon" tools:ignore="UnusedResources">%s block previews are coming soon</string>
     <!-- translators: accessibility text for blocks with invalid content. %d: localized block title -->
     <string name="gutenberg_native_s_block_this_block_has_invalid_content" tools:ignore="UnusedResources">%s block. This block has invalid content</string>
     <!-- translators: %s: name of the reusable block -->
     <string name="gutenberg_native_s_converted_to_regular_blocks" tools:ignore="UnusedResources">%s converted to regular blocks</string>
+    <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
+    <string name="gutenberg_native_s_embed_block_previews_are_coming_soon" tools:ignore="UnusedResources">%s embed block previews are coming soon</string>
     <!-- translators: %s: social link name e.g: "Instagram". -->
     <string name="gutenberg_native_s_has_no_url_set" tools:ignore="UnusedResources">%s has no URL set</string>
     <!-- translators: %s: social link name e.g: "Instagram". -->
@@ -3786,6 +3798,7 @@ translators: Block name. %s: The localized block name -->
     <string name="create_site_notification_create_site_action">Create site</string>
 
     <!-- Weekly Roundup Notification -->
+    <string name="weekly_roundup">Weekly Roundup</string>
     <string name="weekly_roundup_notification_title">Weekly Roundup: %s</string>
     <string name="weekly_roundup_notification_text">Your site got %1$d views, %2$d likes, %3$d comments.</string>
 </resources>

--- a/version.properties
+++ b/version.properties
@@ -1,9 +1,9 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=18.2
-versionCode=1110
+versionName=18.3-rc-1
+versionCode=1111
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
-alpha.versionName=alpha-319
-alpha.versionCode=1109
+alpha.versionName=alpha-320
+alpha.versionCode=1112


### PR DESCRIPTION
First `18.3-rc-1` beta was built, attached to the GH Release, and submitted for review

_(Intermediate branch in case new PRs gets merged in `develop` in the meantime)_

### Note on rc-1 beta publication

Note that `18.3-rc-1` might not be published to beta testers _right away_, because the final 18.2 is still in the "approved but pending starting rollout" state while we figure out if we need to postpone its release or not depending on a final confidence check pending (ref: p1632126186409500/1631899386.380600-slack-C6UJ0KRKQ).

Since, once we submitted release for review and they get approved, the PlayStore Console only allows us to publish _everything_ approved at once (not selectively), this means that hitting the button on PlayStore will publish _both_ `18.3-rc-1` and `18.2` (10%) together. Since we want to wait confirmation for the `18.2` publication, `18.3-rc-1` will have to wait it too.