### PR TITLE
My Site Dashboard - Phase 2 - Initial Structure -  Refresh layout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -519,14 +519,14 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     private fun MySiteFragmentBinding.loadData(cardAndItems: List<MySiteCardAndItem>) {
         recyclerView.setVisible(true)
         actionableEmptyView.setVisible(false)
-        // TODO: annmarie - swipeToRefreshHelper.isRefreshing = false
+        swipeToRefreshHelper.isRefreshing = false
         (recyclerView.adapter as? MySiteAdapter)?.loadData(cardAndItems)
     }
 
     private fun MySiteFragmentBinding.loadEmptyView(shouldShowEmptyViewImage: Boolean) {
         recyclerView.setVisible(false)
         actionableEmptyView.setVisible(true)
-        // TODO: annmarie - swipeToRefreshHelper.isRefreshing = false
+        swipeToRefreshHelper.isRefreshing = false
         actionableEmptyView.image.setVisible(shouldShowEmptyViewImage)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -87,13 +87,16 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MAIN
 import org.wordpress.android.util.AppLog.T.UTILS
+import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarItem.Action
 import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UriWrapper
+import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
 import org.wordpress.android.util.getColorFromAttribute
+import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.USER
 import org.wordpress.android.util.setVisible
@@ -118,6 +121,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     private lateinit var viewModel: MySiteViewModel
     private lateinit var dialogViewModel: BasicDialogViewModel
     private lateinit var dynamicCardMenuViewModel: DynamicCardMenuViewModel
+    private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
 
     private var binding: MySiteFragmentBinding? = null
 
@@ -191,8 +195,17 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         }
 
         recyclerView.adapter = adapter
+
+        swipeToRefreshHelper = buildSwipeToRefreshHelper(swipeRefreshLayout) {
+            if (NetworkUtils.checkConnection(requireActivity())) {
+                viewModel.onPullToRefresh()
+            } else {
+                swipeToRefreshHelper.isRefreshing = false
+            }
+        }
     }
 
+    @Suppress("LongMethod")
     private fun MySiteFragmentBinding.setupObservers() {
         viewModel.uiModel.observe(viewLifecycleOwner, { uiModel ->
             loadGravatar(uiModel.accountAvatarUrl)
@@ -251,6 +264,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             viewModel.onQuickStartMenuInteraction(interaction)
         })
         viewModel.onUploadedItem.observeEvent(viewLifecycleOwner, { handleUploadedItem(it) })
+        viewModel.onShowSwipeRefreshLayout.observeEvent(viewLifecycleOwner, { showSwipeToRefreshLayout(it) })
     }
 
     @Suppress("ComplexMethod")
@@ -505,12 +519,14 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     private fun MySiteFragmentBinding.loadData(cardAndItems: List<MySiteCardAndItem>) {
         recyclerView.setVisible(true)
         actionableEmptyView.setVisible(false)
+        // TODO: annmarie - swipeToRefreshHelper.isRefreshing = false
         (recyclerView.adapter as? MySiteAdapter)?.loadData(cardAndItems)
     }
 
     private fun MySiteFragmentBinding.loadEmptyView(shouldShowEmptyViewImage: Boolean) {
         recyclerView.setVisible(false)
         actionableEmptyView.setVisible(true)
+        // TODO: annmarie - swipeToRefreshHelper.isRefreshing = false
         actionableEmptyView.image.setVisible(shouldShowEmptyViewImage)
     }
 
@@ -534,6 +550,10 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                     )
             )
         }
+    }
+
+    private fun showSwipeToRefreshLayout(isEnabled: Boolean) {
+        swipeToRefreshHelper.setEnabled(isEnabled)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -727,11 +727,7 @@ class MySiteViewModel @Inject constructor(
     }
 
     fun onPullToRefresh() {
-        _onSnackbarMessage.postValue(
-                Event(
-                        SnackbarMessageHolder(UiStringText("TODO: mySiteSources.forEach { it.refresh() }"))
-                )
-        )
+        _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringText("Pull to refresh activated"))))
     }
 
     data class UiModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -60,6 +60,7 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Dis
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Negative
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Positive
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.MediaUtilsWrapper
@@ -70,6 +71,7 @@ import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.util.config.UnifiedCommentsListFeatureConfig
 import org.wordpress.android.util.filter
