### PR TITLE
My Site Dashboard: Selected Site Source refresh prep

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
@@ -45,7 +45,7 @@ class SelectedSiteSource @Inject constructor(
         dispatcher.unregister(this)
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onSiteChanged(event: OnSiteChanged?) {
         // Handled in WPMainActivity, this observe is only to manage the refresh flag

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
@@ -1,6 +1,12 @@
 package org.wordpress.android.ui.mysite
 
+import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.SelectedSite
 import org.wordpress.android.util.filter
 import org.wordpress.android.util.map
@@ -9,12 +15,40 @@ import javax.inject.Singleton
 
 @Singleton
 class SelectedSiteSource @Inject constructor(
-    private val selectedSiteRepository: SelectedSiteRepository
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val dispatcher: Dispatcher
 ) : MySiteSource<SelectedSite> {
+    val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+
     override fun buildSource(
         coroutineScope: CoroutineScope,
         siteLocalId: Int
     ) = selectedSiteRepository.selectedSiteChange
             .filter { it == null || it.id == siteLocalId }
             .map { SelectedSite(it) }
+
+    fun refresh() {
+        selectedSiteRepository.updateSiteSettingsIfNecessary()
+        selectedSiteRepository.getSelectedSite()?.let {
+            refresh.postValue(true)
+            dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(it))
+        }
+    }
+
+    fun isRefreshing() = refresh.value as Boolean
+
+    init {
+        dispatcher.register(this)
+    }
+
+    fun clear() {
+        dispatcher.unregister(this)
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onSiteChanged(event: OnSiteChanged?) {
+        // Handled in WPMainActivity, this observe is only to manage the refresh flag
+        refresh.value = false
+    }
 }


### PR DESCRIPTION
Parent #15215

This PR add a refresh support to the `SelectedSiteSource` flow. 
This PR is part of a series of PRs being written for adding pull-to-refresh to the MySite tab.

**To test:**
There are no visual changes for this PR, so the testing should focus on ensuring that site selection works as expected.

Prerequisite:
- Go to Me -> App Settings -> Test feature configuration
- Disable MySiteDashboardPhase2FeatureConfig 
- Restart the app

Test
- Launch the app
- Navigate to the My Site tab
- Note that items are as expected
- Tap the site selector and change the site
- Note that listed items change to reflect the site chosen 

## Regression Notes
1. Potential unintended areas of impact
The site items are not shown as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + automated tests

3. What automated tests I added (or what prevented me from doing so)
Tests were added to `SelectedSiteSourceTest`

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

