### PR TITLE
Update release notes with gutenberg-mobile release 1.66.0 changes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,8 @@
 18.7
 -----
 * [*] Block editor: Fixed a race condition when autosaving content [https://github.com/WordPress/gutenberg/pull/36072]
+* [**] Block editor: Image block: Add ability to quickly link images to Media Files and Attachment Pages [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3971]
+* [**] Block editor: Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174]
 
 
 18.6


### PR DESCRIPTION
This PR only updates the release notes to include the changes introduced in gutenberg-mobile release 1.66.0, which should have been updated in [#17450](https://github.com/wordpress-mobile/WordPress-Android/pull/15559).

PR submission checklist:

- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
