### PR TITLE
Add checkout step to domain flow

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -699,6 +699,10 @@
             android:label="@string/register_domain"
             android:theme="@style/WordPress.NoActionBar"/>
 
+        <activity
+            android:name=".ui.domains.DomainRegistrationCheckoutWebViewActivity"
+            android:theme="@style/WordPress.NoActionBar"/>
+
         <!-- Me activities -->
         <activity
             android:name=".ui.prefs.MyProfileActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -110,7 +110,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
     }
 
     private fun finishDomainRegistration(event: DomainRegistrationCompletedEvent) {
-        setResult(RESULT_OK, Intent().apply { putExtra(RESULT_REGISTERED_DOMAIN_EMAIL, event.email) })
+        setResult(RESULT_OK, Intent().putExtra(RESULT_REGISTERED_DOMAIN_EMAIL, event.email))
         finish()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -57,6 +57,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
 
             setupToolbar()
             setupViewModel(site, domainRegistrationPurpose)
+            setupObservers()
         }
     }
 
@@ -71,6 +72,9 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
     private fun setupViewModel(site: SiteModel, domainRegistrationPurpose: DomainRegistrationPurpose) {
         viewModel = ViewModelProvider(this, viewModelFactory).get(DomainRegistrationMainViewModel::class.java)
         viewModel.start(site, domainRegistrationPurpose)
+    }
+
+    private fun setupObservers() {
         viewModel.onNavigation.observeEvent(this) {
             when (it) {
                 is OpenDomainSuggestions -> showDomainSuggestions()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationResultFragment.Compani
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitializedListener {
     enum class DomainRegistrationPurpose {
         AUTOMATED_TRANSFER,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -79,7 +79,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
         viewModel.onNavigation.observeEvent(this) {
             when (it) {
                 is OpenDomainSuggestions -> showDomainSuggestions()
-                is OpenDomainRegistrationCheckout -> openDomainRegistrationWebView(it.site, it.details)
+                is OpenDomainRegistrationCheckout -> openDomainRegistrationCheckoutWebView(it.site, it.details)
                 is OpenDomainRegistrationDetails -> showDomainRegistrationDetails(it.details)
                 is OpenDomainRegistrationResult -> showDomainRegistrationResult(it.event)
                 is FinishDomainRegistration -> finishDomainRegistration(it.event)
@@ -93,7 +93,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
         }
     }
 
-    private fun openDomainRegistrationWebView(site: SiteModel, details: DomainProductDetails) {
+    private fun openDomainRegistrationCheckoutWebView(site: SiteModel, details: DomainProductDetails) {
         openCheckout.launch(CheckoutDetails(site, details.domainName))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -11,7 +11,9 @@ import org.wordpress.android.databinding.DomainSuggestionsActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.ScrollableViewInitializedListener
+import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.FinishDomainRegistration
+import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationCheckout
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationDetails
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationResult
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainSuggestions
@@ -33,6 +35,14 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: DomainRegistrationMainViewModel
     private lateinit var binding: DomainSuggestionsActivityBinding
+
+    private val openCheckout = registerForActivityResult(DomainRegistrationCheckoutWebViewActivity.OpenCheckout()) {
+        if (it != null) {
+            viewModel.completeDomainRegistration(it)
+        } else {
+            // TODO Handle checkout failure
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -64,6 +74,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
         viewModel.onNavigation.observeEvent(this) {
             when (it) {
                 is OpenDomainSuggestions -> showDomainSuggestions()
+                is OpenDomainRegistrationCheckout -> openDomainRegistrationWebView(it.site, it.details)
                 is OpenDomainRegistrationDetails -> showDomainRegistrationDetails(it.details)
                 is OpenDomainRegistrationResult -> showDomainRegistrationResult(it.event)
                 is FinishDomainRegistration -> finishDomainRegistration(it.event)
@@ -75,6 +86,10 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
         showFragment(DomainSuggestionsFragment.TAG, true) {
             DomainSuggestionsFragment.newInstance()
         }
+    }
+
+    private fun openDomainRegistrationWebView(site: SiteModel, details: DomainProductDetails) {
+        openCheckout.launch(CheckoutDetails(site, details.domainName))
     }
 
     private fun showDomainRegistrationDetails(details: DomainProductDetails) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.ui.domains
+
+import android.os.Bundle
+import org.wordpress.android.ui.WPWebViewActivity
+
+class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        toggleNavbarVisibility(false)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
@@ -22,6 +22,8 @@ class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity(), DomainReg
         return true
     }
 
+    override fun createWebViewClient(allowedURL: List<String>?) = DomainRegistrationCheckoutWebViewClient(this)
+
     override fun onCheckoutSuccess() {
         setResult(RESULT_OK, intent)
         finish()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.domains
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.Menu
 import androidx.activity.result.contract.ActivityResultContract
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.WPWebViewActivity
@@ -13,6 +14,11 @@ class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         toggleNavbarVisibility(false)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        // We don't want any menu items
+        return true
     }
 
     class OpenCheckout : ActivityResultContract<CheckoutDetails, DomainRegistrationCompletedEvent>() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
@@ -8,9 +8,10 @@ import androidx.activity.result.contract.ActivityResultContract
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails
+import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewClient.DomainRegistrationCheckoutWebViewClientListener
 import org.wordpress.android.util.SiteUtils
 
-class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity() {
+class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity(), DomainRegistrationCheckoutWebViewClientListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         toggleNavbarVisibility(false)
@@ -19,6 +20,11 @@ class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity() {
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         // We don't want any menu items
         return true
+    }
+
+    override fun onCheckoutSuccess() {
+        setResult(RESULT_OK, intent)
+        finish()
     }
 
     class OpenCheckout : ActivityResultContract<CheckoutDetails, DomainRegistrationCompletedEvent>() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewClient.kt
@@ -3,5 +3,9 @@ package org.wordpress.android.ui.domains
 import org.wordpress.android.util.ErrorManagedWebViewClient
 
 class DomainRegistrationCheckoutWebViewClient(
-    baseListener: ErrorManagedWebViewClientListener
-) : ErrorManagedWebViewClient(baseListener)
+    private val listener: DomainRegistrationCheckoutWebViewClientListener
+) : ErrorManagedWebViewClient(listener) {
+    interface DomainRegistrationCheckoutWebViewClientListener : ErrorManagedWebViewClientListener {
+        fun onCheckoutSuccess()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewClient.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.ui.domains
+
+import org.wordpress.android.util.ErrorManagedWebViewClient
+
+class DomainRegistrationCheckoutWebViewClient(
+    baseListener: ErrorManagedWebViewClientListener
+) : ErrorManagedWebViewClient(baseListener)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewClient.kt
@@ -1,11 +1,36 @@
 package org.wordpress.android.ui.domains
 
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
 import org.wordpress.android.util.ErrorManagedWebViewClient
 
 class DomainRegistrationCheckoutWebViewClient(
     private val listener: DomainRegistrationCheckoutWebViewClientListener
 ) : ErrorManagedWebViewClient(listener) {
+    private var hasRegistered = false
+
     interface DomainRegistrationCheckoutWebViewClientListener : ErrorManagedWebViewClientListener {
         fun onCheckoutSuccess()
+    }
+
+    override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
+        val host = request.url.host.orEmpty()
+        val path = request.url.path.orEmpty()
+
+        // TODO Revisit this logic
+        if (host == WPCOM_API_HOST) {
+            if (hasRegistered) {
+                listener.onCheckoutSuccess()
+            } else if (path == "/rest/v1.1/me/transactions") {
+                hasRegistered = true
+            }
+        }
+
+        return super.shouldInterceptRequest(view, request)
+    }
+
+    companion object {
+        private const val WPCOM_API_HOST = "public-api.wordpress.com"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModel.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistr
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.FinishDomainRegistration
+import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationCheckout
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationDetails
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationResult
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainSuggestions
@@ -41,8 +42,13 @@ class DomainRegistrationMainViewModel @Inject constructor(
     }
 
     fun selectDomain(domainProductDetails: DomainProductDetails) {
-        analyticsTracker.track(Stat.DOMAIN_CREDIT_NAME_SELECTED)
-        _onNavigation.value = Event(OpenDomainRegistrationDetails(domainProductDetails))
+        _onNavigation.value = when (domainRegistrationPurpose) {
+            DOMAIN_PURCHASE -> Event(OpenDomainRegistrationCheckout(site, domainProductDetails))
+            else -> {
+                analyticsTracker.track(Stat.DOMAIN_CREDIT_NAME_SELECTED)
+                Event(OpenDomainRegistrationDetails(domainProductDetails))
+            }
+        }
     }
 
     fun completeDomainRegistration(event: DomainRegistrationCompletedEvent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationNavigationAction.kt
@@ -1,7 +1,12 @@
 package org.wordpress.android.ui.domains
 
+import org.wordpress.android.fluxc.model.SiteModel
+
 sealed class DomainRegistrationNavigationAction {
     object OpenDomainSuggestions : DomainRegistrationNavigationAction()
+
+    data class OpenDomainRegistrationCheckout(val site: SiteModel, val details: DomainProductDetails) :
+            DomainRegistrationNavigationAction()
 
     data class OpenDomainRegistrationDetails(val details: DomainProductDetails) :
             DomainRegistrationNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.Companion.DOMAIN_REGISTRATION_PURPOSE_KEY
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
 class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment) {
@@ -57,16 +58,7 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
     private fun DomainSuggestionsFragmentBinding.setupViews() {
         domainSuggestionsList.layoutManager = LinearLayoutManager(activity)
         domainSuggestionsList.setEmptyView(actionableEmptyView)
-        choseDomainButton.setOnClickListener {
-            val selectedDomain = viewModel.selectedSuggestion.value
-
-            mainViewModel.selectDomain(
-                    DomainProductDetails(
-                            selectedDomain!!.productId,
-                            selectedDomain.domainName
-                    )
-            )
-        }
+        choseDomainButton.setOnClickListener { viewModel.onSelectDomainButtonClicked() }
         domainSuggestionKeywordInput.doAfterTextChanged { viewModel.updateSearchQuery(it.toString()) }
         domainSuggestionsList.adapter = DomainSuggestionsAdapter(viewModel::onDomainSuggestionSelected)
     }
@@ -92,6 +84,7 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
             }
         }
         viewModel.choseDomainButtonEnabledState.observe(viewLifecycleOwner) { choseDomainButton.isEnabled = it }
+        viewModel.onDomainSelected.observeEvent(viewLifecycleOwner, mainViewModel::selectDomain)
     }
 
     private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionItem>) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -68,7 +68,7 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
             )
         }
         domainSuggestionKeywordInput.doAfterTextChanged { viewModel.updateSearchQuery(it.toString()) }
-        domainSuggestionsList.adapter = DomainSuggestionsAdapter(::onDomainSuggestionSelected)
+        domainSuggestionsList.adapter = DomainSuggestionsAdapter(viewModel::onDomainSuggestionSelected)
     }
 
     private fun DomainSuggestionsFragmentBinding.setupObservers() {
@@ -97,10 +97,6 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
     private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionItem>) {
         val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
         adapter.submitList(domainSuggestions)
-    }
-
-    private fun onDomainSuggestionSelected(domainSuggestion: DomainSuggestionItem?) {
-        viewModel.onDomainSuggestionsSelected(domainSuggestion)
     }
 
     override fun onResume() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -175,12 +175,7 @@ class DomainSuggestionsViewModel @Inject constructor(
         val selectedSuggestion = _selectedSuggestion.value ?: throw IllegalStateException("Selected suggestion is null")
         when (domainRegistrationPurpose) {
             DOMAIN_PURCHASE -> createCart(selectedSuggestion)
-            else -> _onDomainSelected.value = Event(
-                    DomainProductDetails(
-                            selectedSuggestion.productId,
-                            selectedSuggestion.domainName
-                    )
-            )
+            else -> selectDomain(selectedSuggestion)
         }
     }
 
@@ -215,8 +210,12 @@ class DomainSuggestionsViewModel @Inject constructor(
             // TODO Handle failed cart creation
         } else {
             AppLog.d(T.DOMAIN_REGISTRATION, "Successful cart creation: ${event.cartDetails}")
-            val domainProductDetails = DomainProductDetails(selectedSuggestion.productId, selectedSuggestion.domainName)
-            _onDomainSelected.postValue(Event(domainProductDetails))
+            selectDomain(selectedSuggestion)
         }
+    }
+
+    private fun selectDomain(selectedSuggestion: DomainSuggestionItem) {
+        val domainProductDetails = DomainProductDetails(selectedSuggestion.productId, selectedSuggestion.domainName)
+        _onDomainSelected.postValue(Event(domainProductDetails))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -15,12 +15,14 @@ import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
+import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.SiteDomainsFeatureConfig
 import org.wordpress.android.util.helpers.Debouncer
+import org.wordpress.android.viewmodel.Event
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.properties.Delegates
@@ -46,12 +48,14 @@ class DomainSuggestionsViewModel @Inject constructor(
             }
 
     private val _selectedSuggestion = MutableLiveData<DomainSuggestionItem?>()
-    val selectedSuggestion: LiveData<DomainSuggestionItem?> = _selectedSuggestion
 
     val choseDomainButtonEnabledState = Transformations.map(_selectedSuggestion) { it is DomainSuggestionItem }
 
     private val _isIntroVisible = MutableLiveData(true)
     val isIntroVisible: LiveData<Boolean> = _isIntroVisible
+
+    private val _onDomainSelected = MutableLiveData<Event<DomainProductDetails>>()
+    val onDomainSelected: LiveData<Event<DomainProductDetails>> = _onDomainSelected
 
     private var searchQuery: String by Delegates.observable("") { _, oldValue, newValue ->
         if (newValue != oldValue) {
@@ -158,6 +162,19 @@ class DomainSuggestionsViewModel @Inject constructor(
         _selectedSuggestion.postValue(selectedSuggestion)
         suggestions = suggestions.transform { list ->
             list.map { it.copy(isSelected = selectedSuggestion?.domainName == it.domainName) }
+        }
+    }
+
+    fun onSelectDomainButtonClicked() {
+        val selectedSuggestion = _selectedSuggestion.value ?: throw IllegalStateException("Selected suggestion is null")
+        when (domainRegistrationPurpose) {
+            DOMAIN_PURCHASE -> TODO("Not implemented yet")
+            else -> _onDomainSelected.value = Event(
+                    DomainProductDetails(
+                            selectedSuggestion.productId,
+                            selectedSuggestion.domainName
+                    )
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -91,6 +91,7 @@ class DomainSuggestionsViewModel @Inject constructor(
     override fun onCleared() {
         dispatcher.unregister(this)
         debouncer.shutdown()
+        createCartUseCase.clear()
         super.onCleared()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -112,7 +112,7 @@ class DomainSuggestionsViewModel @Inject constructor(
         dispatcher.dispatch(SiteActionBuilder.newSuggestDomainsAction(suggestDomainsPayload))
 
         // Reset the selected suggestion, if list is updated
-        onDomainSuggestionsSelected(null)
+        onDomainSuggestionSelected(null)
     }
 
     // Network Callback
@@ -154,7 +154,7 @@ class DomainSuggestionsViewModel @Inject constructor(
                 }
     }
 
-    fun onDomainSuggestionsSelected(selectedSuggestion: DomainSuggestionItem?) {
+    fun onDomainSuggestionSelected(selectedSuggestion: DomainSuggestionItem?) {
         _selectedSuggestion.postValue(selectedSuggestion)
         suggestions = suggestions.transform { list ->
             list.map { it.copy(isSelected = selectedSuggestion?.domainName == it.domainName) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.domains
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
-import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -13,9 +13,11 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.models.networkresource.ListState
+import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
+import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.SiteUtils
@@ -23,16 +25,20 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.SiteDomainsFeatureConfig
 import org.wordpress.android.util.helpers.Debouncer
 import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ScopedViewModel
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import javax.inject.Named
 import kotlin.properties.Delegates
 
 class DomainSuggestionsViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val dispatcher: Dispatcher,
     private val debouncer: Debouncer,
-    private val siteDomainsFeatureConfig: SiteDomainsFeatureConfig
-) : ViewModel() {
+    private val siteDomainsFeatureConfig: SiteDomainsFeatureConfig,
+    private val createCartUseCase: CreateCartUseCase,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+) : ScopedViewModel(bgDispatcher) {
     lateinit var site: SiteModel
     lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
 
@@ -168,7 +174,7 @@ class DomainSuggestionsViewModel @Inject constructor(
     fun onSelectDomainButtonClicked() {
         val selectedSuggestion = _selectedSuggestion.value ?: throw IllegalStateException("Selected suggestion is null")
         when (domainRegistrationPurpose) {
-            DOMAIN_PURCHASE -> TODO("Not implemented yet")
+            DOMAIN_PURCHASE -> createCart(selectedSuggestion)
             else -> _onDomainSelected.value = Event(
                     DomainProductDetails(
                             selectedSuggestion.productId,
@@ -186,6 +192,31 @@ class DomainSuggestionsViewModel @Inject constructor(
         } else if (searchQuery != site.name) {
             // Only reinitialize the search query, if it has changed.
             initializeDefaultSuggestions()
+        }
+    }
+
+    private fun createCart(selectedSuggestion: DomainSuggestionItem) = launch {
+        AppLog.d(T.DOMAIN_REGISTRATION, "Creating cart: $selectedSuggestion")
+
+        // TODO Show progress bar
+
+        val event = createCartUseCase.execute(
+                site,
+                selectedSuggestion.productId,
+                selectedSuggestion.domainName,
+                selectedSuggestion.supportsPrivacy,
+                false
+        )
+
+        // TODO Hide progress bar
+
+        if (event.isError) {
+            AppLog.e(T.DOMAIN_REGISTRATION, "Failed cart creation: ${event.error.message}")
+            // TODO Handle failed cart creation
+        } else {
+            AppLog.d(T.DOMAIN_REGISTRATION, "Successful cart creation: ${event.cartDetails}")
+            val domainProductDetails = DomainProductDetails(selectedSuggestion.productId, selectedSuggestion.domainName)
+            _onDomainSelected.postValue(Event(domainProductDetails))
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
@@ -9,6 +9,8 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.DomainsDashboardFragmentBinding
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
+import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
+import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.ClaimDomain
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.GetDomain
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.OpenManageDomains
 import org.wordpress.android.ui.utils.UiHelpers
@@ -49,6 +51,11 @@ class DomainsDashboardFragment : Fragment(R.layout.domains_dashboard_fragment) {
 
     private fun handleNavigationAction(action: DomainsDashboardNavigationAction) = when (action) {
         is GetDomain -> ActivityLauncher.viewDomainRegistrationActivityForResult(
+                activity,
+                action.site,
+                DOMAIN_PURCHASE
+        )
+        is ClaimDomain -> ActivityLauncher.viewDomainRegistrationActivityForResult(
                 activity,
                 action.site,
                 CTA_DOMAIN_CREDIT_REDEMPTION

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardNavigationAction.kt
@@ -4,5 +4,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 
 sealed class DomainsDashboardNavigationAction {
     data class GetDomain(val site: SiteModel) : DomainsDashboardNavigationAction()
+    data class ClaimDomain(val site: SiteModel) : DomainsDashboardNavigationAction()
     data class OpenManageDomains(val url: String) : DomainsDashboardNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.domains.DomainsDashboardItem.PrimaryDomain
 import org.wordpress.android.ui.domains.DomainsDashboardItem.PurchaseDomain
 import org.wordpress.android.ui.domains.DomainsDashboardItem.SiteDomains
 import org.wordpress.android.ui.domains.DomainsDashboardItem.SiteDomainsHeader
+import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.ClaimDomain
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.GetDomain
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.OpenManageDomains
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
@@ -174,8 +175,8 @@ class DomainsDashboardViewModel @Inject constructor(
     }
 
     private fun onClaimDomainClick() {
-        analyticsTrackerWrapper.track(DOMAIN_CREDIT_REDEMPTION_TAPPED, selectedSite)
-        _onNavigation.value = Event(GetDomain(selectedSite))
+        // TODO Add tracking
+        _onNavigation.value = Event(ClaimDomain(selectedSite))
     }
 
     private fun onAddDomainClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/CreateCartUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/CreateCartUseCase.kt
@@ -1,0 +1,54 @@
+package org.wordpress.android.ui.domains.usecases
+
+import org.greenrobot.eventbus.Subscribe
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.TransactionActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.TransactionsStore
+import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartPayload
+import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
+import javax.inject.Inject
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Wraps an [OnShoppingCartCreated] into a coroutine.
+ */
+class CreateCartUseCase @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val transactionsStore: TransactionsStore // needed for events to work
+) {
+    private var continuation: Continuation<OnShoppingCartCreated>? = null
+
+    init {
+        dispatcher.register(this)
+    }
+
+    fun clear() {
+        dispatcher.unregister(this)
+    }
+
+    suspend fun execute(
+        site: SiteModel,
+        productId: Int,
+        domainName: String,
+        isPrivacyEnabled: Boolean,
+        isTemporary: Boolean
+    ): OnShoppingCartCreated {
+        if (continuation != null) {
+            throw IllegalStateException("Cart creation is already in progress!")
+        }
+        return suspendCoroutine {
+            continuation = it
+            val payload = CreateShoppingCartPayload(site, productId, domainName, isPrivacyEnabled, isTemporary)
+            dispatcher.dispatch(TransactionActionBuilder.newCreateShoppingCartAction(payload))
+        }
+    }
+
+    @Subscribe
+    fun onShoppingCartCreated(event: OnShoppingCartCreated) {
+        continuation?.resume(event)
+        continuation = null
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.domains
+package org.wordpress.android.ui.domains
 
 import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.any
@@ -7,7 +7,6 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -55,9 +54,6 @@ import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartErr
 import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartPayload
 import org.wordpress.android.fluxc.store.TransactionsStore.TransactionErrorType.PHONE
 import org.wordpress.android.test
-import org.wordpress.android.ui.domains.DomainProductDetails
-import org.wordpress.android.ui.domains.DomainRegistrationCompletedEvent
-import org.wordpress.android.ui.domains.DomainRegistrationDetailsViewModel
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsViewModel.DomainContactFormModel
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsViewModel.DomainRegistrationDetailsUiState
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
@@ -203,7 +199,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         validateFetchDomainContactAction(actionsDispatched[1])
         validateFetchStatesAction(actionsDispatched[2], primaryCountry.code)
 
-        Assertions.assertThat(uiStateResults.size).isEqualTo(5)
+        assertThat(uiStateResults.size).isEqualTo(5)
 
         val initialState = uiStateResults[0]
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModelTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.domains
+package org.wordpress.android.ui.domains
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -6,13 +6,9 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.domains.DomainProductDetails
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.AUTOMATED_TRANSFER
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
-import org.wordpress.android.ui.domains.DomainRegistrationCompletedEvent
-import org.wordpress.android.ui.domains.DomainRegistrationMainViewModel
-import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.FinishDomainRegistration
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationDetails
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationResult

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.domains
+package org.wordpress.android.ui.domains
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.times
@@ -23,12 +23,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsR
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.test
-import org.wordpress.android.ui.domains.DomainProductDetails
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
-import org.wordpress.android.ui.domains.DomainSuggestionItem
-import org.wordpress.android.ui.domains.DomainSuggestionsViewModel
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.ui.plans.PlansConstants
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -12,6 +13,7 @@ import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.annotations.action.Action
@@ -20,6 +22,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.domains.DomainSuggestionsViewModel
+import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.ui.plans.PlansConstants
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.SiteDomainsFeatureConfig
@@ -30,16 +33,25 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Mock lateinit var debouncer: Debouncer
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
     @Mock lateinit var siteDomainsFeatureConfig: SiteDomainsFeatureConfig
+    @Mock lateinit var createCartUseCase: CreateCartUseCase
 
     private lateinit var site: SiteModel
     private lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
     private lateinit var viewModel: DomainSuggestionsViewModel
 
+    @InternalCoroutinesApi
     @Before
     fun setUp() {
         site = SiteModel().also { it.name = "Test Site" }
         domainRegistrationPurpose = CTA_DOMAIN_CREDIT_REDEMPTION
-        viewModel = DomainSuggestionsViewModel(tracker, dispatcher, debouncer, siteDomainsFeatureConfig)
+        viewModel = DomainSuggestionsViewModel(
+                tracker,
+                dispatcher,
+                debouncer,
+                siteDomainsFeatureConfig,
+                createCartUseCase,
+                TEST_DISPATCHER
+        )
 
         whenever(debouncer.debounce(any(), any(), any(), any())).thenAnswer { invocation ->
             val delayedRunnable = invocation.arguments[1] as Runnable

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/domains/DomainSuggestionsViewModelTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.viewmodel.domains
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -18,9 +19,15 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
+import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
+import org.wordpress.android.test
+import org.wordpress.android.ui.domains.DomainProductDetails
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
+import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
+import org.wordpress.android.ui.domains.DomainSuggestionItem
 import org.wordpress.android.ui.domains.DomainSuggestionsViewModel
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.ui.plans.PlansConstants
@@ -38,6 +45,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     private lateinit var site: SiteModel
     private lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
     private lateinit var viewModel: DomainSuggestionsViewModel
+    private lateinit var onDomainSelectedEvents: MutableList<DomainProductDetails>
 
     @InternalCoroutinesApi
     @Before
@@ -57,6 +65,9 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
             val delayedRunnable = invocation.arguments[1] as Runnable
             delayedRunnable.run()
         }
+
+        onDomainSelectedEvents = mutableListOf()
+        viewModel.onDomainSelected.observeForever { onDomainSelectedEvents.add(it.peekContent()) }
     }
 
     @Test
@@ -136,5 +147,55 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         assertThat(payload.includeDotBlogSubdomain).isTrue()
         assertThat(payload.includeVendorDot).isFalse()
         assertThat(payload.tlds).isNull()
+    }
+
+    @Test
+    fun `clicking select domain button for credit redemption emits selected domain`() = test {
+        viewModel.start(site, CTA_DOMAIN_CREDIT_REDEMPTION)
+        viewModel.onDomainSuggestionSelected(dummySelectedDomainSuggestionItem)
+        viewModel.onSelectDomainButtonClicked()
+
+        verifyZeroInteractions(createCartUseCase)
+
+        assertThat(onDomainSelectedEvents.last()).isEqualTo(DomainProductDetails(DUMMY_PRODUCT_ID, DUMMY_DOMAIN_NAME))
+    }
+
+    @Test
+    fun `clicking select domain button for purchase calls cart creation use case and emits selected domain`() = test {
+        whenever(createCartUseCase.execute(site, DUMMY_PRODUCT_ID, DUMMY_DOMAIN_NAME, true, false))
+                .thenReturn(dummySuccessfulOnShoppingCartCreated)
+
+        viewModel.start(site, DOMAIN_PURCHASE)
+        viewModel.onDomainSuggestionSelected(dummySelectedDomainSuggestionItem)
+        viewModel.onSelectDomainButtonClicked()
+
+        assertThat(onDomainSelectedEvents.last()).isEqualTo(DomainProductDetails(DUMMY_PRODUCT_ID, DUMMY_DOMAIN_NAME))
+    }
+
+    companion object {
+        const val DUMMY_PRODUCT_ID = 1
+        const val DUMMY_DOMAIN_NAME = "domainname.com"
+
+        val dummySuccessfulOnShoppingCartCreated = OnShoppingCartCreated(
+                CreateShoppingCartResponse(
+                        1,
+                        "dummy_cart_key",
+                        emptyList()
+                )
+        )
+
+        val dummySelectedDomainSuggestionItem = DomainSuggestionItem(
+                domainName = DUMMY_DOMAIN_NAME,
+                cost = "$20.00",
+                isFree = false,
+                supportsPrivacy = true,
+                productId = DUMMY_PRODUCT_ID,
+                productSlug = null,
+                vendor = null,
+                relevance = 1.0f,
+                isSelected = true,
+                isCostVisible = true,
+                isFreeWithCredits = false
+        )
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'develop-2a77cd1140c0955caad4e15f499ad646d2ac4f89'
+    fluxCVersion = 'develop-a3f6fb48c48bd585e7c638a8ca91a273d0b810f4'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #15386 and #15366

Depends on #15437

This PR adds the checkout web page to the domains purchase flow:


https://user-images.githubusercontent.com/830056/136635838-de376393-5d6a-47d0-9821-e21bea543540.mp4


The following is out of scope for this PR:
- Cart creation and checkout error handling.
- Post-checkout behavior (success screen).
- A few UI improvements to the Suggestions screen.
- We're still going to add a progress bar after tapping the "Choose domain" button on the Suggestions screen.

### To test

**Setup: Enable feature flag**

1. On the Main screen, tap the Me button.
1. On the Me screen, go to App Settings > Debug settings.
1. On the Debug Settings screen, scroll down to the "Features in development" section and tap `SiteDomainsFeatureConfig` to enable the Domains feature flag.

**Scenario 1: Redeem domain with credits**

1. Open the app and select a site that has domain credits.
1. On the Main screen, tap the "Register Domain" item.
1. On the Domain Suggestions screen, select a domain and tap "Choose domain".
1. Notice the Domain Contact Form screen.

**Scenario 2: Purchase domain**

1. Open the app and select a site that has **no** domain credits.
1. On the Main screen, tap the "Domains" item under the "Configuration" section.
1. On the Domains Dashboard screen, tap the "Search for a domain" button.
1. On the Domain Suggestions screen, select a domain and tap "Choose domain".
1. Notice the Domain Checkout screen.

## Regression Notes
1. Potential unintended areas of impact
Existing domain flows.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests.

3. What automated tests I added (or what prevented me from doing so)
Updated existing unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
