### PR TITLE
Fix media picker crash when picking media from device

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -61,6 +61,7 @@
         android:largeHeap="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:requestLegacyExternalStorage="true"
+        android:preserveLegacyExternalStorage="true"
         android:theme="@style/WordPress"
         tools:replace="allowBackup, icon,android:supportsRtl"
         android:supportsRtl="true"


### PR DESCRIPTION
Fix for media picker crash with Invalid token LIMIT after upgrade to Android 11.

Added an alternative ContentResolver query for SDK 10 and above
Added **preserveLegacyExternalStorage** flag to enable safe migration of any storage items and avoid content loss just in case.

Fixes #15333 

To test:

- Tap on FAB to create a blog post
- add an image, **choose from device**.  _There shouldn't be any crash_
- After adding an image.  **Edit** image.  _There shouldn't be any crash_


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so) N.A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
