### PR TITLE
Related posts featured image fix.

### DIFF
--- a/WordPress/src/main/res/layout/reader_cardview_related_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_related_post.xml
@@ -17,16 +17,17 @@
             android:layout_width="@dimen/reader_related_post_image_width"
             android:layout_height="0dp"
             android:layout_marginEnd="@dimen/margin_extra_large"
-            android:layout_marginTop="@dimen/margin_extra_large"
             android:background="@drawable/bg_rectangle_stroke_placeholder_radius_4dp"
             android:contentDescription="@null"
             android:cropToPadding="true"
             android:padding="@dimen/reader_image_featured_border_width"
-            app:layout_constraintBottom_toTopOf="@id/text_title"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintDimensionRatio="16:9"
             app:layout_constraintEnd_toStartOf="@id/text_title"
+            app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/text_title"


### PR DESCRIPTION
Fixes #15537

I tried to change the featured image constraints as per my understanding of the expected behaviour. Hi @ashiagr 👋 , asking your review since I think you could may be familiar with that reader section and I'm happy to have a double check in case I'm missing anything; thanks as always for your thoughts 🙇 !

| Before changes | After changes |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/140666253-d65b9bc5-feca-458a-b0d8-c4078e76b48e.png) | ![image](https://user-images.githubusercontent.com/47797566/140666227-080f9043-33e6-4c6c-9147-abcd936cc190.png) |


## To test
- Go to the reader and open a post details that present related posts with featured image
- Check the featured image is presented near to the title and excerpt as a 16:9 image

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
It's a layout change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
