### PR TITLE
PostEditorAnalyticsSession - Utilized savedInstanceState instead of extras for the bundle

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -603,7 +603,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     savedInstanceState.getInt(STATE_KEY_POST_LOADING_STATE, 0)));
             mRevision = savedInstanceState.getParcelable(STATE_KEY_REVISION);
             mPostEditorAnalyticsSession = PostEditorAnalyticsSession
-                    .fromBundle(extras, STATE_KEY_EDITOR_SESSION_DATA, mAnalyticsTrackerWrapper);
+                    .fromBundle(savedInstanceState, STATE_KEY_EDITOR_SESSION_DATA, mAnalyticsTrackerWrapper);
 
             // if we have a remote id saved, let's first try that, as the local Id might have changed after FETCH_POSTS
             if (savedInstanceState.containsKey(STATE_KEY_POST_REMOTE_ID)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -63,10 +63,10 @@ public class PostEditorAnalyticsSession implements Serializable {
         PUBLISH
     }
 
-    public static PostEditorAnalyticsSession fromBundle(Bundle extras, String key,
+    public static PostEditorAnalyticsSession fromBundle(Bundle bundle, String key,
                                                         AnalyticsTrackerWrapper analyticsTrackerWrapper) {
         PostEditorAnalyticsSession postEditorAnalyticsSession =
-                (PostEditorAnalyticsSession) extras.getSerializable(key);
+                (PostEditorAnalyticsSession) bundle.getSerializable(key);
         postEditorAnalyticsSession.mAnalyticsTrackerWrapper = analyticsTrackerWrapper;
         return postEditorAnalyticsSession;
     }


### PR DESCRIPTION
Fixes #15578 

Resolves an issue with the `PostEditorAnalyticsSession`  `fromBundle` functionality that is related to https://github.com/wordpress-mobile/WordPress-Android/pull/15465. The `extras` Bundle was utilized instead of `savedInstanceState` therefore this PR performs the change to `savedInstanceState`. 

To test:
1. Create a new post. 
2. Rotate the device multiple times. 
3. Notice no crash occurs. 

https://user-images.githubusercontent.com/1509205/142104958-bea3944d-e303-4376-8c3f-a7755cf3f35d.mov

## Regression Notes

1. Potential unintended areas of impact
None, because now the `fromBundle` functionality for the `PostEditorAnalyticsSession` when the `savedInstanceState` isn't null works as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I checked out the tag for `18.6` and noted that the error was not present there. Then I checked out `18.7`, reproduced the error and then applied this fix and noticed that the crash no longer took place.

3. What automated tests I added (or what prevented me from doing so)
None, since this fix does not warrant such tests. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
