### PR TITLE
Prep for 18.5 code freese: Update login & stories lib versions to stable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ buildscript {
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
-    ext.wordPressLoginVersion = '71-da6693f4a6a8480bdbcf752edbf27c6d11c8d592'
+    ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.64.0'
-    ext.storiesVersion = 'develop-6919e0039bba4204321f9d644250abfd0c900f2d'
+    ext.storiesVersion = '1.1.0'
 
     repositories {
         maven {


### PR DESCRIPTION
Just updates the `login` and `stories` libraries to stable versions on `develop` before I can trigger the a `code_freeze` to create the `release/18.5` branch – as those libraries / binary dependencies need to be pointing to a tag for `code_freeze` to be able to download the strings from them.