### PR TITLE
Add Blogging Reminders entry point to notification settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
@@ -81,7 +81,8 @@ class BloggingRemindersAnalyticsTracker @Inject constructor(
 
     enum class Source(val trackingName: String) {
         PUBLISH_FLOW("publish_flow"),
-        BLOG_SETTINGS("blog_settings")
+        BLOG_SETTINGS("blog_settings"),
+        NOTIFICATION_SETTINGS("notification_settings")
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -102,11 +102,12 @@ class BloggingRemindersViewModel @Inject constructor(
         analyticsTracker.trackScreenShown(screen)
     }
 
-    fun getSettingsState(siteId: Int): LiveData<UiString> {
-        return bloggingRemindersStore.bloggingRemindersModel(siteId).map {
-            mapper.toUiModel(it).let { uiModel -> dayLabelUtils.buildSiteSettingsLabel(uiModel) }
-        }.asLiveData(mainDispatcher)
-    }
+    fun getSettingsState(siteId: Int) = getUiModel(siteId)
+            .map { dayLabelUtils.buildSiteSettingsLabel(it) }
+            .asLiveData(mainDispatcher)
+
+    private fun getUiModel(siteId: Int) =
+            bloggingRemindersStore.bloggingRemindersModel(siteId).map { mapper.toUiModel(it) }
 
     private fun showBottomSheet(siteId: Int, screen: Screen, source: Source) {
         analyticsTracker.setSite(siteId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -222,13 +222,17 @@ class BloggingRemindersViewModel @Inject constructor(
     }
 
     fun onSettingsItemClicked(siteId: Int) {
+        onSettingsItemClicked(siteId, BLOG_SETTINGS)
+    }
+
+    private fun onSettingsItemClicked(siteId: Int, source: Source) {
         launch {
             val screen = if (bloggingRemindersStore.hasModifiedBloggingReminders(siteId)) {
                 SELECTION
             } else {
                 PROLOGUE_SETTINGS
             }
-            showBottomSheet(siteId, screen, BLOG_SETTINGS)
+            showBottomSheet(siteId, screen, source)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source.BLOG_SETTINGS
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source.NOTIFICATION_SETTINGS
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source.PUBLISH_FLOW
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Screen.EPILOGUE
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Screen.PROLOGUE
@@ -223,6 +224,10 @@ class BloggingRemindersViewModel @Inject constructor(
 
     fun onBlogSettingsItemClicked(siteId: Int) {
         onSettingsItemClicked(siteId, BLOG_SETTINGS)
+    }
+
+    fun onNotificationSettingsItemClicked(remoteSiteId: Long) {
+        onSettingsItemClicked(siteStore.getLocalIdForRemoteSiteId(remoteSiteId), NOTIFICATION_SETTINGS)
     }
 
     private fun onSettingsItemClicked(siteId: Int, source: Source) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -107,6 +108,10 @@ class BloggingRemindersViewModel @Inject constructor(
     fun getBlogSettingsUiState(siteId: Int) = getUiModel(siteId)
             .map { dayLabelUtils.buildSiteSettingsLabel(it) }
             .asLiveData(mainDispatcher)
+
+    val notificationsSettingsUiState = combine(siteStore.sites.map { getUiModel(it.id) }) { models ->
+        models.associate { siteStore.getSiteIdForLocalId(it.siteId) to dayLabelUtils.buildSiteSettingsLabel(it) }
+    }.asLiveData(mainDispatcher)
 
     private fun getUiModel(siteId: Int) =
             bloggingRemindersStore.bloggingRemindersModel(siteId).map { mapper.toUiModel(it) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -221,7 +221,7 @@ class BloggingRemindersViewModel @Inject constructor(
         }
     }
 
-    fun onSettingsItemClicked(siteId: Int) {
+    fun onBlogSettingsItemClicked(siteId: Int) {
         onSettingsItemClicked(siteId, BLOG_SETTINGS)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -102,7 +102,7 @@ class BloggingRemindersViewModel @Inject constructor(
         analyticsTracker.trackScreenShown(screen)
     }
 
-    fun getSettingsState(siteId: Int) = getUiModel(siteId)
+    fun getBlogSettingsUiState(siteId: Int) = getUiModel(siteId)
             .map { dayLabelUtils.buildSiteSettingsLabel(it) }
             .asLiveData(mainDispatcher)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source.BLOG_SETTINGS
@@ -41,7 +42,8 @@ class BloggingRemindersViewModel @Inject constructor(
     private val dayLabelUtils: DayLabelUtils,
     private val analyticsTracker: BloggingRemindersAnalyticsTracker,
     private val reminderScheduler: ReminderScheduler,
-    private val mapper: BloggingRemindersModelMapper
+    private val mapper: BloggingRemindersModelMapper,
+    private val siteStore: SiteStore
 ) : ScopedViewModel(mainDispatcher) {
     private val _isBottomSheetShowing = MutableLiveData<Event<Boolean>>()
     val isBottomSheetShowing = _isBottomSheetShowing as LiveData<Event<Boolean>>

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1227,7 +1227,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mBloggingRemindersPref == null || !isAdded()) {
             return;
         }
-        mBloggingRemindersViewModel.onSettingsItemClicked(mSite.getId());
+        mBloggingRemindersViewModel.onBlogSettingsItemClicked(mSite.getId());
     }
 
     private void showHomepageSettings() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1214,7 +1214,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                     BLOGGING_REMINDERS_BOTTOM_SHEET_TAG,
                     () -> getAppCompatActivity().getSupportFragmentManager()
             );
-            mBloggingRemindersViewModel.getSettingsState(mSite.getId()).observe(getAppCompatActivity(), s -> {
+            mBloggingRemindersViewModel.getBlogSettingsUiState(mSite.getId()).observe(getAppCompatActivity(), s -> {
                 if (mBloggingRemindersPref != null) {
                     CharSequence summary = mUiHelpers.getTextOfUiString(getActivity(), s);
                     mBloggingRemindersPref.setSummary(summary);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
@@ -196,7 +196,7 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
 
                 boolean isSettingLast = i == mSettingsArray.length - 1;
 
-                view.addView(setupSettingView(settingName, settingValue, settingSummary, isSettingChecked,
+                view.addView(setupSwitchSettingView(settingName, settingValue, settingSummary, isSettingChecked,
                         isSettingLast, mOnCheckedChangedListener));
             }
         }
@@ -205,7 +205,7 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
         if (mChannel == Channel.BLOGS && mType == Type.DEVICE) {
             String settingName = getContext().getString(R.string.weekly_roundup);
             boolean isSettingChecked = AppPrefs.shouldShowWeeklyRoundupNotification(mBlogId);
-            View settingView = setupSettingView(settingName, null, null, isSettingChecked, true,
+            View settingView = setupSwitchSettingView(settingName, null, null, isSettingChecked, true,
                     (compoundButton, isChecked) -> AppPrefs.setShouldShowWeeklyRoundupNotification(mBlogId, isChecked));
             view.addView(settingView);
         }
@@ -213,7 +213,7 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
         return view;
     }
 
-    private View setupSettingView(String settingName, @Nullable String settingValue,
+    private View setupSwitchSettingView(String settingName, @Nullable String settingValue,
                                         @Nullable String settingSummary, boolean isSettingChecked,
                                         boolean isSettingLast,
                                         CompoundButton.OnCheckedChangeListener onCheckedChangeListener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
@@ -213,9 +213,18 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
         return view;
     }
 
+    private View setupSettingView(String settingName, @Nullable String settingValue,
+                                        @Nullable String settingSummary, boolean isSettingChecked,
+                                        boolean isSettingLast,
+                                        CompoundButton.OnCheckedChangeListener onCheckedChangeListener) {
+        return setupSettingView(settingName, settingValue, settingSummary, isSettingChecked, isSettingLast,
+                onCheckedChangeListener, null);
+    }
+
     private View setupSettingView(String settingName, @Nullable String settingValue, @Nullable String settingSummary,
                                   boolean isSettingChecked, boolean isSettingLast,
-                                  CompoundButton.OnCheckedChangeListener onCheckedChangeListener) {
+                                  @Nullable CompoundButton.OnCheckedChangeListener onCheckedChangeListener,
+                                  @Nullable View.OnClickListener onClickListener) {
         NotificationsSettingsSwitchBinding binding =
                 NotificationsSettingsSwitchBinding.inflate(LayoutInflater.from(getContext()));
 
@@ -233,6 +242,10 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
             binding.rowContainer.setOnClickListener(v -> binding.notificationsSwitch.toggle());
         } else {
             binding.notificationsSwitch.setVisibility(View.GONE);
+        }
+
+        if (onClickListener != null) {
+            binding.rowContainer.setOnClickListener(onClickListener);
         }
 
         if (mShouldDisplayMainSwitch && isSettingLast) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
@@ -221,6 +221,11 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
                 onCheckedChangeListener, null);
     }
 
+    private View setupClickSettingView(String settingName, String settingSummary, boolean isSettingLast,
+                                       View.OnClickListener onClickListener) {
+        return setupSettingView(settingName, null, settingSummary, false, isSettingLast, null, onClickListener);
+    }
+
     private View setupSettingView(String settingName, @Nullable String settingValue, @Nullable String settingSummary,
                                   boolean isSettingChecked, boolean isSettingLast,
                                   @Nullable CompoundButton.OnCheckedChangeListener onCheckedChangeListener,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
@@ -24,6 +24,7 @@ import androidx.core.content.ContextCompat;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.R;
+import org.wordpress.android.databinding.NotificationsSettingsSwitchBinding;
 import org.wordpress.android.models.NotificationsSettings;
 import org.wordpress.android.models.NotificationsSettings.Channel;
 import org.wordpress.android.models.NotificationsSettings.Type;
@@ -215,35 +216,34 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
     private View setupSettingView(String settingName, @Nullable String settingValue, @Nullable String settingSummary,
                                   boolean isSettingChecked, boolean isSettingLast,
                                   CompoundButton.OnCheckedChangeListener onCheckedChangeListener) {
-        View setting = View.inflate(getContext(), R.layout.notifications_settings_switch, null);
-        TextView title = setting.findViewById(R.id.notifications_switch_title);
-        title.setText(settingName);
+        NotificationsSettingsSwitchBinding binding =
+                NotificationsSettingsSwitchBinding.inflate(LayoutInflater.from(getContext()));
+
+        binding.notificationsSwitchTitle.setText(settingName);
 
         if (!TextUtils.isEmpty(settingSummary)) {
-            TextView summary = setting.findViewById(R.id.notifications_switch_summary);
-            summary.setVisibility(View.VISIBLE);
-            summary.setText(settingSummary);
+            binding.notificationsSwitchSummary.setVisibility(View.VISIBLE);
+            binding.notificationsSwitchSummary.setText(settingSummary);
         }
 
-        final SwitchCompat toggleSwitch = setting.findViewById(R.id.notifications_switch);
-        toggleSwitch.setChecked(isSettingChecked);
-        toggleSwitch.setTag(settingValue);
-        toggleSwitch.setOnCheckedChangeListener(onCheckedChangeListener);
-
-        View rowContainer = setting.findViewById(R.id.row_container);
-        rowContainer.setOnClickListener(v -> toggleSwitch.setChecked(!toggleSwitch.isChecked()));
+        if (onCheckedChangeListener != null) {
+            binding.notificationsSwitch.setChecked(isSettingChecked);
+            binding.notificationsSwitch.setTag(settingValue);
+            binding.notificationsSwitch.setOnCheckedChangeListener(onCheckedChangeListener);
+            binding.rowContainer.setOnClickListener(v -> binding.notificationsSwitch.toggle());
+        } else {
+            binding.notificationsSwitch.setVisibility(View.GONE);
+        }
 
         if (mShouldDisplayMainSwitch && isSettingLast) {
-            View divider = setting.findViewById(R.id.notifications_list_divider);
-            if (divider != null) {
-                MarginLayoutParams mlp = (MarginLayoutParams) divider.getLayoutParams();
-                mlp.leftMargin = 0;
-                mlp.rightMargin = 0;
-                divider.setLayoutParams(mlp);
-            }
+            View divider = binding.notificationsListDivider;
+            MarginLayoutParams mlp = (MarginLayoutParams) divider.getLayoutParams();
+            mlp.leftMargin = 0;
+            mlp.rightMargin = 0;
+            divider.setLayoutParams(mlp);
         }
 
-        return setting;
+        return binding.getRoot();
     }
 
     private final CompoundButton.OnCheckedChangeListener mOnCheckedChangedListener =

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
@@ -203,16 +203,22 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
             }
         }
 
-        // Add Weekly Roundup setting
         if (shouldShowLocalNotifications) {
-            String settingName = getContext().getString(R.string.weekly_roundup);
-            boolean isSettingChecked = AppPrefs.shouldShowWeeklyRoundupNotification(mBlogId);
-            View settingView = setupSwitchSettingView(settingName, null, null, isSettingChecked, true,
-                    (compoundButton, isChecked) -> AppPrefs.setShouldShowWeeklyRoundupNotification(mBlogId, isChecked));
-            view.addView(settingView);
+            addWeeklyRoundupSetting(view, true);
         }
 
         return view;
+    }
+
+    private void addWeeklyRoundupSetting(LinearLayout view, boolean isLast) {
+        view.addView(setupSwitchSettingView(
+                getContext().getString(R.string.weekly_roundup),
+                null,
+                null,
+                AppPrefs.shouldShowWeeklyRoundupNotification(mBlogId),
+                isLast,
+                (compoundButton, isChecked) -> AppPrefs.setShouldShowWeeklyRoundupNotification(mBlogId, isChecked)
+        ));
     }
 
     private View setupSwitchSettingView(String settingName, @Nullable String settingValue,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
@@ -204,7 +204,11 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
         }
 
         if (shouldShowLocalNotifications) {
-            addWeeklyRoundupSetting(view, true);
+            boolean isBloggingRemindersEnabled = true; // TODO Handle feature flag
+            addWeeklyRoundupSetting(view, !isBloggingRemindersEnabled);
+            if (isBloggingRemindersEnabled) {
+                addBloggingReminderSetting(view);
+            }
         }
 
         return view;
@@ -218,6 +222,19 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
                 AppPrefs.shouldShowWeeklyRoundupNotification(mBlogId),
                 isLast,
                 (compoundButton, isChecked) -> AppPrefs.setShouldShowWeeklyRoundupNotification(mBlogId, isChecked)
+        ));
+    }
+
+
+    private void addBloggingReminderSetting(LinearLayout view) {
+        view.addView(setupClickSettingView(
+                getContext().getString(R.string.site_settings_blogging_reminders_title),
+                null, // TODO Add summary
+                true,
+                (v -> {
+                    // TODO Handle click
+                    getDialog().dismiss();
+                })
         ));
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
@@ -176,6 +176,8 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
                 break;
         }
 
+        boolean shouldShowLocalNotifications = mChannel == Channel.BLOGS && mType == Type.DEVICE;
+
         if (settingsJson != null && mSettingsArray.length == mSettingsValues.length) {
             for (int i = 0; i < mSettingsArray.length; i++) {
                 String settingName = mSettingsArray[i];
@@ -194,7 +196,7 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
 
                 boolean isSettingChecked = JSONUtils.queryJSON(settingsJson, settingValue, true);
 
-                boolean isSettingLast = i == mSettingsArray.length - 1;
+                boolean isSettingLast = !shouldShowLocalNotifications && i == mSettingsArray.length - 1;
 
                 view.addView(setupSwitchSettingView(settingName, settingValue, settingSummary, isSettingChecked,
                         isSettingLast, mOnCheckedChangedListener));
@@ -202,7 +204,7 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
         }
 
         // Add Weekly Roundup setting
-        if (mChannel == Channel.BLOGS && mType == Type.DEVICE) {
+        if (shouldShowLocalNotifications) {
             String settingName = getContext().getString(R.string.weekly_roundup);
             boolean isSettingChecked = AppPrefs.shouldShowWeeklyRoundupNotification(mBlogId);
             View settingView = setupSwitchSettingView(settingName, null, null, isSettingChecked, true,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -73,6 +73,7 @@ import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.android.util.config.BloggingRemindersFeatureConfig;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -125,6 +126,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     @Inject FollowedBlogsProvider mFollowedBlogsProvider;
     @Inject BuildConfigWrapper mBuildConfigWrapper;
     @Inject ViewModelProvider.Factory mViewModelFactory;
+    @Inject BloggingRemindersFeatureConfig mBloggingRemindersFeatureConfig;
 
     private BloggingRemindersViewModel mBloggingRemindersViewModel;
 
@@ -915,7 +917,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
 
     private final BloggingRemindersProvider mBloggingRemindersProvider = new BloggingRemindersProvider() {
         @Override public boolean isEnabled() {
-            return true; // TODO Handle feature flag
+            return mBloggingRemindersFeatureConfig.isEnabled();
         }
 
         @Override public String getSummary(long blogId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.prefs.notifications;
 
+import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
@@ -24,6 +25,7 @@ import android.widget.ListView;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.view.ViewCompat;
 
@@ -893,5 +895,14 @@ public class NotificationsSettingsFragment extends PreferenceFragment
                 }
             }
         }
+    }
+
+    @Nullable
+    private AppCompatActivity getAppCompatActivity() {
+        final Activity activity = getActivity();
+        if (activity instanceof AppCompatActivity) {
+            return (AppCompatActivity) activity;
+        }
+        return null;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -66,6 +66,8 @@ import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.PreferenceModel;
 import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.PreferenceModel.ClickHandler;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsDialogPreference.BloggingRemindersProvider;
+import org.wordpress.android.ui.utils.UiHelpers;
+import org.wordpress.android.ui.utils.UiString;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.BuildConfigWrapper;
@@ -79,8 +81,10 @@ import org.wordpress.android.util.config.BloggingRemindersFeatureConfig;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -128,8 +132,10 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     @Inject BuildConfigWrapper mBuildConfigWrapper;
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject BloggingRemindersFeatureConfig mBloggingRemindersFeatureConfig;
+    @Inject UiHelpers mUiHelpers;
 
     private BloggingRemindersViewModel mBloggingRemindersViewModel;
+    private final Map<Long, UiString> mBloggingRemindersSummariesBySiteId = new HashMap<>();
 
     private static final String BLOGGING_REMINDERS_BOTTOM_SHEET_TAG = "blogging-reminders-dialog-tag";
 
@@ -924,7 +930,8 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         }
 
         @Override public String getSummary(long blogId) {
-            return null; // TODO Provide summary
+            UiString uiString = mBloggingRemindersSummariesBySiteId.get(blogId);
+            return uiString != null ? mUiHelpers.getTextOfUiString(getContext(), uiString).toString() : null;
         }
 
         @Override public void onClick(long blogId) {
@@ -947,6 +954,9 @@ public class NotificationsSettingsFragment extends PreferenceFragment
                     BLOGGING_REMINDERS_BOTTOM_SHEET_TAG,
                     appCompatActivity::getSupportFragmentManager
             );
+
+            mBloggingRemindersViewModel.getNotificationsSettingsUiState()
+                                       .observe(appCompatActivity, mBloggingRemindersSummariesBySiteId::putAll);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -28,6 +28,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.view.ViewCompat;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -58,6 +59,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.NotificationsSettings;
 import org.wordpress.android.models.NotificationsSettings.Channel;
 import org.wordpress.android.models.NotificationsSettings.Type;
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.PreferenceModel;
@@ -122,6 +124,9 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     @Inject Dispatcher mDispatcher;
     @Inject FollowedBlogsProvider mFollowedBlogsProvider;
     @Inject BuildConfigWrapper mBuildConfigWrapper;
+    @Inject ViewModelProvider.Factory mViewModelFactory;
+
+    private BloggingRemindersViewModel mBloggingRemindersViewModel;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -187,6 +192,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         if (lv != null) {
             ViewCompat.setNestedScrollingEnabled(lv, true);
         }
+        initBloggingReminders();
     }
 
 
@@ -920,4 +926,16 @@ public class NotificationsSettingsFragment extends PreferenceFragment
             // TODO Handle click
         }
     };
+
+    private void initBloggingReminders() {
+        if (!isAdded()) {
+            return;
+        }
+
+        final AppCompatActivity appCompatActivity = getAppCompatActivity();
+        if (appCompatActivity != null) {
+            mBloggingRemindersViewModel = new ViewModelProvider(appCompatActivity, mViewModelFactory)
+                    .get(BloggingRemindersViewModel.class);
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -62,6 +62,7 @@ import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.PreferenceModel;
 import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.PreferenceModel.ClickHandler;
+import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsDialogPreference.BloggingRemindersProvider;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.BuildConfigWrapper;
@@ -740,7 +741,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         if (!TextUtils.isEmpty(deviceID)) {
             NotificationsSettingsDialogPreference devicePreference = new NotificationsSettingsDialogPreference(
                     context, null, channel, NotificationsSettings.Type.DEVICE, blogId, mNotificationsSettings,
-                    mOnSettingsChangedListener
+                    mOnSettingsChangedListener, mBloggingRemindersProvider
             );
             setPreferenceIcon(devicePreference, R.drawable.ic_phone_white_24dp);
             devicePreference.setTitle(R.string.app_notifications);
@@ -905,4 +906,18 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         }
         return null;
     }
+
+    private final BloggingRemindersProvider mBloggingRemindersProvider = new BloggingRemindersProvider() {
+        @Override public boolean isEnabled() {
+            return true; // TODO Handle feature flag
+        }
+
+        @Override public String getSummary(long blogId) {
+            return null; // TODO Provide summary
+        }
+
+        @Override public void onClick(long blogId) {
+            // TODO Handle click
+        }
+    };
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -59,6 +59,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.NotificationsSettings;
 import org.wordpress.android.models.NotificationsSettings.Channel;
 import org.wordpress.android.models.NotificationsSettings.Type;
+import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
@@ -129,6 +130,8 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     @Inject BloggingRemindersFeatureConfig mBloggingRemindersFeatureConfig;
 
     private BloggingRemindersViewModel mBloggingRemindersViewModel;
+
+    private static final String BLOGGING_REMINDERS_BOTTOM_SHEET_TAG = "blogging-reminders-dialog-tag";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -925,7 +928,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         }
 
         @Override public void onClick(long blogId) {
-            // TODO Handle click
+            mBloggingRemindersViewModel.onNotificationSettingsItemClicked(blogId);
         }
     };
 
@@ -938,6 +941,12 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         if (appCompatActivity != null) {
             mBloggingRemindersViewModel = new ViewModelProvider(appCompatActivity, mViewModelFactory)
                     .get(BloggingRemindersViewModel.class);
+            BloggingReminderUtils.observeBottomSheet(
+                    mBloggingRemindersViewModel.isBottomSheetShowing(),
+                    appCompatActivity,
+                    BLOGGING_REMINDERS_BOTTOM_SHEET_TAG,
+                    appCompatActivity::getSupportFragmentManager
+            );
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.MONDAY
 import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.SUNDAY
 import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.WEDNESDAY
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.test
 import org.wordpress.android.toList
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source.BLOG_SETTINGS
@@ -55,6 +56,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Mock lateinit var dayLabelUtils: DayLabelUtils
     @Mock lateinit var analyticsTracker: BloggingRemindersAnalyticsTracker
     @Mock lateinit var reminderScheduler: ReminderScheduler
+    @Mock lateinit var siteStore: SiteStore
     private lateinit var viewModel: BloggingRemindersViewModel
     private val siteId = 123
     private val hour = 10
@@ -75,7 +77,8 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
                 dayLabelUtils,
                 analyticsTracker,
                 reminderScheduler,
-                BloggingRemindersModelMapper()
+                BloggingRemindersModelMapper(),
+                siteStore
         )
         events = mutableListOf()
         events = viewModel.isBottomSheetShowing.eventToList()
@@ -95,7 +98,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     fun `sets blogging reminders as shown from SiteSettings when has no previous blogging reminders`() = test {
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(false)
 
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
 
         verify(bloggingRemindersManager).bloggingRemindersShown(siteId)
     }
@@ -124,7 +127,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         val uiItems = initPrologueBuilderForSiteSettings()
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(false)
 
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
 
         assertThat(uiState.last().uiItems).isEqualTo(uiItems)
     }
@@ -136,7 +139,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         whenever(daySelectionBuilder.buildSelection(eq(model), any(), any())).thenReturn(daySelectionScreen)
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
 
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
 
         assertThat(uiState.last().uiItems).isEqualTo(daySelectionScreen)
     }
@@ -165,7 +168,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         ).thenReturn(dayLabel)
         var uiState: UiString? = null
 
-        viewModel.getSettingsState(siteId).observeForever { uiState = it }
+        viewModel.getBlogSettingsUiState(siteId).observeForever { uiState = it }
 
         assertThat(uiState).isEqualTo(dayLabel)
     }
@@ -203,7 +206,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         initEpilogueBuilder()
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
 
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
 
         clickPrimaryButton()
     }
