### PR TITLE
My Site Dashboard: MySIteSource refactoring for PTR 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
@@ -14,18 +14,13 @@ import javax.inject.Singleton
 class CurrentAvatarSource @Inject constructor(
     private val accountStore: AccountStore
 ) : SiteIndependentSource<CurrentAvatarUrl> {
-    private val avatarUrl = MutableLiveData<CurrentAvatarUrl>()
-    val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
     override fun build(coroutineScope: CoroutineScope): LiveData<CurrentAvatarUrl> {
         val result = MediatorLiveData<CurrentAvatarUrl>()
         result.refreshData()
         result.addSource(refresh) { result.refreshData(refresh.value) }
         return result
-    }
-
-    fun refresh() {
-        refresh.postValue(true)
     }
 
     private fun MediatorLiveData<CurrentAvatarUrl>.refreshData(
@@ -38,10 +33,5 @@ class CurrentAvatarSource @Inject constructor(
             }
             false -> Unit // Do nothing
         }
-    }
-
-    private fun MediatorLiveData<CurrentAvatarUrl>.postState(value: CurrentAvatarUrl) {
-        refresh.postValue(false)
-        this@postState.postValue(value)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
@@ -17,7 +17,7 @@ class CurrentAvatarSource @Inject constructor(
     private val avatarUrl = MutableLiveData<CurrentAvatarUrl>()
     val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
-    override fun buildSource(coroutineScope: CoroutineScope): LiveData<CurrentAvatarUrl> {
+    override fun build(coroutineScope: CoroutineScope): LiveData<CurrentAvatarUrl> {
         val result = MediatorLiveData<CurrentAvatarUrl>()
         result.refreshData()
         result.addSource(refresh) { result.refreshData(refresh.value) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
@@ -5,12 +5,12 @@ import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState
 
 interface MySiteSource<T : PartialState> {
-    fun buildSource(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<T>
+    fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<T>
     interface SiteIndependentSource<T : PartialState> : MySiteSource<T> {
-        fun buildSource(coroutineScope: CoroutineScope): LiveData<T>
-        override fun buildSource(
+        fun build(coroutineScope: CoroutineScope): LiveData<T>
+        override fun build(
             coroutineScope: CoroutineScope,
             siteLocalId: Int
-        ): LiveData<T> = buildSource(coroutineScope)
+        ): LiveData<T> = build(coroutineScope)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
@@ -27,6 +27,10 @@ interface MySiteSource<T : PartialState> {
             refresh.postValue(false)
             this@postState.postValue(value)
         }
+
+        fun onRefreshed() {
+            refresh.value = false
+        }
     }
 
     interface SiteIndependentSource<T : PartialState> : MySiteRefreshSource<T> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
@@ -1,12 +1,35 @@
 package org.wordpress.android.ui.mysite
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState
 
 interface MySiteSource<T : PartialState> {
     fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<T>
-    interface SiteIndependentSource<T : PartialState> : MySiteSource<T> {
+
+    interface MySiteRefreshSource<T : PartialState> : MySiteSource<T> {
+        val refresh: MutableLiveData<Boolean>
+
+        fun refresh() {
+            refresh.postValue(true)
+        }
+
+        fun isRefreshing() = refresh.value
+
+        fun getState(value: T): T {
+            refresh.value = false
+            return value
+        }
+
+        fun MediatorLiveData<T>.postState(value: T) {
+            refresh.postValue(false)
+            this@postState.postValue(value)
+        }
+    }
+
+    interface SiteIndependentSource<T : PartialState> : MySiteRefreshSource<T> {
         fun build(coroutineScope: CoroutineScope): LiveData<T>
         override fun build(
             coroutineScope: CoroutineScope,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -162,10 +162,10 @@ class MySiteViewModel @Inject constructor(
     val state: LiveData<MySiteUiState> = selectedSiteRepository.siteSelected.switchMap { siteLocalId ->
         val result = MediatorLiveData<SiteIdToState>()
         val currentSources = if (siteLocalId != null) {
-            mySiteSources.map { source -> source.buildSource(viewModelScope, siteLocalId).distinctUntilChanged() }
+            mySiteSources.map { source -> source.build(viewModelScope, siteLocalId).distinctUntilChanged() }
         } else {
             mySiteSources.filterIsInstance(SiteIndependentSource::class.java)
-                    .map { source -> source.buildSource(viewModelScope).distinctUntilChanged() }
+                    .map { source -> source.build(viewModelScope).distinctUntilChanged() }
         }
         for (newSource in currentSources) {
             result.addSource(newSource) { partialState ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -21,7 +21,7 @@ class ScanAndBackupSource @Inject constructor(
 ) : MySiteSource<JetpackCapabilities> {
     val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
-    override fun buildSource(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<JetpackCapabilities> {
+    override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<JetpackCapabilities> {
         val result = MediatorLiveData<JetpackCapabilities>()
         result.refreshData(coroutineScope, siteLocalId)
         result.addSource(refresh) { result.refreshData(coroutineScope, siteLocalId, refresh.value) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
+import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.JetpackCapabilities
 import org.wordpress.android.util.SiteUtils
 import javax.inject.Inject
@@ -18,18 +19,14 @@ class ScanAndBackupSource @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val selectedSiteRepository: SelectedSiteRepository,
     private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase
-) : MySiteSource<JetpackCapabilities> {
-    val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+) : MySiteRefreshSource<JetpackCapabilities> {
+    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<JetpackCapabilities> {
         val result = MediatorLiveData<JetpackCapabilities>()
         result.refreshData(coroutineScope, siteLocalId)
         result.addSource(refresh) { result.refreshData(coroutineScope, siteLocalId, refresh.value) }
         return result
-    }
-
-    fun refresh() {
-        refresh.postValue(true)
     }
 
     private fun MediatorLiveData<JetpackCapabilities>.refreshData(
@@ -62,13 +59,6 @@ class ScanAndBackupSource @Inject constructor(
         } else {
             postState(JetpackCapabilities(scanAvailable = false, backupAvailable = false))
         }
-    }
-
-    private fun MediatorLiveData<JetpackCapabilities>.postState(
-        jetpackCapabilities: JetpackCapabilities
-    ) {
-        refresh.postValue(false)
-        this@postState.postValue(jetpackCapabilities)
     }
 
     fun clear() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
@@ -31,7 +31,7 @@ class SelectedSiteSource @Inject constructor(
     override fun refresh() {
         selectedSiteRepository.updateSiteSettingsIfNecessary()
         selectedSiteRepository.getSelectedSite()?.let {
-            refresh.postValue(true)
+            super.refresh()
             dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(it))
         }
     }
@@ -48,6 +48,6 @@ class SelectedSiteSource @Inject constructor(
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onSiteChanged(event: OnSiteChanged?) {
         // Handled in WPMainActivity, this observe is only to manage the refresh flag
-        refresh.value = false
+        onRefreshed()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
@@ -7,6 +7,7 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.SelectedSite
 import org.wordpress.android.util.filter
 import org.wordpress.android.util.map
@@ -17,8 +18,8 @@ import javax.inject.Singleton
 class SelectedSiteSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val dispatcher: Dispatcher
-) : MySiteSource<SelectedSite> {
-    val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+) : MySiteRefreshSource<SelectedSite> {
+    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
     override fun build(
         coroutineScope: CoroutineScope,
@@ -27,15 +28,13 @@ class SelectedSiteSource @Inject constructor(
             .filter { it == null || it.id == siteLocalId }
             .map { SelectedSite(it) }
 
-    fun refresh() {
+    override fun refresh() {
         selectedSiteRepository.updateSiteSettingsIfNecessary()
         selectedSiteRepository.getSelectedSite()?.let {
             refresh.postValue(true)
             dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(it))
         }
     }
-
-    fun isRefreshing() = refresh.value as Boolean
 
     init {
         dispatcher.register(this)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
@@ -20,7 +20,7 @@ class SelectedSiteSource @Inject constructor(
 ) : MySiteSource<SelectedSite> {
     val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
-    override fun buildSource(
+    override fun build(
         coroutineScope: CoroutineScope,
         siteLocalId: Int
     ) = selectedSiteRepository.selectedSiteChange

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteIconProgressSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteIconProgressSource.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 class SiteIconProgressSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository
 ) : MySiteSource<ShowSiteIconProgressBar> {
-    override fun buildSource(
+    override fun build(
         coroutineScope: CoroutineScope,
         siteLocalId: Int
     ) = selectedSiteRepository.showSiteIconProgressBar

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
@@ -37,7 +37,7 @@ class DomainRegistrationSource @Inject constructor(
     private var continuation: CancellableContinuation<OnPlansFetched>? = null
     val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
-    override fun buildSource(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DomainCreditAvailable> {
+    override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DomainCreditAvailable> {
         val data = MediatorLiveData<DomainCreditAvailable>()
         data.refreshData(coroutineScope, siteLocalId)
         data.addSource(refresh) { data.refreshData(coroutineScope, siteLocalId, refresh.value) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore.OnPlansFetched
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.ui.mysite.MySiteSource
+import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DomainCreditAvailable
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.plans.isDomainCreditAvailable
@@ -33,19 +33,15 @@ class DomainRegistrationSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val appLogWrapper: AppLogWrapper,
     private val siteUtils: SiteUtilsWrapper
-) : MySiteSource<DomainCreditAvailable> {
+) : MySiteRefreshSource<DomainCreditAvailable> {
     private var continuation: CancellableContinuation<OnPlansFetched>? = null
-    val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DomainCreditAvailable> {
         val data = MediatorLiveData<DomainCreditAvailable>()
         data.refreshData(coroutineScope, siteLocalId)
         data.addSource(refresh) { data.refreshData(coroutineScope, siteLocalId, refresh.value) }
         return data
-    }
-
-    fun refresh() {
-        refresh.postValue(true)
     }
 
     private fun MediatorLiveData<DomainCreditAvailable>.refreshData(
@@ -98,11 +94,6 @@ class DomainRegistrationSource @Inject constructor(
                 postState(DomainCreditAvailable(false))
             }
         }
-    }
-
-    private fun MediatorLiveData<DomainCreditAvailable>.postState(value: DomainCreditAvailable) {
-        refresh.postValue(false)
-        this@postState.postValue(value)
     }
 
     init {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSource.kt
@@ -6,28 +6,23 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
-import org.wordpress.android.ui.mysite.MySiteSource
+import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.PostsUpdate
 import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedDataJsonUtils
-import org.wordpress.android.ui.mysite.cards.post.mockdata.MockedPostsData
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class PostCardsSource @Inject constructor(
     private val mockedDataJsonUtils: MockedDataJsonUtils
-) : MySiteSource<PostsUpdate> {
-    val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+) : MySiteRefreshSource<PostsUpdate> {
+    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<PostsUpdate> {
         val result = MediatorLiveData<PostsUpdate>()
         result.refreshData(coroutineScope)
         result.addSource(refresh) { result.refreshData(coroutineScope, refresh.value) }
         return result
-    }
-
-    fun refresh() {
-        refresh.postValue(true)
     }
 
     private fun MediatorLiveData<PostsUpdate>.refreshData(
@@ -55,12 +50,7 @@ class PostCardsSource @Inject constructor(
     ) {
         coroutineScope.launch {
             val mockedPostsData = mockedDataJsonUtils.getMockedPostsDataFromJsonString(jsonString!!)
-            postState(mockedPostsData)
+            postState(PostsUpdate(mockedPostsData))
         }
-    }
-
-    private fun MediatorLiveData<PostsUpdate>.postState(mockedPostsData: MockedPostsData) {
-        refresh.postValue(false)
-        this@postState.postValue(PostsUpdate(mockedPostsData = mockedPostsData))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSource.kt
@@ -19,7 +19,7 @@ class PostCardsSource @Inject constructor(
 ) : MySiteSource<PostsUpdate> {
     val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
-    override fun buildSource(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<PostsUpdate> {
+    override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<PostsUpdate> {
         val result = MediatorLiveData<PostsUpdate>()
         result.refreshData(coroutineScope)
         result.addSource(refresh) { result.refreshData(coroutineScope, refresh.value) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
@@ -25,7 +25,7 @@ class QuickStartCardSource @Inject constructor(
 ) : MySiteSource<QuickStartUpdate> {
     val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
-    override fun buildSource(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<QuickStartUpdate> {
+    override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<QuickStartUpdate> {
         quickStartRepository.resetTask()
         if (selectedSiteRepository.getSelectedSite()?.showOnFront == ShowOnFront.POSTS.value &&
                 !quickStartStore.hasDoneTask(siteLocalId.toLong(), EDIT_HOMEPAGE)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.fluxc.model.SiteHomepageSettings.ShowOnFront
 import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
-import org.wordpress.android.ui.mysite.MySiteSource
+import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.QuickStartUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.QuickStartUtilsWrapper
@@ -22,8 +22,8 @@ class QuickStartCardSource @Inject constructor(
     private val quickStartStore: QuickStartStore,
     private val quickStartUtilsWrapper: QuickStartUtilsWrapper,
     private val selectedSiteRepository: SelectedSiteRepository
-) : MySiteSource<QuickStartUpdate> {
-    val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+) : MySiteRefreshSource<QuickStartUpdate> {
+    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<QuickStartUpdate> {
         quickStartRepository.resetTask()
@@ -45,12 +45,7 @@ class QuickStartCardSource @Inject constructor(
             } else {
                 listOf()
             }
-            if (refresh.value == true) refresh.value = false
-            QuickStartUpdate(activeTask, categories)
+            getState(QuickStartUpdate(activeTask, categories))
         }
-    }
-
-    fun refresh() {
-        refresh.postValue(true)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
@@ -44,13 +44,6 @@ class DynamicCardsSource
     private fun MediatorLiveData<DynamicCardsUpdate>.refreshData(coroutineScope: CoroutineScope, siteId: Int) {
         coroutineScope.launch {
             val cards = dynamicCardStore.getCards(siteId)
-//            refresh.postValue(false)
-//            this@refreshData.postValue(
-//                    DynamicCardsUpdate(
-//                            pinnedDynamicCard = cards.pinnedItem,
-//                            cards = cards.dynamicCardTypes
-//                    )
-//            )
             postState(DynamicCardsUpdate(pinnedDynamicCard = cards.pinnedItem, cards = cards.dynamicCardTypes))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
@@ -21,7 +21,7 @@ class DynamicCardsSource
 ) : MySiteSource<DynamicCardsUpdate> {
     private val refresh = MutableLiveData<Boolean>()
 
-    override fun buildSource(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DynamicCardsUpdate> {
+    override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DynamicCardsUpdate> {
         val data = MediatorLiveData<DynamicCardsUpdate>()
         data.refreshData(coroutineScope, siteLocalId)
         data.addSource(refresh) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.DynamicCardType
 import org.wordpress.android.fluxc.store.DynamicCardStore
-import org.wordpress.android.ui.mysite.MySiteSource
+import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DynamicCardsUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import javax.inject.Inject
@@ -18,27 +18,40 @@ class DynamicCardsSource
 @Inject constructor(
     private val dynamicCardStore: DynamicCardStore,
     private val selectedSiteRepository: SelectedSiteRepository
-) : MySiteSource<DynamicCardsUpdate> {
-    private val refresh = MutableLiveData<Boolean>()
+) : MySiteRefreshSource<DynamicCardsUpdate> {
+    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DynamicCardsUpdate> {
         val data = MediatorLiveData<DynamicCardsUpdate>()
         data.refreshData(coroutineScope, siteLocalId)
         data.addSource(refresh) {
-            data.refreshData(coroutineScope, siteLocalId)
+            data.refreshData(coroutineScope, siteLocalId, refresh.value)
         }
         return data
+    }
+
+    private fun MediatorLiveData<DynamicCardsUpdate>.refreshData(
+        coroutineScope: CoroutineScope,
+        siteId: Int,
+        isRefresh: Boolean? = null
+    ) {
+        when (isRefresh) {
+            null, true -> refreshData(coroutineScope, siteId)
+            false -> Unit // Do nothing
+        }
     }
 
     private fun MediatorLiveData<DynamicCardsUpdate>.refreshData(coroutineScope: CoroutineScope, siteId: Int) {
         coroutineScope.launch {
             val cards = dynamicCardStore.getCards(siteId)
-            this@refreshData.postValue(
-                    DynamicCardsUpdate(
-                            pinnedDynamicCard = cards.pinnedItem,
-                            cards = cards.dynamicCardTypes
-                    )
-            )
+//            refresh.postValue(false)
+//            this@refreshData.postValue(
+//                    DynamicCardsUpdate(
+//                            pinnedDynamicCard = cards.pinnedItem,
+//                            cards = cards.dynamicCardTypes
+//                    )
+//            )
+            postState(DynamicCardsUpdate(pinnedDynamicCard = cards.pinnedItem, cards = cards.dynamicCardTypes))
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/CurrentAvatarSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/CurrentAvatarSourceTest.kt
@@ -16,10 +16,12 @@ class CurrentAvatarSourceTest : BaseUnitTest() {
     @Mock lateinit var accountStore: AccountStore
     @Mock lateinit var accountModel: AccountModel
     private lateinit var currentAvatarSource: CurrentAvatarSource
+    private lateinit var isRefreshing: MutableList<Boolean>
 
     @Before
     fun setUp() {
         currentAvatarSource = CurrentAvatarSource(accountStore)
+        isRefreshing = mutableListOf()
     }
 
     @Test
@@ -42,5 +44,36 @@ class CurrentAvatarSourceTest : BaseUnitTest() {
         currentAvatarSource.refresh()
 
         assertThat(result!!.url).isEqualTo(avatarUrl)
+    }
+
+    @Test
+    fun `when buildSource is invoked, then refresh is false`() = test {
+        currentAvatarSource.refresh.observeForever { isRefreshing.add(it) }
+
+        currentAvatarSource.build(testScope())
+
+        assertThat(isRefreshing.last()).isFalse
+    }
+
+    @Test
+    fun `when refresh is invoked, then refresh is true`() = test {
+        currentAvatarSource.refresh.observeForever { isRefreshing.add(it) }
+
+        currentAvatarSource.refresh()
+
+        assertThat(isRefreshing.last()).isTrue
+    }
+
+    @Test
+    fun `when data has been refreshed, then refresh is set to false`() = test {
+        whenever(accountStore.account).thenReturn(accountModel)
+        val avatarUrl = "avatar.jpg"
+        whenever(accountModel.avatarUrl).thenReturn(avatarUrl)
+        currentAvatarSource.refresh.observeForever { isRefreshing.add(it) }
+
+        currentAvatarSource.build(testScope()).observeForever { }
+        currentAvatarSource.refresh()
+
+        assertThat(isRefreshing.last()).isFalse
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/CurrentAvatarSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/CurrentAvatarSourceTest.kt
@@ -25,7 +25,7 @@ class CurrentAvatarSourceTest : BaseUnitTest() {
     @Test
     fun `current avatar is empty on start`() = test {
         var result: CurrentAvatarUrl? = null
-        currentAvatarSource.buildSource(testScope()).observeForever { it?.let { result = it } }
+        currentAvatarSource.build(testScope()).observeForever { it?.let { result = it } }
 
         assertThat(result!!.url).isEqualTo("")
     }
@@ -37,7 +37,7 @@ class CurrentAvatarSourceTest : BaseUnitTest() {
         whenever(accountModel.avatarUrl).thenReturn(avatarUrl)
 
         var result: CurrentAvatarUrl? = null
-        currentAvatarSource.buildSource(testScope()).observeForever { it?.let { result = it } }
+        currentAvatarSource.build(testScope()).observeForever { it?.let { result = it } }
 
         currentAvatarSource.refresh()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -237,17 +237,17 @@ class MySiteViewModelTest : BaseUnitTest() {
         onShowSiteIconProgressBar.value = null
         onSiteSelected.value = null
         selectedSite.value = null
-        whenever(domainRegistrationSource.buildSource(any(), any())).thenReturn(isDomainCreditAvailable)
-        whenever(scanAndBackupSource.buildSource(any(), any())).thenReturn(jetpackCapabilities)
-        whenever(currentAvatarSource.buildSource(any())).thenReturn(currentAvatar)
-        whenever(currentAvatarSource.buildSource(any(), any())).thenReturn(currentAvatar)
-        whenever(dynamicCardsSource.buildSource(any(), any())).thenReturn(dynamicCards)
+        whenever(domainRegistrationSource.build(any(), any())).thenReturn(isDomainCreditAvailable)
+        whenever(scanAndBackupSource.build(any(), any())).thenReturn(jetpackCapabilities)
+        whenever(currentAvatarSource.build(any())).thenReturn(currentAvatar)
+        whenever(currentAvatarSource.build(any(), any())).thenReturn(currentAvatar)
+        whenever(dynamicCardsSource.build(any(), any())).thenReturn(dynamicCards)
         whenever(selectedSiteRepository.siteSelected).thenReturn(onSiteSelected)
         whenever(quickStartRepository.activeTask).thenReturn(activeTask)
-        whenever(postCardsSource.buildSource(any(), any())).thenReturn(postsUpdate)
-        whenever(quickStartCardSource.buildSource(any(), any())).thenReturn(quickStartUpdate)
-        whenever(siteIconProgressSource.buildSource(any(), any())).thenReturn(showSiteIconProgressBar)
-        whenever(selectedSiteSource.buildSource(any(), any())).thenReturn(selectedSite)
+        whenever(postCardsSource.build(any(), any())).thenReturn(postsUpdate)
+        whenever(quickStartCardSource.build(any(), any())).thenReturn(quickStartUpdate)
+        whenever(siteIconProgressSource.build(any(), any())).thenReturn(showSiteIconProgressBar)
+        whenever(selectedSiteSource.build(any(), any())).thenReturn(selectedSite)
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(enableMySiteDashboardConfig)
         viewModel = MySiteViewModel(
                 networkUtilsWrapper,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -137,11 +137,45 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
         )
 
-        scanAndBackupSource.build(testScope(), siteLocalId).observeForever { it }
+        scanAndBackupSource.build(testScope(), siteLocalId).observeForever { }
         scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
 
         scanAndBackupSource.refresh()
 
         verify(jetpackCapabilitiesUseCase, times(2)).getJetpackPurchasedProducts(any())
+    }
+
+    @Test
+    fun `when source is invoked, then refresh is false`() = test {
+        scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
+
+        scanAndBackupSource.build(testScope(), siteLocalId)
+
+        assertThat(isRefreshing.last()).isFalse
+    }
+
+    @Test
+    fun `when refresh is invoked, then refresh is true`() = test {
+        scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
+
+        scanAndBackupSource.refresh()
+
+        assertThat(isRefreshing.last()).isTrue
+    }
+
+    @Test
+    fun `when data has been refreshed, then refresh is set to false`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(site.siteId).thenReturn(siteRemoteId)
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
+                flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
+        )
+
+        scanAndBackupSource.build(testScope(), siteLocalId).observeForever { }
+        scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
+
+        scanAndBackupSource.refresh()
+
+        assertThat(isRefreshing.last()).isFalse
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -47,7 +47,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
 
         var result: JetpackCapabilities? = null
-        scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { result = it }
+        scanAndBackupSource.build(testScope(), siteLocalId).observeForever { result = it }
 
         assertThat(result!!.backupAvailable).isFalse
         assertThat(result!!.scanAvailable).isFalse
@@ -62,7 +62,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         )
 
         var result: JetpackCapabilities? = null
-        scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { result = it }
+        scanAndBackupSource.build(testScope(), siteLocalId).observeForever { result = it }
 
         assertThat(result!!.backupAvailable).isTrue
         assertThat(result!!.scanAvailable).isTrue
@@ -77,7 +77,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         )
 
         var result: JetpackCapabilities? = null
-        scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { result = it }
+        scanAndBackupSource.build(testScope(), siteLocalId).observeForever { result = it }
 
         assertThat(result!!.backupAvailable).isFalse
         assertThat(result!!.scanAvailable).isFalse
@@ -93,7 +93,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         whenever(site.isWPCom).thenReturn(true)
 
         var result: JetpackCapabilities? = null
-        scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { result = it }
+        scanAndBackupSource.build(testScope(), siteLocalId).observeForever { result = it }
 
         assertThat(result!!.scanAvailable).isFalse
     }
@@ -108,7 +108,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         whenever(site.isWPComAtomic).thenReturn(true)
 
         var result: JetpackCapabilities? = null
-        scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { result = it }
+        scanAndBackupSource.build(testScope(), siteLocalId).observeForever { result = it }
 
         assertThat(result!!.scanAvailable).isFalse
     }
@@ -124,7 +124,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         whenever(site.isWPComAtomic).thenReturn(false)
 
         var result: JetpackCapabilities? = null
-        scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { result = it }
+        scanAndBackupSource.build(testScope(), siteLocalId).observeForever { result = it }
 
         assertThat(result!!.scanAvailable).isTrue
     }
@@ -137,7 +137,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
         )
 
-        scanAndBackupSource.buildSource(testScope(), siteLocalId).observeForever { it }
+        scanAndBackupSource.build(testScope(), siteLocalId).observeForever { it }
         scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
 
         scanAndBackupSource.refresh()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteSourceTest.kt
@@ -42,7 +42,7 @@ class SelectedSiteSourceTest : BaseUnitTest() {
     fun `when a new site is selected, then source data is not null`() = test {
         onSiteChange.value = site
 
-        source.buildSource(testScope(), siteLocalId).observeForever { result.add(it) }
+        source.build(testScope(), siteLocalId).observeForever { result.add(it) }
 
         assertThat(result.last().site).isNotNull
     }
@@ -69,7 +69,7 @@ class SelectedSiteSourceTest : BaseUnitTest() {
     fun `when buildSource is invoked, then refresh is false`() = test {
         source.refresh.observeForever { isRefreshing.add(it) }
 
-        source.buildSource(testScope(), siteLocalId).observeForever { result.add(it) }
+        source.build(testScope(), siteLocalId).observeForever { result.add(it) }
 
         assertThat(isRefreshing.last()).isFalse
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteIconProgressSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteIconProgressSourceTest.kt
@@ -35,7 +35,7 @@ class SiteIconProgressSourceTest : BaseUnitTest() {
     fun `when source site, then icon progress bar is not visible`() = test {
         onShowSiteIconProgressBar.value = false
 
-        source.buildSource(testScope(), siteLocalId).observeForever { result.add(it) }
+        source.build(testScope(), siteLocalId).observeForever { result.add(it) }
 
         assertThat(siteIconProgressBarVisible).isFalse
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
@@ -109,7 +109,7 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
         buildOnPlansFetchedEvent(site, currentPlan, error)?.let { event ->
             whenever(dispatcher.dispatch(any())).then { source.onPlansFetched(event) }
         }
-        source.buildSource(testScope(), siteLocalId).observeForever { result.add(it) }
+        source.build(testScope(), siteLocalId).observeForever { result.add(it) }
     }
 
     private fun buildOnPlansFetchedEvent(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
@@ -36,6 +36,7 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
     private val site = SiteModel()
     private lateinit var result: MutableList<DomainCreditAvailable>
     private lateinit var source: DomainRegistrationSource
+    private lateinit var isRefreshing: MutableList<Boolean>
 
     @InternalCoroutinesApi
     @Before
@@ -50,6 +51,7 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
         site.id = siteLocalId
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         result = mutableListOf()
+        isRefreshing = mutableListOf()
     }
 
     @Test
@@ -97,6 +99,35 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
         setupSite(site = site, error = GENERIC_ERROR)
 
         assertThat(result.last().isDomainCreditAvailable).isFalse
+    }
+
+    @Test
+    fun `when build is invoked, then refresh is false`() = test {
+        source.refresh.observeForever { isRefreshing.add(it) }
+
+        source.build(testScope(), siteLocalId)
+
+        assertThat(isRefreshing.last()).isFalse
+    }
+
+    @Test
+    fun `when refresh is invoked, then refresh is true`() = test {
+        source.refresh.observeForever { isRefreshing.add(it) }
+
+        source.refresh()
+
+        assertThat(isRefreshing.last()).isTrue
+    }
+
+    @Test
+    fun `when data has been refreshed, then refresh is set to false`() = test {
+        setupSite(site = site, currentPlan = buildPlan(hasDomainCredit = true))
+        source.refresh.observeForever { isRefreshing.add(it) }
+
+        source.build(testScope(), siteLocalId).observeForever { }
+        source.refresh()
+
+        assertThat(isRefreshing.last()).isFalse
     }
 
     private fun setupSite(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSourceTest.kt
@@ -52,6 +52,36 @@ class PostCardsSourceTest : BaseUnitTest() {
         assertThat(result.size).isEqualTo(2)
     }
 
+
+    @Test
+    fun `when source is invoked, then refresh is false`() = test {
+        postCardSource.refresh.observeForever { isRefreshing.add(it) }
+
+        postCardSource.build(testScope(), 1)
+
+        assertThat(isRefreshing.last()).isFalse
+    }
+
+    @Test
+    fun `when refresh is invoked, then refresh is true`() = test {
+        postCardSource.refresh.observeForever { isRefreshing.add(it) }
+
+        postCardSource.refresh()
+
+        assertThat(isRefreshing.last()).isTrue
+    }
+
+    @Test
+    fun `when data has been refreshed, then refresh is set to false`() = test {
+        val result: MutableList<PostsUpdate?> = mutableListOf()
+        postCardSource.build(testScope(), 1).observeForever { it?.let { result.add(it) } }
+        postCardSource.refresh.observeForever { isRefreshing.add(it) }
+
+        postCardSource.refresh()
+
+        assertThat(isRefreshing.last()).isFalse
+    }
+
     private val mockedPostsData: MockedPostsData
         get() = MockedPostsData(
                 posts = Posts(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSourceTest.kt
@@ -52,7 +52,6 @@ class PostCardsSourceTest : BaseUnitTest() {
         assertThat(result.size).isEqualTo(2)
     }
 
-
     @Test
     fun `when source is invoked, then refresh is false`() = test {
         postCardSource.refresh.observeForever { isRefreshing.add(it) }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/post/PostCardsSourceTest.kt
@@ -31,7 +31,7 @@ class PostCardsSourceTest : BaseUnitTest() {
     @Test
     fun `when source is requested upon start, then mocked data is loaded`() = test {
         var result: PostsUpdate? = null
-        postCardSource.buildSource(testScope(), 1).observeForever {
+        postCardSource.build(testScope(), 1).observeForever {
             it?.let {
                 result = it
             }
@@ -42,7 +42,7 @@ class PostCardsSourceTest : BaseUnitTest() {
     @Test
     fun `when refresh is invoked, then data is refreshed`() = test {
         val result: MutableList<PostsUpdate?> = mutableListOf()
-        postCardSource.buildSource(testScope(), 1).observeForever { it?.let { result.add(it) } }
+        postCardSource.build(testScope(), 1).observeForever { it?.let { result.add(it) } }
         postCardSource.refresh.observeForever { isRefreshing.add(it) }
 
         postCardSource.refresh()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
@@ -111,7 +111,7 @@ class QuickStartCardSourceTest : BaseUnitTest() {
         site.id = siteLocalId
         result = mutableListOf()
         isRefreshing = mutableListOf()
-        quickStartCardSource.buildSource(testScope(), siteLocalId).observeForever { result.add(it) }
+        quickStartCardSource.build(testScope(), siteLocalId).observeForever { result.add(it) }
         quickStartCardSource.refresh.observeForever { isRefreshing.add(it) }
     }
 
@@ -197,7 +197,7 @@ class QuickStartCardSourceTest : BaseUnitTest() {
     fun `start marks CREATE_SITE as done and loads model`() = test {
         initStore()
 
-        quickStartCardSource.buildSource(testScope(), site.id)
+        quickStartCardSource.build(testScope(), site.id)
         quickStartCardSource.refresh()
 
         assertModel()
@@ -292,7 +292,7 @@ class QuickStartCardSourceTest : BaseUnitTest() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartStore.hasDoneTask(updatedSiteId.toLong(), EDIT_HOMEPAGE)).thenReturn(false)
 
-        quickStartCardSource.buildSource(testScope(), site.id)
+        quickStartCardSource.build(testScope(), site.id)
         quickStartCardSource.refresh()
 
         verify(quickStartStore).setDoneTask(updatedSiteId.toLong(), EDIT_HOMEPAGE, true)
@@ -305,7 +305,7 @@ class QuickStartCardSourceTest : BaseUnitTest() {
         site.showOnFront = ShowOnFront.PAGE.value
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
 
-        quickStartCardSource.buildSource(testScope(), site.id)
+        quickStartCardSource.build(testScope(), site.id)
         quickStartCardSource.refresh()
 
         verify(quickStartStore, never()).setDoneTask(updatedSiteLocalId.toLong(), EDIT_HOMEPAGE, true)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
@@ -111,7 +111,6 @@ class QuickStartCardSourceTest : BaseUnitTest() {
         site.id = siteLocalId
         result = mutableListOf()
         isRefreshing = mutableListOf()
-        quickStartCardSource.build(testScope(), siteLocalId).observeForever { result.add(it) }
         quickStartCardSource.refresh.observeForever { isRefreshing.add(it) }
     }
 
@@ -322,11 +321,43 @@ class QuickStartCardSourceTest : BaseUnitTest() {
                 assertThat(result.last().activeTask).isEqualTo(PUBLISH_POST)
             }
 
+    @Test
+    fun `when source is invoked, then refresh is false`() = test {
+        initBuild()
+
+        assertThat(isRefreshing.last()).isFalse
+    }
+
+    @Test
+    fun `when refresh is invoked, then refresh is true`() = test {
+        quickStartCardSource.refresh()
+
+        assertThat(isRefreshing.last()).isTrue
+    }
+
+    @Test
+    fun `when data has been refreshed, then refresh is set to false`() = test {
+        initStore()
+
+        val updatedSiteId = 2
+        site.id = updatedSiteId
+        site.showOnFront = ShowOnFront.POSTS.value
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(quickStartStore.hasDoneTask(updatedSiteId.toLong(), EDIT_HOMEPAGE)).thenReturn(false)
+        quickStartCardSource.refresh.observeForever { isRefreshing.add(it) }
+
+        quickStartCardSource.build(testScope(), site.id)
+
+        quickStartCardSource.refresh()
+
+        assertThat(isRefreshing.last()).isFalse
+    }
+
     private fun triggerQSRefreshAfterSameTypeTasksAreComplete() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isEveryQuickStartTaskDoneForType(siteLocalId, GROW)).thenReturn(true)
-        whenever(resourceProvider.getString(any())).thenReturn(Companion.ALL_TASKS_COMPLETED_MESSAGE)
-        whenever(htmlCompat.fromHtml(Companion.ALL_TASKS_COMPLETED_MESSAGE)).thenReturn(ALL_TASKS_COMPLETED_MESSAGE)
+        whenever(resourceProvider.getString(any())).thenReturn(ALL_TASKS_COMPLETED_MESSAGE)
+        whenever(htmlCompat.fromHtml(ALL_TASKS_COMPLETED_MESSAGE)).thenReturn(ALL_TASKS_COMPLETED_MESSAGE)
 
         val task = PUBLISH_POST
         quickStartRepository.setActiveTask(task)
@@ -342,6 +373,7 @@ class QuickStartCardSourceTest : BaseUnitTest() {
     private suspend fun initStore(
         nextUncompletedTask: QuickStartTask? = null
     ) {
+        initBuild()
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(dynamicCardStore.getCards(siteLocalId)).thenReturn(
                 DynamicCardsModel(
@@ -373,6 +405,10 @@ class QuickStartCardSourceTest : BaseUnitTest() {
         whenever(quickStartUtilsWrapper.getNextUncompletedQuickStartTask(siteLocalId.toLong()))
                 .thenReturn(nextUncompletedTask)
         whenever(htmlMessageUtils.getHtmlMessageFromStringFormat(anyOrNull())).thenReturn("")
+    }
+
+    private fun initBuild() {
+        quickStartCardSource.build(testScope(), siteLocalId).observeForever { result.add(it) }
     }
 
     private fun assertModel() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.mysite.dynamiccards
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Java6Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -24,11 +25,14 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     @Mock lateinit var siteModel: SiteModel
     private lateinit var dynamicCardsSource: DynamicCardsSource
     private val siteLocalId: Int = 1
+    private lateinit var isRefreshing: MutableList<Boolean>
 
+    @InternalCoroutinesApi
     @Before
     fun setUp() {
         dynamicCardsSource = DynamicCardsSource(dynamicCardStore, selectedSiteRepository)
         whenever(siteModel.id).thenReturn(siteLocalId)
+        isRefreshing = mutableListOf()
     }
 
     @Test
@@ -100,5 +104,41 @@ class DynamicCardsSourceTest : BaseUnitTest() {
         dynamicCardsSource.unpinItem()
 
         verifyZeroInteractions(dynamicCardStore)
+    }
+
+    @Test
+    fun `when source is invoked, then refresh is false`() = test {
+        dynamicCardsSource.refresh.observeForever { isRefreshing.add(it) }
+
+        dynamicCardsSource.build(testScope(), siteLocalId)
+
+        assertThat(isRefreshing.last()).isFalse
+    }
+
+    @Test
+    fun `when refresh is invoked, then refresh is true`() = test {
+        dynamicCardsSource.refresh.observeForever { isRefreshing.add(it) }
+
+        dynamicCardsSource.refresh()
+
+        assertThat(isRefreshing.last()).isTrue
+    }
+
+    @Test
+    fun `when data has been refreshed, then refresh is set to false`() = test {
+        val pinnedItem = GROW_QUICK_START
+        val dynamicCardTypes = listOf(CUSTOMIZE_QUICK_START, GROW_QUICK_START)
+        whenever(dynamicCardStore.getCards(siteLocalId)).thenReturn(
+                DynamicCardsModel(
+                        pinnedItem,
+                        dynamicCardTypes
+                )
+        )
+        dynamicCardsSource.refresh.observeForever { isRefreshing.add(it) }
+
+        dynamicCardsSource.build(testScope(), siteLocalId).observeForever { }
+        dynamicCardsSource.refresh()
+
+        assertThat(isRefreshing.last()).isFalse
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
@@ -42,7 +42,7 @@ class DynamicCardsSourceTest : BaseUnitTest() {
                 )
         )
         var result: DynamicCardsUpdate? = null
-        dynamicCardsSource.buildSource(testScope(), siteLocalId).observeForever { result = it }
+        dynamicCardsSource.build(testScope(), siteLocalId).observeForever { result = it }
 
         assertThat(result?.pinnedDynamicCard).isEqualTo(pinnedItem)
         assertThat(result?.cards).isEqualTo(dynamicCardTypes)


### PR DESCRIPTION
Parent #15215

This PR is part of a series of PRs being written for adding pull-to-refresh to the MySite tab.

This PR focuses on refactoring `MySiteSource` interface and includes:
1. Renaming `buildSource` to `build`
2. Introduces a new interface `MySiteRefreshSource`:
- Act as a marker interface for when PTR is implemented in MySiteFragment/MySiteViewModel
- Reduce boilerplate code for handing refresh in sources
- Ensure, best we can, that `refresh` liveData is updated before the `partialData`
- Provide flexibility to the implementors to use the getState or postState functions as is OR to implement their own solution
3. Refresh tests were added as needed.

It is best to review this PR commit-by-commit; as the changes are similar across all sources and include:
- Remove `refresh()`
- Remove `postState()`
- Override `refresh` liveData property

`DynamicCardsSource` needed an additional update to use the new interface. That is reflected in the new `refreshData` func. It follows the same pattern as all other sources.

The pull-to-refresh functionality will be implemented separately. This is prep work to keep the PR size down.

**To test:**
The majority of this PR is refactoring and no new logic was added. 
See attached for the test scenarios. 
[test-scenarios.pdf](https://github.com/wordpress-mobile/WordPress-Android/files/7558407/test-scenarios.pdf)


## Regression Notes
1. Potential unintended areas of impact
MySite doesn't display

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + automated tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
