### PR TITLE
Hide prices from domain credit flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
@@ -9,6 +9,7 @@ class DomainSuggestionsAdapter(
 ) : Adapter<DomainSuggestionsViewHolder>() {
     private val list = mutableListOf<DomainSuggestionResponse>()
     var selectedPosition = -1
+    var isSiteDomainsFeatureEnabled: Boolean = false
     var isDomainCreditAvailable: Boolean = false
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DomainSuggestionsViewHolder {
@@ -23,7 +24,12 @@ class DomainSuggestionsAdapter(
     }
 
     override fun onBindViewHolder(holder: DomainSuggestionsViewHolder, position: Int) {
-        holder.bind(list[position], position, selectedPosition == position, isDomainCreditAvailable)
+        holder.bind(
+                list[position],
+                position,
+                selectedPosition == position,
+                isSiteDomainsFeatureEnabled,
+                isDomainCreditAvailable)
     }
 
     private fun onDomainSuggestionSelected(suggestion: DomainSuggestionResponse?, position: Int) {
@@ -36,10 +42,14 @@ class DomainSuggestionsAdapter(
         itemSelectionListener(suggestion, position)
     }
 
-    internal fun updateSuggestionsList(items: List<DomainSuggestionResponse>, isDomainCreditAvailable: Boolean) {
-        this.isDomainCreditAvailable = isDomainCreditAvailable
+    internal fun updateSuggestionsList(items: List<DomainSuggestionResponse>) {
         list.clear()
         list.addAll(items)
         notifyDataSetChanged()
+    }
+
+    internal fun updateDomainCreditAvailable(siteDomainsFeatureEnabled: Boolean, isDomainCreditAvailable: Boolean) {
+        this.isSiteDomainsFeatureEnabled = siteDomainsFeatureEnabled
+        this.isDomainCreditAvailable = isDomainCreditAvailable
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -114,12 +114,19 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
         viewModel.choseDomainButtonEnabledState.observe(viewLifecycleOwner, Observer {
             choseDomainButton.isEnabled = it ?: false
         })
+
+        viewModel.isDomainCreditAvailable.observe(viewLifecycleOwner, {
+            it?.let {
+                val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
+                adapter.updateDomainCreditAvailable(viewModel.isSiteDomainsFeatureConfigEnabled, it)
+            }
+        })
     }
 
     private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionResponse>) {
         val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
         adapter.selectedPosition = viewModel.selectedPosition.value ?: -1
-        adapter.updateSuggestionsList(domainSuggestions, viewModel.isDomainCreditAvailable)
+        adapter.updateSuggestionsList(domainSuggestions)
     }
 
     private fun onDomainSuggestionSelected(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
@@ -25,10 +25,16 @@ class DomainSuggestionsViewHolder(
         suggestion: DomainSuggestionResponse,
         position: Int,
         isSelectedPosition: Boolean,
+        isSiteDomainsFeatureEnabled: Boolean,
         isDomainCreditAvailable: Boolean
     ) {
         domainName.text = suggestion.domain_name
-        domainCost.text = getFormattedCost(suggestion, isDomainCreditAvailable)
+        if (isSiteDomainsFeatureEnabled) {
+            domainCost.visibility = View.VISIBLE
+            domainCost.text = getFormattedCost(suggestion, isDomainCreditAvailable)
+        } else {
+            domainCost.visibility = View.GONE
+        }
         selectionRadioButton.isChecked = isSelectedPosition
 
         container.setOnClickListener {

--- a/WordPress/src/main/res/layout/domain_suggestion_list_item.xml
+++ b/WordPress/src/main/res/layout/domain_suggestion_list_item.xml
@@ -31,18 +31,20 @@
         app:layout_constraintStart_toEndOf="@id/domain_selection_radio_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/domain_cost"
         tools:text="travelwithkids.com"/>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/domain_cost"
+        android:visibility="gone"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_medium"
         android:textAppearance="?attr/textAppearanceListItemSecondary"
-        app:layout_constraintStart_toEndOf="@id/domain_selection_radio_button"
+        app:layout_constraintStart_toStartOf="@id/domain_name"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/domain_name"
         app:layout_constraintBottom_toBottomOf="parent"
-        tools:text="Free for the first year US$18.99/year"/>
+        tools:text="Free for the first year US$18.99/year"
+        tools:visibility="visible"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2428,8 +2428,8 @@
     <string name="domains_suggestions_intro_title">Choose a premium domain name</string>
     <string name="domains_suggestions_intro_description">This is where people will find you on the internet.</string>
     <string name="domain_suggestions_search_hint">Type a keyword for more ideas</string>
-    <string name="domain_suggestions_list_item_cost">%s&lt;span style="color:#50575e;"&gt; /year&lt;span&gt;</string>
-    <string name="domain_suggestions_list_item_cost_free">&lt;strong&gt;&lt;span style="color:#008000;"&gt;Free for the first year &lt;span&gt;&lt;/strong&gt;&lt;span style="color:#50575e;"&gt;&lt;s&gt;%s /year&lt;/s&gt;&lt;span&gt;</string>
+    <string name="domain_suggestions_list_item_cost">%s&lt;span style="color:#50575e;"&gt; /year&lt;/span&gt;</string>
+    <string name="domain_suggestions_list_item_cost_free">&lt;strong&gt;&lt;span style="color:#008000;"&gt;Free for the first year &lt;/span&gt;&lt;/strong&gt;&lt;span style="color:#50575e;"&gt;&lt;s&gt;%s /year&lt;/s&gt;&lt;/span&gt;</string>
     <string name="domain_suggestions_fetch_error">Domain suggestions couldn\'t be loaded</string>
     <string name="domain_registration_contact_form_input_error">Please enter a valid %s</string>
     <string name="domain_registration_privacy_protection_title">Privacy Protection</string>
@@ -2467,7 +2467,7 @@
     <string name="domains_primary_site_address_blurb">Your primary site address is what visitors will see in browser address bar when they visit your website.</string>
     <string name="domains_site_domains">Your site domains</string>
     <string name="domains_site_domain_expires">Expires on %s</string>
-    <string name="domains_site_domain_expires_soon">&lt;span style="color:#d63638;"&gt;Expires on %s&lt;span&gt;</string>
+    <string name="domains_site_domain_expires_soon">&lt;span style="color:#d63638;"&gt;Expires on %s&lt;/span&gt;</string>
     <string name="domains_add_a_domain">Add a domain</string>
     <string name="domains_redirected_domains_blurb">Your domains will redirect to your site at &lt;b&gt;%s&lt;/b&gt;. &lt;a href="https://wordpress.com/support/site-redirect/"&gt;Learn more&lt;/a&gt;.</string>
     <string name="domains_manage_domains">Manage Domains</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrationHandler
 import org.wordpress.android.ui.plans.PlansConstants
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.SiteDomainsFeatureConfig
 import org.wordpress.android.util.helpers.Debouncer
 
 class DomainSuggestionsViewModelTest : BaseUnitTest() {
@@ -27,6 +28,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Mock lateinit var debouncer: Debouncer
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
     @Mock lateinit var domainRegistrationHandler: DomainRegistrationHandler
+    @Mock lateinit var siteDomainsFeatureConfig: SiteDomainsFeatureConfig
 
     private lateinit var site: SiteModel
     private lateinit var viewModel: DomainSuggestionsViewModel
@@ -34,7 +36,8 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Before
     fun setUp() {
         site = SiteModel().also { it.name = "Test Site" }
-        viewModel = DomainSuggestionsViewModel(tracker, dispatcher, debouncer, domainRegistrationHandler)
+        viewModel = DomainSuggestionsViewModel(
+                tracker, dispatcher, debouncer, domainRegistrationHandler, siteDomainsFeatureConfig)
 
         whenever(debouncer.debounce(any(), any(), any(), any())).thenAnswer { invocation ->
             val delayedRunnable = invocation.arguments[1] as Runnable


### PR DESCRIPTION
The changes in this PR were initially submitted to #15416 by @ravishanker, but since that branch was cut from `develop` instead of the frozen branch, I've cherry-picked the relevant commits to a new branch correctly created from `release/18.4` this time.

The main change needed for the fix:
- Displaying prices only when the Domains feature flag is enabled (in https://github.com/wordpress-mobile/WordPress-Android/commit/a87dd939eba8c509bb06b33bb375cc3ecdb44f42)

This PR also includes two other non-user-facing changes that aren't strictly necessary for the fix:
- Fixing price formatting (also in https://github.com/wordpress-mobile/WordPress-Android/commit/a87dd939eba8c509bb06b33bb375cc3ecdb44f42)
- Adding closing span tags to some strings (in https://github.com/wordpress-mobile/WordPress-Android/commit/14cb43c58f1b54d1ebb9491e69fe9901ae6d5cf5)

| Feature flag OFF + domain credits | Feature flag ON + domain credits | Feature flag ON + no domain credits |
|-----|-----|-----|
|<img width=320 src="https://user-images.githubusercontent.com/990349/135995612-bcca4cc8-5e4a-429c-9d87-a3aeba583709.png"/>|<img width=320 src="https://user-images.githubusercontent.com/990349/135995641-676e6033-aad7-40f9-8302-15fb5e9fd176.png"/>|<img width=320 src="https://user-images.githubusercontent.com/990349/135995671-abd90984-094f-45ea-9c75-26858be3f800.png"/>|

### To test

**Setup: Enable/disable feature flag**

1. On the Main screen, tap the Me button.
1. On the Me screen, go to App Settings > Debug settings.
1. On the Debug Settings screen, scroll down to the "Features in development" section and tap `SiteDomainsFeatureConfig` to enable/disable the Domains feature flag.

**Scenario 1: Feature flag OFF + domain credits**

1. Open the app and select a site that has domain credits.
1. On the Main screen, tap the "Register Domain" item.
1. On the Domain Suggestions screen, notice no prices are shown.

- Enable AppSettings -> Debug settings -> SiteDomainsFeatureConfig ✅
- Return to My Site, Notice there's a new item under Configuration -> 🌐 Domains
- Click on Domains, takes your Site Domains Screen
- Select a Get your domain
- Notice the domain search suggestions now show prices 

**Scenario 2: Feature flag ON + domain credit**

1. Open the app and select a site that has domain credits.
1. On the Main screen, tap the "Register Domain" item.
1. On the Domain Suggestions screen, notice strikethrough prices are shown.

**Scenario 3: Feature flag ON + no domain credit**

1. Open the app and select a site that has **no** domain credits.
1. On the Main screen, tap the "Domains" item under the "Configuration" section.
1. On the Domains Dashboard screen, tap the "Search for a domain" button.
1. On the Domain Suggestions screen, notice prices are shown.

## Regression Notes
1. Potential unintended areas of impact
Existing domain credit flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None, but we're planning to add some tests before wrapping up the Domains feature.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
