### PR TITLE
Localization support for stories-android as a binary dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,21 +356,6 @@ jobs:
           timeout: 10m
           results-history-name: CircleCI WPUtils Connected Tests
       - android/save-gradle-cache
-  submodules-strings-check:
-    docker:
-      - image: circleci/ruby:2.6.4
-    steps:
-      - git/shallow-checkout:
-          init-submodules: true
-      - checkout-submodules
-      - run:
-          name: Install bundler
-          command: gem install bundler --version 2.0.2
-      - bundle-install/bundle-install:
-          cache_key_prefix: strings-check-v2
-      - run:
-          name: Validate login strings
-          command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane validate_submodules_strings pr_url:$CIRCLE_PULL_REQUEST
 
 workflows:
   wordpress_android:
@@ -379,7 +364,6 @@ workflows:
         - << pipeline.parameters.generate_screenshots >>
         - << pipeline.parameters.release_build >>
     jobs:
-      - submodules-strings-check
       - Installable Build:
           filters:
             branches:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -752,8 +752,7 @@ REPOSITORY_NAME="WordPress-Android"
   main_strings_path = "./WordPress/src/main/res/values/strings.xml"
   update_strings_path = "./fastlane/resources/values/"
   libraries_strings_path = [
-    {library: "Image Editor", strings_path: "./libs/image-editor/ImageEditor/src/main/res/values/strings.xml", exclusions: []},
-    {library: "Stories Creator", strings_path: "./libs/stories-android/stories/src/main/res/values/strings.xml", exclusions: []}
+    {library: "Image Editor", strings_path: "./libs/image-editor/ImageEditor/src/main/res/values/strings.xml", exclusions: []}
   ]
 
   binary_imported_libraries = [
@@ -773,6 +772,14 @@ REPOSITORY_NAME="WordPress-Android"
       strings_file_path: "WordPressLoginFlow/src/main/res/values/strings.xml",
       github_release_prefix: "",
       exclusions: ["default_web_client_id"]
+    },
+    {
+      name: "Stories Library",
+      import_key: "storiesVersion",
+      repository: "Automattic/stories-android",
+      strings_file_path: "stories/src/main/res/values/strings.xml",
+      github_release_prefix: "",
+      exclusions: []
     },
   ]
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -845,21 +845,6 @@ REPOSITORY_NAME="WordPress-Android"
     end
   end
 
-  # This lane verifies that new strings which have been added to the main strings.xml
-  # and which belongs to features of subtrees and submodules have also been added
-  # to the library strings.xml file.
-  lane :validate_submodules_strings do | options |
-    pr_number = options[:pr_number]
-    pr_number = options[:pr_url].split('/').last unless options[:pr_url].nil?
-
-    diff_url = nil
-    if (pr_number.nil? == false)
-      diff_url = "https://patch-diff.githubusercontent.com/raw/wordpress-mobile/WordPress-Android/pull/#{pr_number}.diff"
-    end
-
-    an_validate_lib_strings(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path, diff_url: diff_url)
-  end
-
 ########################################################################
 # Helper Lanes
 ########################################################################


### PR DESCRIPTION
This PR is targeting https://github.com/wordpress-mobile/WordPress-Android/pull/15301 which is not yet reviewed. I wanted to separate the localization changes so it can be reviewed and tested in isolation. I'm going to leave this as a draft so the base PR will be easier to review, but I'd appreciate a review so it's ready to be merged.

This PR:

* Adds `stories-android` as a binary imported library to fastlane
* Removes `validate_submodules_strings` lane and its CI task. @loremattei mentioned that [`localize_libs` lane](https://github.com/wordpress-mobile/WordPress-Android/blob/9a6f1154a1aa4ee6177843a3f0de8106753a2b80/fastlane/Fastfile#L798) already covers our needs and developers don't need to make any changes anymore. He mentioned that we could have possibly removed this a while back 😅 

**To test:**
I'll leave the testing instructions to @loremattei. I believe they should be very similar to [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/14778).

## Regression Notes
1. Potential unintended areas of impact
Localization issues for stories-android strings

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Asked our localization master a.k.a @loremattei to review & test it 😅 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
