### PR TITLE
My Site Dashboard - Phase 2 - Initial Structure - Split `MySiteViewModel.MySiteUiState` -> `UiModel`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -224,48 +224,15 @@ class MySiteViewModel
     ) ->
         val state = if (site != null) {
             val siteItems = mutableListOf<MySiteCardAndItem>()
-            siteItems.add(
-                    siteInfoCardBuilder.buildSiteInfoCard(
+            siteItems.addAll(
+                    buildCards(
                             site,
                             showSiteIconProgressBar,
-                            this::titleClick,
-                            this::iconClick,
-                            this::urlClick,
-                            this::switchSiteClick,
-                            activeTask == UPDATE_SITE_TITLE,
-                            activeTask == UPLOAD_SITE_ICON
+                            activeTask,
+                            isDomainCreditAvailable,
+                            quickStartCategories
                     )
             )
-            if (!buildConfigWrapper.isJetpackApp) {
-                siteItems.add(
-                        quickActionsCardBuilder.build(
-                                this::quickActionStatsClick,
-                                this::quickActionPagesClick,
-                                this::quickActionPostsClick,
-                                this::quickActionMediaClick,
-                                site.isSelfHostedAdmin || site.hasCapabilityEditPages,
-                                activeTask == CHECK_STATS,
-                                activeTask == EDIT_HOMEPAGE || activeTask == REVIEW_PAGES
-                        )
-                )
-            }
-            if (isDomainCreditAvailable) {
-                analyticsTrackerWrapper.track(DOMAIN_CREDIT_PROMPT_SHOWN)
-                siteItems.add(DomainRegistrationCard(ListItemInteraction.create(this::domainRegistrationClick)))
-            }
-
-            if (!quickStartDynamicCardsFeatureConfig.isEnabled()) {
-                quickStartCategories.takeIf { it.isNotEmpty() }?.let {
-                    siteItems.add(
-                            quickStartCardBuilder.build(
-                                    quickStartCategories,
-                                    this::onQuickStartBlockRemoveMenuItemClick,
-                                    this::onQuickStartTaskTypeItemClick
-                            )
-                    )
-                }
-            }
-
             siteItems.addAll(buildDynamicCards(quickStartCategories, pinnedDynamicCard, visibleDynamicCards))
             siteItems.addAll(buildSiteItems(site, backupAvailable, scanAvailable, activeTask))
             scrollToQuickStartTaskIfNecessary(
@@ -278,6 +245,58 @@ class MySiteViewModel
             State.NoSites(shouldShowImage)
         }
         UiModel(currentAvatarUrl.orEmpty(), state)
+    }
+
+    private fun buildCards(
+        site: SiteModel,
+        showSiteIconProgressBar: Boolean,
+        activeTask: QuickStartTask?,
+        isDomainCreditAvailable: Boolean,
+        quickStartCategories: List<QuickStartCategory>
+    ): List<MySiteCardAndItem> {
+        val cards = mutableListOf<MySiteCardAndItem>()
+        cards.add(
+                siteInfoCardBuilder.buildSiteInfoCard(
+                        site,
+                        showSiteIconProgressBar,
+                        this::titleClick,
+                        this::iconClick,
+                        this::urlClick,
+                        this::switchSiteClick,
+                        activeTask == UPDATE_SITE_TITLE,
+                        activeTask == UPLOAD_SITE_ICON
+                )
+        )
+        if (!buildConfigWrapper.isJetpackApp) {
+            cards.add(
+                    quickActionsCardBuilder.build(
+                            this::quickActionStatsClick,
+                            this::quickActionPagesClick,
+                            this::quickActionPostsClick,
+                            this::quickActionMediaClick,
+                            site.isSelfHostedAdmin || site.hasCapabilityEditPages,
+                            activeTask == CHECK_STATS,
+                            activeTask == EDIT_HOMEPAGE || activeTask == REVIEW_PAGES
+                    )
+            )
+        }
+        if (isDomainCreditAvailable) {
+            analyticsTrackerWrapper.track(DOMAIN_CREDIT_PROMPT_SHOWN)
+            cards.add(DomainRegistrationCard(ListItemInteraction.create(this::domainRegistrationClick)))
+        }
+
+        if (!quickStartDynamicCardsFeatureConfig.isEnabled()) {
+            quickStartCategories.takeIf { it.isNotEmpty() }?.let {
+                cards.add(
+                        quickStartCardBuilder.build(
+                                quickStartCategories,
+                                this::onQuickStartBlockRemoveMenuItemClick,
+                                this::onQuickStartTaskTypeItemClick
+                        )
+                )
+            }
+        }
+        return cards
     }
 
     fun buildDynamicCards(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -70,8 +70,7 @@ import javax.inject.Inject
 import javax.inject.Named
 
 @Suppress("LongMethod")
-class MySiteViewModel
-@Inject constructor(
+class MySiteViewModel @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     @param:Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -46,6 +46,8 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard
+import org.wordpress.android.ui.mysite.MySiteViewModel.State.NoSites
+import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ChangeSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ShowRemoveNextStepsDialog
@@ -223,28 +225,55 @@ class MySiteViewModel
             visibleDynamicCards
     ) ->
         val state = if (site != null) {
-            val siteItems = mutableListOf<MySiteCardAndItem>()
-            siteItems.addAll(
-                    buildCards(
-                            site,
-                            showSiteIconProgressBar,
-                            activeTask,
-                            isDomainCreditAvailable,
-                            quickStartCategories
-                    )
-            )
-            siteItems.addAll(buildDynamicCards(quickStartCategories, pinnedDynamicCard, visibleDynamicCards))
-            siteItems.addAll(buildSiteItems(site, backupAvailable, scanAvailable, activeTask))
-            scrollToQuickStartTaskIfNecessary(
+            buildSiteSelectedState(
+                    site,
+                    showSiteIconProgressBar,
                     activeTask,
-                    siteItems.indexOfFirst { it.activeQuickStartItem })
-            State.SiteSelected(siteItems)
+                    isDomainCreditAvailable,
+                    quickStartCategories,
+                    pinnedDynamicCard,
+                    visibleDynamicCards,
+                    backupAvailable,
+                    scanAvailable
+            )
         } else {
-            // Hide actionable empty view image when screen height is under 600 pixels.
-            val shouldShowImage = displayUtilsWrapper.getDisplayPixelHeight() >= 600
-            State.NoSites(shouldShowImage)
+            buildNoSiteState()
         }
         UiModel(currentAvatarUrl.orEmpty(), state)
+    }
+
+    @Suppress("LongParameterList")
+    private fun buildSiteSelectedState(
+        site: SiteModel,
+        showSiteIconProgressBar: Boolean,
+        activeTask: QuickStartTask?,
+        isDomainCreditAvailable: Boolean,
+        quickStartCategories: List<QuickStartCategory>,
+        pinnedDynamicCard: DynamicCardType?,
+        visibleDynamicCards: List<DynamicCardType>,
+        backupAvailable: Boolean,
+        scanAvailable: Boolean
+    ): SiteSelected {
+        val siteItems = mutableListOf<MySiteCardAndItem>()
+        siteItems.addAll(
+                buildCards(
+                        site,
+                        showSiteIconProgressBar,
+                        activeTask,
+                        isDomainCreditAvailable,
+                        quickStartCategories
+                )
+        )
+        siteItems.addAll(buildDynamicCards(quickStartCategories, pinnedDynamicCard, visibleDynamicCards))
+        siteItems.addAll(buildSiteItems(site, backupAvailable, scanAvailable, activeTask))
+        scrollToQuickStartTaskIfNecessary(activeTask, siteItems.indexOfFirst { it.activeQuickStartItem })
+        return SiteSelected(siteItems)
+    }
+
+    private fun buildNoSiteState(): NoSites {
+        // Hide actionable empty view image when screen height is under 600 pixels.
+        val shouldShowImage = displayUtilsWrapper.getDisplayPixelHeight() >= 600
+        return NoSites(shouldShowImage)
     }
 
     private fun buildCards(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -267,18 +267,7 @@ class MySiteViewModel
             }
 
             siteItems.addAll(buildDynamicCards(quickStartCategories, pinnedDynamicCard, visibleDynamicCards))
-
-            siteItems.addAll(
-                    siteItemsBuilder.buildSiteItems(
-                            site,
-                            this::onItemClick,
-                            backupAvailable,
-                            scanAvailable,
-                            activeTask == QuickStartTask.VIEW_SITE,
-                            activeTask == ENABLE_POST_SHARING,
-                            activeTask == EXPLORE_PLANS
-                    )
-            )
+            siteItems.addAll(buildSiteItems(site, backupAvailable, scanAvailable, activeTask))
             scrollToQuickStartTaskIfNecessary(
                     activeTask,
                     siteItems.indexOfFirst { it.activeQuickStartItem })
@@ -314,6 +303,21 @@ class MySiteViewModel
         }.associateBy { it.dynamicCardType }
         return visibleDynamicCards.mapNotNull { dynamicCardType -> dynamicCards[dynamicCardType] }
     }
+
+    private fun buildSiteItems(
+        site: SiteModel,
+        backupAvailable: Boolean,
+        scanAvailable: Boolean,
+        activeTask: QuickStartTask?
+    ) = siteItemsBuilder.buildSiteItems(
+            site,
+            this::onItemClick,
+            backupAvailable,
+            scanAvailable,
+            activeTask == QuickStartTask.VIEW_SITE,
+            activeTask == ENABLE_POST_SHARING,
+            activeTask == EXPLORE_PLANS
+    )
 
     private fun scrollToQuickStartTaskIfNecessary(
         quickStartTask: QuickStartTask?,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -32,7 +32,6 @@ import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilde
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
-import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoCardBuilder
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment.DynamicCardMenuModel
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction.Hide
@@ -50,7 +49,6 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Dis
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Negative
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Positive
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.MediaUtilsWrapper
@@ -80,7 +78,6 @@ class MySiteViewModel
     @param:Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val siteInfoCardBuilder: SiteInfoCardBuilder,
     private val siteItemsBuilder: SiteItemsBuilder,
     private val accountStore: AccountStore,
     private val selectedSiteRepository: SelectedSiteRepository,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -69,7 +69,7 @@ import java.io.File
 import javax.inject.Inject
 import javax.inject.Named
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "LongParameterList", "TooManyFunctions")
 class MySiteViewModel @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     @param:Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
@@ -238,8 +238,8 @@ class MySiteViewModel @Inject constructor(
     )
 
     private fun buildNoSiteState(): NoSites {
-        // Hide actionable empty view image when screen height is under 600 pixels.
-        val shouldShowImage = displayUtilsWrapper.getDisplayPixelHeight() >= 600
+        // Hide actionable empty view image when screen height is under specified min height.
+        val shouldShowImage = displayUtilsWrapper.getDisplayPixelHeight() >= MIN_DISPLAY_PX_HEIGHT_NO_SITE_IMAGE
         return NoSites(shouldShowImage)
     }
 
@@ -254,6 +254,7 @@ class MySiteViewModel @Inject constructor(
         }
     }
 
+    @Suppress("ComplexMethod")
     private fun onItemClick(action: ListItemAction) {
         selectedSiteRepository.getSelectedSite()?.let { selectedSite ->
             val navigationAction = when (action) {
@@ -548,6 +549,7 @@ class MySiteViewModel @Inject constructor(
         _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(getEmailValidationMessage(email))))
     }
 
+    @Suppress("ReturnCount")
     private fun startSiteIconUpload(filePath: String) {
         if (TextUtils.isEmpty(filePath)) {
             _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.error_locating_image))))
@@ -682,6 +684,7 @@ class MySiteViewModel @Inject constructor(
     )
 
     companion object {
+        private const val MIN_DISPLAY_PX_HEIGHT_NO_SITE_IMAGE = 600
         const val TAG_ADD_SITE_ICON_DIALOG = "TAG_ADD_SITE_ICON_DIALOG"
         const val TAG_CHANGE_SITE_ICON_DIALOG = "TAG_CHANGE_SITE_ICON_DIALOG"
         const val TAG_REMOVE_NEXT_STEPS_DIALOG = "TAG_REMOVE_NEXT_STEPS_DIALOG"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.ui.mysite.SiteDialogModel.ChangeSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ShowRemoveNextStepsDialog
 import org.wordpress.android.ui.mysite.cards.CardsBuilder
 import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrationHandler
-import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
@@ -93,7 +92,6 @@ class MySiteViewModel
     private val quickStartRepository: QuickStartRepository,
     private val quickStartItemBuilder: QuickStartItemBuilder,
     private val quickStartCardBuilder: QuickStartCardBuilder,
-    private val quickActionsCardBuilder: QuickActionsCardBuilder,
     private val currentAvatarSource: CurrentAvatarSource,
     private val dynamicCardsSource: DynamicCardsSource,
     private val unifiedCommentsListFeatureConfig: UnifiedCommentsListFeatureConfig,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -10,36 +10,12 @@ import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_ICON_CROPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_ICON_GALLERY_PICKED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_ICON_REMOVED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_ICON_SHOT_NEW
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_ICON_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_ACTION_MEDIA_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_ACTION_PAGES_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_ACTION_POSTS_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_ACTION_STATS_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_HIDE_CARD_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REMOVE_CARD_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REMOVE_DIALOG_NEGATIVE_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REMOVE_DIALOG_POSITIVE_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.DynamicCardType
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_POST_SHARING
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EXPLORE_PLANS
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.REVIEW_PAGES
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
@@ -51,35 +27,6 @@ import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ChangeSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ShowRemoveNextStepsDialog
-import org.wordpress.android.ui.mysite.SiteNavigationAction.AddNewSite
-import org.wordpress.android.ui.mysite.SiteNavigationAction.ConnectJetpackForStats
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenActivityLog
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenAdmin
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenBackup
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenComments
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenCropActivity
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomainRegistration
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomains
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenJetpackSettings
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMeScreen
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMedia
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMediaPicker
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenPages
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenPeople
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenPlan
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenPlugins
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenPosts
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenQuickStartFullScreenDialog
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenScan
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenSharing
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenSite
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenSitePicker
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenSiteSettings
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenStats
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenThemes
-import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenUnifiedComments
-import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialog
-import org.wordpress.android.ui.mysite.SiteNavigationAction.StartWPComLoginForJetpackStats
 import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrationHandler
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
@@ -95,24 +42,6 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsSource
 import org.wordpress.android.ui.mysite.dynamiccards.quickstart.QuickStartItemBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsBuilder
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.ACTIVITY_LOG
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.ADMIN
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.BACKUP
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.COMMENTS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.DOMAINS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.JETPACK_SETTINGS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.MEDIA
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.PAGES
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.PEOPLE
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.PLAN
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.PLUGINS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.POSTS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.SCAN
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.SHARING
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.SITE_SETTINGS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.STATS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.THEMES
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.VIEW_SITE
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource.ANDROID_CAMERA
@@ -292,8 +221,8 @@ class MySiteViewModel
                         this::iconClick,
                         this::urlClick,
                         this::switchSiteClick,
-                        activeTask == UPDATE_SITE_TITLE,
-                        activeTask == UPLOAD_SITE_ICON
+                        activeTask == QuickStartTask.UPDATE_SITE_TITLE,
+                        activeTask == QuickStartTask.UPLOAD_SITE_ICON
                 )
         )
         if (!buildConfigWrapper.isJetpackApp) {
@@ -304,13 +233,13 @@ class MySiteViewModel
                             this::quickActionPostsClick,
                             this::quickActionMediaClick,
                             site.isSelfHostedAdmin || site.hasCapabilityEditPages,
-                            activeTask == CHECK_STATS,
-                            activeTask == EDIT_HOMEPAGE || activeTask == REVIEW_PAGES
+                            activeTask == QuickStartTask.CHECK_STATS,
+                            activeTask == QuickStartTask.EDIT_HOMEPAGE || activeTask == QuickStartTask.REVIEW_PAGES
                     )
             )
         }
         if (isDomainCreditAvailable) {
-            analyticsTrackerWrapper.track(DOMAIN_CREDIT_PROMPT_SHOWN)
+            analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_PROMPT_SHOWN)
             cards.add(DomainRegistrationCard(ListItemInteraction.create(this::domainRegistrationClick)))
         }
 
