### PR TITLE
My Site Dashboard-Phase 2: Initial Structure - Introduce Pull-to-refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -519,14 +519,14 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     private fun MySiteFragmentBinding.loadData(cardAndItems: List<MySiteCardAndItem>) {
         recyclerView.setVisible(true)
-        swipeToRefreshHelper.isRefreshing=false
+        swipeToRefreshHelper.isRefreshing = false
         actionableEmptyView.setVisible(false)
         (recyclerView.adapter as? MySiteAdapter)?.loadData(cardAndItems)
     }
 
     private fun MySiteFragmentBinding.loadEmptyView(shouldShowEmptyViewImage: Boolean) {
         recyclerView.setVisible(false)
-        swipeToRefreshHelper.isRefreshing=false
+        swipeToRefreshHelper.isRefreshing = false
         actionableEmptyView.setVisible(true)
         actionableEmptyView.image.setVisible(shouldShowEmptyViewImage)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -147,7 +147,7 @@ class MySiteViewModel @Inject constructor(
             scanAndBackupSource,
             dynamicCardsSource,
             postCardsSource
-    ).state.map  { (
+    ).state.map { (
             currentAvatarUrl,
             site,
             showSiteIconProgressBar,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSource.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.mysite.cards.post
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -9,6 +10,7 @@ import org.wordpress.android.ui.mysite.MySiteSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.PostsUpdate
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedDataJsonUtils
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
+import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,14 +18,32 @@ import javax.inject.Singleton
 class PostCardsSource @Inject constructor(
     private val mockedDataJsonUtils: MockedDataJsonUtils
 ) : MySiteSource<PostsUpdate> {
+    private val data = MutableLiveData<PostsUpdate>()
+    private val _refreshFinished = MutableLiveData<Event<Unit>>()
+    val refreshFinished = _refreshFinished as LiveData<Event<Unit>>
+
     override fun buildSource(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<PostsUpdate> {
-        val result = MutableLiveData<PostsUpdate>()
+        val result = MediatorLiveData<PostsUpdate>()
         result.value = PostsUpdate(MockedPostsData())
         coroutineScope.launch {
             val jsonString = mockedDataJsonUtils.getJsonStringFromRawResource(R.raw.mocked_posts_data)
             val mockedPostsData = mockedDataJsonUtils.getMockedPostsDataFromJsonString(jsonString!!)
-            result.postValue(PostsUpdate(mockedPostsData = mockedPostsData))
+            result.value = PostsUpdate(mockedPostsData = mockedPostsData)
+            result.addSource(data) {
+                result.value = it
+            }
         }
         return result
+    }
+
+    fun refresh(coroutineScope: CoroutineScope) {
+        coroutineScope.launch {
+            val jsonString = mockedDataJsonUtils.getJsonStringFromRawResource(R.raw.mocked_refresh_posts_data)
+            val mockedPostsData = mockedDataJsonUtils.getMockedPostsDataFromJsonString(jsonString!!)
+            _refreshFinished.postValue(Event(Unit))
+            if (mockedPostsData != data.value?.mockedPostsData) {
+                data.postValue(PostsUpdate(mockedPostsData = mockedPostsData))
+            }
+        }
     }
 }

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -35,18 +35,27 @@
         android:layout_height="wrap_content"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler_view"
-            android:layout_width="0dp"
+        <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+            android:id="@+id/swipe_refresh_layout"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:clipToPadding="false"
-            android:paddingBottom="@dimen/my_site_bottom_spacing"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintWidth_max="@dimen/my_site_content_area" />
+            app:layout_constraintTop_toTopOf="parent">
 
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recycler_view"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:clipToPadding="false"
+                android:paddingBottom="@dimen/my_site_bottom_spacing"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_max="@dimen/my_site_content_area" />
+        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <org.wordpress.android.ui.ActionableEmptyView

--- a/WordPress/src/main/res/raw/mocked_refresh_posts_data.json
+++ b/WordPress/src/main/res/raw/mocked_refresh_posts_data.json
@@ -1,0 +1,39 @@
+{
+  "posts": {
+    "has_published_posts": true,
+    "draft": [
+      {
+        "id": 3172,
+        "title": "A refreshed draft post 1...",
+        "modified": "2021-07-27T16:07:45+00:00",
+        "featured_image_url": "https://draft_1_feature_image_url"
+      },
+      {
+        "id": 3173,
+        "title": "A refreshed draft post 2...",
+        "modified": "2021-07-28T16:07:45+00:00",
+        "featured_image_url": "https://draft_2_feature_image_url"
+      }
+    ],
+    "scheduled": [
+      {
+        "id": 4172,
+        "title": "A refreshed scheduled post 1...",
+        "modified": "2021-07-27T16:07:45+00:00",
+        "featured_image_url": "https://schedule_1_feature_image_url"
+      },
+      {
+        "id": 4173,
+        "title": "A refreshed scheduled post 2...",
+        "modified": "2021-07-28T16:07:45+00:00",
+        "featured_image_url": "https://schedule_2_feature_image_url"
+      },
+      {
+        "id": 4174,
+        "title": "A refreshed scheduled post 3...",
+        "modified": "2021-07-29T16:07:45+00:00",
+        "featured_image_url": "https://schedule_3_feature_image_url"
+      }
+    ]
+  }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -112,6 +112,7 @@ import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.util.config.UnifiedCommentsListFeatureConfig
 import org.wordpress.android.viewmodel.ContextProvider
@@ -147,6 +148,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var cardsBuilder: CardsBuilder
     @Mock lateinit var dynamicCardsBuilder: DynamicCardsBuilder
     @Mock lateinit var postCardsSource: PostCardsSource
+    @Mock lateinit var mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<UiModel>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -154,6 +156,8 @@ class MySiteViewModelTest : BaseUnitTest() {
     private lateinit var dialogModels: MutableList<SiteDialogModel>
     private lateinit var dynamicCardMenu: MutableList<DynamicCardMenuModel>
     private lateinit var navigationActions: MutableList<SiteNavigationAction>
+    private lateinit var showSwipeRefreshLayout: MutableList<Boolean>
+    private lateinit var isRefreshFinished: MutableList<Unit>
     private val avatarUrl = "https://1.gravatar.com/avatar/1000?s=96&d=identicon"
     private val siteLocalId = 1
     private val siteUrl = "http://site.com"
@@ -206,9 +210,14 @@ class MySiteViewModelTest : BaseUnitTest() {
     private var quickActionsMediaClickAction: (() -> Unit)? = null
 
     @InternalCoroutinesApi
-    @Suppress("LongMethod")
     @Before
-    fun setUp() = test {
+    fun setUp() {
+        init()
+    }
+
+    @InternalCoroutinesApi
+    @Suppress("LongMethod")
+    fun init(enableMySiteDashboardConfig: Boolean = false) = test {
         onSiteChange.value = null
         onShowSiteIconProgressBar.value = null
         onSiteSelected.value = null
@@ -223,6 +232,8 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(selectedSiteRepository.showSiteIconProgressBar).thenReturn(onShowSiteIconProgressBar)
         whenever(quickStartRepository.activeTask).thenReturn(activeTask)
         whenever(postCardsSource.buildSource(any(), any())).thenReturn(postsUpdate)
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(enableMySiteDashboardConfig)
+
         viewModel = MySiteViewModel(
                 networkUtilsWrapper,
                 TEST_DISPATCHER,
@@ -250,7 +261,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 snackbarSequencer,
                 cardsBuilder,
                 dynamicCardsBuilder,
-                postCardsSource
+                postCardsSource,
+                mySiteDashboardPhase2FeatureConfig
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()
@@ -258,6 +270,8 @@ class MySiteViewModelTest : BaseUnitTest() {
         dialogModels = mutableListOf()
         navigationActions = mutableListOf()
         dynamicCardMenu = mutableListOf()
+        showSwipeRefreshLayout = mutableListOf()
+        isRefreshFinished = mutableListOf()
         launch(Dispatchers.Default) {
             viewModel.uiModel.observeForever {
                 uiModels.add(it)
@@ -286,6 +300,11 @@ class MySiteViewModelTest : BaseUnitTest() {
         viewModel.onDynamicCardMenuShown.observeForever { event ->
             event?.getContentIfNotHandled()?.let {
                 dynamicCardMenu.add(it)
+            }
+        }
+        viewModel.onShowSwipeRefreshLayout.observeForever { event ->
+            event?.getContentIfNotHandled()?.let {
+                showSwipeRefreshLayout.add(it)
             }
         }
         site = SiteModel()
@@ -1240,6 +1259,23 @@ class MySiteViewModelTest : BaseUnitTest() {
         viewModel.onSiteNameChooserDismissed()
 
         verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    /* SWIPE REFRESH */
+    @InternalCoroutinesApi
+    @Test
+    fun `when my site feature flag is enabled, then swipe refresh layout is enabled`() = test {
+        init(enableMySiteDashboardConfig = true)
+
+        assertThat(showSwipeRefreshLayout.last()).isEqualTo(true)
+    }
+
+    @InternalCoroutinesApi
+    @Test
+    fun `when my site feature flag is disabled, then swipe refresh layout is disabled`() {
+        init(enableMySiteDashboardConfig = false)
+
+        assertThat(showSwipeRefreshLayout.last()).isEqualTo(false)
     }
 
     private fun findQuickActionsCard() = getLastItems().find { it is QuickActionsCard } as QuickActionsCard?


### PR DESCRIPTION
Parent #14215

This PR introduces pull-to-refresh to the My Site view controlled by the `MySiteDashboardPhase2FeatureConfig` feature flag.

A `mocked_refresh_posts_data.json` raw resource was added to show the difference from initial load and PTR request. This will be removed once the true endpoint gets hooked up. 

We may want to consider adding a call to `PostsDataSource.refresh()` to the MySiteViewModel.refresh fun so that Posts cards get updated on return to the MySite tab. I did not hook this up in this PR, so PTR can be tested and can be visually verify that the data changed. All all likelihood, the data won't change often.

I had to split the `@Before` setUp in MySiteViewModelTest to support testing the PTR enabled flag. `setUp` now calls `init()` with a parameter for setting the `MySiteDashboardPhase2FeatureConfig` feature flag. If there is a better way, I am open to exploring it. 


https://user-images.githubusercontent.com/506707/138352339-25b097fe-b946-4b90-b6ac-8510e469284b.mp4


**To test:**
- Launch the app with `MySiteDashboardPhase2FeatureConfig` set to off
- Try to swipe to refresh
- Note: swipe to refresh is not active
- Navigate to My Site -> App Settings -> Debug Settings and set `MySiteDashboardPhase2FeatureConfig` to on
- Restart the App
- Navigate back to My Site tab
- Try to swipe to refresh
- Note: swipe to refresh indicator is shown and the posts cards change to "refreshed" in the title


## Regression Notes
1. Potential unintended areas of impact
My Site view allows PTR when the feature flag is off

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + 
Added two tests to `MySiteViewModelTest` to cover testing the enabling/disabling of the swipe refresh layout.

3. What automated tests I added (or what prevented me from doing so)
Added two tests to `MySiteViewModelTest` 

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
