### PR TITLE
Upload lint, checkstyle & detekt artifacts to Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,21 +11,29 @@ steps:
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew checkstyle
+    artifact_paths:
+      - "**/build/reports/checkstyle/checkstyle.*"
   - label: "ktlint"
     <<: *docker-container
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew ciktlint
+    artifact_paths:
+      - "**/build/ktlint.xml"
   - label: "detekt"
     <<: *docker-container
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew WordPress:detekt
+    artifact_paths:
+      - "**/build/reports/detekt/detekt.html"
   - label: "lint"
     <<: *docker-container
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew lintWordpressVanillaRelease
+    artifact_paths:
+      - "**/build/reports/lint-results*.*"
   - label: "Test WordPress"
     <<: *docker-container
     command: |


### PR DESCRIPTION
Adds support for uploading `lint`, `checkstyle` & `detekt` artifacts to Buildkite, so developers can access it especially when there is an error.

Note that the `checkstyle` & `ktlint` artifacts are a little bit on the excessive side at the moment. However, since the artifacts are very small, and addressing this issue won't have a big impact, I thought it'd be fine to keep it as is and address them at a later date.

**To test**
* Go to Buildkite job and check the artifacts tab for `checkstyle`, `ktlint`, `detekt` & `lint` jobs and verify the artifacts uploaded.
* Here is a similar PR for WordPress-Utils-Android which showcases that the artifacts will be uploaded when the job fails: https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/94

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
