### PR TITLE
Update aztecVersion to v1.5.0

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.aztecVersion = 'v1.4.0'
+    ext.aztecVersion = 'v1.5.0'
 }
 
 repositories {


### PR DESCRIPTION
This PR updates `aztecVersion` to `v1.5.0` which is the latest version and matches the version used by `react-native-aztec` project as it was updated in this PR: https://github.com/WordPress/gutenberg/pull/36034

This version of Aztec Editor has the `-sources.jar` file, so developers should be able to navigate to the source code while using the binary dependency. There are no other changes.

**To test:**

This was tested as part of https://github.com/wordpress-mobile/WordPress-Android/pull/15506 and shouldn't need to be tested again.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
