### PR TITLE
Add A8C P2 filter to Weekly Roundup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.push.NotificationPushIds.WEEKLY_ROUNDUP_NOTIFICATION_ID
 import org.wordpress.android.push.NotificationType.WEEKLY_ROUNDUP
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.Organization
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe.WEEK
@@ -38,6 +39,7 @@ class WeeklyRoundupNotifier @Inject constructor(
                 .awaitAll()
                 .asSequence()
                 .filterNotNull()
+                .filter { it.site.organizationId != Organization.A8C.orgId } // Filters A8C P2s
                 .filter { appPrefs.shouldShowWeeklyRoundupNotification(it.site.siteId) }
                 .sortedByDescending { it.score }
                 .take(TOP_FIVE_SITES)

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '2131-adc90d6a59817943192f7f91412a0e7a6a3344fa'
+    fluxCVersion = 'develop-d32de86947dea4d0bc1b6ea247eb10fa73cc2777'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.26.0'
+    fluxCVersion = '2131-adc90d6a59817943192f7f91412a0e7a6a3344fa'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
This PR adds a filter to Weekly Roundup to prevent it from showing A8C P2s.

Related FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2131

### To test

You will need to follow the steps below twice. First with the current version of the app and then again with the changes in this PR. When running it with these changes, you should make sure you get notifications only for sites that are **not** A8C P2s.

1. From the Main screen, go to Me > App Settings > Debug settings.
1. On the Debug Settings screen, scroll down to the Tools section and tap "Force show Weekly Roundup notification".
1. Notice the Weekly Roundup notifications (this might take a while).

## Regression Notes

1. Potential unintended areas of impact
Other Weekly Roundup notifications.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
