### PR TITLE
Enable Connected Tests on Gutenberg Mobile releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,6 +374,7 @@ workflows:
               ignore:
                 - develop
                 - /^release.*/
+                - /^gutenberg\/integrate_release_.*/
                 - /pull\/[0-9]+/
       - Connected Tests:
           requires: [Hold]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,7 @@ workflows:
               only:
                 - develop
                 - /^release.*/
+                - /^gutenberg\/integrate_release_.*/
   Optional Tests:
     unless:
       or:


### PR DESCRIPTION
This enables automatic execution of our optional Connected Tests suite on PRs used for Gutenberg Mobile releases. Releases will now benefit from optional tests being ran by default, without release wranglers needing to manually run them.

The regex used here matches the branch name used by the release automation script [here](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/6595c075e00aff342164b469dcfbaf84e4bda561/release_automation.sh#L262).

| Before | After |
| - | - |
| <img width="504" alt="Screen Shot 2021-10-12 at 09 09 09" src="https://user-images.githubusercontent.com/1898325/136953453-bf47faf2-5001-471a-af6e-da1075afdbfe.png"> | <img width="580" alt="Screen Shot 2021-10-13 at 08 47 12" src="https://user-images.githubusercontent.com/1898325/137126798-c460bd1b-acb6-4b03-8a83-633ff4f3bb7d.png"> |

This is a follow up to https://github.com/wordpress-mobile/WordPress-iOS/pull/16233 which made the same changes for WPiOS.

Fixes https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/issues/65

### To test
1. Notice that the branch of this PR follows the Gutenberg release branch naming convention i.e. `gutenberg/integrate_release_X.XX.X`, so we can expect GitHub to now automatically run UI tests on this branch
2. Verify that UI tests are automatically run

## Regression Notes
Not applicable since this isn't a user-facing change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