@@ -233,7 +236,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Test
     fun `showBottomSheet tracks flow start with correct source`() = test {
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
         viewModel.onPublishingPost(siteId, true)
 
@@ -246,7 +249,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         whenever(bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)).thenReturn(true)
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
         viewModel.onPublishingPost(siteId, true)
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
 
         verify(analyticsTracker).trackScreenShown(PROLOGUE)
         verify(analyticsTracker).trackScreenShown(SELECTION)
@@ -279,7 +282,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         initDaySelectionBuilder()
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
 
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
 
         clickPrimaryButton()
 
@@ -308,7 +311,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Test
     fun `dismissing bottom sheet on selection screen tracks dismiss event`() = test {
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
         viewModel.onBottomSheetDismissed()
 
         verify(analyticsTracker).trackFlowDismissed(SELECTION)
@@ -329,7 +332,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         initDaySelectionBuilder()
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
 
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
 
         clickPrimaryButton()
 
@@ -347,7 +350,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         initDaySelectionBuilder()
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
 
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
 
         clickPrimaryButton()
 
@@ -391,7 +394,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
 
         initPrologueBuilderForSiteSettings()
 
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
 
         assertPrologue()
     }
@@ -403,7 +406,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         initEmptyStore()
         initDaySelectionBuilder()
 
