### PR TITLE
Update DomainsDashboardViewModel.kt

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -84,7 +84,7 @@ class DomainsDashboardViewModel @Inject constructor(
 
     private fun getSiteDomainsList() {
         // TODO: Probably needs a loading spinner here instead
-        _uiModel.value = site.unmappedUrl?.let { getFreeDomainItems(getHomeUrlOrHostName(it), false)}
+        _uiModel.value = site.unmappedUrl?.let { getFreeDomainItems(getHomeUrlOrHostName(it), false) }
 
         launch {
             val result = siteStore.fetchSiteDomains(site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -84,7 +84,7 @@ class DomainsDashboardViewModel @Inject constructor(
 
     private fun getSiteDomainsList() {
         // TODO: Probably needs a loading spinner here instead
-        _uiModel.value = getFreeDomainItems(getHomeUrlOrHostName(site.unmappedUrl), false)
+        _uiModel.value = site.unmappedUrl?.let { getFreeDomainItems(getHomeUrlOrHostName(it), false)}
 
         launch {
             val result = siteStore.fetchSiteDomains(site)


### PR DESCRIPTION
Added null check to site.unmappedUrl to fix for #15500

Fixes #15500 

This has been raised against 18.5.  However, the feature itself is under a flag, not being released.  In fact, it is de-scoped for now.  Shouldn't impact any users at all.  So targeting develop.

To test:

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
