### PR TITLE
Remove git submodule commands from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,6 @@ commands:
         - run:
             name: Update memory setting
             command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-<< parameters.jvmargs >> -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false /" gradle.properties
-  checkout-submodules:
-    steps:
-      - run:
-          name: Checkout submodules
-          command: git submodule update --init --recursive --depth 1
 
 version: 2.1
 jobs:
@@ -41,9 +36,7 @@ jobs:
       name: android/default
       api-version: "29"
     steps:
-      - git/shallow-checkout:
-          init-submodules: true
-      - checkout-submodules
+      - git/shallow-checkout
       - bundle-install/bundle-install:
           cache_key_prefix: installable-build-v4
       - run:
@@ -98,9 +91,7 @@ jobs:
           command: |
             SLACKMSG_APP_NAME=$(echo "<< parameters.app >>" | sed s/wordpress/WordPress/i | sed s/jetpack/Jetpack/i)
             echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for ${SLACKMSG_APP_NAME} Android failed!'" >> $BASH_ENV
-      - git/shallow-checkout:
-          init-submodules: true
-      - checkout-submodules
+      - git/shallow-checkout
       - bundle-install/bundle-install:
           cache_key_prefix: &release-build-cache-key release-build-v2
       - run:
@@ -164,8 +155,7 @@ jobs:
       name: android/default
       api-version: "29"
     steps:
-      - git/shallow-checkout:
-          init-submodules: false
+      - git/shallow-checkout
       - bundle-install/bundle-install:
           cache_key_prefix: *release-build-cache-key
       - attach_workspace:
@@ -186,9 +176,7 @@ jobs:
       name: android/default
       api-version: "29"
     steps:
-      - git/shallow-checkout:
-          init-submodules: true
-      - checkout-submodules
+      - git/shallow-checkout
       - android/restore-gradle-cache
       - copy-gradle-properties
       - update-gradle-memory:
@@ -228,9 +216,7 @@ jobs:
       api-version: "29"
     working_directory: /tmp/workspace
     steps:
-      - git/shallow-checkout:
-          init-submodules: true
-      - checkout-submodules
+      - git/shallow-checkout
       - bundle-install/bundle-install:
           cache_key_prefix: raw-screenshots-v2
       - android/restore-gradle-cache
@@ -334,9 +320,7 @@ jobs:
       name: android/default
       api-version: "29"
     steps:
-      - git/shallow-checkout:
-          init-submodules: true
-      - checkout-submodules
+      - git/shallow-checkout
       - android/restore-gradle-cache
       - copy-gradle-properties
       - update-gradle-memory


### PR DESCRIPTION
This PR targets https://github.com/wordpress-mobile/WordPress-Android/pull/15368 which is targeting https://github.com/wordpress-mobile/WordPress-Android/pull/15301. I am separating these PRs like this to keep the PR reviews very simple. I am leaving this PR as a draft so the base PRs will be easier to review, but I'd still appreciate a review so it's all ready to be merged.

This PR removes all the submodule commands from CircleCI with stories-android becoming a binary dependency we no longer have any git submodules 🥳 

**To test:**
* If CI is green we are good

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
