### PR TITLE
My Site Dashboard-Phase 2: Refactor SiteItemBuilder to use a parameter class

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
+import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 
 sealed class MySiteCardAndItemBuilderParams {
     data class DomainRegistrationCardBuilderParams(
@@ -37,5 +38,13 @@ sealed class MySiteCardAndItemBuilderParams {
         val urlClick: () -> Unit,
         val switchSiteClick: () -> Unit,
         val activeTask: QuickStartTask?
+    ) : MySiteCardAndItemBuilderParams()
+
+    data class SiteItemsBuilderParams(
+        val site: SiteModel,
+        val activeTask: QuickStartTask? = null,
+        val backupAvailable: Boolean = false,
+        val scanAvailable: Boolean = false,
+        val onClick: (ListItemAction) -> Unit
     ) : MySiteCardAndItemBuilderParams()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBu
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteItemsBuilderParams
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.NoSites
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
@@ -252,14 +253,14 @@ class MySiteViewModel @Inject constructor(
             visibleDynamicCards,
             this::onDynamicCardMoreClick,
             this::onQuickStartTaskCardClick
-    ) + siteItemsBuilder.buildSiteItems(
-            site,
-            this::onItemClick,
-            backupAvailable,
-            scanAvailable,
-            activeTask == QuickStartTask.VIEW_SITE,
-            activeTask == QuickStartTask.ENABLE_POST_SHARING,
-            activeTask == QuickStartTask.EXPLORE_PLANS
+    ) + siteItemsBuilder.build(
+            SiteItemsBuilderParams(
+                    site = site,
+                    activeTask = activeTask,
+                    backupAvailable = backupAvailable,
+                    scanAvailable = scanAvailable,
+                    onClick = this::onItemClick,
+            )
     )
 
     private fun buildNoSiteState(): NoSites {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -259,7 +259,7 @@ class MySiteViewModel @Inject constructor(
                     activeTask = activeTask,
                     backupAvailable = backupAvailable,
                     scanAvailable = scanAvailable,
-                    onClick = this::onItemClick,
+                    onClick = this::onItemClick
             )
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -1,10 +1,13 @@
 package org.wordpress.android.ui.mysite.items
 
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_POST_SHARING
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EXPLORE_PLANS
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.VIEW_SITE
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.ListItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteItemsBuilderParams
 import org.wordpress.android.ui.mysite.items.categoryheader.SiteCategoryItemBuilder
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.mysite.items.listitem.SiteListItemBuilder
@@ -16,62 +19,61 @@ class SiteItemsBuilder @Inject constructor(
     private val siteCategoryItemBuilder: SiteCategoryItemBuilder,
     private val siteListItemBuilder: SiteListItemBuilder
 ) {
-    @Suppress("LongParameterList")
-    fun buildSiteItems(
-        site: SiteModel,
-        onClick: (ListItemAction) -> Unit,
-        isBackupAvailable: Boolean = false,
-        isScanAvailable: Boolean = false,
-        showViewSiteFocusPoint: Boolean = false,
-        showEnablePostSharingFocusPoint: Boolean = false,
-        showExplorePlansFocusPoint: Boolean = false
-    ): List<MySiteCardAndItem> {
+    fun build(params: SiteItemsBuilderParams): List<MySiteCardAndItem> {
+        val showViewSiteFocusPoint = params.activeTask == VIEW_SITE
+        val showEnablePostSharingFocusPoint = params.activeTask == ENABLE_POST_SHARING
+        val showExplorePlansFocusPoint = params.activeTask == EXPLORE_PLANS
+
         return listOfNotNull(
-                siteListItemBuilder.buildPlanItemIfAvailable(site, showExplorePlansFocusPoint, onClick),
-                siteCategoryItemBuilder.buildJetpackCategoryIfAvailable(site),
+                siteListItemBuilder.buildPlanItemIfAvailable(params.site, showExplorePlansFocusPoint, params.onClick),
+                siteCategoryItemBuilder.buildJetpackCategoryIfAvailable(params.site),
                 ListItem(
                         R.drawable.ic_stats_alt_white_24dp,
                         UiStringRes(R.string.stats),
-                        onClick = ListItemInteraction.create(ListItemAction.STATS, onClick)
+                        onClick = ListItemInteraction.create(ListItemAction.STATS, params.onClick)
                 ),
-                siteListItemBuilder.buildActivityLogItemIfAvailable(site, onClick),
-                siteListItemBuilder.buildBackupItemIfAvailable(onClick, isBackupAvailable),
-                siteListItemBuilder.buildScanItemIfAvailable(onClick, isScanAvailable),
-                siteListItemBuilder.buildJetpackItemIfAvailable(site, onClick),
+                siteListItemBuilder.buildActivityLogItemIfAvailable(params.site, params.onClick),
+                siteListItemBuilder.buildBackupItemIfAvailable(params.onClick, params.backupAvailable),
+                siteListItemBuilder.buildScanItemIfAvailable(params.onClick, params.scanAvailable),
+                siteListItemBuilder.buildJetpackItemIfAvailable(params.site, params.onClick),
                 CategoryHeaderItem(UiStringRes(R.string.my_site_header_publish)),
                 ListItem(
                         R.drawable.ic_posts_white_24dp,
                         UiStringRes(R.string.my_site_btn_blog_posts),
-                        onClick = ListItemInteraction.create(ListItemAction.POSTS, onClick)
+                        onClick = ListItemInteraction.create(ListItemAction.POSTS, params.onClick)
                 ),
                 ListItem(
                         R.drawable.ic_media_white_24dp,
                         UiStringRes(R.string.media),
-                        onClick = ListItemInteraction.create(ListItemAction.MEDIA, onClick)
+                        onClick = ListItemInteraction.create(ListItemAction.MEDIA, params.onClick)
                 ),
-                siteListItemBuilder.buildPagesItemIfAvailable(site, onClick),
+                siteListItemBuilder.buildPagesItemIfAvailable(params.site, params.onClick),
                 ListItem(
                         R.drawable.ic_comment_white_24dp,
                         UiStringRes(R.string.my_site_btn_comments),
-                        onClick = ListItemInteraction.create(ListItemAction.COMMENTS, onClick)
+                        onClick = ListItemInteraction.create(ListItemAction.COMMENTS, params.onClick)
                 ),
-                siteCategoryItemBuilder.buildLookAndFeelHeaderIfAvailable(site),
-                siteListItemBuilder.buildThemesItemIfAvailable(site, onClick),
-                siteCategoryItemBuilder.buildConfigurationHeaderIfAvailable(site),
-                siteListItemBuilder.buildPeopleItemIfAvailable(site, onClick),
-                siteListItemBuilder.buildPluginItemIfAvailable(site, onClick),
-                siteListItemBuilder.buildShareItemIfAvailable(site, onClick, showEnablePostSharingFocusPoint),
-                siteListItemBuilder.buildDomainsItemIfAvailable(site, onClick),
-                siteListItemBuilder.buildSiteSettingsItemIfAvailable(site, onClick),
+                siteCategoryItemBuilder.buildLookAndFeelHeaderIfAvailable(params.site),
+                siteListItemBuilder.buildThemesItemIfAvailable(params.site, params.onClick),
+                siteCategoryItemBuilder.buildConfigurationHeaderIfAvailable(params.site),
+                siteListItemBuilder.buildPeopleItemIfAvailable(params.site, params.onClick),
+                siteListItemBuilder.buildPluginItemIfAvailable(params.site, params.onClick),
+                siteListItemBuilder.buildShareItemIfAvailable(
+                        params.site,
+                        params.onClick,
+                        showEnablePostSharingFocusPoint
+                ),
+                siteListItemBuilder.buildDomainsItemIfAvailable(params.site, params.onClick),
+                siteListItemBuilder.buildSiteSettingsItemIfAvailable(params.site, params.onClick),
                 CategoryHeaderItem(UiStringRes(R.string.my_site_header_external)),
                 ListItem(
                         R.drawable.ic_globe_white_24dp,
                         UiStringRes(R.string.my_site_btn_view_site),
                         secondaryIcon = R.drawable.ic_external_white_24dp,
-                        onClick = ListItemInteraction.create(ListItemAction.VIEW_SITE, onClick),
+                        onClick = ListItemInteraction.create(ListItemAction.VIEW_SITE, params.onClick),
                         showFocusPoint = showViewSiteFocusPoint
                 ),
-                siteListItemBuilder.buildAdminItemIfAvailable(site, onClick)
+                siteListItemBuilder.buildAdminItemIfAvailable(params.site, params.onClick)
         )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
@@ -45,6 +44,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegi
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteItemsBuilderParams
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DomainCreditAvailable
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DynamicCardsUpdate
@@ -166,7 +166,12 @@ class MySiteViewModelTest : BaseUnitTest() {
     private val onSiteSelected = MutableLiveData<Int>()
     private val onShowSiteIconProgressBar = MutableLiveData<Boolean>()
     private val isDomainCreditAvailable = MutableLiveData(DomainCreditAvailable(false))
-    private val jetpackCapabilities = MutableLiveData(JetpackCapabilities(false, false))
+    private val jetpackCapabilities = MutableLiveData(
+            JetpackCapabilities(
+                    scanAvailable = false,
+                    backupAvailable = false
+            )
+    )
     private val currentAvatar = MutableLiveData(CurrentAvatarUrl(""))
     private val quickStartUpdate = MutableLiveData(QuickStartUpdate())
     private val activeTask = MutableLiveData<QuickStartTask>()
@@ -1088,15 +1093,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         jetpackCapabilities.value = JetpackCapabilities(scanAvailable = false, backupAvailable = false)
 
-        verify(siteItemsBuilder, times(1)).buildSiteItems(
-                site = eq(site),
-                onClick = any(),
-                isBackupAvailable = eq(false),
-                isScanAvailable = any(),
-                showViewSiteFocusPoint = eq(false),
-                showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any()
-        )
+        verify(siteItemsBuilder, times(1)).build(any())
     }
 
     @Test
@@ -1105,15 +1102,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         jetpackCapabilities.value = JetpackCapabilities(scanAvailable = false, backupAvailable = false)
 
-        verify(siteItemsBuilder, times(1)).buildSiteItems(
-                site = eq(site),
-                onClick = any(),
-                isBackupAvailable = any(),
-                isScanAvailable = eq(false),
-                showViewSiteFocusPoint = any(),
-                showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any()
-        )
+        verify(siteItemsBuilder, times(1)).build(any())
     }
 
     @Test
@@ -1122,15 +1111,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         jetpackCapabilities.value = JetpackCapabilities(scanAvailable = true, backupAvailable = false)
 
-        verify(siteItemsBuilder).buildSiteItems(
-                site = eq(site),
-                onClick = any(),
-                isBackupAvailable = any(),
-                isScanAvailable = eq(true),
-                showViewSiteFocusPoint = eq(false),
-                showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any()
-        )
+        verify(siteItemsBuilder, times(2)).build(any())
     }
 
     @Test
@@ -1139,15 +1120,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         jetpackCapabilities.value = JetpackCapabilities(scanAvailable = false, backupAvailable = true)
 
-        verify(siteItemsBuilder).buildSiteItems(
-                site = eq(site),
-                onClick = any(),
-                isBackupAvailable = eq(true),
-                isScanAvailable = any(),
-                showViewSiteFocusPoint = any(),
-                showEnablePostSharingFocusPoint = any(),
-                showExplorePlansFocusPoint = any()
-        )
+        verify(siteItemsBuilder, times(2)).build(any())
     }
 
     /* ADD SITE ICON DIALOG */
@@ -1272,9 +1245,10 @@ class MySiteViewModelTest : BaseUnitTest() {
     private fun invokeItemClickAction(action: ListItemAction) {
         var clickAction: ((ListItemAction) -> Unit)? = null
         doAnswer {
-            clickAction = it.getArgument(1)
+            val params = (it.arguments.filterIsInstance<SiteItemsBuilderParams>()).first()
+            clickAction = params.onClick
             listOf<MySiteCardAndItem>()
-        }.whenever(siteItemsBuilder).buildSiteItems(eq(site), any(), any(), any(), any(), any(), any())
+        }.whenever(siteItemsBuilder).build(any())
 
         initSelectedSite()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
@@ -8,6 +8,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EXPLORE_PLANS
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteItemsBuilderParams
 import org.wordpress.android.ui.mysite.items.categoryheader.SiteCategoryItemBuilder
 import org.wordpress.android.ui.mysite.items.listitem.SiteListItemBuilder
 
@@ -27,7 +29,10 @@ class SiteItemsBuilderTest {
     fun `always adds stats, publish, posts, media, comment, external and view site items`() {
         setupHeaders(addJetpackHeader = false, addLookAndFeelHeader = false, addConfigurationHeader = false)
 
-        val buildSiteItems = siteItemsBuilder.buildSiteItems(siteModel, SITE_ITEM_ACTION)
+        val buildSiteItems = siteItemsBuilder.build(SiteItemsBuilderParams(
+                site = siteModel,
+                onClick = SITE_ITEM_ACTION)
+        )
 
         assertThat(buildSiteItems).containsExactly(
                 STATS_ITEM,
@@ -60,7 +65,10 @@ class SiteItemsBuilderTest {
                 addScanItem = true
         )
 
-        val buildSiteItems = siteItemsBuilder.buildSiteItems(siteModel, SITE_ITEM_ACTION)
+        val buildSiteItems = siteItemsBuilder.build(SiteItemsBuilderParams(
+                site = siteModel,
+                onClick = SITE_ITEM_ACTION)
+        )
 
         assertThat(buildSiteItems).containsExactly(
                 PLAN_ITEM,
@@ -93,15 +101,16 @@ class SiteItemsBuilderTest {
         val showPlansFocusPoint = true
         setupHeaders(addPlanItem = true, showPlansFocusPoint = showPlansFocusPoint)
 
-        val buildSiteItems = siteItemsBuilder.buildSiteItems(
-                siteModel,
-                SITE_ITEM_ACTION,
-                showExplorePlansFocusPoint = showPlansFocusPoint
+        val buildSiteItems = siteItemsBuilder.build(SiteItemsBuilderParams(
+                site = siteModel,
+                onClick = SITE_ITEM_ACTION,
+                activeTask = EXPLORE_PLANS)
         )
 
         assertThat(buildSiteItems.first()).isEqualTo(PLAN_ITEM.copy(showFocusPoint = showPlansFocusPoint))
     }
 
+    @Suppress("ComplexMethod", "LongMethod", "LongParameterList")
     private fun setupHeaders(
         addJetpackHeader: Boolean = false,
         addJetpackSettings: Boolean = false,


### PR DESCRIPTION
Parent #15215

This PR refactors `SiteItemsBuilder` so that it uses a parameters object. Passed via `MySiteViewModel`. This PR only includes refactoring, there has been no new functionality added.

Existing tests have been refactored to account for the new params classes.

**Notes**
- The best way to review this PR is to go commit-by-commit. Deteket/ktlint come later on in the commit history. 
- These changes are not controlled by a feature flag, and will merge to develop as is. Given this is only the first week of the sprint, we should be able to test thoroughly before the next version moves to beta. ⚠️ 

**To test:**
- Smoke test the app and make sure the site items are displayed as expected.


## Regression Notes
1. Potential unintended areas of impact
These changes are not controlled by a feature flag, and will merge to develop as is. Given this is only the first week of the sprint, we should be able to test thoroughly before the next version moves to beta. ⚠️

2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

