### PR TITLE
Merge release/18.2.1 into trunk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.61.1'
+    ext.gutenbergMobileVersion = '4036-96c541bb8c36237d0dbee34b26d5aacab65e3848'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '4036-96c541bb8c36237d0dbee34b26d5aacab65e3848'
+    ext.gutenbergMobileVersion = '4036-98761639f3be6ba6a633e8393f0bba1dbdb33f8b'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '4036-98761639f3be6ba6a633e8393f0bba1dbdb33f8b'
+    ext.gutenbergMobileVersion = 'v1.61.2'
 
     repositories {
         maven {

--- a/version.properties
+++ b/version.properties
@@ -1,8 +1,8 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=18.2
-versionCode=1110
+versionName=18.2.1
+versionCode=1113
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
 alpha.versionName=alpha-319


### PR DESCRIPTION
Hotfix [18.2.1](https://github.com/wordpress-mobile/WordPress-Android/releases/tag/18.2.1) includes [this Gutenberg hotfix](https://github.com/wordpress-mobile/WordPress-Android/pull/15375)

Binary has just been submitted to PlayStore.
