### PR TITLE
[SPIKE] [GB] Try loading wpcom specifc extras

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -255,3 +255,4 @@
     </codeStyleSettings>
   </code_scheme>
 </component>
+

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.63.0-alpha1'
+    ext.gutenbergMobileVersion = '4050-6e8625791aae398ab79978409da1d92241f3ab1f'
 
     repositories {
         maven {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergBridgeJS2ParentWPCOM.kt
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergBridgeJS2ParentWPCOM.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.editor.gutenberg
+
+interface GutenbergBridgeJS2ParentWPCOM {
+    fun justToast(text: String?)
+}

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment;
 import org.wordpress.android.editor.BuildConfig;
 import org.wordpress.android.editor.ExceptionLogger;
 import org.wordpress.android.editor.R;
+import org.wordpress.android.editor.gutenberg.WPAndroidGlueCodeWPCOM.GutenbergBridgeJS2ParentWPCOMListener;
 import org.wordpress.mobile.WPAndroidGlue.ShowSuggestionsUtil;
 import org.wordpress.mobile.WPAndroidGlue.GutenbergProps;
 import org.wordpress.mobile.WPAndroidGlue.RequestExecutor;
@@ -77,7 +78,8 @@ public class GutenbergContainerFragment extends Fragment {
                                   OnGutenbergDidRequestPreviewListener
                                           onGutenbergDidRequestPreviewListener,
                                   OnBlockTypeImpressionsEventListener onBlockTypeImpressionsListener,
-                                  boolean isDarkMode) {
+                                  boolean isDarkMode,
+                                  GutenbergBridgeJS2ParentWPCOMListener gutenbergBridgeJS2ParentWPCOMListener) {
             mWPAndroidGlueCode.attachToContainer(
                     viewGroup,
                     onMediaLibraryButtonListener,
@@ -97,7 +99,8 @@ public class GutenbergContainerFragment extends Fragment {
                     onFPPTooltipShownEventListener,
                     onGutenbergDidRequestPreviewListener,
                     onBlockTypeImpressionsListener,
-                    isDarkMode);
+                    isDarkMode,
+                    gutenbergBridgeJS2ParentWPCOMListener);
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -43,7 +43,7 @@ public class GutenbergContainerFragment extends Fragment {
     private boolean mHtmlModeEnabled;
     private boolean mHasReceivedAnyContent;
 
-    private WPAndroidGlueCode mWPAndroidGlueCode;
+    private WPAndroidGlueCodeWPCOM mWPAndroidGlueCode;
     public static GutenbergContainerFragment newInstance(GutenbergPropsBuilder gutenbergPropsBuilder) {
         GutenbergContainerFragment fragment = new GutenbergContainerFragment();
         Bundle args = new Bundle();
@@ -114,7 +114,7 @@ public class GutenbergContainerFragment extends Fragment {
             breadcrumbLogger = exceptionLoggingActivity.getBreadcrumbLogger();
         }
 
-        mWPAndroidGlueCode = new WPAndroidGlueCode();
+        mWPAndroidGlueCode = new WPAndroidGlueCodeWPCOM();
         mWPAndroidGlueCode.onCreate(getContext());
         mWPAndroidGlueCode.onCreateView(
                 getContext(),

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -47,6 +47,7 @@ import org.wordpress.android.editor.R;
 import org.wordpress.android.editor.WPGutenbergWebViewActivity;
 import org.wordpress.android.editor.gutenberg.GutenbergDialogFragment.GutenbergDialogPositiveClickInterface;
 import org.wordpress.android.editor.gutenberg.GutenbergDialogFragment.GutenbergDialogNegativeClickInterface;
+import org.wordpress.android.editor.gutenberg.WPAndroidGlueCodeWPCOM.GutenbergBridgeJS2ParentWPCOMListener;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -506,7 +507,13 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                         mEditorFragmentListener.onSetBlockTypeImpressions(impressions);
                     }
                 },
-                GutenbergUtils.isDarkMode(getActivity()));
+                GutenbergUtils.isDarkMode(getActivity()),
+                new GutenbergBridgeJS2ParentWPCOMListener() {
+                    @Override public void justToast(@Nullable String text) {
+                        ToastUtils.showToast(getContext(), text);
+                    }
+                }
+        );
 
         // request dependency injection. Do this after setting min/max dimensions
         if (getActivity() instanceof EditorFragmentActivity) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/RNExampleModule.kt
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/RNExampleModule.kt
@@ -1,0 +1,30 @@
+package org.wordpress.android.editor.gutenberg
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
+import org.wordpress.mobile.WPAndroidGlue.DeferredEventEmitter.JSEventEmitter
+
+class RNExampleModule(
+    private val mReactContext: ReactApplicationContext,
+    private val mGutenbergBridgeJS2ParentWPCOM: GutenbergBridgeJS2ParentWPCOM
+) : ReactContextBaseJavaModule(
+        mReactContext
+),
+        JSEventEmitter {
+    override fun getName(): String {
+        return "RNExampleModule"
+    }
+
+    override fun emitToJS(eventName: String?, data: WritableMap?) {
+        mReactContext.getJSModule(RCTDeviceEventEmitter::class.java).emit(
+                eventName!!, data
+        )
+    }
+
+    @ReactMethod fun justToast(text: String?) {
+        mGutenbergBridgeJS2ParentWPCOM.justToast(text)
+    }
+}

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/RNExamplePackage.kt
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/RNExamplePackage.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.editor.gutenberg
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+import java.util.Arrays
+
+class RNExamplePackage(private val mGutenbergBridgeJS2ParentWPCOM: GutenbergBridgeJS2ParentWPCOM) : ReactPackage {
+    var exampleModule: RNExampleModule? = null
+        private set
+
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        exampleModule = RNExampleModule(reactContext, mGutenbergBridgeJS2ParentWPCOM)
+        return Arrays.asList<NativeModule>(exampleModule)
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return emptyList()
+    }
+}
+

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/WPAndroidGlueCodeWPCOM.kt
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/WPAndroidGlueCodeWPCOM.kt
@@ -1,0 +1,72 @@
+package org.wordpress.android.editor.gutenberg
+
+import android.view.ViewGroup
+import com.facebook.react.ReactPackage
+import org.wordpress.android.util.ToastUtils
+import org.wordpress.mobile.WPAndroidGlue.RequestExecutor
+import org.wordpress.mobile.WPAndroidGlue.ShowSuggestionsUtil
+import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode
+
+class WPAndroidGlueCodeWPCOM : WPAndroidGlueCode() {
+    private val lateinit mGutenbergBridgeJS2ParentWPCOMListener: GutenbergBridgeJS2ParentWPCOMListener?
+
+    override fun getPackages(): MutableList<ReactPackage> {
+        val packages: MutableList<ReactPackage> = super.getPackages()
+        packages.add(RNExamplePackage(object: GutenbergBridgeJS2ParentWPCOM {
+            override fun justToast(text: String?) {
+                ToastUtils.showToast(text)
+            }
+        }))
+        return packages
+    }
+
+    interface GutenbergBridgeJS2ParentWPCOMListener {
+        fun justToast(text: String?)
+    }
+
+    fun attachToContainer(
+        viewGroup: ViewGroup?,
+        onMediaLibraryButtonListener: OnMediaLibraryButtonListener?,
+        onReattachMediaUploadQueryListener: OnReattachMediaUploadQueryListener?,
+        onReattachMediaSavingQueryListener: OnReattachMediaSavingQueryListener?,
+        onSetFeaturedImageListener: OnSetFeaturedImageListener?,
+        onEditorMountListener: OnEditorMountListener?,
+        onEditorAutosaveListener: OnEditorAutosaveListener?,
+        onAuthHeaderRequestedListener: OnAuthHeaderRequestedListener?,
+        fetchExecutor: RequestExecutor?,
+        onImageFullscreenPreviewListener: OnImageFullscreenPreviewListener?,
+        onMediaEditorListener: OnMediaEditorListener?,
+        onGutenbergDidRequestUnsupportedBlockFallbackListener: OnGutenbergDidRequestUnsupportedBlockFallbackListener?,
+        onGutenbergDidSendButtonPressedActionListener: OnGutenbergDidSendButtonPressedActionListener?,
+        showSuggestionsUtil: ShowSuggestionsUtil?,
+        onMediaFilesCollectionBasedBlockEditorListener: OnMediaFilesCollectionBasedBlockEditorListener?,
+        onFocalPointPickerTooltipListener: OnFocalPointPickerTooltipShownEventListener?,
+        onGutenbergDidRequestPreviewListener: OnGutenbergDidRequestPreviewListener?,
+        onBlockTypeImpressionsEventListener: OnBlockTypeImpressionsEventListener?,
+        isDarkMode: Boolean,
+        gutenbergBridgeJS2ParentWPCOMListener: GutenbergBridgeJS2ParentWPCOMListener?
+    ) {
+        super.attachToContainer(
+                viewGroup,
+                onMediaLibraryButtonListener,
+                onReattachMediaUploadQueryListener,
+                onReattachMediaSavingQueryListener,
+                onSetFeaturedImageListener,
+                onEditorMountListener,
+                onEditorAutosaveListener,
+                onAuthHeaderRequestedListener,
+                fetchExecutor,
+                onImageFullscreenPreviewListener,
+                onMediaEditorListener,
+                onGutenbergDidRequestUnsupportedBlockFallbackListener,
+                onGutenbergDidSendButtonPressedActionListener,
+                showSuggestionsUtil,
+                onMediaFilesCollectionBasedBlockEditorListener,
+                onFocalPointPickerTooltipListener,
+                onGutenbergDidRequestPreviewListener,
+                onBlockTypeImpressionsEventListener,
+                isDarkMode
+        )
+        mGutenbergBridgeJS2ParentWPCOMListener = gutenbergBridgeJS2ParentWPCOMListener
+    }
+}

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/WPAndroidGlueCodeWPCOM.kt
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/WPAndroidGlueCodeWPCOM.kt
@@ -2,19 +2,18 @@ package org.wordpress.android.editor.gutenberg
 
 import android.view.ViewGroup
 import com.facebook.react.ReactPackage
-import org.wordpress.android.util.ToastUtils
 import org.wordpress.mobile.WPAndroidGlue.RequestExecutor
 import org.wordpress.mobile.WPAndroidGlue.ShowSuggestionsUtil
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode
 
 class WPAndroidGlueCodeWPCOM : WPAndroidGlueCode() {
-    private val lateinit mGutenbergBridgeJS2ParentWPCOMListener: GutenbergBridgeJS2ParentWPCOMListener?
+    private var mGutenbergBridgeJS2ParentWPCOMListener: GutenbergBridgeJS2ParentWPCOMListener? = null
 
     override fun getPackages(): MutableList<ReactPackage> {
-        val packages: MutableList<ReactPackage> = super.getPackages()
+        val packages: ArrayList<ReactPackage> = ArrayList(super.getPackages())
         packages.add(RNExamplePackage(object: GutenbergBridgeJS2ParentWPCOM {
             override fun justToast(text: String?) {
-                ToastUtils.showToast(text)
+                mGutenbergBridgeJS2ParentWPCOMListener?.justToast(text)
             }
         }))
         return packages
@@ -44,7 +43,7 @@ class WPAndroidGlueCodeWPCOM : WPAndroidGlueCode() {
         onGutenbergDidRequestPreviewListener: OnGutenbergDidRequestPreviewListener?,
         onBlockTypeImpressionsEventListener: OnBlockTypeImpressionsEventListener?,
         isDarkMode: Boolean,
-        gutenbergBridgeJS2ParentWPCOMListener: GutenbergBridgeJS2ParentWPCOMListener?
+        gutenbergBridgeJS2ParentWPCOMListener: GutenbergBridgeJS2ParentWPCOMListener
     ) {
         super.attachToContainer(
                 viewGroup,


### PR DESCRIPTION
Fixes #

### Related PRs
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/4050

Notice that there is no Gutenberg PR since there are no changes needed on the Gutenberg repo side.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
