### PR TITLE
[Tooling] Update Fastfile with latest toolkit breaking changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git@github.com:wordpress-mobile/release-toolkit.git
-  revision: 4885e0fc55f445e82a30f9eeb875f0ada9e5118c
-  branch: jetpack/cleanup
+  revision: 11268a941622ea7dc0454598d04849f8eded61d0
+  branch: develop
   specs:
     fastlane-plugin-wpmreleasetoolkit (1.4.0)
       activesupport (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git@github.com:wordpress-mobile/release-toolkit.git
-  revision: 908ff74c45a3ccd022adb028b2b4a2fad296e27a
-  ref: 908ff74c45a3ccd022adb028b2b4a2fad296e27a
+  revision: b3d5a36bb3cc4f4718a9f89acf3a164ea75d33e7
+  branch: jetpack/cleanup
   specs:
     fastlane-plugin-wpmreleasetoolkit (1.4.0)
       activesupport (~> 5)
@@ -195,11 +195,11 @@ GEM
     octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.13.2)
+    oj (3.13.9)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)
-    parallel (1.20.1)
+    parallel (1.21.0)
     plist (3.6.0)
     progress_bar (1.3.3)
       highline (>= 1.6, < 3)
@@ -272,4 +272,4 @@ DEPENDENCIES
   rmagick (~> 4.1)
 
 BUNDLED WITH
-   2.2.19
+   2.2.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:wordpress-mobile/release-toolkit.git
-  revision: b3d5a36bb3cc4f4718a9f89acf3a164ea75d33e7
+  revision: 4885e0fc55f445e82a30f9eeb875f0ada9e5118c
   branch: jetpack/cleanup
   specs:
     fastlane-plugin-wpmreleasetoolkit (1.4.0)
@@ -64,7 +64,7 @@ GEM
     dotenv (2.7.6)
     emoji_regex (3.2.2)
     excon (0.85.0)
-    faraday (1.7.0)
+    faraday (1.8.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -189,7 +189,7 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
-    nokogiri (1.12.3)
+    nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     octokit (4.21.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -427,7 +427,7 @@ REPOSITORY_NAME="WordPress-Android"
     android_build_preflight() unless options[:skip_prechecks]
 
     # Create the file names
-    app = options[:app]
+    app = get_app_name_option!(options)
     version = android_get_release_version()
     build_bundle(version: version, app: app, flavor:"Vanilla", buildType: "Release")
 
@@ -460,8 +460,9 @@ REPOSITORY_NAME="WordPress-Android"
       final: false
     )
     android_build_preflight() unless (options[:skip_prechecks])
-    build_alpha(skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release], app: options[:app])
-    build_beta(skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release], app: options[:app])
+    app = get_app_name_option!(options)
+    build_alpha(skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release], app: app)
+    build_beta(skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release], app: app)
   end
 
   #####################################################################################
@@ -483,7 +484,7 @@ REPOSITORY_NAME="WordPress-Android"
     android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names
-    app = options[:app]
+    app = get_app_name_option!(options)
     version = android_get_alpha_version()
     build_bundle(version: version, app: app, flavor:"Zalpha", buildType: "Release")
 
@@ -515,7 +516,7 @@ REPOSITORY_NAME="WordPress-Android"
     android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names
-    app = options[:app]
+    app = get_app_name_option!(options)
     version = android_get_release_version()
     build_bundle(version: version, app: app, flavor:"Vanilla", buildType: "Release")
 
@@ -547,7 +548,7 @@ REPOSITORY_NAME="WordPress-Android"
     android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names
-    app = options[:app]
+    app = get_app_name_option!(options)
     version = android_get_release_version()
     build_bundle(version: version, app: app, flavor:"Zalpha", buildType: "Debug")
 
@@ -576,7 +577,7 @@ REPOSITORY_NAME="WordPress-Android"
   desc "Upload Build to Play Store"
   lane :upload_build_to_play_store do |options|
 
-    app = options[:app]
+    app = get_app_name_option!(options)
     package_name = app.downcase == "jetpack" ? JP_PACKAGE_NAME : WP_PACKAGE_NAME
 
     version = options[:version]
@@ -857,7 +858,7 @@ REPOSITORY_NAME="WordPress-Android"
   lane :build_bundle do | options |
     # Create the file names
     version = options[:version]
-    app = options[:app]
+    app = get_app_name_option!(options)
 
     if version.nil?
       UI.message("Version specified for #{app} bundle is nil. Skipping ahead")
@@ -942,7 +943,7 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane create_gh_release app:jetpack version:{name:12.3-rc-4} prerelease:true # Includes only existing asset for JPBeta 12.3-rc-4
   #####################################################################################
   lane :create_gh_release do |options|
-    apps = options[:app].nil? ? ['wordpress', 'jetpack'] : [options[:app]]
+    apps = options[:app].nil? ? ['wordpress', 'jetpack'] : [get_app_name_option!(options)]
     versions = options[:version].nil? ? [android_get_alpha_version(), android_get_release_version()] : [options[:version]]
 
     release_assets = apps.flat_map do |app|
