### PR TITLE
Remove the mention of MSWord fix from WPAndroid release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,6 @@
 -----
 * [*] Block editor: Fixed a race condition when autosaving content [https://github.com/WordPress/gutenberg/pull/36072]
 * [**] Block editor: Image block: Add ability to quickly link images to Media Files and Attachment Pages [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3971]
-* [**] Block editor: Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174]
 
 18.6
 -----

--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -15,7 +15,6 @@ msgctxt "release_note_187"
 msgid ""
 "18.7:\n"
 "- We added Media File and Attachment Page options to the image block's Link To menu so you can set commonly used URLs.\n"
-"- We fixed an issue that made the interface crash when users copied and pasted lists from Microsoft Word.\n"
 "- We solved a problem with content autosaves so they now run more smoothly.\n"
 msgstr ""
 

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,3 +1,2 @@
 - We added Media File and Attachment Page options to the image block's Link To menu so you can set commonly used URLs.
-- We fixed an issue that made the interface crash when users copied and pasted lists from Microsoft Word.
 - We solved a problem with content autosaves so they now run more smoothly.

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -15,7 +15,6 @@ msgctxt "release_note_187"
 msgid ""
 "18.7:\n"
 "- We added Media File and Attachment Page options to the image block's Link To menu so you can set commonly used URLs.\n"
-"- We fixed an issue that made the interface crash when users copied and pasted lists from Microsoft Word.\n"
 "- We solved a problem with content autosaves so they now run more smoothly.\n"
 msgstr ""
 

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,3 +1,2 @@
 - We added Media File and Attachment Page options to the image block's Link To menu so you can set commonly used URLs.
-- We fixed an issue that made the interface crash when users copied and pasted lists from Microsoft Word.
 - We solved a problem with content autosaves so they now run more smoothly.


### PR DESCRIPTION
According to @twstokes comment [ref: p5T066-2MQ-p2#comment-10601], the fix in Gutenberg about MSWord pasting was only affecting WPiOS and not WPAndroid, so this item in the Release Notes for 18.7 should not be present after all.