### PR TITLE
My Site Dashboard: DomainRegistrationSource Refresh 

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
@@ -93,10 +93,10 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when fetch fails, don't emit value`() = test {
+    fun `when fetch fails, emit false value`() = test {
         setupSite(site = site, error = GENERIC_ERROR)
 
-        assertThat(result.count()).isEqualTo(0)
+        assertThat(result.last().isDomainCreditAvailable).isFalse
     }
 
     private fun setupSite(


### PR DESCRIPTION
Parent #15215

This PR changes the way `DomainRegistrationSource` gets/refreshes data through the use of MediatorLiveData.
This PR is part of a series of PRs being written for adding pull-to-refresh to the MySite tab.


### To test
1. Launch the app
2. Navigate to the My Site screen.
3. Switch to a site on a free plan.
4. Notice the domain registration item is not shown.
5. Switch to a site on any paid plan and with unredeemed domain credit.
6. Notice the domain registration item is now being shown.
7. Tap on the domain registration item and notice the Domain Registration screen.
8. Register a domain name.
9. Back on the My Site screen, notice the domain registration item is not shown anymore.

## Regression Notes
1. Potential unintended areas of impact
Domain registration card doesn't show as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + automated tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
