### PR TITLE
Gutenberg mobile Android target API 30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.61.0'
+    ext.gutenbergMobileVersion = '4049-1e1ab213144eaa04f13618c4689d2a0971fec07d'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '4049-1e1ab213144eaa04f13618c4689d2a0971fec07d'
+    ext.gutenbergMobileVersion = '4049-9add7266e79ec921dd418c29887a36290d7321bd'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '4049-9add7266e79ec921dd418c29887a36290d7321bd'
+    ext.gutenbergMobileVersion = 'v1.64.0-alpha1'
 
     repositories {
         maven {


### PR DESCRIPTION
Adds the gutenberg-mobile API 30 changes on top of https://github.com/wordpress-mobile/WordPress-Android/pull/15331.

### Related PRs
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/4049
* https://github.com/WordPress/gutenberg/pull/35212

### To test:

The block editor should launch and work OK.

## Regression Notes
1. Potential unintended areas of impact

Bumping the tergetSdkVersion might be "removing" compatibility flags that could affect the behavior of the block editor but, none that I know of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Nothing special. I did a "smoke test" by launching the editor, and doing some simple edits in paragraph and image blocks.

3. What automated tests I added (or what prevented me from doing so)

Nothing specific to test or protect against so, no tests added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
