### PR TITLE
Update Gutenberg mobile version to v1.65.0-alpha2 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.65.0-alpha1'
+    ext.gutenbergMobileVersion = 'v1.65.0-alpha2'
     ext.storiesVersion = '1.1.0'
 
     repositories {


### PR DESCRIPTION
Updates the Gutenberg mobile version to `v1.65.0-alpha2`

To include the latest betafix.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
