### PR TITLE
Unified Edit comment unit test

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
@@ -17,6 +17,8 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.UnifiedCommentsEditFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.ActivityId
+import org.wordpress.android.ui.ActivityId.COMMENT_EDITOR
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.EditCommentActionEvent.CLOSE
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.EditCommentActionEvent.DONE
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.FieldType.COMMENT
@@ -43,6 +45,8 @@ class UnifiedCommentsEditFragment : Fragment(R.layout.unified_comments_edit_frag
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
         viewModel = ViewModelProvider(this, viewModelFactory).get(UnifiedCommentsEditViewModel::class.java)
+
+        ActivityId.trackLastActivity(COMMENT_EDITOR)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentsEditViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentsEditViewModelTest.kt
@@ -1,0 +1,179 @@
+package org.wordpress.android.ui.comments.viewmodels
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.CommentsStore
+import org.wordpress.android.fluxc.store.CommentsStore.CommentsActionPayload
+import org.wordpress.android.fluxc.store.CommentsStore.CommentsData.CommentsActionData
+import org.wordpress.android.test
+import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel
+import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.CommentEssentials
+import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.EditCommentActionEvent
+import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.EditCommentActionEvent.CLOSE
+import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.EditCommentActionEvent.DONE
+import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.EditCommentUiState
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
+
+@InternalCoroutinesApi
+class UnifiedCommentsEditViewModelTest : BaseUnitTest() {
+    @Mock lateinit var commentsStore: CommentsStore
+    @Mock lateinit var resourceProvider: ResourceProvider
+    @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+
+    private lateinit var viewModel: UnifiedCommentsEditViewModel
+
+    private var uiState: MutableList<EditCommentUiState> = mutableListOf()
+    private var uiActionEvent: MutableList<EditCommentActionEvent> = mutableListOf()
+    private var onSnackbarMessage: MutableList<SnackbarMessageHolder> = mutableListOf()
+
+    private val site = SiteModel()
+    private val commentId = 1000
+
+    @Before
+    fun setup() = test {
+        whenever(commentsStore.getCommentByLocalId(commentId.toLong())).thenReturn(listOf(DEFAULT_COMMENT))
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+
+        viewModel = UnifiedCommentsEditViewModel(
+                mainDispatcher = TEST_DISPATCHER,
+                bgDispatcher = TEST_DISPATCHER,
+                commentsStore = commentsStore,
+                resourceProvider = resourceProvider,
+                networkUtilsWrapper = networkUtilsWrapper
+        )
+
+        setupObservers()
+    }
+
+    @Test
+    fun `watchers are init on view recreation`() {
+        viewModel.start(site, commentId)
+
+        viewModel.start(site, commentId)
+
+        assertThat(uiState.first().shouldInitWatchers).isFalse
+        assertThat(uiState.last().shouldInitWatchers).isTrue
+    }
+
+    @Test
+    fun `snackbar notification is triggered on comment get error`() = test {
+        whenever(commentsStore.getCommentByLocalId(commentId.toLong())).thenReturn(listOf())
+        viewModel.start(site, commentId)
+        assertThat(onSnackbarMessage.firstOrNull()).isNotNull
+    }
+
+    @Test
+    fun `view is init`() = test {
+        viewModel.start(site, commentId)
+
+        verify(commentsStore, times(1)).getCommentByLocalId(commentId.toLong())
+
+        assertThat(uiState[0].showProgress).isTrue
+        assertThat(uiState[1].editedComment).isEqualTo(DEFAULT_COMMENT_ESSENTIALS)
+        assertThat(uiState[2].showProgress).isFalse
+    }
+
+    @Test
+    fun `onActionMenuClicked triggers snackbar if no network`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+        viewModel.onActionMenuClicked()
+        assertThat(onSnackbarMessage.firstOrNull()).isNotNull
+    }
+
+    @Test
+    fun `onActionMenuClicked triggers snackbar if comment update error`() = test {
+        whenever(commentsStore.updateEditComment(eq(site), any())).thenReturn(
+                CommentsActionPayload(CommentError(GENERIC_ERROR, "error"))
+        )
+        viewModel.start(site, commentId)
+        viewModel.onActionMenuClicked()
+        assertThat(onSnackbarMessage.firstOrNull()).isNotNull
+    }
+
+    @Test
+    fun `onActionMenuClicked triggers DONE action if comment update successfully`() = test {
+        whenever(commentsStore.updateEditComment(eq(site), any())).thenReturn(CommentsActionPayload(CommentsActionData(
+                comments = listOf(),
+                rowsAffected = 0
+        )))
+        viewModel.start(site, commentId)
+        viewModel.onActionMenuClicked()
+        assertThat(uiActionEvent.firstOrNull()).isEqualTo(DONE)
+    }
+
+    @Test
+    fun `onBackPressed triggers CLOSE`() {
+        viewModel.onBackPressed()
+        assertThat(uiActionEvent.firstOrNull()).isEqualTo(CLOSE)
+    }
+
+    private fun setupObservers() {
+        uiState.clear()
+        uiActionEvent.clear()
+        onSnackbarMessage.clear()
+
+        viewModel.uiState.observeForever {
+            uiState.add(it)
+        }
+
+        viewModel.uiActionEvent.observeForever {
+            it.applyIfNotHandled {
+                uiActionEvent.add(this)
+            }
+        }
+
+        viewModel.onSnackbarMessage.observeForever {
+            it.applyIfNotHandled {
+                onSnackbarMessage.add(this)
+            }
+        }
+    }
+
+    companion object {
+        private val DEFAULT_COMMENT = CommentEntity(
+                id = 1000,
+                remoteCommentId = 0,
+                remotePostId = 0,
+                remoteParentCommentId = 0,
+                localSiteId = 0,
+                remoteSiteId = 0,
+                authorUrl = "authorUrl",
+                authorName = "authorName",
+                authorEmail = "authorEmail",
+                authorProfileImageUrl = null,
+                postTitle = null,
+                status = null,
+                datePublished = null,
+                publishedTimestamp = 0,
+                content = "content",
+                url = null,
+                hasParent = false,
+                parentId = 0,
+                iLike = false
+        )
+
+        private val DEFAULT_COMMENT_ESSENTIALS = CommentEssentials(
+                commentId = DEFAULT_COMMENT.id,
+                userName = DEFAULT_COMMENT.authorName!!,
+                commentText = DEFAULT_COMMENT.content!!,
+                userWebAddress = DEFAULT_COMMENT.authorUrl!!,
+                userEmail = DEFAULT_COMMENT.authorEmail!!
+        )
+    }
+}


### PR DESCRIPTION
Part of #15394 ,  this PR depends on #15393 and does the following:

- adds the ActivityId.trackLastActivity(COMMENT_EDITOR) to track the last activity used in 
```
application_closed, ..."last_visible_screen":"Comment Editor"...
```
- adds a bit of unit testing coverage to the VM

## To test
- check the unit tests pass
- go in the edit screen, place the app in background and check you get the following in the Tracked events in logcat
   
```
application_closed, ..."last_visible_screen":"Comment Editor"...
```

   - this is a regression check since the events should be there without modifications: in logcat make sure we still get the `comment_editor_opened` when opening the edit comment screen, and the `comment_edited` event when saving a modified event.


## Regression Notes
1. Potential unintended areas of impact
Feature is still behind feature flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Feature is still behind feature flag.

3. What automated tests I added (or what prevented me from doing so)
Feature is still behind feature flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