@@ -978,7 +979,7 @@ REPOSITORY_NAME="WordPress-Android"
 #####################################################################################
 
   private_lane :delete_old_changelogs do |options|
-    app = options[:app] || 'wordpress'
+    app = get_app_name_option!(options)
     app_values = APP_SPECIFIC_VALUES[app.to_sym]
     Dir.glob(File.join(app_values[:metadata_dir], 'android', '*', 'changelogs', '*')).each do |file|
       File.delete(file) if Integer(File.basename(file, ".*")) < Integer(options[:build]) rescue puts "Cannot delete file #{file}"
@@ -999,6 +1000,12 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   # Utils
   #####################################################################################
+  def get_app_name_option!(options)
+    app = options[:app].downcase
+    UI.user_error!("Invalid 'app' parameter '#{app}'. Expected 'wordpress' or 'jetpack'") unless ['wordpress', 'jetpack'].include?(app)
+    return app
+  end
+
   def release_notes_path(app)
     paths = {
       wordpress: "#{ENV["PROJECT_ROOT_FOLDER"]}WordPress/metadata/release_notes.txt",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -785,7 +785,7 @@ REPOSITORY_NAME="WordPress-Android"
 
   desc "Import strings from binary dependencies"
   lane :localize_binary_deps do |options|
-    binary_imported_libraries.each do  | lib |
+    binary_imported_libraries.each do |lib|
       download_path = android_download_file_by_version(
         library_name: lib[:name],
         import_key: lib[:import_key],
@@ -986,7 +986,7 @@ REPOSITORY_NAME="WordPress-Android"
   private_lane :cleanup_release_files do |options|
     files = options[:files]
 
-    files.each do | f |
+    files.each do |f|
       File.open(f, "w") {}
       sh("git add #{f}")
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -139,7 +139,6 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Creates a new release branch from the current develop"
   lane :code_freeze do | options |
-    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
     old_version = android_codefreeze_prechecks(skip_confirm: options[:skip_confirm])
 
     android_bump_version_release()
@@ -188,7 +187,6 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Trigger a release build for a given app after code freeze"
   lane :complete_code_freeze do | options |
-    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
     android_completecodefreeze_prechecks(skip_confirm: options[:skip_confirm])
     new_version = android_get_app_version()
     trigger_release_build(branch_to_build: "release/#{new_version}")
@@ -308,7 +306,6 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Updates a release branch for a new beta release"
   lane :new_beta_release do |options|
-    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
     android_betabuild_prechecks(base_version: options[:base_version], skip_confirm: options[:skip_confirm])
     send_strings_for_translation()
     download_translations()
@@ -332,7 +329,6 @@ REPOSITORY_NAME="WordPress-Android"
   lane :new_hotfix_release do |options|
     hotfix_version = options[:version_name] || UI.input('Version number for the new hotfix?')
     previous_tag = android_hotfix_prechecks(version_name: hotfix_version, skip_confirm: options[:skip_confirm])
-    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
     android_bump_version_hotfix(previous_version_name: previous_tag, version_name: hotfix_version, version_code: options[:version_code])
   end
 
@@ -349,7 +345,6 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Finalizes a hotfix release by triggering a release build"
   lane :finalize_hotfix_release do |options|
-    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
     new_version = android_get_app_version()
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end
@@ -368,7 +363,6 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Updates store metadata and runs the release checks"
   lane :finalize_release do | options |
-    # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
     UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix()
 
     android_finalize_prechecks(skip_confirm: options[:skip_confirm])
@@ -424,7 +418,6 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_and_upload_release do |options|
-    # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
     android_build_prechecks(
       skip_confirm: options[:skip_confirm],
       alpha: false,
@@ -460,7 +453,6 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_and_upload_pre_releases do |options|
-    # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
     android_build_prechecks(
       skip_confirm: options[:skip_confirm],
       alpha: true,
@@ -487,7 +479,6 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_alpha do |options|
-    # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
     android_build_prechecks(skip_confirm: options[:skip_confirm], alpha: true) unless (options[:skip_prechecks])
     android_build_preflight() unless (options[:skip_prechecks])
 
@@ -520,7 +511,6 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_beta do |options|
-    # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
     android_build_prechecks(skip_confirm: options[:skip_confirm], beta: true) unless (options[:skip_prechecks])
     android_build_preflight() unless (options[:skip_prechecks])
 
@@ -553,7 +543,6 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   desc "Builds and updates for internal testing"
   lane :build_internal do |options|
-    # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
     android_build_prechecks(skip_confirm: options[:skip_confirm]) unless (options[:skip_prechecks])
     android_build_preflight() unless (options[:skip_prechecks])
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -309,7 +309,7 @@ REPOSITORY_NAME="WordPress-Android"
   desc "Updates a release branch for a new beta release"
   lane :new_beta_release do |options|
     # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
-    android_betabuild_prechecks(options.merge({app: 'wp_jp'}))
+    android_betabuild_prechecks(base_version: options[:base_version], skip_confirm: options[:skip_confirm])
     send_strings_for_translation()
     download_translations()
     android_bump_version_beta(app: 'wp_jp')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -138,7 +138,7 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane code_freeze skip_confirm:true
   #####################################################################################
   desc "Creates a new release branch from the current develop"
-  lane :code_freeze do | options |
+  lane :code_freeze do |options|
     old_version = android_codefreeze_prechecks(skip_confirm: options[:skip_confirm])
 
     android_bump_version_release()
@@ -186,7 +186,7 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane complete_code_freeze skip_confirm:true
   #####################################################################################
   desc "Trigger a release build for a given app after code freeze"
-  lane :complete_code_freeze do | options |
+  lane :complete_code_freeze do |options|
     android_completecodefreeze_prechecks(skip_confirm: options[:skip_confirm])
     new_version = android_get_app_version()
     trigger_release_build(branch_to_build: "release/#{new_version}")
@@ -362,7 +362,7 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane finalize_release skip_confirm:true
   #####################################################################################
   desc "Updates store metadata and runs the release checks"
-  lane :finalize_release do | options |
+  lane :finalize_release do |options|
     UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix()
 
     android_finalize_prechecks(skip_confirm: options[:skip_confirm])
@@ -615,7 +615,7 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane trigger_release_build branch_to_build:<branch_name>
   #
   #####################################################################################
-  lane :trigger_release_build do | options |
+  lane :trigger_release_build do |options|
     circleci_trigger_job(
       circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"],
       repository: REPOSITORY_NAME,
@@ -638,7 +638,7 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane upload_and_replace_screenshots_in_play_store
   #####################################################################################
   desc "Upload Screenshots to Play Store and Replaces the existing ones"
-  lane :upload_and_replace_screenshots_in_play_store do | options |
+  lane :upload_and_replace_screenshots_in_play_store do |options|
     upload_to_play_store(
       package_name: 'org.wordpress.android',
       skip_upload_apk: true,
@@ -761,13 +761,13 @@ REPOSITORY_NAME="WordPress-Android"
     },
   ]
 
-  private_lane :send_strings_for_translation do | options |
+  private_lane :send_strings_for_translation do |options|
     sh("cd .. && mkdir -p #{update_strings_path} && cp #{main_strings_path} #{update_strings_path} && git add #{update_strings_path}strings.xml")
     sh("git diff-index --quiet HEAD || git commit -m \"Send strings to translation.\"")
     sh("git push origin HEAD")
   end
 
-  private_lane :commit_strings do | options |
+  private_lane :commit_strings do |options|
     if (options[:auto_commit]) then
        sh("cd .. && git add #{main_strings_path}")
        sh("git commit -m 'Update strings for translation'")
@@ -780,14 +780,14 @@ REPOSITORY_NAME="WordPress-Android"
 
 
   desc "Merge libraries strings files into the main app one"
-  lane :localize_libs do | options |
+  lane :localize_libs do |options|
     if (an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path)) then
       commit_strings(options)
     end
   end
 
   desc "Import strings from binary dependencies"
-  lane :localize_binary_deps do | options |
+  lane :localize_binary_deps do |options|
     binary_imported_libraries.each do  | lib |
       download_path = android_download_file_by_version(
         library_name: lib[:name],
@@ -826,7 +826,7 @@ REPOSITORY_NAME="WordPress-Android"
   # This lane verifies that new strings which have been added to the main strings.xml
   # and which belongs to features of subtrees and submodules have also been added
   # to the library strings.xml file.
-  lane :validate_submodules_strings do | options |
+  lane :validate_submodules_strings do |options|
     pr_number = options[:pr_number]
     pr_number = options[:pr_url].split('/').last unless options[:pr_url].nil?
 
@@ -842,7 +842,7 @@ REPOSITORY_NAME="WordPress-Android"
 # Helper Lanes
 ########################################################################
   desc "Get a list of pull request from `start_tag` to the current state"
-  lane :get_pullrequests_list do | options |
+  lane :get_pullrequests_list do |options|
     get_prs_list(repository:GHHELPER_REPO, milestone:"#{options[:milestone]}", report_path:"#{File.expand_path('~')}/wpandroid_prs_list.txt")
   end
 
@@ -855,7 +855,7 @@ REPOSITORY_NAME="WordPress-Android"
   # bundle exec fastlane build_bundle app:<wordpress|jetpack> version:<version> flavor:<flavor> buildType:<debug|release> [skip_lint:<true|false>]
   #####################################################################################
   desc "Builds an app bundle"
-  lane :build_bundle do | options |
+  lane :build_bundle do |options|
     # Create the file names
     version = options[:version]
     app = get_app_name_option!(options)
@@ -986,7 +986,7 @@ REPOSITORY_NAME="WordPress-Android"
     end
   end
 
-  private_lane :cleanup_release_files do | options |
+  private_lane :cleanup_release_files do |options|
     files = options[:files]
 
     files.each do | f |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -429,8 +429,7 @@ REPOSITORY_NAME="WordPress-Android"
       skip_confirm: options[:skip_confirm],
       alpha: false,
       beta: false,
-      final: true,
-      app: 'wp_jp'
+      final: true
     )
     android_build_preflight() unless options[:skip_prechecks]
 
@@ -466,8 +465,7 @@ REPOSITORY_NAME="WordPress-Android"
       skip_confirm: options[:skip_confirm],
       alpha: true,
       beta: true,
-      final: false,
-      app: 'wp_jp'
+      final: false
     )
     android_build_preflight() unless (options[:skip_prechecks])
     build_alpha(skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release], app: options[:app])
@@ -490,7 +488,7 @@ REPOSITORY_NAME="WordPress-Android"
   desc "Builds and updates for distribution"
   lane :build_alpha do |options|
     # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
-    android_build_prechecks(skip_confirm: options[:skip_confirm], alpha: true, app: 'wp_jp') unless (options[:skip_prechecks])
+    android_build_prechecks(skip_confirm: options[:skip_confirm], alpha: true) unless (options[:skip_prechecks])
     android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names
@@ -523,7 +521,7 @@ REPOSITORY_NAME="WordPress-Android"
   desc "Builds and updates for distribution"
   lane :build_beta do |options|
     # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
-    android_build_prechecks(skip_confirm: options[:skip_confirm], beta: true, app: 'wp_jp') unless (options[:skip_prechecks])
+    android_build_prechecks(skip_confirm: options[:skip_confirm], beta: true) unless (options[:skip_prechecks])
     android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names
@@ -556,7 +554,7 @@ REPOSITORY_NAME="WordPress-Android"
   desc "Builds and updates for internal testing"
   lane :build_internal do |options|
     # TODO: remove 'app' parameter from this toolkit action. For now since it's not used anymore as JP and WP are being unified, use a dummy value to not break API
-    android_build_prechecks(skip_confirm: options[:skip_confirm], app: 'wp_jp') unless (options[:skip_prechecks])
+    android_build_prechecks(skip_confirm: options[:skip_confirm]) unless (options[:skip_prechecks])
     android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -142,7 +142,7 @@ REPOSITORY_NAME="WordPress-Android"
     # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
     old_version = android_codefreeze_prechecks(options.merge({app: 'wp_jp'}))
 
-    android_bump_version_release(app: 'wp_jp')
+    android_bump_version_release()
     new_version = android_get_app_version(app: 'wp_jp')
 
     # need to get prs list before version update to frozen tag

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -852,7 +852,7 @@ REPOSITORY_NAME="WordPress-Android"
   # This lane builds an app bundle
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_bundle [skip_confirm:<skip confirm>]
+  # bundle exec fastlane build_bundle app:<wordpress|jetpack> version:<version> flavor:<flavor> buildType:<debug|release> [skip_lint:<true|false>]
   #####################################################################################
   desc "Builds an app bundle"
   lane :build_bundle do | options |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -371,7 +371,7 @@ REPOSITORY_NAME="WordPress-Android"
     # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
     UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix()
 
-    android_finalize_prechecks(options.merge({app: 'wp_jp'}))
+    android_finalize_prechecks(skip_confirm: options[:skip_confirm])
     configure_apply(force: is_ci)
 
     UI.message('Checking app strings translation status...')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -140,7 +140,7 @@ REPOSITORY_NAME="WordPress-Android"
   desc "Creates a new release branch from the current develop"
   lane :code_freeze do | options |
     # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
-    old_version = android_codefreeze_prechecks(options.merge({app: 'wp_jp'}))
+    old_version = android_codefreeze_prechecks(skip_confirm: options[:skip_confirm])
 
     android_bump_version_release()
     new_version = android_get_app_version(app: 'wp_jp')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -312,7 +312,7 @@ REPOSITORY_NAME="WordPress-Android"
     android_betabuild_prechecks(base_version: options[:base_version], skip_confirm: options[:skip_confirm])
     send_strings_for_translation()
     download_translations()
-    android_bump_version_beta(app: 'wp_jp')
+    android_bump_version_beta()
     new_version = android_get_app_version(app: 'wp_jp')
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -77,21 +77,18 @@ JP_RELEASE_NOTES_LOCALES = ALL_LOCALES
 APP_SPECIFIC_VALUES = {
   wordpress: {
     metadata_dir: 'metadata',
-    gp_url: 'https://translate.wordpress.org/projects/apps/android/release-notes/'
+    gp_url: 'https://translate.wordpress.org/projects/apps/android/release-notes/',
+    package_name: 'org.wordpress.android',
+    bundle_name_prefix: 'wpandroid'
   },
   jetpack: {
     metadata_dir: 'jetpack_metadata',
-    gp_url: 'https://translate.wordpress.com/projects/jetpack/apps/android/release-notes/'
+    gp_url: 'https://translate.wordpress.com/projects/jetpack/apps/android/release-notes/',
+    package_name: 'com.jetpack.android',
+    bundle_name_prefix: 'jpandroid'
   }
 }.freeze
 
-# Global app vars (TODO: move them to APP_SPECIFIC_VALUES)
-
-WP_PACKAGE_NAME = "org.wordpress.android"
-WP_PREFIX = "wpandroid"
-
-JP_PACKAGE_NAME = "com.jetpack.android"
-JP_PREFIX = "jpandroid"
 
 UPLOAD_TO_PLAY_STORE_JSON_KEY = File.join(Dir.home, '.configure', 'wordpress-android', 'secrets', 'google-upload-credentials.json')
 
@@ -578,7 +575,7 @@ REPOSITORY_NAME="WordPress-Android"
   lane :upload_build_to_play_store do |options|
 
     app = get_app_name_option!(options)
-    package_name = app.downcase == "jetpack" ? JP_PACKAGE_NAME : WP_PACKAGE_NAME
+    package_name = APP_SPECIFIC_VALUES[app.to_sym][:package_name]
 
     version = options[:version]
 
@@ -865,8 +862,8 @@ REPOSITORY_NAME="WordPress-Android"
       next
     end
 
-    prefix = app.downcase == "jetpack" ? JP_PREFIX : WP_PREFIX
-    name="#{prefix}-#{version["name"]}.aab"
+    prefix = APP_SPECIFIC_VALUES[app.to_sym][:bundle_name_prefix]
+    name = "#{prefix}-#{version["name"]}.aab"
 
     aab_file="org.wordpress.android-#{app}-#{options[:flavor]}-#{options[:buildType]}.aab".downcase
     output_dir="WordPress/build/outputs/bundle/"
@@ -1023,7 +1020,7 @@ REPOSITORY_NAME="WordPress-Android"
   end
 
   def bundle_file_path(app, version)
-    prefix = app.downcase == "jetpack" ? JP_PREFIX : WP_PREFIX
+    prefix = APP_SPECIFIC_VALUES[app.to_sym][:bundle_name_prefix]
     project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
     File.join(project_root, "build", "#{prefix}-#{version["name"]}.aab")
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -438,7 +438,7 @@ REPOSITORY_NAME="WordPress-Android"
     version = android_get_release_version()
     build_bundle(version: version, app: app, flavor:"Vanilla", buildType: "Release")
 
-    upload_build_to_play_store(version: version, track: "production", app: app)
+    upload_build_to_play_store(app: app, version: version, track: "production")
 
     if (options[:create_release])
       create_gh_release(app: app, version: version)
@@ -497,7 +497,7 @@ REPOSITORY_NAME="WordPress-Android"
     build_bundle(version: version, app: app, flavor:"Zalpha", buildType: "Release")
 
     if (options[:upload_to_play_store]) then
-       upload_build_to_play_store(version: version, track: "alpha", app: app)
+       upload_build_to_play_store(app: app, version: version, track: "alpha")
     end
 
     if (options[:create_release])
@@ -530,7 +530,7 @@ REPOSITORY_NAME="WordPress-Android"
     build_bundle(version: version, app: app, flavor:"Vanilla", buildType: "Release")
 
     if (options[:upload_to_play_store]) then
-       upload_build_to_play_store(version: version, track: "beta", app: app)
+       upload_build_to_play_store(app: app, version: version, track: "beta")
     end
 
     if (options[:create_release])
@@ -563,7 +563,7 @@ REPOSITORY_NAME="WordPress-Android"
     build_bundle(version: version, app: app, flavor:"Zalpha", buildType: "Debug")
 
     if (options[:upload_to_play_store]) then
-       upload_build_to_play_store(version: version, track: "internal", app: app)
+       upload_build_to_play_store(app: app, version: version, track: "internal")
     end
 
     if (options[:create_release])
@@ -577,12 +577,12 @@ REPOSITORY_NAME="WordPress-Android"
   # This lane uploads the build to Play Store for the given version to the given track
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane upload_build_to_play_store version:<version> track:<track>
+  # bundle exec fastlane upload_build_to_play_store app:<wordpress|jetpack> version:<version> track:<track>
   #
   # Example:
-  # bundle exec fastlane upload_build_to_play_store version:15.0 track:production
-  # bundle exec fastlane upload_build_to_play_store version:alpha-228 track:alpha
-  # bundle exec fastlane upload_build_to_play_store version:15.0-rc-1 track:beta
+  # bundle exec fastlane upload_build_to_play_store app:wordpress version:15.0 track:production
+  # bundle exec fastlane upload_build_to_play_store app:wordpress version:alpha-228 track:alpha
+  # bundle exec fastlane upload_build_to_play_store app:jetpack version:15.0-rc-1 track:beta
   #####################################################################################
   desc "Upload Build to Play Store"
   lane :upload_build_to_play_store do |options|
@@ -867,7 +867,7 @@ REPOSITORY_NAME="WordPress-Android"
   desc "Builds an app bundle"
   lane :build_bundle do | options |
     # Create the file names
-    version=options[:version]
+    version = options[:version]
     app = options[:app]
 
     if version.nil?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -189,7 +189,7 @@ REPOSITORY_NAME="WordPress-Android"
   desc "Trigger a release build for a given app after code freeze"
   lane :complete_code_freeze do | options |
     # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
-    android_completecodefreeze_prechecks(options.merge({app: 'wp_jp'}))
+    android_completecodefreeze_prechecks(skip_confirm: options[:skip_confirm])
     new_version = android_get_app_version(app: 'wp_jp')
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -998,8 +998,9 @@ REPOSITORY_NAME="WordPress-Android"
   # Utils
   #####################################################################################
   def get_app_name_option!(options)
-    app = options[:app].downcase
-    UI.user_error!("Invalid 'app' parameter '#{app}'. Expected 'wordpress' or 'jetpack'") unless ['wordpress', 'jetpack'].include?(app)
+    app = options[:app]&.downcase
+    UI.user_error!("Missing 'app' parameter. Expected 'app:wordpress' or 'app:jetpack'") if app.nil?
+    UI.user_error!("Invalid 'app' parameter #{app.inspect}. Expected 'wordpress' or 'jetpack'") unless ['wordpress', 'jetpack'].include?(app)
     return app
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -394,7 +394,7 @@ REPOSITORY_NAME="WordPress-Android"
 
     download_translations()
 
-    android_bump_version_final_release(app: 'wp_jp')
+    android_bump_version_final_release()
     version = android_get_release_version(app: 'wp_jp')
     download_metadata_strings(version: version["name"], build_number: version["code"])
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -448,10 +448,10 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   # build_and_upload_pre_releases
   # -----------------------------------------------------------------------------------
-  # This lane builds the app it for both internal and external distribution and uploads them
+  # This lane builds the app for both internal and external distribution and uploads them
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_pre_releases [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
+  # bundle exec fastlane build_and_upload_pre_releases app:<wordpress|jetpack> [skip_confirm:<true|false>] [skip_prechecks:<true|false>] <[create_release:<true|false>]
   #
   # Example:
   # bundle exec fastlane build_and_upload_pre_releases
@@ -475,7 +475,7 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   # build_alpha
   # -----------------------------------------------------------------------------------
-  # This lane builds the app it for internal testing and optionally uploads it
+  # This lane builds the app for internal testing and optionally uploads it
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane build_alpha app:<wordpress|jetpack> [skip_confirm:<true|false>] [upload_to_play_store:<true|false>] [create_release:<true|false>]
@@ -508,7 +508,7 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   # build_beta
   # -----------------------------------------------------------------------------------
-  # This lane builds the app it for internal testing and optionally uploads it
+  # This lane builds the app for internal testing and optionally uploads it
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane build_beta app:<wordpress|jetpack> [skip_confirm:<true|false>] [upload_to_play_store:<true|false>] [create_release:<true|false>]
@@ -544,7 +544,7 @@ REPOSITORY_NAME="WordPress-Android"
   # This lane builds the app for restricted internal testing, and optionally uploads it to PlayStore's Internal track
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_internal app:<wordpress|jetpack>] [skip_confirm:<true|false>] [upload_to_play_store:<true|false>] [create_release:<true|false>]
+  # bundle exec fastlane build_internal app:<wordpress|jetpack> [skip_confirm:<true|false>] [upload_to_play_store:<true|false>] [create_release:<true|false>]
   #
   # Example:
   # bundle exec fastlane build_internal app:wordpress

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -395,7 +395,7 @@ REPOSITORY_NAME="WordPress-Android"
     download_translations()
 
     android_bump_version_final_release()
-    version = android_get_release_version(app: 'wp_jp')
+    version = android_get_release_version()
     download_metadata_strings(version: version["name"], build_number: version["code"])
 
     # Wrap up
@@ -435,7 +435,7 @@ REPOSITORY_NAME="WordPress-Android"
 
     # Create the file names
     app = options[:app]
-    version = android_get_release_version(app: 'wp_jp')
+    version = android_get_release_version()
     build_bundle(version: version, app: app, flavor:"Vanilla", buildType: "Release")
 
     upload_build_to_play_store(version: version, track: "production", app: app)
@@ -526,7 +526,7 @@ REPOSITORY_NAME="WordPress-Android"
 
     # Create the file names
     app = options[:app]
-    version = android_get_release_version(app: 'wp_jp')
+    version = android_get_release_version()
     build_bundle(version: version, app: app, flavor:"Vanilla", buildType: "Release")
 
     if (options[:upload_to_play_store]) then
@@ -559,7 +559,7 @@ REPOSITORY_NAME="WordPress-Android"
 
     # Create the file names
     app = options[:app]
-    version = android_get_release_version(app: 'wp_jp')
+    version = android_get_release_version()
     build_bundle(version: version, app: app, flavor:"Zalpha", buildType: "Debug")
 
     if (options[:upload_to_play_store]) then
@@ -954,7 +954,7 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   lane :create_gh_release do |options|
     apps = options[:app].nil? ? ['wordpress', 'jetpack'] : [options[:app]]
-    versions = options[:version].nil? ? [android_get_alpha_version(), android_get_release_version(app: 'wp_jp')] : [options[:version]]
+    versions = options[:version].nil? ? [android_get_alpha_version(), android_get_release_version()] : [options[:version]]
 
     release_assets = apps.flat_map do |app|
       versions.flat_map { |vers| bundle_file_path(app, vers) }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -493,7 +493,7 @@ REPOSITORY_NAME="WordPress-Android"
 
     # Create the file names
     app = options[:app]
-    version = android_get_alpha_version(app: 'wp_jp')
+    version = android_get_alpha_version()
     build_bundle(version: version, app: app, flavor:"Zalpha", buildType: "Release")
 
     if (options[:upload_to_play_store]) then
@@ -954,7 +954,7 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   lane :create_gh_release do |options|
     apps = options[:app].nil? ? ['wordpress', 'jetpack'] : [options[:app]]
-    versions = options[:version].nil? ? [android_get_alpha_version(app: 'wp_jp'), android_get_release_version(app: 'wp_jp')] : [options[:version]]
+    versions = options[:version].nil? ? [android_get_alpha_version(), android_get_release_version(app: 'wp_jp')] : [options[:version]]
 
     release_assets = apps.flat_map do |app|
       versions.flat_map { |vers| bundle_file_path(app, vers) }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -333,7 +333,7 @@ REPOSITORY_NAME="WordPress-Android"
     hotfix_version = options[:version_name] || UI.input('Version number for the new hotfix?')
     previous_tag = android_hotfix_prechecks(version_name: hotfix_version, skip_confirm: options[:skip_confirm])
     # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
-    android_bump_version_hotfix(previous_version_name: previous_tag, version_name: hotfix_version, version_code: options[:version_code], app: 'wp_jp')
+    android_bump_version_hotfix(previous_version_name: previous_tag, version_name: hotfix_version, version_code: options[:version_code])
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -143,7 +143,7 @@ REPOSITORY_NAME="WordPress-Android"
     old_version = android_codefreeze_prechecks(skip_confirm: options[:skip_confirm])
 
     android_bump_version_release()
-    new_version = android_get_app_version(app: 'wp_jp')
+    new_version = android_get_app_version()
 
     # need to get prs list before version update to frozen tag
     get_prs_list(repository: GHHELPER_REPO, milestone: new_version, report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{new_version}.txt")
@@ -190,7 +190,7 @@ REPOSITORY_NAME="WordPress-Android"
   lane :complete_code_freeze do | options |
     # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
     android_completecodefreeze_prechecks(skip_confirm: options[:skip_confirm])
-    new_version = android_get_app_version(app: 'wp_jp')
+    new_version = android_get_app_version()
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 
@@ -313,7 +313,7 @@ REPOSITORY_NAME="WordPress-Android"
     send_strings_for_translation()
     download_translations()
     android_bump_version_beta()
-    new_version = android_get_app_version(app: 'wp_jp')
+    new_version = android_get_app_version()
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 
@@ -350,7 +350,7 @@ REPOSITORY_NAME="WordPress-Android"
   desc "Finalizes a hotfix release by triggering a release build"
   lane :finalize_hotfix_release do |options|
     # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
-    new_version = android_get_app_version(app: 'wp_jp')
+    new_version = android_get_app_version()
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -429,7 +429,7 @@ REPOSITORY_NAME="WordPress-Android"
     # Create the file names
     app = get_app_name_option!(options)
     version = android_get_release_version()
-    build_bundle(version: version, app: app, flavor:"Vanilla", buildType: "Release")
+    build_bundle(app: app, version: version, flavor:"Vanilla", buildType: "Release")
 
     upload_build_to_play_store(app: app, version: version, track: "production")
 
@@ -461,8 +461,8 @@ REPOSITORY_NAME="WordPress-Android"
     )
     android_build_preflight() unless (options[:skip_prechecks])
     app = get_app_name_option!(options)
-    build_alpha(skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release], app: app)
-    build_beta(skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release], app: app)
+    build_alpha(app: app, skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release])
+    build_beta(app: app, skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release])
   end
 
   #####################################################################################
