### PR TITLE
Update WordPress `release_notes.txt` with copy for 18.5

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -11,15 +11,17 @@ msgstr ""
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
-msgctxt "release_note_short_183"
+#. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_185"
 msgid ""
-"18.3:\n"
-"In the block editor, we fixed a toolbar issue on devices set to an RTL language, and made updates to the Embed block, like enabling WordPress, Instagram, and Vimeo previews and adding options to retry or convert media into a link.\n"
+"18.5:\n"
+"Embedding external content just got easier with the new Facebook, Instagram, Loom, and Smartframe embed blocks.\n"
 "\n"
-"More updates include a fix affecting video on some sites, and updating My Site menu labels (“Posts” and “Pages”).\n"
+"Plus, we now detect embeddable URLs when pasted into an empty paragraph, and we fixed a bug with prevented embedded URLs from being edited.\n"
+"\n"
+"Finally, Pullquote and Preformatted blocks now have customizable text and background color.\n"
 msgstr ""
 
-#. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
 msgctxt "release_note_184"
 msgid ""
 "18.4:\n"
@@ -27,14 +29,6 @@ msgid ""
 "The gallery block now adds images even if the post is closed during the upload.\n"
 "Site comments allow the author’s name, email, and web address to be edited.\n"
 "You can now contact support directly from the editor screen.\n"
