### PR TITLE
Domains: Handle checkout result – Part 1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -38,10 +38,8 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
     private lateinit var binding: DomainSuggestionsActivityBinding
 
     private val openCheckout = registerForActivityResult(DomainRegistrationCheckoutWebViewActivity.OpenCheckout()) {
-        if (it != null) {
+        it?.let {
             viewModel.completeDomainRegistration(it)
-        } else {
-            // TODO Handle checkout failure
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -7,7 +7,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.databinding.DomainSuggestionsActivityBinding
+import org.wordpress.android.databinding.DomainRegistrationActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.ScrollableViewInitializedListener
@@ -35,7 +35,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
 
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: DomainRegistrationMainViewModel
-    private lateinit var binding: DomainSuggestionsActivityBinding
+    private lateinit var binding: DomainRegistrationActivityBinding
 
     private val openCheckout = registerForActivityResult(DomainRegistrationCheckoutWebViewActivity.OpenCheckout()) {
         it?.let {
@@ -46,7 +46,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
-        with(DomainSuggestionsActivityBinding.inflate(layoutInflater)) {
+        with(DomainRegistrationActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
             binding = this
 
@@ -60,7 +60,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
         }
     }
 
-    private fun DomainSuggestionsActivityBinding.setupToolbar() {
+    private fun DomainRegistrationActivityBinding.setupToolbar() {
         setSupportActionBar(toolbarDomain)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
@@ -29,7 +29,7 @@ class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity(), DomainReg
         finish()
     }
 
-    class OpenCheckout : ActivityResultContract<CheckoutDetails, DomainRegistrationCompletedEvent>() {
+    class OpenCheckout : ActivityResultContract<CheckoutDetails, DomainRegistrationCompletedEvent?>() {
         override fun createIntent(context: Context, input: CheckoutDetails) =
                 Intent(context, DomainRegistrationCheckoutWebViewActivity::class.java).apply {
                     putExtra(USE_GLOBAL_WPCOM_USER, true)
@@ -40,13 +40,11 @@ class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity(), DomainReg
                 }
 
         override fun parseResult(resultCode: Int, intent: Intent?): DomainRegistrationCompletedEvent? {
-            if (resultCode == RESULT_OK) {
-                val domainName = intent?.getStringExtra(REGISTRATION_DOMAIN_NAME).orEmpty()
-                val email = intent?.getStringExtra(REGISTRATION_EMAIL).orEmpty()
-                // TODO Handle empty domain and email
+            val domainName = intent?.getStringExtra(REGISTRATION_DOMAIN_NAME).orEmpty()
+            val email = intent?.getStringExtra(REGISTRATION_EMAIL).orEmpty()
+            if (resultCode == RESULT_OK && domainName.isNotBlank() && email.isNotBlank()) {
                 return DomainRegistrationCompletedEvent(domainName, email)
             }
-            // TODO Handle checkout failure
             return null
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewClient.kt
@@ -2,8 +2,8 @@ package org.wordpress.android.ui.domains
 
 import android.net.Uri
 import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
 import android.webkit.WebView
+import androidx.core.net.toUri
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewNavigationDelegate.toUrl
 import org.wordpress.android.util.ErrorManagedWebViewClient
 
@@ -11,33 +11,26 @@ class DomainRegistrationCheckoutWebViewClient(
     private val listener: DomainRegistrationCheckoutWebViewClientListener
 ) : ErrorManagedWebViewClient(listener) {
     private val navigationDelegate = DomainRegistrationCheckoutWebViewNavigationDelegate
-    private var hasRegistered = false
 
     interface DomainRegistrationCheckoutWebViewClientListener : ErrorManagedWebViewClientListener {
         fun onCheckoutSuccess()
-    }
-
-    override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
-        val host = request.url.host.orEmpty()
-        val path = request.url.path.orEmpty()
-
-        // TODO Revisit this logic
-        if (host == WPCOM_API_HOST) {
-            if (hasRegistered) {
-                listener.onCheckoutSuccess()
-            } else if (path == "/rest/v1.1/me/transactions") {
-                hasRegistered = true
-            }
-        }
-
-        return super.shouldInterceptRequest(view, request)
     }
 
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest) = !canNavigateTo(request.url)
 
     private fun canNavigateTo(uri: Uri) = navigationDelegate.canNavigateTo(uri.toUrl())
 
+    override fun doUpdateVisitedHistory(view: WebView, url: String, isReload: Boolean) {
+        if (isCheckoutSuccessPage(url.toUri())) {
+            listener.onCheckoutSuccess()
+        } else {
+            super.doUpdateVisitedHistory(view, url, isReload)
+        }
+    }
+
+    private fun isCheckoutSuccessPage(uri: Uri) = uri.path.orEmpty().startsWith(CHECKOUT_SUCCESS_PATH_PREFIX)
+
     companion object {
-        private const val WPCOM_API_HOST = "public-api.wordpress.com"
+        private const val CHECKOUT_SUCCESS_PATH_PREFIX = "/checkout/thank-you/"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewClient.kt
@@ -1,13 +1,16 @@
 package org.wordpress.android.ui.domains
 
+import android.net.Uri
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
+import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewNavigationDelegate.toUrl
 import org.wordpress.android.util.ErrorManagedWebViewClient
 
 class DomainRegistrationCheckoutWebViewClient(
     private val listener: DomainRegistrationCheckoutWebViewClientListener
 ) : ErrorManagedWebViewClient(listener) {
+    private val navigationDelegate = DomainRegistrationCheckoutWebViewNavigationDelegate
     private var hasRegistered = false
 
     interface DomainRegistrationCheckoutWebViewClientListener : ErrorManagedWebViewClientListener {
@@ -29,6 +32,10 @@ class DomainRegistrationCheckoutWebViewClient(
 
         return super.shouldInterceptRequest(view, request)
     }
+
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest) = !canNavigateTo(request.url)
+
+    private fun canNavigateTo(uri: Uri) = navigationDelegate.canNavigateTo(uri.toUrl())
 
     companion object {
         private const val WPCOM_API_HOST = "public-api.wordpress.com"

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewNavigationDelegate.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewNavigationDelegate.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.ui.domains
+
+import android.net.Uri
+
+object DomainRegistrationCheckoutWebViewNavigationDelegate {
+    private val optionalLanguagePath = "(?:/(?:\\w{2}-)?\\w{2})?".toRegex()
+    private val allowedUrls = listOf(
+            UrlMatcher(
+                    ".*wordpress.com".toRegex(),
+                    listOf(
+                            "/automattic-domain-name-registration-agreement.*".toRegex(),
+                            "/checkout.*".toRegex(),
+                            "$optionalLanguagePath/tos.*".toRegex(),
+                            "$optionalLanguagePath/support.*".toRegex()
+                    )
+            )
+    )
+
+    fun canNavigateTo(url: Url) = allowedUrls.any { it.matches(url) }
+
+    data class UrlMatcher(
+        private val host: Regex,
+        private val paths: List<Regex>
+    ) {
+        private fun matchesHost(url: Url) = url.host.matches(host)
+        private fun matchesPath(url: Url) = paths.any { url.path.matches(it) }
+        fun matches(url: Url) = matchesHost(url) && matchesPath(url)
+    }
+
+    data class Url(val host: String, val path: String)
+
+    fun Uri.toUrl() = Url(host.orEmpty(), path.orEmpty())
+}

--- a/WordPress/src/main/res/layout/domain_registration_activity.xml
+++ b/WordPress/src/main/res/layout/domain_registration_activity.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/coordinator_layout">
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-   <com.google.android.material.appbar.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_domain"
-            app:navigationIcon="@drawable/ic_cross_white_24dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:navigationIcon="@drawable/ic_cross_white_24dp"
             app:theme="@style/WordPress.ActionBar" />
-
     </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout

--- a/WordPress/src/main/res/layout/domain_registration_activity.xml
+++ b/WordPress/src/main/res/layout/domain_registration_activity.xml
@@ -14,7 +14,7 @@
             android:id="@+id/toolbar_domain"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:navigationIcon="@drawable/ic_cross_white_24dp"
+            app:navigationIcon="@drawable/ic_arrow_back_white_24dp"
             app:theme="@style/WordPress.ActionBar" />
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewNavigationDelegateTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewNavigationDelegateTest.kt
@@ -1,0 +1,87 @@
+package org.wordpress.android.ui.domains
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewNavigationDelegate.Url
+
+class DomainRegistrationCheckoutWebViewNavigationDelegateTest : BaseUnitTest() {
+    private val navigationDelegate = DomainRegistrationCheckoutWebViewNavigationDelegate
+
+    @Test
+    fun `checkout web view can navigate to checkout paths`() {
+        assertThat(
+                buildUrls(
+                        "/checkout/",
+                        "/checkout/dummywpcomsite.wordpress.com",
+                        "/checkout/thank-you/"
+                )
+        ).allMatch {
+            navigationDelegate.canNavigateTo(it)
+        }
+    }
+
+    @Test
+    fun `checkout web view can navigate to TOS paths`() {
+        assertThat(
+                buildUrls(
+                        "/tos/",
+                        "/en/tos/",
+                        "/pt-br/tos/"
+                )
+        ).allMatch {
+            navigationDelegate.canNavigateTo(it)
+        }
+    }
+
+    @Test
+    fun `checkout web view can navigate to registration agreement paths`() {
+        assertThat(
+                buildUrls(
+                        "/automattic-domain-name-registration-agreement/"
+                )
+        ).allMatch {
+            navigationDelegate.canNavigateTo(it)
+        }
+    }
+
+    @Test
+    fun `checkout web view can navigate to support paths`() {
+        assertThat(
+                buildUrls(
+                        "/support/",
+                        "/es/support/",
+                        "/pt-br/support/",
+                        "/support/payment/#using-a-payment-method-for-all-subscriptions",
+                        "/es/support/payment/#using-a-payment-method-for-all-subscriptions",
+                        "/pt-br/support/payment/#using-a-payment-method-for-all-subscriptions"
+                )
+        ).allMatch {
+            navigationDelegate.canNavigateTo(it)
+        }
+    }
+
+    @Test
+    fun `checkout web view cannot navigate to unallowed paths`() {
+        assertThat(
+                buildUrls(
+                        "/blog/",
+                        "/plans/",
+                        "/themes/",
+                        "/invalid/support/"
+                )
+        ).noneMatch {
+            navigationDelegate.canNavigateTo(it)
+        }
+    }
+
+    @Test
+    fun `checkout web view can navigate to host subdomain`() {
+        assertThat(navigationDelegate.canNavigateTo(Url("subdomain.wordpress.com", "/checkout"))).isTrue
+    }
+
+    companion object {
+        private fun buildUrls(vararg paths: String) = paths.toList().map { Url("wordpress.com", it) }
+    }
+}
+

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewNavigationDelegateTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewNavigationDelegateTest.kt
@@ -84,4 +84,3 @@ class DomainRegistrationCheckoutWebViewNavigationDelegateTest : BaseUnitTest() {
         private fun buildUrls(vararg paths: String) = paths.toList().map { Url("wordpress.com", it) }
     }
 }
-


### PR DESCRIPTION
This PR introduces the following changes:

1. The checkout web view is now restricted to `wordpress.com` under the following paths:
    - `/automattic-domain-name-registration-agreement`
    - `/checkout`
    - `/tos` + localized paths, like `/pt-br/tos` or `/es/tos`
    - `/support` + localized paths, like `/pt-br/support` or `/es/support`

Links that navigate away from these paths have been disabled. In the future, we might consider notifying the user when such a link is clicked.

2. The checkout success page is now correctly intercepted. This took me a while to figure out because the redirect to the `/checkout/thank-you/` page is done via JavaScript and as such is not detected through the `shouldOverrideUrlLoading` method. I had to use `doUpdateVisitedHistory` instead. It seems to work well, but I don't if there's a better way of doing this.
3. The success screen is not shown after pressing back from the checkout web view. Instead, we go back to the suggestions screen.
4. The toolbar home icon is now an arrow instead of an X, to be consistent with the actual behavior we currently have.

The following changes are out of scope for this PR and should be handled in the next one:
- Any post-checkout behavior, such as setting the domain as primary or refreshing the data on the dashboard screen.

#### To test

**Setup: Enable feature flag**

1. On the Main screen, tap the Me button.
1. On the Me screen, go to App Settings > Debug settings.
1. On the Debug Settings screen, scroll down to the "Features in development" section and tap `SiteDomainsFeatureConfig` to enable the Domains feature flag.

**Main scenario**

1. Open the app.
1. On the Main screen, tap the "Domains" item under the "Configuration" section.
1. On the Domains Dashboard screen, tap the "Search for a domain" button.
1. Notice the toolbar home icon is now an arrow.
1. On the Domain Suggestions screen, select a domain and tap "Select domain".
1. Wait a moment and notice the Checkout web view screen.
1. On the Checkout web view, try to click on some of the links on the page.
1. Notice that you can only navigate to the paths mentioned in the list above.
1. Press back.
1. Notice the Suggestions screen. (You might need to press back multiple times if you had navigated to other pages.)
1. On the Domain Suggestions screen, select a domain again and tap "Select domain".
1. Wait a moment and notice the Checkout web view screen.
1. Finish the checkout process.
1. Wait a moment and notice the Success screen.

## Regression Notes
1. Potential unintended areas of impact
None that I could think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests.

3. What automated tests I added (or what prevented me from doing so)
Unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
