### PR TITLE
Feature/15426 add domains ctas to next steps on my site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -17,6 +17,8 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CLAIM_DOMAIN
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GET_DOMAIN
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
@@ -312,9 +314,24 @@ class MySiteViewModel @Inject constructor(
 
     private fun onQuickStartTaskTypeItemClick(type: QuickStartTaskType) {
         clearActiveQuickStartTask()
-        _onNavigation.value = Event(
-                SiteNavigationAction.OpenQuickStartFullScreenDialog(type, quickStartCardBuilder.getTitle(type))
-        )
+
+        if (type == GET_DOMAIN || type == CLAIM_DOMAIN) {
+            val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
+
+            if (type == CLAIM_DOMAIN) {
+                analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED, selectedSite)
+            } else {
+                // TODO: add tracker for purchase domain
+            }
+
+            _onNavigation.value = Event(
+                    SiteNavigationAction.OpenDomains(selectedSite) // Should this open dashboard or search?
+            )
+        } else {
+            _onNavigation.value = Event(
+                    SiteNavigationAction.OpenQuickStartFullScreenDialog(type, quickStartCardBuilder.getTitle(type))
+            )
+        }
     }
 
     fun onQuickStartTaskCardClick(task: QuickStartTask) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard.QuickStartTaskTypeItem
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -35,13 +36,7 @@ class QuickStartCardBuilder @Inject constructor() {
                 quickStartTaskType = quickStartTaskType,
                 title = UiStringRes(getTitle(quickStartTaskType)),
                 titleEnabled = countUncompleted > 0,
-                subtitle = UiStringResWithParams(
-                        R.string.quick_start_sites_type_tasks_completed,
-                        listOf(
-                                UiStringText("$countCompleted"),
-                                UiStringText("${countCompleted + countUncompleted}")
-                        )
-                ),
+                subtitle = getSubTitle(quickStartTaskType, countCompleted, countUncompleted),
                 strikeThroughTitle = countUncompleted == 0,
                 progressColor = R.color.colorPrimary,
                 progress = getProgress(countCompleted, countCompleted + countUncompleted),
@@ -52,7 +47,29 @@ class QuickStartCardBuilder @Inject constructor() {
     fun getTitle(taskType: QuickStartTaskType): Int {
         return when (taskType) {
             QuickStartTaskType.CUSTOMIZE -> R.string.quick_start_sites_type_customize
+            QuickStartTaskType.CLAIM_DOMAIN -> R.string.quick_start_sites_type_claim_domain_title
+            QuickStartTaskType.GET_DOMAIN -> R.string.quick_start_sites_type_get_domain_title
             QuickStartTaskType.GROW -> R.string.quick_start_sites_type_grow
+            QuickStartTaskType.UNKNOWN -> throw IllegalArgumentException(UNEXPECTED_QUICK_START_TYPE)
+        }
+    }
+
+    fun getSubTitle(taskType: QuickStartTaskType, countCompleted: Int, countUncompleted: Int): UiString {
+        return when (taskType) {
+            QuickStartTaskType.CUSTOMIZE, QuickStartTaskType.GROW -> {
+                UiStringResWithParams(
+                    R.string.quick_start_sites_type_tasks_completed,
+                    listOf(
+                            UiStringText("$countCompleted"),
+                            UiStringText("${countCompleted + countUncompleted}")
+                    ))
+            }
+            QuickStartTaskType.CLAIM_DOMAIN -> {
+                UiStringRes(R.string.quick_start_sites_type_claim_domain_sub_title)
+            }
+            QuickStartTaskType.GET_DOMAIN -> {
+                UiStringRes(R.string.quick_start_sites_type_get_domain_sub_title)
+            }
             QuickStartTaskType.UNKNOWN -> throw IllegalArgumentException(UNEXPECTED_QUICK_START_TYPE)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardViewHolder.kt
@@ -13,7 +13,9 @@ import org.wordpress.android.R
 import org.wordpress.android.databinding.MySiteCardToolbarBinding
 import org.wordpress.android.databinding.QuickStartCardBinding
 import org.wordpress.android.databinding.QuickStartTaskTypeItemBinding
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CLAIM_DOMAIN
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CUSTOMIZE
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GET_DOMAIN
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard.QuickStartTaskTypeItem
@@ -29,6 +31,8 @@ class QuickStartCardViewHolder(
     fun bind(card: QuickStartCard) = with(binding) {
         mySiteCardToolbar.update(card)
         quickStartCustomize.update(card.taskTypeItems.first { it.quickStartTaskType == CUSTOMIZE })
+        quickStartDomains.updateDomains(card.taskTypeItems.first { it.quickStartTaskType == CLAIM_DOMAIN })
+        quickStartDomains.updateDomains(card.taskTypeItems.first { it.quickStartTaskType == GET_DOMAIN })
         quickStartGrow.update(card.taskTypeItems.first { it.quickStartTaskType == GROW })
     }
 
@@ -56,6 +60,13 @@ class QuickStartCardViewHolder(
         }
         itemSubtitle.text = uiHelpers.getTextOfUiString(itemView.context, item.subtitle)
         itemProgress.update(item)
+        itemRoot.setOnClickListener { item.onClick.click() }
+    }
+
+    private fun QuickStartTaskTypeItemBinding.updateDomains(item: QuickStartTaskTypeItem) {
+        itemTitle.text = uiHelpers.getTextOfUiString(itemView.context, item.title)
+        itemSubtitle.text = uiHelpers.getTextOfUiString(itemView.context, item.subtitle)
+        itemProgress.isVisible = false
         itemRoot.setOnClickListener { item.onClick.click() }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -7,11 +7,14 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.DynamicCardType
+import org.wordpress.android.fluxc.model.DynamicCardType.CLAIM_DOMAIN_QUICK_START
 import org.wordpress.android.fluxc.model.DynamicCardType.CUSTOMIZE_QUICK_START
+import org.wordpress.android.fluxc.model.DynamicCardType.GET_DOMAIN_QUICK_START
 import org.wordpress.android.fluxc.model.DynamicCardType.GROW_QUICK_START
 import org.wordpress.android.fluxc.model.SiteHomepageSettings.ShowOnFront
 import org.wordpress.android.fluxc.store.DynamicCardStore
@@ -20,7 +23,9 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CLAIM_DOMAIN
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CUSTOMIZE
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GET_DOMAIN
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.UNKNOWN
 import org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartPayload
@@ -127,7 +132,7 @@ class QuickStartRepository
         return if (quickStartDynamicCardsFeatureConfig.isEnabled()) {
             dynamicCardStore.getCards(siteLocalId).dynamicCardTypes.map { it.toQuickStartTaskType() }
         } else {
-            listOf(CUSTOMIZE, GROW)
+            listOf(CUSTOMIZE, CLAIM_DOMAIN, GET_DOMAIN, GROW)
         }
     }
 
@@ -226,8 +231,10 @@ class QuickStartRepository
     }
 
     private fun getCategoryCompletionMessage(taskType: QuickStartTaskType) = when (taskType) {
-        CUSTOMIZE -> R.string.quick_start_completed_type_customize_message
-        GROW -> R.string.quick_start_completed_type_grow_message
+        CUSTOMIZE -> string.quick_start_completed_type_customize_message
+        CLAIM_DOMAIN -> string.quick_start_completed_type_customize_message
+        GET_DOMAIN -> string.quick_start_completed_type_customize_message
+        GROW -> string.quick_start_completed_type_grow_message
         UNKNOWN -> throw IllegalArgumentException("Unexpected quick start type")
     }.let { resourceProvider.getString(it) }
 
@@ -236,6 +243,8 @@ class QuickStartRepository
     private fun DynamicCardType.toQuickStartTaskType(): QuickStartTaskType {
         return when (this) {
             CUSTOMIZE_QUICK_START -> CUSTOMIZE
+            CLAIM_DOMAIN_QUICK_START -> CLAIM_DOMAIN
+            GET_DOMAIN_QUICK_START -> GET_DOMAIN
             GROW_QUICK_START -> GROW
         }
     }
@@ -243,6 +252,8 @@ class QuickStartRepository
     private fun QuickStartTaskType.toDynamicCardType(): DynamicCardType {
         return when (this) {
             CUSTOMIZE -> CUSTOMIZE_QUICK_START
+            CLAIM_DOMAIN -> CLAIM_DOMAIN_QUICK_START
+            GET_DOMAIN -> GET_DOMAIN_QUICK_START
             GROW -> GROW_QUICK_START
             UNKNOWN -> throw IllegalArgumentException("Unexpected quick start type")
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartItemBuilder.kt
@@ -122,7 +122,7 @@ class QuickStartItemBuilder
         )
     }
 
-    @DrawableRes
+    @Suppress("ComplexMethod") @DrawableRes
     private fun getIllustration(task: QuickStartTask): Int {
         return when (task) {
             UPDATE_SITE_TITLE -> drawable.img_illustration_quick_start_task_set_site_title

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartItemBuilder.kt
@@ -2,22 +2,32 @@ package org.wordpress.android.ui.mysite.dynamiccards.quickstart
 
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
-import org.wordpress.android.R
+import org.wordpress.android.R.color
+import org.wordpress.android.R.drawable
+import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.DynamicCardType
+import org.wordpress.android.fluxc.model.DynamicCardType.CLAIM_DOMAIN_QUICK_START
+import org.wordpress.android.fluxc.model.DynamicCardType.CUSTOMIZE_QUICK_START
+import org.wordpress.android.fluxc.model.DynamicCardType.GET_DOMAIN_QUICK_START
+import org.wordpress.android.fluxc.model.DynamicCardType.GROW_QUICK_START
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CLAIM_FREE_DOMAIN
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CREATE_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_POST_SHARING
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EXPLORE_PLANS
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.FOLLOW_SITE
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.GET_SITE_DOMAIN
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.PUBLISH_POST
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.REVIEW_PAGES
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.VIEW_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CLAIM_DOMAIN
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CUSTOMIZE
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GET_DOMAIN
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.UNKNOWN
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartDynamicCard
@@ -63,8 +73,10 @@ class QuickStartItemBuilder
 
     private fun QuickStartTaskType.toDynamicCardType(): DynamicCardType {
         return when (this) {
-            CUSTOMIZE -> DynamicCardType.CUSTOMIZE_QUICK_START
-            GROW -> DynamicCardType.GROW_QUICK_START
+            CUSTOMIZE -> CUSTOMIZE_QUICK_START
+            CLAIM_DOMAIN -> CLAIM_DOMAIN_QUICK_START
+            GET_DOMAIN -> GET_DOMAIN_QUICK_START
+            GROW -> GROW_QUICK_START
             UNKNOWN -> throw IllegalArgumentException("Unexpected quick start type")
         }
     }
@@ -76,16 +88,20 @@ class QuickStartItemBuilder
     @ColorRes
     private fun getAccentColor(taskType: QuickStartTaskType): Int {
         return when (taskType) {
-            CUSTOMIZE -> R.color.green_20
-            GROW -> R.color.orange_40
+            CUSTOMIZE -> color.green_20
+            CLAIM_DOMAIN -> color.green_20
+            GET_DOMAIN -> color.green_20
+            GROW -> color.orange_40
             UNKNOWN -> throw IllegalArgumentException("Unexpected quick start type")
         }
     }
 
     private fun getTitle(taskType: QuickStartTaskType): Int {
         return when (taskType) {
-            CUSTOMIZE -> R.string.quick_start_sites_type_customize
-            GROW -> R.string.quick_start_sites_type_grow
+            CUSTOMIZE -> string.quick_start_sites_type_customize
+            CLAIM_DOMAIN -> string.quick_start_sites_type_claim_domain_title
+            GET_DOMAIN -> string.quick_start_sites_type_get_domain_title
+            GROW -> string.quick_start_sites_type_grow
             UNKNOWN -> throw IllegalArgumentException("Unexpected quick start type")
         }
     }
@@ -109,18 +125,20 @@ class QuickStartItemBuilder
     @DrawableRes
     private fun getIllustration(task: QuickStartTask): Int {
         return when (task) {
-            UPDATE_SITE_TITLE -> R.drawable.img_illustration_quick_start_task_set_site_title
-            UPLOAD_SITE_ICON -> R.drawable.img_illustration_quick_start_task_edit_site_icon
-            VIEW_SITE -> R.drawable.img_illustration_quick_start_task_visit_your_site
-            ENABLE_POST_SHARING -> R.drawable.img_illustration_quick_start_task_enable_post_sharing
-            PUBLISH_POST -> R.drawable.img_illustration_quick_start_task_publish_post
-            FOLLOW_SITE -> R.drawable.img_illustration_quick_start_task_follow_other_sites
-            CHECK_STATS -> R.drawable.img_illustration_quick_start_task_check_site_stats
-            EDIT_HOMEPAGE -> R.drawable.img_illustration_quick_start_task_edit_your_homepage
-            REVIEW_PAGES -> R.drawable.img_illustration_quick_start_task_review_site_pages
-            EXPLORE_PLANS -> R.drawable.img_illustration_quick_start_task_explore_plans
-            CREATE_SITE -> R.drawable.img_illustration_quick_start_task_create_site
-            QuickStartTask.UNKNOWN -> R.drawable.img_illustration_quick_start_task_placeholder
+            UPDATE_SITE_TITLE -> drawable.img_illustration_quick_start_task_set_site_title
+            UPLOAD_SITE_ICON -> drawable.img_illustration_quick_start_task_edit_site_icon
+            VIEW_SITE -> drawable.img_illustration_quick_start_task_visit_your_site
+            ENABLE_POST_SHARING -> drawable.img_illustration_quick_start_task_enable_post_sharing
+            PUBLISH_POST -> drawable.img_illustration_quick_start_task_publish_post
+            FOLLOW_SITE -> drawable.img_illustration_quick_start_task_follow_other_sites
+            CHECK_STATS -> drawable.img_illustration_quick_start_task_check_site_stats
+            EDIT_HOMEPAGE -> drawable.img_illustration_quick_start_task_edit_your_homepage
+            REVIEW_PAGES -> drawable.img_illustration_quick_start_task_review_site_pages
+            EXPLORE_PLANS -> drawable.img_illustration_quick_start_task_explore_plans
+            CREATE_SITE -> drawable.img_illustration_quick_start_task_create_site
+            QuickStartTask.UNKNOWN -> drawable.img_illustration_quick_start_task_placeholder
+            CLAIM_FREE_DOMAIN -> drawable.img_illustration_quick_start_task_placeholder
+            GET_SITE_DOMAIN -> drawable.img_illustration_quick_start_task_placeholder
         }
     }
 }

--- a/WordPress/src/main/res/layout/quick_start_card.xml
+++ b/WordPress/src/main/res/layout/quick_start_card.xml
@@ -21,13 +21,31 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <include
-            android:id="@+id/quick_start_customize"
+            android:id="@+id/quick_start_domains"
             layout="@layout/quick_start_task_type_item"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/my_site_card_toolbar" />
+
+        <View
+            android:id="@+id/divider_domain"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/listDivider"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/quick_start_domains" />
+
+        <include
+            android:id="@+id/quick_start_customize"
+            layout="@layout/quick_start_task_type_item"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider_domain" />
 
         <View
             android:id="@+id/divider"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3006,6 +3006,10 @@
     <string name="quick_start_list_review_pages_title" translatable="false">@string/quick_start_dialog_review_pages_title</string>
     <string name="quick_start_sites">Next Steps</string>
     <string name="quick_start_sites_type_customize">Customize your site</string>
+    <string name="quick_start_sites_type_claim_domain_title">Claim your free domain</string>
+    <string name="quick_start_sites_type_claim_domain_sub_title">You have a free domain available</string>
+    <string name="quick_start_sites_type_get_domain_title">Get your domain</string>
+    <string name="quick_start_sites_type_get_domain_sub_title">Find a unique name for your site</string>
     <string name="quick_start_sites_type_grow">Grow your audience</string>
     <string name="quick_start_sites_type_tasks_completed">%1$s out of %2$s complete</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -29,7 +29,9 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOM
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_POST_SHARING
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.PUBLISH_POST
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CLAIM_DOMAIN
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CUSTOMIZE
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GET_DOMAIN
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
 import org.wordpress.android.test
 import org.wordpress.android.testScope
@@ -170,7 +172,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
 
                 triggerQSRefreshAfterSameTypeTasksAreComplete()
 
-                assertThat(result.last().categories.map { it.taskType }).isEqualTo(listOf(CUSTOMIZE, GROW))
+                assertThat(result.last().categories.map { it.taskType }).isEqualTo(
+                        listOf(CUSTOMIZE, CLAIM_DOMAIN, GET_DOMAIN, GROW))
             }
 
     @Test
@@ -494,13 +497,15 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     private fun assertModel() {
         val quickStartUpdate = result.last()
         quickStartUpdate.categories.let { categories ->
-            assertThat(categories).hasSize(2)
+            assertThat(categories).hasSize(4)
             assertThat(categories[0].taskType).isEqualTo(CUSTOMIZE)
             assertThat(categories[0].uncompletedTasks).containsExactly(CREATE_SITE_TUTORIAL)
             assertThat(categories[0].completedTasks).containsExactly(QuickStartTaskDetails.UPDATE_SITE_TITLE)
-            assertThat(categories[1].taskType).isEqualTo(GROW)
-            assertThat(categories[1].uncompletedTasks).containsExactly(SHARE_SITE_TUTORIAL)
-            assertThat(categories[1].completedTasks).containsExactly(PUBLISH_POST_TUTORIAL)
+            assertThat(categories[1].taskType).isEqualTo(CLAIM_DOMAIN)
+            assertThat(categories[2].taskType).isEqualTo(GET_DOMAIN)
+            assertThat(categories[3].taskType).isEqualTo(GROW)
+            assertThat(categories[3].uncompletedTasks).containsExactly(SHARE_SITE_TUTORIAL)
+            assertThat(categories[3].completedTasks).containsExactly(PUBLISH_POST_TUTORIAL)
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'develop-a3f6fb48c48bd585e7c638a8ca91a273d0b810f4'
+    fluxCVersion = '2154-50b3da312916a88c1926867d511d39c197878f57'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #15426 

<img width=320 src="https://user-images.githubusercontent.com/990349/137432877-7c8c277b-42c6-42f0-b4db-ae2238c9db44.png" />


To test:

- Create a new site
- Enable quick start steps
- Logout and login if required
- Next steps should now show Get your domain or Claim your free domain task


## Regression Notes
1. Potential unintended areas of impact
Next steps

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
