### PR TITLE
Editing: Replace snackbar with compact notice when switching editor mode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 18.8
 -----
+* [*] Editor: Replace snackbar with compact notice when switching between HTML or Visual mode [https://github.com/wordpress-mobile/WordPress-Android/pull/15583]
 
 
 18.7

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1506,14 +1506,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
         return false;
     }
 
-    private void toggledHtmlModeSnackbar(View.OnClickListener onUndoClickListener) {
-        mUploadUtilsWrapper.showSnackbarSuccessActionOrange(findViewById(R.id.editor_activity),
-                mHtmlModeMenuStateOn ? R.string.menu_html_mode_done_snackbar
-                        : R.string.menu_visual_mode_done_snackbar,
-                R.string.menu_undo_snackbar_action,
-                onUndoClickListener);
-    }
-
     private void refreshEditorContent() {
         mHasSetPostContent = false;
         fillContentEditorFields();
@@ -1583,21 +1575,15 @@ public class EditPostActivity extends LocaleAwareActivity implements
         mHtmlModeMenuStateOn = !mHtmlModeMenuStateOn;
         trackPostSessionEditorModeSwitch();
         invalidateOptionsMenu();
-        showToggleHtmlModeSnackbar();
+        showEditorModeSwitchedNotice();
     }
 
