### PR TITLE
Feature/15548 add about word press under me

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -50,6 +50,7 @@ import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource.ANDROID_CAMERA
+import org.wordpress.android.ui.prefs.AboutActivity
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MAIN
@@ -129,8 +130,6 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             ActivityLauncher.viewHelpAndSupport(requireContext(), ME_SCREEN_HELP, viewModel.getSite(), null)
         }
 
-        initRecommendUiState()
-
         rowLogout.setOnClickListener {
             if (accountStore.hasAccessToken()) {
                 signOutWordPressComWithConfirmation()
@@ -152,6 +151,17 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         }
 
         viewModel = ViewModelProvider(this@MeFragment, viewModelFactory).get(MeViewModel::class.java)
+
+        if (viewModel.unifiedAboutFeatureConfig.isEnabled()) {
+            initUnifiedAboutUiState()
+        } else {
+            initRecommendUiState()
+        }
+
+        viewModel.showUnifiedAbout.observeEvent(viewLifecycleOwner, {
+            startActivity(Intent(activity, AboutActivity::class.java))
+        })
+
         viewModel.showDisconnectDialog.observeEvent(viewLifecycleOwner, {
             when (it) {
                 true -> showDisconnectDialog()
@@ -192,6 +202,16 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         } else {
             recommendTheAppContainer.visibility = View.GONE
+        }
+    }
+
+    private fun MeFragmentBinding.initUnifiedAboutUiState() {
+        setRecommendLoadingState(false)
+        meShareIcon.setImageResource(R.drawable.ic_wordpress_white_24dp)
+        meShareTextView.setText(R.string.me_btn_about)
+
+        rowRecommendTheApp.setOnClickListener {
+            viewModel.showUnifiedAbout()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -97,10 +97,13 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding = MeFragmentBinding.bind(view).apply { onBind(savedInstanceState) }
+        binding = MeFragmentBinding.bind(view).apply {
+            setupViews()
+            setupObservers(savedInstanceState)
+        }
     }
 
-    private fun MeFragmentBinding.onBind(savedInstanceState: Bundle?) {
+    private fun MeFragmentBinding.setupViews() {
         with(requireActivity() as AppCompatActivity) {
             setSupportActionBar(toolbarMain)
             supportActionBar?.apply {
@@ -141,6 +144,11 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
                 }
             }
         }
+    }
+
+    private fun MeFragmentBinding.setupObservers(savedInstanceState: Bundle?) {
+        viewModel = ViewModelProvider(this@MeFragment, viewModelFactory).get(MeViewModel::class.java)
+
         if (savedInstanceState != null) {
             if (savedInstanceState.getBoolean(IS_DISCONNECTING, false)) {
                 viewModel.openDisconnectDialog()
@@ -150,13 +158,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        viewModel = ViewModelProvider(this@MeFragment, viewModelFactory).get(MeViewModel::class.java)
-
-        if (viewModel.unifiedAboutFeatureConfig.isEnabled()) {
-            initUnifiedAboutUiState()
-        } else {
-            initRecommendUiState()
-        }
+        if (viewModel.unifiedAboutFeatureConfig.isEnabled()) initUnifiedAboutUiState() else initRecommendUiState()
 
         viewModel.showUnifiedAbout.observeEvent(viewLifecycleOwner, {
             startActivity(Intent(activity, AboutActivity::class.java))

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -64,6 +64,7 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.config.RecommendTheAppFeatureConfig
+import org.wordpress.android.util.config.UnifiedAboutFeatureConfig
 import org.wordpress.android.util.getColorFromAttribute
 import org.wordpress.android.util.image.ImageManager.RequestListener
 import org.wordpress.android.util.image.ImageType.AVATAR_WITHOUT_BACKGROUND
@@ -85,6 +86,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     @Inject lateinit var mediaPickerLauncher: MediaPickerLauncher
     @Inject lateinit var recommendTheAppFeatureConfig: RecommendTheAppFeatureConfig
     @Inject lateinit var sequencer: SnackbarSequencer
+    @Inject lateinit var unifiedAboutFeatureConfig: UnifiedAboutFeatureConfig
     private lateinit var viewModel: MeViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -158,7 +160,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        if (viewModel.unifiedAboutFeatureConfig.isEnabled()) initUnifiedAboutUiState() else initRecommendUiState()
+        if (unifiedAboutFeatureConfig.isEnabled()) initUnifiedAboutUiState() else initRecommendUiState()
 
         viewModel.showUnifiedAbout.observeEvent(viewLifecycleOwner, {
             startActivity(Intent(activity, AboutActivity::class.java))

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -12,6 +12,7 @@ import android.text.TextUtils
 import android.view.View
 import android.view.View.OnClickListener
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -160,7 +161,16 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        if (unifiedAboutFeatureConfig.isEnabled()) initUnifiedAboutUiState() else initRecommendUiState()
+        if (unifiedAboutFeatureConfig.isEnabled()) {
+            recommendTheAppContainer.isVisible = false
+            aboutTheAppContainer.isVisible = true
+
+            rowAboutTheApp.setOnClickListener {
+                viewModel.showUnifiedAbout()
+            }
+        } else {
+            initRecommendUiState()
+        }
 
         viewModel.showUnifiedAbout.observeEvent(viewLifecycleOwner, {
             startActivity(Intent(activity, AboutActivity::class.java))
@@ -206,16 +216,6 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         } else {
             recommendTheAppContainer.visibility = View.GONE
-        }
-    }
-
-    private fun MeFragmentBinding.initUnifiedAboutUiState() {
-        setRecommendLoadingState(false)
-        meShareIcon.setImageResource(R.drawable.ic_wordpress_white_24dp)
-        meShareTextView.setText(R.string.me_btn_about)
-
-        rowRecommendTheApp.setOnClickListener {
-            viewModel.showUnifiedAbout()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.recommend.RecommendAppState
 import org.wordpress.android.ui.recommend.RecommendAppState.ApiFetchedResult
 import org.wordpress.android.ui.recommend.RecommendAppState.FetchingApi
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
-import org.wordpress.android.util.config.UnifiedAboutFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -33,8 +32,7 @@ class MeViewModel
     @Named(BG_THREAD) val bgDispatcher: CoroutineDispatcher,
     private val selectedSiteRepository: SelectedSiteRepository,
     private val recommendApiCallsProvider: RecommendApiCallsProvider,
-    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper,
-    val unifiedAboutFeatureConfig: UnifiedAboutFeatureConfig
+    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private val _showDisconnectDialog = MutableLiveData<Event<Boolean>>()
     val showDisconnectDialog: LiveData<Event<Boolean>> = _showDisconnectDialog

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.recommend.RecommendAppState
 import org.wordpress.android.ui.recommend.RecommendAppState.ApiFetchedResult
 import org.wordpress.android.ui.recommend.RecommendAppState.FetchingApi
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.util.config.UnifiedAboutFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -32,13 +33,17 @@ class MeViewModel
     @Named(BG_THREAD) val bgDispatcher: CoroutineDispatcher,
     private val selectedSiteRepository: SelectedSiteRepository,
     private val recommendApiCallsProvider: RecommendApiCallsProvider,
-    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper
+    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper,
+    val unifiedAboutFeatureConfig: UnifiedAboutFeatureConfig
 ) : ScopedViewModel(mainDispatcher) {
     private val _showDisconnectDialog = MutableLiveData<Event<Boolean>>()
     val showDisconnectDialog: LiveData<Event<Boolean>> = _showDisconnectDialog
 
     private val _recommendUiState = MutableLiveData<RecommendAppState>()
     val recommendUiState: LiveData<Event<RecommendAppUiState>> = _recommendUiState.map { it.toUiState() }
+
+    private val _showUnifiedAbout = MutableLiveData<Event<Boolean>>()
+    val showUnifiedAbout: LiveData<Event<Boolean>> = _showUnifiedAbout
 
     data class RecommendAppUiState(
         val showLoading: Boolean = false,
@@ -74,6 +79,10 @@ class MeViewModel
     }
 
     fun getSite() = selectedSiteRepository.getSelectedSite()
+
+    fun showUnifiedAbout() {
+        _showUnifiedAbout.value = Event(true)
+    }
 
     fun onRecommendTheApp() {
         when (val state = _recommendUiState.value) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -56,6 +56,7 @@ import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.ui.debug.DebugSettingsActivity;
+import org.wordpress.android.util.config.UnifiedAboutFeatureConfig;
 import org.wordpress.android.viewmodel.ContextProvider;
 
 import java.util.EnumSet;
@@ -90,6 +91,7 @@ public class AppSettingsFragment extends PreferenceFragment
     @Inject ContextProvider mContextProvider;
     @Inject FeatureAnnouncementProvider mFeatureAnnouncementProvider;
     @Inject BuildConfigWrapper mBuildConfigWrapper;
+    @Inject UnifiedAboutFeatureConfig mUnifiedAboutFeatureConfig;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -187,6 +189,10 @@ public class AppSettingsFragment extends PreferenceFragment
         removeWhatsNewPreference();
         mDispatcher.dispatch(WhatsNewActionBuilder.newFetchCachedAnnouncementAction());
 
+        if (mUnifiedAboutFeatureConfig.isEnabled()) {
+            removeAboutCategory();
+        }
+
         if (!BuildConfig.OFFER_GUTENBERG) {
             removeExperimentalCategory();
         }
@@ -224,6 +230,13 @@ public class AppSettingsFragment extends PreferenceFragment
         preferenceScreen.removePreference(experimentalPreference);
     }
 
+    private void removeAboutCategory() {
+        PreferenceCategory aboutPreferenceCategory =
+                (PreferenceCategory) findPreference(getString(R.string.pref_key_about_section));
+        PreferenceScreen preferenceScreen =
+                (PreferenceScreen) findPreference(getString(R.string.pref_key_app_settings_root));
+        preferenceScreen.removePreference(aboutPreferenceCategory);
+    }
 
     private void removeWhatsNewPreference() {
         PreferenceCategory aboutTheAppPreferenceCategory =

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -234,6 +234,35 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/about_the_app_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <LinearLayout
+                    android:id="@+id/row_about_the_app"
+                    style="@style/MeListRowLayout">
+
+                    <ImageView
+                        android:id="@+id/me_about_icon"
+                        style="@style/MeListRowIcon"
+                        android:contentDescription="@null"
+                        android:src="@drawable/ic_wordpress_white_24dp" />
+
+                    <org.wordpress.android.util.widgets.AutoResizeTextView
+                        android:id="@+id/me_about_text_view"
+                        style="@style/MeListRowTextView"
+                        android:text="@string/me_btn_about" />
+
+                </LinearLayout>
+
+                <View style="@style/MeListSectionDividerView" />
+
+            </LinearLayout>
+
+            <LinearLayout
                 android:id="@+id/row_logout"
                 style="@style/MeListRowLayout">
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2228,6 +2228,7 @@
     <string name="me_btn_app_settings">App Settings</string>
     <string name="me_btn_support">Help &amp; Support</string>
     <string name="me_btn_share">Share WordPress with a friend</string>
+    <string name="me_btn_about">About WordPress</string>
     <string name="me_btn_login_logout">Login/Logout</string>
     <string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
     <string name="me_disconnect_from_wordpress_com">Log out of WordPress.com</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
@@ -45,8 +45,7 @@ class MeViewModelTest : BaseUnitTest() {
                 TEST_DISPATCHER,
                 selectedSiteRepository,
                 recommendApiCallsProvider,
-                analyticsUtilsWrapper,
-                unifiedAboutFeatureConfig
+                analyticsUtilsWrapper
         )
 
         setupObservers()

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.ui.main.MeViewModel.RecommendAppUiState
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.analytics.AnalyticsUtils.RecommendAppSource
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
-import org.wordpress.android.util.config.UnifiedAboutFeatureConfig
 import org.wordpress.android.viewmodel.Event
 
 @InternalCoroutinesApi
@@ -32,7 +31,6 @@ class MeViewModelTest : BaseUnitTest() {
     @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
     @Mock lateinit var recommendApiCallsProvider: RecommendApiCallsProvider
     @Mock lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
-    @Mock lateinit var unifiedAboutFeatureConfig: UnifiedAboutFeatureConfig
 
     private lateinit var viewModel: MeViewModel
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/MeViewModelTest.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.main.MeViewModel.RecommendAppUiState
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.analytics.AnalyticsUtils.RecommendAppSource
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.util.config.UnifiedAboutFeatureConfig
 import org.wordpress.android.viewmodel.Event
 
 @InternalCoroutinesApi
@@ -31,6 +32,7 @@ class MeViewModelTest : BaseUnitTest() {
     @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
     @Mock lateinit var recommendApiCallsProvider: RecommendApiCallsProvider
     @Mock lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
+    @Mock lateinit var unifiedAboutFeatureConfig: UnifiedAboutFeatureConfig
 
     private lateinit var viewModel: MeViewModel
 
@@ -43,7 +45,8 @@ class MeViewModelTest : BaseUnitTest() {
                 TEST_DISPATCHER,
                 selectedSiteRepository,
                 recommendApiCallsProvider,
-                analyticsUtilsWrapper
+                analyticsUtilsWrapper,
+                unifiedAboutFeatureConfig
         )
 
         setupObservers()


### PR DESCRIPTION
Fixes #15548 

<img width=320 src="https://user-images.githubusercontent.com/990349/141051555-76e00e84-5f18-43a1-9c81-0bb1229dc0c1.png" />


When unified about feature is enabled
- Adds **About WordPress** under Me in place of **Share WordPress with a friend** option
- Removes **About the app** section from Me -> App Settings


To test:
- Go to Me -> App Settings -> Debug Settings and 
- enable UnifiedAboutFeatureConfig [ ] under Feature in development then click on RESTART THE APP
- Go to Me and find About WordPress.  Tap on it to open About screen
- Go to Me -> App Settings, scroll down and notice About the app is removed

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
