### PR TITLE
Updates Utils & FluxC to a version with sources jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_coroutines_version = '1.3.9'
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
-    ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
+    ext.wordPressUtilsVersion = '95-1b9fd4ddf4a74ecf1e82effd589d5385faddfc76'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.64.0'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_coroutines_version = '1.3.9'
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
-    ext.wordPressUtilsVersion = '95-1b9fd4ddf4a74ecf1e82effd589d5385faddfc76'
+    ext.wordPressUtilsVersion = '95-e08e6d2d18f2ac78ae16e63a3cbbf1daa7656d42'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.64.0'
@@ -132,7 +132,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '2160-7ed5d2247456bda1db5ba665b027c92001a495ac'
+    fluxCVersion = '2160-cc4ed9133cc2579aafad9aa71c2530b6dff09674'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.28.0'
+    fluxCVersion = '2160-7ed5d2247456bda1db5ba665b027c92001a495ac'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
**This PR is used for testing purposes only.**

I am working on publishing the `-sources.jar` files for our projects that are published to S3 and I'd like to use this PR to verify that it works as expected. I've published both FluxC and WordPress-Utils-Android artifacts with their `-sources.jar` files to S3 and now I can navigate to the source files without any issues. @malinajirka @wzieba Can I bother you to test this PR to verify that it works as you were expecting it to?

_Please don't forget to disable composite builds for FluxC & WordPress-Utils-Android projects._

For each of the following lines, I used Android Studio's go to declaration feature (either Command+B or Command+click with a default setup) to test the changes:
* `PostStore` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt#L64) to verify `org.wordpress:fluxc` module
* `VersionUtils` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java#L333) to verify a Kotlin source file for `org.wordpress:utils` module
* `UrlUtils` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/models/ReaderBlog.java#L187) to verify a Java source file for `org.wordpress:utils` module

**Here are screenshots from current `develop`. Notice the `Decompiled .class` banner:**

![Screen Shot 2021-10-21 at 7 41 43 PM](https://user-images.githubusercontent.com/662023/138372551-355050b3-538e-4893-8dd3-9d8d455594c5.png)
![Screen Shot 2021-10-21 at 7 41 28 PM](https://user-images.githubusercontent.com/662023/138372555-e59c5386-4904-4465-912a-d151c0b5c7f5.png)
![Screen Shot 2021-10-21 at 7 41 15 PM](https://user-images.githubusercontent.com/662023/138372556-43658b01-1407-417d-84e8-0e516f893195.png)

**Here are screenshots from this PR:**

![Screen Shot 2021-10-21 at 7 40 22 PM](https://user-images.githubusercontent.com/662023/138372568-5d54f192-3263-46c0-a283-db8590253c86.png)
![Screen Shot 2021-10-21 at 7 39 53 PM](https://user-images.githubusercontent.com/662023/138372569-0bb35b3c-287c-42e9-8998-aeadf8d24314.png)
![Screen Shot 2021-10-21 at 7 37 53 PM](https://user-images.githubusercontent.com/662023/138372570-5f2d9b02-1814-46e5-b175-3d0c8fec3d6a.png)