### PR TITLE
My Site Dashboard: ScanAndBackupSource refreshData

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -45,7 +45,7 @@ class ScanAndBackupSource @Inject constructor(
 
     private fun MediatorLiveData<JetpackCapabilities>.refreshData(
         coroutineScope: CoroutineScope,
-        siteLocalId: Int,
+        siteLocalId: Int
     ) {
         val selectedSite = selectedSiteRepository.getSelectedSite()
         if (selectedSite != null && selectedSite.id == siteLocalId) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -137,7 +137,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
         )
 
-        scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { result = it }
+        scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { it }
         scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
 
         scanAndBackupSource.refresh()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -137,7 +137,6 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
         )
 
-        var result: JetpackCapabilities? = null
         scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { result = it }
         scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -1,5 +1,8 @@
 package org.wordpress.android.ui.mysite
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.flow
@@ -23,6 +26,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
     private lateinit var scanAndBackupSource: ScanAndBackupSource
     private val siteLocalId = 1
     private val siteRemoteId = 2L
+    private lateinit var isRefreshing: MutableList<Boolean>
 
     @InternalCoroutinesApi
     @Before
@@ -35,6 +39,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         whenever(site.id).thenReturn(siteLocalId)
         whenever(site.isWPCom).thenReturn(false)
         whenever(site.isWPComAtomic).thenReturn(false)
+        isRefreshing = mutableListOf()
     }
 
     @Test
@@ -122,5 +127,22 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { result = it }
 
         assertThat(result!!.scanAvailable).isTrue
+    }
+
+    @Test
+    fun `when refresh is invoked, then data is refreshed`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(site.siteId).thenReturn(siteRemoteId)
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
+                flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
+        )
+
+        var result: JetpackCapabilities? = null
+        scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { result = it }
+        scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
+
+        scanAndBackupSource.refresh()
+
+        verify(jetpackCapabilitiesUseCase, times(2)).getJetpackPurchasedProducts(any())
     }
 }


### PR DESCRIPTION
Parent #15215

This PR changes the way `ScanAndBackupSource` gets/refreshes data through the use of MediatorLiveData.
This PR is part of a series of PRs being written for adding pull-to-refresh to the MySite tab.

### To test
1. Launch the app
2. Select a site which has Jetpack "Backup" or "Scan" features enabled
3. Select MySite tab
4. Note that the "Backup" or "Scan" features are shown
5. Navigate to the site picker and select a site that doesn't have Jetpack "Backup" or "Scan" features enabled
6. Notice that the "Backup"/"Scan" items are now shown on the My Site tab

## Regression Notes
1. Potential unintended areas of impact
Scan & backup options don't show when they should

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + automated tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

