### PR TITLE
Follow by notification enable feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 18.5
 -----
+* [**] Reader: allow users to enable push notifications to follow a post comments conversation [WPAndroid - https://github.com/wordpress-mobile/WordPress-Android/pull/15459]
 * [*] Fixed an issue where navigating through a couple of related posts in Reader caused the incorrect post to be loaded after rotation [https://github.com/wordpress-mobile/WordPress-Android/issues/14195]
 * [*] Allow users to mark Posts as sticky [https://github.com/wordpress-mobile/WordPress-Android/pull/15351]
 * [*] Fixed a crash in Page Template chooser [https://github.com/wordpress-mobile/WordPress-Android/pull/15415]

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -181,8 +181,6 @@ android {
 
             versionName versionProperties.getProperty("alpha.versionName")
             versionCode versionProperties.getProperty("alpha.versionCode").toInteger()
-
-            buildConfigField "boolean", "FOLLOW_BY_PUSH_NOTIFICATION", "true"
         }
 
         jalapeno { // Pre-Alpha version, used for PR builds, can be installed along release, alpha, beta, dev versions

--- a/WordPress/src/main/java/org/wordpress/android/util/config/FollowByPushNotificationFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/FollowByPushNotificationFeatureConfig.kt
@@ -1,11 +1,17 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.FollowByPushNotificationFeatureConfig.Companion.FOLLOW_BY_PUSH_NOTIFICATION_REMOTE_FIELD
 import javax.inject.Inject
 
-@FeatureInDevelopment
+@Feature(FOLLOW_BY_PUSH_NOTIFICATION_REMOTE_FIELD, true)
 class FollowByPushNotificationFeatureConfig @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.FOLLOW_BY_PUSH_NOTIFICATION
-)
+        BuildConfig.FOLLOW_BY_PUSH_NOTIFICATION,
+        FOLLOW_BY_PUSH_NOTIFICATION_REMOTE_FIELD
+) {
+    companion object {
+        const val FOLLOW_BY_PUSH_NOTIFICATION_REMOTE_FIELD = "follow_by_push_notification_remote_field"
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderCommentListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderCommentListViewModelTest.kt
@@ -126,6 +126,84 @@ class ReaderCommentListViewModelTest : BaseUnitTest() {
         }
     }
 
+    @Test
+    fun `onFollowTapped toggles follow status`() = test {
+        var stateChanged = FollowStateChanged(blogId, postId, false, false)
+        doAnswer {
+            followStatusUpdate.postValue(stateChanged)
+        }.whenever(followCommentsHandler).handleFollowCommentsStatusRequest(anyLong(), anyLong(), anyBoolean())
+
+        doAnswer {
+            stateChanged = FollowStateChanged(blogId, postId, true, false)
+            followStatusUpdate.postValue(stateChanged)
+        }.whenever(followCommentsHandler).handleFollowCommentsClicked(blogId, postId, true, null)
+
+        setupObserversAndStart()
+
+        requireNotNull(uiState).let {
+            assertThat(it.type).isEqualTo(VISIBLE_WITH_STATE)
+            assertThat(it.isFollowing).isFalse()
+            it.onFollowTapped?.invoke()
+        }
+
+        requireNotNull(uiState).let {
+            assertThat(it.type).isEqualTo(VISIBLE_WITH_STATE)
+            assertThat(it.isFollowing).isTrue()
+        }
+    }
+
+    @Test
+    fun `onUnfollowTapped toggles follow status`() = test {
+        var stateChanged = FollowStateChanged(blogId, postId, true, false)
+        doAnswer {
+            followStatusUpdate.postValue(stateChanged)
+        }.whenever(followCommentsHandler).handleFollowCommentsStatusRequest(anyLong(), anyLong(), anyBoolean())
+
+        doAnswer {
+            stateChanged = FollowStateChanged(blogId, postId, false, false)
+            followStatusUpdate.postValue(stateChanged)
+        }.whenever(followCommentsHandler).handleFollowCommentsClicked(blogId, postId, false, null)
+
+        setupObserversAndStart()
+
+        requireNotNull(uiState).let {
+            assertThat(it.type).isEqualTo(VISIBLE_WITH_STATE)
+            assertThat(it.isFollowing).isTrue()
+            viewModel.onUnfollowTapped()
+        }
+
+        requireNotNull(uiState).let {
+            assertThat(it.type).isEqualTo(VISIBLE_WITH_STATE)
+            assertThat(it.isFollowing).isFalse()
+        }
+    }
+
+    @Test
+    fun `onChangePushNotificationsRequest toggles push notifications status`() = test {
+        var stateChanged = FollowStateChanged(blogId, postId, true, false)
+        doAnswer {
+            followStatusUpdate.postValue(stateChanged)
+        }.whenever(followCommentsHandler).handleFollowCommentsStatusRequest(anyLong(), anyLong(), anyBoolean())
+
+        doAnswer {
+            stateChanged = FollowStateChanged(blogId, postId, true, true)
+            followStatusUpdate.postValue(stateChanged)
+        }.whenever(followCommentsHandler).handleEnableByPushNotificationsClicked(blogId, postId, true, null)
+
+        setupObserversAndStart()
+
+        requireNotNull(uiState).let {
+            assertThat(it.type).isEqualTo(VISIBLE_WITH_STATE)
+            assertThat(it.isReceivingNotifications).isFalse()
+            viewModel.onChangePushNotificationsRequest(true)
+        }
+
+        requireNotNull(uiState).let {
+            assertThat(it.type).isEqualTo(VISIBLE_WITH_STATE)
+            assertThat(it.isReceivingNotifications).isTrue()
+        }
+    }
+
     private fun setupObserversAndStart() {
         viewModel.updateFollowUiState.observeForever {
             uiState = it

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFollowCommentsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFollowCommentsHandlerTest.kt
@@ -95,6 +95,38 @@ class ReaderFollowCommentsHandlerTest {
         }
     }
 
+    @Test
+    fun `handleFollowCommentsClicked adds a snackbar with action`() = test {
+        val userMessage = UiStringText("handleFollowCommentsClicked")
+        val snackbarAction = {}
+        val state = FollowCommentsState.FollowStateChanged(
+                blogId = blogId,
+                postId = postId,
+                isFollowing = true,
+                isReceivingNotifications = false,
+                isInit = false,
+                userMessage = userMessage
+        )
+
+        whenever(readerCommentsFollowUseCase.setMySubscriptionToPost(blogId, postId, true)).thenReturn(
+                flow { emit(state) }
+        )
+
+        setupObservers()
+
+
+        followCommentsHandler.handleFollowCommentsClicked(blogId, postId, true, snackbarAction)
+
+        requireNotNull(uiState).let {
+            assertThat(it).isEqualTo(state)
+        }
+
+        requireNotNull(holder).let {
+            assertThat(it.message).isEqualTo(userMessage)
+            assertThat(it.buttonAction == snackbarAction).isTrue()
+        }
+    }
+
     private fun setupObservers() {
         uiState = null
 


### PR DESCRIPTION
Part of #15460, this PR enables the remote feature flag for the new follow conversation by push notification feature. Also added some unit testing.

Main feature PR: #15459
References: `pctCYC-9x-p2`

https://user-images.githubusercontent.com/47797566/137237202-919e2e15-d218-47f9-b36e-21db5408ffc0.mov

## To test
- Check the unit tests pass
- Remove the app if already installed
- Use the jalapeno apk from this CI to install the WordPress app and check the feature with the option menu in the threaded comment screen is available without any need to activate the feature flag
- Smoke test the feature (you can follow the test instructions from [here](https://github.com/wordpress-mobile/WordPress-Android/pull/15459#issue-1025828713))
- Try to disable the feature flag remotely, restart the app and check you get the previous Follow by email button. Smoke test the follow by email functionality

## Regression Notes
1. Potential unintended areas of impact
The already available follow conversation by email could potentially be affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing, and unit testing was already in place.

3. What automated tests I added (or what prevented me from doing so)
Added dedicated unit testing to cover the additional part that enables push notifications on top of email notifications.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
