### PR TITLE
My Site Dashboard: PostCardsSource refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -60,7 +60,6 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Dis
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Negative
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Positive
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.MediaUtilsWrapper
@@ -113,7 +112,7 @@ class MySiteViewModel @Inject constructor(
     private val snackbarSequencer: SnackbarSequencer,
     private val cardsBuilder: CardsBuilder,
     private val dynamicCardsBuilder: DynamicCardsBuilder,
-    postCardsSource: PostCardsSource,
+    private val postCardsSource: PostCardsSource,
     quickStartCardSource: QuickStartCardSource,
     selectedSiteSource: SelectedSiteSource,
     siteIconProgressSource: SiteIconProgressSource,
@@ -727,7 +726,7 @@ class MySiteViewModel @Inject constructor(
     }
 
     fun onPullToRefresh() {
-        _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringText("Pull to refresh activated"))))
+        postCardsSource.refresh()
     }
 
     data class UiModel(

--- a/WordPress/src/main/res/raw/mocked_refresh_posts_data.json
+++ b/WordPress/src/main/res/raw/mocked_refresh_posts_data.json
@@ -1,0 +1,39 @@
+{
+  "posts": {
+    "has_published_posts": true,
+    "draft": [
+      {
+        "id": 3172,
+        "title": "A refreshed draft post 1...",
+        "modified": "2021-07-27T16:07:45+00:00",
+        "featured_image_url": "https://draft_1_feature_image_url"
+      },
+      {
+        "id": 3173,
+        "title": "A refreshed draft post 2...",
+        "modified": "2021-07-28T16:07:45+00:00",
+        "featured_image_url": "https://draft_2_feature_image_url"
+      }
+    ],
+    "scheduled": [
+      {
+        "id": 4172,
+        "title": "A refreshed scheduled post 1...",
+        "modified": "2021-07-27T16:07:45+00:00",
+        "featured_image_url": "https://schedule_1_feature_image_url"
+      },
+      {
+        "id": 4173,
+        "title": "A refreshed scheduled post 2...",
+        "modified": "2021-07-28T16:07:45+00:00",
+        "featured_image_url": "https://schedule_2_feature_image_url"
+      },
+      {
+        "id": 4174,
+        "title": "A refreshed scheduled post 3...",
+        "modified": "2021-07-29T16:07:45+00:00",
+        "featured_image_url": "https://schedule_3_feature_image_url"
+      }
+    ]
+  }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSourceTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.mysite.cards.post
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -9,21 +11,53 @@ import org.wordpress.android.test
 import org.wordpress.android.testScope
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.PostsUpdate
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedDataJsonUtils
+import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
+import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData.Post
+import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData.Posts
 
 class PostCardsSourceTest : BaseUnitTest() {
     @Mock lateinit var mockedDataJsonUtils: MockedDataJsonUtils
     private lateinit var postCardSource: PostCardsSource
+    private lateinit var isRefreshing: MutableList<Boolean>
 
     @Before
     fun setUp() {
+        whenever(mockedDataJsonUtils.getJsonStringFromRawResource(any())).thenReturn("string")
+        whenever(mockedDataJsonUtils.getMockedPostsDataFromJsonString(any())).thenReturn(mockedPostsData)
         postCardSource = PostCardsSource(mockedDataJsonUtils)
+        isRefreshing = mutableListOf()
     }
 
     @Test
     fun `when source is requested upon start, then mocked data is loaded`() = test {
         var result: PostsUpdate? = null
-        postCardSource.buildSource(testScope(), 1).observeForever { it?.let { result = it } }
-
+        postCardSource.buildSource(testScope(), 1).observeForever {
+            it?.let {
+                result = it
+            }
+        }
         assertThat(result?.mockedPostsData).isNotNull
     }
+
+    @Test
+    fun `when refresh is invoked, then data is refreshed`() = test {
+        val result: MutableList<PostsUpdate?> = mutableListOf()
+        postCardSource.buildSource(testScope(), 1).observeForever { it?.let { result.add(it) } }
+        postCardSource.refresh.observeForever { isRefreshing.add(it) }
+
+        postCardSource.refresh()
+
+        assertThat(result.first()?.mockedPostsData).isNotNull
+        assertThat(result.last()?.mockedPostsData).isNotNull
+        assertThat(result.size).isEqualTo(2)
+    }
+
+    private val mockedPostsData: MockedPostsData
+        get() = MockedPostsData(
+                posts = Posts(
+                        hasPublishedPosts = true,
+                        draft = listOf(Post(id = "1", title = "draft")),
+                        scheduled = listOf(Post(id = "1", title = "scheduled"))
+                )
+        )
 }


### PR DESCRIPTION
Parent #15215

This PR changes the way `PostCardsSource` gets/refreshes data through the use of MediatorLiveData.
This PR is part of a series of PRs being written for adding pull-to-refresh to the MySite tab.

**To test:**
- Launch the app
- Navigate to Me -> App Settings -> Debug Settings
- Enable `MySiteDashboardPhase2FeatureConfig`
- Restart the app
- Navigate to My Site tab
- Note that post cards are shown
- Swipe down from the top of the view to initiate the pull-to-refresh
- Note the post cards data now includes the word "refreshed"

## Regression Notes
1. Potential unintended areas of impact
The post cards are shown when the flag is off

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + automated tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