-        viewModel.onSettingsItemClicked(siteId)
+        viewModel.onBlogSettingsItemClicked(siteId)
 
         assertDaySelection()
     }


### PR DESCRIPTION
Fixes #15321

This PR adds a new Blogging Reminders entry point to the notification settings screen:

https://user-images.githubusercontent.com/830056/134975192-079618a7-6d21-46cf-8543-f9637d833311.mp4

After experimenting with a bunch of different approaches, I've settled on the following changes:
- Created a new `BloggingRemindersProvider` interface that is implemented by `NotificationsSettingsFragment` and passed to `NotificationsSettingsDialogPreference` in order to handle showing/hiding the Blogging Reminders bottom sheet and also to show the formatted Blogging Reminders summary for each site. 
- This `BloggingRemindersProvider` implementation is backed by a few new methods in the `BloggingRemindersViewModel`, which is now being injected into `NotificationsSettingsFragment`.
- Added a new `notification_settings` source to differentiate from flows started from the site settings screen entry point.

### To test

#### From Your Sites category

1. Open the app.
1. Tap the notifications tab.
1. Tap the gear on the top right corner of the screen.
1. On the Notification Settings screen, tap any site under the "Your Sites" section.
1. Tap "App notifications".
1. On the App notifications dialog, notice the Blogging Reminders item with the correct summary.
1. Tap the Blogging Reminders item. 
1. Notice the Blogging Reminders dialog.
1. Complete the flow.
1. Tap "App notifications" again.
1. On the App notifications dialog, notice the Blogging Reminders item summary was updated.

