### PR TITLE
Media Picker: Choose From Device: Fix Video thumbnails do not load

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/VideoLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/VideoLoader.kt
@@ -48,7 +48,7 @@ class VideoLoader
                 }
             }
             withContext(mainDispatcher) {
-                if (length > MIN_SIZE && length < SIZE_LIMIT_10_MB) {
+                if (length in (MIN_SIZE + 1) until SIZE_LIMIT_10_MB) {
                     loadAction()
                 } else {
                     fallbackAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/VideoLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/VideoLoader.kt
@@ -1,5 +1,8 @@
 package org.wordpress.android.ui.media
 
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -9,6 +12,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.utils.AuthenticationUtils
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.MediaUtilsWrapper
 import java.io.IOException
 import java.net.URL
 import javax.inject.Inject
@@ -19,7 +23,9 @@ class VideoLoader
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     @param:Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val authenticationUtils: AuthenticationUtils,
-    private val appLogWrapper: AppLogWrapper
+    private val appLogWrapper: AppLogWrapper,
+    private val mediaUtilsWrapper: MediaUtilsWrapper,
+    private val appContext: Context
 ) {
     fun runIfMediaNotTooBig(
         scope: CoroutineScope,
@@ -31,7 +37,12 @@ class VideoLoader
             var length = MIN_SIZE
             withContext(bgDispatcher) {
                 try {
-                    length = getSizeFromURL(URL(filePath))
+                    val uri = Uri.parse(filePath)
+                    length = if (mediaUtilsWrapper.isInMediaStore(uri)) {
+                        getSizeFromContentUri(uri)
+                    } else {
+                        getSizeFromURL(URL(filePath))
+                    }
                 } catch (ioe: IOException) {
                     appLogWrapper.e(T.MEDIA, "Failed to load video thumbnail: ${ioe.stackTrace}")
                 }
@@ -45,6 +56,14 @@ class VideoLoader
             }
         }
     }
+
+    private fun getSizeFromContentUri(contentUri: Uri) =
+            appContext.contentResolver.query(contentUri, null, null, null, null, null).use { cursor ->
+                cursor?.moveToFirst()?.takeIf { true }?.let {
+                    val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+                    if (!cursor.isNull(sizeIndex)) cursor.getInt(sizeIndex) else null
+                } ?: 0
+            }
 
     private fun getSizeFromURL(url: URL): Int {
         val urlConnection = url.openConnection()

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/VideoLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/VideoLoader.kt
@@ -31,17 +31,7 @@ class VideoLoader
             var length = MIN_SIZE
             withContext(bgDispatcher) {
                 try {
-                    val url = URL(filePath)
-
-                    val urlConnection = url.openConnection()
-                    for ((key, value) in authenticationUtils.getAuthHeaders(filePath).entries) {
-                        urlConnection.addRequestProperty(key, value)
-                    }
-
-                    length = urlConnection.contentLength
-                    if (length <= MIN_SIZE) {
-                        length = urlConnection.getHeaderFieldInt("Content-Length", MIN_SIZE)
-                    }
+                    length = getSizeFromURL(URL(filePath))
                 } catch (ioe: IOException) {
                     appLogWrapper.e(T.MEDIA, "Failed to load video thumbnail: ${ioe.stackTrace}")
                 }
@@ -54,6 +44,19 @@ class VideoLoader
                 }
             }
         }
+    }
+
+    private fun getSizeFromURL(url: URL): Int {
+        val urlConnection = url.openConnection()
+        for ((key, value) in authenticationUtils.getAuthHeaders(url.toString()).entries) {
+            urlConnection.addRequestProperty(key, value)
+        }
+
+        var length = urlConnection.contentLength
+        if (length <= MIN_SIZE) {
+            length = urlConnection.getHeaderFieldInt("Content-Length", MIN_SIZE)
+        }
+        return length
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -397,7 +397,9 @@ class MediaPickerViewModel @Inject constructor(
         }
         when (identifier) {
             is LocalUri -> {
-                _onNavigate.postValue(Event(PreviewUrl(identifier.value.toString())))
+                mediaUtilsWrapper.getRealPathFromURI(identifier.value.uri)?.let { path ->
+                    _onNavigate.postValue(Event(PreviewUrl(path)))
+                }
             }
             is StockMediaIdentifier -> {
                 if (identifier.url != null) {

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.text.TextUtils
@@ -143,8 +144,11 @@ class ImageManager @Inject constructor(
                 },
                 fallbackAction = {
                     if (!context.isAvailable()) return@runIfMediaNotTooBig
+                    val fallbackDrawable = placeholderManager.getErrorResource(imageType)?.let {
+                        ColorDrawable(ContextCompat.getColor(context, it))
+                    }
                     GlideApp.with(context)
-                            .load(placeholderManager.getErrorResource(imageType))
+                            .load(fallbackDrawable)
                             .addPlaceholder(imageType)
                             .addFallback(imageType)
                             .into(imageView)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.mediapicker
 
 import android.content.Context
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.times
@@ -278,6 +279,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `navigates to preview on item click`() = test {
+        whenever(mediaUtilsWrapper.getRealPathFromURI(anyOrNull())).thenReturn(firstItem.url)
         setupViewModel(listOf(firstItem, secondItem), singleSelectMediaPickerSetup)
 
         viewModel.refreshData(false)


### PR DESCRIPTION
Fixes #14618 & #15306

This PR displays thumbnails for local videos having URLs with content URI protocol, detects them as videos, and plays them on the media preview screen.

- `VideoLoader` did not take into consideration local videos with content URI protocol when checking for media size, and when such URLs were passed to it, it failed with `MalformedURLException`. To address this, file size for such files is checked according to the [suggested approach](https://developer.android.com/training/secure-file-sharing/retrieve-info#RetrieveFileInfo) in 258f726.

- Real path for local URI is passed in 983b21b so that they get detected as videos in `MediaPreviewFragment` via `MediaUtils.isVideo` otherwise they were displayed as images.

- Once detected as local videos, they're played using `ExoPlayer` adjustments for local videos in 46e6aeb.

To test:

1. Launch the app and go to My Site -> Post
2. Add a Video block
3. Select “Choose from device”
4. Notice that media picker is displayed and thumbnails are loaded 
5. Long press a thumbnail 
6. Notice that video plays properly

## Regression Notes
1. Potential unintended areas of impact
`VideoLoader` is used for both remote and local videos

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually that thumbnails for local as well remote videos are loaded properly and videos gets played as well

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
