### PR TITLE
Add feature flag for "My Site Dashboard - Phase 2"

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -111,6 +111,7 @@ android {
         buildConfigField "boolean", "SITE_DOMAINS", "false"
         buildConfigField "boolean", "RECOMMEND_THE_APP", "false"
         buildConfigField "boolean", "UNIFIED_COMMENTS_COMMENT_EDIT", "false"
+        buildConfigField "boolean", "MY_SITE_DASHBOARD_PHASE_2", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardPhase2FeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardPhase2FeatureConfig.kt
@@ -4,9 +4,14 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.annotation.FeatureInDevelopment
 import javax.inject.Inject
 
+/**
+ * Configuration of the 'My Site Dashboard - Phase 2', which amongst others includes the new 'Dashboard Post Cards'
+ * that will be added on the 'My Site' screen.
+ */
 @FeatureInDevelopment
-class MySiteDashboardPhase2FeatureConfig
-@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+class MySiteDashboardPhase2FeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
         appConfig,
         BuildConfig.MY_SITE_DASHBOARD_PHASE_2
 )

--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardPhase2FeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardPhase2FeatureConfig.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+@FeatureInDevelopment
+class MySiteDashboardPhase2FeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.MY_SITE_DASHBOARD_PHASE_2
+)


### PR DESCRIPTION
Fixes #15423

This PR adds a feature flag for "My Site Dashboard - Phase 2".

PS: I added a generic name  "MY_SITE_DASHBOARD_PHASE_2" instead of "DASHBOARD_POST_CARDS" as we might end up adding few improvements in addition to the post-based cards' implementation. 

To test:

1. Launch the app.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Test Feature Configuration`.
3. Notice that `MySiteDashboardPhase2FeatureConfig` exists under `Features in development` section.

    ![device-2021-10-06-112429](https://user-images.githubusercontent.com/1405144/136149233-52ee978e-db4b-4ef4-bb1b-70f1e8d6378d.png)

## Regression Notes
1. Potential unintended areas of impact 🟢 


2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 


3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
