### PR TITLE
Adjust softInputMode to address keyboard leaving white space upon dismiss

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
+import android.view.WindowManager
 import android.widget.ImageView
 import androidx.annotation.StringRes
 import androidx.appcompat.widget.TooltipCompat
@@ -122,6 +123,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // The following prevents the soft keyboard from leaving a white space when dismissed.
+        requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
         (requireActivity().application as WordPress).component().inject(this)
         viewModel = ViewModelProvider(this, viewModelFactory).get(MySiteViewModel::class.java)
         dialogViewModel = ViewModelProvider(requireActivity(), viewModelFactory)


### PR DESCRIPTION
Fixes #15466

This PR is an attempt to circumvent the issue with the soft keyboard maintaining space on the My Site View when returning from editing a post.

I found two articles ([here](https://stackoverflow.com/questions/30092330/android-a-blank-space-remains-when-the-keyboard-disappears) & [here](https://stackoverflow.com/questions/42597256/background-glitch-on-keyboard-closure)) on SO that point to the same resolution. Adjusting the LayoutParams in the fragment as such:
`requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)`

This seems to fix the issue and doesn’t appear to break anything else. I have only tested in Pixel 5, so more testing needs to be done before moving forward with this short-term solution.

Note: I tried adding the config settings to the manifest, but that did not work in our case.

For reference:

```
"adjustPan"
The activity's main window is not resized to make room for the soft keyboard. Rather, the contents of the window are automatically panned so that the current focus is never obscured by the keyboard and users can always see what they are typing. This is generally less desirable than resizing, because the user may need to close the soft keyboard to get at and interact with obscured parts of the window.
```


I'm not 100% certain this is the only way to address the issue long-term; however it gives us time to review different approaches while providing a solution for our users. We'll review this solution when tackling the snackbar whitespace issues.


**To test:**

- From the My Site screen open the editor
- Close the editor
- Notice that the part of the screen that was covered with the keyboard shows the My Site view and not whitespace

## Regression Notes
1. Potential unintended areas of impact
My Site view looks weird

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual Test

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
