### PR TITLE
Merge release/18.7 into develop (Code Freeze)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,6 @@
 * [**] Block editor: Image block: Add ability to quickly link images to Media Files and Attachment Pages [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3971]
 * [**] Block editor: Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174]
 
-
 18.6
 -----
 * [**] Block editor: Search block - Text and background color support [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4127]
@@ -19,7 +18,6 @@
 * [**] Block editor: Block inserter indicates newly available block types [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4047]
 * [*] Block editor: Add support for the Mark HTML tag [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4162]
 * [*] Block editor: Fixed a crash that could occur when copying lists from Microsoft Word [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174]
-
 
 18.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+18.8
+-----
+
+
 18.7
 -----
 * [*] Block editor: Fixed a race condition when autosaving content [https://github.com/WordPress/gutenberg/pull/36072]

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,5 +1,3 @@
 * [*] Block editor: Fixed a race condition when autosaving content [https://github.com/WordPress/gutenberg/pull/36072]
 * [**] Block editor: Image block: Add ability to quickly link images to Media Files and Attachment Pages [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3971]
 * [**] Block editor: Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174]
-
-

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,4 +1,5 @@
-- You can now use the Mark HTML tag and change the Search block button's text and background color.
-- Native editor onboarding features are available to everyone, including the new block badge.
-- The Help screen won't break out of its box when rotated between portrait and landscape.
-- We fixed more loading glitches in the Embed block.
+* [*] Block editor: Fixed a race condition when autosaving content [https://github.com/WordPress/gutenberg/pull/36072]
+* [**] Block editor: Image block: Add ability to quickly link images to Media Files and Attachment Pages [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3971]
+* [**] Block editor: Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174]
+
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,5 +1,3 @@
 * [*] Block editor: Fixed a race condition when autosaving content [https://github.com/WordPress/gutenberg/pull/36072]
 * [**] Block editor: Image block: Add ability to quickly link images to Media Files and Attachment Pages [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3971]
 * [**] Block editor: Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174]
-
-

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,4 +1,5 @@
-- You can now use the Mark HTML tag and change the Search block button's text and background color.
-- Native editor onboarding features are available to everyone, including the new block badge.
-- The Help screen won't break out of its box when rotated between portrait and landscape.
-- We fixed more loading glitches in the Embed block.
+* [*] Block editor: Fixed a race condition when autosaving content [https://github.com/WordPress/gutenberg/pull/36072]
+* [**] Block editor: Image block: Add ability to quickly link images to Media Files and Attachment Pages [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3971]
+* [**] Block editor: Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174]
+
+

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3405,6 +3405,7 @@
     <string name="gutenberg_native_current_unit_is_s" tools:ignore="UnusedResources">Current unit is %s</string>
     <!-- translators: %s: current cell value. -->
     <string name="gutenberg_native_current_value_is_s" tools:ignore="UnusedResources">Current value is %s</string>
+    <string name="gutenberg_native_custom_url" tools:ignore="UnusedResources">Custom URL</string>
     <string name="gutenberg_native_customize" tools:ignore="UnusedResources">CUSTOMIZE</string>
     <string name="gutenberg_native_customize_blocks" tools:ignore="UnusedResources">Customize blocks</string>
     <string name="gutenberg_native_customize_gradient" tools:ignore="UnusedResources">Customize Gradient</string>
@@ -3491,7 +3492,6 @@
     <string name="gutenberg_native_how_to_edit_your_post" tools:ignore="UnusedResources">How to edit your post</string>
     <!-- translators: accessibility text. %s: image caption. -->
     <string name="gutenberg_native_image_caption_s" tools:ignore="UnusedResources">Image caption. %s</string>
-    <string name="gutenberg_native_image_link_url" tools:ignore="UnusedResources">Image Link URL</string>
     <string name="gutenberg_native_image_settings" tools:ignore="UnusedResources">Image settings</string>
     <string name="gutenberg_native_insert_crosspost" tools:ignore="UnusedResources">Insert crosspost</string>
     <string name="gutenberg_native_insert_mention" tools:ignore="UnusedResources">Insert mention</string>
@@ -3566,6 +3566,7 @@
     <string name="gutenberg_native_problem_opening_the_audio" tools:ignore="UnusedResources">Problem opening the audio</string>
     <string name="gutenberg_native_problem_opening_the_video" tools:ignore="UnusedResources">Problem opening the video</string>
     <string name="gutenberg_native_remove_as_featured_image" tools:ignore="UnusedResources">Remove as Featured Image </string>
+    <string name="gutenberg_native_remove_block" tools:ignore="UnusedResources">Remove block</string>
     <string name="gutenberg_native_replace_audio" tools:ignore="UnusedResources">Replace audio</string>
     <string name="gutenberg_native_replace_current_block" tools:ignore="UnusedResources">Replace Current Block</string>
     <string name="gutenberg_native_replace_file" tools:ignore="UnusedResources">Replace file</string>

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.29.0'
+    fluxCVersion = '1.30.0'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -666,9 +666,10 @@
 
     <!-- Categories -->
     <string name="site_settings_categories_title">Categories</string>
-    <string name="site_settings_categories_empty_button">Create a category</string>
-    <string name="site_settings_categories_empty_subtitle">Add your frequently used categories here so they can be quickly selected when categorizing your posts</string>
-    <string name="site_settings_categories_empty_title">You don\'t have any categories</string>
+    <string name="site_settings_categories_no_network_title" translatable="false">@string/no_network_title</string>
+    <string name="site_settings_categories_no_network_subtitle" translatable="false">@string/no_network_message</string>
+    <string name="site_settings_categories_request_failed_title" translatable="false">@string/scan_request_failed_title</string>
+    <string name="site_settings_categories_request_failed_subtitle" translatable="false">@string/request_failed_message</string>
 
     <!-- Media -->
     <string name="site_settings_quota_header">Media</string>
@@ -2202,6 +2203,13 @@
     <string name="my_site_bottom_sheet_add_story">Story post</string>
     <string name="my_site_quick_actions_title">Quick Links</string>
 
+    <!-- My Site - Post Card -->
+    <string name="my_site_post_card_draft_title">Work on a draft post</string>
+    <string name="my_site_post_card_scheduled_title">Upcoming scheduled posts</string>
+    <string name="my_site_untitled_post">Untitled</string>
+    <string name="my_site_create_first_post_title">Create your first post</string>
+    <string name="my_site_create_first_post_excerpt">Posts appear on your blog page in reverse chronological order. It\'s time to share your ideas with the world!</string>
+
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>
     <string name="site_picker_edit_visibility">Show/hide sites</string>
@@ -2485,6 +2493,8 @@
     <string name="domains_manage_domains">Manage Domains</string>
     <string name="domains_paid_plan_claim_your_domain_title">Claim your free domain</string>
     <string name="domains_paid_plan_claim_your_domain_caption">You have a free one-year domain registration included with your plan</string>
+    <string name="domains_paid_plan_add_your_domain_title">Add your domain</string>
+    <string name="domains_paid_plan_add_your_domain_caption">Adding a custom domain makes it easy for visitors to find your site</string>
     <string name="domains_free_plan_get_your_domain_title">Get your domain</string>
     <string name="domains_free_plan_get_your_domain_caption">Domains purchased on this site will redirect visitors to &lt;b&gt;%s&lt;/b&gt;</string>
     <string name="domains_search_for_a_domain_button">Search for a domain</string>
@@ -3395,6 +3405,7 @@
     <string name="gutenberg_native_current_unit_is_s" tools:ignore="UnusedResources">Current unit is %s</string>
     <!-- translators: %s: current cell value. -->
     <string name="gutenberg_native_current_value_is_s" tools:ignore="UnusedResources">Current value is %s</string>
+    <string name="gutenberg_native_custom_url" tools:ignore="UnusedResources">Custom URL</string>
     <string name="gutenberg_native_customize" tools:ignore="UnusedResources">CUSTOMIZE</string>
     <string name="gutenberg_native_customize_blocks" tools:ignore="UnusedResources">Customize blocks</string>
     <string name="gutenberg_native_customize_gradient" tools:ignore="UnusedResources">Customize Gradient</string>
@@ -3481,7 +3492,6 @@
     <string name="gutenberg_native_how_to_edit_your_post" tools:ignore="UnusedResources">How to edit your post</string>
     <!-- translators: accessibility text. %s: image caption. -->
     <string name="gutenberg_native_image_caption_s" tools:ignore="UnusedResources">Image caption. %s</string>
-    <string name="gutenberg_native_image_link_url" tools:ignore="UnusedResources">Image Link URL</string>
     <string name="gutenberg_native_image_settings" tools:ignore="UnusedResources">Image settings</string>
     <string name="gutenberg_native_insert_crosspost" tools:ignore="UnusedResources">Insert crosspost</string>
     <string name="gutenberg_native_insert_mention" tools:ignore="UnusedResources">Insert mention</string>
@@ -3556,6 +3566,7 @@
     <string name="gutenberg_native_problem_opening_the_audio" tools:ignore="UnusedResources">Problem opening the audio</string>
     <string name="gutenberg_native_problem_opening_the_video" tools:ignore="UnusedResources">Problem opening the video</string>
     <string name="gutenberg_native_remove_as_featured_image" tools:ignore="UnusedResources">Remove as Featured Image </string>
+    <string name="gutenberg_native_remove_block" tools:ignore="UnusedResources">Remove block</string>
     <string name="gutenberg_native_replace_audio" tools:ignore="UnusedResources">Replace audio</string>
     <string name="gutenberg_native_replace_current_block" tools:ignore="UnusedResources">Replace Current Block</string>
     <string name="gutenberg_native_replace_file" tools:ignore="UnusedResources">Replace file</string>

--- a/tools/rename_apk_aab.sh
+++ b/tools/rename_apk_aab.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# This script aims to rename any `.apk` or `.aab` file to `[wpandroid|jpandroid]-{version}[-Signed].apk/aab`
+# depending on the APK/AAB package name, version name and package signature.
+#
+# The main use of this tool os to easily rename the signed `.apk` and/or original `.aab` downloaded from the PlayStore
+# (and re-signed by Google depending on the context), as when you download those their basename is usually just the
+# versionCode and whose name doesn't distinguish from a binary corresponding to WordPress vs Jetpack.
+#
+# By running this script on the APK or AAB files provided – defaulting to all the APK and AAB files in `~/Downloads` if
+# no parameter provided – the files will be renamed with a basename appropriate to the ones we use when attaching
+# those files to the GitHub release.
+
+### Input Parameters ###
+
+# Usage:
+#   rename_apk_aab.sh [file1.apk] [file2.aab] [...]
+#
+# Without any parameter, applies the rename to every APK/AAB file found in ~/Downloads
+#
+INPUT_FILES=( "$@" )
+if [[ $# -lt 1 ]]; then
+  IFS=$'\n'
+  INPUT_FILES=( $(find ~/Downloads -name *.apk -o -name *.aab) )
+  unset IFS
+fi
+
+
+##################################
+### Path to Android tools used ###
+##################################
+AAPT2=$(ls -1t $ANDROID_SDK_ROOT/build-tools/*/aapt2 | head -n1)
+APKSIGNER=$(ls -1t $ANDROID_SDK_ROOT/build-tools/*/apksigner | head -n1)
+BUNDLETOOL="/usr/local/bin/bundletool"
+
+######################
+### Helper Methods ###
+######################
+
+### Extract info from a single APK file
+# Sets PKG, VNAME, VCODE and SIGNED_SUFFIX
+info_for_apk() {
+  # Use aapt2 to extract package name, versionCode and versionName
+  INFO_LINE=$($AAPT2 dump badging "$1" | head -n 1)
+  [[ "$INFO_LINE" =~ name=\'([^\']*)\'[[:blank:]]versionCode=\'([^\']*)\'[[:blank:]]versionName=\'([^\']*)\' ]] && PKG=${BASH_REMATCH[1]} && VCODE=${BASH_REMATCH[2]} && VNAME=${BASH_REMATCH[3]}
+  SIGNED_SUFFIX=$($APKSIGNER verify --print-certs "$1" | grep -qE "(CN=Android, OU=Android, O=Google Inc.)|(O=Automattic Inc.)" && echo "-Signed")
+}
+
+### Extract info from a single AAB file
+# Sets PKG, VNAME, VCODE
+info_for_aab() {
+  PKG=$(bundletool dump manifest --bundle "$1" --xpath /manifest/@package)
+  VCODE=$(bundletool dump manifest --bundle "$1" --xpath /manifest/@android:versionCode)
+  VNAME=$(bundletool dump manifest --bundle "$1" --xpath /manifest/@android:versionName)
+}
+
+### Extract info from a single APK or AAB file
+info_for_file() {
+  echo "== $1 =="
+  unset PKG
+  unset VNAME
+  unset VCODE
+  unset SIGNED_SUFFIX
+  
+  ext="${1##*.}"
+  case $ext in
+    apk)
+      info_for_apk "$1"
+      ;;
+    aab)
+      info_for_aab "$1"
+      ;;
+    *)
+      echo "Error: Unsupported extension ${ext} for ${1}"
+      ;;
+  esac
+}
+
+### Rename a APK or AAB file based on its package name, versionName, signature and extension
+auto_rename_file() {
+  ext="${1##*.}"
+  info_for_file "$1"
+  
+  case $PKG in
+    org.wordpress.android)
+      BASENAME=wpandroid-$VNAME
+      ;;
+    com.jetpack.android)
+      BASENAME=jpandroid-$VNAME
+      ;;
+    *)
+      echo "Unrecognized package name: ${PKG}"
+      ;;
+  esac
+
+  if [[ "$ext" == "apk" ]]; then
+    NEW_NAME="${BASENAME}${SIGNED_SUFFIX}.apk"
+  else
+    NEW_NAME="$BASENAME.aab"
+  fi
+
+  echo "$(basename "$1") ==> $NEW_NAME"
+  mv "$1" "$(dirname "$1")/$NEW_NAME"
+}
+
+
+#### MAIN ####
+
+for f in "${INPUT_FILES[@]}"; do
+  auto_rename_file "$f"
+done

