### PR TITLE
Fix/domains redeem domains price display

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
@@ -9,6 +9,7 @@ class DomainSuggestionsAdapter(
 ) : Adapter<DomainSuggestionsViewHolder>() {
     private val list = mutableListOf<DomainSuggestionResponse>()
     var selectedPosition = -1
+    var isSiteDomainsFeatureEnabled: Boolean = false
     var isDomainCreditAvailable: Boolean = false
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DomainSuggestionsViewHolder {
@@ -23,7 +24,12 @@ class DomainSuggestionsAdapter(
     }
 
     override fun onBindViewHolder(holder: DomainSuggestionsViewHolder, position: Int) {
-        holder.bind(list[position], position, selectedPosition == position, isDomainCreditAvailable)
+        holder.bind(
+                list[position],
+                position,
+                selectedPosition == position,
+                isSiteDomainsFeatureEnabled,
+                isDomainCreditAvailable)
     }
 
     private fun onDomainSuggestionSelected(suggestion: DomainSuggestionResponse?, position: Int) {
@@ -36,10 +42,14 @@ class DomainSuggestionsAdapter(
         itemSelectionListener(suggestion, position)
     }
 
-    internal fun updateSuggestionsList(items: List<DomainSuggestionResponse>, isDomainCreditAvailable: Boolean) {
-        this.isDomainCreditAvailable = isDomainCreditAvailable
+    internal fun updateSuggestionsList(items: List<DomainSuggestionResponse>) {
         list.clear()
         list.addAll(items)
         notifyDataSetChanged()
+    }
+
+    internal fun updateDomainCreditAvailable(siteDomainsFeatureEnabled: Boolean, isDomainCreditAvailable: Boolean) {
+        this.isSiteDomainsFeatureEnabled = siteDomainsFeatureEnabled
+        this.isDomainCreditAvailable = isDomainCreditAvailable
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -114,12 +114,19 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
         viewModel.choseDomainButtonEnabledState.observe(viewLifecycleOwner, Observer {
             choseDomainButton.isEnabled = it ?: false
         })
+
+        viewModel.isDomainCreditAvailable.observe(viewLifecycleOwner, {
+            it?.let {
+                val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
+                adapter.updateDomainCreditAvailable(viewModel.isSiteDomainsFeatureConfigEnabled, it)
+            }
+        })
     }
 
     private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionResponse>) {
         val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
         adapter.selectedPosition = viewModel.selectedPosition.value ?: -1
-        adapter.updateSuggestionsList(domainSuggestions, viewModel.isDomainCreditAvailable)
+        adapter.updateSuggestionsList(domainSuggestions)
     }
 
     private fun onDomainSuggestionSelected(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
@@ -25,10 +25,16 @@ class DomainSuggestionsViewHolder(
         suggestion: DomainSuggestionResponse,
         position: Int,
         isSelectedPosition: Boolean,
+        isSiteDomainsFeatureEnabled: Boolean,
         isDomainCreditAvailable: Boolean
     ) {
         domainName.text = suggestion.domain_name
-        domainCost.text = getFormattedCost(suggestion, isDomainCreditAvailable)
+        if (isSiteDomainsFeatureEnabled) {
+            domainCost.visibility = View.VISIBLE
+            domainCost.text = getFormattedCost(suggestion, isDomainCreditAvailable)
+        } else {
+            domainCost.visibility = View.GONE
+        }
         selectionRadioButton.isChecked = isSelectedPosition
 
         container.setOnClickListener {

--- a/WordPress/src/main/res/layout/domain_suggestion_list_item.xml
+++ b/WordPress/src/main/res/layout/domain_suggestion_list_item.xml
@@ -31,18 +31,20 @@
         app:layout_constraintStart_toEndOf="@id/domain_selection_radio_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/domain_cost"
         tools:text="travelwithkids.com"/>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/domain_cost"
+        android:visibility="gone"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_medium"
         android:textAppearance="?attr/textAppearanceListItemSecondary"
-        app:layout_constraintStart_toEndOf="@id/domain_selection_radio_button"
+        app:layout_constraintStart_toStartOf="@id/domain_name"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/domain_name"
         app:layout_constraintBottom_toBottomOf="parent"
-        tools:text="Free for the first year US$18.99/year"/>
+        tools:text="Free for the first year US$18.99/year"
+        tools:visibility="visible"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2428,8 +2428,8 @@
     <string name="domains_suggestions_intro_title">Choose a premium domain name</string>
     <string name="domains_suggestions_intro_description">This is where people will find you on the internet.</string>
     <string name="domain_suggestions_search_hint">Type a keyword for more ideas</string>
-    <string name="domain_suggestions_list_item_cost">%s&lt;span style="color:#50575e;"&gt; /year&lt;span&gt;</string>
-    <string name="domain_suggestions_list_item_cost_free">&lt;strong&gt;&lt;span style="color:#008000;"&gt;Free for the first year &lt;span&gt;&lt;/strong&gt;&lt;span style="color:#50575e;"&gt;&lt;s&gt;%s /year&lt;/s&gt;&lt;span&gt;</string>
+    <string name="domain_suggestions_list_item_cost">%s&lt;span style="color:#50575e;"&gt; /year&lt;/span&gt;</string>
+    <string name="domain_suggestions_list_item_cost_free">&lt;strong&gt;&lt;span style="color:#008000;"&gt;Free for the first year &lt;/span&gt;&lt;/strong&gt;&lt;span style="color:#50575e;"&gt;&lt;s&gt;%s /year&lt;/s&gt;&lt;/span&gt;</string>
     <string name="domain_suggestions_fetch_error">Domain suggestions couldn\'t be loaded</string>
     <string name="domain_registration_contact_form_input_error">Please enter a valid %s</string>
     <string name="domain_registration_privacy_protection_title">Privacy Protection</string>
@@ -2467,7 +2467,7 @@
     <string name="domains_primary_site_address_blurb">Your primary site address is what visitors will see in browser address bar when they visit your website.</string>
     <string name="domains_site_domains">Your site domains</string>
     <string name="domains_site_domain_expires">Expires on %s</string>
-    <string name="domains_site_domain_expires_soon">&lt;span style="color:#d63638;"&gt;Expires on %s&lt;span&gt;</string>
+    <string name="domains_site_domain_expires_soon">&lt;span style="color:#d63638;"&gt;Expires on %s&lt;/span&gt;</string>
     <string name="domains_add_a_domain">Add a domain</string>
     <string name="domains_redirected_domains_blurb">Your domains will redirect to your site at &lt;b&gt;%s&lt;/b&gt;. &lt;a href="https://wordpress.com/support/site-redirect/"&gt;Learn more&lt;/a&gt;.</string>
     <string name="domains_manage_domains">Manage Domains</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrationHandler
 import org.wordpress.android.ui.plans.PlansConstants
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.SiteDomainsFeatureConfig
 import org.wordpress.android.util.helpers.Debouncer
 
 class DomainSuggestionsViewModelTest : BaseUnitTest() {
@@ -27,6 +28,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Mock lateinit var debouncer: Debouncer
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
     @Mock lateinit var domainRegistrationHandler: DomainRegistrationHandler
+    @Mock lateinit var siteDomainsFeatureConfig: SiteDomainsFeatureConfig
 
     private lateinit var site: SiteModel
     private lateinit var viewModel: DomainSuggestionsViewModel
@@ -34,7 +36,8 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Before
     fun setUp() {
         site = SiteModel().also { it.name = "Test Site" }
-        viewModel = DomainSuggestionsViewModel(tracker, dispatcher, debouncer, domainRegistrationHandler)
+        viewModel = DomainSuggestionsViewModel(
+                tracker, dispatcher, debouncer, domainRegistrationHandler, siteDomainsFeatureConfig)
 
         whenever(debouncer.debounce(any(), any(), any(), any())).thenAnswer { invocation ->
             val delayedRunnable = invocation.arguments[1] as Runnable


### PR DESCRIPTION
Fixes #15315


<table><tr><td><img width=320 src="https://user-images.githubusercontent.com/990349/135995612-bcca4cc8-5e4a-429c-9d87-a3aeba583709.png"</td><td><img width=320 src="https://user-images.githubusercontent.com/990349/135995641-676e6033-aad7-40f9-8302-15fb5e9fd176.png"</td><td><img width=320 src="https://user-images.githubusercontent.com/990349/135995671-abd90984-094f-45ea-9c75-26858be3f800.png"</td></tr></table>

To test:


- Enable AppSettings -> Debug settings -> SiteDomainsFeatureConfig ✅
- Return to My Site, Notice there's a new item under Configuration -> 🌐 Domains
- Click on Domains, takes your Site Domains Screen
- Select a Get your domain
- Notice the domain search suggestions now show prices 

Test with 

1. feature not enabled ( no prices are shown)
2. feature enabled and paid plan ( should show free for one year)
3. feature enabled and free plan (prices are shown and no free for one year is shown)



## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
