### PR TITLE
Fixes: RTL support for PPN Categories 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 18.8
 -----
 * [*] Editor: Replace snackbar with compact notice when switching between HTML or Visual mode [https://github.com/wordpress-mobile/WordPress-Android/pull/15583]
+* [*] Fixed an issue where multiple screens were rendered incorrectly in RTL interface languages [https://github.com/wordpress-mobile/WordPress-Android/pull/15597]
 
 
 18.7

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1242,6 +1242,7 @@
 
     <style name="MainBottomSheetRowTextView" parent="MySiteListRowTextView">
         <item name="android:layout_gravity">center_vertical</item>
+        <item name="android:textAlignment">viewStart</item>
         <item name="android:layout_centerVertical">true</item>
         <item name="android:layout_alignParentEnd">true</item>
         <item name="android:layout_width">match_parent</item>


### PR DESCRIPTION
Fixes #15581

We can fix this issue by adding the property `android:textAlignment="viewStart"` to the `TextView`.

> `android:textAlignment="viewStart"` - Align to the start of the view, which is ALIGN_LEFT if the view’s resolved layoutDirection is LTR, and ALIGN_RIGHT otherwise.

### Ways to Fix 
We can either add this property 
1. To the TextView showing Category Name. `prepublishing_categories_row -> prepublishing_category_text ` which would only fix the issue to this layout 
2. To the Style(`MainBottomSheetRowTextView`) used by the text view which would affect other places which uses this style. 


The style `MainBottomSheetRowTextView` is used in the following XML files. 

1. `debug_setttings_feature.xml`   
2. `debug_settings_row.xml` 
3. `main_action_list_item.xml`
4. `prepublishing_categories_row.xml`
5. `quick_start_menu_fragment.xml` 

PFB the Screenshots of the above said screens on RTL configuration 

#### 1. `debug_setttings_feature.xml` and 2. `debug_settings_row.xml` 
![Screenshot_1637285253](https://user-images.githubusercontent.com/17463767/142581043-2633630b-12e3-4df8-a5e0-78b83e60f296.png)

#### 3.  main_action_list_item
![Screenshot_1637285615](https://user-images.githubusercontent.com/17463767/142582062-3b48cd4d-987d-4e0c-8c59-ee188585259f.png)

#### 4. `prepublishing_categories_row.xml`
![Screenshot_1637037075](https://user-images.githubusercontent.com/17463767/142581079-3cebf2e7-3b06-4ecf-8f3d-59dd9c31bf97.png)

#### 5. `quick_start_menu_fragment.xml` 
![Screenshot 2021-11-19 at 12 57 25 PM](https://user-images.githubusercontent.com/17463767/142582466-71307fcc-acbb-44aa-8a78-a61a4cabdb9d.png)

----

## Done 
Here I went with Fix(2) as it made more sense rather than adding the property `android:textAlignment="viewStart"` to the the TextView. This required regression testing all the layouts which use this style. 


### Layouts Using `MainBottomSheetRowTextView` after fix 🟢 
#### 1. `debug_setttings_feature.xml` and 2. `debug_settings_row.xml` 

![Screenshot_1637290663](https://user-images.githubusercontent.com/17463767/142588623-722b3f7b-8475-44b6-bb65-82e5a5d9c9d1.png)

#### 3.  main_action_list_item
![Screenshot_1637290640](https://user-images.githubusercontent.com/17463767/142588756-0659f043-9fc1-4610-bad7-0ccc09e621a6.png)

#### 4. `prepublishing_categories_row.xml`
![Screenshot_1637290689](https://user-images.githubusercontent.com/17463767/142588815-6c8678a0-7403-4254-8547-51b584d09139.png)

#### 5. `quick_start_menu_fragment.xml` 
![Screenshot 2021-11-19 at 8 22 02 AM](https://user-images.githubusercontent.com/17463767/142588915-dc7c9fef-47a4-4b59-ba46-432bd11dc030.png)

## Regression Notes
1. Potential unintended areas of impact
Following Layouts not being rendered properly on LTR and RTL configuration
     1. `debug_setttings_feature.xml`
     2. `debug_settings_row.xml`
     3. `main_action_list_item.xml`
     4. `prepublishing_categories_row.xml`
     5. `quick_start_menu_fragment.xml`

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the affected layouts on LTR and RTL configuration and ensured that the items are shown properly. 

3. What automated tests I added (or what prevented me from doing so)
None required 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