-    private void showToggleHtmlModeSnackbar() {
-        if (mEditorFragment instanceof AztecEditorFragment) {
-            toggledHtmlModeSnackbar(view -> {
-                // switch back
-                ((AztecEditorFragment) mEditorFragment).onToolbarHtmlButtonClicked();
-            });
-        } else if (mEditorFragment instanceof GutenbergEditorFragment) {
-            toggledHtmlModeSnackbar(view -> {
-                // switch back
-                ((GutenbergEditorFragment) mEditorFragment).onToggleHtmlMode();
-            });
-        }
+    private void showEditorModeSwitchedNotice() {
+        String message = getString(mHtmlModeMenuStateOn
+                ? R.string.menu_html_mode_done_snackbar
+                : R.string.menu_visual_mode_done_snackbar
+        );
+        mEditorFragment.showNotice(message);
     }
 
     private void trackPostSessionEditorModeSwitch() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1580,8 +1580,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     private void showEditorModeSwitchedNotice() {
         String message = getString(mHtmlModeMenuStateOn
-                ? R.string.menu_html_mode_done_snackbar
-                : R.string.menu_visual_mode_done_snackbar
+                ? R.string.menu_html_mode_switched_notice
+                : R.string.menu_visual_mode_switched_notice
         );
         mEditorFragment.showNotice(message);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -402,22 +402,6 @@ public class UploadUtils {
         );
     }
 
-    public static void showSnackbarSuccessActionOrange(View view, int messageRes, int buttonTitleRes,
-                                                       View.OnClickListener onClickListener,
-                                                       SnackbarSequencer snackbarSequencer) {
-        snackbarSequencer.enqueue(new SnackbarItem(
-                new Info(
-                        view,
-                        new UiStringRes(messageRes),
-                        Snackbar.LENGTH_LONG,
-                        true
-                ),
-                new Action(new UiStringRes(buttonTitleRes), onClickListener),
-                null,
-                null
-        ));
-    }
-
     public static void showSnackbar(View view, int messageRes, SnackbarSequencer sequencer) {
         sequencer.enqueue(
                 new SnackbarItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
@@ -118,13 +118,6 @@ class UploadUtilsWrapper @Inject constructor(
         messageText: String
     ) = UploadUtils.showSnackbar(view, messageText, sequencer)
 
-    fun showSnackbarSuccessActionOrange(
-        view: View?,
-        messageRes: Int,
-        buttonTitleRes: Int,
-        onClickListener: OnClickListener?
-    ) = UploadUtils.showSnackbarSuccessActionOrange(view, messageRes, buttonTitleRes, onClickListener, sequencer)
-
     fun getErrorMessageResIdFromPostError(
         postStatus: PostStatus,
         isPage: Boolean,

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1680,9 +1680,9 @@
     <string name="menu_preview">Preview</string>
     <string name="menu_history">History</string>
     <string name="menu_html_mode">HTML Mode</string>
-    <string name="menu_html_mode_done_snackbar">Switched to HTML mode</string>
+    <string name="menu_html_mode_switched_notice">Switched to HTML mode</string>
     <string name="menu_visual_mode">Visual Mode</string>
-    <string name="menu_visual_mode_done_snackbar">Switched to Visual mode</string>
+    <string name="menu_visual_mode_switched_notice">Switched to Visual mode</string>
 
     <string name="menu_undo">Undo</string>
     <string name="menu_redo">Redo</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1683,7 +1683,6 @@
     <string name="menu_html_mode_done_snackbar">Switched to HTML mode</string>
     <string name="menu_visual_mode">Visual Mode</string>
     <string name="menu_visual_mode_done_snackbar">Switched to Visual mode</string>
-    <string name="menu_undo_snackbar_action">UNDO</string>
 
     <string name="menu_undo">Undo</string>
     <string name="menu_redo">Redo</string>


### PR DESCRIPTION
Fixes #11819

It was brought to our attention that some users find the snackbar appearing at the bottom of the screen when the editor mode is switched to HTML annoying because they cannot edit the last lines before it disappears.

This PR replaces the snackbar at the bottom with a compact notice shown at the top of the screen, below the main top bar of the app (see screenshots).
This solution was suggested after a [discussion in the issue](https://github.com/wordpress-mobile/WordPress-Android/issues/11819#issuecomment-969670515) where we also explored the option of not showing any notice.

The snackbar is now replaced with the notice in both cases:
- When we switch the editor to HTML mode
- When we switch the editor to Visual Mode

## To test
1. From My Site press the Posts button or scroll down and select Blog Posts from the list
2. In post cards mode press the More button / In post list mode press the dots at the right of the post
3. Press Edit (first button)
4. In the editor, Tap the 3 dots in the upper right corner
5. Tap HTML Mode (3rd button)
6. **Verify** that a compact notice appears at the top of the editor, and no snackbar is shown
7. Tap again the 3 dots in the upper right corner
8. Tap Visual Mode  (3rd button)
6. **Verify** that a compact notice appears at the top of the editor, and no snackbar is shown

## Screenshots

<details>
 <summary>Switching to HTML mode</summary>

| Before | After |
| ----- | ----- |
| ![android_switch_to_html_before](https://user-images.githubusercontent.com/4588074/141684301-a6df03c3-ad4a-47db-a495-8cad238250b3.png) | ![5_android_switch_to_html_after](https://user-images.githubusercontent.com/4588074/142202337-3703a411-f034-4ea6-888d-84616f3ea450.png) |
</details>

<details>
 <summary>Switching to Visual mode</summary>

| Before | After |
| ----- | ----- |
| ![android_switch_to_visual_before](https://user-images.githubusercontent.com/4588074/141684310-1e2c8ada-34ba-445e-a3d9-f6a2462124af.png) | ![6_android_switch_to_visual_after](https://user-images.githubusercontent.com/4588074/142202517-ebca3a2d-36c4-4b8e-9186-a1025e2f9e8d.png) |
</details>

<details>
 <summary>GIF Preview</summary>

| Notice when switching editor mode |
|---|
| <img alt="gif_preview_notice" src="https://user-images.githubusercontent.com/4588074/142202679-988f1513-5844-4def-a5f9-6762ab87d2c5.gif" width="250" /> |

</details>


## Regression Notes
1. Potential unintended areas of impact
    None, because the snackbar that is replaced was only shown when switching editor mode, and now we show a notice instead.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manual testing.

3. What automated tests I added (or what prevented me from doing so)
    None, since this change does not warrant such tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
