### PR TITLE
My Site Dashboard: CurrentAvatarSource Refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
@@ -31,16 +31,17 @@ class CurrentAvatarSource @Inject constructor(
     private fun MediatorLiveData<CurrentAvatarUrl>.refreshData(
         isRefresh: Boolean? = null
     ) {
-        val url = accountStore.account?.avatarUrl.orEmpty()
         when (isRefresh) {
-            null -> this@refreshData.postValue(CurrentAvatarUrl(url))
-            true -> {
-                refresh.postValue(false)
-                if (url != avatarUrl.value?.url) {
-                    this@refreshData.postValue(CurrentAvatarUrl(url))
-                }
+            null, true -> {
+                val url = accountStore.account?.avatarUrl.orEmpty()
+                postState(CurrentAvatarUrl(url))
             }
             false -> Unit // Do nothing
         }
+    }
+
+    private fun MediatorLiveData<CurrentAvatarUrl>.postState(value: CurrentAvatarUrl) {
+        refresh.postValue(false)
+        this@postState.postValue(value)
     }
 }


### PR DESCRIPTION
Parent #15215

This PR changes the way `CurrentAvatarSource` gets/refreshes data through the use of MediatorLiveData.
This PR is part of a series of PRs being written for adding pull-to-refresh to the MySite tab.

**To test:**
- Launch the app with an account that has an avatar
- Navigate to My Site tab
- Note that current avatar is shown 
- Tap on the avatar to launch the Me view
- Tap the Change Photo link and choose a new photo
- Navigate back to My Site view
- Note that the avatar has refreshed to the new photo that it was changed to

## Regression Notes
1. Potential unintended areas of impact
Avatar refreshes

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + automated tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