#### From All My Sites screen

1. Open the app with an account that has more than 3 sites.
1. Tap the notifications tab.
1. Tap the gear on the top right corner of the screen.
1. On the Notification Settings screen, tap the "All My Sites" item under the "Your Sites" section.
1. On the All My Sites screen, tap any site.
1. Tap "App notifications".
1. On the App notifications dialog, notice the Blogging Reminders item with the correct summary.
1. Tap the Blogging Reminders item. 
1. Notice the Blogging Reminders dialog.
1. Complete the flow.
1. Tap "App notifications" again.
1. On the App notifications dialog, notice the Blogging Reminders item summary was updated.

#### From search screen

1. Open the app.
1. Tap the notifications tab.
1. Tap the gear on the top right corner of the screen.
1. On the Notification Settings screen, tap the "Search" icon on the top right corner of the screen.
1. Search for any site name.
1. On the search result screen, tap any site.
1. Tap "App notifications".
1. On the App notifications dialog, notice the Blogging Reminders item with the correct summary.
1. Tap the Blogging Reminders item. 
1. Notice the Blogging Reminders dialog.
1. Complete the flow.
1. Tap "App notifications" again.
1. On the App notifications dialog, notice the Blogging Reminders item summary was updated.

## Regression Notes
1. Potential unintended areas of impact
Other notification settings.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
