### PR TITLE
Integrate gutenberg-mobile release 1.66.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = '2.2.0'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.66.0-alpha1'
+    ext.gutenbergMobileVersion = '4230-2aa8fbb9feb66e387ef7d94314d5dbb1180afccb'
     ext.storiesVersion = '1.2.0'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = '2.2.0'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '4230-2aa8fbb9feb66e387ef7d94314d5dbb1180afccb'
+    ext.gutenbergMobileVersion = 'v1.66.0'
     ext.storiesVersion = '1.2.0'
 
     repositories {


### PR DESCRIPTION
## Description
This PR incorporates the 1.66.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4230

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.