### PR TITLE
Feature/15354 show redirect banner on domain suggestions screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.domains
 
 import android.os.Bundle
-import android.text.Html
 import android.view.View
 import androidx.core.text.HtmlCompat
 import androidx.core.view.isGone
@@ -19,7 +18,6 @@ import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.Companion.DOMAIN_REGISTRATION_PURPOSE_KEY
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
-import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.domains
 
 import android.os.Bundle
 import android.view.View
-import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
 import androidx.core.text.parseAsHtml
 import androidx.core.view.isGone
 import androidx.core.view.isInvisible

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.ui.domains
 
 import android.os.Bundle
+import android.text.Html
 import android.view.View
+import androidx.core.text.HtmlCompat
 import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
@@ -17,6 +19,7 @@ import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.Companion.DOMAIN_REGISTRATION_PURPOSE_KEY
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
+import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -65,6 +68,16 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
 
     private fun DomainSuggestionsFragmentBinding.setupObservers() {
         viewModel.isIntroVisible.observe(viewLifecycleOwner) { introductionContainer.isVisible = it }
+        viewModel.showRedirectMessage.observe(viewLifecycleOwner) {
+            it?.let {
+                introductionContainer.isVisible = false
+                redirectMessageCard.isVisible = true
+                redirectMessage.text = HtmlCompat.fromHtml(
+                        getString(R.string.domains_free_plan_get_your_domain_caption, it),
+                        HtmlCompat.FROM_HTML_MODE_LEGACY
+                )
+            }
+        }
         viewModel.suggestionsLiveData.observe(viewLifecycleOwner) { listState ->
             val isLoading = listState is ListState.Loading<*>
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -2,7 +2,8 @@ package org.wordpress.android.ui.domains
 
 import android.os.Bundle
 import android.view.View
-import androidx.core.text.HtmlCompat
+import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
+import androidx.core.text.parseAsHtml
 import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
@@ -68,12 +69,12 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
         viewModel.isIntroVisible.observe(viewLifecycleOwner) { introductionContainer.isVisible = it }
         viewModel.showRedirectMessage.observe(viewLifecycleOwner) {
             it?.let {
-                introductionContainer.isVisible = false
-                redirectMessageCard.isVisible = true
-                redirectMessage.text = HtmlCompat.fromHtml(
-                        getString(R.string.domains_free_plan_get_your_domain_caption, it),
-                        HtmlCompat.FROM_HTML_MODE_LEGACY
-                )
+                introLine1.isVisible = false
+                introLine2.isVisible = false
+
+                redirectMessage.isVisible = true
+                redirectDivider.isVisible = true
+                redirectMessage.text = getString(R.string.domains_free_plan_get_your_domain_caption, it).parseAsHtml()
             }
         }
         viewModel.suggestionsLiveData.observe(viewLifecycleOwner) { listState ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -60,6 +60,9 @@ class DomainSuggestionsViewModel @Inject constructor(
     private val _isIntroVisible = MutableLiveData(true)
     val isIntroVisible: LiveData<Boolean> = _isIntroVisible
 
+    private val _showRedirectMessage = MutableLiveData<String?>()
+    val showRedirectMessage: LiveData<String?> = _showRedirectMessage
+
     private val _onDomainSelected = MutableLiveData<Event<DomainProductDetails>>()
     val onDomainSelected: LiveData<Event<DomainProductDetails>> = _onDomainSelected
 
@@ -102,11 +105,18 @@ class DomainSuggestionsViewModel @Inject constructor(
         this.site = site
         this.domainRegistrationPurpose = domainRegistrationPurpose
         initializeDefaultSuggestions()
+        shouldShowRedirectMessage()
         isStarted = true
     }
 
     private fun initializeDefaultSuggestions() {
         searchQuery = site.name
+    }
+
+    private fun shouldShowRedirectMessage() {
+        if (this.domainRegistrationPurpose == DOMAIN_PURCHASE) {
+            _showRedirectMessage.value = SiteUtils.getHomeURLOrHostName(site)
+        }
     }
 
     // Network Request

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -31,6 +31,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlin.properties.Delegates
 
+@Suppress("TooManyFunctions")
 class DomainSuggestionsViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val dispatcher: Dispatcher,

--- a/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
+++ b/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
@@ -6,11 +6,51 @@
     android:layout_height="match_parent"
     android:animateLayoutChanges="true">
 
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/redirect_message_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="@dimen/margin_extra_large">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/redirect_message"
+                android:text="@string/domains_primary_site_address"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="@dimen/margin_extra_large"
+                android:paddingEnd="@dimen/margin_extra_large"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="Domains purchase on this site will redirect to travelwithkids.wordpress.com"/>
+
+            <View
+                android:id="@+id/time_line_bottom"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/gray_5"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                app:layout_constraintTop_toBottomOf="@id/redirect_message"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
     <LinearLayout
         android:id="@+id/introduction_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
+        android:layout_below="@id/redirect_message_card"
         android:orientation="vertical"
         android:paddingStart="@dimen/domain_suggestions_intro_horizontal_padding"
         android:paddingTop="@dimen/domain_suggestions_intro_vertical_padding"

--- a/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
+++ b/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
@@ -6,51 +6,11 @@
     android:layout_height="match_parent"
     android:animateLayoutChanges="true">
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/redirect_message_card"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        tools:visibility="visible">
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@dimen/margin_extra_large">
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/redirect_message"
-                android:text="@string/domains_primary_site_address"
-                android:textAppearance="?attr/textAppearanceSubtitle1"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="@dimen/margin_extra_large"
-                android:paddingEnd="@dimen/margin_extra_large"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="Domains purchase on this site will redirect to travelwithkids.wordpress.com"/>
-
-            <View
-                android:id="@+id/time_line_bottom"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/gray_5"
-                android:layout_marginTop="@dimen/margin_extra_large"
-                app:layout_constraintTop_toBottomOf="@id/redirect_message"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"/>
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-    </com.google.android.material.card.MaterialCardView>
-
     <LinearLayout
         android:id="@+id/introduction_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/redirect_message_card"
+        android:layout_alignParentTop="true"
         android:orientation="vertical"
         android:paddingStart="@dimen/domain_suggestions_intro_horizontal_padding"
         android:paddingTop="@dimen/domain_suggestions_intro_vertical_padding"
@@ -58,6 +18,25 @@
         android:paddingBottom="@dimen/domain_suggestions_intro_vertical_padding">
 
         <TextView
+            android:id="@+id/redirect_message"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="@dimen/margin_extra_large"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            tools:text="@string/domains_free_plan_get_your_domain_caption"
+            tools:visibility="visible"/>
+
+        <View
+            android:id="@+id/redirect_divider"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/divider_size"
+            android:background="?android:attr/listDivider"
+            tools:visibility="visible"/>
+
+        <TextView
+            android:id="@+id/intro_line1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
@@ -66,6 +45,7 @@
             android:textAppearance="?attr/textAppearanceSubtitle1" />
 
         <TextView
+            android:id="@+id/intro_line2"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2477,7 +2477,7 @@
     <string name="domains_paid_plan_claim_your_domain_title">Claim your free domain</string>
     <string name="domains_paid_plan_claim_your_domain_caption">You have a free one-year domain registration included with your plan</string>
     <string name="domains_free_plan_get_your_domain_title">Get your domain</string>
-    <string name="domains_free_plan_get_your_domain_caption">Domains purchased on this site will redirect visitors to &lt;b&gt;%s.&lt;/b&gt;</string>
+    <string name="domains_free_plan_get_your_domain_caption">Domains purchased on this site will redirect visitors to &lt;b&gt;%s&lt;/b&gt;</string>
     <string name="domains_search_for_a_domain_button">Search for a domain</string>
 
     <!-- Automated Transfer Eligibility Errors -->

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -68,6 +68,16 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `redirect message is visible when purchasing a domain at start`() {
+        domainRegistrationPurpose = DOMAIN_PURCHASE
+        viewModel.start(site, domainRegistrationPurpose)
+        assertNotNull(viewModel.showRedirectMessage.value)
+        viewModel.showRedirectMessage.value?.let { siteUrl ->
+            assertNotNull(siteUrl)
+        }
+    }
+
+    @Test
     fun `intro is visible at start`() {
         viewModel.start(site, domainRegistrationPurpose)
         assertNotNull(viewModel.isIntroVisible.value)


### PR DESCRIPTION
Fixes #15354 

Show domain redirect message when domain registration purpose is purchase

<image width=320 src="https://user-images.githubusercontent.com/990349/136944083-83e16f41-8ebb-4146-a5ac-c97cb7c8f421.png" />

To test:

- Enable AppSettings -> Debug settings -> SiteDomainsFeatureConfig ✅
- Return to My Site, Notice there's a new item under Configuration -> 🌐 Domains
- Click on Domains, takes you to Domains dashboard screen
- Click on search for a domain
- Notice domain redirect message at the top in place of intro.
- Test with a site that has free plan

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so) 
Added a unit test

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
