### PR TITLE
Edit comment flag activation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 18.4
 -----
-
+* [**] Site Comments: when editing a Comment, the author's name, email address, and web address can now be changed. (https://github.com/wordpress-mobile/WordPress-Android/pull/15402)
 
 18.3
 -----

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -178,8 +178,6 @@ android {
 
             versionName versionProperties.getProperty("alpha.versionName")
             versionCode versionProperties.getProperty("alpha.versionCode").toInteger()
-
-            buildConfigField "boolean", "UNIFIED_COMMENTS_COMMENT_EDIT", "true"
         }
 
         jalapeno { // Pre-Alpha version, used for PR builds, can be installed along release, alpha, beta, dev versions

--- a/WordPress/src/main/java/org/wordpress/android/util/config/UnifiedCommentsCommentEditFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/UnifiedCommentsCommentEditFeatureConfig.kt
@@ -1,11 +1,17 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.UnifiedCommentsCommentEditFeatureConfig.Companion.UNIFIED_COMMENTS_COMMENT_EDIT_FIELD
 import javax.inject.Inject
 
-@FeatureInDevelopment
+@Feature(UNIFIED_COMMENTS_COMMENT_EDIT_FIELD, true)
 class UnifiedCommentsCommentEditFeatureConfig @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.UNIFIED_COMMENTS_COMMENT_EDIT
-)
+        BuildConfig.UNIFIED_COMMENTS_COMMENT_EDIT,
+        UNIFIED_COMMENTS_COMMENT_EDIT_FIELD
+) {
+    companion object {
+        const val UNIFIED_COMMENTS_COMMENT_EDIT_FIELD = "unified_comments_comment_edit_enabled"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/UnifiedCommentsCommentEditFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/UnifiedCommentsCommentEditFeatureConfig.kt
@@ -2,16 +2,16 @@ package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.annotation.Feature
-import org.wordpress.android.util.config.UnifiedCommentsCommentEditFeatureConfig.Companion.UNIFIED_COMMENTS_COMMENT_EDIT_FIELD
+import org.wordpress.android.util.config.UnifiedCommentsCommentEditFeatureConfig.Companion.UNIFIED_COMMENTS_EDIT_REMOTE_FIELD
 import javax.inject.Inject
 
-@Feature(UNIFIED_COMMENTS_COMMENT_EDIT_FIELD, true)
+@Feature(UNIFIED_COMMENTS_EDIT_REMOTE_FIELD, true)
 class UnifiedCommentsCommentEditFeatureConfig @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
         BuildConfig.UNIFIED_COMMENTS_COMMENT_EDIT,
-        UNIFIED_COMMENTS_COMMENT_EDIT_FIELD
+        UNIFIED_COMMENTS_EDIT_REMOTE_FIELD
 ) {
     companion object {
-        const val UNIFIED_COMMENTS_COMMENT_EDIT_FIELD = "unified_comments_comment_edit_enabled"
+        const val UNIFIED_COMMENTS_EDIT_REMOTE_FIELD = "unified_comments_edit_remote_field"
     }
 }


### PR DESCRIPTION
Part of #15394, this PR enables the remote feature flag for the new Edit comment component in the My Site > Comments > Comment Details.

| ![image](https://user-images.githubusercontent.com/47797566/135636098-88c745c6-eb16-4c68-b411-a304007643ce.png) | ![image](https://user-images.githubusercontent.com/47797566/135636123-b3741db2-f1dd-41cc-8bc7-deb89d7336c2.png) |
|---|---|

Relevant PRs #15393, #15401

### To test
- Remove the app if already installed
- Use the jalapeno apk from this CI to install the WordPress app and check the confirm the new Edit Comment screen IS available by default (only in My Site > Comments; in Notifications the previous one should be used)
- Smoke test the feature both in My Site > Comments > Comment Details and Notifications > Comment Details (you can refer to the linked PRs description in for more details if needed)

## Regression Notes
1. Potential unintended areas of impact
Edit comment in Notifications.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + unit testing.

3. What automated tests I added (or what prevented me from doing so)
Added unit testing.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