@@ -486,7 +486,7 @@ REPOSITORY_NAME="WordPress-Android"
     # Create the file names
     app = get_app_name_option!(options)
     version = android_get_alpha_version()
-    build_bundle(version: version, app: app, flavor:"Zalpha", buildType: "Release")
+    build_bundle(app: app, version: version, flavor:"Zalpha", buildType: "Release")
 
     if (options[:upload_to_play_store]) then
        upload_build_to_play_store(app: app, version: version, track: "alpha")
@@ -518,7 +518,7 @@ REPOSITORY_NAME="WordPress-Android"
     # Create the file names
     app = get_app_name_option!(options)
     version = android_get_release_version()
-    build_bundle(version: version, app: app, flavor:"Vanilla", buildType: "Release")
+    build_bundle(app: app, version: version, flavor:"Vanilla", buildType: "Release")
 
     if (options[:upload_to_play_store]) then
        upload_build_to_play_store(app: app, version: version, track: "beta")
@@ -550,7 +550,7 @@ REPOSITORY_NAME="WordPress-Android"
     # Create the file names
     app = get_app_name_option!(options)
     version = android_get_release_version()
-    build_bundle(version: version, app: app, flavor:"Zalpha", buildType: "Debug")
+    build_bundle(app: app, version: version, flavor:"Zalpha", buildType: "Debug")
 
     if (options[:upload_to_play_store]) then
        upload_build_to_play_store(app: app, version: version, track: "internal")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -369,7 +369,7 @@ REPOSITORY_NAME="WordPress-Android"
   desc "Updates store metadata and runs the release checks"
   lane :finalize_release do | options |
     # TODO: remove 'app' parameter entirely in toolkit. For now just use a dummy value to not break API until toolkit is updated.
