### PR TITLE
Integrate gutenberg-mobile release 1.63.0-alpha2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.63.0-alpha1'
+    ext.gutenbergMobileVersion = '4046-988a6a65f1e262eac1af0acc879f3f6dd8feecfa'
 
     repositories {
         maven {


### PR DESCRIPTION
## Description
This PR incorporates the 1.63.0-alpha2 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4046

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.