### PR TITLE
Update debug cookies feature to support `WebView`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookie.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookie.kt
@@ -13,6 +13,8 @@ data class DebugCookie(
 
     val oldRfcDomain = ".$host"
 
+    val headerValue = name + "=" + value.orEmpty()
+
     fun toURI(): URI = URI(host)
 
     fun toHttpCookie(): HttpCookie = HttpCookie(name, value).apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookie.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookie.kt
@@ -5,21 +5,17 @@ import java.net.HttpCookie
 import java.net.URI
 
 data class DebugCookie(
-    val domain: String,
+    val host: String,
     val name: String,
-    val value: String?,
-    val scheme: String = "https",
-    val path: String = "/",
-    val version: Int = 0
+    val value: String?
 ) {
-    val key = domain + "_" + name
+    val key = host + "_" + name
 
-    fun toURI(): URI = URI(scheme, domain, path, null)
+    fun toURI(): URI = URI(host)
 
     fun toHttpCookie(): HttpCookie = HttpCookie(name, value).apply {
-        version = this@DebugCookie.version
-        domain = this@DebugCookie.domain
-        path = this@DebugCookie.path
+        version = 0
+        domain = host
     }
 
     fun encode(gson: Gson): String = gson.toJson(this)

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookie.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookie.kt
@@ -11,6 +11,8 @@ data class DebugCookie(
 ) {
     val key = host + "_" + name
 
+    val oldRfcDomain = ".$host"
+
     fun toURI(): URI = URI(host)
 
     fun toHttpCookie(): HttpCookie = HttpCookie(name, value).apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookie.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookie.kt
@@ -11,14 +11,14 @@ data class DebugCookie(
 ) {
     val key = host + "_" + name
 
-    val oldRfcDomain = ".$host"
+    val oldRfcDomain = ".$host" // Append leading dot to match subdomains under RFC2109 and RFC2965
 
     val headerValue = name + "=" + value.orEmpty()
 
     fun toURI(): URI = URI(host)
 
     fun toHttpCookie(): HttpCookie = HttpCookie(name, value).apply {
-        version = 0
+        version = 0 // Use Netscape specification to maintain compatibility with java.net.CookieManager
         domain = host
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookieManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookieManager.kt
@@ -11,17 +11,17 @@ import java.net.CookieManager
 import javax.inject.Inject
 
 /**
- * This class wraps a [CookieStore][java.net.CookieStore] and a [SharedPreferences][android.content.SharedPreferences],
- * and syncs [DebugCookie]s between them.
+ * This class syncs [DebugCookie]s between a [java.net.CookieManager], a [android.webkit.CookieManager], and a
+ * [SharedPreferences][android.content.SharedPreferences].
  *
  * Note: this class was not designed with production use in mind, and because of that, it makes several assumptions
  * about the format of the cookies. If we ever need to use this for anything other than manually setting debug cookies,
- * then we should consider introducing our own [CookieStore][java.net.CookieStore] implementation instead.
+ * then we should consider introducing our own [java.net.CookieStore] implementation instead.
  *
- * @param context The [Context][android.content.Context] from which the
- * [SharedPreferences][android.content.SharedPreferences] will be built.
- * @param cookieManager The [CookieManager][java.net.CookieManager] from which the [CookieStore][java.net.CookieStore]
- * will be retrieved.
+ * @param httpCookieManager [java.net.CookieManager] instance used by HTTP calls.
+ * @param webViewCookieManager [android.webkit.CookieManager] instance used by [WebView][android.webkit.WebView]s.
+ * @param preferences [SharedPreferences][android.content.SharedPreferences] instance to store [DebugCookie]s.
+ * @param gson Gson instance to encode/decode [DebugCookie]s for [SharedPreferences][android.content.SharedPreferences].
  */
 class DebugCookieManager internal constructor(
     private val httpCookieManager: CookieManager,

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookieManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookieManager.kt
@@ -2,7 +2,9 @@ package org.wordpress.android.ui.debug.cookies
 
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import org.wordpress.android.util.BuildConfigWrapper
 import java.net.CookieManager
@@ -21,40 +23,61 @@ import javax.inject.Inject
  * @param cookieManager The [CookieManager][java.net.CookieManager] from which the [CookieStore][java.net.CookieStore]
  * will be retrieved.
  */
-class DebugCookieManager @Inject constructor(
-    context: Context,
-    cookieManager: CookieManager,
+class DebugCookieManager internal constructor(
+    private val httpCookieManager: CookieManager,
+    private val webViewCookieManager: android.webkit.CookieManager,
+    private val preferences: SharedPreferences,
+    private val gson: Gson,
     private val buildConfig: BuildConfigWrapper
 ) {
-    private val preferences = context.getSharedPreferences(DEBUG_COOKIE_PREFERENCES, MODE_PRIVATE)
-    private val store = cookieManager.cookieStore
-    private val gson = GsonBuilder().serializeNulls().create()
+    @Inject constructor(
+        context: Context,
+        cookieManager: CookieManager,
+        buildConfig: BuildConfigWrapper
+    ) : this(
+            cookieManager,
+            android.webkit.CookieManager.getInstance(),
+            context.getSharedPreferences(DEBUG_COOKIE_PREFERENCES, MODE_PRIVATE),
+            GsonBuilder().serializeNulls().create(),
+            buildConfig
+    )
 
     fun sync() {
         if (buildConfig.isDebugSettingsEnabled()) {
-            getAll().forEach { addToStore(it) }
+            getAll().forEach {
+                httpCookieManager.add(it)
+                webViewCookieManager.add(it)
+            }
         }
     }
 
     fun getAll() = preferences.all.values.mapNotNull { DebugCookie.decode(gson, it as? String?) }
 
     fun add(cookie: DebugCookie) {
-        addToStore(cookie)
-        addToPreferences(cookie)
+        httpCookieManager.add(cookie)
+        webViewCookieManager.add(cookie)
+        preferences.add(cookie)
     }
 
     fun remove(cookie: DebugCookie) {
-        removeFromStore(cookie)
-        removeFromPreferences(cookie)
+        httpCookieManager.remove(cookie)
+        webViewCookieManager.remove(cookie)
+        preferences.remove(cookie)
     }
 
-    private fun addToStore(cookie: DebugCookie) = store.add(cookie.toURI(), cookie.toHttpCookie())
+    private fun CookieManager.add(cookie: DebugCookie) = cookieStore.add(cookie.toURI(), cookie.toHttpCookie())
 
-    private fun removeFromStore(cookie: DebugCookie) = store.remove(cookie.toURI(), cookie.toHttpCookie())
+    private fun CookieManager.remove(cookie: DebugCookie) = cookieStore.remove(cookie.toURI(), cookie.toHttpCookie())
 
-    private fun addToPreferences(cookie: DebugCookie) = preferences.edit { putString(cookie.key, cookie.encode(gson)) }
+    private fun android.webkit.CookieManager.remove(cookie: DebugCookie) =
+            setCookie(cookie.oldRfcDomain, cookie.copy(value = null).headerValue)
 
-    private fun removeFromPreferences(cookie: DebugCookie) = preferences.edit { remove(cookie.key) }
+    private fun android.webkit.CookieManager.add(cookie: DebugCookie) =
+            setCookie(cookie.oldRfcDomain, cookie.headerValue)
+
+    private fun SharedPreferences.add(cookie: DebugCookie) = edit { putString(cookie.key, cookie.encode(gson)) }
+
+    private fun SharedPreferences.remove(cookie: DebugCookie) = edit { remove(cookie.key) }
 
     companion object {
         private const val DEBUG_COOKIE_PREFERENCES = "debug-cookie-preferences"

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesAdapter.kt
@@ -20,7 +20,7 @@ class DebugCookiesAdapter : ListAdapter<DebugCookieItem, DebugCookieItemViewHold
 
     class DebugCookieItemViewHolder(private val binding: DebugCookieItemBinding) : ViewHolder(binding.root) {
         fun onBind(item: DebugCookieItem) = with(binding) {
-            cookieDomain.text = item.domain
+            cookieHost.text = item.host
             cookieName.text = item.name
             cookieValue.text = item.value
 
@@ -36,7 +36,7 @@ class DebugCookiesAdapter : ListAdapter<DebugCookieItem, DebugCookieItemViewHold
 
     data class DebugCookieItem(
         val key: String,
-        val domain: String,
+        val host: String,
         val name: String,
         val value: String?,
         val onClick: ListItemInteraction,

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesFragment.kt
@@ -51,7 +51,7 @@ class DebugCookiesFragment : Fragment(R.layout.debug_cookies_fragment) {
 
         setCookieButton.setOnClickListener {
             viewModel.setCookie(
-                    domainInput.text.toString(),
+                    hostInput.text.toString(),
                     nameInput.text.toString(),
                     valueInput.text.toString()
             )
@@ -61,7 +61,7 @@ class DebugCookiesFragment : Fragment(R.layout.debug_cookies_fragment) {
     private fun DebugCookiesFragmentBinding.setupObservers() {
         viewModel.uiState.observe(viewLifecycleOwner) { uiState ->
             (recyclerView.adapter as? DebugCookiesAdapter)?.submitList(uiState.items)
-            uiState.domainInputText?.let { domainInput.setTextAndMoveCursor(it) }
+            uiState.hostInputText?.let { hostInput.setTextAndMoveCursor(it) }
             uiState.nameInputText?.let { nameInput.setTextAndMoveCursor(it) }
             uiState.valueInputText?.let { valueInput.setTextAndMoveCursor(it) }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesViewModel.kt
@@ -27,7 +27,7 @@ class DebugCookiesViewModel @Inject constructor(
 
     private fun onItemClick(debugCookie: DebugCookie) {
         _uiState.value = _uiState.value?.copy(
-                domainInputText = debugCookie.domain,
+                domainInputText = debugCookie.host,
                 nameInputText = debugCookie.name,
                 valueInputText = debugCookie.value
         )
@@ -43,7 +43,7 @@ class DebugCookiesViewModel @Inject constructor(
     private fun getUpdatedItems() = debugCookieManager.getAll().sortedBy { it.key }.map {
         DebugCookieItem(
                 it.key,
-                it.domain,
+                it.host,
                 it.name,
                 it.value,
                 ListItemInteraction.create(it, ::onItemClick),

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesViewModel.kt
@@ -13,12 +13,12 @@ class DebugCookiesViewModel @Inject constructor(
     private val _uiState = MutableLiveData(UiState(getUpdatedItems()))
     val uiState: LiveData<UiState> = _uiState
 
-    fun setCookie(domain: String?, name: String?, value: String?) {
-        if (!domain.isNullOrBlank() && !name.isNullOrBlank()) {
-            debugCookieManager.add(DebugCookie(domain, name, value))
+    fun setCookie(host: String?, name: String?, value: String?) {
+        if (!host.isNullOrBlank() && !name.isNullOrBlank()) {
+            debugCookieManager.add(DebugCookie(host, name, value))
             _uiState.value = UiState(
                     items = getUpdatedItems(),
-                    domainInputText = domain,
+                    hostInputText = host,
                     nameInputText = name,
                     valueInputText = value
             )
@@ -27,7 +27,7 @@ class DebugCookiesViewModel @Inject constructor(
 
     private fun onItemClick(debugCookie: DebugCookie) {
         _uiState.value = _uiState.value?.copy(
-                domainInputText = debugCookie.host,
+                hostInputText = debugCookie.host,
                 nameInputText = debugCookie.name,
                 valueInputText = debugCookie.value
         )
@@ -53,7 +53,7 @@ class DebugCookiesViewModel @Inject constructor(
 
     data class UiState(
         val items: List<DebugCookieItem>,
-        val domainInputText: String? = null,
+        val hostInputText: String? = null,
         val nameInputText: String? = null,
         val valueInputText: String? = null
     )

--- a/WordPress/src/main/res/layout/debug_cookie_item.xml
+++ b/WordPress/src/main/res/layout/debug_cookie_item.xml
@@ -10,7 +10,7 @@
     android:paddingStart="@dimen/margin_medium">
 
     <TextView
-        android:id="@+id/cookie_domain"
+        android:id="@+id/cookie_host"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_medium"
@@ -28,7 +28,7 @@
         android:textAppearance="?attr/textAppearanceCaption"
         app:layout_constraintEnd_toStartOf="@+id/delete_cookie_button"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/cookie_domain"
+        app:layout_constraintTop_toBottomOf="@+id/cookie_host"
         tools:text="cookie_name" />
 
     <TextView

--- a/WordPress/src/main/res/layout/debug_cookies_fragment.xml
+++ b/WordPress/src/main/res/layout/debug_cookies_fragment.xml
@@ -54,12 +54,12 @@
             app:hintEnabled="false">
 
             <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/domain_input"
+                android:id="@+id/host_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/debug_cookies_cookie_domain_hint"
+                android:hint="@string/debug_cookies_cookie_host_hint"
                 android:inputType="textUri"
-                android:text="@string/debug_cookies_cookie_domain_hint" />
+                android:text="@string/debug_cookies_cookie_host_hint" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -918,7 +918,7 @@
     <!-- Debug cookies -->
     <string name="debug_cookies_title" translatable="false">Debug cookies</string>
     <string name="debug_cookies_set_cookie" translatable="false">Set cookie</string>
-    <string name="debug_cookies_cookie_domain_hint" translatable="false">wordpress.com</string>
+    <string name="debug_cookies_cookie_host_hint" translatable="false">wordpress.com</string>
     <string name="debug_cookies_cookie_name_hint" translatable="false">cookie_name</string>
     <string name="debug_cookies_cookie_value_hint" translatable="false">cookie_value</string>
 


### PR DESCRIPTION
This PR builds on top of the work done in #15152 and #15153 to introduce support for cookies used by our application's `WebView` instances. Additionally, it also simplifies the `DebugCookie` model to make it more focused on what we need.

### To test

Please, follow the instructions in #15153 and make sure the same applies to `WebView`s. 

## Regression Notes
1. Potential unintended areas of impact
None that I can think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
