### PR TITLE
Adds composite build support for AztecEditor-Android

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -70,11 +70,11 @@ dependencies {
     implementation 'com.android.volley:volley:1.1.1'
     implementation 'org.wordpress:utils:1.25'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
-    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:$aztecVersion") {
+    api ("$gradle.ext.aztecAndroidAztecPath:$aztecVersion") {
         exclude group: "com.android.volley"
     }
-    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:$aztecVersion")
-    api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:$aztecVersion")
+    api ("$gradle.ext.aztecAndroidWordPressShortcodesPath:$aztecVersion")
+    api ("$gradle.ext.aztecAndroidWordPressCommentsPath:$aztecVersion")
 
     // This dependency will be substituted if the `local-builds.gradle` file contains
     // `localGutenbergMobilePath`. Details for this can be found in the `settings.gradle` file.

--- a/local-builds.gradle-example
+++ b/local-builds.gradle-example
@@ -19,4 +19,5 @@ ext {
     //localGutenbergMobilePath = "../gutenberg-mobile"
     //localLoginFlowPath = "../WordPress-Login-Flow-Android"
     //localStoriesAndroidPath = "../stories-android"
+    //localAztecAndroidPath = "../AztecEditor-Android"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,11 @@ gradle.ext.loginFlowBinaryPath = "org.wordpress:login"
 gradle.ext.storiesAndroidPath = "com.automattic:stories"
 gradle.ext.storiesAndroidMp4ComposePath = "com.automattic.stories:mp4compose"
 gradle.ext.storiesAndroidPhotoEditorPath = "com.automattic.stories:photoeditor"
+gradle.ext.aztecAndroidAztecPath = "com.github.wordpress-mobile.WordPress-Aztec-Android:aztec"
+gradle.ext.aztecAndroidWordPressShortcodesPath = "com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes"
+gradle.ext.aztecAndroidWordPressCommentsPath = "com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments"
+gradle.ext.aztecAndroidGlideLoaderPath = "com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader"
+gradle.ext.aztecAndroidPicassoLoaderPath = "com.github.wordpress-mobile.WordPress-Aztec-Android:picasso-loader"
 
 def localBuilds = new File('local-builds.gradle')
 if (localBuilds.exists()) {
@@ -82,6 +87,19 @@ if (localBuilds.exists()) {
                 substitute module("$gradle.ext.storiesAndroidPath") with project(':stories')
                 substitute module("$gradle.ext.storiesAndroidMp4ComposePath") with project(':mp4compose')
                 substitute module("$gradle.ext.storiesAndroidPhotoEditorPath") with project(':photoeditor')
+            }
+        }
+    }
+
+    if (ext.has("localAztecAndroidPath")) {
+        includeBuild(ext.localAztecAndroidPath) {
+            dependencySubstitution {
+                println "Substituting AztecEditor-Android with the local build"
+                substitute module("$gradle.ext.aztecAndroidAztecPath") with project(':aztec')
+                substitute module("$gradle.ext.aztecAndroidWordPressShortcodesPath") with project(':wordpress-shortcodes')
+                substitute module("$gradle.ext.aztecAndroidWordPressCommentsPath") with project(':wordpress-comments')
+                substitute module("$gradle.ext.aztecAndroidGlideLoaderPath") with project(':glide-loader')
+                substitute module("$gradle.ext.aztecAndroidPicassoLoaderPath") with project(':picasso-loader')
             }
         }
     }


### PR DESCRIPTION
This PR adds composite build support for [AztecEditor-Android](https://github.com/wordpress-mobile/AztecEditor-Android). It works exactly the same way as other composite builds, so there is not too much to explain. The only thing to be aware of is that even if the modules of this library were to be added as a dependency to one of the dependencies of WPAndroid (a dependency of `react-native-aztec` for example instead of directly being added) the composite build would still work. This is the case for every other composite build as well, but it's more important to be aware of for this project as explained below.

There was an interesting decision to be made here about how to setup composite build for this project, because the main client for the library is actually [react-native-aztec](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-aztec/android/build.gradle#L84-L87) however it's also used for the classic editor in WPAndroid. I opted for the simplest solution right now, as this is very familiar for developers and how it works will be clear to everyone who uses it.

The main setback of this approach is that [react-native-aztec](https://github.com/WordPress/gutenberg/tree/trunk/packages/react-native-aztec) or [react-native-editor](https://github.com/WordPress/gutenberg/tree/trunk/packages/react-native-editor) can't directly use the composite build setup. (not without using it in WPAndroid) However, if we were to go for a solution to support that, it'd not only be harder to setup, but more importantly it'd also require some understanding or guessing by developers on how the dependency resolution will work for each project. If a developer forgets to turn off composite build at a library level, it'll also be a lot harder for #platform9 to help the developer when they are having build issues. So, I think this is a good start and we can re-visit it once developers get a chance to use it and report back on their needs.

**To test:**
1. Copy `local-builds.gradle-example` as `local-builds.gradle`
2. Uncomment and update `localAztecAndroidPath` to reflect your local path
3. Go to your local copy of your AztecEditor-Android and checkout [this PR](https://github.com/wordpress-mobile/AztecEditor-Android/pull/940) which is a requirement
4. Gradle sync in Android Studio which should bring up the project
5. Make a change in [AztecAttributes](https://github.com/wordpress-mobile/AztecEditor-Android/blob/develop/aztec/src/main/kotlin/org/wordpress/aztec/AztecAttributes.kt) - For example, you can add an `isNotEmpty()` method
6. Call that method in [MetadataUtils](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MetadataUtils.java#L140) and verify that the project builds

Test steps (5) & (6) are mostly for demonstration purposes.

Another test for the curious is to create a Gradle scan for example by running `./gradlew assembleWordPressVanillaDebug --scan`, going into the `Dependencies` section and searching for `aztec` to verify the dependencies were resolved as the local module. [Here is an example scan.](https://scans.gradle.com/s/7cyw52yindcje/dependencies?dependencies=aztec&expandAll)

## Regression Notes
1. Potential unintended areas of impact
N/A - because this change can't have any impact on the CI builds as the composite builds are ignore

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
