### PR TITLE
Adds Github action for updating gutenbergMobileVersion

### DIFF
--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -1,0 +1,46 @@
+on:
+  workflow_dispatch:
+    inputs:
+      gutenbergMobileVersion:
+        required: true
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    env:
+      GUTENBERG_MOBILE_VERSION: ${{ github.event.inputs.gutenbergMobileVersion }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Update Gutenberg Mobile Version
+        run: |
+          sed -i "s/ext\.gutenbergMobileVersion = '.*'/ext.gutenbergMobileVersion = '$GUTENBERG_MOBILE_VERSION'/g" build.gradle
+      - name: Compute vars
+        id: vars
+        run: |
+          # Check if the version contains a "-" character
+          if [[ $GUTENBERG_MOBILE_VERSION == *"-"* ]]; then
+            # Get the substring up to "-" which should be either "trunk" or the PR number
+            VERSION_PREFIX=$(echo $GUTENBERG_MOBILE_VERSION | cut -d'-' -f1)
+
+            if [[ "$VERSION_PREFIX" == "trunk" ]]; then
+              echo ::set-output name=branch_name::update-gb-mobile-version/for-trunk-update
+              echo ::set-output name=title::"Automated gutenberg-mobile version update for $VERSION_PREFIX"
+            else
+              echo ::set-output name=branch_name::update-gb-mobile-version/for-pr-$VERSION_PREFIX
+              echo ::set-output name=title::"Automated gutenberg-mobile version update for PR $VERSION_PREFIX"
+            fi
+          else
+            # If the version doesn't contain a "-", it should be a tag
+            echo ::set-output name=branch_name::update-gb-mobile-version/for-tag-$GUTENBERG_MOBILE_VERSION
+            echo ::set-output name=title::"Automated gutenberg-mobile version update for tag $GUTENBERG_MOBILE_VERSION"
+          fi
+          echo ::set-output name=commit_message::"Update gutenbergMobileVersion to $GUTENBERG_MOBILE_VERSION"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: ${{ steps.vars.outputs.commit_message }}
+          title: ${{ steps.vars.outputs.title }}
+          branch: ${{ steps.vars.outputs.branch_name }}
+          delete-branch: true


### PR DESCRIPTION
This PR adds a Github action that'll create/update a PR for updating the `gutenbergMobileVersion` in `build.gradle`. This will be used to automated the https://github.com/wordpress-mobile/gutenberg-mobile updates. This is only a first draft, but unfortunately we need it to be merged in first so we can iterate on it.

To test:
* No testing steps right now

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
