### PR TITLE
Display editor help button for all users

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,7 @@
 * [*] Embed block: Fix URL update when edited after setting a bad URL of a provider. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4002]
 * [**] Users can now contact support from inside the block editor screen. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3975]
 * [**] Site Comments: when editing a Comment, the author's name, email address, and web address can now be changed. (https://github.com/wordpress-mobile/WordPress-Android/pull/15402)
-* [**] Block editor: Support articles available within the block editor help menu [#15421]
+* [**] Block editor: Help menu with guides about how to work with blocks [#15421]
 
 18.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 * [*] Embed block: Fix URL update when edited after setting a bad URL of a provider. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4002]
 * [**] Users can now contact support from inside the block editor screen. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3975]
 * [**] Site Comments: when editing a Comment, the author's name, email address, and web address can now be changed. (https://github.com/wordpress-mobile/WordPress-Android/pull/15402)
+* [**] Block editor: Support articles available within the block editor help menu [#15421]
 
 18.3
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1269,7 +1269,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
         if (helpMenuItem != null) {
             if (mEditorFragment instanceof GutenbergEditorFragment
-                && canViewEditorOnboarding()
                 && showMenuItems
             ) {
                 helpMenuItem.setVisible(true);


### PR DESCRIPTION
## Description

We decided to enable the help section for all users, which includes a list of support articles and the ability to open a support ticket from #15328. 

## Testing

For the installable build:
1. Remove any previous WPAndroid app installations and install build from this PR. 
1. Launch the block editor. 
2. Tap the three-dot menu in the top-right corner of the editor. 
3. Tap "Help & Support." 
4. **Expected:** The list of support articles are displayed alongside the "contact support" button. 

For a local development build: 
1. Remove any previous WPAndroid app installations and build to device from this branch. 
1. Apply the following patch for the branch locally disabling automatic cohort inclusion for development builds. 
    ```diff
    diff --git a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
    index d31804f4f6..3b12325b10 100644
    --- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
    +++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
    @@ -306,7 +306,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
        private static final int PAGE_SETTINGS = 1;
        private static final int PAGE_PUBLISH_SETTINGS = 2;
        private static final int PAGE_HISTORY = 3;
    -    private static final int EDITOR_ONBOARDING_PHASE_PERCENTAGE = 50;
    +    private static final int EDITOR_ONBOARDING_PHASE_PERCENTAGE = 0;
    
        private AztecImageLoader mAztecImageLoader;
    
    @@ -2355,7 +2355,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
            }
    
            int hashedUserId = convertUserIdToHash(userId, "can_view_editor_onboarding");
    -        return hashedUserId % 100 >= (100 - EDITOR_ONBOARDING_PHASE_PERCENTAGE) || BuildConfig.DEBUG;
    +        return hashedUserId % 100 >= (100 - EDITOR_ONBOARDING_PHASE_PERCENTAGE);
        }
    
        /**

    ```
1. Launch the block editor. 
2. Open the block inserter. 
3. ℹ️ **Expected:** There are no ["new" block sparkle badges](https://github.com/WordPress/gutenberg/pull/33119) on any block button.<sup>1</sup>  
2. Tap the three-dot menu in the top-right corner of the editor. 
3. Tap "Help & Support." 
4. ℹ️ **Expected:** The list of support articles are displayed alongside the "contact support" button. 

[1]: The "new" block badges will not be present due to patch applied. 

## Regression Notes
1. Potential unintended areas of impact
    The single line removal hopefully minimizes the possibility that any other items in the menu are effected. 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Navigated to each of the items in the menu. 
3. What automated tests I added (or what prevented me from doing so)
    Out of scope for this minimal PR to unblock shipping #15328. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
