### PR TITLE
Add check for null site model during site deletion

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -886,9 +886,12 @@ public class SiteSettingsFragment extends PreferenceFragment
     private void updateTitle() {
         if (mSite != null) {
             SiteModel updatedSite = mSiteStore.getSiteByLocalId(mSite.getId());
-            updatedSite.setName(mSiteSettings.getTitle());
-            // Locally save the site
-            mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(updatedSite));
+            // updatedSite can be null after site deletion or site removal (.org sites)
+            if (updatedSite != null) {
+                updatedSite.setName(mSiteSettings.getTitle());
+                // Locally save the site
+                mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(updatedSite));
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #15409

This PR adds a simple `null` check inside the `SiteSettingsFragment::updateTitle` method in order to prevent a crash. We were already doing this for `mSite`, but not for `updatedSite`.

### To test

1. Open the app.
1. Create a new WP.com site.
1. On the My Site screen, tap "Site Settings".
1. On the Site Settings screen, scroll to the "Advanced" section and tap "Delete Site".
1. On the first confirmation dialog, tap "Yes".
1. On the second confirmation dialog, type the site address and tap "Delete".
1. Notice the My Site screen.
1. Tap "Site Settings".
1. Notice how the app doesn't crash and instead, the Site Settings screen closes with a Toast message: "Couldn't retrieve site info".

## Regression Notes
1. Potential unintended areas of impact
None that I could think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