@@ -363,8 +292,8 @@ class MySiteViewModel
             backupAvailable,
             scanAvailable,
             activeTask == QuickStartTask.VIEW_SITE,
-            activeTask == ENABLE_POST_SHARING,
-            activeTask == EXPLORE_PLANS
+            activeTask == QuickStartTask.ENABLE_POST_SHARING,
+            activeTask == QuickStartTask.EXPLORE_PLANS
     )
 
     private fun scrollToQuickStartTaskIfNecessary(
@@ -381,45 +310,45 @@ class MySiteViewModel
     private fun onItemClick(action: ListItemAction) {
         selectedSiteRepository.getSelectedSite()?.let { selectedSite ->
             val navigationAction = when (action) {
-                ACTIVITY_LOG -> OpenActivityLog(selectedSite)
-                BACKUP -> OpenBackup(selectedSite)
-                SCAN -> OpenScan(selectedSite)
-                PLAN -> {
-                    quickStartRepository.completeTask(EXPLORE_PLANS)
-                    OpenPlan(selectedSite)
+                ListItemAction.ACTIVITY_LOG -> SiteNavigationAction.OpenActivityLog(selectedSite)
+                ListItemAction.BACKUP -> SiteNavigationAction.OpenBackup(selectedSite)
+                ListItemAction.SCAN -> SiteNavigationAction.OpenScan(selectedSite)
+                ListItemAction.PLAN -> {
+                    quickStartRepository.completeTask(QuickStartTask.EXPLORE_PLANS)
+                    SiteNavigationAction.OpenPlan(selectedSite)
                 }
-                POSTS -> OpenPosts(selectedSite)
-                PAGES -> {
-                    quickStartRepository.completeTask(REVIEW_PAGES)
-                    OpenPages(selectedSite)
+                ListItemAction.POSTS -> SiteNavigationAction.OpenPosts(selectedSite)
+                ListItemAction.PAGES -> {
+                    quickStartRepository.completeTask(QuickStartTask.REVIEW_PAGES)
+                    SiteNavigationAction.OpenPages(selectedSite)
                 }
-                ADMIN -> OpenAdmin(selectedSite)
-                PEOPLE -> OpenPeople(selectedSite)
-                SHARING -> {
-                    quickStartRepository.requestNextStepOfTask(ENABLE_POST_SHARING)
-                    OpenSharing(selectedSite)
+                ListItemAction.ADMIN -> SiteNavigationAction.OpenAdmin(selectedSite)
+                ListItemAction.PEOPLE -> SiteNavigationAction.OpenPeople(selectedSite)
+                ListItemAction.SHARING -> {
+                    quickStartRepository.requestNextStepOfTask(QuickStartTask.ENABLE_POST_SHARING)
+                    SiteNavigationAction.OpenSharing(selectedSite)
                 }
-                DOMAINS -> OpenDomains(selectedSite)
-                SITE_SETTINGS -> OpenSiteSettings(selectedSite)
-                THEMES -> OpenThemes(selectedSite)
-                PLUGINS -> OpenPlugins(selectedSite)
-                STATS -> {
-                    quickStartRepository.completeTask(CHECK_STATS)
+                ListItemAction.DOMAINS -> SiteNavigationAction.OpenDomains(selectedSite)
+                ListItemAction.SITE_SETTINGS -> SiteNavigationAction.OpenSiteSettings(selectedSite)
+                ListItemAction.THEMES -> SiteNavigationAction.OpenThemes(selectedSite)
+                ListItemAction.PLUGINS -> SiteNavigationAction.OpenPlugins(selectedSite)
+                ListItemAction.STATS -> {
+                    quickStartRepository.completeTask(QuickStartTask.CHECK_STATS)
                     getStatsNavigationActionForSite(selectedSite)
                 }
-                MEDIA -> OpenMedia(selectedSite)
-                COMMENTS -> {
+                ListItemAction.MEDIA -> SiteNavigationAction.OpenMedia(selectedSite)
+                ListItemAction.COMMENTS -> {
                     if (unifiedCommentsListFeatureConfig.isEnabled()) {
-                        OpenUnifiedComments(selectedSite)
+                        SiteNavigationAction.OpenUnifiedComments(selectedSite)
                     } else {
-                        OpenComments(selectedSite)
+                        SiteNavigationAction.OpenComments(selectedSite)
                     }
                 }
-                VIEW_SITE -> {
+                ListItemAction.VIEW_SITE -> {
                     quickStartRepository.completeTask(QuickStartTask.VIEW_SITE)
-                    OpenSite(selectedSite)
+                    SiteNavigationAction.OpenSite(selectedSite)
                 }
-                JETPACK_SETTINGS -> OpenJetpackSettings(selectedSite)
+                ListItemAction.JETPACK_SETTINGS -> SiteNavigationAction.OpenJetpackSettings(selectedSite)
             }
             _onNavigation.postValue(Event(navigationAction))
         } ?: _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.site_cannot_be_loaded))))
@@ -435,7 +364,9 @@ class MySiteViewModel
 
     private fun onQuickStartTaskTypeItemClick(type: QuickStartTaskType) {
         clearActiveQuickStartTask()
-        _onNavigation.value = Event(OpenQuickStartFullScreenDialog(type, quickStartCardBuilder.getTitle(type)))
+        _onNavigation.value = Event(
+                SiteNavigationAction.OpenQuickStartFullScreenDialog(type, quickStartCardBuilder.getTitle(type))
+        )
     }
 
     fun onQuickStartTaskCardClick(task: QuickStartTask) {
@@ -470,7 +401,7 @@ class MySiteViewModel
 
     private fun iconClick() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
-        analyticsTrackerWrapper.track(MY_SITE_ICON_TAPPED)
+        analyticsTrackerWrapper.track(Stat.MY_SITE_ICON_TAPPED)
         val hasIcon = selectedSite.iconUrl != null
         if (selectedSite.hasCapabilityManageOptions && selectedSite.hasCapabilityUploadFiles) {
             if (hasIcon) {
@@ -496,45 +427,45 @@ class MySiteViewModel
 
     private fun urlClick() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
-        _onNavigation.value = Event(OpenSite(selectedSite))
+        _onNavigation.value = Event(SiteNavigationAction.OpenSite(selectedSite))
     }
 
     private fun switchSiteClick() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
-        _onNavigation.value = Event(OpenSitePicker(selectedSite))
+        _onNavigation.value = Event(SiteNavigationAction.OpenSitePicker(selectedSite))
     }
 
     private fun quickActionStatsClick() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
-        analyticsTrackerWrapper.track(QUICK_ACTION_STATS_TAPPED)
-        quickStartRepository.completeTask(CHECK_STATS)
+        analyticsTrackerWrapper.track(Stat.QUICK_ACTION_STATS_TAPPED)
+        quickStartRepository.completeTask(QuickStartTask.CHECK_STATS)
         _onNavigation.value = Event(getStatsNavigationActionForSite(selectedSite))
     }
 
     private fun quickActionPagesClick() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
-        analyticsTrackerWrapper.track(QUICK_ACTION_PAGES_TAPPED)
-        quickStartRepository.requestNextStepOfTask(EDIT_HOMEPAGE)
-        quickStartRepository.completeTask(REVIEW_PAGES)
-        _onNavigation.value = Event(OpenPages(selectedSite))
+        analyticsTrackerWrapper.track(Stat.QUICK_ACTION_PAGES_TAPPED)
+        quickStartRepository.requestNextStepOfTask(QuickStartTask.EDIT_HOMEPAGE)
+        quickStartRepository.completeTask(QuickStartTask.REVIEW_PAGES)
+        _onNavigation.value = Event(SiteNavigationAction.OpenPages(selectedSite))
     }
 
     private fun quickActionPostsClick() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
-        analyticsTrackerWrapper.track(QUICK_ACTION_POSTS_TAPPED)
-        _onNavigation.value = Event(OpenPosts(selectedSite))
+        analyticsTrackerWrapper.track(Stat.QUICK_ACTION_POSTS_TAPPED)
+        _onNavigation.value = Event(SiteNavigationAction.OpenPosts(selectedSite))
     }
 
     private fun quickActionMediaClick() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
-        analyticsTrackerWrapper.track(QUICK_ACTION_MEDIA_TAPPED)
-        _onNavigation.value = Event(OpenMedia(selectedSite))
+        analyticsTrackerWrapper.track(Stat.QUICK_ACTION_MEDIA_TAPPED)
+        _onNavigation.value = Event(SiteNavigationAction.OpenMedia(selectedSite))
     }
 
     private fun domainRegistrationClick() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
-        analyticsTrackerWrapper.track(DOMAIN_CREDIT_REDEMPTION_TAPPED, selectedSite)
-        _onNavigation.value = Event(OpenDomainRegistration(selectedSite))
+        analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED, selectedSite)
+        _onNavigation.value = Event(SiteNavigationAction.OpenDomainRegistration(selectedSite))
     }
 
     fun refresh() {
@@ -568,7 +499,7 @@ class MySiteViewModel
     fun onSiteNameChooserDismissed() {
         // This callback is called even when the dialog interaction is positive,
         // otherwise we would need to call 'completeTask' on 'onSiteNameChosen' as well.
-        quickStartRepository.completeTask(UPDATE_SITE_TITLE, true)
+        quickStartRepository.completeTask(QuickStartTask.UPDATE_SITE_TITLE, true)
         quickStartRepository.checkAndShowQuickStartNotice()
     }
 
@@ -576,21 +507,23 @@ class MySiteViewModel
         when (interaction) {
             is Positive -> when (interaction.tag) {
                 TAG_ADD_SITE_ICON_DIALOG, TAG_CHANGE_SITE_ICON_DIALOG -> {
-                    quickStartRepository.completeTask(UPLOAD_SITE_ICON)
+                    quickStartRepository.completeTask(QuickStartTask.UPLOAD_SITE_ICON)
                     _onNavigation.postValue(
-                            Event(OpenMediaPicker(requireNotNull(selectedSiteRepository.getSelectedSite())))
+                            Event(
+                                    SiteNavigationAction.OpenMediaPicker(requireNotNull(selectedSiteRepository.getSelectedSite()))
+                            )
                     )
                 }
                 TAG_REMOVE_NEXT_STEPS_DIALOG -> onRemoveNextStepsDialogPositiveButtonClicked()
             }
             is Negative -> when (interaction.tag) {
                 TAG_ADD_SITE_ICON_DIALOG -> {
-                    quickStartRepository.completeTask(UPLOAD_SITE_ICON, true)
+                    quickStartRepository.completeTask(QuickStartTask.UPLOAD_SITE_ICON, true)
                     quickStartRepository.checkAndShowQuickStartNotice()
                 }
                 TAG_CHANGE_SITE_ICON_DIALOG -> {
-                    analyticsTrackerWrapper.track(MY_SITE_ICON_REMOVED)
-                    quickStartRepository.completeTask(UPLOAD_SITE_ICON, true)
+                    analyticsTrackerWrapper.track(Stat.MY_SITE_ICON_REMOVED)
+                    quickStartRepository.completeTask(QuickStartTask.UPLOAD_SITE_ICON, true)
                     quickStartRepository.checkAndShowQuickStartNotice()
                     selectedSiteRepository.updateSiteIconMediaId(0, true)
                 }
@@ -598,7 +531,7 @@ class MySiteViewModel
             }
             is Dismissed -> when (interaction.tag) {
                 TAG_ADD_SITE_ICON_DIALOG, TAG_CHANGE_SITE_ICON_DIALOG -> {
-                    quickStartRepository.completeTask(UPLOAD_SITE_ICON, true)
+                    quickStartRepository.completeTask(QuickStartTask.UPLOAD_SITE_ICON, true)
                     quickStartRepository.checkAndShowQuickStartNotice()
                 }
             }
@@ -606,18 +539,18 @@ class MySiteViewModel
     }
 
     private fun onRemoveNextStepsDialogPositiveButtonClicked() {
-        analyticsTrackerWrapper.track(QUICK_START_REMOVE_DIALOG_POSITIVE_TAPPED)
+        analyticsTrackerWrapper.track(Stat.QUICK_START_REMOVE_DIALOG_POSITIVE_TAPPED)
         quickStartRepository.skipQuickStart()
         refresh()
         clearActiveQuickStartTask()
     }
 
     private fun onRemoveNextStepsDialogNegativeButtonClicked() {
-        analyticsTrackerWrapper.track(QUICK_START_REMOVE_DIALOG_NEGATIVE_TAPPED)
+        analyticsTrackerWrapper.track(Stat.QUICK_START_REMOVE_DIALOG_NEGATIVE_TAPPED)
     }
 
     fun handleTakenSiteIcon(iconUrl: String?, source: PhotoPickerMediaSource?) {
-        val stat = if (source == ANDROID_CAMERA) MY_SITE_ICON_SHOT_NEW else MY_SITE_ICON_GALLERY_PICKED
+        val stat = if (source == ANDROID_CAMERA) Stat.MY_SITE_ICON_SHOT_NEW else Stat.MY_SITE_ICON_GALLERY_PICKED
         analyticsTrackerWrapper.track(stat)
         val imageUri = Uri.parse(iconUrl)?.let { UriWrapper(it) }
         if (imageUri != null) {
@@ -625,7 +558,7 @@ class MySiteViewModel
             launch(bgDispatcher) {
                 val fetchMedia = wpMediaUtilsWrapper.fetchMediaToUriWrapper(imageUri)
                 if (fetchMedia != null) {
-                    _onNavigation.postValue(Event(OpenCropActivity(fetchMedia)))
+                    _onNavigation.postValue(Event(SiteNavigationAction.OpenCropActivity(fetchMedia)))
                 } else {
                     selectedSiteRepository.showSiteIconProgressBar(false)
                 }
@@ -639,7 +572,7 @@ class MySiteViewModel
 
     fun handleCropResult(croppedUri: Uri?, success: Boolean) {
         if (success && croppedUri != null) {
-            analyticsTrackerWrapper.track(MY_SITE_ICON_CROPPED)
+            analyticsTrackerWrapper.track(Stat.MY_SITE_ICON_CROPPED)
             selectedSiteRepository.showSiteIconProgressBar(true)
             launch(bgDispatcher) {
                 wpMediaUtilsWrapper.fetchMediaToUriWrapper(UriWrapper(croppedUri))?.let { fetchMedia ->
@@ -654,11 +587,15 @@ class MySiteViewModel
     }
 
     fun handleSuccessfulLoginResult() {
-        selectedSiteRepository.getSelectedSite()?.let { site -> _onNavigation.value = Event(OpenStats(site)) }
+        selectedSiteRepository.getSelectedSite()?.let { site ->
+            _onNavigation.value = Event(
+                    SiteNavigationAction.OpenStats(site)
+            )
+        }
     }
 
     fun handleSuccessfulDomainRegistrationResult(email: String?) {
-        analyticsTrackerWrapper.track(DOMAIN_CREDIT_REDEMPTION_SUCCESS)
+        analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS)
         _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(getEmailValidationMessage(email))))
     }
 
@@ -693,21 +630,21 @@ class MySiteViewModel
 
     private fun getStatsNavigationActionForSite(site: SiteModel) = when {
         // If the user is not logged in and the site is already connected to Jetpack, ask to login.
-        !accountStore.hasAccessToken() && site.isJetpackConnected -> StartWPComLoginForJetpackStats
+        !accountStore.hasAccessToken() && site.isJetpackConnected -> SiteNavigationAction.StartWPComLoginForJetpackStats
 
         // If it's a WordPress.com or Jetpack site, show the Stats screen.
-        site.isWPCom || site.isJetpackInstalled && site.isJetpackConnected -> OpenStats(site)
+        site.isWPCom || site.isJetpackInstalled && site.isJetpackConnected -> SiteNavigationAction.OpenStats(site)
 
         // If it's a self-hosted site, ask to connect to Jetpack.
-        else -> ConnectJetpackForStats(site)
+        else -> SiteNavigationAction.ConnectJetpackForStats(site)
     }
 
     fun onAvatarPressed() {
-        _onNavigation.value = Event(OpenMeScreen)
+        _onNavigation.value = Event(SiteNavigationAction.OpenMeScreen)
     }
 
     fun onAddSitePressed() {
-        _onNavigation.value = Event(AddNewSite(accountStore.hasAccessToken()))
+        _onNavigation.value = Event(SiteNavigationAction.AddNewSite(accountStore.hasAccessToken()))
     }
 
     override fun onCleared() {
@@ -737,14 +674,14 @@ class MySiteViewModel
         launch {
             when (interaction) {
                 is DynamicCardMenuInteraction.Remove -> {
-                    analyticsTrackerWrapper.track(QUICK_START_REMOVE_CARD_TAPPED)
+                    analyticsTrackerWrapper.track(Stat.QUICK_START_REMOVE_CARD_TAPPED)
                     dynamicCardsSource.removeItem(interaction.cardType)
                     quickStartRepository.refresh()
                 }
                 is Pin -> dynamicCardsSource.pinItem(interaction.cardType)
                 is Unpin -> dynamicCardsSource.unpinItem()
                 is Hide -> {
-                    analyticsTrackerWrapper.track(QUICK_START_HIDE_CARD_TAPPED)
+                    analyticsTrackerWrapper.track(Stat.QUICK_START_HIDE_CARD_TAPPED)
                     dynamicCardsSource.hideItem(interaction.cardType)
                     quickStartRepository.refresh()
                 }
@@ -756,7 +693,7 @@ class MySiteViewModel
         if (siteModel != null && quickStartUtilsWrapper.isQuickStartAvailableForTheSite(siteModel)) {
             _onNavigation.postValue(
                     Event(
-                            ShowQuickStartDialog(
+                            SiteNavigationAction.ShowQuickStartDialog(
                                     R.string.quick_start_dialog_need_help_manage_site_title,
                                     R.string.quick_start_dialog_need_help_manage_site_message,
                                     R.string.quick_start_dialog_need_help_manage_site_button_positive,
@@ -768,12 +705,12 @@ class MySiteViewModel
     }
 
     fun startQuickStart() {
-        analyticsTrackerWrapper.track(QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED)
+        analyticsTrackerWrapper.track(Stat.QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED)
         quickStartRepository.startQuickStart(selectedSiteRepository.getSelectedSiteLocalId())
     }
 
     fun ignoreQuickStart() {
-        analyticsTrackerWrapper.track(QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
+        analyticsTrackerWrapper.track(Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
     }
 
     data class UiModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -99,7 +99,6 @@ class MySiteViewModel
     private val quickActionsCardBuilder: QuickActionsCardBuilder,
     private val currentAvatarSource: CurrentAvatarSource,
     private val dynamicCardsSource: DynamicCardsSource,
-    private val buildConfigWrapper: BuildConfigWrapper,
     private val unifiedCommentsListFeatureConfig: UnifiedCommentsListFeatureConfig,
     private val quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig,
     private val quickStartUtilsWrapper: QuickStartUtilsWrapper,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.Dyn
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction.Hide
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction.Pin
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction.Unpin
+import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsBuilder
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsSource
 import org.wordpress.android.ui.mysite.dynamiccards.quickstart.QuickStartItemBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsBuilder
@@ -98,7 +99,8 @@ class MySiteViewModel
     private val quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig,
     private val quickStartUtilsWrapper: QuickStartUtilsWrapper,
     private val snackbarSequencer: SnackbarSequencer,
-    private val cardsBuilder: CardsBuilder
+    private val cardsBuilder: CardsBuilder,
+    private val dynamicCardsBuilder: DynamicCardsBuilder
 ) : ScopedViewModel(mainDispatcher) {
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val _onTechInputDialogShown = MutableLiveData<Event<TextInputDialogModel>>()
@@ -228,25 +230,13 @@ class MySiteViewModel
         quickStartCategories: List<QuickStartCategory>,
         pinnedDynamicCard: DynamicCardType?,
         visibleDynamicCards: List<DynamicCardType>
-    ): List<DynamicCard> {
-        val dynamicCards = mutableListOf<DynamicCard>().also { list ->
-            // Add all possible future dynamic cards here. If we ever have a remote source of dynamic cards, we'd
-            // need to implement a smarter solution where we'd build the sources based on the dynamic cards.
-            // This means that the stream of dynamic cards would emit a new stream for each of the cards. The
-            // current solution is good enough for a few sources.
-            if (quickStartDynamicCardsFeatureConfig.isEnabled()) {
-                list.addAll(quickStartCategories.map { category ->
-                    quickStartItemBuilder.build(
-                            category,
-                            pinnedDynamicCard,
-                            this::onDynamicCardMoreClick,
-                            this::onQuickStartTaskCardClick
-                    )
-                })
-            }
-        }.associateBy { it.dynamicCardType }
-        return visibleDynamicCards.mapNotNull { dynamicCardType -> dynamicCards[dynamicCardType] }
-    }
+    ): List<DynamicCard> = dynamicCardsBuilder.build(
+            quickStartCategories,
+            pinnedDynamicCard,
+            visibleDynamicCards,
+            this::onDynamicCardMoreClick,
+            this::onQuickStartTaskCardClick
+    )
 
     private fun buildSiteItems(
         site: SiteModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -477,7 +477,9 @@ class MySiteViewModel
                     quickStartRepository.completeTask(QuickStartTask.UPLOAD_SITE_ICON)
                     _onNavigation.postValue(
                             Event(
-                                    SiteNavigationAction.OpenMediaPicker(requireNotNull(selectedSiteRepository.getSelectedSite()))
+                                    SiteNavigationAction.OpenMediaPicker(
+                                            requireNotNull(selectedSiteRepository.getSelectedSite())
+                                    )
                             )
                     )
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -38,7 +38,6 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.Dyn
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction.Unpin
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsBuilder
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsSource
-import org.wordpress.android.ui.mysite.dynamiccards.quickstart.QuickStartItemBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsBuilder
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
@@ -91,7 +90,6 @@ class MySiteViewModel
     private val scanAndBackupSource: ScanAndBackupSource,
     private val displayUtilsWrapper: DisplayUtilsWrapper,
     private val quickStartRepository: QuickStartRepository,
-    private val quickStartItemBuilder: QuickStartItemBuilder,
     private val quickStartCardBuilder: QuickStartCardBuilder,
     private val currentAvatarSource: CurrentAvatarSource,
     private val dynamicCardsSource: DynamicCardsSource,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -46,39 +46,35 @@ class CardsBuilder
     ): List<MySiteCardAndItem> {
         val cards = mutableListOf<MySiteCardAndItem>()
         cards.add(
-                siteInfoCardBuilder.buildSiteInfoCard(
+                buildSiteInfoCard(
                         site,
                         showSiteIconProgressBar,
                         titleClick,
                         iconClick,
                         urlClick,
                         switchSiteClick,
-                        activeTask == QuickStartTask.UPDATE_SITE_TITLE,
-                        activeTask == QuickStartTask.UPLOAD_SITE_ICON
+                        activeTask
                 )
         )
         if (!buildConfigWrapper.isJetpackApp) {
             cards.add(
-                    quickActionsCardBuilder.build(
+                    buildQuickActionsCard(
                             quickActionStatsClick,
                             quickActionPagesClick,
                             quickActionPostsClick,
                             quickActionMediaClick,
-                            site.isSelfHostedAdmin || site.hasCapabilityEditPages,
-                            activeTask == QuickStartTask.CHECK_STATS,
-                            activeTask == QuickStartTask.EDIT_HOMEPAGE || activeTask == QuickStartTask.REVIEW_PAGES
+                            site,
+                            activeTask
                     )
             )
         }
         if (isDomainCreditAvailable) {
-            analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_PROMPT_SHOWN)
-            cards.add(DomainRegistrationCard(ListItemInteraction.create(domainRegistrationClick)))
+            cards.add(buildAndTrackDomainRegistrationCard(domainRegistrationClick))
         }
-
         if (!quickStartDynamicCardsFeatureConfig.isEnabled()) {
             quickStartCategories.takeIf { it.isNotEmpty() }?.let {
                 cards.add(
-                        quickStartCardBuilder.build(
+                        buildQuickStartCard(
                                 quickStartCategories,
                                 onQuickStartBlockRemoveMenuItemClick,
                                 onQuickStartTaskTypeItemClick
@@ -88,4 +84,57 @@ class CardsBuilder
         }
         return cards
     }
+
+    @Suppress("LongParameterList")
+    private fun buildSiteInfoCard(
+        site: SiteModel,
+        showSiteIconProgressBar: Boolean,
+        titleClick: () -> Unit,
+        iconClick: () -> Unit,
+        urlClick: () -> Unit,
+        switchSiteClick: () -> Unit,
+        activeTask: QuickStartTask?
+    ) = siteInfoCardBuilder.buildSiteInfoCard(
+            site,
+            showSiteIconProgressBar,
+            titleClick,
+            iconClick,
+            urlClick,
+            switchSiteClick,
+            activeTask == QuickStartTask.UPDATE_SITE_TITLE,
+            activeTask == QuickStartTask.UPLOAD_SITE_ICON
+    )
+
+    @Suppress("LongParameterList")
+    private fun buildQuickActionsCard(
+        quickActionStatsClick: () -> Unit,
+        quickActionPagesClick: () -> Unit,
+        quickActionPostsClick: () -> Unit,
+        quickActionMediaClick: () -> Unit,
+        site: SiteModel,
+        activeTask: QuickStartTask?
+    ) = quickActionsCardBuilder.build(
+            quickActionStatsClick,
+            quickActionPagesClick,
+            quickActionPostsClick,
+            quickActionMediaClick,
+            site.isSelfHostedAdmin || site.hasCapabilityEditPages,
+            activeTask == QuickStartTask.CHECK_STATS,
+            activeTask == QuickStartTask.EDIT_HOMEPAGE || activeTask == QuickStartTask.REVIEW_PAGES
+    )
+
+    private fun buildAndTrackDomainRegistrationCard(domainRegistrationClick: () -> Unit): DomainRegistrationCard {
+        analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_PROMPT_SHOWN)
+        return DomainRegistrationCard(ListItemInteraction.create(domainRegistrationClick))
+    }
+
+    private fun buildQuickStartCard(
+        quickStartCategories: List<QuickStartCategory>,
+        onQuickStartBlockRemoveMenuItemClick: () -> Unit,
+        onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit
+    ) = quickStartCardBuilder.build(
+            quickStartCategories,
+            onQuickStartBlockRemoveMenuItemClick,
+            onQuickStartTaskTypeItemClick
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -1,0 +1,91 @@
+package org.wordpress.android.ui.mysite.cards
+
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
+import org.wordpress.android.ui.mysite.MySiteCardAndItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
+import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
+import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoCardBuilder
+import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
+import javax.inject.Inject
+
+class CardsBuilder
+@Inject constructor(
+    private val buildConfigWrapper: BuildConfigWrapper,
+    private val quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig,
+    private val siteInfoCardBuilder: SiteInfoCardBuilder,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val quickActionsCardBuilder: QuickActionsCardBuilder,
+    private val quickStartCardBuilder: QuickStartCardBuilder
+) {
+    @Suppress("LongParameterList")
+    fun build(
+        site: SiteModel,
+        showSiteIconProgressBar: Boolean,
+        activeTask: QuickStartTask?,
+        isDomainCreditAvailable: Boolean,
+        quickStartCategories: List<QuickStartCategory>,
+        titleClick: () -> Unit,
+        iconClick: () -> Unit,
+        urlClick: () -> Unit,
+        switchSiteClick: () -> Unit,
+        quickActionStatsClick: () -> Unit,
+        quickActionPagesClick: () -> Unit,
+        quickActionPostsClick: () -> Unit,
+        quickActionMediaClick: () -> Unit,
+        domainRegistrationClick: () -> Unit,
+        onQuickStartBlockRemoveMenuItemClick: () -> Unit,
+        onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit
+    ): List<MySiteCardAndItem> {
+        val cards = mutableListOf<MySiteCardAndItem>()
+        cards.add(
+                siteInfoCardBuilder.buildSiteInfoCard(
+                        site,
+                        showSiteIconProgressBar,
+                        titleClick,
+                        iconClick,
+                        urlClick,
+                        switchSiteClick,
+                        activeTask == QuickStartTask.UPDATE_SITE_TITLE,
+                        activeTask == QuickStartTask.UPLOAD_SITE_ICON
+                )
+        )
+        if (!buildConfigWrapper.isJetpackApp) {
+            cards.add(
+                    quickActionsCardBuilder.build(
+                            quickActionStatsClick,
+                            quickActionPagesClick,
+                            quickActionPostsClick,
+                            quickActionMediaClick,
+                            site.isSelfHostedAdmin || site.hasCapabilityEditPages,
+                            activeTask == QuickStartTask.CHECK_STATS,
+                            activeTask == QuickStartTask.EDIT_HOMEPAGE || activeTask == QuickStartTask.REVIEW_PAGES
+                    )
+            )
+        }
+        if (isDomainCreditAvailable) {
+            analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_PROMPT_SHOWN)
+            cards.add(DomainRegistrationCard(ListItemInteraction.create(domainRegistrationClick)))
+        }
+
+        if (!quickStartDynamicCardsFeatureConfig.isEnabled()) {
+            quickStartCategories.takeIf { it.isNotEmpty() }?.let {
+                cards.add(
+                        quickStartCardBuilder.build(
+                                quickStartCategories,
+                                onQuickStartBlockRemoveMenuItemClick,
+                                onQuickStartTaskTypeItemClick
+                        )
+                )
+            }
+        }
+        return cards
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -16,8 +16,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import javax.inject.Inject
 
-class CardsBuilder
-@Inject constructor(
+class CardsBuilder @Inject constructor(
     private val buildConfigWrapper: BuildConfigWrapper,
     private val quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig,
     private val siteInfoCardBuilder: SiteInfoCardBuilder,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -69,7 +69,7 @@ class CardsBuilder
             )
         }
         if (isDomainCreditAvailable) {
-            cards.add(buildAndTrackDomainRegistrationCard(domainRegistrationClick))
+            cards.add(trackAndBuildDomainRegistrationCard(domainRegistrationClick))
         }
         if (!quickStartDynamicCardsFeatureConfig.isEnabled()) {
             quickStartCategories.takeIf { it.isNotEmpty() }?.let {
@@ -123,7 +123,7 @@ class CardsBuilder
             activeTask == QuickStartTask.EDIT_HOMEPAGE || activeTask == QuickStartTask.REVIEW_PAGES
     )
 
-    private fun buildAndTrackDomainRegistrationCard(domainRegistrationClick: () -> Unit): DomainRegistrationCard {
+    private fun trackAndBuildDomainRegistrationCard(domainRegistrationClick: () -> Unit): DomainRegistrationCard {
         analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_PROMPT_SHOWN)
         return DomainRegistrationCard(ListItemInteraction.create(domainRegistrationClick))
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilder.kt
@@ -1,0 +1,42 @@
+package org.wordpress.android.ui.mysite.dynamiccards
+
+import org.wordpress.android.fluxc.model.DynamicCardType
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
+import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment.DynamicCardMenuModel
+import org.wordpress.android.ui.mysite.dynamiccards.quickstart.QuickStartItemBuilder
+import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
+import javax.inject.Inject
+
+class DynamicCardsBuilder
+@Inject constructor(
+    private val quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig,
+    private val quickStartItemBuilder: QuickStartItemBuilder
+) {
+    fun build(
+        quickStartCategories: List<QuickStartCategory>,
+        pinnedDynamicCard: DynamicCardType?,
+        visibleDynamicCards: List<DynamicCardType>,
+        onDynamicCardMoreClick: (DynamicCardMenuModel) -> Unit,
+        onQuickStartTaskCardClick: (QuickStartTask) -> Unit
+    ): List<DynamicCard> {
+        val dynamicCards = mutableListOf<DynamicCard>().also { list ->
+            // Add all possible future dynamic cards here. If we ever have a remote source of dynamic cards, we'd
+            // need to implement a smarter solution where we'd build the sources based on the dynamic cards.
+            // This means that the stream of dynamic cards would emit a new stream for each of the cards. The
+            // current solution is good enough for a few sources.
+            if (quickStartDynamicCardsFeatureConfig.isEnabled()) {
+                list.addAll(quickStartCategories.map { category ->
+                    quickStartItemBuilder.build(
+                            category,
+                            pinnedDynamicCard,
+                            onDynamicCardMoreClick,
+                            onQuickStartTaskCardClick
+                    )
+                })
+            }
+        }.associateBy { it.dynamicCardType }
+        return visibleDynamicCards.mapNotNull { dynamicCardType -> dynamicCards[dynamicCardType] }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilder.kt
@@ -9,8 +9,7 @@ import org.wordpress.android.ui.mysite.dynamiccards.quickstart.QuickStartItemBui
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import javax.inject.Inject
 
-class DynamicCardsBuilder
-@Inject constructor(
+class DynamicCardsBuilder @Inject constructor(
     private val quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig,
     private val quickStartItemBuilder: QuickStartItemBuilder
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -12,8 +12,7 @@ import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import javax.inject.Inject
 
-class SiteItemsBuilder
-@Inject constructor(
+class SiteItemsBuilder @Inject constructor(
     private val siteCategoryItemBuilder: SiteCategoryItemBuilder,
     private val siteListItemBuilder: SiteListItemBuilder
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -32,8 +32,7 @@ import java.util.GregorianCalendar
 import java.util.TimeZone
 import javax.inject.Inject
 
-class SiteListItemBuilder
-@Inject constructor(
+class SiteListItemBuilder @Inject constructor(
     private val accountStore: AccountStore,
     private val pluginUtilsWrapper: PluginUtilsWrapper,
     private val siteUtilsWrapper: SiteUtilsWrapper,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -32,6 +32,7 @@ import java.util.GregorianCalendar
 import java.util.TimeZone
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 class SiteListItemBuilder @Inject constructor(
     private val accountStore: AccountStore,
     private val pluginUtilsWrapper: PluginUtilsWrapper,
@@ -86,6 +87,7 @@ class SiteListItemBuilder @Inject constructor(
         } else null
     }
 
+    @Suppress("ComplexCondition")
     fun buildPlanItemIfAvailable(
         site: SiteModel,
         showFocusPoint: Boolean,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -375,6 +375,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
     }
 
+    /* SITE STATE */
     @Test
     fun `model is empty with no selected site`() {
         onSiteSelected.value = null
@@ -393,6 +394,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(getLastItems().first()).isInstanceOf(SiteInfoCard::class.java)
     }
 
+    /* SITE INFO CARD */
     @Test
     fun `site info card title click shows snackbar message when network not available`() = test {
         initQuickActionsCard()
@@ -626,6 +628,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(findSiteInfoCard()!!.showIconFocusPoint).isTrue
     }
 
+    /* AVATAR */
     @Test
     fun `account avatar url value is emitted and updated from the source`() {
         initSelectedSite()
@@ -642,6 +645,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(navigationActions).containsOnly(OpenMeScreen)
     }
 
+    /* QUICK ACTIONS CARD */
     @Test
     fun `quick actions does not show pages button when site doesn't have the required capability`() {
         site.hasCapabilityEditPages = false
@@ -770,6 +774,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(navigationActions).containsOnly(OpenMedia(site))
     }
 
+    /* LOGIN - NAVIGATION TO STATS */
     @Test
     fun `handling successful login result opens stats screen`() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
@@ -779,6 +784,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(navigationActions).containsOnly(OpenStats(site))
     }
 
+    /* ITEM CLICK */
     @Test
     fun `activity item click emits OpenActivity navigation event`() {
         invokeItemClickAction(ACTIVITY_LOG)
@@ -921,6 +927,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(navigationActions).containsExactly(ConnectJetpackForStats(site))
     }
 
+    /* DOMAIN REGISTRATION CARD */
     @Test
     fun `domain registration item click opens domain registration`() {
         initSelectedSite()
@@ -968,6 +975,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(snackbars).containsOnly(SnackbarMessageHolder(message))
     }
 
+    /* ITEM VISIBILITY */
     @Test
     fun `backup menu item is NOT visible, when getJetpackMenuItemsVisibility is false`() = test {
         initSelectedSite()
@@ -1036,6 +1044,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         )
     }
 
+    /* EMPTY VIEW */
     @Test
     fun `when no site is selected and screen height is higher than 600 pixels, show empty view image`() {
         whenever(displayUtilsWrapper.getDisplayPixelHeight()).thenReturn(600)
@@ -1058,6 +1067,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat((uiModels.last().state as NoSites).shouldShowImage).isFalse
     }
 
+    /* ADD NEW SITE */
     @Test
     fun `add new site press is handled correctly`() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
@@ -1067,6 +1077,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(navigationActions).containsOnly(AddNewSite(true))
     }
 
+    /* QUICK START CARD + DYNAMIC CARD */
     @Test
     fun `hides quick start menu item in quickStartRepository`() {
         val id = CUSTOMIZE_QUICK_START
@@ -1209,6 +1220,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         verify(quickStartRepository).setActiveTask(task)
     }
 
+    /* QUICK ACTIONS CARD */
     @Test
     fun `when build is Jetpack, then quick action card is not built`() {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
@@ -1231,6 +1243,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(quickActionsCard).isNotNull
     }
 
+    /* START/IGNORE QUICK START + QUICK START DIALOG */
     @Test
     fun `given QS dynamic cards cards feature is on, when check and start QS is triggered, then QS starts`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(true)
@@ -1302,6 +1315,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         verify(analyticsTrackerWrapper).track(QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
     }
 
+    /* REFRESH */
     @Test
     fun `when refresh is triggered, then update site settings if necessary`() {
         viewModel.refresh()
@@ -1337,6 +1351,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         verify(quickStartRepository).checkAndShowQuickStartNotice()
     }
 
+    /* ADD SITE ICON DIALOG */
     @Test
     fun `when add site icon dialog +ve btn is clicked, then upload site icon task marked complete without refresh`() {
         viewModel.onDialogInteraction(DialogInteraction.Positive(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG))
@@ -1418,6 +1433,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         verify(quickStartRepository).checkAndShowQuickStartNotice()
     }
 
+    /* SITE CHOOSER DIALOG */
     @Test
     fun `when site chooser is dismissed, then check and show quick start notice`() {
         viewModel.onSiteNameChooserDismissed()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -785,13 +785,6 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given quick start is not in progress, when site is selected, then quick start card not built`() {
-        initSelectedSite(isQuickStartInProgress = false)
-
-        assertThat(findQuickStartCard()).isNull()
-    }
-
-    @Test
     fun `given quick start is not in progress, when site is selected, then QS dynamic card not built`() {
         initSelectedSite(isQuickStartInProgress = false)
 
@@ -810,20 +803,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(isQuickStartDynamicCardEnabled = true, isQuickStartInProgress = true)
 
         assertThat(findQuickStartDynamicCard()).isNotNull
-    }
-
-    @Test
-    fun `given dynamic card disabled + quick start in progress, when site is selected, then QS card built`() {
-        initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
-
-        assertThat(findQuickStartCard()).isNotNull
-    }
-
-    @Test
-    fun `given dynamic card enabled + quick start in progress, when site is selected, then QS card not built`() {
-        initSelectedSite(isQuickStartDynamicCardEnabled = true, isQuickStartInProgress = true)
-
-        assertThat(findQuickStartCard()).isNull()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -21,12 +21,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.Mock
+import org.mockito.invocation.InvocationOnMock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED
@@ -139,6 +139,7 @@ private const val CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION = 5
 private const val CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION = 6
 private const val CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION = 7
 private const val CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION = 8
+private const val CARDS_BUILDER_DOMAIN_REGISTRATION_CLICK_PARAM_POSITION = 13
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -798,19 +799,6 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `correct event is tracked when domain registration item is shown`() = test {
-        initQuickActionsCard()
-
-        onSiteSelected.value = siteLocalId
-        onSiteChange.value = site
-        isDomainCreditAvailable.value = DomainCreditAvailable(true)
-
-        delay(1000)
-
-        verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_PROMPT_SHOWN)
-    }
-
-    @Test
     fun `snackbar is shown and event is tracked when handling successful domain registration result without email`() {
         viewModel.handleSuccessfulDomainRegistrationResult(null)
 
@@ -1443,7 +1431,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                         (it.getArgument(CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION) as () -> Unit).invoke()
                     }
             )
-            listOf<MySiteCardAndItem>(siteInfoCard)
+            val domainRegistrationCard = initDomainRegistrationCard(it)
+            listOf<MySiteCardAndItem>(siteInfoCard, domainRegistrationCard)
         }.whenever(cardsBuilder).build(
                 site = eq(site),
                 showSiteIconProgressBar = any(),
@@ -1463,4 +1452,11 @@ class MySiteViewModelTest : BaseUnitTest() {
                 onQuickStartTaskTypeItemClick = any()
         )
     }
+
+    private fun initDomainRegistrationCard(mockInvocation: InvocationOnMock) = DomainRegistrationCard(
+            ListItemInteraction.create {
+                (mockInvocation.getArgument(CARDS_BUILDER_DOMAIN_REGISTRATION_CLICK_PARAM_POSITION) as () -> Unit)
+                        .invoke()
+            }
+    )
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1254,7 +1254,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         isQuickStartDynamicCardEnabled: Boolean = false,
         isQuickStartInProgress: Boolean = false
     ) {
-        if (isQuickStartDynamicCardEnabled) setUpDynamicCardsBuilder()
+        setUpDynamicCardsBuilder(isQuickStartDynamicCardEnabled)
         quickStartUpdate.value = QuickStartUpdate(
                 categories = if (isQuickStartInProgress) listOf(quickStartCategory) else emptyList()
         )
@@ -1293,10 +1293,11 @@ class MySiteViewModelTest : BaseUnitTest() {
         )
     }
 
-    private fun setUpDynamicCardsBuilder() {
+    private fun setUpDynamicCardsBuilder(isQuickStartDynamicCardEnabled: Boolean) {
         doAnswer {
-            val dynamicQuickStartCard = initDynamicQuickStartCard(it)
-            listOf<DynamicCard>(dynamicQuickStartCard)
+            mutableListOf<DynamicCard>().apply {
+                if (isQuickStartDynamicCardEnabled) add(initDynamicQuickStartCard(it))
+            }.toList()
         }.whenever(dynamicCardsBuilder).build(
                 quickStartCategories = any(),
                 pinnedDynamicCard = anyOrNull(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -124,7 +124,6 @@ import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
-import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.MediaUtilsWrapper
@@ -161,7 +160,6 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var scanAndBackupSource: ScanAndBackupSource
     @Mock lateinit var currentAvatarSource: CurrentAvatarSource
     @Mock lateinit var dynamicCardsSource: DynamicCardsSource
-    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var unifiedCommentsListFeatureConfig: UnifiedCommentsListFeatureConfig
     @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
     @Mock lateinit var quickStartUtilsWrapper: QuickStartUtilsWrapper
@@ -295,7 +293,6 @@ class MySiteViewModelTest : BaseUnitTest() {
                 quickActionsCardBuilder,
                 currentAvatarSource,
                 dynamicCardsSource,
-                buildConfigWrapper,
                 unifiedCommentsListFeatureConfig,
                 quickStartDynamicCardsFeatureConfig,
                 quickStartUtilsWrapper,
@@ -725,28 +722,6 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* QUICK ACTIONS CARD */
-    @Test
-    fun `when build is Jetpack, then quick action card is not built`() {
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
-
-        initSelectedSite()
-
-        val quickActionsCard = findQuickActionsCard()
-
-        assertThat(quickActionsCard).isNull()
-    }
-
-    @Test
-    fun `when build is WordPress, then quick action card is built`() {
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
-
-        initSelectedSite()
-
-        val quickActionsCard = findQuickActionsCard()
-
-        assertThat(quickActionsCard).isNotNull
-    }
-
     @Test
     fun `quick actions does not show pages button when site doesn't have the required capability`() {
         site.hasCapabilityEditPages = false

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -726,6 +726,28 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     /* QUICK ACTIONS CARD */
     @Test
+    fun `when build is Jetpack, then quick action card is not built`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
+
+        initSelectedSite()
+
+        val quickActionsCard = findQuickActionsCard()
+
+        assertThat(quickActionsCard).isNull()
+    }
+
+    @Test
+    fun `when build is WordPress, then quick action card is built`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
+
+        initSelectedSite()
+
+        val quickActionsCard = findQuickActionsCard()
+
+        assertThat(quickActionsCard).isNotNull
+    }
+
+    @Test
     fun `quick actions does not show pages button when site doesn't have the required capability`() {
         site.hasCapabilityEditPages = false
 
@@ -1254,29 +1276,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         viewModel.onQuickStartTaskCardClick(task)
 
         verify(quickStartRepository).setActiveTask(task)
-    }
-
-    /* QUICK ACTIONS CARD */
-    @Test
-    fun `when build is Jetpack, then quick action card is not built`() {
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
-
-        initSelectedSite()
-
-        val quickActionsCard = findQuickActionsCard()
-
-        assertThat(quickActionsCard).isNull()
-    }
-
-    @Test
-    fun `when build is WordPress, then quick action card is built`() {
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
-
-        initSelectedSite()
-
-        val quickActionsCard = findQuickActionsCard()
-
-        assertThat(quickActionsCard).isNotNull
     }
 
     /* START/IGNORE QUICK START + QUICK START DIALOG */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -276,7 +276,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.siteId = siteLocalId.toLong()
 
         setUpCardsBuilder()
-        setUpDynamicCardsBuilder()
 
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
@@ -1253,7 +1252,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         isQuickStartDynamicCardEnabled: Boolean = false,
         isQuickStartInProgress: Boolean = false
     ) {
-        whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(isQuickStartDynamicCardEnabled)
+        if (isQuickStartDynamicCardEnabled) setUpDynamicCardsBuilder()
         quickStartUpdate.value = QuickStartUpdate(
                 categories = if (isQuickStartInProgress) listOf(quickStartCategory) else emptyList()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -27,20 +27,11 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED
 import org.wordpress.android.fluxc.model.DynamicCardType.CUSTOMIZE_QUICK_START
 import org.wordpress.android.fluxc.model.DynamicCardType.GROW_QUICK_START
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EXPLORE_PLANS
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.REVIEW_PAGES
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.test
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
@@ -60,10 +51,6 @@ import org.wordpress.android.ui.mysite.MySiteViewModel.State.NoSites
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.MySiteViewModel.TextInputDialogModel
 import org.wordpress.android.ui.mysite.MySiteViewModel.UiModel
-import org.wordpress.android.ui.mysite.MySiteViewModelTest.SiteInfoCardAction.ICON_CLICK
-import org.wordpress.android.ui.mysite.MySiteViewModelTest.SiteInfoCardAction.SWITCH_SITE_CLICK
-import org.wordpress.android.ui.mysite.MySiteViewModelTest.SiteInfoCardAction.TITLE_CLICK
-import org.wordpress.android.ui.mysite.MySiteViewModelTest.SiteInfoCardAction.URL_CLICK
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ChangeSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ShowRemoveNextStepsDialog
@@ -101,20 +88,6 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsSource
 import org.wordpress.android.ui.mysite.dynamiccards.quickstart.QuickStartItemBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsBuilder
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.ACTIVITY_LOG
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.ADMIN
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.COMMENTS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.MEDIA
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.PAGES
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.PLAN
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.PLUGINS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.POSTS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.SCAN
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.SHARING
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.SITE_SETTINGS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.STATS
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.THEMES
-import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.VIEW_SITE
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
@@ -225,17 +198,6 @@ class MySiteViewModelTest : BaseUnitTest() {
     private var quickActionsPagesClickAction: (() -> Unit)? = null
     private var quickActionsPostsClickAction: (() -> Unit)? = null
     private var quickActionsMediaClickAction: (() -> Unit)? = null
-    private val quickActionsCard: QuickActionsCard
-        get() = QuickActionsCard(
-                title = UiStringText(""),
-                onStatsClick = ListItemInteraction.create { quickActionsStatsClickAction },
-                onPagesClick = ListItemInteraction.create { quickActionsPagesClickAction },
-                onPostsClick = ListItemInteraction.create { quickActionsPostsClickAction },
-                onMediaClick = ListItemInteraction.create { quickActionsMediaClickAction },
-                showPages = site.isSelfHostedAdmin || site.hasCapabilityEditPages,
-                showPagesFocusPoint = false,
-                showStatsFocusPoint = false
-        )
 
     @InternalCoroutinesApi
     @Before
@@ -442,7 +404,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `site info card title click shows snackbar message when network not available`() = test {
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
 
-        invokeSiteInfoCardAction(TITLE_CLICK)
+        invokeSiteInfoCardAction(SiteInfoCardAction.TITLE_CLICK)
 
         assertThat(textInputDialogModels).isEmpty()
         assertThat(snackbars).containsOnly(
@@ -455,7 +417,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.hasCapabilityManageOptions = false
         site.origin = SiteModel.ORIGIN_WPCOM_REST
 
-        invokeSiteInfoCardAction(TITLE_CLICK)
+        invokeSiteInfoCardAction(SiteInfoCardAction.TITLE_CLICK)
 
         assertThat(textInputDialogModels).isEmpty()
         assertThat(snackbars).containsOnly(
@@ -470,7 +432,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.hasCapabilityManageOptions = true
         site.origin = SiteModel.ORIGIN_XMLRPC
 
-        invokeSiteInfoCardAction(TITLE_CLICK)
+        invokeSiteInfoCardAction(SiteInfoCardAction.TITLE_CLICK)
 
         assertThat(textInputDialogModels).isEmpty()
         assertThat(snackbars).containsOnly(
@@ -484,7 +446,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.origin = SiteModel.ORIGIN_WPCOM_REST
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
 
-        invokeSiteInfoCardAction(TITLE_CLICK)
+        invokeSiteInfoCardAction(SiteInfoCardAction.TITLE_CLICK)
 
         assertThat(snackbars).isEmpty()
         assertThat(textInputDialogModels.last()).isEqualTo(
@@ -505,7 +467,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.hasCapabilityUploadFiles = true
         site.iconUrl = siteIcon
 
-        invokeSiteInfoCardAction(ICON_CLICK)
+        invokeSiteInfoCardAction(SiteInfoCardAction.ICON_CLICK)
 
         assertThat(dialogModels.last()).isEqualTo(ChangeSiteIconDialogModel)
     }
@@ -516,7 +478,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.hasCapabilityUploadFiles = true
         site.iconUrl = null
 
-        invokeSiteInfoCardAction(ICON_CLICK)
+        invokeSiteInfoCardAction(SiteInfoCardAction.ICON_CLICK)
 
         assertThat(dialogModels.last()).isEqualTo(AddSiteIconDialogModel)
     }
@@ -528,7 +490,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 site.hasCapabilityUploadFiles = false
                 site.setIsWPCom(false)
 
-                invokeSiteInfoCardAction(ICON_CLICK)
+                invokeSiteInfoCardAction(SiteInfoCardAction.ICON_CLICK)
 
                 assertThat(dialogModels).isEmpty()
                 assertThat(snackbars).containsOnly(
@@ -543,7 +505,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.setIsWPCom(true)
         site.iconUrl = siteIcon
 
-        invokeSiteInfoCardAction(ICON_CLICK)
+        invokeSiteInfoCardAction(SiteInfoCardAction.ICON_CLICK)
 
         assertThat(dialogModels).isEmpty()
         assertThat(snackbars).containsOnly(
@@ -558,7 +520,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.setIsWPCom(true)
         site.iconUrl = null
 
-        invokeSiteInfoCardAction(ICON_CLICK)
+        invokeSiteInfoCardAction(SiteInfoCardAction.ICON_CLICK)
 
         assertThat(dialogModels).isEmpty()
         assertThat(snackbars).containsOnly(
@@ -589,14 +551,14 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `site info card url click opens site`() = test {
-        invokeSiteInfoCardAction(URL_CLICK)
+        invokeSiteInfoCardAction(SiteInfoCardAction.URL_CLICK)
 
         assertThat(navigationActions).containsOnly(OpenSite(site))
     }
 
     @Test
     fun `site info card switch click opens site picker`() = test {
-        invokeSiteInfoCardAction(SWITCH_SITE_CLICK)
+        invokeSiteInfoCardAction(SiteInfoCardAction.SWITCH_SITE_CLICK)
 
         assertThat(navigationActions).containsOnly(OpenSitePicker(site))
     }
@@ -689,7 +651,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         requireNotNull(quickActionsStatsClickAction).invoke()
 
-        verify(quickStartRepository).completeTask(CHECK_STATS)
+        verify(quickStartRepository).completeTask(QuickStartTask.CHECK_STATS)
     }
 
     @Test
@@ -698,7 +660,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         requireNotNull(quickActionsPagesClickAction).invoke()
 
-        verify(quickStartRepository).requestNextStepOfTask(EDIT_HOMEPAGE)
+        verify(quickStartRepository).requestNextStepOfTask(QuickStartTask.EDIT_HOMEPAGE)
         assertThat(navigationActions).containsOnly(OpenPages(site))
     }
 
@@ -708,7 +670,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         requireNotNull(quickActionsPagesClickAction).invoke()
 
-        verify(quickStartRepository).completeTask(REVIEW_PAGES)
+        verify(quickStartRepository).completeTask(QuickStartTask.REVIEW_PAGES)
         assertThat(navigationActions).containsOnly(OpenPages(site))
     }
 
@@ -738,7 +700,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         findDomainRegistrationCard()?.onClick?.click()
 
-        verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_REDEMPTION_TAPPED, site)
+        verify(analyticsTrackerWrapper).track(Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED, site)
 
         assertThat(navigationActions).containsOnly(OpenDomainRegistration(site))
     }
@@ -747,7 +709,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `snackbar is shown and event is tracked when handling successful domain registration result without email`() {
         viewModel.handleSuccessfulDomainRegistrationResult(null)
 
-        verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_REDEMPTION_SUCCESS)
+        verify(analyticsTrackerWrapper).track(Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS)
 
         val message = UiStringRes(R.string.my_site_verify_your_email_without_email)
 
@@ -758,7 +720,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `snackbar is shown and event is tracked when handling successful domain registration result with email`() {
         viewModel.handleSuccessfulDomainRegistrationResult(emailAddress)
 
-        verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_REDEMPTION_SUCCESS)
+        verify(analyticsTrackerWrapper).track(Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS)
 
         val message = UiStringResWithParams(R.string.my_site_verify_your_email, listOf(UiStringText(emailAddress)))
 
@@ -940,7 +902,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `when start QS is triggered, then QS request dialog positive tapped is tracked`() {
         viewModel.startQuickStart()
 
-        verify(analyticsTrackerWrapper).track(QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED)
+        verify(analyticsTrackerWrapper).track(Stat.QUICK_START_REQUEST_DIALOG_POSITIVE_TAPPED)
     }
 
     @Test
@@ -956,99 +918,99 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `when ignore QS is triggered, then QS request dialog negative tapped is tracked`() {
         viewModel.ignoreQuickStart()
 
-        verify(analyticsTrackerWrapper).track(QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
+        verify(analyticsTrackerWrapper).track(Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
     }
 
     /* ITEM CLICK */
     @Test
     fun `activity item click emits OpenActivity navigation event`() {
-        invokeItemClickAction(ACTIVITY_LOG)
+        invokeItemClickAction(ListItemAction.ACTIVITY_LOG)
 
         assertThat(navigationActions).containsExactly(OpenActivityLog(site))
     }
 
     @Test
     fun `scan item click emits OpenScan navigation event`() {
-        invokeItemClickAction(SCAN)
+        invokeItemClickAction(ListItemAction.SCAN)
 
         assertThat(navigationActions).containsExactly(OpenScan(site))
     }
 
     @Test
     fun `plan item click emits OpenPlan navigation event and completes EXPLORE_PLANS quick task`() {
-        invokeItemClickAction(PLAN)
+        invokeItemClickAction(ListItemAction.PLAN)
 
-        verify(quickStartRepository).completeTask(EXPLORE_PLANS)
+        verify(quickStartRepository).completeTask(QuickStartTask.EXPLORE_PLANS)
         assertThat(navigationActions).containsExactly(OpenPlan(site))
     }
 
     @Test
     fun `posts item click emits OpenPosts navigation event`() {
-        invokeItemClickAction(POSTS)
+        invokeItemClickAction(ListItemAction.POSTS)
 
         assertThat(navigationActions).containsExactly(OpenPosts(site))
     }
 
     @Test
     fun `pages item click emits OpenPages navigation event`() {
-        invokeItemClickAction(PAGES)
+        invokeItemClickAction(ListItemAction.PAGES)
 
-        verify(quickStartRepository).completeTask(REVIEW_PAGES)
+        verify(quickStartRepository).completeTask(QuickStartTask.REVIEW_PAGES)
         assertThat(navigationActions).containsExactly(OpenPages(site))
     }
 
     @Test
     fun `admin item click emits OpenAdmin navigation event`() {
-        invokeItemClickAction(ADMIN)
+        invokeItemClickAction(ListItemAction.ADMIN)
 
         assertThat(navigationActions).containsExactly(OpenAdmin(site))
     }
 
     @Test
     fun `sharing item click emits OpenSharing navigation event`() {
-        invokeItemClickAction(SHARING)
+        invokeItemClickAction(ListItemAction.SHARING)
 
         assertThat(navigationActions).containsExactly(OpenSharing(site))
     }
 
     @Test
     fun `site settings item click emits OpenSiteSettings navigation event`() {
-        invokeItemClickAction(SITE_SETTINGS)
+        invokeItemClickAction(ListItemAction.SITE_SETTINGS)
 
         assertThat(navigationActions).containsExactly(OpenSiteSettings(site))
     }
 
     @Test
     fun `themes item click emits OpenThemes navigation event`() {
-        invokeItemClickAction(THEMES)
+        invokeItemClickAction(ListItemAction.THEMES)
 
         assertThat(navigationActions).containsExactly(OpenThemes(site))
     }
 
     @Test
     fun `plugins item click emits OpenPlugins navigation event`() {
-        invokeItemClickAction(PLUGINS)
+        invokeItemClickAction(ListItemAction.PLUGINS)
 
         assertThat(navigationActions).containsExactly(OpenPlugins(site))
     }
 
     @Test
     fun `media item click emits OpenMedia navigation event`() {
-        invokeItemClickAction(MEDIA)
+        invokeItemClickAction(ListItemAction.MEDIA)
 
         assertThat(navigationActions).containsExactly(OpenMedia(site))
     }
 
     @Test
     fun `comments item click emits OpenMedia navigation event`() {
-        invokeItemClickAction(COMMENTS)
+        invokeItemClickAction(ListItemAction.COMMENTS)
 
         assertThat(navigationActions).containsExactly(OpenComments(site))
     }
 
     @Test
     fun `view site item click emits OpenSite navigation event`() {
-        invokeItemClickAction(VIEW_SITE)
+        invokeItemClickAction(ListItemAction.VIEW_SITE)
 
         assertThat(navigationActions).containsExactly(OpenSite(site))
     }
@@ -1058,7 +1020,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         site.setIsWPCom(true)
 
-        invokeItemClickAction(STATS)
+        invokeItemClickAction(ListItemAction.STATS)
 
         assertThat(navigationActions).containsExactly(OpenStats(site))
     }
@@ -1069,16 +1031,16 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.setIsJetpackConnected(true)
         site.setIsJetpackInstalled(true)
 
-        invokeItemClickAction(STATS)
+        invokeItemClickAction(ListItemAction.STATS)
 
         assertThat(navigationActions).containsExactly(OpenStats(site))
     }
 
     @Test
     fun `stats item click completes CHECK_STATS task`() {
-        invokeItemClickAction(STATS)
+        invokeItemClickAction(ListItemAction.STATS)
 
-        verify(quickStartRepository).completeTask(CHECK_STATS)
+        verify(quickStartRepository).completeTask(QuickStartTask.CHECK_STATS)
     }
 
     @Test
@@ -1086,7 +1048,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(accountStore.hasAccessToken()).thenReturn(false)
         site.setIsJetpackConnected(true)
 
-        invokeItemClickAction(STATS)
+        invokeItemClickAction(ListItemAction.STATS)
 
         assertThat(navigationActions).containsExactly(StartWPComLoginForJetpackStats)
     }
@@ -1097,7 +1059,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.setIsJetpackConnected(false)
         site.setIsWPCom(false)
 
-        invokeItemClickAction(STATS)
+        invokeItemClickAction(ListItemAction.STATS)
 
         assertThat(navigationActions).containsExactly(ConnectJetpackForStats(site))
     }
@@ -1176,35 +1138,35 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `when add site icon dialog +ve btn is clicked, then upload site icon task marked complete without refresh`() {
         viewModel.onDialogInteraction(DialogInteraction.Positive(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG))
 
-        verify(quickStartRepository).completeTask(task = UPLOAD_SITE_ICON, refreshImmediately = false)
+        verify(quickStartRepository).completeTask(task = QuickStartTask.UPLOAD_SITE_ICON, refreshImmediately = false)
     }
 
     @Test
     fun `when change site icon dialog +ve btn clicked, then upload site icon task marked complete without refresh`() {
         viewModel.onDialogInteraction(DialogInteraction.Positive(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG))
 
-        verify(quickStartRepository).completeTask(task = UPLOAD_SITE_ICON, refreshImmediately = false)
+        verify(quickStartRepository).completeTask(task = QuickStartTask.UPLOAD_SITE_ICON, refreshImmediately = false)
     }
 
     @Test
     fun `when add site icon dialog -ve btn is clicked, then upload site icon task marked complete with refresh`() {
         viewModel.onDialogInteraction(DialogInteraction.Negative(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG))
 
-        verify(quickStartRepository).completeTask(task = UPLOAD_SITE_ICON, refreshImmediately = true)
+        verify(quickStartRepository).completeTask(task = QuickStartTask.UPLOAD_SITE_ICON, refreshImmediately = true)
     }
 
     @Test
     fun `when change site icon dialog -ve btn is clicked, then upload site icon task marked complete with refresh`() {
         viewModel.onDialogInteraction(DialogInteraction.Negative(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG))
 
-        verify(quickStartRepository).completeTask(task = UPLOAD_SITE_ICON, refreshImmediately = true)
+        verify(quickStartRepository).completeTask(task = QuickStartTask.UPLOAD_SITE_ICON, refreshImmediately = true)
     }
 
     @Test
     fun `when site icon dialog is dismissed, then upload site icon task is marked complete with refresh`() {
         viewModel.onDialogInteraction(DialogInteraction.Dismissed(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG))
 
-        verify(quickStartRepository).completeTask(task = UPLOAD_SITE_ICON, refreshImmediately = true)
+        verify(quickStartRepository).completeTask(task = QuickStartTask.UPLOAD_SITE_ICON, refreshImmediately = true)
     }
 
     @Test
@@ -1263,8 +1225,6 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     private fun findQuickActionsCard() = getLastItems().find { it is QuickActionsCard } as QuickActionsCard?
 
-    private fun findQuickStartCard() = getLastItems().find { it is QuickStartCard } as QuickStartCard?
-
     private fun findQuickStartDynamicCard() = getLastItems().find { it is DynamicCard } as DynamicCard?
 
     private fun findDomainRegistrationCard() =
@@ -1283,10 +1243,10 @@ class MySiteViewModelTest : BaseUnitTest() {
         }
         val siteInfoCard = findSiteInfoCard()!!
         when (action) {
-            TITLE_CLICK -> siteInfoCard.onTitleClick!!.click()
-            ICON_CLICK -> siteInfoCard.onIconClick.click()
-            URL_CLICK -> siteInfoCard.onUrlClick.click()
-            SWITCH_SITE_CLICK -> siteInfoCard.onSwitchSiteClick.click()
+            SiteInfoCardAction.TITLE_CLICK -> siteInfoCard.onTitleClick!!.click()
+            SiteInfoCardAction.ICON_CLICK -> siteInfoCard.onIconClick.click()
+            SiteInfoCardAction.URL_CLICK -> siteInfoCard.onUrlClick.click()
+            SiteInfoCardAction.SWITCH_SITE_CLICK -> siteInfoCard.onSwitchSiteClick.click()
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -875,149 +875,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(navigationActions).containsOnly(OpenMedia(site))
     }
 
-    /* ITEM CLICK */
-    @Test
-    fun `activity item click emits OpenActivity navigation event`() {
-        invokeItemClickAction(ACTIVITY_LOG)
-
-        assertThat(navigationActions).containsExactly(OpenActivityLog(site))
-    }
-
-    @Test
-    fun `scan item click emits OpenScan navigation event`() {
-        invokeItemClickAction(SCAN)
-
-        assertThat(navigationActions).containsExactly(OpenScan(site))
-    }
-
-    @Test
-    fun `plan item click emits OpenPlan navigation event and completes EXPLORE_PLANS quick task`() {
-        invokeItemClickAction(PLAN)
-
-        verify(quickStartRepository).completeTask(EXPLORE_PLANS)
-        assertThat(navigationActions).containsExactly(OpenPlan(site))
-    }
-
-    @Test
-    fun `posts item click emits OpenPosts navigation event`() {
-        invokeItemClickAction(POSTS)
-
-        assertThat(navigationActions).containsExactly(OpenPosts(site))
-    }
-
-    @Test
-    fun `pages item click emits OpenPages navigation event`() {
-        invokeItemClickAction(PAGES)
-
-        verify(quickStartRepository).completeTask(REVIEW_PAGES)
-        assertThat(navigationActions).containsExactly(OpenPages(site))
-    }
-
-    @Test
-    fun `admin item click emits OpenAdmin navigation event`() {
-        invokeItemClickAction(ADMIN)
-
-        assertThat(navigationActions).containsExactly(OpenAdmin(site))
-    }
-
-    @Test
-    fun `sharing item click emits OpenSharing navigation event`() {
-        invokeItemClickAction(SHARING)
-
-        assertThat(navigationActions).containsExactly(OpenSharing(site))
-    }
-
-    @Test
-    fun `site settings item click emits OpenSiteSettings navigation event`() {
-        invokeItemClickAction(SITE_SETTINGS)
-
-        assertThat(navigationActions).containsExactly(OpenSiteSettings(site))
-    }
-
-    @Test
-    fun `themes item click emits OpenThemes navigation event`() {
-        invokeItemClickAction(THEMES)
-
-        assertThat(navigationActions).containsExactly(OpenThemes(site))
-    }
-
-    @Test
-    fun `plugins item click emits OpenPlugins navigation event`() {
-        invokeItemClickAction(PLUGINS)
-
-        assertThat(navigationActions).containsExactly(OpenPlugins(site))
-    }
-
-    @Test
-    fun `media item click emits OpenMedia navigation event`() {
-        invokeItemClickAction(MEDIA)
-
-        assertThat(navigationActions).containsExactly(OpenMedia(site))
-    }
-
-    @Test
-    fun `comments item click emits OpenMedia navigation event`() {
-        invokeItemClickAction(COMMENTS)
-
-        assertThat(navigationActions).containsExactly(OpenComments(site))
-    }
-
-    @Test
-    fun `view site item click emits OpenSite navigation event`() {
-        invokeItemClickAction(VIEW_SITE)
-
-        assertThat(navigationActions).containsExactly(OpenSite(site))
-    }
-
-    @Test
-    fun `stats item click emits OpenStats navigation event if site is WPCom and has access token`() {
-        whenever(accountStore.hasAccessToken()).thenReturn(true)
-        site.setIsWPCom(true)
-
-        invokeItemClickAction(STATS)
-
-        assertThat(navigationActions).containsExactly(OpenStats(site))
-    }
-
-    @Test
-    fun `stats item click emits OpenStats navigation event if site is Jetpack and has access token`() {
-        whenever(accountStore.hasAccessToken()).thenReturn(true)
-        site.setIsJetpackConnected(true)
-        site.setIsJetpackInstalled(true)
-
-        invokeItemClickAction(STATS)
-
-        assertThat(navigationActions).containsExactly(OpenStats(site))
-    }
-
-    @Test
-    fun `stats item click completes CHECK_STATS task`() {
-        invokeItemClickAction(STATS)
-
-        verify(quickStartRepository).completeTask(CHECK_STATS)
-    }
-
-    @Test
-    fun `stats item click emits StartWPComLoginForJetpackStats if site is Jetpack and doesn't have access token`() {
-        whenever(accountStore.hasAccessToken()).thenReturn(false)
-        site.setIsJetpackConnected(true)
-
-        invokeItemClickAction(STATS)
-
-        assertThat(navigationActions).containsExactly(StartWPComLoginForJetpackStats)
-    }
-
-    @Test
-    fun `stats item click emits ConnectJetpackForStats if neither Jetpack, nor WPCom and no access token`() {
-        whenever(accountStore.hasAccessToken()).thenReturn(false)
-        site.setIsJetpackConnected(false)
-        site.setIsWPCom(false)
-
-        invokeItemClickAction(STATS)
-
-        assertThat(navigationActions).containsExactly(ConnectJetpackForStats(site))
-    }
-
     /* DOMAIN REGISTRATION CARD */
     @Test
     fun `domain registration item click opens domain registration`() {
@@ -1064,75 +921,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         val message = UiStringResWithParams(R.string.my_site_verify_your_email, listOf(UiStringText(emailAddress)))
 
         assertThat(snackbars).containsOnly(SnackbarMessageHolder(message))
-    }
-
-    /* ITEM VISIBILITY */
-    @Test
-    fun `backup menu item is NOT visible, when getJetpackMenuItemsVisibility is false`() = test {
-        initSelectedSite()
-
-        jetpackCapabilities.value = JetpackCapabilities(scanAvailable = false, backupAvailable = false)
-
-        verify(siteItemsBuilder, times(1)).buildSiteItems(
-                site = eq(site),
-                onClick = any(),
-                isBackupAvailable = eq(false),
-                isScanAvailable = any(),
-                showViewSiteFocusPoint = eq(false),
-                showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any()
-        )
-    }
-
-    @Test
-    fun `scan menu item is NOT visible, when getJetpackMenuItemsVisibility is false`() = test {
-        initSelectedSite()
-
-        jetpackCapabilities.value = JetpackCapabilities(scanAvailable = false, backupAvailable = false)
-
-        verify(siteItemsBuilder, times(1)).buildSiteItems(
-                site = eq(site),
-                onClick = any(),
-                isBackupAvailable = any(),
-                isScanAvailable = eq(false),
-                showViewSiteFocusPoint = any(),
-                showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any()
-        )
-    }
-
-    @Test
-    fun `scan menu item is visible, when getJetpackMenuItemsVisibility is true`() = test {
-        initSelectedSite()
-
-        jetpackCapabilities.value = JetpackCapabilities(scanAvailable = true, backupAvailable = false)
-
-        verify(siteItemsBuilder).buildSiteItems(
-                site = eq(site),
-                onClick = any(),
-                isBackupAvailable = any(),
-                isScanAvailable = eq(true),
-                showViewSiteFocusPoint = eq(false),
-                showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any()
-        )
-    }
-
-    @Test
-    fun `backup menu item is visible, when getJetpackMenuItemsVisibility is true`() = test {
-        initSelectedSite()
-
-        jetpackCapabilities.value = JetpackCapabilities(scanAvailable = false, backupAvailable = true)
-
-        verify(siteItemsBuilder).buildSiteItems(
-                site = eq(site),
-                onClick = any(),
-                isBackupAvailable = eq(true),
-                isScanAvailable = any(),
-                showViewSiteFocusPoint = any(),
-                showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any()
-        )
     }
 
     /* QUICK START CARD + DYNAMIC CARD */
@@ -1348,6 +1136,218 @@ class MySiteViewModelTest : BaseUnitTest() {
         viewModel.ignoreQuickStart()
 
         verify(analyticsTrackerWrapper).track(QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
+    }
+
+    /* ITEM CLICK */
+    @Test
+    fun `activity item click emits OpenActivity navigation event`() {
+        invokeItemClickAction(ACTIVITY_LOG)
+
+        assertThat(navigationActions).containsExactly(OpenActivityLog(site))
+    }
+
+    @Test
+    fun `scan item click emits OpenScan navigation event`() {
+        invokeItemClickAction(SCAN)
+
+        assertThat(navigationActions).containsExactly(OpenScan(site))
+    }
+
+    @Test
+    fun `plan item click emits OpenPlan navigation event and completes EXPLORE_PLANS quick task`() {
+        invokeItemClickAction(PLAN)
+
+        verify(quickStartRepository).completeTask(EXPLORE_PLANS)
+        assertThat(navigationActions).containsExactly(OpenPlan(site))
+    }
+
+    @Test
+    fun `posts item click emits OpenPosts navigation event`() {
+        invokeItemClickAction(POSTS)
+
+        assertThat(navigationActions).containsExactly(OpenPosts(site))
+    }
+
+    @Test
+    fun `pages item click emits OpenPages navigation event`() {
+        invokeItemClickAction(PAGES)
+
+        verify(quickStartRepository).completeTask(REVIEW_PAGES)
+        assertThat(navigationActions).containsExactly(OpenPages(site))
+    }
+
+    @Test
+    fun `admin item click emits OpenAdmin navigation event`() {
+        invokeItemClickAction(ADMIN)
+
+        assertThat(navigationActions).containsExactly(OpenAdmin(site))
+    }
+
+    @Test
+    fun `sharing item click emits OpenSharing navigation event`() {
+        invokeItemClickAction(SHARING)
+
+        assertThat(navigationActions).containsExactly(OpenSharing(site))
+    }
+
+    @Test
+    fun `site settings item click emits OpenSiteSettings navigation event`() {
+        invokeItemClickAction(SITE_SETTINGS)
+
+        assertThat(navigationActions).containsExactly(OpenSiteSettings(site))
+    }
+
+    @Test
+    fun `themes item click emits OpenThemes navigation event`() {
+        invokeItemClickAction(THEMES)
+
+        assertThat(navigationActions).containsExactly(OpenThemes(site))
+    }
+
+    @Test
+    fun `plugins item click emits OpenPlugins navigation event`() {
+        invokeItemClickAction(PLUGINS)
+
+        assertThat(navigationActions).containsExactly(OpenPlugins(site))
+    }
+
+    @Test
+    fun `media item click emits OpenMedia navigation event`() {
+        invokeItemClickAction(MEDIA)
+
+        assertThat(navigationActions).containsExactly(OpenMedia(site))
+    }
+
+    @Test
+    fun `comments item click emits OpenMedia navigation event`() {
+        invokeItemClickAction(COMMENTS)
+
+        assertThat(navigationActions).containsExactly(OpenComments(site))
+    }
+
+    @Test
+    fun `view site item click emits OpenSite navigation event`() {
+        invokeItemClickAction(VIEW_SITE)
+
+        assertThat(navigationActions).containsExactly(OpenSite(site))
+    }
+
+    @Test
+    fun `stats item click emits OpenStats navigation event if site is WPCom and has access token`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        site.setIsWPCom(true)
+
+        invokeItemClickAction(STATS)
+
+        assertThat(navigationActions).containsExactly(OpenStats(site))
+    }
+
+    @Test
+    fun `stats item click emits OpenStats navigation event if site is Jetpack and has access token`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        site.setIsJetpackConnected(true)
+        site.setIsJetpackInstalled(true)
+
+        invokeItemClickAction(STATS)
+
+        assertThat(navigationActions).containsExactly(OpenStats(site))
+    }
+
+    @Test
+    fun `stats item click completes CHECK_STATS task`() {
+        invokeItemClickAction(STATS)
+
+        verify(quickStartRepository).completeTask(CHECK_STATS)
+    }
+
+    @Test
+    fun `stats item click emits StartWPComLoginForJetpackStats if site is Jetpack and doesn't have access token`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        site.setIsJetpackConnected(true)
+
+        invokeItemClickAction(STATS)
+
+        assertThat(navigationActions).containsExactly(StartWPComLoginForJetpackStats)
+    }
+
+    @Test
+    fun `stats item click emits ConnectJetpackForStats if neither Jetpack, nor WPCom and no access token`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        site.setIsJetpackConnected(false)
+        site.setIsWPCom(false)
+
+        invokeItemClickAction(STATS)
+
+        assertThat(navigationActions).containsExactly(ConnectJetpackForStats(site))
+    }
+
+    /* ITEM VISIBILITY */
+    @Test
+    fun `backup menu item is NOT visible, when getJetpackMenuItemsVisibility is false`() = test {
+        initSelectedSite()
+
+        jetpackCapabilities.value = JetpackCapabilities(scanAvailable = false, backupAvailable = false)
+
+        verify(siteItemsBuilder, times(1)).buildSiteItems(
+                site = eq(site),
+                onClick = any(),
+                isBackupAvailable = eq(false),
+                isScanAvailable = any(),
+                showViewSiteFocusPoint = eq(false),
+                showEnablePostSharingFocusPoint = any(),
+                showExplorePlansFocusPoint = any()
+        )
+    }
+
+    @Test
+    fun `scan menu item is NOT visible, when getJetpackMenuItemsVisibility is false`() = test {
+        initSelectedSite()
+
+        jetpackCapabilities.value = JetpackCapabilities(scanAvailable = false, backupAvailable = false)
+
+        verify(siteItemsBuilder, times(1)).buildSiteItems(
+                site = eq(site),
+                onClick = any(),
+                isBackupAvailable = any(),
+                isScanAvailable = eq(false),
+                showViewSiteFocusPoint = any(),
+                showEnablePostSharingFocusPoint = any(),
+                showExplorePlansFocusPoint = any()
+        )
+    }
+
+    @Test
+    fun `scan menu item is visible, when getJetpackMenuItemsVisibility is true`() = test {
+        initSelectedSite()
+
+        jetpackCapabilities.value = JetpackCapabilities(scanAvailable = true, backupAvailable = false)
+
+        verify(siteItemsBuilder).buildSiteItems(
+                site = eq(site),
+                onClick = any(),
+                isBackupAvailable = any(),
+                isScanAvailable = eq(true),
+                showViewSiteFocusPoint = eq(false),
+                showEnablePostSharingFocusPoint = any(),
+                showExplorePlansFocusPoint = any()
+        )
+    }
+
+    @Test
+    fun `backup menu item is visible, when getJetpackMenuItemsVisibility is true`() = test {
+        initSelectedSite()
+
+        jetpackCapabilities.value = JetpackCapabilities(scanAvailable = false, backupAvailable = true)
+
+        verify(siteItemsBuilder).buildSiteItems(
+                site = eq(site),
+                onClick = any(),
+                isBackupAvailable = eq(true),
+                isScanAvailable = any(),
+                showViewSiteFocusPoint = any(),
+                showEnablePostSharingFocusPoint = any(),
+                showExplorePlansFocusPoint = any()
+        )
     }
 
     /* ADD SITE ICON DIALOG */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -282,6 +282,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* SITE STATE */
+
     @Test
     fun `model is empty with no selected site`() {
         onSiteSelected.value = null
@@ -300,6 +301,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* AVATAR */
+
     @Test
     fun `account avatar url value is emitted and updated from the source`() {
         initSelectedSite()
@@ -317,6 +319,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* LOGIN - NAVIGATION TO STATS */
+
     @Test
     fun `handling successful login result opens stats screen`() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
@@ -327,6 +330,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* EMPTY VIEW */
+
     @Test
     fun `when no site is selected and screen height is higher than 600 pixels, show empty view image`() {
         whenever(displayUtilsWrapper.getDisplayPixelHeight()).thenReturn(600)
@@ -350,6 +354,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* EMPTY VIEW - ADD SITE */
+
     @Test
     fun `add new site press is handled correctly`() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
@@ -360,6 +365,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* REFRESH */
+
     @Test
     fun `when refresh is triggered, then update site settings if necessary`() {
         viewModel.refresh()
@@ -396,6 +402,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* SITE INFO CARD */
+
     @Test
     fun `site info card title click shows snackbar message when network not available`() = test {
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
@@ -560,6 +567,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* QUICK ACTIONS CARD */
+
     @Test
     fun `quick actions does not show pages button when site doesn't have the required capability`() {
         site.hasCapabilityEditPages = false
@@ -909,6 +917,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* ITEM CLICK */
+
     @Test
     fun `activity item click emits OpenActivity navigation event`() {
         invokeItemClickAction(ListItemAction.ACTIVITY_LOG)
@@ -1052,6 +1061,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* ITEM VISIBILITY */
+
     @Test
     fun `backup menu item is NOT visible, when getJetpackMenuItemsVisibility is false`() = test {
         initSelectedSite()
@@ -1121,6 +1131,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* ADD SITE ICON DIALOG */
+
     @Test
     fun `when add site icon dialog +ve btn is clicked, then upload site icon task marked complete without refresh`() {
         viewModel.onDialogInteraction(DialogInteraction.Positive(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG))
@@ -1203,6 +1214,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* SITE CHOOSER DIALOG */
+
     @Test
     fun `when site chooser is dismissed, then check and show quick start notice`() {
         viewModel.onSiteNameChooserDismissed()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -321,18 +321,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.iconUrl = siteIcon
         site.siteId = siteLocalId.toLong()
 
-        siteInfoCard = SiteInfoCard(
-                title = siteName,
-                url = siteUrl,
-                iconState = IconState.Visible(siteIcon),
-                showTitleFocusPoint = false,
-                showIconFocusPoint = false,
-                onTitleClick = mock(),
-                onIconClick = mock(),
-                onUrlClick = mock(),
-                onSwitchSiteClick = mock()
-        )
-
         setUpCardsBuilder()
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
@@ -1394,20 +1382,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     private fun setUpCardsBuilder() {
         doAnswer {
-            siteInfoCard = siteInfoCard.copy(
-                    onTitleClick = ListItemInteraction.create {
-                        (it.getArgument(CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION) as () -> Unit).invoke()
-                    },
-                    onIconClick = ListItemInteraction.create {
-                        (it.getArgument(CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION) as () -> Unit).invoke()
-                    },
-                    onUrlClick = ListItemInteraction.create {
-                        (it.getArgument(CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION) as () -> Unit).invoke()
-                    },
-                    onSwitchSiteClick = ListItemInteraction.create {
-                        (it.getArgument(CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION) as () -> Unit).invoke()
-                    }
-            )
+            siteInfoCard = initSiteInfoCard(it)
             val domainRegistrationCard = initDomainRegistrationCard(it)
             val quickStartCard = initQuickStartCard(it)
             listOf<MySiteCardAndItem>(siteInfoCard, domainRegistrationCard, quickStartCard)
@@ -1430,6 +1405,26 @@ class MySiteViewModelTest : BaseUnitTest() {
                 onQuickStartTaskTypeItemClick = any()
         )
     }
+
+    private fun initSiteInfoCard(mockInvocation: InvocationOnMock) = SiteInfoCard(
+            title = siteName,
+            url = siteUrl,
+            iconState = IconState.Visible(siteIcon),
+            showTitleFocusPoint = false,
+            showIconFocusPoint = false,
+            onTitleClick = ListItemInteraction.create {
+                (mockInvocation.getArgument(CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION) as () -> Unit).invoke()
+            },
+            onIconClick = ListItemInteraction.create {
+                (mockInvocation.getArgument(CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION) as () -> Unit).invoke()
+            },
+            onUrlClick = ListItemInteraction.create {
+                (mockInvocation.getArgument(CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION) as () -> Unit).invoke()
+            },
+            onSwitchSiteClick = ListItemInteraction.create {
+                (mockInvocation.getArgument(CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION) as () -> Unit).invoke()
+            }
+    )
 
     private fun initDomainRegistrationCard(mockInvocation: InvocationOnMock) = DomainRegistrationCard(
             ListItemInteraction.create {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -725,24 +725,6 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     /* QUICK START CARD */
     @Test
-    fun `hides quick start menu item in quickStartRepository`() {
-        val id = DynamicCardType.CUSTOMIZE_QUICK_START
-        viewModel.onQuickStartMenuInteraction(DynamicCardMenuInteraction.Hide(id))
-
-        verify(analyticsTrackerWrapper).track(Stat.QUICK_START_HIDE_CARD_TAPPED)
-        verify(quickStartRepository).refresh()
-    }
-
-    @Test
-    fun `removes quick start menu item in quickStartRepository`() {
-        val id = DynamicCardType.CUSTOMIZE_QUICK_START
-        viewModel.onQuickStartMenuInteraction(DynamicCardMenuInteraction.Remove(id))
-
-        verify(analyticsTrackerWrapper).track(Stat.QUICK_START_REMOVE_CARD_TAPPED)
-        verify(quickStartRepository).refresh()
-    }
-
-    @Test
     fun `when quick start task type item is clicked, then quick start full screen dialog is opened`() {
         initSelectedSite(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
 
@@ -904,6 +886,26 @@ class MySiteViewModelTest : BaseUnitTest() {
         findQuickStartDynamicCard()!!.onMoreClick.click()
 
         assertThat(dynamicCardMenu.last()).isNotNull
+    }
+
+    @Test
+    fun `when dynamic QS hide menu item is clicked, then the card is hidden`() = test {
+        val id = DynamicCardType.CUSTOMIZE_QUICK_START
+        viewModel.onQuickStartMenuInteraction(DynamicCardMenuInteraction.Hide(id))
+
+        verify(analyticsTrackerWrapper).track(Stat.QUICK_START_HIDE_CARD_TAPPED)
+        verify(dynamicCardsSource).hideItem(id)
+        verify(quickStartRepository).refresh()
+    }
+
+    @Test
+    fun `when dynamic QS remove menu item is clicked, then the card is removed`() = test {
+        val id = DynamicCardType.CUSTOMIZE_QUICK_START
+        viewModel.onQuickStartMenuInteraction(DynamicCardMenuInteraction.Remove(id))
+
+        verify(analyticsTrackerWrapper).track(Stat.QUICK_START_REMOVE_CARD_TAPPED)
+        verify(dynamicCardsSource).removeItem(id)
+        verify(quickStartRepository).refresh()
     }
 
     /* ITEM CLICK */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -90,6 +90,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenStats
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenThemes
 import org.wordpress.android.ui.mysite.SiteNavigationAction.ShowQuickStartDialog
 import org.wordpress.android.ui.mysite.SiteNavigationAction.StartWPComLoginForJetpackStats
+import org.wordpress.android.ui.mysite.cards.CardsBuilder
 import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrationHandler
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
@@ -165,6 +166,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
     @Mock lateinit var quickStartUtilsWrapper: QuickStartUtilsWrapper
     @Mock lateinit var snackbarSequencer: SnackbarSequencer
+    @Mock lateinit var cardsBuilder: CardsBuilder
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<UiModel>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -297,7 +299,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 unifiedCommentsListFeatureConfig,
                 quickStartDynamicCardsFeatureConfig,
                 quickStartUtilsWrapper,
-                snackbarSequencer
+                snackbarSequencer,
+                cardsBuilder
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.mysite.cards
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
@@ -11,8 +12,11 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard.IconState
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
 import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoCardBuilder
@@ -21,6 +25,8 @@ import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 
+private const val SITE_INFO_SHOW_UPDATE_SITE_TITLE_FOCUS_POINT_PARAM_POSITION = 6
+private const val SITE_INFO_SHOW_UPDATE_SITE_ICON_FOCUS_POINT_PARAM_POSITION = 7
 private const val QUICK_ACTION_SHOW_PAGES_FOCUS_POINT_PARAM_POSITION = 5
 private const val QUICK_ACTION_SHOW_STATS_FOCUS_POINT_PARAM_POSITION = 6
 
@@ -39,7 +45,23 @@ class CardsBuilderTest {
     @Before
     fun setUp() {
         setUpCardsBuilder()
+        setUpSiteInfoCardBuilder()
         setUpQuickActionsBuilder()
+    }
+
+    /* SITE INFO CARD */
+    @Test
+    fun `when active task is update site title, then title focus point is shown in the site info card`() {
+        val cards = buildCards(activeTask = QuickStartTask.UPDATE_SITE_TITLE)
+
+        assertThat(cards.findSiteInfoCard()?.showTitleFocusPoint).isTrue
+    }
+
+    @Test
+    fun `when active task is update site icon, then icon focus point is shown in the site info card`() {
+        val cards = buildCards(activeTask = QuickStartTask.UPLOAD_SITE_ICON)
+
+        assertThat(cards.findSiteInfoCard()?.showIconFocusPoint).isTrue
     }
 
     /* QUICK ACTIONS CARD */
@@ -62,10 +84,12 @@ class CardsBuilderTest {
     private fun List<MySiteCardAndItem>.findQuickActionsCard() =
             this.find { it is QuickActionsCard } as QuickActionsCard?
 
-    private fun buildCards() = cardsBuilder.build(
+    private fun List<MySiteCardAndItem>.findSiteInfoCard() = this.find { it is SiteInfoCard } as SiteInfoCard?
+
+    private fun buildCards(activeTask: QuickStartTask? = null) = cardsBuilder.build(
             site = site,
             showSiteIconProgressBar = false,
-            activeTask = null,
+            activeTask = activeTask,
             isDomainCreditAvailable = false,
             quickStartCategories = emptyList(),
             titleClick = mock(),
@@ -80,6 +104,32 @@ class CardsBuilderTest {
             onQuickStartBlockRemoveMenuItemClick = mock(),
             onQuickStartTaskTypeItemClick = mock()
     )
+
+    fun setUpSiteInfoCardBuilder() {
+        doAnswer {
+            val siteInfoCard = SiteInfoCard(
+                    title = "",
+                    url = "",
+                    iconState = IconState.Visible(""),
+                    showTitleFocusPoint = it.getArgument(SITE_INFO_SHOW_UPDATE_SITE_TITLE_FOCUS_POINT_PARAM_POSITION),
+                    showIconFocusPoint = it.getArgument(SITE_INFO_SHOW_UPDATE_SITE_ICON_FOCUS_POINT_PARAM_POSITION),
+                    onTitleClick = mock(),
+                    onIconClick = mock(),
+                    onUrlClick = mock(),
+                    onSwitchSiteClick = mock()
+            )
+            siteInfoCard
+        }.whenever(siteInfoCardBuilder).buildSiteInfoCard(
+                site = eq(site),
+                showSiteIconProgressBar = any(),
+                titleClick = any(),
+                iconClick = any(),
+                urlClick = any(),
+                switchSiteClick = any(),
+                showUpdateSiteTitleFocusPoint = any(),
+                showUploadSiteIconFocusPoint = any()
+        )
+    }
 
     fun setUpQuickActionsBuilder() {
         doAnswer {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -1,15 +1,28 @@
 package org.wordpress.android.ui.mysite.cards
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.mysite.MySiteCardAndItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
 import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoCardBuilder
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
+
+private const val QUICK_ACTION_SHOW_PAGES_FOCUS_POINT_PARAM_POSITION = 5
+private const val QUICK_ACTION_SHOW_STATS_FOCUS_POINT_PARAM_POSITION = 6
 
 @RunWith(MockitoJUnitRunner::class)
 class CardsBuilderTest {
@@ -19,11 +32,80 @@ class CardsBuilderTest {
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
     @Mock lateinit var quickActionsCardBuilder: QuickActionsCardBuilder
     @Mock lateinit var quickStartCardBuilder: QuickStartCardBuilder
+    @Mock lateinit var site: SiteModel
 
     private lateinit var cardsBuilder: CardsBuilder
 
     @Before
     fun setUp() {
+        setUpCardsBuilder()
+        setUpQuickActionsBuilder()
+    }
+
+    /* QUICK ACTIONS CARD */
+    @Test
+    fun `when build is Jetpack, then quick action card is not built`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
+        val cards = buildCards()
+
+        assertThat(cards.findQuickActionsCard()).isNull()
+    }
+
+    @Test
+    fun `when build is WordPress, then quick action card is built`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
+        val cards = buildCards()
+
+        assertThat(cards.findQuickActionsCard()).isNotNull
+    }
+
+    private fun List<MySiteCardAndItem>.findQuickActionsCard() =
+            this.find { it is QuickActionsCard } as QuickActionsCard?
+
+    private fun buildCards() = cardsBuilder.build(
+            site = site,
+            showSiteIconProgressBar = false,
+            activeTask = null,
+            isDomainCreditAvailable = false,
+            quickStartCategories = emptyList(),
+            titleClick = mock(),
+            iconClick = mock(),
+            urlClick = mock(),
+            switchSiteClick = mock(),
+            quickActionStatsClick = mock(),
+            quickActionPagesClick = mock(),
+            quickActionPostsClick = mock(),
+            quickActionMediaClick = mock(),
+            domainRegistrationClick = mock(),
+            onQuickStartBlockRemoveMenuItemClick = mock(),
+            onQuickStartTaskTypeItemClick = mock()
+    )
+
+    fun setUpQuickActionsBuilder() {
+        doAnswer {
+            val siteInfoCard = QuickActionsCard(
+                    title = UiStringText(""),
+                    onStatsClick = mock(),
+                    onPagesClick = mock(),
+                    onPostsClick = mock(),
+                    onMediaClick = mock(),
+                    showPages = false,
+                    showPagesFocusPoint = it.getArgument(QUICK_ACTION_SHOW_PAGES_FOCUS_POINT_PARAM_POSITION),
+                    showStatsFocusPoint = it.getArgument(QUICK_ACTION_SHOW_STATS_FOCUS_POINT_PARAM_POSITION)
+            )
+            siteInfoCard
+        }.whenever(quickActionsCardBuilder).build(
+                onQuickActionStatsClick = any(),
+                onQuickActionPagesClick = any(),
+                onQuickActionPostsClick = any(),
+                onQuickActionMediaClick = any(),
+                showPages = any(),
+                showStatsFocusPoint = any(),
+                showPagesFocusPoint = any()
+        )
+    }
+
+    private fun setUpCardsBuilder() {
         cardsBuilder = CardsBuilder(
                 buildConfigWrapper,
                 quickStartDynamicCardsFeatureConfig,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -11,6 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
@@ -64,6 +66,14 @@ class CardsBuilderTest {
         assertThat(cards.findSiteInfoCard()?.showIconFocusPoint).isTrue
     }
 
+    /* DOMAIN REGISTRATION CARD */
+    @Test
+    fun `when domain credit is available, then correct event is tracked`() {
+        buildCards(isDomainCreditAvailable = true)
+
+        verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_PROMPT_SHOWN)
+    }
+
     /* QUICK ACTIONS CARD */
     @Test
     fun `when build is Jetpack, then quick action card is not built`() {
@@ -86,11 +96,14 @@ class CardsBuilderTest {
 
     private fun List<MySiteCardAndItem>.findSiteInfoCard() = this.find { it is SiteInfoCard } as SiteInfoCard?
 
-    private fun buildCards(activeTask: QuickStartTask? = null) = cardsBuilder.build(
+    private fun buildCards(
+        activeTask: QuickStartTask? = null,
+        isDomainCreditAvailable: Boolean = false
+    ) = cardsBuilder.build(
             site = site,
             showSiteIconProgressBar = false,
             activeTask = activeTask,
-            isDomainCreditAvailable = false,
+            isDomainCreditAvailable = isDomainCreditAvailable,
             quickStartCategories = emptyList(),
             titleClick = mock(),
             iconClick = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -1,0 +1,36 @@
+package org.wordpress.android.ui.mysite.cards
+
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
+import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoCardBuilder
+import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
+
+@RunWith(MockitoJUnitRunner::class)
+class CardsBuilderTest {
+    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
+    @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
+    @Mock lateinit var siteInfoCardBuilder: SiteInfoCardBuilder
+    @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Mock lateinit var quickActionsCardBuilder: QuickActionsCardBuilder
+    @Mock lateinit var quickStartCardBuilder: QuickStartCardBuilder
+
+    private lateinit var cardsBuilder: CardsBuilder
+
+    @Before
+    fun setUp() {
+        cardsBuilder = CardsBuilder(
+                buildConfigWrapper,
+                quickStartDynamicCardsFeatureConfig,
+                siteInfoCardBuilder,
+                analyticsTrackerWrapper,
+                quickActionsCardBuilder,
+                quickStartCardBuilder
+        )
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -11,6 +11,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.invocation.InvocationOnMock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
 import org.wordpress.android.fluxc.model.SiteModel
@@ -161,18 +162,7 @@ class CardsBuilderTest {
 
     fun setUpSiteInfoCardBuilder() {
         doAnswer {
-            val siteInfoCard = SiteInfoCard(
-                    title = "",
-                    url = "",
-                    iconState = IconState.Visible(""),
-                    showTitleFocusPoint = it.getArgument(SITE_INFO_SHOW_UPDATE_SITE_TITLE_FOCUS_POINT_PARAM_POSITION),
-                    showIconFocusPoint = it.getArgument(SITE_INFO_SHOW_UPDATE_SITE_ICON_FOCUS_POINT_PARAM_POSITION),
-                    onTitleClick = mock(),
-                    onIconClick = mock(),
-                    onUrlClick = mock(),
-                    onSwitchSiteClick = mock()
-            )
-            siteInfoCard
+            initSiteInfoCard(it)
         }.whenever(siteInfoCardBuilder).buildSiteInfoCard(
                 site = eq(site),
                 showSiteIconProgressBar = any(),
@@ -187,17 +177,7 @@ class CardsBuilderTest {
 
     fun setUpQuickActionsBuilder() {
         doAnswer {
-            val siteInfoCard = QuickActionsCard(
-                    title = UiStringText(""),
-                    onStatsClick = mock(),
-                    onPagesClick = mock(),
-                    onPostsClick = mock(),
-                    onMediaClick = mock(),
-                    showPages = false,
-                    showPagesFocusPoint = it.getArgument(QUICK_ACTION_SHOW_PAGES_FOCUS_POINT_PARAM_POSITION),
-                    showStatsFocusPoint = it.getArgument(QUICK_ACTION_SHOW_STATS_FOCUS_POINT_PARAM_POSITION)
-            )
-            siteInfoCard
+            initQuickActionsCard(it)
         }.whenever(quickActionsCardBuilder).build(
                 onQuickActionStatsClick = any(),
                 onQuickActionPagesClick = any(),
@@ -215,6 +195,42 @@ class CardsBuilderTest {
         }.whenever(quickStartCardBuilder).build(any(), any(), any())
     }
 
+    private fun setUpCardsBuilder() {
+        cardsBuilder = CardsBuilder(
+                buildConfigWrapper,
+                quickStartDynamicCardsFeatureConfig,
+                siteInfoCardBuilder,
+                analyticsTrackerWrapper,
+                quickActionsCardBuilder,
+                quickStartCardBuilder
+        )
+    }
+
+    private fun initSiteInfoCard(mockInvocation: InvocationOnMock) = SiteInfoCard(
+            title = "",
+            url = "",
+            iconState = IconState.Visible(""),
+            showTitleFocusPoint = mockInvocation
+                    .getArgument(SITE_INFO_SHOW_UPDATE_SITE_TITLE_FOCUS_POINT_PARAM_POSITION),
+            showIconFocusPoint = mockInvocation
+                    .getArgument(SITE_INFO_SHOW_UPDATE_SITE_ICON_FOCUS_POINT_PARAM_POSITION),
+            onTitleClick = mock(),
+            onIconClick = mock(),
+            onUrlClick = mock(),
+            onSwitchSiteClick = mock()
+    )
+
+    private fun initQuickActionsCard(mockInvocation: InvocationOnMock) = QuickActionsCard(
+            title = UiStringText(""),
+            onStatsClick = mock(),
+            onPagesClick = mock(),
+            onPostsClick = mock(),
+            onMediaClick = mock(),
+            showPages = false,
+            showPagesFocusPoint = mockInvocation.getArgument(QUICK_ACTION_SHOW_PAGES_FOCUS_POINT_PARAM_POSITION),
+            showStatsFocusPoint = mockInvocation.getArgument(QUICK_ACTION_SHOW_STATS_FOCUS_POINT_PARAM_POSITION)
+    )
+
     private fun initQuickStartCard() = QuickStartCard(
             title = UiStringText(""),
             onRemoveMenuItemClick = mock(),
@@ -231,15 +247,4 @@ class CardsBuilderTest {
                     )
             )
     )
-
-    private fun setUpCardsBuilder() {
-        cardsBuilder = CardsBuilder(
-                buildConfigWrapper,
-                quickStartDynamicCardsFeatureConfig,
-                siteInfoCardBuilder,
-                analyticsTrackerWrapper,
-                quickActionsCardBuilder,
-                quickStartCardBuilder
-        )
-    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -65,6 +65,7 @@ class CardsBuilderTest {
     }
 
     /* SITE INFO CARD */
+
     @Test
     fun `when active task is update site title, then title focus point is shown in the site info card`() {
         val cards = buildCards(activeTask = QuickStartTask.UPDATE_SITE_TITLE)
@@ -80,6 +81,7 @@ class CardsBuilderTest {
     }
 
     /* DOMAIN REGISTRATION CARD */
+
     @Test
     fun `when domain credit is available, then correct event is tracked`() {
         buildCards(isDomainCreditAvailable = true)
@@ -88,6 +90,7 @@ class CardsBuilderTest {
     }
 
     /* QUICK ACTIONS CARD */
+
     @Test
     fun `when build is Jetpack, then quick action card is not built`() {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
@@ -105,6 +108,7 @@ class CardsBuilderTest {
     }
 
     /* QUICK START CARD */
+
     @Test
     fun `given quick start is not in progress, then quick start card not built`() {
         val cards = buildCards(isQuickStartInProgress = false)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -164,7 +164,7 @@ class CardsBuilderTest {
         )
     }
 
-    fun setUpSiteInfoCardBuilder() {
+    private fun setUpSiteInfoCardBuilder() {
         doAnswer {
             initSiteInfoCard(it)
         }.whenever(siteInfoCardBuilder).buildSiteInfoCard(
@@ -179,7 +179,7 @@ class CardsBuilderTest {
         )
     }
 
-    fun setUpQuickActionsBuilder() {
+    private fun setUpQuickActionsBuilder() {
         doAnswer {
             initQuickActionsCard(it)
         }.whenever(quickActionsCardBuilder).build(
@@ -193,7 +193,7 @@ class CardsBuilderTest {
         )
     }
 
-    fun setUpQuickStartCardBuilder() {
+    private fun setUpQuickStartCardBuilder() {
         doAnswer {
             initQuickStartCard()
         }.whenever(quickStartCardBuilder).build(any(), any(), any())

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilderTest.kt
@@ -64,7 +64,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
 
     private fun List<DynamicCard>.findQuickStartDynamicCard() = this.find { it is QuickStartDynamicCard }
 
-    fun buildDynamicCards(
+    private fun buildDynamicCards(
         isQuickStartDynamicCardEnabled: Boolean,
         isQuickStartInProgress: Boolean
     ): List<DynamicCard> {
@@ -85,7 +85,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
         dynamicCardsBuilder = DynamicCardsBuilder(quickStartDynamicCardsFeatureConfig, quickStartItemBuilder)
     }
 
-    fun setUpQuickStartDynamicCardBuilder() {
+    private fun setUpQuickStartDynamicCardBuilder() {
         doAnswer {
             initQuickStartDynamicCard()
         }.whenever(quickStartItemBuilder).build(any(), anyOrNull(), any(), any())

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilderTest.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.ui.mysite.dynamiccards
+
+import org.junit.Before
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.mysite.dynamiccards.quickstart.QuickStartItemBuilder
+import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
+
+class DynamicCardsBuilderTest : BaseUnitTest() {
+    @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
+    @Mock lateinit var quickStartItemBuilder: QuickStartItemBuilder
+    private lateinit var dynamicCardsBuilder: DynamicCardsBuilder
+
+    @Before
+    fun setUp() {
+        setUpDynamicCardsBuilder()
+    }
+
+    private fun setUpDynamicCardsBuilder() {
+        dynamicCardsBuilder = DynamicCardsBuilder(quickStartDynamicCardsFeatureConfig, quickStartItemBuilder)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilderTest.kt
@@ -1,22 +1,103 @@
 package org.wordpress.android.ui.mysite.dynamiccards
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.DynamicCardType
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartDynamicCard
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.dynamiccards.quickstart.QuickStartItemBuilder
+import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 
 class DynamicCardsBuilderTest : BaseUnitTest() {
     @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
     @Mock lateinit var quickStartItemBuilder: QuickStartItemBuilder
+
     private lateinit var dynamicCardsBuilder: DynamicCardsBuilder
+    private val quickStartCategory: QuickStartCategory
+        get() = QuickStartCategory(
+                taskType = QuickStartTaskType.CUSTOMIZE,
+                uncompletedTasks = listOf(QuickStartTaskDetails.UPDATE_SITE_TITLE),
+                completedTasks = emptyList()
+        )
 
     @Before
     fun setUp() {
         setUpDynamicCardsBuilder()
+        setUpQuickStartDynamicCardBuilder()
+        whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(true)
+    }
+
+    /* QUICK START DYNAMIC CARD */
+    @Test
+    fun `given quick start is not in progress, when site is selected, then QS dynamic card not built`() {
+        val dynamicCards = buildDynamicCards(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = false)
+
+        assertThat(dynamicCards.findQuickStartDynamicCard()).isNull()
+    }
+
+    @Test
+    fun `given dynamic card disabled + QS in progress, when site is selected, then QS dynamic card not built`() {
+        val dynamicCards = buildDynamicCards(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = true)
+
+        assertThat(dynamicCards.findQuickStartDynamicCard()).isNull()
+    }
+
+    @Test
+    fun `given dynamic card enabled + quick start in progress, when site is selected, then QS dynamic card built`() {
+        val dynamicCards = buildDynamicCards(isQuickStartDynamicCardEnabled = true, isQuickStartInProgress = true)
+
+        assertThat(dynamicCards.findQuickStartDynamicCard()).isNotNull
+    }
+
+    private fun List<DynamicCard>.findQuickStartDynamicCard() = this.find { it is QuickStartDynamicCard }
+
+    fun buildDynamicCards(
+        isQuickStartDynamicCardEnabled: Boolean,
+        isQuickStartInProgress: Boolean
+    ): List<DynamicCard> {
+        whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(isQuickStartDynamicCardEnabled)
+        return dynamicCardsBuilder.build(
+                quickStartCategories = if (isQuickStartInProgress) listOf(quickStartCategory) else emptyList(),
+                pinnedDynamicCard = mock(),
+                visibleDynamicCards = listOf(
+                        DynamicCardType.CUSTOMIZE_QUICK_START,
+                        DynamicCardType.GROW_QUICK_START
+                ),
+                onDynamicCardMoreClick = mock(),
+                onQuickStartTaskCardClick = mock()
+        )
     }
 
     private fun setUpDynamicCardsBuilder() {
         dynamicCardsBuilder = DynamicCardsBuilder(quickStartDynamicCardsFeatureConfig, quickStartItemBuilder)
+    }
+
+    fun setUpQuickStartDynamicCardBuilder() {
+        doAnswer {
+            initQuickStartDynamicCard()
+        }.whenever(quickStartItemBuilder).build(any(), anyOrNull(), any(), any())
+    }
+
+    private fun initQuickStartDynamicCard(): QuickStartDynamicCard {
+        return QuickStartDynamicCard(
+                id = DynamicCardType.CUSTOMIZE_QUICK_START,
+                title = UiStringRes(0),
+                taskCards = mock(),
+                accentColor = 0,
+                progress = 0,
+                onMoreClick = mock()
+        )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsBuilderTest.kt
@@ -40,6 +40,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     }
 
     /* QUICK START DYNAMIC CARD */
+
     @Test
     fun `given quick start is not in progress, when site is selected, then QS dynamic card not built`() {
         val dynamicCards = buildDynamicCards(isQuickStartDynamicCardEnabled = false, isQuickStartInProgress = false)


### PR DESCRIPTION
Parent #15215

PS: Don't worry about the size of the PR. It involves only refactoring effort and adds no new functionality.

The PR refactors `MySiteViewModel` to split `MySiteViewModel.MySiteUiState `-> `UiModel` mapping, and moves 
- Cards building logic to new `CardsBuilder` and 
- Dynamic cards building logic to new `DynamicCardsBuilder`.

Site Items are already built using `SiteItemsBuilder` and no changes are made to it.

Tests:  Note that no new tests are added at this point, and only existing card building tests are moved from `MySiteViewModelTest` to respective new builder test classes. Let's continue to add more tests as we find more time.

To test:

- Reviewing by each commit might be the best way to review this PR.
- Smoke test the app to check that the following cards are rendered properly as the refactoring involves the movement of cards building logic to separate builders:
    - `QuickStartCard` or `QuickStartDynamicCard`: Ensure that toggling `quickStartDynamicCardsFeatureConfig`  displays cards appropriately.
    - `SiteInfoCard`
    - `QuickActionsCard` (Visible for WordPress App, hidden for Jetpack app)
    - `DomainRegistrationCard` (Visible for paid plan site when `SiteDomainFeatureConfig` flag enabled, hidden otherwise.) 
        
        ![device-2021-10-08-100224](https://user-images.githubusercontent.com/1405144/136499262-5cc4b88b-0ac6-4f6b-8b3a-b9d0d1a44002.png)


⚠️: The changes are not under any feature flag, and will merge to `develop`. As we're still in the first week of this sprint, we should be able to test it well before they move to `beta`.

## Regression Notes
1. Potential unintended areas of impact 
See above.

2. What I did to test those areas of impact (or what existing automated tests I relied on) 
N/A

3. What automated tests I added (or what prevented me from doing so) 
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
