### PR TITLE
Domains Dashboard improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
@@ -43,7 +43,7 @@ sealed class DomainsDashboardItem(val type: Type) {
     data class ManageDomains(val onClick: ListItemInteraction) : DomainsDashboardItem(MANAGE_DOMAINS)
 
     data class PurchaseDomain(
-        @DrawableRes val image: Int,
+        @DrawableRes val image: Int?,
         val title: UiString,
         val body: UiString,
         val onClick: ListItemInteraction

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
@@ -102,6 +102,7 @@ sealed class DomainsDashboardViewHolder<T : ViewBinding>(
             parent.viewBinding(DomainPurchaseCardBinding::inflate)
     ) {
         fun onBind(item: PurchaseDomain) = with(binding) {
+            uiHelpers.setImageOrHide(purchaseDomainImage, item.image)
             uiHelpers.setTextOrHide(purchaseDomainTitle, item.title)
             uiHelpers.setTextOrHide(purchaseDomainCaption, item.body)
             searchDomainsButton.setOnClickListener { item.onClick.click() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -116,18 +116,18 @@ class DomainsDashboardViewModel @Inject constructor(
 
         customDomains.forEach {
             listItems += SiteDomains(
-                    UiStringText(it.domain.toString()),
+                    UiStringText(it.domain.orEmpty()),
                     if (it.expirySoon) {
                         UiStringText(
                                 htmlMessageUtils.getHtmlMessageFromStringFormatResId(
                                         R.string.domains_site_domain_expires_soon,
-                                        it.expiry.toString()
+                                        it.expiry.orEmpty()
                                 )
                         )
                     } else {
                         UiStringResWithParams(
                                 R.string.domains_site_domain_expires,
-                                listOf(UiStringText(it.expiry.toString()))
+                                listOf(UiStringText(it.expiry.orEmpty()))
                         )
                     },
                     it.primaryDomain

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -106,15 +106,13 @@ class DomainsDashboardViewModel @Inject constructor(
         listItems += FreeDomain(UiStringText(freeDomainUrl), freeDomainIsPrimary, this::onChangeSiteClick)
 
         val customDomains = domains.filter { !it.wpcomDomain }
-
         val hasCustomDomains = customDomains.isNotEmpty()
         val hasDomainCredit = isDomainCreditAvailable(plans)
         val hasPaidPlan = !SiteUtils.onFreePlan(site)
 
         if (hasCustomDomains) listItems += SiteDomainsHeader(UiStringRes(R.string.domains_site_domains))
-
-        customDomains.forEach {
-            listItems += SiteDomains(
+        listItems += customDomains.map {
+            SiteDomains(
                     UiStringText(it.domain.orEmpty()),
                     if (it.expirySoon) {
                         UiStringText(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -110,26 +110,7 @@ class DomainsDashboardViewModel @Inject constructor(
         val hasDomainCredit = isDomainCreditAvailable(plans)
         val hasPaidPlan = !SiteUtils.onFreePlan(site)
 
-        if (hasCustomDomains) listItems += SiteDomainsHeader(UiStringRes(R.string.domains_site_domains))
-        listItems += customDomains.map {
-            SiteDomains(
-                    UiStringText(it.domain.orEmpty()),
-                    if (it.expirySoon) {
-                        UiStringText(
-                                htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                                        R.string.domains_site_domain_expires_soon,
-                                        it.expiry.orEmpty()
-                                )
-                        )
-                    } else {
-                        UiStringResWithParams(
-                                R.string.domains_site_domain_expires,
-                                listOf(UiStringText(it.expiry.orEmpty()))
-                        )
-                    },
-                    it.primaryDomain
-            )
-        }
+        listItems += buildCustomDomainItems(customDomains, hasCustomDomains)
 
         if (hasDomainCredit) {
             listItems += PurchaseDomain(
@@ -177,6 +158,34 @@ class DomainsDashboardViewModel @Inject constructor(
 //        }
 
         _uiModel.postValue(listItems)
+    }
+
+    private fun buildCustomDomainItems(
+        customDomains: List<Domain>,
+        hasCustomDomains: Boolean
+    ): List<DomainsDashboardItem> {
+        val listItems = mutableListOf<DomainsDashboardItem>()
+        if (hasCustomDomains) listItems += SiteDomainsHeader(UiStringRes(R.string.domains_site_domains))
+        listItems += customDomains.map {
+            SiteDomains(
+                    UiStringText(it.domain.orEmpty()),
+                    if (it.expirySoon) {
+                        UiStringText(
+                                htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                                        R.string.domains_site_domain_expires_soon,
+                                        it.expiry.orEmpty()
+                                )
+                        )
+                    } else {
+                        UiStringResWithParams(
+                                R.string.domains_site_domain_expires,
+                                listOf(UiStringText(it.expiry.orEmpty()))
+                        )
+                    },
+                    it.primaryDomain
+            )
+        }
+        return listItems
     }
 
     private fun getCleanUrl(url: String) = StringUtils.removeTrailingSlash(UrlUtils.removeScheme(url))

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -201,7 +201,7 @@ class DomainsDashboardViewModel @Inject constructor(
         }
 
         if (domains.isNotEmpty()) {
-            listItems += AddDomain(ListItemInteraction.create(this::onAddDomainClick))
+            listItems += AddDomain(ListItemInteraction.create(hasDomainCredit, this::onAddDomainClick))
             listItems += DomainBlurb(
                     UiStringResWithParams(
                             R.string.domains_redirected_domains_blurb,
@@ -228,7 +228,7 @@ class DomainsDashboardViewModel @Inject constructor(
         _onNavigation.value = Event(ClaimDomain(site))
     }
 
-    private fun onAddDomainClick() {
+    private fun onAddDomainClick(hasDomainCredit: Boolean) {
         analyticsTrackerWrapper.track(DOMAINS_DASHBOARD_ADD_DOMAIN_TAPPED, site)
         if (hasDomainCredit) onClaimDomainClick() else onGetDomainClick()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -152,17 +152,26 @@ class DomainsDashboardViewModel @Inject constructor(
                 )
             }
         } else {
-            listItems += PurchaseDomain(
-                    R.drawable.img_illustration_domains_card_header,
-                    UiStringRes(R.string.domains_free_plan_get_your_domain_title),
-                    UiStringText(
-                            htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                                    R.string.domains_free_plan_get_your_domain_caption,
-                                    freeDomainUrl
-                            )
-                    ),
-                    ListItemInteraction.create(this::onGetDomainClick)
-            )
+            listItems += if (hasPaidPlan) {
+                PurchaseDomain(
+                        R.drawable.img_illustration_domains_card_header,
+                        UiStringRes(R.string.domains_paid_plan_add_your_domain_title),
+                        UiStringRes(R.string.domains_paid_plan_add_your_domain_caption),
+                        ListItemInteraction.create(this::onGetDomainClick)
+                )
+            } else {
+                PurchaseDomain(
+                        R.drawable.img_illustration_domains_card_header,
+                        UiStringRes(R.string.domains_free_plan_get_your_domain_title),
+                        UiStringText(
+                                htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                                        R.string.domains_free_plan_get_your_domain_caption,
+                                        freeDomainUrl
+                                )
+                        ),
+                        ListItemInteraction.create(this::onGetDomainClick)
+                )
+            }
         }
 
 //        NOTE: Manage domains option is de-scoped for v1 release

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -170,7 +170,7 @@ class DomainsDashboardViewModel @Inject constructor(
 //        NOTE: Manage domains option is de-scoped for v1 release
 //        listItems += ManageDomains(ListItemInteraction.create(this::onManageDomainClick))
 
-        _uiModel.value = listItems
+        _uiModel.postValue(listItems)
     }
 
     private fun getCleanUrl(url: String) = StringUtils.removeTrailingSlash(UrlUtils.removeScheme(url))

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -136,12 +136,14 @@ class DomainsDashboardViewModel @Inject constructor(
 
         if (hasCustomDomains) {
             listItems += AddDomain(ListItemInteraction.create(hasDomainCredit, this::onAddDomainClick))
-            listItems += DomainBlurb(
-                    UiStringResWithParams(
-                            R.string.domains_redirected_domains_blurb,
-                            listOf(UiStringText(freeDomainUrl))
-                    )
-            )
+            if (!hasPaidPlan) {
+                listItems += DomainBlurb(
+                        UiStringResWithParams(
+                                R.string.domains_redirected_domains_blurb,
+                                listOf(UiStringText(freeDomainUrl))
+                        )
+                )
+            }
         }
 
         listItems += if (hasDomainCredit) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -106,8 +106,36 @@ class DomainsDashboardViewModel @Inject constructor(
 
         val customDomains = domains.filter { !it.wpcomDomain }
 
-        customDomains.let {
-            listItems += getManageDomainsItems(freeDomain?.domain.toString(), customDomains)
+        if (customDomains.isNotEmpty()) listItems += SiteDomainsHeader(UiStringRes(R.string.domains_site_domains))
+
+        customDomains.forEach {
+            listItems += SiteDomains(
+                    UiStringText(it.domain.toString()),
+                    if (it.expirySoon) {
+                        UiStringText(
+                                htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                                        R.string.domains_site_domain_expires_soon,
+                                        it.expiry.toString()
+                                )
+                        )
+                    } else {
+                        UiStringResWithParams(
+                                R.string.domains_site_domain_expires,
+                                listOf(UiStringText(it.expiry.toString()))
+                        )
+                    },
+                    it.primaryDomain
+            )
+        }
+
+        if (customDomains.isNotEmpty()) {
+            listItems += AddDomain(ListItemInteraction.create(hasDomainCredit, this::onAddDomainClick))
+            listItems += DomainBlurb(
+                    UiStringResWithParams(
+                            R.string.domains_redirected_domains_blurb,
+                            listOf(UiStringText(freeDomainUrl))
+                    )
+            )
         }
 
         listItems += if (hasDomainCredit) {
@@ -115,6 +143,9 @@ class DomainsDashboardViewModel @Inject constructor(
         } else {
             getPurchaseDomainItems(freeDomain?.domain.toString())
         }
+
+//        NOTE: Manage domains option is de-scoped for v1 release
+//        listItems += ManageDomains(ListItemInteraction.create(this::onManageDomainClick))
 
         _uiModel.value = listItems
     }
@@ -144,48 +175,6 @@ class DomainsDashboardViewModel @Inject constructor(
                             ListItemInteraction.create(this::onClaimDomainClick)
                     )
             )
-
-    // if site has a custom registered domain then show Site Domains, Add Domain and Manage Domains
-    private fun getManageDomainsItems(siteUrl: String, domains: List<Domain>): List<DomainsDashboardItem> {
-        val listItems = mutableListOf<DomainsDashboardItem>()
-
-        if (domains.isNotEmpty()) listItems += SiteDomainsHeader(UiStringRes(R.string.domains_site_domains))
-
-        domains.forEach {
-            listItems += SiteDomains(
-                    UiStringText(it.domain.toString()),
-                    if (it.expirySoon) {
-                        UiStringText(
-                                htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                                        R.string.domains_site_domain_expires_soon,
-                                        it.expiry.toString()
-                                )
-                        )
-                    } else {
-                        UiStringResWithParams(
-                                R.string.domains_site_domain_expires,
-                                listOf(UiStringText(it.expiry.toString()))
-                        )
-                    },
-                    it.primaryDomain
-            )
-        }
-
-        if (domains.isNotEmpty()) {
-            listItems += AddDomain(ListItemInteraction.create(hasDomainCredit, this::onAddDomainClick))
-            listItems += DomainBlurb(
-                    UiStringResWithParams(
-                            R.string.domains_redirected_domains_blurb,
-                            listOf(UiStringText(siteUrl))
-                    )
-            )
-        }
-
-//        NOTE: Manage domains option is de-scoped for v1 release
-//        listItems += ManageDomains(ListItemInteraction.create(this::onManageDomainClick))
-
-        return listItems
-    }
 
     private fun getCleanUrl(url: String) = StringUtils.removeTrailingSlash(UrlUtils.removeScheme(url))
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.DOMAIN_REGISTRATION
+import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -109,6 +110,7 @@ class DomainsDashboardViewModel @Inject constructor(
 
         val hasCustomDomains = customDomains.isNotEmpty()
         val hasDomainCredit = isDomainCreditAvailable(plans)
+        val hasPaidPlan = !SiteUtils.onFreePlan(site)
 
         if (hasCustomDomains) listItems += SiteDomainsHeader(UiStringRes(R.string.domains_site_domains))
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.ClaimDo
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.GetDomain
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.OpenManageDomains
 import org.wordpress.android.ui.domains.usecases.FetchPlansUseCase
+import org.wordpress.android.ui.plans.isDomainCreditAvailable
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -105,6 +106,8 @@ class DomainsDashboardViewModel @Inject constructor(
         listItems += FreeDomain(UiStringText(freeDomainUrl), freeDomainIsPrimary, this::onChangeSiteClick)
 
         val customDomains = domains.filter { !it.wpcomDomain }
+
+        val hasDomainCredit = isDomainCreditAvailable(plans)
 
         if (customDomains.isNotEmpty()) listItems += SiteDomainsHeader(UiStringRes(R.string.domains_site_domains))
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.PlanModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.Domain
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.domains.DomainsDashboardItem.Action
 import org.wordpress.android.ui.domains.DomainsDashboardItem.Action.CHANGE_SITE_ADDRESS
@@ -48,8 +49,8 @@ class DomainsDashboardViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val htmlMessageUtils: HtmlMessageUtils,
     private val fetchPlansUseCase: FetchPlansUseCase,
-    @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher
-) : ScopedViewModel(uiDispatcher) {
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+) : ScopedViewModel(bgDispatcher) {
     lateinit var site: SiteModel
     private var hasDomainCredit: Boolean = false
     private var isStarted: Boolean = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -7,7 +7,6 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.Constants
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAINS_DASHBOARD_ADD_DOMAIN_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAINS_DASHBOARD_GET_DOMAIN_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAINS_DASHBOARD_VIEWED
@@ -147,31 +146,39 @@ class DomainsDashboardViewModel @Inject constructor(
     }
 
     private fun getFreeDomainItems(siteUrl: String, isPrimary: Boolean) =
-        listOf(FreeDomain(UiStringText(siteUrl), isPrimary, this::onChangeSiteClick))
+            listOf(FreeDomain(UiStringText(siteUrl), isPrimary, this::onChangeSiteClick))
 
     // for v1 release image/anim is de-scoped, set the image visibility to gone in layout for now.
     private fun getPurchaseDomainItems(siteUrl: String) =
-            listOf(PurchaseDomain(
-                    R.drawable.media_image_placeholder,
-                    UiStringRes(string.domains_free_plan_get_your_domain_title),
-                    UiStringText(htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                            string.domains_free_plan_get_your_domain_caption, siteUrl)),
-                    ListItemInteraction.create(this::onGetDomainClick)
-            ))
+            listOf(
+                    PurchaseDomain(
+                            R.drawable.media_image_placeholder,
+                            UiStringRes(R.string.domains_free_plan_get_your_domain_title),
+                            UiStringText(
+                                    htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                                            R.string.domains_free_plan_get_your_domain_caption,
+                                            siteUrl
+                                    )
+                            ),
+                            ListItemInteraction.create(this::onGetDomainClick)
+                    )
+            )
 
     private fun getClaimDomainItems() =
-            listOf(PurchaseDomain(
-                    R.drawable.media_image_placeholder,
-                    UiStringRes(string.domains_paid_plan_claim_your_domain_title),
-                    UiStringRes(string.domains_paid_plan_claim_your_domain_caption),
-                    ListItemInteraction.create(this::onClaimDomainClick)
-            ))
+            listOf(
+                    PurchaseDomain(
+                            R.drawable.media_image_placeholder,
+                            UiStringRes(R.string.domains_paid_plan_claim_your_domain_title),
+                            UiStringRes(R.string.domains_paid_plan_claim_your_domain_caption),
+                            ListItemInteraction.create(this::onClaimDomainClick)
+                    )
+            )
 
     // if site has a custom registered domain then show Site Domains, Add Domain and Manage Domains
     private fun getManageDomainsItems(siteUrl: String, domains: List<Domain>): List<DomainsDashboardItem> {
         val listItems = mutableListOf<DomainsDashboardItem>()
 
-        if (domains.isNotEmpty()) listItems += SiteDomainsHeader(UiStringRes(string.domains_site_domains))
+        if (domains.isNotEmpty()) listItems += SiteDomainsHeader(UiStringRes(R.string.domains_site_domains))
 
         domains.forEach {
             listItems += SiteDomains(
@@ -179,12 +186,13 @@ class DomainsDashboardViewModel @Inject constructor(
                     if (it.expirySoon) {
                         UiStringText(
                                 htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                                        string.domains_site_domain_expires_soon, it.expiry.toString()
+                                        R.string.domains_site_domain_expires_soon,
+                                        it.expiry.toString()
                                 )
                         )
                     } else {
                         UiStringResWithParams(
-                                string.domains_site_domain_expires,
+                                R.string.domains_site_domain_expires,
                                 listOf(UiStringText(it.expiry.toString()))
                         )
                     },
@@ -194,8 +202,12 @@ class DomainsDashboardViewModel @Inject constructor(
 
         if (domains.isNotEmpty()) {
             listItems += AddDomain(ListItemInteraction.create(this::onAddDomainClick))
-            listItems += DomainBlurb(UiStringResWithParams(
-                    string.domains_redirected_domains_blurb, listOf(UiStringText(siteUrl))))
+            listItems += DomainBlurb(
+                    UiStringResWithParams(
+                            R.string.domains_redirected_domains_blurb,
+                            listOf(UiStringText(siteUrl))
+                    )
+            )
         }
 
 //        NOTE: Manage domains option is de-scoped for v1 release
@@ -229,10 +241,12 @@ class DomainsDashboardViewModel @Inject constructor(
         _onNavigation.postValue(Event(OpenManageDomains("${Constants.URL_MANAGE_DOMAINS}/${site.siteId}")))
     }
 
-//  NOTE: Change site option is de-scoped for v1 release
+    //  NOTE: Change site option is de-scoped for v1 release
     private fun onChangeSiteClick(action: Action): Boolean {
         when (action) {
-            CHANGE_SITE_ADDRESS -> {} // TODO: next PR
+            CHANGE_SITE_ADDRESS -> {
+                TODO("Not yet implemented")
+            }
         }
         return true
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -148,14 +148,14 @@ class DomainsDashboardViewModel @Inject constructor(
 
         listItems += if (hasDomainCredit) {
             PurchaseDomain(
-                    R.drawable.media_image_placeholder,
+                    R.drawable.img_illustration_domains_card_header,
                     UiStringRes(R.string.domains_paid_plan_claim_your_domain_title),
                     UiStringRes(R.string.domains_paid_plan_claim_your_domain_caption),
                     ListItemInteraction.create(this::onClaimDomainClick)
             )
         } else {
             PurchaseDomain(
-                    R.drawable.media_image_placeholder,
+                    R.drawable.img_illustration_domains_card_header,
                     UiStringRes(R.string.domains_free_plan_get_your_domain_title),
                     UiStringText(
                             htmlMessageUtils.getHtmlMessageFromStringFormatResId(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -88,7 +88,7 @@ class DomainsDashboardViewModel @Inject constructor(
 
     private fun getSiteDomainsList() {
         // TODO: Probably needs a loading spinner here instead
-        _uiModel.value = getFreeDomainItems(getHomeUrlOrHostName(site.unmappedUrl), false)
+        _uiModel.value = getFreeDomainItems(getCleanUrl(site.unmappedUrl), false)
 
         launch {
             val result = siteStore.fetchSiteDomains(site)
@@ -216,11 +216,7 @@ class DomainsDashboardViewModel @Inject constructor(
         return listItems
     }
 
-    private fun getHomeUrlOrHostName(unmappedUrl: String): String {
-        var homeURL = UrlUtils.removeScheme(unmappedUrl)
-        homeURL = StringUtils.removeTrailingSlash(homeURL)
-        return homeURL
-    }
+    private fun getCleanUrl(url: String) = StringUtils.removeTrailingSlash(UrlUtils.removeScheme(url))
 
     private fun onGetDomainClick() {
         analyticsTrackerWrapper.track(DOMAINS_DASHBOARD_GET_DOMAIN_TAPPED, site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -139,9 +139,24 @@ class DomainsDashboardViewModel @Inject constructor(
         }
 
         listItems += if (hasDomainCredit) {
-            getClaimDomainItems()
+            PurchaseDomain(
+                    R.drawable.media_image_placeholder,
+                    UiStringRes(R.string.domains_paid_plan_claim_your_domain_title),
+                    UiStringRes(R.string.domains_paid_plan_claim_your_domain_caption),
+                    ListItemInteraction.create(this::onClaimDomainClick)
+            )
         } else {
-            getPurchaseDomainItems(freeDomain?.domain.toString())
+            PurchaseDomain(
+                    R.drawable.media_image_placeholder,
+                    UiStringRes(R.string.domains_free_plan_get_your_domain_title),
+                    UiStringText(
+                            htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                                    R.string.domains_free_plan_get_your_domain_caption,
+                                    freeDomainUrl
+                            )
+                    ),
+                    ListItemInteraction.create(this::onGetDomainClick)
+            )
         }
 
 //        NOTE: Manage domains option is de-scoped for v1 release
@@ -149,32 +164,6 @@ class DomainsDashboardViewModel @Inject constructor(
 
         _uiModel.value = listItems
     }
-
-    // for v1 release image/anim is de-scoped, set the image visibility to gone in layout for now.
-    private fun getPurchaseDomainItems(siteUrl: String) =
-            listOf(
-                    PurchaseDomain(
-                            R.drawable.media_image_placeholder,
-                            UiStringRes(R.string.domains_free_plan_get_your_domain_title),
-                            UiStringText(
-                                    htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                                            R.string.domains_free_plan_get_your_domain_caption,
-                                            siteUrl
-                                    )
-                            ),
-                            ListItemInteraction.create(this::onGetDomainClick)
-                    )
-            )
-
-    private fun getClaimDomainItems() =
-            listOf(
-                    PurchaseDomain(
-                            R.drawable.media_image_placeholder,
-                            UiStringRes(R.string.domains_paid_plan_claim_your_domain_title),
-                            UiStringRes(R.string.domains_paid_plan_claim_your_domain_caption),
-                            ListItemInteraction.create(this::onClaimDomainClick)
-                    )
-            )
 
     private fun getCleanUrl(url: String) = StringUtils.removeTrailingSlash(UrlUtils.removeScheme(url))
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -199,7 +199,7 @@ class DomainsDashboardViewModel @Inject constructor(
         return listItems
     }
 
-    private fun getCleanUrl(url: String) = StringUtils.removeTrailingSlash(UrlUtils.removeScheme(url))
+    private fun getCleanUrl(url: String?) = StringUtils.removeTrailingSlash(UrlUtils.removeScheme(url))
 
     private fun onGetDomainClick() {
         analyticsTrackerWrapper.track(DOMAINS_DASHBOARD_GET_DOMAIN_TAPPED, site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -112,6 +112,23 @@ class DomainsDashboardViewModel @Inject constructor(
 
         listItems += buildCustomDomainItems(customDomains, hasCustomDomains)
 
+        listItems += buildCtaItems(freeDomainUrl, hasCustomDomains, hasDomainCredit, hasPaidPlan)
+
+//        NOTE: Manage domains option is de-scoped for v1 release
+//        if (hasCustomDomains) {
+//            listItems += ManageDomains(ListItemInteraction.create(this::onManageDomainClick))
+//        }
+
+        _uiModel.postValue(listItems)
+    }
+
+    private fun buildCtaItems(
+        freeDomainUrl: String,
+        hasCustomDomains: Boolean,
+        hasDomainCredit: Boolean,
+        hasPaidPlan: Boolean
+    ): List<DomainsDashboardItem> {
+        val listItems = mutableListOf<DomainsDashboardItem>()
         if (hasDomainCredit) {
             listItems += PurchaseDomain(
                     null,
@@ -151,13 +168,7 @@ class DomainsDashboardViewModel @Inject constructor(
                 )
             }
         }
-
-//        NOTE: Manage domains option is de-scoped for v1 release
-//        if (hasCustomDomains) {
-//            listItems += ManageDomains(ListItemInteraction.create(this::onManageDomainClick))
-//        }
-
-        _uiModel.postValue(listItems)
+        return listItems
     }
 
     private fun buildCustomDomainItems(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -134,7 +134,14 @@ class DomainsDashboardViewModel @Inject constructor(
             )
         }
 
-        if (hasCustomDomains) {
+        if (hasDomainCredit) {
+            listItems += PurchaseDomain(
+                    null,
+                    UiStringRes(R.string.domains_paid_plan_claim_your_domain_title),
+                    UiStringRes(R.string.domains_paid_plan_claim_your_domain_caption),
+                    ListItemInteraction.create(this::onClaimDomainClick)
+            )
+        } else if (hasCustomDomains) {
             listItems += AddDomain(ListItemInteraction.create(hasDomainCredit, this::onAddDomainClick))
             if (!hasPaidPlan) {
                 listItems += DomainBlurb(
@@ -144,17 +151,8 @@ class DomainsDashboardViewModel @Inject constructor(
                         )
                 )
             }
-        }
-
-        listItems += if (hasDomainCredit) {
-            PurchaseDomain(
-                    R.drawable.img_illustration_domains_card_header,
-                    UiStringRes(R.string.domains_paid_plan_claim_your_domain_title),
-                    UiStringRes(R.string.domains_paid_plan_claim_your_domain_caption),
-                    ListItemInteraction.create(this::onClaimDomainClick)
-            )
         } else {
-            PurchaseDomain(
+            listItems += PurchaseDomain(
                     R.drawable.img_illustration_domains_card_header,
                     UiStringRes(R.string.domains_free_plan_get_your_domain_title),
                     UiStringText(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -99,11 +99,12 @@ class DomainsDashboardViewModel @Inject constructor(
         val listItems = mutableListOf<DomainsDashboardItem>()
 
         val freeDomain = domains.firstOrNull { it.wpcomDomain }
-        val customDomains = domains.filter { !it.wpcomDomain }
+        val freeDomainUrl = freeDomain?.domain ?: getCleanUrl(site.unmappedUrl)
+        val freeDomainIsPrimary = freeDomain?.primaryDomain ?: false
 
-        freeDomain?.let {
-            listItems += getFreeDomainItems(it.domain.toString(), it.primaryDomain)
-        }
+        listItems += FreeDomain(UiStringText(freeDomainUrl), freeDomainIsPrimary, this::onChangeSiteClick)
+
+        val customDomains = domains.filter { !it.wpcomDomain }
 
         customDomains.let {
             listItems += getManageDomainsItems(freeDomain?.domain.toString(), customDomains)
@@ -117,9 +118,6 @@ class DomainsDashboardViewModel @Inject constructor(
 
         _uiModel.value = listItems
     }
-
-    private fun getFreeDomainItems(siteUrl: String, isPrimary: Boolean) =
-            listOf(FreeDomain(UiStringText(siteUrl), isPrimary, this::onChangeSiteClick))
 
     // for v1 release image/anim is de-scoped, set the image visibility to gone in layout for now.
     private fun getPurchaseDomainItems(siteUrl: String) =

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.Domain
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.domains.DomainsDashboardItem.Action
 import org.wordpress.android.ui.domains.DomainsDashboardItem.Action.CHANGE_SITE_ADDRESS
 import org.wordpress.android.ui.domains.DomainsDashboardItem.AddDomain
@@ -99,8 +98,8 @@ class DomainsDashboardViewModel @Inject constructor(
     private fun buildDashboardItems(site: SiteModel, plans: List<PlanModel>, domains: List<Domain>) {
         val listItems = mutableListOf<DomainsDashboardItem>()
 
-        val freeDomain = domains.firstOrNull { it.wpcomDomain || it.isWpcomStagingDomain }
-        val customDomains = domains.filter { !it.wpcomDomain && !it.isWpcomStagingDomain }
+        val freeDomain = domains.firstOrNull { it.wpcomDomain }
+        val customDomains = domains.filter { !it.wpcomDomain }
 
         freeDomain?.let {
             listItems += getFreeDomainItems(it.domain.toString(), it.primaryDomain)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -107,9 +107,10 @@ class DomainsDashboardViewModel @Inject constructor(
 
         val customDomains = domains.filter { !it.wpcomDomain }
 
+        val hasCustomDomains = customDomains.isNotEmpty()
         val hasDomainCredit = isDomainCreditAvailable(plans)
 
-        if (customDomains.isNotEmpty()) listItems += SiteDomainsHeader(UiStringRes(R.string.domains_site_domains))
+        if (hasCustomDomains) listItems += SiteDomainsHeader(UiStringRes(R.string.domains_site_domains))
 
         customDomains.forEach {
             listItems += SiteDomains(
@@ -131,7 +132,7 @@ class DomainsDashboardViewModel @Inject constructor(
             )
         }
 
-        if (customDomains.isNotEmpty()) {
+        if (hasCustomDomains) {
             listItems += AddDomain(ListItemInteraction.create(hasDomainCredit, this::onAddDomainClick))
             listItems += DomainBlurb(
                     UiStringResWithParams(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -175,7 +175,9 @@ class DomainsDashboardViewModel @Inject constructor(
         }
 
 //        NOTE: Manage domains option is de-scoped for v1 release
-//        listItems += ManageDomains(ListItemInteraction.create(this::onManageDomainClick))
+//        if (hasCustomDomains) {
+//            listItems += ManageDomains(ListItemInteraction.create(this::onManageDomainClick))
+//        }
 
         _uiModel.postValue(listItems)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -53,7 +53,6 @@ class DomainsDashboardViewModel @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(bgDispatcher) {
     lateinit var site: SiteModel
-    private var hasDomainCredit: Boolean = false
     private var isStarted: Boolean = false
 
     private val _onNavigation = MutableLiveData<Event<DomainsDashboardNavigationAction>>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchPlansUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchPlansUseCase.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.ui.domains.usecases
+
+import org.greenrobot.eventbus.Subscribe
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnPlansFetched
+import javax.inject.Inject
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Wraps an [OnPlansFetched] into a coroutine.
+ */
+class FetchPlansUseCase @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val siteStore: SiteStore // needed for events to work
+) {
+    private var continuation: Continuation<OnPlansFetched>? = null
+
+    init {
+        dispatcher.register(this)
+    }
+
+    fun clear() {
+        dispatcher.unregister(this)
+    }
+
+    suspend fun execute(
+        site: SiteModel
+    ): OnPlansFetched {
+        if (continuation != null) {
+            throw IllegalStateException("FetchSite is already in progress!")
+        }
+        return suspendCoroutine {
+            continuation = it
+            dispatcher.dispatch(SiteActionBuilder.newFetchPlansAction(site))
+        }
+    }
+
+    @Subscribe
+    fun onPlansFetched(event: OnPlansFetched) {
+        continuation?.resume(event)
+        continuation = null
+    }
+}

--- a/WordPress/src/main/res/layout/domain_purchase_card.xml
+++ b/WordPress/src/main/res/layout/domain_purchase_card.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/purchase_domain_card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -38,7 +39,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/img_illustration_domains_card_header" />
+            tools:src="@drawable/img_illustration_domains_card_header" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/purchase_domain_caption"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2485,6 +2485,8 @@
     <string name="domains_manage_domains">Manage Domains</string>
     <string name="domains_paid_plan_claim_your_domain_title">Claim your free domain</string>
     <string name="domains_paid_plan_claim_your_domain_caption">You have a free one-year domain registration included with your plan</string>
+    <string name="domains_paid_plan_add_your_domain_title">Add your domain</string>
+    <string name="domains_paid_plan_add_your_domain_caption">Adding a custom domain makes it easy for visitors to find your site</string>
     <string name="domains_free_plan_get_your_domain_title">Get your domain</string>
     <string name="domains_free_plan_get_your_domain_caption">Domains purchased on this site will redirect visitors to &lt;b&gt;%s&lt;/b&gt;</string>
     <string name="domains_search_for_a_domain_button">Search for a domain</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainsDashboardViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainsDashboardViewModelTest.kt
@@ -14,8 +14,6 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.PlanModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.Domain
-import org.wordpress.android.fluxc.network.rest.wpcom.site.GoogleAppsSubscription
-import org.wordpress.android.fluxc.network.rest.wpcom.site.TitanMailSubscription
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.FetchedDomainsPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnPlansFetched


### PR DESCRIPTION
This PR contains some final improvements to the Domains Dashboard screen to ensure it behaves as expected in all of the following scenarios:

|Scenario|Spec|App|
|-----|-----|-----|
|**1. Free plan with custom domains**|<img width="300" alt="1-expected" src="https://user-images.githubusercontent.com/830056/137177207-445a925f-76e0-4bf3-b4c1-c5ad01721739.png">|<img width="300" alt="1-actual" src="https://user-images.githubusercontent.com/830056/139773186-95f9de5c-7483-4c8c-bdab-bdda0429d1a0.png">|
|**2. Free plan with no custom domains**|<img width="300" alt="2-expected" src="https://user-images.githubusercontent.com/830056/137177208-ccc0d90a-d5ad-4e3d-b112-2bb524380959.png">|<img width="300" alt="2-actual" src="https://user-images.githubusercontent.com/830056/139773189-103e98b3-3353-450e-82c9-537b38c54879.png">|
|**3. Paid plan with custom domains and credits**|<img width="300" alt="3-expected" src="https://user-images.githubusercontent.com/830056/137177191-d74bbb90-e207-4b5f-9fdd-d070a6b1bb18.png">|<img width="300" alt="3-actual" src="https://user-images.githubusercontent.com/830056/139773190-665415df-a517-457b-a023-f6bdfdddceaf.png">|
|**4. Paid plan with custom domains and no credits**|<img width="300" alt="4-expected" src="https://user-images.githubusercontent.com/830056/137177209-2c148035-745e-4feb-a42e-2d1dd79b4400.png">|<img width="300" alt="4-actual" src="https://user-images.githubusercontent.com/830056/139773193-1087b51f-5c08-4fa3-9494-fb88035e60e1.png">|
|**5. Paid plan with no custom domains and credits**|<img width="300" alt="7-expected" src="https://user-images.githubusercontent.com/830056/137177210-84c68bf4-241e-4824-ae41-96c9ea48ea0a.png">|<img width="300" alt="5-actual" src="https://user-images.githubusercontent.com/830056/139773195-b4429f28-8194-4e29-a5dd-47bff5635651.png">|
|**6. Paid plan with no custom domains and no credits**|<img width="300" alt="8-expected" src="https://user-images.githubusercontent.com/830056/137177206-786fd0d5-4a2a-4881-9033-1bbda0523dbe.png">|<img width="300" alt="8-actual" src="https://user-images.githubusercontent.com/830056/139773198-e2500ed5-380b-42d3-9a48-867d46c6f5d5.png">|

Depends on #15520

### To test

**Setup: Enable feature flag**

1. On the Main screen, tap the Me button.
1. On the Me screen, go to App Settings > Debug settings.
1. On the Debug Settings screen, scroll down to the "Features in development" section and tap `SiteDomainsFeatureConfig` to enable the Domains feature flag.

**Main scenarios**

Go to each of the scenarios above and make sure you can correctly reproduce them.

## Regression Notes
1. Potential unintended areas of impact
Some other unwanted scenario involving custom domains, plans, and credits.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
Unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