-    UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix(app: 'wp_jp')
+    UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix()
 
     android_finalize_prechecks(options.merge({app: 'wp_jp'}))
     configure_apply(force: is_ci)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -195,8 +195,8 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   # update_appstore_strings
   # -----------------------------------------------------------------------------------
-  # This lane gets the data from the txt files in the WordPress/metadata/ and
-  # WordPress/jetpack_metadata folders and updates the .po files that is then
+  # This lane gets the data from the txt files in the `WordPress/metadata/` and
+  # `WordPress/jetpack_metadata/` folders and updates the `.po` files that is then
   # picked by GlotPress for translations.
   # -----------------------------------------------------------------------------------
   # Usage:
@@ -214,8 +214,8 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   # update_wordpress_appstore_strings
   # -----------------------------------------------------------------------------------
-  # This lane gets the data from the txt files in the WordPress/metadata/ folder
-  # and updates the .po file that is then picked by GlotPress for translations.
+  # This lane gets the data from the txt files in the `WordPress/metadata/` folder
+  # and updates the `.po` file that is then picked by GlotPress for translations.
   # -----------------------------------------------------------------------------------
   # Usage:
   # fastlane update_wordpress_appstore_strings version:<version>
@@ -260,8 +260,8 @@ REPOSITORY_NAME="WordPress-Android"
   #####################################################################################
   # update_jetpack_appstore_strings
   # -----------------------------------------------------------------------------------
