### PR TITLE
Domains improvements – Part 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionItem.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.ui.domains
+
+data class DomainSuggestionItem(
+    val domainName: String,
+    val cost: String,
+    val isFree: Boolean,
+    val supportsPrivacy: Boolean,
+    val productId: Int,
+    val productSlug: String?,
+    val vendor: String?,
+    val relevance: Float,
+    val isSelected: Boolean,
+    val isCostVisible: Boolean,
+    val isFreeWithCredits: Boolean
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
@@ -4,51 +4,25 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.Adapter
 
 class DomainSuggestionsAdapter(
-    private val itemSelectionListener: (DomainSuggestionItem?, Int) -> Unit
+    private val itemSelectionListener: (DomainSuggestionItem?) -> Unit
 ) : Adapter<DomainSuggestionsViewHolder>() {
     private val list = mutableListOf<DomainSuggestionItem>()
     var selectedPosition = -1
-    var isSiteDomainsFeatureEnabled: Boolean = false
-    var isDomainCreditAvailable: Boolean = false
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DomainSuggestionsViewHolder {
-        return DomainSuggestionsViewHolder(
-                parent,
-                this::onDomainSuggestionSelected
-        )
-    }
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+            DomainSuggestionsViewHolder(parent, itemSelectionListener)
 
     override fun getItemCount(): Int {
         return list.size
     }
 
     override fun onBindViewHolder(holder: DomainSuggestionsViewHolder, position: Int) {
-        holder.bind(
-                list[position],
-                position,
-                selectedPosition == position,
-                isSiteDomainsFeatureEnabled,
-                isDomainCreditAvailable)
-    }
-
-    private fun onDomainSuggestionSelected(suggestion: DomainSuggestionItem?, position: Int) {
-        val previousSelectedPosition = selectedPosition
-        selectedPosition = position
-        notifyItemChanged(previousSelectedPosition)
-        if (previousSelectedPosition != selectedPosition) {
-            notifyItemChanged(selectedPosition)
-        }
-        itemSelectionListener(suggestion, position)
+        holder.bind(list[position])
     }
 
     internal fun updateSuggestionsList(items: List<DomainSuggestionItem>) {
         list.clear()
         list.addAll(items)
         notifyDataSetChanged()
-    }
-
-    internal fun updateDomainCreditAvailable(siteDomainsFeatureEnabled: Boolean, isDomainCreditAvailable: Boolean) {
-        this.isSiteDomainsFeatureEnabled = siteDomainsFeatureEnabled
-        this.isDomainCreditAvailable = isDomainCreditAvailable
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
@@ -1,28 +1,23 @@
 package org.wordpress.android.ui.domains
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.RecyclerView.Adapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 
 class DomainSuggestionsAdapter(
     private val itemSelectionListener: (DomainSuggestionItem?) -> Unit
-) : Adapter<DomainSuggestionsViewHolder>() {
-    private val list = mutableListOf<DomainSuggestionItem>()
-    var selectedPosition = -1
-
+) : ListAdapter<DomainSuggestionItem, DomainSuggestionsViewHolder>(DomainSuggestionItemDiffCallback()) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
             DomainSuggestionsViewHolder(parent, itemSelectionListener)
 
-    override fun getItemCount(): Int {
-        return list.size
-    }
-
     override fun onBindViewHolder(holder: DomainSuggestionsViewHolder, position: Int) {
-        holder.bind(list[position])
+        holder.bind(getItem(position))
     }
 
-    internal fun updateSuggestionsList(items: List<DomainSuggestionItem>) {
-        list.clear()
-        list.addAll(items)
-        notifyDataSetChanged()
+    private class DomainSuggestionItemDiffCallback : DiffUtil.ItemCallback<DomainSuggestionItem>() {
+        override fun areItemsTheSame(old: DomainSuggestionItem, new: DomainSuggestionItem) =
+                old.domainName == new.domainName
+
+        override fun areContentsTheSame(old: DomainSuggestionItem, new: DomainSuggestionItem) = old == new
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsAdapter.kt
@@ -2,12 +2,11 @@ package org.wordpress.android.ui.domains
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.Adapter
-import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
 
 class DomainSuggestionsAdapter(
-    private val itemSelectionListener: (DomainSuggestionResponse?, Int) -> Unit
+    private val itemSelectionListener: (DomainSuggestionItem?, Int) -> Unit
 ) : Adapter<DomainSuggestionsViewHolder>() {
-    private val list = mutableListOf<DomainSuggestionResponse>()
+    private val list = mutableListOf<DomainSuggestionItem>()
     var selectedPosition = -1
     var isSiteDomainsFeatureEnabled: Boolean = false
     var isDomainCreditAvailable: Boolean = false
@@ -32,7 +31,7 @@ class DomainSuggestionsAdapter(
                 isDomainCreditAvailable)
     }
 
-    private fun onDomainSuggestionSelected(suggestion: DomainSuggestionResponse?, position: Int) {
+    private fun onDomainSuggestionSelected(suggestion: DomainSuggestionItem?, position: Int) {
         val previousSelectedPosition = selectedPosition
         selectedPosition = position
         notifyItemChanged(previousSelectedPosition)
@@ -42,7 +41,7 @@ class DomainSuggestionsAdapter(
         itemSelectionListener(suggestion, position)
     }
 
-    internal fun updateSuggestionsList(items: List<DomainSuggestionResponse>) {
+    internal fun updateSuggestionsList(items: List<DomainSuggestionItem>) {
         list.clear()
         list.addAll(items)
         notifyDataSetChanged()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -97,7 +97,7 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
 
     private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionItem>) {
         val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
-        adapter.updateSuggestionsList(domainSuggestions)
+        adapter.submitList(domainSuggestions)
     }
 
     private fun onDomainSuggestionSelected(domainSuggestion: DomainSuggestionItem?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -47,10 +47,12 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
         with(DomainSuggestionsFragmentBinding.bind(view)) {
             val intent = requireActivity().intent
             val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
+            val domainRegistrationPurpose = intent.getSerializableExtra(DOMAIN_REGISTRATION_PURPOSE_KEY)
+                    as DomainRegistrationPurpose
 
             setupViews()
             setupObservers()
-            viewModel.start(site)
+            viewModel.start(site, domainRegistrationPurpose)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.DomainSuggestionsFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
 import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.Companion.DOMAIN_REGISTRATION_PURPOSE_KEY
@@ -64,8 +63,8 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
 
             mainViewModel.selectDomain(
                     DomainProductDetails(
-                            selectedDomain!!.product_id,
-                            selectedDomain.domain_name
+                            selectedDomain!!.productId,
+                            selectedDomain.domainName
                     )
             )
         }
@@ -96,13 +95,13 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
         viewModel.choseDomainButtonEnabledState.observe(viewLifecycleOwner) { choseDomainButton.isEnabled = it }
     }
 
-    private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionResponse>) {
+    private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionItem>) {
         val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
         adapter.selectedPosition = viewModel.selectedPosition.value ?: -1
         adapter.updateSuggestionsList(domainSuggestions)
     }
 
-    private fun onDomainSuggestionSelected(domainSuggestion: DomainSuggestionResponse?, selectedPosition: Int) {
+    private fun onDomainSuggestionSelected(domainSuggestion: DomainSuggestionItem?, selectedPosition: Int) {
         viewModel.onDomainSuggestionsSelected(domainSuggestion, selectedPosition)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -94,10 +94,6 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
             }
         }
         viewModel.choseDomainButtonEnabledState.observe(viewLifecycleOwner) { choseDomainButton.isEnabled = it }
-        viewModel.isDomainCreditAvailable.observe(viewLifecycleOwner) {
-            val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
-            adapter.updateDomainCreditAvailable(viewModel.isSiteDomainsFeatureConfigEnabled, it)
-        }
     }
 
     private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionResponse>) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -97,12 +97,11 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
 
     private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionItem>) {
         val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
-        adapter.selectedPosition = viewModel.selectedPosition.value ?: -1
         adapter.updateSuggestionsList(domainSuggestions)
     }
 
-    private fun onDomainSuggestionSelected(domainSuggestion: DomainSuggestionItem?, selectedPosition: Int) {
-        viewModel.onDomainSuggestionsSelected(domainSuggestion, selectedPosition)
+    private fun onDomainSuggestionSelected(domainSuggestion: DomainSuggestionItem?) {
+        viewModel.onDomainSuggestionsSelected(domainSuggestion)
     }
 
     override fun onResume() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
@@ -8,11 +8,10 @@ import android.widget.TextView
 import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
 
 class DomainSuggestionsViewHolder(
     parent: ViewGroup,
-    private val itemSelectionListener: (DomainSuggestionResponse?, Int) -> Unit
+    private val itemSelectionListener: (DomainSuggestionItem?, Int) -> Unit
 ) : RecyclerView.ViewHolder(
         LayoutInflater.from(parent.context).inflate(R.layout.domain_suggestion_list_item, parent, false)
 ) {
@@ -22,13 +21,13 @@ class DomainSuggestionsViewHolder(
     private val container: View = itemView.findViewById(R.id.domain_suggestions_container)
 
     fun bind(
-        suggestion: DomainSuggestionResponse,
+        suggestion: DomainSuggestionItem,
         position: Int,
         isSelectedPosition: Boolean,
         isSiteDomainsFeatureEnabled: Boolean,
         isDomainCreditAvailable: Boolean
     ) {
-        domainName.text = suggestion.domain_name
+        domainName.text = suggestion.domainName
         if (isSiteDomainsFeatureEnabled) {
             domainCost.visibility = View.VISIBLE
             domainCost.text = getFormattedCost(suggestion, isDomainCreditAvailable)
@@ -49,10 +48,10 @@ class DomainSuggestionsViewHolder(
     }
 
     private fun getFormattedCost(
-        suggestion: DomainSuggestionResponse,
+        suggestion: DomainSuggestionItem,
         isDomainCreditAvailable: Boolean
     ) = when {
-        suggestion.is_free -> {
+        suggestion.isFree -> {
             suggestion.cost
         }
         isDomainCreditAvailable -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
@@ -6,12 +6,13 @@ import android.view.ViewGroup
 import android.widget.RadioButton
 import android.widget.TextView
 import androidx.core.text.HtmlCompat
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
 
 class DomainSuggestionsViewHolder(
     parent: ViewGroup,
-    private val itemSelectionListener: (DomainSuggestionItem?, Int) -> Unit
+    private val itemSelectionListener: (DomainSuggestionItem?) -> Unit
 ) : RecyclerView.ViewHolder(
         LayoutInflater.from(parent.context).inflate(R.layout.domain_suggestion_list_item, parent, false)
 ) {
@@ -20,46 +21,29 @@ class DomainSuggestionsViewHolder(
     private val selectionRadioButton: RadioButton = itemView.findViewById(R.id.domain_selection_radio_button)
     private val container: View = itemView.findViewById(R.id.domain_suggestions_container)
 
-    fun bind(
-        suggestion: DomainSuggestionItem,
-        position: Int,
-        isSelectedPosition: Boolean,
-        isSiteDomainsFeatureEnabled: Boolean,
-        isDomainCreditAvailable: Boolean
-    ) {
+    fun bind(suggestion: DomainSuggestionItem) {
         domainName.text = suggestion.domainName
-        if (isSiteDomainsFeatureEnabled) {
-            domainCost.visibility = View.VISIBLE
-            domainCost.text = getFormattedCost(suggestion, isDomainCreditAvailable)
-        } else {
-            domainCost.visibility = View.GONE
-        }
-        selectionRadioButton.isChecked = isSelectedPosition
+        domainCost.isVisible = suggestion.isCostVisible
+        domainCost.text = getFormattedCost(suggestion)
+        selectionRadioButton.isChecked = suggestion.isSelected
 
         container.setOnClickListener {
             val isSuggestionSelected = !selectionRadioButton.isChecked
             selectionRadioButton.isChecked = isSuggestionSelected
             if (isSuggestionSelected) {
-                itemSelectionListener(suggestion, position)
+                itemSelectionListener(suggestion)
             } else {
-                itemSelectionListener(null, -1)
+                itemSelectionListener(null)
             }
         }
     }
 
-    private fun getFormattedCost(
-        suggestion: DomainSuggestionItem,
-        isDomainCreditAvailable: Boolean
-    ) = when {
-        suggestion.isFree -> {
-            suggestion.cost
-        }
-        isDomainCreditAvailable -> {
+    private fun getFormattedCost(suggestion: DomainSuggestionItem) = when {
+        suggestion.isFree -> suggestion.cost
+        suggestion.isFreeWithCredits -> {
             HtmlCompat.fromHtml(
                     String.format(
-                            container.context.getString(
-                                    R.string.domain_suggestions_list_item_cost_free
-                            ),
+                            container.context.getString(R.string.domain_suggestions_list_item_cost_free),
                             suggestion.cost
                     ),
                     HtmlCompat.FROM_HTML_MODE_LEGACY
@@ -68,9 +52,7 @@ class DomainSuggestionsViewHolder(
         else -> { // on free plan
             HtmlCompat.fromHtml(
                     String.format(
-                            container.context.getString(
-                                    R.string.domain_suggestions_list_item_cost
-                            ),
+                            container.context.getString(R.string.domain_suggestions_list_item_cost),
                             suggestion.cost
                     ),
                     HtmlCompat.FROM_HTML_MODE_LEGACY

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.viewmodel.domains
 
-import android.text.TextUtils
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -54,8 +53,7 @@ class DomainSuggestionsViewModel @Inject constructor(
     val isDomainCreditAvailable = MediatorLiveData<Boolean>()
 
     private val _suggestions = MutableLiveData<DomainSuggestionsListState>()
-    val suggestionsLiveData: LiveData<DomainSuggestionsListState>
-        get() = _suggestions
+    val suggestionsLiveData: LiveData<DomainSuggestionsListState> = _suggestions
 
     private var suggestions: ListState<DomainSuggestionResponse>
             by Delegates.observable(ListState.Init()) { _, _, new ->
@@ -63,19 +61,15 @@ class DomainSuggestionsViewModel @Inject constructor(
             }
 
     private val _selectedSuggestion = MutableLiveData<DomainSuggestionResponse?>()
-    val selectedSuggestion: LiveData<DomainSuggestionResponse?>
-        get() = _selectedSuggestion
+    val selectedSuggestion: LiveData<DomainSuggestionResponse?> = _selectedSuggestion
 
-    val choseDomainButtonEnabledState: LiveData<Boolean>
-        get() = Transformations.map(_selectedSuggestion) { it is DomainSuggestionResponse }
+    val choseDomainButtonEnabledState = Transformations.map(_selectedSuggestion) { it is DomainSuggestionResponse }
 
     private val _selectedPosition = MutableLiveData<Int>()
-    val selectedPosition: LiveData<Int>
-        get() = _selectedPosition
+    val selectedPosition: LiveData<Int> = _selectedPosition
 
-    private val _isIntroVisible = MutableLiveData<Boolean>().apply { value = true }
-    val isIntroVisible: LiveData<Boolean>
-        get() = _isIntroVisible
+    private val _isIntroVisible = MutableLiveData(true)
+    val isIntroVisible: LiveData<Boolean> = _isIntroVisible
 
     private var searchQuery: String by Delegates.observable("") { _, oldValue, newValue ->
         if (newValue != oldValue) {
@@ -175,9 +169,9 @@ class DomainSuggestionsViewModel @Inject constructor(
     }
 
     fun updateSearchQuery(query: String) {
-        _isIntroVisible.value = query.isEmpty()
+        _isIntroVisible.value = query.isBlank()
 
-        if (!TextUtils.isEmpty(query)) {
+        if (query.isNotBlank()) {
             searchQuery = query
         } else if (searchQuery != site.name) {
             // Only reinitialize the search query, if it has changed.

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionRespo
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.models.networkresource.ListState
+import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrationHandler
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -38,6 +39,8 @@ class DomainSuggestionsViewModel @Inject constructor(
     siteDomainsFeatureConfig: SiteDomainsFeatureConfig
 ) : ViewModel() {
     lateinit var site: SiteModel
+    lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
+
     private var isStarted = false
     private var isQueryTrackingCompleted = false
 
@@ -103,11 +106,12 @@ class DomainSuggestionsViewModel @Inject constructor(
         super.onCleared()
     }
 
-    fun start(site: SiteModel) {
+    fun start(site: SiteModel, domainRegistrationPurpose: DomainRegistrationPurpose) {
         if (isStarted) {
             return
         }
         this.site = site
+        this.domainRegistrationPurpose = domainRegistrationPurpose
         checkDomainCreditAvailability()
         initializeDefaultSuggestions()
         isStarted = true

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModel.kt
@@ -51,9 +51,6 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     val choseDomainButtonEnabledState = Transformations.map(_selectedSuggestion) { it is DomainSuggestionItem }
 
-    private val _selectedPosition = MutableLiveData<Int>()
-    val selectedPosition: LiveData<Int> = _selectedPosition
-
     private val _isIntroVisible = MutableLiveData(true)
     val isIntroVisible: LiveData<Boolean> = _isIntroVisible
 
@@ -116,7 +113,7 @@ class DomainSuggestionsViewModel @Inject constructor(
         dispatcher.dispatch(SiteActionBuilder.newSuggestDomainsAction(suggestDomainsPayload))
 
         // Reset the selected suggestion, if list is updated
-        onDomainSuggestionsSelected(null, -1)
+        onDomainSuggestionsSelected(null)
     }
 
     // Network Callback
@@ -158,9 +155,11 @@ class DomainSuggestionsViewModel @Inject constructor(
                 }
     }
 
-    fun onDomainSuggestionsSelected(selectedSuggestion: DomainSuggestionItem?, selectedPosition: Int) {
-        _selectedPosition.postValue(selectedPosition)
+    fun onDomainSuggestionsSelected(selectedSuggestion: DomainSuggestionItem?) {
         _selectedSuggestion.postValue(selectedSuggestion)
+        suggestions = suggestions.transform { list ->
+            list.map { it.copy(isSelected = selectedSuggestion?.domainName == it.domainName) }
+        }
     }
 
     fun updateSearchQuery(query: String) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
@@ -17,7 +17,8 @@ import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
-import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrationHandler
+import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
+import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.plans.PlansConstants
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.SiteDomainsFeatureConfig
@@ -27,17 +28,17 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Mock lateinit var dispatcher: Dispatcher
     @Mock lateinit var debouncer: Debouncer
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
-    @Mock lateinit var domainRegistrationHandler: DomainRegistrationHandler
     @Mock lateinit var siteDomainsFeatureConfig: SiteDomainsFeatureConfig
 
     private lateinit var site: SiteModel
+    private lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
     private lateinit var viewModel: DomainSuggestionsViewModel
 
     @Before
     fun setUp() {
         site = SiteModel().also { it.name = "Test Site" }
-        viewModel = DomainSuggestionsViewModel(
-                tracker, dispatcher, debouncer, domainRegistrationHandler, siteDomainsFeatureConfig)
+        domainRegistrationPurpose = CTA_DOMAIN_CREDIT_REDEMPTION
+        viewModel = DomainSuggestionsViewModel(tracker, dispatcher, debouncer, siteDomainsFeatureConfig)
 
         whenever(debouncer.debounce(any(), any(), any(), any())).thenAnswer { invocation ->
             val delayedRunnable = invocation.arguments[1] as Runnable
@@ -47,7 +48,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `intro is visible at start`() {
-        viewModel.start(site)
+        viewModel.start(site, domainRegistrationPurpose)
         assertNotNull(viewModel.isIntroVisible.value)
         viewModel.isIntroVisible.value?.let { isIntroVisible ->
             assert(isIntroVisible)
@@ -56,7 +57,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `intro is hidden when search query is not empty`() {
-        viewModel.start(site)
+        viewModel.start(site, domainRegistrationPurpose)
         viewModel.updateSearchQuery("Hello World")
 
         assertNotNull(viewModel.isIntroVisible.value)
@@ -67,7 +68,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `intro is visible when search query is empty`() {
-        viewModel.start(site)
+        viewModel.start(site, domainRegistrationPurpose)
         viewModel.updateSearchQuery("Hello World")
         viewModel.updateSearchQuery("")
 
@@ -80,7 +81,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Test
     fun `site on blogger plan is requesting only dot blog domain suggestions`() {
         site.planId = PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
-        viewModel.start(site)
+        viewModel.start(site, domainRegistrationPurpose)
         viewModel.updateSearchQuery("test")
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
@@ -104,7 +105,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Test
     fun `site on non blogger plan is requesting all possible domain suggestions`() {
         site.planId = PlansConstants.PREMIUM_PLAN_ID
-        viewModel.start(site)
+        viewModel.start(site, domainRegistrationPurpose)
         viewModel.updateSearchQuery("test")
 
         val captor = ArgumentCaptor.forClass(Action::class.java)


### PR DESCRIPTION
This PR introduces a series of improvements in preparation for the checkout step of the flow.

It depends on Part 1: #15433

This PR focuses on improvements to the `DomainsSuggestionFragment` and classes related to it. The biggest changes are:
- The introduction of `DomainSuggestionItem`, which allows us to have more control of the list item from the view model.
- The use of `DomainRegistrationPurpose` inside `DomainSuggestionsViewModel`
- The conversion of `DomainSuggestionsAdapter` to a `ListAdapter`

### To test

Go over the flow and make sure nothing looks out of place.

## Regression Notes
1. Potential unintended areas of impact
Existing domain flows.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests.

3. What automated tests I added (or what prevented me from doing so)
Updated existing unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
