### PR TITLE
Feature/15481 show discounts on domains search

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionItem.kt
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.domains
 data class DomainSuggestionItem(
     val domainName: String,
     val cost: String,
+    val isOnSale: Boolean,
+    val saleCost: String,
     val isFree: Boolean,
     val supportsPrivacy: Boolean,
     val productId: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
@@ -51,6 +51,16 @@ class DomainSuggestionsViewHolder(
 
     private fun getFormattedCost(suggestion: DomainSuggestionItem) = when {
         suggestion.isFree -> suggestion.cost
+        suggestion.isOnSale -> {
+            HtmlCompat.fromHtml(
+                    String.format(
+                            container.context.getString(R.string.domain_suggestions_list_item_cost_on_sale),
+                            suggestion.saleCost,
+                            suggestion.cost
+                    ),
+                    HtmlCompat.FROM_HTML_MODE_LEGACY
+            )
+        }
         suggestion.isFreeWithCredits -> {
             HtmlCompat.fromHtml(
                     String.format(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -113,7 +113,6 @@ class DomainSuggestionsViewModel @Inject constructor(
         this.site = site
         this.domainRegistrationPurpose = domainRegistrationPurpose
         fetchProducts() // required for finding domains on sale
-        initializeDefaultSuggestions()
         shouldShowRedirectMessage()
         isStarted = true
     }
@@ -136,10 +135,12 @@ class DomainSuggestionsViewModel @Inject constructor(
             when {
                 result.isError -> {
                     AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching site domains")
+                    initializeDefaultSuggestions()
                 }
                 else -> {
                     AppLog.d(T.DOMAIN_REGISTRATION, result.products.toString())
                     result.products?.let { products = it }
+                    initializeDefaultSuggestions()
                 }
             }
         }
@@ -182,8 +183,8 @@ class DomainSuggestionsViewModel @Inject constructor(
                     DomainSuggestionItem(
                             domainName = it.domain_name,
                             cost = it.cost,
-                            isOnSale = isSaleDomain(product),
-                            saleCost = saleCostForDisplay(product),
+                            isOnSale = product?.isSaleDomain() ?: false,
+                            saleCost = product?.saleCostForDisplay().toString(),
                             isFree = it.is_free,
                             supportsPrivacy = it.supports_privacy,
                             productId = it.product_id,
@@ -229,10 +230,9 @@ class DomainSuggestionsViewModel @Inject constructor(
         }
     }
 
-    private fun isSaleDomain(product: Product?): Boolean = product?.saleCost?.let { it.compareTo(0.0) > 0 } == true
+    internal fun Product.isSaleDomain(): Boolean = this.saleCost?.let { it.compareTo(0.0) > 0 } == true
 
-    private fun saleCostForDisplay(product: Product?): String =
-            product?.costDisplay?.slice(0..2) + "%.2f".format(product?.saleCost)
+    internal fun Product.saleCostForDisplay(): String = this.currencyCode + "%.2f".format(this.saleCost)
 
     private fun createCart(selectedSuggestion: DomainSuggestionItem) = launch {
         AppLog.d(T.DOMAIN_REGISTRATION, "Creating cart: $selectedSuggestion")

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -10,6 +10,8 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.products.Product
+import org.wordpress.android.fluxc.store.ProductsStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.models.networkresource.ListState
@@ -33,6 +35,7 @@ import kotlin.properties.Delegates
 
 @Suppress("TooManyFunctions")
 class DomainSuggestionsViewModel @Inject constructor(
+    private val productsStore: ProductsStore,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val dispatcher: Dispatcher,
     private val debouncer: Debouncer,
@@ -42,6 +45,7 @@ class DomainSuggestionsViewModel @Inject constructor(
 ) : ScopedViewModel(bgDispatcher) {
     lateinit var site: SiteModel
     lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
+    var products: List<Product>? = null
 
     private var isStarted = false
     private var isQueryTrackingCompleted = false
@@ -108,6 +112,7 @@ class DomainSuggestionsViewModel @Inject constructor(
         }
         this.site = site
         this.domainRegistrationPurpose = domainRegistrationPurpose
+        fetchProducts() // required for finding domains on sale
         initializeDefaultSuggestions()
         shouldShowRedirectMessage()
         isStarted = true
@@ -124,6 +129,21 @@ class DomainSuggestionsViewModel @Inject constructor(
     }
 
     // Network Request
+
+    private fun fetchProducts() {
+        launch {
+            val result = productsStore.fetchProducts()
+            when {
+                result.isError -> {
+                    AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching site domains")
+                }
+                else -> {
+                    AppLog.d(T.DOMAIN_REGISTRATION, result.products.toString())
+                    result.products?.let { products = it }
+                }
+            }
+        }
+    }
 
     private fun fetchSuggestions() {
         suggestions = ListState.Loading(suggestions)
@@ -158,9 +178,12 @@ class DomainSuggestionsViewModel @Inject constructor(
 
         event.suggestions
                 .map {
+                    val product = products?.firstOrNull { product -> product.productId == it.product_id }
                     DomainSuggestionItem(
                             domainName = it.domain_name,
                             cost = it.cost,
+                            isOnSale = isSaleDomain(product),
+                            saleCost = saleCostForDisplay(product),
                             isFree = it.is_free,
                             supportsPrivacy = it.supports_privacy,
                             productId = it.product_id,
@@ -205,6 +228,11 @@ class DomainSuggestionsViewModel @Inject constructor(
             initializeDefaultSuggestions()
         }
     }
+
+    private fun isSaleDomain(product: Product?): Boolean = product?.saleCost?.let { it.compareTo(0.0) > 0 } == true
+
+    private fun saleCostForDisplay(product: Product?): String =
+            product?.costDisplay?.slice(0..2) + "%.2f".format(product?.saleCost)
 
     private fun createCart(selectedSuggestion: DomainSuggestionItem) = launch {
         AppLog.d(T.DOMAIN_REGISTRATION, "Creating cart: $selectedSuggestion")

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2443,6 +2443,7 @@
     <string name="domain_suggestions_search_hint">Type a keyword for more ideas</string>
     <string name="domain_suggestions_list_item_cost">%s&lt;span style="color:#50575e;"&gt; /year&lt;/span&gt;</string>
     <string name="domain_suggestions_list_item_cost_free">&lt;span style="color:#008000;"&gt;Free for the first year &lt;/span&gt;&lt;span style="color:#50575e;"&gt;&lt;s&gt;%s /year&lt;/s&gt;&lt;/span&gt;</string>
+    <string name="domain_suggestions_list_item_cost_on_sale">&lt;span style="color:#B26200;"&gt;%1$s for the first year &lt;/span&gt;&lt;span style="color:#50575e;"&gt;&lt;s&gt;%2$s /year&lt;/s&gt;&lt;/span&gt;</string>
     <string name="domain_suggestions_fetch_error">Domain suggestions couldn\'t be loaded</string>
     <string name="domain_registration_contact_form_input_error">Please enter a valid %s</string>
     <string name="domain_registration_privacy_protection_title">Privacy Protection</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -113,13 +113,14 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `site on blogger plan is requesting only dot blog domain suggestions`() {
+    fun `site on blogger plan is requesting only dot blog domain suggestions`() = test {
         site.planId = PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
+
         viewModel.start(site, domainRegistrationPurpose)
         viewModel.updateSearchQuery("test")
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(2)).dispatch(captor.capture())
+        verify(dispatcher, times(1)).dispatch(captor.capture())
 
         val lastAction = captor.value
 
@@ -137,13 +138,13 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `site on non blogger plan is requesting all possible domain suggestions`() {
+    fun `site on non blogger plan is requesting all possible domain suggestions`() = test {
         site.planId = PlansConstants.PREMIUM_PLAN_ID
         viewModel.start(site, domainRegistrationPurpose)
         viewModel.updateSearchQuery("test")
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(2)).dispatch(captor.capture())
+        verify(dispatcher, times(1)).dispatch(captor.capture())
 
         val lastAction = captor.value
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
+import org.wordpress.android.fluxc.store.ProductsStore
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.test
@@ -38,6 +39,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
     @Mock lateinit var siteDomainsFeatureConfig: SiteDomainsFeatureConfig
     @Mock lateinit var createCartUseCase: CreateCartUseCase
+    @Mock lateinit var productsStore: ProductsStore
 
     private lateinit var site: SiteModel
     private lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
@@ -50,6 +52,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         site = SiteModel().also { it.name = "Test Site" }
         domainRegistrationPurpose = CTA_DOMAIN_CREDIT_REDEMPTION
         viewModel = DomainSuggestionsViewModel(
+                productsStore,
                 tracker,
                 dispatcher,
                 debouncer,
@@ -194,6 +197,8 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         val dummySelectedDomainSuggestionItem = DomainSuggestionItem(
                 domainName = DUMMY_DOMAIN_NAME,
                 cost = "$20.00",
+                isOnSale = false,
+                saleCost = "0.0",
                 isFree = false,
                 supportsPrivacy = true,
                 productId = DUMMY_PRODUCT_ID,

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '2162-a83f06fec3c49ab7788890da01f98ad8d1318f9e'
+    fluxCVersion = 'develop-9be74fa6c324ba5f9096a764f9207af5217d44e5'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.28.0'
+    fluxCVersion = '2162-a83f06fec3c49ab7788890da01f98ad8d1318f9e'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #15481 

Display domain discounts for domains on sale.
- Fetches products from endpoint (see [FluxC part](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2162))
- Match on product id to find if a product is on sale and substitute the sale cost if it is as shown below


|Discount Display|Checkout Display|
|-----|-----|
|![discount-display](https://user-images.githubusercontent.com/990349/139002718-00ce51b0-5905-4d67-a0c0-3a04588a56bd.png)|![checkout-display](https://user-images.githubusercontent.com/990349/139002729-8087db65-4a22-4128-a0c3-74d34ad0050a.png)|


To test:

**Setup: Enable feature flag**

1. On the Main screen, tap the Me button.
1. On the Me screen, go to App Settings > Debug settings.
1. On the Debug Settings screen, scroll down to the "Features in development" section and tap `SiteDomainsFeatureConfig` to enable the Domains feature flag.

**Scenario 1: Purchase domain**

1. Open the app and select a site that has **no** domain credits.
1. On the Main screen, tap the "Domains" item under the "Configuration" section.
1. On the Domains Dashboard screen, tap the "Search for a domain" button.
1. Should see domains on sale in brow as shown in the first image above
1. You can verify the same on checkout screen after selecting a domain and tapping on select domain button


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Unit testing

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