-  # This lane gets the data from the txt files in the WordPress/jetpack_metadata/ folder
-  # and updates the .po file that is then picked by GlotPress for translations.
+  # This lane gets the data from the txt files in the `WordPress/jetpack_metadata/` folder
+  # and updates the `.po` file that is then picked by GlotPress for translations.
   # -----------------------------------------------------------------------------------
   # Usage:
   # fastlane update_jetpack_appstore_strings version:<version>

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-# Pointing to the result of merging https://github.com/wordpress-mobile/release-toolkit/pull/298 until we're ready to do a breaking release.
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', ref: '908ff74c45a3ccd022adb028b2b4a2fad296e27a'
+# Pointing to the branch with pending breaking changes just to be sure it works as expected in the clients before doing the major version
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', branch: 'jetpack/cleanup'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-# Pointing to the branch with pending breaking changes just to be sure it works as expected in the clients before doing the major version
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', branch: 'jetpack/cleanup'
+# Pointing to develop which contains pending breaking changes from #300, so we use it for a while to be sure it works as expected in the clients before doing the official major version release.
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', branch: 'develop'


### PR DESCRIPTION
This is part of project ref paaHJt-2sc-p2

⚠️  This PR targets the `release/18.4` branch as I'm hoping to get it merged before this sprint's store submission in order to take the occasion to test it both for 18.4's `finalize_release` and for 18.5's `code_freeze` lanes, so that we can check nothing breaks before officially doing the major release of the toolkit.