@@ -114,7 +116,8 @@ class MySiteViewModel @Inject constructor(
     postCardsSource: PostCardsSource,
     quickStartCardSource: QuickStartCardSource,
     selectedSiteSource: SelectedSiteSource,
-    siteIconProgressSource: SiteIconProgressSource
+    siteIconProgressSource: SiteIconProgressSource,
+    mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig,
 ) : ScopedViewModel(mainDispatcher) {
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val _onTechInputDialogShown = MutableLiveData<Event<TextInputDialogModel>>()
@@ -123,6 +126,7 @@ class MySiteViewModel @Inject constructor(
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     private val _onMediaUpload = MutableLiveData<Event<MediaModel>>()
     private val _activeTaskPosition = MutableLiveData<Pair<QuickStartTask, Int>>()
+    private val _onShowSwipeRefreshLayout = MutableLiveData((Event(mySiteDashboardPhase2FeatureConfig.isEnabled())))
 
     val onScrollTo: LiveData<Event<Int>> = merge(
             _activeTaskPosition.distinctUntilChanged(),
@@ -142,6 +146,7 @@ class MySiteViewModel @Inject constructor(
     val onNavigation = merge(_onNavigation, siteStoriesHandler.onNavigation)
     val onMediaUpload = _onMediaUpload as LiveData<Event<MediaModel>>
     val onUploadedItem = siteIconUploadHandler.onUploadedItem
+    val onShowSwipeRefreshLayout = _onShowSwipeRefreshLayout
 
     private val mySiteSources: List<MySiteSource<*>> = listOf(
             selectedSiteSource,
@@ -719,6 +724,14 @@ class MySiteViewModel @Inject constructor(
 
     fun ignoreQuickStart() {
         analyticsTrackerWrapper.track(Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
+    }
+
+    fun onPullToRefresh() {
+        _onSnackbarMessage.postValue(
+                Event(
+                        SnackbarMessageHolder(UiStringText("TODO: mySiteSources.forEach { it.refresh() }"))
+                )
+        )
     }
 
     data class UiModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -117,7 +117,7 @@ class MySiteViewModel @Inject constructor(
     quickStartCardSource: QuickStartCardSource,
     selectedSiteSource: SelectedSiteSource,
     siteIconProgressSource: SiteIconProgressSource,
-    mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig,
+    mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig
 ) : ScopedViewModel(mainDispatcher) {
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val _onTechInputDialogShown = MutableLiveData<Event<TextInputDialogModel>>()

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -35,18 +35,27 @@
         android:layout_height="wrap_content"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler_view"
-            android:layout_width="0dp"
+        <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+            android:id="@+id/swipe_refresh_layout"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:clipToPadding="false"
-            android:paddingBottom="@dimen/my_site_bottom_spacing"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintWidth_max="@dimen/my_site_content_area" />
+            app:layout_constraintTop_toTopOf="parent">
 
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recycler_view"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:clipToPadding="false"
+                android:paddingBottom="@dimen/my_site_bottom_spacing"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_max="@dimen/my_site_content_area" />
+        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <org.wordpress.android.ui.ActionableEmptyView


### PR DESCRIPTION
Parent #15215

This goal of this PR is to introduce the pull-to-refresh layout changes to the My Site view controlled by the `MySiteDashboardPhase2FeatureConfig` feature flag. This PR does not include any logic to actually refresh the sources.

**Notes**
- I split the @Before setUp in MySiteViewModelTest to support testing the PTR enabled flag. setUp now calls init() with a parameter for setting the MySiteDashboardPhase2FeatureConfig feature flag. If there is a better way, I am open to exploring it.
- The refresh indicator will remain showing. This feature will be implemented in a future PR. As it's behind a feature flag, this is okay for now. I can always add in temporary logic to dismiss it. lmk.

**Merge Instructions**
- Ensure that PR #15501 has been merged
- Remove Not Ready for Merge label
- Merge as normal

**To test:**
- Launch the app with MySiteDashboardPhase2FeatureConfig set to off
- Try to swipe to refresh
- Note: swipe to refresh is not active
- Navigate to My Site -> App Settings -> Debug Settings and set MySiteDashboardPhase2FeatureConfig to on
- Restart the App
- Navigate back to My Site tab
- Try to swipe to refresh
- Note: swipe to refresh indicator is shown and a snackbar notes that the action was requested

## Regression Notes
1. Potential unintended areas of impact
N/A -Logic is behind a feature flag

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing

3. What automated tests I added (or what prevented me from doing so)
- Added refresh tests to MySiteViewModelTest

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
