### PR TITLE
Updates aztec android to use S3 dependency

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -17,6 +17,7 @@ repositories {
         url "https://a8c-libs.s3.amazonaws.com/android"
         content {
             includeGroup "org.wordpress"
+            includeGroup "org.wordpress.aztec"
             includeGroup "org.wordpress.fluxc"
             includeGroup "org.wordpress-mobile.gutenberg-mobile"
             includeGroup "com.automattic"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '71-da6693f4a6a8480bdbcf752edbf27c6d11c8d592'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.64.0-alpha2'
+    ext.gutenbergMobileVersion = '4116-8179aefb1ba83a4d1df71efb9dce0fa753687728'
     ext.storiesVersion = 'develop-6919e0039bba4204321f9d644250abfd0c900f2d'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '71-da6693f4a6a8480bdbcf752edbf27c6d11c8d592'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '4116-8179aefb1ba83a4d1df71efb9dce0fa753687728'
+    ext.gutenbergMobileVersion = 'develop-31cae6abc011a38f7a63f32d4306735358e144d4'
     ext.storiesVersion = 'develop-6919e0039bba4204321f9d644250abfd0c900f2d'
 
     repositories {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,11 +1,13 @@
 buildscript {
-    ext.aztecVersion = 'v1.3.45'
+    ext.aztecVersion = '941-2f19466228b2290105b111881dfbabc454be19c2'
 }
 
 repositories {
     maven {
         url "https://a8c-libs.s3.amazonaws.com/android"
         content {
+            includeGroup "org.wordpress"
+            includeGroup "org.wordpress.aztec"
             includeGroup "org.wordpress-mobile.gutenberg-mobile"
         }
     }
@@ -24,7 +26,6 @@ repositories {
     google()
     jcenter()
     maven { url "https://www.jitpack.io" }
-    maven { url "https://a8c-libs.s3.amazonaws.com/android" }
     maven { url "https://a8c-libs.s3.amazonaws.com/android/hermes-mirror" }
 }
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.aztecVersion = '941-2f19466228b2290105b111881dfbabc454be19c2'
+    ext.aztecVersion = 'v1.4.0'
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,11 +22,11 @@ gradle.ext.loginFlowBinaryPath = "org.wordpress:login"
 gradle.ext.storiesAndroidPath = "com.automattic:stories"
 gradle.ext.storiesAndroidMp4ComposePath = "com.automattic.stories:mp4compose"
 gradle.ext.storiesAndroidPhotoEditorPath = "com.automattic.stories:photoeditor"
-gradle.ext.aztecAndroidAztecPath = "com.github.wordpress-mobile.WordPress-Aztec-Android:aztec"
-gradle.ext.aztecAndroidWordPressShortcodesPath = "com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes"
-gradle.ext.aztecAndroidWordPressCommentsPath = "com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments"
-gradle.ext.aztecAndroidGlideLoaderPath = "com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader"
-gradle.ext.aztecAndroidPicassoLoaderPath = "com.github.wordpress-mobile.WordPress-Aztec-Android:picasso-loader"
+gradle.ext.aztecAndroidAztecPath = "org.wordpress:aztec"
+gradle.ext.aztecAndroidWordPressShortcodesPath = "org.wordpress.aztec:wordpress-shortcodes"
+gradle.ext.aztecAndroidWordPressCommentsPath = "org.wordpress.aztec:wordpress-comments"
+gradle.ext.aztecAndroidGlideLoaderPath = "org.wordpress.aztec:glide-loader"
+gradle.ext.aztecAndroidPicassoLoaderPath = "org.wordpress.aztec:picasso-loader"
 
 def localBuilds = new File('local-builds.gradle')
 if (localBuilds.exists()) {


### PR DESCRIPTION
https://github.com/wordpress-mobile/AztecEditor-Android/pull/941 adds support for publishing library artifacts to S3. https://github.com/WordPress/gutenberg/pull/35606 updates `react-native-aztec` to use S3 dependencies and this PR does the same for WPAndroid and updates the gb-mobile version.

**To test:**
* Smoke test the gutenberg editor
* Smoke test the classic editor - I can't figure out how to get the classic editor so I couldn't test it. It used to be in App Settings but then I think it was moved to Site Settings and now I can't find it in either 😓 

## Regression Notes
1. Potential unintended areas of impact
Gutenberg-mobile or classic editor not loading/working - this should be all or nothing, meaning it'll either work fine or it'll not work at all.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested block editor.

3. What automated tests I added (or what prevented me from doing so)
There are some automated tests for the editor which should help ease our minds. Any editor test is helpful.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
