### PR TITLE
Feature/15386 launch web checkout flow for free plan

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -935,6 +935,11 @@
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".ui.domains.DomainRegistrationWebViewActivity"
+            android:theme="@style/WordPress.NoActionBar" />
+
         <receiver
             android:name=".util.analytics.receiver.InstallationReferrerReceiver"
             android:permission="android.permission.INSTALL_PACKAGES"

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModel.kt
@@ -3,12 +3,26 @@ package org.wordpress.android.ui.domains
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.TransactionActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.TransactionsStore
+import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartPayload
+import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.SiteDomainsFeatureConfig
 import javax.inject.Inject
 
 class DomainRegistrationMainViewModel @Inject constructor(
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val siteDomainsFeatureConfig: SiteDomainsFeatureConfig,
+    private val dispatcher: Dispatcher,
+    private val transactionsStore: TransactionsStore, // needed for events to work
 ) : ViewModel() {
     private val _domainSuggestionsVisible = MutableLiveData<Boolean>()
     val domainSuggestionsVisible: LiveData<Boolean> = _domainSuggestionsVisible
@@ -19,12 +33,18 @@ class DomainRegistrationMainViewModel @Inject constructor(
     private val _domainRegistrationCompleted = MutableLiveData<DomainRegistrationCompletedEvent>()
     val domainRegistrationCompleted: LiveData<DomainRegistrationCompletedEvent> = _domainRegistrationCompleted
 
+    private val _cartCreated = MutableLiveData<CartCreatedEvent>()
+    val cartCreated: LiveData<CartCreatedEvent> = _cartCreated
+
+    val isSiteDomainsEnabled = siteDomainsFeatureConfig.isEnabled()
+    private lateinit var site: SiteModel
+
     private var isStarted: Boolean = false
-    fun start() {
+    fun start(site: SiteModel) {
         if (isStarted) {
             return
         }
-
+        this.site = site
         _domainSuggestionsVisible.value = true
 
         isStarted = true
@@ -40,4 +60,44 @@ class DomainRegistrationMainViewModel @Inject constructor(
         _selectedDomain.value = null
         _domainRegistrationCompleted.value = domainRegistrationCompletedEvent
     }
+
+    init {
+        dispatcher.register(this)
+    }
+
+    override fun onCleared() {
+        dispatcher.unregister(this)
+        super.onCleared()
+    }
+
+    fun createCart(domainProductDetails: DomainProductDetails, isPrivacyProtectionEnabled: Boolean = true) {
+        AppLog.d(T.DOMAIN_REGISTRATION, "Create cart: $domainProductDetails")
+        dispatcher.dispatch(
+                TransactionActionBuilder.newCreateShoppingCartAction(
+                        CreateShoppingCartPayload(
+                                site,
+                                domainProductDetails.productId,
+                                domainProductDetails.domainName,
+                                isPrivacyProtectionEnabled
+                        )
+                )
+        )
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onShoppingCartCreated(event: OnShoppingCartCreated) {
+        if (event.isError) {
+            AppLog.e(T.DOMAIN_REGISTRATION, "Error creating cart: ${event.error.message}")
+            // TODO Handle shopping creation failure
+        } else {
+            AppLog.d(T.DOMAIN_REGISTRATION, "Cart created: ${event.cartDetails}")
+            _cartCreated.value = CartCreatedEvent(site)
+        }
+    }
+
+    fun handleSuccessfulRegistration() {
+        completeDomainRegistration(DomainRegistrationCompletedEvent(_selectedDomain.value?.domainName.orEmpty(), ""))
+    }
+
+    data class CartCreatedEvent(val site: SiteModel)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationWebViewActivity.kt
@@ -1,0 +1,53 @@
+package org.wordpress.android.ui.domains
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.webkit.WebViewClient
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.WPWebViewActivity
+import org.wordpress.android.ui.domains.DomainRegistrationWebViewClient.DomainRegistrationWebViewClientListener
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.DOMAIN_REGISTRATION
+import org.wordpress.android.util.SiteUtils
+
+class DomainRegistrationWebViewActivity : WPWebViewActivity(), DomainRegistrationWebViewClientListener {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        toggleNavbarVisibility(false)
+    }
+
+    override fun createWebViewClient(allowedURL: List<String>?): WebViewClient {
+        return DomainRegistrationWebViewClient(this, this)
+    }
+
+    override fun onRegistrationSuccess() {
+        setResult(RESULT_OK)
+        finish()
+    }
+
+    companion object {
+        const val DOMAIN_REGISTRATION_REQUEST_CODE = 100123
+
+        fun openCheckout(activity: Activity, site: SiteModel) {
+            val checkoutUrl = getCheckoutUrl(site)
+
+            AppLog.d(DOMAIN_REGISTRATION, "Opening checkout URL: $checkoutUrl")
+
+            if (!checkContextAndUrl(activity, checkoutUrl)) {
+                return
+            }
+
+            val intent = Intent(activity, DomainRegistrationWebViewActivity::class.java).apply {
+                putExtra(USE_GLOBAL_WPCOM_USER, true)
+                putExtra(URL_TO_LOAD, checkoutUrl)
+                putExtra(AUTHENTICATION_URL, WPCOM_LOGIN_URL)
+            }
+
+            activity.startActivityForResult(intent, DOMAIN_REGISTRATION_REQUEST_CODE)
+        }
+
+        private fun getCheckoutUrl(site: SiteModel) =
+                "https://wordpress.com/checkout/${SiteUtils.getHomeURLOrHostName(site)}"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationWebViewClient.kt
@@ -1,0 +1,38 @@
+package org.wordpress.android.ui.domains
+
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import org.wordpress.android.util.ErrorManagedWebViewClient
+
+class DomainRegistrationWebViewClient(
+    private val listener: DomainRegistrationWebViewClientListener,
+    baseListener: ErrorManagedWebViewClientListener
+) : ErrorManagedWebViewClient(baseListener) {
+
+    private var hasRegistered = false
+
+    interface DomainRegistrationWebViewClientListener {
+        fun onRegistrationSuccess()
+    }
+
+    override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
+        val host = request.url.host.orEmpty()
+        val path = request.url.path.orEmpty()
+
+        // TODO Revisit this logic
+        if (host == WPCOM_API_HOST) {
+            if (hasRegistered) {
+                listener.onRegistrationSuccess()
+            } else if (path == "/rest/v1.1/me/transactions") {
+                hasRegistered = true
+            }
+        }
+
+        return super.shouldInterceptRequest(view, request)
+    }
+
+    companion object {
+        private const val WPCOM_API_HOST = "public-api.wordpress.com"
+    }
+}

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2416,8 +2416,8 @@
     <string name="domains_suggestions_intro_title">Choose a premium domain name</string>
     <string name="domains_suggestions_intro_description">This is where people will find you on the internet.</string>
     <string name="domain_suggestions_search_hint">Type a keyword for more ideas</string>
-    <string name="domain_suggestions_list_item_cost">%s&lt;span style="color:#50575e;"&gt; /year&lt;span&gt;</string>
-    <string name="domain_suggestions_list_item_cost_free">&lt;strong&gt;&lt;span style="color:#008000;"&gt;Free for the first year &lt;span&gt;&lt;/strong&gt;&lt;span style="color:#50575e;"&gt;&lt;s&gt;%s /year&lt;/s&gt;&lt;span&gt;</string>
+    <string name="domain_suggestions_list_item_cost">%s&lt;span style="color:#50575e;"&gt; /year&lt;/span&gt;</string>
+    <string name="domain_suggestions_list_item_cost_free">&lt;strong&gt;&lt;span style="color:#008000;"&gt;Free for the first year &lt;/span&gt;&lt;/strong&gt;&lt;span style="color:#50575e;"&gt;&lt;s&gt;%s /year&lt;/s&gt;&lt;/span&gt;</string>
     <string name="domain_suggestions_fetch_error">Domain suggestions couldn\'t be loaded</string>
     <string name="domain_registration_contact_form_input_error">Please enter a valid %s</string>
     <string name="domain_registration_privacy_protection_title">Privacy Protection</string>
@@ -2455,6 +2455,7 @@
     <string name="domains_primary_site_address_blurb">Your primary site address is what visitors will see in browser address bar when they visit your website.</string>
     <string name="domains_site_domains">Your site domains</string>
     <string name="domains_site_domain_expires">Expires on %s</string>
+    <string name="domains_site_domain_expires_soon">&lt;span style="color:#d63638;"&gt;Expires on %s&lt;/span&gt;</string>
     <string name="domains_add_a_domain">Add a domain</string>
     <string name="domains_redirected_domains_blurb">Your domains will redirect to your site at &lt;b&gt;%s&lt;/b&gt;. &lt;a href="https://wordpress.com/support/site-redirect/"&gt;Learn more&lt;/a&gt;.</string>
     <string name="domains_manage_domains">Manage Domains</string>


### PR DESCRIPTION
Fixes #15386 and #15366 

This PR builds of POC done by Renan with domain cookies and a permanent cart

<img width=320 src="https://user-images.githubusercontent.com/990349/136014052-7aa5d668-e3c2-4d3c-9965-53d96f573b57.png" />

To test:

Enable AppSettings -> Debug settings -> SiteDomainsFeatureConfig ✅
Return to My Site, Notice there's a new item under Configuration -> 🌐 Domains
Click on Domains, takes your Site Domains Screen
Select a Get your domain card, Click on search for a domain button
On Register Domain screen,  Select a domain and Click on Choose domain button
Should launch web checkout page.
Pay for domain or use a sandbox to test the purchase and return to a success screen.

Please, follow the instructions in #15153 to test with a sandbox site without making actual purchase

NOTE:  At the moment, Success screen shows-up irrespective of failure or cancel flow.  Which will be handled separately after this.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
