### PR TITLE
Fix MySite's Domain Registration card logic

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
@@ -77,7 +77,7 @@ class DomainRegistrationSource
         dispatcher.unregister(this)
     }
 
-    private fun shouldFetchPlans(site: SiteModel) = !siteUtils.onFreePlan(site) && !siteUtils.hasCustomDomain(site)
+    private fun shouldFetchPlans(site: SiteModel) = !siteUtils.onFreePlan(site)
 
     private fun fetchPlans(site: SiteModel) = dispatcher.dispatch(SiteActionBuilder.newFetchPlansAction(site))
 

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -50,7 +50,6 @@ public class SiteUtils {
      * Strategy: Check if there is the old app-wide preference still available (v12.9 and before used it).
      * -- 12.9 ON -> turn all sites ON in 13.0
      * -- 12.9 OPTED OUT (were auto-opted in but turned it OFF) -> turn all sites OFF in 13.0
-     *
      */
     public static void migrateAppWideMobileEditorPreferenceToRemote(final AccountStore accountStore,
                                                                     final SiteStore siteStore,
@@ -370,10 +369,6 @@ public class SiteUtils {
     public static boolean onBloggerPlan(@NonNull SiteModel site) {
         return site.getPlanId() == PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
                || site.getPlanId() == PlansConstants.BLOGGER_PLAN_TWO_YEARS_ID;
-    }
-
-    public static boolean hasCustomDomain(@NonNull SiteModel site) {
-        return !site.getUrl().contains(".wordpress.com") && !site.getUrl().contains(".wpcomstaging.com");
     }
 
     public static boolean hasFullAccessToContent(@Nullable SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
@@ -20,6 +20,5 @@ class SiteUtilsWrapper @Inject constructor() {
 
     fun isAccessedViaWPComRest(site: SiteModel): Boolean = SiteUtils.isAccessedViaWPComRest(site)
     fun onFreePlan(site: SiteModel): Boolean = SiteUtils.onFreePlan(site)
-    fun hasCustomDomain(site: SiteModel): Boolean = SiteUtils.hasCustomDomain(site)
     fun getSiteNameOrHomeURL(site: SiteModel): String = SiteUtils.getSiteNameOrHomeURL(site)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
@@ -54,16 +54,7 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
 
     @Test
     fun `when site is free, emit false and don't fetch`() = test {
-        setupSite(site = site, isFree = true, hasCustomDomain = false)
-
-        assertThat(result.last().isDomainCreditAvailable).isFalse
-
-        verify(dispatcher, never()).dispatch(any())
-    }
-
-    @Test
-    fun `when site has custom domain, emit false and don't fetch`() = test {
-        setupSite(site = site, isFree = false, hasCustomDomain = true)
+        setupSite(site = site, isFree = true)
 
         assertThat(result.last().isDomainCreditAvailable).isFalse
 
@@ -111,12 +102,10 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
     private fun setupSite(
         site: SiteModel,
         isFree: Boolean = false,
-        hasCustomDomain: Boolean = false,
         currentPlan: PlanModel? = null,
         error: PlansErrorType? = null
     ) {
         whenever(siteUtils.onFreePlan(any())).thenReturn(isFree)
-        whenever(siteUtils.hasCustomDomain(any())).thenReturn(hasCustomDomain)
         buildOnPlansFetchedEvent(site, currentPlan, error)?.let { event ->
             whenever(dispatcher.dispatch(any())).then { source.onPlansFetched(event) }
         }

--- a/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
@@ -46,17 +46,6 @@ class SiteUtilsTest {
     }
 
     @Test
-    fun `hasCustomDomain returns true when site has custom domain`() {
-        val site = SiteModel()
-        site.url = "http://wordpress.com"
-
-        assertTrue(SiteUtils.hasCustomDomain(site))
-
-        site.url = "https://***.wordpress.com"
-        assertFalse(SiteUtils.hasCustomDomain(site))
-    }
-
-    @Test
     fun `checkMinimalJetpackVersion doesnt fail when Jetpack version is false`() {
         val site = SiteModel()
         site.jetpackVersion = "false"


### PR DESCRIPTION
Fixes #15347 

To verify if a site has domain credits, we need to fetch some additional information about its current plan. Previously, we wouldn't fetch this information if the site had a custom primary domain, as we assumed that any available credit would have already been redeemed to register that domain. We now know this assumption was incorrect, as some sites can acquire and set custom primary domains without using the available credits. This PR removes that erroneous check to account for those cases.

<img width=300 src="https://user-images.githubusercontent.com/830056/139930687-68aecb88-e314-45a1-9640-b50ea16cd5d1.png"/>

### To test

1. Purchase a custom domain for a site with a free plan.
1. Upgrade that site's plan to a paid one.
1. Set the previously purchased domain as the primary one — the site now has a paid plan, a custom primary domain, and available domain credits. 
1. Open the app.
1. Select the site from the steps above.
1. On the My Site screen, notice the Domain Registration card.

## Regression Notes

1. Potential unintended areas of impact
Other domain registration scenarios.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
None, as I relied on existing tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