---

## What it does

This PR points to the breaking changes introduced in https://github.com/wordpress-mobile/release-toolkit/pull/300, in preparation for the next major version of the release-toolkit.

It updates the `Fastfile` accordingly to fix the call sites of the actions that have been changed in the toolkit:

 - Removes the dummy `app: 'wp_jp'` parameters in calls for those actions.
 - Add a `get_app_name_option!` helper method which checks, for the lanes where the `app:` parameter is still needed (especially the `build_*` "internal" lanes), that the passed parameter is a valid one (either `wordpress` or `jetpack`)
 - Removes the related `# TODO` notes
 - Fix some documentation comments
 - Additional cleanup: move top-level constants like `{WP,JP}_PREFIX` and `{WP,JP}_PACKAGE_NAME` to the dedicated `APP_SPECIFIC_VALUES`

## To Test

As usual with those changes about `Fastfile`, it's super tricky to test without creating side-effects and actual releases.
Some ideas of what we could test still:

 - Run `rubocop` on the `fastlane/Fastfile`, not much to check the style violations (there are many, I actually plan to submit a subsequent PR about this on top of those changes later, but better keep those separate for review-ability), but mostly to check that there are no syntax errors and `rubocop` can read the structure of the file (i.e. there's no missing `end` for each matching `do`, etc)
 - Run `bundle exec fastlane build_internal skip_prechecks:true` and check that the lane complains that the `app:` parameter is missing
 - Run `bundle exec fastlane build_internal app:foo skip_prechecks:true` and check that the lane complains that the `app:` parameter is invalid
 - Run `bundle exec fastlane build_internal app:wordpress skip_prechecks:true` and check that the lane doesn't crash, and lints + builds wordpress Zalpha Debug
 - Run `bundle exec fastlane build_alpha app:wordpress skip_prechecks:true` and check that the lane doesn't crash, and lints + builds wordpress Zalpha Release
 - Run `bundle exec fastlane build_beta app:wordpress skip_prechecks:true` and check that the lane doesn't crash, and lints + builds wordpress Vanilla Release