-msgstr ""
-
-msgctxt "release_note_183"
-msgid ""
-"18.3:\n"
-"Lots of improvements in the block editor! We fixed a toolbar issue affecting devices set to an RTL language, and made many updates to the Embed block, including enabling WordPress, Instagram, and Vimeo previews and offering options to retry or convert media into a link if it’s not embeddable.\n"
-"\n"
-"Other updates include a fix affecting .mp4 video on some sites, and streamlining My Site menu labels (“Posts” and “Pages”).\n"
 msgstr ""
 
 #. translators: Short description of the Jetpack app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -10,7 +10,6 @@ msgstr ""
 "X-Generator: VsCode\n"
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
-#. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
 msgctxt "release_note_185"
 msgid ""

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,12 +1,5 @@
-* [**] Reader: allow users to enable push notifications to follow a post comments conversation [WPAndroid - https://github.com/wordpress-mobile/WordPress-Android/pull/15459]
-* [*] Fixed an issue where navigating through a couple of related posts in Reader caused the incorrect post to be loaded after rotation [https://github.com/wordpress-mobile/WordPress-Android/issues/14195]
-* [*] Allow users to mark Posts as sticky [https://github.com/wordpress-mobile/WordPress-Android/pull/15351]
-* [*] Fixed a crash in Page Template chooser [https://github.com/wordpress-mobile/WordPress-Android/pull/15415]
-* [**] Block editor: Embed block: Include Jetpack embed variants. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
-* [*] Block editor: Unsupported Block Editor: Fix text selection bug for Android [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3937]
-* [*] Block editor: Embed block: Fix inline preview cut-off when editing URL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4072]
-* [*] Block editor: Embed block: Fix URL not editable after dismissing the edit URL bottom sheet with empty value [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4094]
-* [**] Block editor: Embed block: Detect when an embeddable URL is pasted into an empty paragraph. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4048]
-* [**] Block editor: Pullquote block - Added support for text and background color customization [https://github.com/WordPress/gutenberg/pull/34451]
-* [**] Block editor: Preformatted block - Added support for text and background color customization [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4071]
+Embedding external content just got easier with the new Facebook, Instagram, Loom, and Smartframe embed blocks.
 
+Plus, we now detect embeddable URLs when pasted into an empty paragraph, and we fixed a bug with prevented embedded URLs from being edited.
+
+Finally, Pullquote and Preformatted blocks now have customizable text and background color.

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -10,7 +10,6 @@ msgstr ""
 "X-Generator: VsCode\n"
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
-#. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
 msgctxt "release_note_185"
 msgid ""

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -11,15 +11,17 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
-msgctxt "release_note_short_183"
+#. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_185"
 msgid ""
-"18.3:\n"
-"In the block editor, we fixed a toolbar issue on devices set to an RTL language, and made updates to the Embed block, like enabling WordPress, Instagram, and Vimeo previews and adding options to retry or convert media into a link.\n"
+"18.5:\n"
+"Embedding external content just got easier with the new Facebook, Instagram, Loom, and Smartframe embed blocks.\n"
 "\n"
-"More updates include a fix affecting video on some sites, and updating My Site menu labels (“Posts” and “Pages”).\n"
+"Always be up-to-date with the conversations you follow via the new Reader push notifications for followed post comments conversations.\n"
+"\n"
+"Plus, you can now customize text and background color in the Pullquote and Preformatted blocks.\n"
 msgstr ""
 
-#. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
 msgctxt "release_note_184"
 msgid ""
 "18.4:\n"
@@ -27,14 +29,6 @@ msgid ""
 "The gallery block now adds images even if the post is closed during the upload.\n"
 "Site comments allow the author’s name, email, and web address to be edited.\n"
 "You can now contact support directly from the editor screen.\n"
-msgstr ""
-
-msgctxt "release_note_183"
-msgid ""
-"18.3:\n"
-"Lots of improvements in the block editor! We fixed a toolbar issue affecting devices set to an RTL language, and made many updates to the Embed block, including enabling WordPress, Instagram, and Vimeo previews and offering options to retry or convert media into a link if it’s not embeddable.\n"
-"\n"
-"Other updates include a fix affecting .mp4 video on some sites, and streamlining My Site menu labels (“Posts” and “Pages”).\n"
 msgstr ""
 
 msgctxt "sample_post_content"

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,12 +1,5 @@
-* [**] Reader: allow users to enable push notifications to follow a post comments conversation [WPAndroid - https://github.com/wordpress-mobile/WordPress-Android/pull/15459]
-* [*] Fixed an issue where navigating through a couple of related posts in Reader caused the incorrect post to be loaded after rotation [https://github.com/wordpress-mobile/WordPress-Android/issues/14195]
-* [*] Allow users to mark Posts as sticky [https://github.com/wordpress-mobile/WordPress-Android/pull/15351]
-* [*] Fixed a crash in Page Template chooser [https://github.com/wordpress-mobile/WordPress-Android/pull/15415]
-* [**] Block editor: Embed block: Include Jetpack embed variants. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
-* [*] Block editor: Unsupported Block Editor: Fix text selection bug for Android [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3937]
-* [*] Block editor: Embed block: Fix inline preview cut-off when editing URL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4072]
-* [*] Block editor: Embed block: Fix URL not editable after dismissing the edit URL bottom sheet with empty value [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4094]
-* [**] Block editor: Embed block: Detect when an embeddable URL is pasted into an empty paragraph. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4048]
-* [**] Block editor: Pullquote block - Added support for text and background color customization [https://github.com/WordPress/gutenberg/pull/34451]
-* [**] Block editor: Preformatted block - Added support for text and background color customization [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4071]
+Embedding external content just got easier with the new Facebook, Instagram, Loom, and Smartframe embed blocks.
 
+Always be up-to-date with the conversations you follow via the new Reader push notifications for followed post comments conversations.
+
+Plus, you can now customize text and background color in the Pullquote and Preformatted blocks.


### PR DESCRIPTION
I decided to open a PR myself for this just to save @AliSoftware some time, given that I've been the bottle neck in this process.

However, I've never done this kind of work for Android, so I decided to open a PR against `release/18.5` instead of working directly on the release branch. In particular, I was unsure about what to do with `release_notes_short.txt`.

As far as I understand, e.g. by reading [here](https://github.com/wordpress-mobile/WordPress-Android/pull/13760#discussion_r556588017), it's okay not to have them in this PR, because both versions are less that 350 characters.