### PR TITLE
Removes --info flag from the Buildkite lint task

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
     <<: *docker-container
     command: |
       cp gradle.properties-example gradle.properties
-      ./gradlew lintWordpressVanillaRelease --info
+      ./gradlew lintWordpressVanillaRelease
   - label: "Test WordPress"
     <<: *docker-container
     command: |


### PR DESCRIPTION
The `--info` flag makes the logs very verbose and a lot harder to find the information we are looking for. It's also useful on very specific situations, mainly when we are trying to understand what Gradle is doing instead of debugging one of our own tasks, so [we decided not to include it in the CI runs](https://github.com/wordpress-mobile/WordPress-Android/pull/15324#discussion_r710218936). 

**To test:**
N/A

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
