### PR TITLE
Integrate gutenberg-mobile release 1.64.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.64.0'
+    ext.gutenbergMobileVersion = '4135-79ed1b8a4b087faed06ffd637aff00a34d7e89b1'
     ext.storiesVersion = '1.1.0'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '4135-807664d7713a08eee3e1808d4ffbb48d7ee69e08'
+    ext.gutenbergMobileVersion = 'v1.64.1'
     ext.storiesVersion = '1.1.0'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '4135-79ed1b8a4b087faed06ffd637aff00a34d7e89b1'
+    ext.gutenbergMobileVersion = '4135-807664d7713a08eee3e1808d4ffbb48d7ee69e08'
     ext.storiesVersion = '1.1.0'
 
     repositories {


### PR DESCRIPTION
## Description
This PR incorporates the 1.64.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4135

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.