--- a/tools/rename_apk_aab.sh
+++ b/tools/rename_apk_aab.sh
@@ -3,13 +3,15 @@
 # This script aims to rename any `.apk` or `.aab` file to `[wpandroid|jpandroid]-{version}[-Signed].apk/aab`
 # depending on the APK/AAB package name, version name and package signature.
 #
-# The main use of this tool os to easily rename the signed `.apk` and/or original `.aab` downloaded from the PlayStore
-# (and re-signed by Google depending on the context), as when you download those their basename is usually just the
-# versionCode and whose name doesn't distinguish from a binary corresponding to WordPress vs Jetpack.
+# The main use of this tool is to easily rename the signed `.apk` and/or original `.aab` downloaded from the PlayStore
+# (and re-signed by Google depending on the context), as when you download those, their basename is usually just the
+# versionCode and doesn't distinguish from a binary corresponding to WordPress vs Jetpack.
 #
 # By running this script on the APK or AAB files provided – defaulting to all the APK and AAB files in `~/Downloads` if
 # no parameter provided – the files will be renamed with a basename appropriate to the ones we use when attaching
 # those files to the GitHub release.
+
+
 
 ### Input Parameters ###
 

--- a/version.properties
+++ b/version.properties
@@ -1,9 +1,9 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=18.6
-versionCode=1133
+versionName=18.7-rc-1
+versionCode=1134
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
-alpha.versionName=alpha-328
-alpha.versionCode=1132
+alpha.versionName=alpha-329
+alpha.versionCode=1135


### PR DESCRIPTION
Resyncing `develop` after code freeze for `18.7`

Also contains a script in `tools/` to rename the `.apk` downloaded from PlayStore to the appropriate name before I can attach them to the GitHub Release (see comment below). I've already used that script on the 3 APKs of the last 2 builds (final and beta builds) and it helped a lot so I figured I might as well commit them in `tools/` rather than keeping it for myself in my local Mac.