### PR TITLE
Fixes IllegalArgumentException due to uninitialised site in page template picker

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 18.5
 -----
-
+* [*] Fixed a crash in Page Template chooser [https://github.com/wordpress-mobile/WordPress-Android/pull/15415]
 
 18.4
 -----

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -205,7 +205,7 @@ public class SiteUtils {
         dispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(siteModel));
     }
 
-    public static boolean isBlockEditorDefaultForNewPost(SiteModel site) {
+    public static boolean isBlockEditorDefaultForNewPost(@Nullable SiteModel site) {
         if (site == null) {
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
@@ -62,7 +62,7 @@ class ModalLayoutPickerViewModel @Inject constructor(
     val onCreateNewPageRequested: LiveData<PageRequest.Create> = _onCreateNewPageRequested
 
     private val site: SiteModel? by lazy {
-        siteStore.getSiteByLocalId(selectedSiteRepository.getSelectedSiteLocalId())
+        siteStore.getSiteByLocalId(selectedSiteRepository.getSelectedSiteLocalId(true))
     }
 
     override val useCachedData: Boolean = true

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
@@ -113,7 +113,7 @@ class ModalLayoutPickerViewModelTest {
                 id = 1
                 mobileEditor = GB_EDITOR_NAME
             }
-            whenever(selectedSiteRepository.getSelectedSiteLocalId()).thenReturn(site.id)
+            whenever(selectedSiteRepository.getSelectedSiteLocalId(true)).thenReturn(site.id)
             if (isSiteUnavailable) {
                 whenever(siteStore.getSiteByLocalId(site.id)).thenReturn(null)
             } else {


### PR DESCRIPTION
Fixes #15408

To test:
* I don't have consistent steps to trigger the [reported crash](https://github.com/wordpress-mobile/WordPress-Android/issues/15408). A way to test this may involve using the debugger to set a null value for the SiteModel.
* Verify that the tests pass

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added a [test case](https://github.com/wordpress-mobile/WordPress-Android/commit/3613d887c532e743587af305226c4be3f6986ad3)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
