### PR TITLE
Fix npe on pre-publishing bottom sheet rotation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/KeyboardResizeViewUtil.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/KeyboardResizeViewUtil.java
@@ -72,8 +72,14 @@ public class KeyboardResizeViewUtil {
     };
 
     private int getInsetBottom() {
-        WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(mContentView);
-        return insets != null ? insets.getSystemWindowInsetBottom() : 0;
+        int insetsBottom = 0;
+        try {
+            WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(mContentView);
+            insetsBottom = insets != null ? insets.getSystemWindowInsetBottom() : 0;
+        } catch (NullPointerException e) {
+            AppLog.e(AppLog.T.PREPUBLISHING_NUDGES, "Error in getting window insets on keyboard resize:", e);
+        }
+        return insetsBottom;
     }
 
     private int getRealScreenHeight() {

--- a/WordPress/src/main/java/org/wordpress/android/util/KeyboardResizeViewUtil.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/KeyboardResizeViewUtil.java
@@ -18,8 +18,10 @@ import androidx.core.view.WindowInsetsCompat;
  * Basic idea for this solution found here: http://stackoverflow.com/a/9108219/325479
  */
 public class KeyboardResizeViewUtil {
-    private final View mDecorView;
-    private final View mContentView;
+    @SuppressWarnings("FieldMayBeFinal")
+    private View mDecorView;
+    @SuppressWarnings("FieldMayBeFinal")
+    private View mContentView;
 
     public KeyboardResizeViewUtil(Activity activity, View contentView) {
         this.mDecorView = activity.getWindow().getDecorView();


### PR DESCRIPTION
Fixes #15410

I was able to reproduce the crash on rotating the device a few times with the pre-publishing nudges bottom sheet displayed. When the screen is rotated, the earlier fragment view gets destroyed, and the `final` fields in `KeyboardResizeViewUtil` cause issues in resetting the field with the new view. When passed to `ViewCompat.getRootWindowInsets` which accepts a `NonNull` view,  a crash occurs. This PR makes the fields non-final and suppresses the "Field May Be Final" inspection. 

To test:

1. Go to `My Site`.
2. Click FAB at the bottom of the tab to add a new blog post.
3. Click `Publish` on the new post so that the pre-publishing bottom sheet is displayed.
4. Rotate the device a couple of times.
5. Notice that the app does not crash due to NPE.

Review Instructions:
Only 1 reviewer is required. Anyone can review.

Merge Instructions:
Targets `release/18.4` due to rising numbers in Sentry and being at the beginning of the next release cycle. 
Cc @AliSoftware 

## Regression Notes
1. Potential unintended areas of impact 🟢 


2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 


3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
