### PR TITLE
Fix logic to handle domain checkout cancellation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
@@ -40,9 +40,10 @@ class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity(), DomainReg
                 }
 
         override fun parseResult(resultCode: Int, intent: Intent?): DomainRegistrationCompletedEvent? {
-            val domainName = intent?.getStringExtra(REGISTRATION_DOMAIN_NAME).orEmpty()
-            val email = intent?.getStringExtra(REGISTRATION_EMAIL).orEmpty()
-            if (resultCode == RESULT_OK && domainName.isNotBlank() && email.isNotBlank()) {
+            val data = intent?.takeIf { it.hasExtra(REGISTRATION_DOMAIN_NAME) && it.hasExtra(REGISTRATION_EMAIL) }
+            if (resultCode == RESULT_OK && data != null) {
+                val domainName = data.getStringExtra(REGISTRATION_DOMAIN_NAME).orEmpty()
+                val email = data.getStringExtra(REGISTRATION_EMAIL).orEmpty()
                 return DomainRegistrationCompletedEvent(domainName, email)
             }
             return null


### PR DESCRIPTION
The logic introduced in #15483 wasn't working as expected, as the `email` property can be `null` even on checkout success. This PR changes that logic to check whether the `domainName` and `email` properties exist, instead of whether their values are not null or empty.

### To test

**Setup: Enable feature flag**

1. On the Main screen, tap the Me button.
1. On the Me screen, go to App Settings > Debug settings.
1. On the Debug Settings screen, scroll down to the "Features in development" section and tap `SiteDomainsFeatureConfig` to enable the Domains feature flag.

**Scenario 1: Checkout cancellation**

1. Open the app.
1. On the Main screen, tap the "Domains" item under the "Configuration" section.
1. On the Domains Dashboard screen, tap the "Search for a domain" button.
1. On the Domain Suggestions screen, select a domain and tap "Select domain".
1. Wait a moment and notice the Checkout web view screen.
1. Press back.
1. Notice the Suggestions screen.

**Scenario 2: Checkout success**
1. Open the app.
1. On the Main screen, tap the "Domains" item under the "Configuration" section.
1. On the Domains Dashboard screen, tap the "Search for a domain" button.
1. On the Domain Suggestions screen, select a domain and tap "Select domain".
1. Wait a moment and notice the Checkout web view screen.
1. Finish the checkout process.
1. Wait a moment and notice the Success screen.

## Regression Notes
1. Potential unintended areas of impact
None that I could think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests.

3. What automated tests I added (or what prevented me from doing so)
Unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
