### PR TITLE
Edit comment confirmation dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -44,6 +44,7 @@ import org.wordpress.android.ui.comments.CommentsActivity;
 import org.wordpress.android.ui.comments.CommentsDetailActivity;
 import org.wordpress.android.ui.comments.CommentsListFragment;
 import org.wordpress.android.ui.comments.EditCommentActivity;
+import org.wordpress.android.ui.comments.unified.EditCancelDialogFragment;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentListAdapter;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentListFragment;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsActivity;
@@ -687,6 +688,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(UnifiedCommentListAdapter object);
 
     void inject(UnifiedCommentsEditFragment object);
+
+    void inject(EditCancelDialogFragment object);
 
     void inject(BloggingReminderBottomSheetFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/EditCancelDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/EditCancelDialogFragment.kt
@@ -33,7 +33,7 @@ class EditCancelDialogFragment : DialogFragment() {
             setTitle(R.string.comment_edit_cancel_dialog_title)
             setMessage(R.string.comment_edit_cancel_dialog_message)
             setPositiveButton(R.string.button_discard) { _, _ ->
-                viewModel?.onConfirmEditingCancel()
+                viewModel?.onConfirmEditingDiscard()
             }
             setNegativeButton(R.string.cancel) { _, _ ->
                 // nothing to be done here.

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/EditCancelDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/EditCancelDialogFragment.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class EditCancelDialogFragment : DialogFragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
-    private var viewModel:UnifiedCommentsEditViewModel? = null
+    private var viewModel: UnifiedCommentsEditViewModel? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/EditCancelDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/EditCancelDialogFragment.kt
@@ -1,0 +1,53 @@
+package org.wordpress.android.ui.comments.unified
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import javax.inject.Inject
+
+class EditCancelDialogFragment : DialogFragment() {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+
+    private var viewModel:UnifiedCommentsEditViewModel? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = MaterialAlertDialogBuilder(requireContext())
+
+        (parentFragment as? UnifiedCommentsEditFragment)?.let {
+            viewModel = ViewModelProvider(
+                    it,
+                    viewModelFactory
+            ).get(UnifiedCommentsEditViewModel::class.java)
+        }
+
+        builder.apply {
+            setTitle(R.string.comment_edit_cancel_dialog_title)
+            setMessage(R.string.comment_edit_cancel_dialog_message)
+            setPositiveButton(R.string.button_discard) { _, _ ->
+                viewModel?.onConfirmEditingCancel()
+            }
+            setNegativeButton(R.string.cancel) { _, _ ->
+                // nothing to be done here.
+            }
+            builder.setCancelable(true)
+        }
+        return builder.create()
+    }
+
+    companion object {
+        const val EDIT_CANCEL_DIALOG_TAG = "edit_cancel_dialog_tag"
+
+        fun newInstance(): EditCancelDialogFragment {
+            return EditCancelDialogFragment()
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.Fi
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.FieldType.WEB_ADDRESS
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarItem.Action
 import org.wordpress.android.util.SnackbarItem.Info
@@ -87,10 +88,7 @@ class UnifiedCommentsEditFragment : Fragment(R.layout.unified_comments_edit_frag
 
     private fun hideKeyboard() {
         if (!isAdded || view == null) return
-        activity?.let {
-            val imm: InputMethodManager = it.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-            imm.hideSoftInputFromWindow(view?.rootView?.windowToken, 0)
-        }
+        ActivityUtils.hideKeyboardForced(view)
     }
 
     private fun UnifiedCommentsEditFragmentBinding.setupObservers(site: SiteModel, commentId: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
@@ -1,13 +1,11 @@
 package org.wordpress.android.ui.comments.unified
 
-import android.app.Activity
 import android.app.Activity.RESULT_OK
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.inputmethod.InputMethodManager
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.doAfterTextChanged
@@ -128,7 +126,7 @@ class UnifiedCommentsEditFragment : Fragment(R.layout.unified_comments_edit_frag
             if (uiState.shouldInitComment) {
                 uiState.originalComment.let {
                     userName.setText(it.userName)
-                    commentEditWebAddress.setText(it.userWebAddress)
+                    commentEditWebAddress.setText(it.userUrl)
                     commentEditEmailAddress.setText(it.userEmail)
                     commentEditComment.setText(it.commentText)
                 }
@@ -140,7 +138,7 @@ class UnifiedCommentsEditFragment : Fragment(R.layout.unified_comments_edit_frag
 
             uiState.editErrorStrings.let { errors ->
                 userName.error = errors.userNameError
-                commentEditWebAddress.error = errors.userWebAddressError
+                commentEditWebAddress.error = errors.userUrlError
                 commentEditEmailAddress.error = errors.userEmailError
                 commentEditComment.error = errors.commentTextError
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
@@ -194,7 +194,7 @@ class UnifiedCommentsEditViewModel @Inject constructor(
         }
     }
 
-    fun onConfirmEditingCancel() {
+    fun onConfirmEditingDiscard() {
         _uiActionEvent.value = Event(CLOSE)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
@@ -54,7 +54,7 @@ class UnifiedCommentsEditViewModel @Inject constructor(
     data class EditErrorStrings(
         val userNameError: String? = null,
         val commentTextError: String? = null,
-        val userWebAddressError: String? = null,
+        val userUrlError: String? = null,
         val userEmailError: String? = null
     )
 
@@ -62,7 +62,7 @@ class UnifiedCommentsEditViewModel @Inject constructor(
         val commentId: Long = 0,
         val userName: String = "",
         val commentText: String = "",
-        val userWebAddress: String = "",
+        val userUrl: String = "",
         val userEmail: String = ""
     )
 
@@ -88,6 +88,11 @@ class UnifiedCommentsEditViewModel @Inject constructor(
         USER_EMAIL(R.string.comment_edit_user_email_error, { isValidUserEmail(it) }),
         WEB_ADDRESS(R.string.comment_edit_web_address_error, { isValidWebAddress(it) }),
         COMMENT(R.string.comment_edit_comment_error, { isValidComment(it) });
+
+        // This is here for testing purposes
+        fun matches(expectedField: FieldType): Boolean {
+            return this == expectedField
+        }
 
         companion object {
             private fun isValidUserName(userName: String): Boolean {
@@ -164,7 +169,7 @@ class UnifiedCommentsEditViewModel @Inject constructor(
 
                 comment?.let {
                     val updatedComment = comment.copy(
-                            authorUrl = editedContent.userWebAddress,
+                            authorUrl = editedContent.userUrl,
                             authorName = editedContent.userName,
                             authorEmail = editedContent.userEmail,
                             content = editedContent.commentText
@@ -220,7 +225,7 @@ class UnifiedCommentsEditViewModel @Inject constructor(
                         commentId = comment.id,
                         userName = comment.authorName ?: "",
                         commentText = comment.content ?: "",
-                        userWebAddress = comment.authorUrl ?: "",
+                        userUrl = comment.authorUrl ?: "",
                         userEmail = comment.authorEmail ?: ""
                 )
 
@@ -253,17 +258,17 @@ class UnifiedCommentsEditViewModel @Inject constructor(
             val previousErrors = it.editErrorStrings
 
             val editedComment = previousComment.copy(
-                userName = if (fieldType == USER_NAME) field else previousComment.userName,
-                commentText = if (fieldType == COMMENT) field else previousComment.commentText,
-                userWebAddress = if (fieldType == WEB_ADDRESS) field else previousComment.userWebAddress,
-                userEmail = if (fieldType == USER_EMAIL) field else previousComment.userEmail
+                userName = if (fieldType.matches(USER_NAME)) field else previousComment.userName,
+                commentText = if (fieldType.matches(COMMENT)) field else previousComment.commentText,
+                userUrl = if (fieldType.matches(WEB_ADDRESS)) field else previousComment.userUrl,
+                userEmail = if (fieldType.matches(USER_EMAIL)) field else previousComment.userEmail
             )
 
             val errors = previousErrors.copy(
-                userNameError = if (fieldType == USER_NAME) fieldError else previousErrors.userNameError,
-                commentTextError = if (fieldType == COMMENT) fieldError else previousErrors.commentTextError,
-                userWebAddressError = if (fieldType == WEB_ADDRESS) fieldError else previousErrors.userWebAddressError,
-                userEmailError = if (fieldType == USER_EMAIL) fieldError else previousErrors.userEmailError
+                userNameError = if (fieldType.matches(USER_NAME)) fieldError else previousErrors.userNameError,
+                commentTextError = if (fieldType.matches(COMMENT)) fieldError else previousErrors.commentTextError,
+                userUrlError = if (fieldType.matches(WEB_ADDRESS)) fieldError else previousErrors.userUrlError,
+                userEmailError = if (fieldType.matches(USER_EMAIL)) fieldError else previousErrors.userEmailError
             )
 
             _uiState.value = it.copy(
@@ -280,7 +285,7 @@ class UnifiedCommentsEditViewModel @Inject constructor(
         return !(this.commentText == other.commentText &&
                 this.userEmail == other.userEmail &&
                 this.userName == other.userName &&
-                this.userWebAddress == other.userWebAddress)
+                this.userUrl == other.userUrl)
     }
 
     private fun EditErrorStrings.hasError(): Boolean {
@@ -288,7 +293,7 @@ class UnifiedCommentsEditViewModel @Inject constructor(
                 this.commentTextError,
                 this.userEmailError,
                 this.userNameError,
-                this.userWebAddressError
+                this.userUrlError
         ).any { !it.isNullOrEmpty() }
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -497,6 +497,8 @@
     <string name="comment_edit_web_address_error">Web address not valid</string>
     <string name="comment_edit_user_email_error">User email not valid</string>
     <string name="comment_edit_comment_error">Comment cannot be empty</string>
+    <string name="comment_edit_cancel_dialog_title">There are unsaved changes</string>
+    <string name="comment_edit_cancel_dialog_message">Do you want to discard them?</string>
 
     <!-- context menu -->
     <string name="remove_account">Remove site</string>


### PR DESCRIPTION
Part of #15394 , this PR add a cancel confirmation dialog when the user is leaving the edit screen and there are valid changes.

![image](https://user-images.githubusercontent.com/47797566/135617286-624407f7-eccc-44d5-8af6-f4253de810e2.png)

## To test
- Check the dialog is not presented if no changes
- Check the dialog is presented if changes are present
- Check cancel button only dismiss the dialog
- Check discard button closes the editor without saving any edit

## Regression Notes
1. Potential unintended areas of impact
Feature is still behind feature flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Feature is still behind feature flag.

3. What automated tests I added (or what prevented me from doing so)
Feature is still behind feature flag. But added uni testing.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
