### PR TITLE
Remove PR list generation at code freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -139,9 +139,6 @@ REPOSITORY_NAME = 'WordPress-Android'
     android_bump_version_release()
     new_version = android_get_app_version()
 
-    # need to get prs list before version update to frozen tag
-    get_prs_list(repository: GHHELPER_REPO, milestone: new_version, report_path: "#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{new_version}.txt")
-
     extract_release_notes_for_version(
       version: new_version,
       release_notes_file_path: "#{ENV['PROJECT_ROOT_FOLDER']}RELEASE-NOTES.txt",
@@ -812,11 +809,6 @@ REPOSITORY_NAME = 'WordPress-Android'
 ########################################################################
 # Helper Lanes
 ########################################################################
-  desc 'Get a list of pull request from `start_tag` to the current state'
-  lane :get_pullrequests_list do |options|
-    get_prs_list(repository: GHHELPER_REPO, milestone: "#{options[:milestone]}", report_path: "#{File.expand_path('~')}/wpandroid_prs_list.txt")
-  end
-
   #####################################################################################
   # build_bundle
   # -----------------------------------------------------------------------------------


### PR DESCRIPTION
This PR removes the step in Fastlane's `code_freeze` lane that generates a text file with a list of the PRs that made it to the new version. With the current process to generate the release notes and the new tooling we built to generate the draft of the release announcement, this file is not used anymore.

This is also removing the `get_pullrequests_list` lane.

## Regression Notes
1. Potential unintended areas of impact
--

2. What I did to test those areas of impact (or what existing automated tests I relied on)
--

3. What automated tests I added (or what prevented me from doing so)
--

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
