### PR TITLE
My Site Dashboard-Phase 2: Refactor Builder parameter classes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -1,8 +1,12 @@
 package org.wordpress.android.ui.mysite
 
+import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
+
 sealed class MySiteCardAndItemBuilderParams {
     data class DomainRegistrationCardBuilderParams(
         val isDomainCreditAvailable: Boolean,
         val domainRegistrationClick: () -> Unit
     ) : MySiteCardAndItemBuilderParams()
+
+    data class PostCardBuilderParams(val mockedPostsData: MockedPostsData?) : MySiteCardAndItemBuilderParams()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.ui.mysite
+
+sealed class MySiteCardAndItemBuilderParams {
+    data class DomainRegistrationCardBuilderParams(
+        val isDomainCreditAvailable: Boolean,
+        val domainRegistrationClick: () -> Unit
+    ) : MySiteCardAndItemBuilderParams()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -2,7 +2,9 @@ package org.wordpress.android.ui.mysite
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 
 sealed class MySiteCardAndItemBuilderParams {
     data class DomainRegistrationCardBuilderParams(
@@ -19,5 +21,11 @@ sealed class MySiteCardAndItemBuilderParams {
         val onQuickActionPagesClick: () -> Unit,
         val onQuickActionPostsClick: () -> Unit,
         val onQuickActionMediaClick: () -> Unit
+    ) : MySiteCardAndItemBuilderParams()
+
+    data class QuickStartCardBuilderParams(
+        val quickStartCategories: List<QuickStartCategory>,
+        val onQuickStartBlockRemoveMenuItemClick: () -> Unit,
+        val onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit
     ) : MySiteCardAndItemBuilderParams()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.mysite
 
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
 
 sealed class MySiteCardAndItemBuilderParams {
@@ -9,4 +11,13 @@ sealed class MySiteCardAndItemBuilderParams {
     ) : MySiteCardAndItemBuilderParams()
 
     data class PostCardBuilderParams(val mockedPostsData: MockedPostsData?) : MySiteCardAndItemBuilderParams()
+
+    data class QuickActionsCardBuilderParams(
+        val siteModel: SiteModel,
+        val activeTask: QuickStartTask?,
+        val onQuickActionStatsClick: () -> Unit,
+        val onQuickActionPagesClick: () -> Unit,
+        val onQuickActionPostsClick: () -> Unit,
+        val onQuickActionMediaClick: () -> Unit
+    ) : MySiteCardAndItemBuilderParams()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -28,4 +28,14 @@ sealed class MySiteCardAndItemBuilderParams {
         val onQuickStartBlockRemoveMenuItemClick: () -> Unit,
         val onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit
     ) : MySiteCardAndItemBuilderParams()
+
+    data class SiteInfoCardBuilderParams(
+        val site: SiteModel,
+        val showSiteIconProgressBar: Boolean,
+        val titleClick: () -> Unit,
+        val iconClick: () -> Unit,
+        val urlClick: () -> Unit,
+        val switchSiteClick: () -> Unit,
+        val activeTask: QuickStartTask?
+    ) : MySiteCardAndItemBuilderParams()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.NoSites
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
@@ -217,7 +218,6 @@ class MySiteViewModel @Inject constructor(
             site,
             showSiteIconProgressBar,
             activeTask,
-            isDomainCreditAvailable,
             quickStartCategories,
             mockedPostsData,
             this::titleClick,
@@ -228,9 +228,12 @@ class MySiteViewModel @Inject constructor(
             this::quickActionPagesClick,
             this::quickActionPostsClick,
             this::quickActionMediaClick,
-            this::domainRegistrationClick,
             this::onQuickStartBlockRemoveMenuItemClick,
-            this::onQuickStartTaskTypeItemClick
+            this::onQuickStartTaskTypeItemClick,
+            DomainRegistrationCardBuilderParams(
+                    isDomainCreditAvailable = isDomainCreditAvailable,
+                    domainRegistrationClick = this::domainRegistrationClick
+            )
     ) + dynamicCardsBuilder.build(
             quickStartCategories,
             pinnedDynamicCard,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -230,8 +230,8 @@ class MySiteViewModel @Inject constructor(
                     onQuickActionStatsClick = this::quickActionStatsClick,
                     onQuickActionPagesClick = this::quickActionPagesClick,
                     onQuickActionPostsClick = this::quickActionPostsClick,
-                    onQuickActionMediaClick = this::quickActionMediaClick,
-                    ),
+                    onQuickActionMediaClick = this::quickActionMediaClick
+            ),
             QuickStartCardBuilderParams(
                     quickStartCategories,
                     this::onQuickStartBlockRemoveMenuItemClick,
@@ -245,7 +245,7 @@ class MySiteViewModel @Inject constructor(
                     this::urlClick,
                     this::switchSiteClick,
                     activeTask
-            ),
+            )
     ) + dynamicCardsBuilder.build(
             quickStartCategories,
             pinnedDynamicCard,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegi
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.NoSites
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
@@ -218,13 +219,6 @@ class MySiteViewModel @Inject constructor(
         scanAvailable: Boolean,
         mockedPostsData: MockedPostsData?
     ) = cardsBuilder.build(
-            site,
-            showSiteIconProgressBar,
-            activeTask,
-            this::titleClick,
-            this::iconClick,
-            this::urlClick,
-            this::switchSiteClick,
             DomainRegistrationCardBuilderParams(
                     isDomainCreditAvailable = isDomainCreditAvailable,
                     domainRegistrationClick = this::domainRegistrationClick
@@ -242,7 +236,16 @@ class MySiteViewModel @Inject constructor(
                     quickStartCategories,
                     this::onQuickStartBlockRemoveMenuItemClick,
                     this::onQuickStartTaskTypeItemClick
-            )
+            ),
+            SiteInfoCardBuilderParams(
+                    site,
+                    showSiteIconProgressBar,
+                    this::titleClick,
+                    this::iconClick,
+                    this::urlClick,
+                    this::switchSiteClick,
+                    activeTask
+            ),
     ) + dynamicCardsBuilder.build(
             quickStartCategories,
             pinnedDynamicCard,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.NoSites
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
@@ -224,17 +225,21 @@ class MySiteViewModel @Inject constructor(
             this::iconClick,
             this::urlClick,
             this::switchSiteClick,
-            this::quickActionStatsClick,
-            this::quickActionPagesClick,
-            this::quickActionPostsClick,
-            this::quickActionMediaClick,
             this::onQuickStartBlockRemoveMenuItemClick,
             this::onQuickStartTaskTypeItemClick,
             DomainRegistrationCardBuilderParams(
                     isDomainCreditAvailable = isDomainCreditAvailable,
                     domainRegistrationClick = this::domainRegistrationClick
             ),
-            PostCardBuilderParams(mockedPostsData = mockedPostsData)
+            PostCardBuilderParams(mockedPostsData = mockedPostsData),
+            QuickActionsCardBuilderParams(
+                    siteModel = site,
+                    activeTask = activeTask,
+                    onQuickActionStatsClick = this::quickActionStatsClick,
+                    onQuickActionPagesClick = this::quickActionPagesClick,
+                    onQuickActionPostsClick = this::quickActionPostsClick,
+                    onQuickActionMediaClick = this::quickActionMediaClick,
+                    )
     ) + dynamicCardsBuilder.build(
             quickStartCategories,
             pinnedDynamicCard,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -233,18 +233,18 @@ class MySiteViewModel @Inject constructor(
                     onQuickActionMediaClick = this::quickActionMediaClick
             ),
             QuickStartCardBuilderParams(
-                    quickStartCategories,
-                    this::onQuickStartBlockRemoveMenuItemClick,
-                    this::onQuickStartTaskTypeItemClick
+                    quickStartCategories = quickStartCategories,
+                    onQuickStartBlockRemoveMenuItemClick = this::onQuickStartBlockRemoveMenuItemClick,
+                    onQuickStartTaskTypeItemClick = this::onQuickStartTaskTypeItemClick
             ),
             SiteInfoCardBuilderParams(
-                    site,
-                    showSiteIconProgressBar,
-                    this::titleClick,
-                    this::iconClick,
-                    this::urlClick,
-                    this::switchSiteClick,
-                    activeTask
+                    site = site,
+                    showSiteIconProgressBar = showSiteIconProgressBar,
+                    titleClick = this::titleClick,
+                    iconClick = this::iconClick,
+                    urlClick = this::urlClick,
+                    switchSiteClick = this::switchSiteClick,
+                    activeTask = activeTask
             )
     ) + dynamicCardsBuilder.build(
             quickStartCategories,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.NoSites
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
@@ -219,7 +220,6 @@ class MySiteViewModel @Inject constructor(
             showSiteIconProgressBar,
             activeTask,
             quickStartCategories,
-            mockedPostsData,
             this::titleClick,
             this::iconClick,
             this::urlClick,
@@ -233,7 +233,8 @@ class MySiteViewModel @Inject constructor(
             DomainRegistrationCardBuilderParams(
                     isDomainCreditAvailable = isDomainCreditAvailable,
                     domainRegistrationClick = this::domainRegistrationClick
-            )
+            ),
+            PostCardBuilderParams(mockedPostsData = mockedPostsData)
     ) + dynamicCardsBuilder.build(
             quickStartCategories,
             pinnedDynamicCard,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.NoSites
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
@@ -220,13 +221,10 @@ class MySiteViewModel @Inject constructor(
             site,
             showSiteIconProgressBar,
             activeTask,
-            quickStartCategories,
             this::titleClick,
             this::iconClick,
             this::urlClick,
             this::switchSiteClick,
-            this::onQuickStartBlockRemoveMenuItemClick,
-            this::onQuickStartTaskTypeItemClick,
             DomainRegistrationCardBuilderParams(
                     isDomainCreditAvailable = isDomainCreditAvailable,
                     domainRegistrationClick = this::domainRegistrationClick
@@ -239,7 +237,12 @@ class MySiteViewModel @Inject constructor(
                     onQuickActionPagesClick = this::quickActionPagesClick,
                     onQuickActionPostsClick = this::quickActionPostsClick,
                     onQuickActionMediaClick = this::quickActionMediaClick,
-                    )
+                    ),
+            QuickStartCardBuilderParams(
+                    quickStartCategories,
+                    this::onQuickStartBlockRemoveMenuItemClick,
+                    this::onQuickStartTaskTypeItemClick
+            )
     ) + dynamicCardsBuilder.build(
             quickStartCategories,
             pinnedDynamicCard,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -30,7 +30,6 @@ class CardsBuilder @Inject constructor(
     private val postCardBuilder: PostCardBuilder,
     private val mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig
 ) {
-    @Suppress("LongParameterList")
     fun build(
         domainRegistrationCardBuilderParams: DomainRegistrationCardBuilderParams,
         postCardBuilderParams: PostCardBuilderParams,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -59,10 +59,12 @@ class CardsBuilder @Inject constructor(
 
     private fun buildSiteInfoCard(params: SiteInfoCardBuilderParams) = siteInfoCardBuilder.buildSiteInfoCard(params)
 
-    private fun buildQuickActionsCard(params: QuickActionsCardBuilderParams
+    private fun buildQuickActionsCard(
+        params: QuickActionsCardBuilderParams
     ) = quickActionsCardBuilder.build(params)
 
-    private fun trackAndBuildDomainRegistrationCard(params: DomainRegistrationCardBuilderParams
+    private fun trackAndBuildDomainRegistrationCard(
+        params: DomainRegistrationCardBuilderParams
     ): DomainRegistrationCard {
         analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_PROMPT_SHOWN)
         return DomainRegistrationCard(ListItemInteraction.create(params.domainRegistrationClick))

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -38,29 +38,23 @@ class CardsBuilder @Inject constructor(
         siteInfoCardBuilderParams: SiteInfoCardBuilderParams
     ): List<MySiteCardAndItem> {
         val cards = mutableListOf<MySiteCardAndItem>()
-        cards.add(buildSiteInfoCard(siteInfoCardBuilderParams))
+        cards.add(siteInfoCardBuilder.buildSiteInfoCard(siteInfoCardBuilderParams))
         if (!buildConfigWrapper.isJetpackApp) {
-            cards.add(buildQuickActionsCard(quickActionsCardBuilderParams))
+            cards.add(quickActionsCardBuilder.build(quickActionsCardBuilderParams))
         }
         if (domainRegistrationCardBuilderParams.isDomainCreditAvailable) {
             cards.add(trackAndBuildDomainRegistrationCard(domainRegistrationCardBuilderParams))
         }
         if (!quickStartDynamicCardsFeatureConfig.isEnabled()) {
             quickStartCardBuilderParams.quickStartCategories.takeIf { it.isNotEmpty() }?.let {
-                cards.add(buildQuickStartCard(quickStartCardBuilderParams))
+                cards.add(quickStartCardBuilder.build(quickStartCardBuilderParams))
             }
         }
         if (mySiteDashboardPhase2FeatureConfig.isEnabled()) {
-            cards.addAll(buildPostCards(postCardBuilderParams))
+            cards.addAll(postCardBuilder.build(postCardBuilderParams))
         }
         return cards
     }
-
-    private fun buildSiteInfoCard(params: SiteInfoCardBuilderParams) = siteInfoCardBuilder.buildSiteInfoCard(params)
-
-    private fun buildQuickActionsCard(
-        params: QuickActionsCardBuilderParams
-    ) = quickActionsCardBuilder.build(params)
 
     private fun trackAndBuildDomainRegistrationCard(
         params: DomainRegistrationCardBuilderParams
@@ -68,8 +62,4 @@ class CardsBuilder @Inject constructor(
         analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_PROMPT_SHOWN)
         return DomainRegistrationCard(ListItemInteraction.create(params.domainRegistrationClick))
     }
-
-    private fun buildQuickStartCard(params: QuickStartCardBuilderParams) = quickStartCardBuilder.build(params)
-
-    private fun buildPostCards(params: PostCardBuilderParams) = postCardBuilder.build(params)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -3,16 +3,15 @@ package org.wordpress.android.ui.mysite.cards
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
-import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoCardBuilder
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.BuildConfigWrapper
@@ -37,17 +36,15 @@ class CardsBuilder @Inject constructor(
         site: SiteModel,
         showSiteIconProgressBar: Boolean,
         activeTask: QuickStartTask?,
-        quickStartCategories: List<QuickStartCategory>,
         titleClick: () -> Unit,
         iconClick: () -> Unit,
         urlClick: () -> Unit,
         switchSiteClick: () -> Unit,
-        onQuickStartBlockRemoveMenuItemClick: () -> Unit,
-        onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit,
         // Start transition to using param classes - alphabetically starting
         domainRegistrationCardBuilderParams: DomainRegistrationCardBuilderParams,
         postCardBuilderParams: PostCardBuilderParams,
-        quickActionsCardBuilderParams: QuickActionsCardBuilderParams
+        quickActionsCardBuilderParams: QuickActionsCardBuilderParams,
+        quickStartCardBuilderParams: QuickStartCardBuilderParams
     ): List<MySiteCardAndItem> {
         val cards = mutableListOf<MySiteCardAndItem>()
         cards.add(
@@ -68,14 +65,8 @@ class CardsBuilder @Inject constructor(
             cards.add(trackAndBuildDomainRegistrationCard(domainRegistrationCardBuilderParams))
         }
         if (!quickStartDynamicCardsFeatureConfig.isEnabled()) {
-            quickStartCategories.takeIf { it.isNotEmpty() }?.let {
-                cards.add(
-                        buildQuickStartCard(
-                                quickStartCategories,
-                                onQuickStartBlockRemoveMenuItemClick,
-                                onQuickStartTaskTypeItemClick
-                        )
-                )
+            quickStartCardBuilderParams.quickStartCategories.takeIf { it.isNotEmpty() }?.let {
+                cards.add(buildQuickStartCard(quickStartCardBuilderParams))
             }
         }
         if (mySiteDashboardPhase2FeatureConfig.isEnabled()) {
@@ -113,15 +104,7 @@ class CardsBuilder @Inject constructor(
         return DomainRegistrationCard(ListItemInteraction.create(params.domainRegistrationClick))
     }
 
-    private fun buildQuickStartCard(
-        quickStartCategories: List<QuickStartCategory>,
-        onQuickStartBlockRemoveMenuItemClick: () -> Unit,
-        onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit
-    ) = quickStartCardBuilder.build(
-            quickStartCategories,
-            onQuickStartBlockRemoveMenuItemClick,
-            onQuickStartTaskTypeItemClick
-    )
+    private fun buildQuickStartCard(params: QuickStartCardBuilderParams) = quickStartCardBuilder.build(params)
 
     private fun buildPostCards(params: PostCardBuilderParams) = postCardBuilder.build(params)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -7,8 +7,8 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder
-import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
@@ -37,7 +37,6 @@ class CardsBuilder @Inject constructor(
         showSiteIconProgressBar: Boolean,
         activeTask: QuickStartTask?,
         quickStartCategories: List<QuickStartCategory>,
-        mockedPostsData: MockedPostsData? = null,
         titleClick: () -> Unit,
         iconClick: () -> Unit,
         urlClick: () -> Unit,
@@ -50,6 +49,7 @@ class CardsBuilder @Inject constructor(
         onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit,
         // Start transition to using param classes - alphabetically starting
         domainRegistrationCardBuilderParams: DomainRegistrationCardBuilderParams,
+        postCardBuilderParams: PostCardBuilderParams
     ): List<MySiteCardAndItem> {
         val cards = mutableListOf<MySiteCardAndItem>()
         cards.add(
@@ -90,7 +90,7 @@ class CardsBuilder @Inject constructor(
             }
         }
         if (mySiteDashboardPhase2FeatureConfig.isEnabled()) {
-            mockedPostsData?.let { cards.addAll(buildPostCards(it)) }
+            cards.addAll(buildPostCards(postCardBuilderParams))
         }
         return cards
     }
@@ -149,5 +149,5 @@ class CardsBuilder @Inject constructor(
             onQuickStartTaskTypeItemClick
     )
 
-    private fun buildPostCards(mockedPostsData: MockedPostsData) = postCardBuilder.build(mockedPostsData)
+    private fun buildPostCards(params: PostCardBuilderParams) = postCardBuilder.build(params)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
@@ -41,15 +42,12 @@ class CardsBuilder @Inject constructor(
         iconClick: () -> Unit,
         urlClick: () -> Unit,
         switchSiteClick: () -> Unit,
-        quickActionStatsClick: () -> Unit,
-        quickActionPagesClick: () -> Unit,
-        quickActionPostsClick: () -> Unit,
-        quickActionMediaClick: () -> Unit,
         onQuickStartBlockRemoveMenuItemClick: () -> Unit,
         onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit,
         // Start transition to using param classes - alphabetically starting
         domainRegistrationCardBuilderParams: DomainRegistrationCardBuilderParams,
-        postCardBuilderParams: PostCardBuilderParams
+        postCardBuilderParams: PostCardBuilderParams,
+        quickActionsCardBuilderParams: QuickActionsCardBuilderParams
     ): List<MySiteCardAndItem> {
         val cards = mutableListOf<MySiteCardAndItem>()
         cards.add(
@@ -64,16 +62,7 @@ class CardsBuilder @Inject constructor(
                 )
         )
         if (!buildConfigWrapper.isJetpackApp) {
-            cards.add(
-                    buildQuickActionsCard(
-                            quickActionStatsClick,
-                            quickActionPagesClick,
-                            quickActionPostsClick,
-                            quickActionMediaClick,
-                            site,
-                            activeTask
-                    )
-            )
+            cards.add(buildQuickActionsCard(quickActionsCardBuilderParams))
         }
         if (domainRegistrationCardBuilderParams.isDomainCreditAvailable) {
             cards.add(trackAndBuildDomainRegistrationCard(domainRegistrationCardBuilderParams))
@@ -115,23 +104,8 @@ class CardsBuilder @Inject constructor(
             activeTask == QuickStartTask.UPLOAD_SITE_ICON
     )
 
-    @Suppress("LongParameterList")
-    private fun buildQuickActionsCard(
-        quickActionStatsClick: () -> Unit,
-        quickActionPagesClick: () -> Unit,
-        quickActionPostsClick: () -> Unit,
-        quickActionMediaClick: () -> Unit,
-        site: SiteModel,
-        activeTask: QuickStartTask?
-    ) = quickActionsCardBuilder.build(
-            quickActionStatsClick,
-            quickActionPagesClick,
-            quickActionPostsClick,
-            quickActionMediaClick,
-            site.isSelfHostedAdmin || site.hasCapabilityEditPages,
-            activeTask == QuickStartTask.CHECK_STATS,
-            activeTask == QuickStartTask.EDIT_HOMEPAGE || activeTask == QuickStartTask.REVIEW_PAGES
-    )
+    private fun buildQuickActionsCard(params: QuickActionsCardBuilderParams
+    ) = quickActionsCardBuilder.build(params)
 
     private fun trackAndBuildDomainRegistrationCard(params: DomainRegistrationCardBuilderParams
     ): DomainRegistrationCard {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
@@ -35,7 +36,6 @@ class CardsBuilder @Inject constructor(
         site: SiteModel,
         showSiteIconProgressBar: Boolean,
         activeTask: QuickStartTask?,
-        isDomainCreditAvailable: Boolean,
         quickStartCategories: List<QuickStartCategory>,
         mockedPostsData: MockedPostsData? = null,
         titleClick: () -> Unit,
@@ -46,9 +46,10 @@ class CardsBuilder @Inject constructor(
         quickActionPagesClick: () -> Unit,
         quickActionPostsClick: () -> Unit,
         quickActionMediaClick: () -> Unit,
-        domainRegistrationClick: () -> Unit,
         onQuickStartBlockRemoveMenuItemClick: () -> Unit,
-        onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit
+        onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit,
+        // Start transition to using param classes - alphabetically starting
+        domainRegistrationCardBuilderParams: DomainRegistrationCardBuilderParams,
     ): List<MySiteCardAndItem> {
         val cards = mutableListOf<MySiteCardAndItem>()
         cards.add(
@@ -74,8 +75,8 @@ class CardsBuilder @Inject constructor(
                     )
             )
         }
-        if (isDomainCreditAvailable) {
-            cards.add(trackAndBuildDomainRegistrationCard(domainRegistrationClick))
+        if (domainRegistrationCardBuilderParams.isDomainCreditAvailable) {
+            cards.add(trackAndBuildDomainRegistrationCard(domainRegistrationCardBuilderParams))
         }
         if (!quickStartDynamicCardsFeatureConfig.isEnabled()) {
             quickStartCategories.takeIf { it.isNotEmpty() }?.let {
@@ -132,9 +133,10 @@ class CardsBuilder @Inject constructor(
             activeTask == QuickStartTask.EDIT_HOMEPAGE || activeTask == QuickStartTask.REVIEW_PAGES
     )
 
-    private fun trackAndBuildDomainRegistrationCard(domainRegistrationClick: () -> Unit): DomainRegistrationCard {
+    private fun trackAndBuildDomainRegistrationCard(params: DomainRegistrationCardBuilderParams
+    ): DomainRegistrationCard {
         analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_PROMPT_SHOWN)
-        return DomainRegistrationCard(ListItemInteraction.create(domainRegistrationClick))
+        return DomainRegistrationCard(ListItemInteraction.create(params.domainRegistrationClick))
     }
 
     private fun buildQuickStartCard(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -1,14 +1,13 @@
 package org.wordpress.android.ui.mysite.cards
 
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
@@ -33,31 +32,14 @@ class CardsBuilder @Inject constructor(
 ) {
     @Suppress("LongParameterList")
     fun build(
-        site: SiteModel,
-        showSiteIconProgressBar: Boolean,
-        activeTask: QuickStartTask?,
-        titleClick: () -> Unit,
-        iconClick: () -> Unit,
-        urlClick: () -> Unit,
-        switchSiteClick: () -> Unit,
-        // Start transition to using param classes - alphabetically starting
         domainRegistrationCardBuilderParams: DomainRegistrationCardBuilderParams,
         postCardBuilderParams: PostCardBuilderParams,
         quickActionsCardBuilderParams: QuickActionsCardBuilderParams,
-        quickStartCardBuilderParams: QuickStartCardBuilderParams
+        quickStartCardBuilderParams: QuickStartCardBuilderParams,
+        siteInfoCardBuilderParams: SiteInfoCardBuilderParams
     ): List<MySiteCardAndItem> {
         val cards = mutableListOf<MySiteCardAndItem>()
-        cards.add(
-                buildSiteInfoCard(
-                        site,
-                        showSiteIconProgressBar,
-                        titleClick,
-                        iconClick,
-                        urlClick,
-                        switchSiteClick,
-                        activeTask
-                )
-        )
+        cards.add(buildSiteInfoCard(siteInfoCardBuilderParams))
         if (!buildConfigWrapper.isJetpackApp) {
             cards.add(buildQuickActionsCard(quickActionsCardBuilderParams))
         }
@@ -75,25 +57,7 @@ class CardsBuilder @Inject constructor(
         return cards
     }
 
-    @Suppress("LongParameterList")
-    private fun buildSiteInfoCard(
-        site: SiteModel,
-        showSiteIconProgressBar: Boolean,
-        titleClick: () -> Unit,
-        iconClick: () -> Unit,
-        urlClick: () -> Unit,
-        switchSiteClick: () -> Unit,
-        activeTask: QuickStartTask?
-    ) = siteInfoCardBuilder.buildSiteInfoCard(
-            site,
-            showSiteIconProgressBar,
-            titleClick,
-            iconClick,
-            urlClick,
-            switchSiteClick,
-            activeTask == QuickStartTask.UPDATE_SITE_TITLE,
-            activeTask == QuickStartTask.UPLOAD_SITE_ICON
-    )
+    private fun buildSiteInfoCard(params: SiteInfoCardBuilderParams) = siteInfoCardBuilder.buildSiteInfoCard(params)
 
     private fun buildQuickActionsCard(params: QuickActionsCardBuilderParams
     ) = quickActionsCardBuilder.build(params)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/post/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/post/PostCardBuilder.kt
@@ -1,14 +1,14 @@
 package org.wordpress.android.ui.mysite.cards.post
 
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard
-import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import javax.inject.Inject
 
 class PostCardBuilder @Inject constructor() {
-    fun build(mockedPostsData: MockedPostsData): List<PostCard> {
+    fun build(params: PostCardBuilderParams): List<PostCard> {
         val cards = mutableListOf<PostCard>()
-        mockedPostsData.posts?.draft?.map {
+        params.mockedPostsData?.posts?.draft?.map {
             cards.add(
                     PostCard(
                             title = UiStringText(DRAFT_TITLE),
@@ -16,7 +16,7 @@ class PostCardBuilder @Inject constructor() {
                     )
             )
         }
-        mockedPostsData.posts?.scheduled?.map {
+        params.mockedPostsData?.posts?.scheduled?.map {
             cards.add(
                     PostCard(
                             title = UiStringText(SCHEDULED_TITLE),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsCardBuilder.kt
@@ -1,29 +1,23 @@
 package org.wordpress.android.ui.mysite.cards.quickactions
 
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import javax.inject.Inject
 
 class QuickActionsCardBuilder @Inject constructor() {
-    @Suppress("LongParameterList")
-    fun build(
-        onQuickActionStatsClick: () -> Unit,
-        onQuickActionPagesClick: () -> Unit,
-        onQuickActionPostsClick: () -> Unit,
-        onQuickActionMediaClick: () -> Unit,
-        showPages: Boolean,
-        showStatsFocusPoint: Boolean,
-        showPagesFocusPoint: Boolean
-    ) = QuickActionsCard(
+    fun build(params: QuickActionsCardBuilderParams) = QuickActionsCard(
             title = UiStringRes(R.string.my_site_quick_actions_title),
-            onStatsClick = ListItemInteraction.create { onQuickActionStatsClick.invoke() },
-            onPagesClick = ListItemInteraction.create { onQuickActionPagesClick.invoke() },
-            onPostsClick = ListItemInteraction.create { onQuickActionPostsClick.invoke() },
-            onMediaClick = ListItemInteraction.create { onQuickActionMediaClick.invoke() },
-            showPages = showPages,
-            showStatsFocusPoint = showStatsFocusPoint,
-            showPagesFocusPoint = showPagesFocusPoint
+            onStatsClick = ListItemInteraction.create { params.onQuickActionStatsClick.invoke() },
+            onPagesClick = ListItemInteraction.create { params.onQuickActionPagesClick.invoke() },
+            onPostsClick = ListItemInteraction.create { params.onQuickActionPostsClick.invoke() },
+            onMediaClick = ListItemInteraction.create { params.onQuickActionMediaClick.invoke() },
+            showPages = params.siteModel.isSelfHostedAdmin || params.siteModel.hasCapabilityEditPages,
+            showStatsFocusPoint = params.activeTask == QuickStartTask.CHECK_STATS,
+            showPagesFocusPoint = params.activeTask == QuickStartTask.EDIT_HOMEPAGE ||
+                    params.activeTask == QuickStartTask.REVIEW_PAGES
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard.QuickStartTaskTypeItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -13,14 +14,15 @@ import javax.inject.Inject
 import kotlin.math.roundToInt
 
 class QuickStartCardBuilder @Inject constructor() {
-    fun build(
-        categories: List<QuickStartCategory>,
-        onRemoveMenuItemClick: () -> Unit,
-        onItemClick: (QuickStartTaskType) -> Unit
-    ) = QuickStartCard(
+    fun build(params: QuickStartCardBuilderParams) = QuickStartCard(
             title = UiStringRes(R.string.quick_start_sites),
-            onRemoveMenuItemClick = ListItemInteraction.create { onRemoveMenuItemClick.invoke() },
-            taskTypeItems = categories.map { buildQuickStartTaskTypeItem(it, onItemClick) }
+            onRemoveMenuItemClick = ListItemInteraction.create { params.onQuickStartBlockRemoveMenuItemClick.invoke() },
+            taskTypeItems = params.quickStartCategories.map {
+                buildQuickStartTaskTypeItem(
+                        it,
+                        params.onQuickStartTaskTypeItemClick
+                )
+            }
     )
 
     private fun buildQuickStartTaskTypeItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoCardBuilder.kt
@@ -2,8 +2,10 @@ package org.wordpress.android.ui.mysite.cards.siteinfo
 
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard.IconState
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -11,27 +13,17 @@ import javax.inject.Inject
 
 class SiteInfoCardBuilder
 @Inject constructor(private val resourceProvider: ResourceProvider) {
-    @Suppress("LongParameterList")
-    fun buildSiteInfoCard(
-        site: SiteModel,
-        showSiteIconProgressBar: Boolean,
-        titleClick: () -> Unit,
-        iconClick: () -> Unit,
-        urlClick: () -> Unit,
-        switchSiteClick: () -> Unit,
-        showUpdateSiteTitleFocusPoint: Boolean,
-        showUploadSiteIconFocusPoint: Boolean
-    ): SiteInfoCard {
-        val homeUrl = SiteUtils.getHomeURLOrHostName(site)
-        val blogTitle = SiteUtils.getSiteNameOrHomeURL(site)
-        val siteIcon = if (!showSiteIconProgressBar && !site.iconUrl.isNullOrEmpty()) {
+    fun buildSiteInfoCard(params: SiteInfoCardBuilderParams): SiteInfoCard {
+        val homeUrl = SiteUtils.getHomeURLOrHostName(params.site)
+        val blogTitle = SiteUtils.getSiteNameOrHomeURL(params.site)
+        val siteIcon = if (!params.showSiteIconProgressBar && !params.site.iconUrl.isNullOrEmpty()) {
             IconState.Visible(
                     SiteUtils.getSiteIconUrl(
-                            site,
+                            params.site,
                             resourceProvider.getDimensionPixelSize(R.dimen.blavatar_sz_small)
                     )
             )
-        } else if (showSiteIconProgressBar) {
+        } else if (params.showSiteIconProgressBar) {
             IconState.Progress
         } else {
             IconState.Visible()
@@ -40,12 +32,12 @@ class SiteInfoCardBuilder
                 blogTitle,
                 homeUrl,
                 siteIcon,
-                showUpdateSiteTitleFocusPoint,
-                showUploadSiteIconFocusPoint,
-                buildTitleClick(site, titleClick),
-                ListItemInteraction.create(iconClick),
-                ListItemInteraction.create(urlClick),
-                ListItemInteraction.create(switchSiteClick)
+                params.activeTask == QuickStartTask.UPDATE_SITE_TITLE,
+                params.activeTask == QuickStartTask.UPLOAD_SITE_ICON,
+                buildTitleClick(params.site, params.titleClick),
+                ListItemInteraction.create(params.iconClick),
+                ListItemInteraction.create(params.urlClick),
+                ListItemInteraction.create(params.switchSiteClick)
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard.IconS
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartDynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DomainCreditAvailable
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DynamicCardsUpdate
@@ -118,8 +119,8 @@ private const val CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION = 4
 private const val CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION = 5
 private const val CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION = 6
 private const val CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION = 7
-private const val CARDS_BUILDER_QUICK_START_REMOVE_MENU_CLICK_PARAM_POSITION = 12
-private const val CARDS_BUILDER_QUICK_START_TASK_TYPE_ITEM_CLICK_PARAM_POSITION = 13
+private const val CARDS_BUILDER_QUICK_START_REMOVE_MENU_CLICK_PARAM_POSITION = 8
+private const val CARDS_BUILDER_QUICK_START_TASK_TYPE_ITEM_CLICK_PARAM_POSITION = 9
 private const val DYNAMIC_CARDS_BUILDER_MORE_CLICK_PARAM_POSITION = 3
 
 @ExperimentalCoroutinesApi
@@ -1319,14 +1320,11 @@ class MySiteViewModelTest : BaseUnitTest() {
                 iconClick = any(),
                 urlClick = any(),
                 switchSiteClick = any(),
-                quickActionStatsClick = any(),
-                quickActionPagesClick = any(),
-                quickActionPostsClick = any(),
-                quickActionMediaClick = any(),
                 onQuickStartBlockRemoveMenuItemClick = any(),
                 onQuickStartTaskTypeItemClick = any(),
                 domainRegistrationCardBuilderParams = any(),
-                postCardBuilderParams = any()
+                postCardBuilderParams = any(),
+                quickActionsCardBuilderParams = any()
         )
     }
 
@@ -1365,16 +1363,17 @@ class MySiteViewModelTest : BaseUnitTest() {
     )
 
     private fun initQuickActionsCard(mockInvocation: InvocationOnMock): QuickActionsCard {
-        quickActionsStatsClickAction = mockInvocation.getArgument(8)
-        quickActionsPagesClickAction = mockInvocation.getArgument(9)
-        quickActionsPostsClickAction = mockInvocation.getArgument(10)
-        quickActionsMediaClickAction = mockInvocation.getArgument(11)
+        val params = (mockInvocation.arguments.filterIsInstance<QuickActionsCardBuilderParams>() [0])
+        quickActionsStatsClickAction = params.onQuickActionStatsClick
+        quickActionsPagesClickAction = params.onQuickActionPagesClick
+        quickActionsPostsClickAction = params.onQuickActionPostsClick
+        quickActionsMediaClickAction = params.onQuickActionMediaClick
         return QuickActionsCard(
                 title = UiStringText(""),
-                onStatsClick = ListItemInteraction.create { (quickActionsStatsClickAction as () -> Unit).invoke() },
-                onPagesClick = ListItemInteraction.create { (quickActionsPagesClickAction as () -> Unit).invoke() },
-                onPostsClick = ListItemInteraction.create { (quickActionsPostsClickAction as () -> Unit).invoke() },
-                onMediaClick = ListItemInteraction.create { (quickActionsMediaClickAction as () -> Unit).invoke() },
+                onStatsClick = ListItemInteraction.create { params.onQuickActionStatsClick.invoke() },
+                onPagesClick = ListItemInteraction.create { params.onQuickActionPagesClick.invoke() },
+                onPostsClick = ListItemInteraction.create { params.onQuickActionPostsClick.invoke() },
+                onMediaClick = ListItemInteraction.create { params.onQuickActionMediaClick.invoke() },
                 showPages = site.isSelfHostedAdmin || site.hasCapabilityEditPages,
                 showPagesFocusPoint = false,
                 showStatsFocusPoint = false

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1377,7 +1377,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 title = UiStringText(""),
                 onRemoveMenuItemClick = ListItemInteraction.create {
                     params.onQuickStartBlockRemoveMenuItemClick.invoke()
-                                                                   },
+                },
                 taskTypeItems = listOf(
                         QuickStartTaskTypeItem(
                                 quickStartTaskType = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -114,12 +114,12 @@ import org.wordpress.android.util.config.UnifiedCommentsListFeatureConfig
 import org.wordpress.android.viewmodel.ContextProvider
 
 /* These values can change if a new parameter is added to CardsBuilder constructor before clicks */
-private const val CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION = 5
-private const val CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION = 6
-private const val CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION = 7
-private const val CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION = 8
-private const val CARDS_BUILDER_QUICK_START_REMOVE_MENU_CLICK_PARAM_POSITION = 13
-private const val CARDS_BUILDER_QUICK_START_TASK_TYPE_ITEM_CLICK_PARAM_POSITION = 14
+private const val CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION = 4
+private const val CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION = 5
+private const val CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION = 6
+private const val CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION = 7
+private const val CARDS_BUILDER_QUICK_START_REMOVE_MENU_CLICK_PARAM_POSITION = 12
+private const val CARDS_BUILDER_QUICK_START_TASK_TYPE_ITEM_CLICK_PARAM_POSITION = 13
 private const val DYNAMIC_CARDS_BUILDER_MORE_CLICK_PARAM_POSITION = 3
 
 @ExperimentalCoroutinesApi
@@ -1315,7 +1315,6 @@ class MySiteViewModelTest : BaseUnitTest() {
                 showSiteIconProgressBar = any(),
                 activeTask = anyOrNull(),
                 quickStartCategories = any(),
-                mockedPostsData = any(),
                 titleClick = any(),
                 iconClick = any(),
                 urlClick = any(),
@@ -1326,7 +1325,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 quickActionMediaClick = any(),
                 onQuickStartBlockRemoveMenuItemClick = any(),
                 onQuickStartTaskTypeItemClick = any(),
-                domainRegistrationCardBuilderParams = any()
+                domainRegistrationCardBuilderParams = any(),
+                postCardBuilderParams = any()
         )
     }
 
@@ -1365,10 +1365,10 @@ class MySiteViewModelTest : BaseUnitTest() {
     )
 
     private fun initQuickActionsCard(mockInvocation: InvocationOnMock): QuickActionsCard {
-        quickActionsStatsClickAction = mockInvocation.getArgument(9)
-        quickActionsPagesClickAction = mockInvocation.getArgument(10)
-        quickActionsPostsClickAction = mockInvocation.getArgument(11)
-        quickActionsMediaClickAction = mockInvocation.getArgument(12)
+        quickActionsStatsClickAction = mockInvocation.getArgument(8)
+        quickActionsPagesClickAction = mockInvocation.getArgument(9)
+        quickActionsPostsClickAction = mockInvocation.getArgument(10)
+        quickActionsMediaClickAction = mockInvocation.getArgument(11)
         return QuickActionsCard(
                 title = UiStringText(""),
                 onStatsClick = ListItemInteraction.create { (quickActionsStatsClickAction as () -> Unit).invoke() },

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -44,6 +44,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartD
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DomainCreditAvailable
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DynamicCardsUpdate
@@ -115,11 +116,6 @@ import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.util.config.UnifiedCommentsListFeatureConfig
 import org.wordpress.android.viewmodel.ContextProvider
 
-/* These values can change if a new parameter is added to CardsBuilder constructor before clicks */
-private const val CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION = 3
-private const val CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION = 4
-private const val CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION = 5
-private const val CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION = 6
 private const val DYNAMIC_CARDS_BUILDER_MORE_CLICK_PARAM_POSITION = 3
 
 @ExperimentalCoroutinesApi
@@ -1311,17 +1307,11 @@ class MySiteViewModelTest : BaseUnitTest() {
             val postCard = initPostCard()
             listOf<MySiteCardAndItem>(siteInfoCard, quickActionsCard, domainRegistrationCard, quickStartCard, postCard)
         }.whenever(cardsBuilder).build(
-                site = eq(site),
-                showSiteIconProgressBar = any(),
-                activeTask = anyOrNull(),
-                titleClick = any(),
-                iconClick = any(),
-                urlClick = any(),
-                switchSiteClick = any(),
                 domainRegistrationCardBuilderParams = any(),
                 postCardBuilderParams = any(),
                 quickActionsCardBuilderParams = any(),
-                quickStartCardBuilderParams = any()
+                quickStartCardBuilderParams = any(),
+                siteInfoCardBuilderParams = any()
         )
     }
 
@@ -1339,25 +1329,20 @@ class MySiteViewModelTest : BaseUnitTest() {
         )
     }
 
-    private fun initSiteInfoCard(mockInvocation: InvocationOnMock) = SiteInfoCard(
-            title = siteName,
-            url = siteUrl,
-            iconState = IconState.Visible(siteIcon),
-            showTitleFocusPoint = false,
-            showIconFocusPoint = false,
-            onTitleClick = ListItemInteraction.create {
-                (mockInvocation.getArgument(CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION) as () -> Unit).invoke()
-            },
-            onIconClick = ListItemInteraction.create {
-                (mockInvocation.getArgument(CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION) as () -> Unit).invoke()
-            },
-            onUrlClick = ListItemInteraction.create {
-                (mockInvocation.getArgument(CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION) as () -> Unit).invoke()
-            },
-            onSwitchSiteClick = ListItemInteraction.create {
-                (mockInvocation.getArgument(CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION) as () -> Unit).invoke()
-            }
-    )
+    private fun initSiteInfoCard(mockInvocation: InvocationOnMock): SiteInfoCard {
+        val params = (mockInvocation.arguments.filterIsInstance<SiteInfoCardBuilderParams>() [0])
+        return SiteInfoCard(
+                title = siteName,
+                url = siteUrl,
+                iconState = IconState.Visible(siteIcon),
+                showTitleFocusPoint = false,
+                showIconFocusPoint = false,
+                onTitleClick = ListItemInteraction.create { params.titleClick.invoke() },
+                onIconClick = ListItemInteraction.create { params.iconClick.invoke() },
+                onUrlClick = ListItemInteraction.create { params.urlClick.invoke() },
+                onSwitchSiteClick = ListItemInteraction.create { params.switchSiteClick.invoke() }
+        )
+    }
 
     private fun initQuickActionsCard(mockInvocation: InvocationOnMock): QuickActionsCard {
         val params = (mockInvocation.arguments.filterIsInstance<QuickActionsCardBuilderParams>() [0])

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -19,7 +19,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.junit.MockitoJUnitRunner
@@ -42,6 +41,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard.IconState
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartDynamicCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DomainCreditAvailable
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DynamicCardsUpdate
@@ -114,13 +114,12 @@ import org.wordpress.android.util.config.UnifiedCommentsListFeatureConfig
 import org.wordpress.android.viewmodel.ContextProvider
 
 /* These values can change if a new parameter is added to CardsBuilder constructor before clicks */
-private const val CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION = 6
-private const val CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION = 7
-private const val CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION = 8
-private const val CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION = 9
-private const val CARDS_BUILDER_DOMAIN_REGISTRATION_CLICK_PARAM_POSITION = 14
-private const val CARDS_BUILDER_QUICK_START_REMOVE_MENU_CLICK_PARAM_POSITION = 15
-private const val CARDS_BUILDER_QUICK_START_TASK_TYPE_ITEM_CLICK_PARAM_POSITION = 16
+private const val CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION = 5
+private const val CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION = 6
+private const val CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION = 7
+private const val CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION = 8
+private const val CARDS_BUILDER_QUICK_START_REMOVE_MENU_CLICK_PARAM_POSITION = 13
+private const val CARDS_BUILDER_QUICK_START_TASK_TYPE_ITEM_CLICK_PARAM_POSITION = 14
 private const val DYNAMIC_CARDS_BUILDER_MORE_CLICK_PARAM_POSITION = 3
 
 @ExperimentalCoroutinesApi
@@ -1315,7 +1314,6 @@ class MySiteViewModelTest : BaseUnitTest() {
                 site = eq(site),
                 showSiteIconProgressBar = any(),
                 activeTask = anyOrNull(),
-                isDomainCreditAvailable = anyBoolean(),
                 quickStartCategories = any(),
                 mockedPostsData = any(),
                 titleClick = any(),
@@ -1326,9 +1324,9 @@ class MySiteViewModelTest : BaseUnitTest() {
                 quickActionPagesClick = any(),
                 quickActionPostsClick = any(),
                 quickActionMediaClick = any(),
-                domainRegistrationClick = any(),
                 onQuickStartBlockRemoveMenuItemClick = any(),
-                onQuickStartTaskTypeItemClick = any()
+                onQuickStartTaskTypeItemClick = any(),
+                domainRegistrationCardBuilderParams = any()
         )
     }
 
@@ -1367,10 +1365,10 @@ class MySiteViewModelTest : BaseUnitTest() {
     )
 
     private fun initQuickActionsCard(mockInvocation: InvocationOnMock): QuickActionsCard {
-        quickActionsStatsClickAction = mockInvocation.getArgument(10)
-        quickActionsPagesClickAction = mockInvocation.getArgument(11)
-        quickActionsPostsClickAction = mockInvocation.getArgument(12)
-        quickActionsMediaClickAction = mockInvocation.getArgument(13)
+        quickActionsStatsClickAction = mockInvocation.getArgument(9)
+        quickActionsPagesClickAction = mockInvocation.getArgument(10)
+        quickActionsPostsClickAction = mockInvocation.getArgument(11)
+        quickActionsMediaClickAction = mockInvocation.getArgument(12)
         return QuickActionsCard(
                 title = UiStringText(""),
                 onStatsClick = ListItemInteraction.create { (quickActionsStatsClickAction as () -> Unit).invoke() },
@@ -1385,8 +1383,8 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     private fun initDomainRegistrationCard(mockInvocation: InvocationOnMock) = DomainRegistrationCard(
             ListItemInteraction.create {
-                (mockInvocation.getArgument(CARDS_BUILDER_DOMAIN_REGISTRATION_CLICK_PARAM_POSITION) as () -> Unit)
-                        .invoke()
+                (mockInvocation.arguments.filterIsInstance<DomainRegistrationCardBuilderParams>() [0])
+                        .domainRegistrationClick.invoke()
             }
     )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -43,6 +43,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartDynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DomainCreditAvailable
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DynamicCardsUpdate
@@ -115,12 +116,10 @@ import org.wordpress.android.util.config.UnifiedCommentsListFeatureConfig
 import org.wordpress.android.viewmodel.ContextProvider
 
 /* These values can change if a new parameter is added to CardsBuilder constructor before clicks */
-private const val CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION = 4
-private const val CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION = 5
-private const val CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION = 6
-private const val CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION = 7
-private const val CARDS_BUILDER_QUICK_START_REMOVE_MENU_CLICK_PARAM_POSITION = 8
-private const val CARDS_BUILDER_QUICK_START_TASK_TYPE_ITEM_CLICK_PARAM_POSITION = 9
+private const val CARDS_BUILDER_SITE_INFO_TITLE_CLICK_PARAM_POSITION = 3
+private const val CARDS_BUILDER_SITE_INFO_ICON_CLICK_PARAM_POSITION = 4
+private const val CARDS_BUILDER_SITE_INFO_URL_CLICK_PARAM_POSITION = 5
+private const val CARDS_BUILDER_SITE_INFO_SWITCH_SITE_PARAM_POSITION = 6
 private const val DYNAMIC_CARDS_BUILDER_MORE_CLICK_PARAM_POSITION = 3
 
 @ExperimentalCoroutinesApi
@@ -1315,16 +1314,14 @@ class MySiteViewModelTest : BaseUnitTest() {
                 site = eq(site),
                 showSiteIconProgressBar = any(),
                 activeTask = anyOrNull(),
-                quickStartCategories = any(),
                 titleClick = any(),
                 iconClick = any(),
                 urlClick = any(),
                 switchSiteClick = any(),
-                onQuickStartBlockRemoveMenuItemClick = any(),
-                onQuickStartTaskTypeItemClick = any(),
                 domainRegistrationCardBuilderParams = any(),
                 postCardBuilderParams = any(),
-                quickActionsCardBuilderParams = any()
+                quickActionsCardBuilderParams = any(),
+                quickStartCardBuilderParams = any()
         )
     }
 
@@ -1388,17 +1385,14 @@ class MySiteViewModelTest : BaseUnitTest() {
     )
 
     private fun initQuickStartCard(mockInvocation: InvocationOnMock): QuickStartCard {
-        removeMenuItemClickAction = mockInvocation.getArgument(
-                CARDS_BUILDER_QUICK_START_REMOVE_MENU_CLICK_PARAM_POSITION
-        ) as () -> Unit
-        quickStartTaskTypeItemClickAction = mockInvocation.getArgument(
-                CARDS_BUILDER_QUICK_START_TASK_TYPE_ITEM_CLICK_PARAM_POSITION
-        ) as ((QuickStartTaskType) -> Unit)
+        val params = (mockInvocation.arguments.filterIsInstance<QuickStartCardBuilderParams>() [0])
+        removeMenuItemClickAction = params.onQuickStartBlockRemoveMenuItemClick
+        quickStartTaskTypeItemClickAction = params.onQuickStartTaskTypeItemClick
         return QuickStartCard(
                 title = UiStringText(""),
                 onRemoveMenuItemClick = ListItemInteraction.create {
-                    (removeMenuItemClickAction as () -> Unit).invoke()
-                },
+                    params.onQuickStartBlockRemoveMenuItemClick.invoke()
+                                                                   },
                 taskTypeItems = listOf(
                         QuickStartTaskTypeItem(
                                 quickStartTaskType = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1330,7 +1330,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     private fun initSiteInfoCard(mockInvocation: InvocationOnMock): SiteInfoCard {
-        val params = (mockInvocation.arguments.filterIsInstance<SiteInfoCardBuilderParams>() [0])
+        val params = (mockInvocation.arguments.filterIsInstance<SiteInfoCardBuilderParams>()).first()
         return SiteInfoCard(
                 title = siteName,
                 url = siteUrl,
@@ -1345,7 +1345,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     private fun initQuickActionsCard(mockInvocation: InvocationOnMock): QuickActionsCard {
-        val params = (mockInvocation.arguments.filterIsInstance<QuickActionsCardBuilderParams>() [0])
+        val params = (mockInvocation.arguments.filterIsInstance<QuickActionsCardBuilderParams>()).first()
         quickActionsStatsClickAction = params.onQuickActionStatsClick
         quickActionsPagesClickAction = params.onQuickActionPagesClick
         quickActionsPostsClickAction = params.onQuickActionPostsClick
@@ -1364,13 +1364,13 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     private fun initDomainRegistrationCard(mockInvocation: InvocationOnMock) = DomainRegistrationCard(
             ListItemInteraction.create {
-                (mockInvocation.arguments.filterIsInstance<DomainRegistrationCardBuilderParams>() [0])
+                (mockInvocation.arguments.filterIsInstance<DomainRegistrationCardBuilderParams>()).first()
                         .domainRegistrationClick.invoke()
             }
     )
 
     private fun initQuickStartCard(mockInvocation: InvocationOnMock): QuickStartCard {
-        val params = (mockInvocation.arguments.filterIsInstance<QuickStartCardBuilderParams>() [0])
+        val params = (mockInvocation.arguments.filterIsInstance<QuickStartCardBuilderParams>()).first()
         removeMenuItemClickAction = params.onQuickStartBlockRemoveMenuItemClick
         quickStartTaskTypeItemClickAction = params.onQuickStartTaskTypeItemClick
         return QuickStartCard(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard.QuickStartTaskTypeItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard.IconState
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData.Post
@@ -99,7 +100,6 @@ class CardsBuilderTest {
     }
 
     /* DOMAIN REGISTRATION CARD */
-
     @Test
     fun `when domain credit is available, then correct event is tracked`() {
         buildCards(isDomainCreditAvailable = true)
@@ -185,7 +185,6 @@ class CardsBuilderTest {
                 site = site,
                 showSiteIconProgressBar = false,
                 activeTask = activeTask,
-                isDomainCreditAvailable = isDomainCreditAvailable,
                 quickStartCategories = if (isQuickStartInProgress) listOf(quickStartCategory) else emptyList(),
                 titleClick = mock(),
                 iconClick = mock(),
@@ -195,10 +194,13 @@ class CardsBuilderTest {
                 quickActionPagesClick = mock(),
                 quickActionPostsClick = mock(),
                 quickActionMediaClick = mock(),
-                domainRegistrationClick = mock(),
                 onQuickStartBlockRemoveMenuItemClick = mock(),
                 onQuickStartTaskTypeItemClick = mock(),
-                mockedPostsData = mockedPostsData
+                mockedPostsData = mockedPostsData,
+                domainRegistrationCardBuilderParams = DomainRegistrationCardBuilderParams(
+                        isDomainCreditAvailable = isDomainCreditAvailable,
+                        domainRegistrationClick = mock()
+                )
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard.IconState
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData.Post
@@ -43,8 +44,6 @@ import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 
 private const val SITE_INFO_SHOW_UPDATE_SITE_TITLE_FOCUS_POINT_PARAM_POSITION = 6
 private const val SITE_INFO_SHOW_UPDATE_SITE_ICON_FOCUS_POINT_PARAM_POSITION = 7
-private const val QUICK_ACTION_SHOW_PAGES_FOCUS_POINT_PARAM_POSITION = 5
-private const val QUICK_ACTION_SHOW_STATS_FOCUS_POINT_PARAM_POSITION = 6
 
 @RunWith(MockitoJUnitRunner::class)
 class CardsBuilderTest {
@@ -191,17 +190,21 @@ class CardsBuilderTest {
                 iconClick = mock(),
                 urlClick = mock(),
                 switchSiteClick = mock(),
-                quickActionStatsClick = mock(),
-                quickActionPagesClick = mock(),
-                quickActionPostsClick = mock(),
-                quickActionMediaClick = mock(),
                 onQuickStartBlockRemoveMenuItemClick = mock(),
                 onQuickStartTaskTypeItemClick = mock(),
                 domainRegistrationCardBuilderParams = DomainRegistrationCardBuilderParams(
                         isDomainCreditAvailable = isDomainCreditAvailable,
                         domainRegistrationClick = mock()
                 ),
-                postCardBuilderParams = PostCardBuilderParams(mockedPostsData)
+                postCardBuilderParams = PostCardBuilderParams(mockedPostsData),
+                quickActionsCardBuilderParams = QuickActionsCardBuilderParams(
+                        siteModel = site,
+                        activeTask = activeTask,
+                        onQuickActionMediaClick = mock(),
+                        onQuickActionPagesClick = mock(),
+                        onQuickActionPostsClick = mock(),
+                        onQuickActionStatsClick = mock()
+                )
         )
     }
 
@@ -223,15 +226,7 @@ class CardsBuilderTest {
     private fun setUpQuickActionsBuilder() {
         doAnswer {
             initQuickActionsCard(it)
-        }.whenever(quickActionsCardBuilder).build(
-                onQuickActionStatsClick = any(),
-                onQuickActionPagesClick = any(),
-                onQuickActionPostsClick = any(),
-                onQuickActionMediaClick = any(),
-                showPages = any(),
-                showStatsFocusPoint = any(),
-                showPagesFocusPoint = any()
-        )
+        }.whenever(quickActionsCardBuilder).build(any())
     }
 
     private fun setUpQuickStartCardBuilder() {
@@ -273,16 +268,21 @@ class CardsBuilderTest {
             onSwitchSiteClick = mock()
     )
 
-    private fun initQuickActionsCard(mockInvocation: InvocationOnMock) = QuickActionsCard(
-            title = UiStringText(""),
-            onStatsClick = mock(),
-            onPagesClick = mock(),
-            onPostsClick = mock(),
-            onMediaClick = mock(),
-            showPages = false,
-            showPagesFocusPoint = mockInvocation.getArgument(QUICK_ACTION_SHOW_PAGES_FOCUS_POINT_PARAM_POSITION),
-            showStatsFocusPoint = mockInvocation.getArgument(QUICK_ACTION_SHOW_STATS_FOCUS_POINT_PARAM_POSITION)
-    )
+    private fun initQuickActionsCard(mockInvocation: InvocationOnMock) : QuickActionsCard {
+        val params = (mockInvocation.arguments.filterIsInstance<QuickActionsCardBuilderParams>() [0])
+        return QuickActionsCard(
+                title = UiStringText(""),
+                onStatsClick = mock(),
+                onPagesClick = mock(),
+                onPostsClick = mock(),
+                onMediaClick = mock(),
+                showPages = false,
+                showStatsFocusPoint = params.activeTask == QuickStartTask.CHECK_STATS,
+                showPagesFocusPoint = params.activeTask == QuickStartTask.EDIT_HOMEPAGE ||
+                        params.activeTask == QuickStartTask.REVIEW_PAGES
+        )
+    }
+
 
     private fun initQuickStartCard() = QuickStartCard(
             title = UiStringText(""),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard.Qui
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard.IconState
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData.Post
@@ -196,11 +197,11 @@ class CardsBuilderTest {
                 quickActionMediaClick = mock(),
                 onQuickStartBlockRemoveMenuItemClick = mock(),
                 onQuickStartTaskTypeItemClick = mock(),
-                mockedPostsData = mockedPostsData,
                 domainRegistrationCardBuilderParams = DomainRegistrationCardBuilderParams(
                         isDomainCreditAvailable = isDomainCreditAvailable,
                         domainRegistrationClick = mock()
-                )
+                ),
+                postCardBuilderParams = PostCardBuilderParams(mockedPostsData)
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.mysite.cards
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -28,6 +27,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegi
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData.Post
@@ -42,9 +42,6 @@ import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
-
-private const val SITE_INFO_SHOW_UPDATE_SITE_TITLE_FOCUS_POINT_PARAM_POSITION = 6
-private const val SITE_INFO_SHOW_UPDATE_SITE_ICON_FOCUS_POINT_PARAM_POSITION = 7
 
 @RunWith(MockitoJUnitRunner::class)
 class CardsBuilderTest {
@@ -183,13 +180,6 @@ class CardsBuilderTest {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(isQuickStartDynamicCardEnabled)
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(isMySiteDashboardPhase2FeatureConfigEnabled)
         return cardsBuilder.build(
-                site = site,
-                showSiteIconProgressBar = false,
-                activeTask = activeTask,
-                titleClick = mock(),
-                iconClick = mock(),
-                urlClick = mock(),
-                switchSiteClick = mock(),
                 domainRegistrationCardBuilderParams = DomainRegistrationCardBuilderParams(
                         isDomainCreditAvailable = isDomainCreditAvailable,
                         domainRegistrationClick = mock()
@@ -207,6 +197,15 @@ class CardsBuilderTest {
                         if (isQuickStartInProgress) listOf(quickStartCategory) else emptyList(),
                         mock(),
                         mock()
+                ),
+                siteInfoCardBuilderParams = SiteInfoCardBuilderParams(
+                        site,
+                        showSiteIconProgressBar = false,
+                        mock(),
+                        mock(),
+                        mock(),
+                        mock(),
+                        activeTask
                 )
         )
     }
@@ -214,16 +213,7 @@ class CardsBuilderTest {
     private fun setUpSiteInfoCardBuilder() {
         doAnswer {
             initSiteInfoCard(it)
-        }.whenever(siteInfoCardBuilder).buildSiteInfoCard(
-                site = eq(site),
-                showSiteIconProgressBar = any(),
-                titleClick = any(),
-                iconClick = any(),
-                urlClick = any(),
-                switchSiteClick = any(),
-                showUpdateSiteTitleFocusPoint = any(),
-                showUploadSiteIconFocusPoint = any()
-        )
+        }.whenever(siteInfoCardBuilder).buildSiteInfoCard(any())
     }
 
     private fun setUpQuickActionsBuilder() {
@@ -257,19 +247,20 @@ class CardsBuilderTest {
         )
     }
 
-    private fun initSiteInfoCard(mockInvocation: InvocationOnMock) = SiteInfoCard(
-            title = "",
-            url = "",
-            iconState = IconState.Visible(""),
-            showTitleFocusPoint = mockInvocation
-                    .getArgument(SITE_INFO_SHOW_UPDATE_SITE_TITLE_FOCUS_POINT_PARAM_POSITION),
-            showIconFocusPoint = mockInvocation
-                    .getArgument(SITE_INFO_SHOW_UPDATE_SITE_ICON_FOCUS_POINT_PARAM_POSITION),
-            onTitleClick = mock(),
-            onIconClick = mock(),
-            onUrlClick = mock(),
-            onSwitchSiteClick = mock()
-    )
+    private fun initSiteInfoCard(mockInvocation: InvocationOnMock): SiteInfoCard {
+        val params = (mockInvocation.arguments.filterIsInstance<SiteInfoCardBuilderParams>()[0])
+        return SiteInfoCard(
+                title = "",
+                url = "",
+                iconState = IconState.Visible(""),
+                showTitleFocusPoint = params.activeTask == QuickStartTask.UPDATE_SITE_TITLE,
+                showIconFocusPoint = params.activeTask == QuickStartTask.UPLOAD_SITE_ICON,
+                onTitleClick = mock(),
+                onIconClick = mock(),
+                onUrlClick = mock(),
+                onSwitchSiteClick = mock()
+        )
+    }
 
     private fun initQuickActionsCard(mockInvocation: InvocationOnMock) : QuickActionsCard {
         val params = (mockInvocation.arguments.filterIsInstance<QuickActionsCardBuilderParams>() [0])

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -248,7 +248,7 @@ class CardsBuilderTest {
     }
 
     private fun initSiteInfoCard(mockInvocation: InvocationOnMock): SiteInfoCard {
-        val params = (mockInvocation.arguments.filterIsInstance<SiteInfoCardBuilderParams>()[0])
+        val params = (mockInvocation.arguments.filterIsInstance<SiteInfoCardBuilderParams>()).first()
         return SiteInfoCard(
                 title = "",
                 url = "",
@@ -263,7 +263,7 @@ class CardsBuilderTest {
     }
 
     private fun initQuickActionsCard(mockInvocation: InvocationOnMock): QuickActionsCard {
-        val params = (mockInvocation.arguments.filterIsInstance<QuickActionsCardBuilderParams>()[0])
+        val params = (mockInvocation.arguments.filterIsInstance<QuickActionsCardBuilderParams>()).first()
         return QuickActionsCard(
                 title = UiStringText(""),
                 onStatsClick = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -262,8 +262,8 @@ class CardsBuilderTest {
         )
     }
 
-    private fun initQuickActionsCard(mockInvocation: InvocationOnMock) : QuickActionsCard {
-        val params = (mockInvocation.arguments.filterIsInstance<QuickActionsCardBuilderParams>() [0])
+    private fun initQuickActionsCard(mockInvocation: InvocationOnMock): QuickActionsCard {
+        val params = (mockInvocation.arguments.filterIsInstance<QuickActionsCardBuilderParams>()[0])
         return QuickActionsCard(
                 title = UiStringText(""),
                 onStatsClick = mock(),
@@ -276,7 +276,6 @@ class CardsBuilderTest {
                         params.activeTask == QuickStartTask.REVIEW_PAGES
         )
     }
-
 
     private fun initQuickStartCard() = QuickStartCard(
             title = UiStringText(""),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard.IconS
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData.Post
@@ -185,13 +186,10 @@ class CardsBuilderTest {
                 site = site,
                 showSiteIconProgressBar = false,
                 activeTask = activeTask,
-                quickStartCategories = if (isQuickStartInProgress) listOf(quickStartCategory) else emptyList(),
                 titleClick = mock(),
                 iconClick = mock(),
                 urlClick = mock(),
                 switchSiteClick = mock(),
-                onQuickStartBlockRemoveMenuItemClick = mock(),
-                onQuickStartTaskTypeItemClick = mock(),
                 domainRegistrationCardBuilderParams = DomainRegistrationCardBuilderParams(
                         isDomainCreditAvailable = isDomainCreditAvailable,
                         domainRegistrationClick = mock()
@@ -204,6 +202,11 @@ class CardsBuilderTest {
                         onQuickActionPagesClick = mock(),
                         onQuickActionPostsClick = mock(),
                         onQuickActionStatsClick = mock()
+                ),
+                quickStartCardBuilderParams = QuickStartCardBuilderParams(
+                        if (isQuickStartInProgress) listOf(quickStartCategory) else emptyList(),
+                        mock(),
+                        mock()
                 )
         )
     }
@@ -232,7 +235,7 @@ class CardsBuilderTest {
     private fun setUpQuickStartCardBuilder() {
         doAnswer {
             initQuickStartCard()
-        }.whenever(quickStartCardBuilder).build(any(), any(), any())
+        }.whenever(quickStartCardBuilder).build(any())
     }
 
     private fun setUpPostCardBuilder() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/post/PostCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/post/PostCardBuilderTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder.Companion.DRAFT_TITLE
 import org.wordpress.android.ui.mysite.cards.post.PostCardBuilder.Companion.SCHEDULED_TITLE
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
@@ -31,7 +32,7 @@ class PostCardBuilderTest : BaseUnitTest() {
         builder = PostCardBuilder()
     }
 
-    private fun buildPostCards() = builder.build(mockedPostsData)
+    private fun buildPostCards() = builder.build(PostCardBuilderParams(mockedPostsData))
 
     @Test
     fun `when toolbar is built, then card title exists`() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsCardBuilderTest.kt
@@ -1,16 +1,22 @@
 package org.wordpress.android.ui.mysite.cards.quickactions
 
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 
 @InternalCoroutinesApi
 class QuickActionsCardBuilderTest : BaseUnitTest() {
+    @Mock lateinit var siteModel: SiteModel
     private lateinit var builder: QuickActionsCardBuilder
 
     private val onStatsClick: () -> Unit = {}
@@ -48,14 +54,26 @@ class QuickActionsCardBuilderTest : BaseUnitTest() {
         showStatsFocusPoint: Boolean = false,
         showPagesFocusPoint: Boolean = false
     ): QuickActionsCard {
+        setShowPages(showPages)
         return builder.build(
+                QuickActionsCardBuilderParams(
+                siteModel,
+                setActiveTask(showStatsFocusPoint, showPagesFocusPoint),
                 onStatsClick,
                 onPagesClick,
                 onPostsClick,
-                onMediaClick,
-                showPages,
-                showStatsFocusPoint,
-                showPagesFocusPoint
-        )
+                onMediaClick
+        ))
+    }
+    private fun setShowPages(showPages: Boolean) {
+        whenever(siteModel.isSelfHostedAdmin).thenReturn(showPages)
+    }
+
+    private fun setActiveTask(showStats: Boolean, showPages: Boolean): QuickStartTask? {
+        return when {
+            showStats -> QuickStartTask.CHECK_STATS
+            showPages -> QuickStartTask.EDIT_HOMEPAGE
+            else -> null
+        }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilderTest.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.utils.ListItemInteraction
@@ -177,7 +178,13 @@ class QuickStartCardBuilderTest : BaseUnitTest() {
     ): QuickStartCard {
         val customizeCategory = buildQuickStartCategory(QuickStartTaskType.CUSTOMIZE, completedTasks, uncompletedTasks)
         val growCategory = buildQuickStartCategory(QuickStartTaskType.GROW, completedTasks, uncompletedTasks)
-        return builder.build(listOf(customizeCategory, growCategory), onRemoveMenuItemClick, onItemClick)
+        return builder.build(
+                QuickStartCardBuilderParams(
+                        listOf(customizeCategory, growCategory),
+                        onRemoveMenuItemClick,
+                        onItemClick
+                )
+        )
     }
 
     private fun buildQuickStartCategory(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoCardBuilderTest.kt
@@ -7,6 +7,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
 import org.wordpress.android.viewmodel.ResourceProvider
 
 @RunWith(MockitoJUnitRunner::class)
@@ -59,9 +61,26 @@ class SiteInfoCardBuilderTest {
     private fun buildSiteInfoCard(
         showUpdateSiteTitleFocusPoint: Boolean = false,
         showUploadSiteIconFocusPoint: Boolean = false
-    ) = siteInfoCardBuilder.buildSiteInfoCard(site,
-            showUploadSiteIconFocusPoint, {}, {}, {}, {},
-            showUpdateSiteTitleFocusPoint = showUpdateSiteTitleFocusPoint,
-            showUploadSiteIconFocusPoint = showUploadSiteIconFocusPoint
+    ) = siteInfoCardBuilder.buildSiteInfoCard(
+            SiteInfoCardBuilderParams(
+                    site = site,
+                    showSiteIconProgressBar = showUploadSiteIconFocusPoint,
+                    titleClick = {},
+                    iconClick = {},
+                    urlClick = {},
+                    switchSiteClick = {},
+                    setActiveTask(showUpdateSiteTitleFocusPoint, showUploadSiteIconFocusPoint)
+            )
     )
+
+    private fun setActiveTask(
+        showUpdateSiteTitleFocusPoint: Boolean,
+        showUploadSiteIconFocusPoint: Boolean
+    ): QuickStartTask? {
+        return when {
+            showUpdateSiteTitleFocusPoint -> QuickStartTask.UPDATE_SITE_TITLE
+            showUploadSiteIconFocusPoint -> QuickStartTask.UPLOAD_SITE_ICON
+            else -> null
+        }
+    }
 }


### PR DESCRIPTION
Parent #15215

This PR refactors `CardBuilder` so that each card type uses its own parameters object which is passed via `MySiteViewModel`. This PR only includes refactoring, there has been no new functionality added.

Included in this PR are the following cards types:
- Domain Registration
- Quick Actions
- Quick Start
- Post
- Site Info

Not included
`DynamicCardsBuilder` and `SiteItemsBuilder`. They will be addressed separately.

Existing tests have been refactored to account for the new params classes.

**Notes**
- The best way to review this PR is to go commit-by-commit. Deteket/ktlint and further refactoring come later on in the commit history. 
- I had one case in which I was undecided on a refactor, that was in `CardsBuilder` and possibly removing all the single line functions and placing the logic directly in the build. I was hesitant because I'm not sure if we are going to be adding any tracking before building. I'm open to it and can make the change before this PR is merged. Let me know.
- These changes are not controlled by a feature flag, and will merge to develop as is. Given this is only the first week of the sprint, we should be able to test thoroughly before the next version moves to beta. ⚠️ 

**To test:**
- Smoke test the app and make sure the cards are displayed as expected.
- The post card is still behind a feature flag, so test with the flag on and off
- Quick Actions - should be visible for WordPress and hidden for Jetpack
- Site Info Card - all interactions work as expected
- Quick Start - all interactions work as expected (and when the quickStartDynamicCardsFeatureConfig is on, then this card doesn't show)
- Domain Registration -  (Visible for paid plan site when SiteDomainFeatureConfig flag enabled, hidden otherwise.)


## Regression Notes
1. Potential unintended areas of impact
These changes are not controlled by a feature flag, and will merge to develop as is. Given this is only the first week of the sprint, we should be able to test thoroughly before the next version moves to beta. ⚠️

2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
