### PR TITLE
Test: publish-to-s3-plugin update for gb-mobile and aztec-editor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.65.0-alpha5'
+    ext.gutenbergMobileVersion = '4177-b3462f28e9ced77523f71b27c3cb7d334933bdad'
     ext.storiesVersion = '1.1.0'
 
     repositories {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.aztecVersion = 'v1.4.0'
+    ext.aztecVersion = 'v1.5.0'
 }
 
 repositories {


### PR DESCRIPTION
This PR is used to test https://github.com/WordPress/gutenberg/pull/36034 which updates publish-to-s3 Gradle plugin for `react-native-bridge` & `react-native-aztec` libraries and adds support for publishing `-sources.jar` files.

More information about these changes is available in https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/29 & https://github.com/wordpress-mobile/WordPress-Android/pull/15492.

**To test:**
* Go to https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java#L47 and navigate to definition for `AztecText` (cmd+click)
* Verify that the source code for `AztecText` is opened correctly and matches https://github.com/wordpress-mobile/AztecEditor-Android/blob/v1.5.0/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
* Go to https://github.com/wordpress-mobile/WordPress-Android/blob/develop/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java#L17 and navigate to definition for `WPAndroidGlueCode` (cmd+click)
* Verify that the source code for `WPAndroidGlueCode` is opened correctly and matches https://github.com/WordPress/gutenberg/blob/update-publish-to-s3-plugin-to-0.7.0/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java