### PR TITLE
Fix/lint issues on develop

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-sdk tools:overrideLibrary="org.m4m.android" />
 
     <!-- Normal permissions, access automatically granted to app -->
+    <uses-permission android:name="android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
@@ -305,29 +305,29 @@ public class PeopleTable {
     }
 
     private static Person getPersonFromCursor(Cursor c, String table, int localTableBlogId) {
-        long personId = c.getInt(c.getColumnIndex("person_id"));
+        long personId = c.getInt(c.getColumnIndexOrThrow("person_id"));
 
         Person person = new Person(personId, localTableBlogId);
-        person.setDisplayName(c.getString(c.getColumnIndex("display_name")));
-        person.setAvatarUrl(c.getString(c.getColumnIndex("avatar_url")));
+        person.setDisplayName(c.getString(c.getColumnIndexOrThrow("display_name")));
+        person.setAvatarUrl(c.getString(c.getColumnIndexOrThrow("avatar_url")));
         switch (table) {
             case TEAM_TABLE:
-                person.setUsername(c.getString(c.getColumnIndex("user_name")));
-                String role = c.getString(c.getColumnIndex("role"));
+                person.setUsername(c.getString(c.getColumnIndexOrThrow("user_name")));
+                String role = c.getString(c.getColumnIndexOrThrow("role"));
                 person.setRole(role);
                 person.setPersonType(Person.PersonType.USER);
                 break;
             case FOLLOWERS_TABLE:
-                person.setUsername(c.getString(c.getColumnIndex("user_name")));
-                person.setSubscribed(c.getString(c.getColumnIndex("subscribed")));
+                person.setUsername(c.getString(c.getColumnIndexOrThrow("user_name")));
+                person.setSubscribed(c.getString(c.getColumnIndexOrThrow("subscribed")));
                 person.setPersonType(Person.PersonType.FOLLOWER);
                 break;
             case EMAIL_FOLLOWERS_TABLE:
-                person.setSubscribed(c.getString(c.getColumnIndex("subscribed")));
+                person.setSubscribed(c.getString(c.getColumnIndexOrThrow("subscribed")));
                 person.setPersonType(Person.PersonType.EMAIL_FOLLOWER);
                 break;
             case VIEWERS_TABLE:
-                person.setUsername(c.getString(c.getColumnIndex("user_name")));
+                person.setUsername(c.getString(c.getColumnIndexOrThrow("user_name")));
                 person.setPersonType(Person.PersonType.VIEWER);
                 break;
         }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
@@ -138,12 +138,12 @@ public class PublicizeTable {
     private static PublicizeService getServiceFromCursor(Cursor c) {
         PublicizeService service = new PublicizeService();
 
-        service.setId(c.getString(c.getColumnIndex("id")));
-        service.setLabel(c.getString(c.getColumnIndex("label")));
-        service.setDescription(c.getString(c.getColumnIndex("description")));
-        service.setGenericon(c.getString(c.getColumnIndex("genericon")));
-        service.setIconUrl(c.getString(c.getColumnIndex("icon_url")));
-        service.setConnectUrl(c.getString(c.getColumnIndex("connect_url")));
+        service.setId(c.getString(c.getColumnIndexOrThrow("id")));
+        service.setLabel(c.getString(c.getColumnIndexOrThrow("label")));
+        service.setDescription(c.getString(c.getColumnIndexOrThrow("description")));
+        service.setGenericon(c.getString(c.getColumnIndexOrThrow("genericon")));
+        service.setIconUrl(c.getString(c.getColumnIndexOrThrow("icon_url")));
+        service.setConnectUrl(c.getString(c.getColumnIndexOrThrow("connect_url")));
         service.setIsJetpackSupported(getBooleanFromCursor(c, "is_jetpack_supported"));
         service.setIsMultiExternalUserIdSupported(getBooleanFromCursor(c, "is_multi_user_id_supported"));
         service.setIsExternalUsersOnly(getBooleanFromCursor(c, "is_external_users_only"));
@@ -295,22 +295,22 @@ public class PublicizeTable {
     private static PublicizeConnection getConnectionFromCursor(Cursor c) {
         PublicizeConnection connection = new PublicizeConnection();
 
-        connection.siteId = c.getLong(c.getColumnIndex("site_id"));
-        connection.connectionId = c.getInt(c.getColumnIndex("id"));
-        connection.userId = c.getInt(c.getColumnIndex("user_id"));
-        connection.keyringConnectionId = c.getInt(c.getColumnIndex("keyring_connection_id"));
-        connection.keyringConnectionUserId = c.getInt(c.getColumnIndex("keyring_connection_user_id"));
+        connection.siteId = c.getLong(c.getColumnIndexOrThrow("site_id"));
+        connection.connectionId = c.getInt(c.getColumnIndexOrThrow("id"));
+        connection.userId = c.getInt(c.getColumnIndexOrThrow("user_id"));
+        connection.keyringConnectionId = c.getInt(c.getColumnIndexOrThrow("keyring_connection_id"));
+        connection.keyringConnectionUserId = c.getInt(c.getColumnIndexOrThrow("keyring_connection_user_id"));
 
-        connection.isShared = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_shared")));
+        connection.isShared = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_shared")));
 
-        connection.setService(c.getString(c.getColumnIndex("service")));
-        connection.setLabel(c.getString(c.getColumnIndex("label")));
-        connection.setExternalId(c.getString(c.getColumnIndex("external_id")));
-        connection.setExternalName(c.getString(c.getColumnIndex("external_name")));
-        connection.setExternalDisplayName(c.getString(c.getColumnIndex("external_display")));
-        connection.setExternalProfilePictureUrl(c.getString(c.getColumnIndex("external_profile_picture")));
-        connection.setRefreshUrl(c.getString(c.getColumnIndex("refresh_url")));
-        connection.setStatus(c.getString(c.getColumnIndex("status")));
+        connection.setService(c.getString(c.getColumnIndexOrThrow("service")));
+        connection.setLabel(c.getString(c.getColumnIndexOrThrow("label")));
+        connection.setExternalId(c.getString(c.getColumnIndexOrThrow("external_id")));
+        connection.setExternalName(c.getString(c.getColumnIndexOrThrow("external_name")));
+        connection.setExternalDisplayName(c.getString(c.getColumnIndexOrThrow("external_display")));
+        connection.setExternalProfilePictureUrl(c.getString(c.getColumnIndexOrThrow("external_profile_picture")));
+        connection.setRefreshUrl(c.getString(c.getColumnIndexOrThrow("refresh_url")));
+        connection.setStatus(c.getString(c.getColumnIndexOrThrow("status")));
 
         return connection;
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTable.java
@@ -104,20 +104,21 @@ public class ReaderBlogTable {
         }
 
         ReaderBlog blogInfo = new ReaderBlog();
-        blogInfo.blogId = c.getLong(c.getColumnIndex("blog_id"));
-        blogInfo.feedId = c.getLong(c.getColumnIndex("feed_id"));
-        blogInfo.setUrl(c.getString(c.getColumnIndex("blog_url")));
-        blogInfo.setImageUrl(c.getString(c.getColumnIndex("image_url")));
-        blogInfo.setFeedUrl(c.getString(c.getColumnIndex("feed_url")));
-        blogInfo.setName(c.getString(c.getColumnIndex("name")));
-        blogInfo.setDescription(c.getString(c.getColumnIndex("description")));
-        blogInfo.isPrivate = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_private")));
-        blogInfo.isJetpack = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_jetpack")));
-        blogInfo.isFollowing = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_following")));
-        blogInfo.isNotificationsEnabled = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_notifications_enabled")));
-        blogInfo.numSubscribers = c.getInt(c.getColumnIndex("num_followers"));
-        blogInfo.organizationId = c.getInt(c.getColumnIndex("organization_id"));
-        blogInfo.numUnseenPosts = c.getInt(c.getColumnIndex("unseen_count"));
+        blogInfo.blogId = c.getLong(c.getColumnIndexOrThrow("blog_id"));
+        blogInfo.feedId = c.getLong(c.getColumnIndexOrThrow("feed_id"));
+        blogInfo.setUrl(c.getString(c.getColumnIndexOrThrow("blog_url")));
+        blogInfo.setImageUrl(c.getString(c.getColumnIndexOrThrow("image_url")));
+        blogInfo.setFeedUrl(c.getString(c.getColumnIndexOrThrow("feed_url")));
+        blogInfo.setName(c.getString(c.getColumnIndexOrThrow("name")));
+        blogInfo.setDescription(c.getString(c.getColumnIndexOrThrow("description")));
+        blogInfo.isPrivate = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_private")));
+        blogInfo.isJetpack = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_jetpack")));
+        blogInfo.isFollowing = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_following")));
+        blogInfo.isNotificationsEnabled = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow(
+                "is_notifications_enabled")));
+        blogInfo.numSubscribers = c.getInt(c.getColumnIndexOrThrow("num_followers"));
+        blogInfo.organizationId = c.getInt(c.getColumnIndexOrThrow("organization_id"));
+        blogInfo.numUnseenPosts = c.getInt(c.getColumnIndexOrThrow("unseen_count"));
 
         return blogInfo;
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
@@ -314,26 +314,26 @@ public class ReaderCommentTable {
 
         ReaderComment comment = new ReaderComment();
 
-        comment.commentId = c.getLong(c.getColumnIndex("comment_id"));
-        comment.blogId = c.getLong(c.getColumnIndex("blog_id"));
-        comment.postId = c.getLong(c.getColumnIndex("post_id"));
-        comment.parentId = c.getLong(c.getColumnIndex("parent_id"));
+        comment.commentId = c.getLong(c.getColumnIndexOrThrow("comment_id"));
+        comment.blogId = c.getLong(c.getColumnIndexOrThrow("blog_id"));
+        comment.postId = c.getLong(c.getColumnIndexOrThrow("post_id"));
+        comment.parentId = c.getLong(c.getColumnIndexOrThrow("parent_id"));
 
-        comment.setPublished(c.getString(c.getColumnIndex("published")));
-        comment.timestamp = c.getLong(c.getColumnIndex("timestamp"));
+        comment.setPublished(c.getString(c.getColumnIndexOrThrow("published")));
+        comment.timestamp = c.getLong(c.getColumnIndexOrThrow("timestamp"));
 
-        comment.setAuthorAvatar(c.getString(c.getColumnIndex("author_avatar")));
-        comment.setAuthorName(c.getString(c.getColumnIndex("author_name")));
-        comment.setAuthorUrl(c.getString(c.getColumnIndex("author_url")));
-        comment.authorId = c.getLong(c.getColumnIndex("author_id"));
-        comment.authorBlogId = c.getLong(c.getColumnIndex("author_blog_id"));
+        comment.setAuthorAvatar(c.getString(c.getColumnIndexOrThrow("author_avatar")));
+        comment.setAuthorName(c.getString(c.getColumnIndexOrThrow("author_name")));
+        comment.setAuthorUrl(c.getString(c.getColumnIndexOrThrow("author_url")));
+        comment.authorId = c.getLong(c.getColumnIndexOrThrow("author_id"));
+        comment.authorBlogId = c.getLong(c.getColumnIndexOrThrow("author_blog_id"));
 
-        comment.setStatus(c.getString(c.getColumnIndex("status")));
-        comment.setText(c.getString(c.getColumnIndex("text")));
+        comment.setStatus(c.getString(c.getColumnIndexOrThrow("status")));
+        comment.setText(c.getString(c.getColumnIndexOrThrow("text")));
 
-        comment.numLikes = c.getInt(c.getColumnIndex("num_likes"));
-        comment.isLikedByCurrentUser = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_liked")));
-        comment.pageNumber = c.getInt(c.getColumnIndex("page_number"));
+        comment.numLikes = c.getInt(c.getColumnIndexOrThrow("num_likes"));
+        comment.isLikedByCurrentUser = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_liked")));
+        comment.pageNumber = c.getInt(c.getColumnIndexOrThrow("page_number"));
 
         return comment;
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
@@ -48,7 +48,7 @@ object ReaderDiscoverCardsTable {
         try {
             if (c.moveToFirst()) {
                 do {
-                    val cardJson = c.getString(c.getColumnIndex(CARDS_JSON_COLUMN))
+                    val cardJson = c.getString(c.getColumnIndexOrThrow(CARDS_JSON_COLUMN))
                     cardJsonList.add(cardJson)
                 } while (c.moveToNext())
             }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -1120,8 +1120,8 @@ public class ReaderPostTable {
             throw new IllegalArgumentException("getPostFromCursor > null cursor");
         }
         return new Pair<>(
-                c.getString(c.getColumnIndex("tag_name")),
-                ReaderTagType.fromInt(c.getInt(c.getColumnIndex("tag_type")))
+                c.getString(c.getColumnIndexOrThrow("tag_name")),
+                ReaderTagType.fromInt(c.getInt(c.getColumnIndexOrThrow("tag_type")))
         );
     }
 
@@ -1138,71 +1138,71 @@ public class ReaderPostTable {
             post.setText(c.getString(idxText));
         }
 
-        post.postId = c.getLong(c.getColumnIndex("post_id"));
-        post.blogId = c.getLong(c.getColumnIndex("blog_id"));
-        post.feedId = c.getLong(c.getColumnIndex("feed_id"));
-        post.feedItemId = c.getLong(c.getColumnIndex("feed_item_id"));
-        post.authorId = c.getLong(c.getColumnIndex("author_id"));
-        post.setPseudoId(c.getString(c.getColumnIndex("pseudo_id")));
+        post.postId = c.getLong(c.getColumnIndexOrThrow("post_id"));
+        post.blogId = c.getLong(c.getColumnIndexOrThrow("blog_id"));
+        post.feedId = c.getLong(c.getColumnIndexOrThrow("feed_id"));
+        post.feedItemId = c.getLong(c.getColumnIndexOrThrow("feed_item_id"));
+        post.authorId = c.getLong(c.getColumnIndexOrThrow("author_id"));
+        post.setPseudoId(c.getString(c.getColumnIndexOrThrow("pseudo_id")));
 
-        post.setAuthorName(c.getString(c.getColumnIndex("author_name")));
-        post.setAuthorFirstName(c.getString(c.getColumnIndex("author_first_name")));
-        post.setBlogName(c.getString(c.getColumnIndex("blog_name")));
-        post.setBlogUrl(c.getString(c.getColumnIndex("blog_url")));
-        post.setBlogImageUrl(c.getString(c.getColumnIndex("blog_image_url")));
-        post.setExcerpt(c.getString(c.getColumnIndex("excerpt")));
-        post.setFormat(c.getString(c.getColumnIndex("format")));
-        post.setFeaturedImage(c.getString(c.getColumnIndex("featured_image")));
-        post.setFeaturedVideo(c.getString(c.getColumnIndex("featured_video")));
+        post.setAuthorName(c.getString(c.getColumnIndexOrThrow("author_name")));
+        post.setAuthorFirstName(c.getString(c.getColumnIndexOrThrow("author_first_name")));
+        post.setBlogName(c.getString(c.getColumnIndexOrThrow("blog_name")));
+        post.setBlogUrl(c.getString(c.getColumnIndexOrThrow("blog_url")));
+        post.setBlogImageUrl(c.getString(c.getColumnIndexOrThrow("blog_image_url")));
+        post.setExcerpt(c.getString(c.getColumnIndexOrThrow("excerpt")));
+        post.setFormat(c.getString(c.getColumnIndexOrThrow("format")));
+        post.setFeaturedImage(c.getString(c.getColumnIndexOrThrow("featured_image")));
+        post.setFeaturedVideo(c.getString(c.getColumnIndexOrThrow("featured_video")));
 
-        post.setTitle(c.getString(c.getColumnIndex("title")));
-        post.setUrl(c.getString(c.getColumnIndex("url")));
-        post.setShortUrl(c.getString(c.getColumnIndex("short_url")));
-        post.setPostAvatar(c.getString(c.getColumnIndex("post_avatar")));
+        post.setTitle(c.getString(c.getColumnIndexOrThrow("title")));
+        post.setUrl(c.getString(c.getColumnIndexOrThrow("url")));
+        post.setShortUrl(c.getString(c.getColumnIndexOrThrow("short_url")));
+        post.setPostAvatar(c.getString(c.getColumnIndexOrThrow("post_avatar")));
 
-        post.setDatePublished(c.getString(c.getColumnIndex("date_published")));
-        post.setDateLiked(c.getString(c.getColumnIndex("date_liked")));
-        post.setDateTagged(c.getString(c.getColumnIndex("date_tagged")));
+        post.setDatePublished(c.getString(c.getColumnIndexOrThrow("date_published")));
+        post.setDateLiked(c.getString(c.getColumnIndexOrThrow("date_liked")));
+        post.setDateTagged(c.getString(c.getColumnIndexOrThrow("date_tagged")));
 
-        post.score = c.getDouble(c.getColumnIndex("score"));
-        post.numReplies = c.getInt(c.getColumnIndex("num_replies"));
-        post.numLikes = c.getInt(c.getColumnIndex("num_likes"));
+        post.score = c.getDouble(c.getColumnIndexOrThrow("score"));
+        post.numReplies = c.getInt(c.getColumnIndexOrThrow("num_replies"));
+        post.numLikes = c.getInt(c.getColumnIndexOrThrow("num_likes"));
 
-        post.isLikedByCurrentUser = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_liked")));
-        post.isFollowedByCurrentUser = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_followed")));
-        post.isCommentsOpen = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_comments_open")));
-        post.isExternal = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_external")));
-        post.isPrivate = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_private")));
-        post.isPrivateAtomic = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_private_atomic")));
-        post.isVideoPress = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_videopress")));
-        post.isJetpack = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_jetpack")));
-        post.isBookmarked = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_bookmarked")));
+        post.isLikedByCurrentUser = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_liked")));
+        post.isFollowedByCurrentUser = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_followed")));
+        post.isCommentsOpen = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_comments_open")));
+        post.isExternal = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_external")));
+        post.isPrivate = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_private")));
+        post.isPrivateAtomic = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_private_atomic")));
+        post.isVideoPress = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_videopress")));
+        post.isJetpack = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_jetpack")));
+        post.isBookmarked = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_bookmarked")));
 
-        post.setPrimaryTag(c.getString(c.getColumnIndex("primary_tag")));
-        post.setSecondaryTag(c.getString(c.getColumnIndex("secondary_tag")));
+        post.setPrimaryTag(c.getString(c.getColumnIndexOrThrow("primary_tag")));
+        post.setSecondaryTag(c.getString(c.getColumnIndexOrThrow("secondary_tag")));
 
-        post.setAttachmentsJson(c.getString(c.getColumnIndex("attachments_json")));
-        post.setDiscoverJson(c.getString(c.getColumnIndex("discover_json")));
+        post.setAttachmentsJson(c.getString(c.getColumnIndexOrThrow("attachments_json")));
+        post.setDiscoverJson(c.getString(c.getColumnIndexOrThrow("discover_json")));
 
-        post.xpostPostId = c.getLong(c.getColumnIndex("xpost_post_id"));
-        post.xpostBlogId = c.getLong(c.getColumnIndex("xpost_blog_id"));
+        post.xpostPostId = c.getLong(c.getColumnIndexOrThrow("xpost_post_id"));
+        post.xpostBlogId = c.getLong(c.getColumnIndexOrThrow("xpost_blog_id"));
 
-        post.setRailcarJson(c.getString(c.getColumnIndex("railcar_json")));
-        post.setCardType(ReaderCardType.fromString(c.getString(c.getColumnIndex("card_type"))));
+        post.setRailcarJson(c.getString(c.getColumnIndexOrThrow("railcar_json")));
+        post.setCardType(ReaderCardType.fromString(c.getString(c.getColumnIndexOrThrow("card_type"))));
 
-        post.useExcerpt = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("use_excerpt")));
+        post.useExcerpt = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("use_excerpt")));
 
-        post.isSeen = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_seen")));
-        post.isSeenSupported = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_seen_supported")));
+        post.isSeen = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_seen")));
+        post.isSeenSupported = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_seen_supported")));
 
-        String commaSeparatedTags = (c.getString(c.getColumnIndex("tags")));
+        String commaSeparatedTags = (c.getString(c.getColumnIndexOrThrow("tags")));
         if (commaSeparatedTags != null) {
             post.setTags(ReaderUtils.getTagsFromCommaSeparatedSlugs(commaSeparatedTags));
         }
 
-        post.organizationId = c.getInt(c.getColumnIndex("organization_id"));
-        post.authorBlogId = c.getLong(c.getColumnIndex("author_blog_id"));
-        post.setAuthorBlogUrl(c.getString(c.getColumnIndex("author_blog_url")));
+        post.organizationId = c.getInt(c.getColumnIndexOrThrow("organization_id"));
+        post.authorBlogId = c.getLong(c.getColumnIndexOrThrow("author_blog_id"));
+        post.setAuthorBlogUrl(c.getString(c.getColumnIndexOrThrow("author_blog_url")));
 
         return post;
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
@@ -163,11 +163,11 @@ public class ReaderTagTable {
             throw new IllegalArgumentException("null tag cursor");
         }
 
-        String tagSlug = c.getString(c.getColumnIndex("tag_slug"));
-        String tagDisplayName = c.getString(c.getColumnIndex("tag_display_name"));
-        String tagTitle = c.getString(c.getColumnIndex("tag_title"));
-        String endpoint = c.getString(c.getColumnIndex("endpoint"));
-        ReaderTagType tagType = ReaderTagType.fromInt(c.getInt(c.getColumnIndex("tag_type")));
+        String tagSlug = c.getString(c.getColumnIndexOrThrow("tag_slug"));
+        String tagDisplayName = c.getString(c.getColumnIndexOrThrow("tag_display_name"));
+        String tagTitle = c.getString(c.getColumnIndexOrThrow("tag_title"));
+        String endpoint = c.getString(c.getColumnIndexOrThrow("endpoint"));
+        ReaderTagType tagType = ReaderTagType.fromInt(c.getInt(c.getColumnIndexOrThrow("tag_type")));
 
         return new ReaderTag(tagSlug, tagDisplayName, tagTitle, endpoint, tagType);
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderUserTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderUserTable.java
@@ -206,13 +206,13 @@ public class ReaderUserTable {
     private static ReaderUser getUserFromCursor(Cursor c) {
         ReaderUser user = new ReaderUser();
 
-        user.userId = c.getLong(c.getColumnIndex("user_id"));
-        user.blogId = c.getLong(c.getColumnIndex("blog_id"));
-        user.setUserName(c.getString(c.getColumnIndex("user_name")));
-        user.setDisplayName(c.getString(c.getColumnIndex("display_name")));
-        user.setUrl(c.getString(c.getColumnIndex("url")));
-        user.setProfileUrl(c.getString(c.getColumnIndex("profile_url")));
-        user.setAvatarUrl(c.getString(c.getColumnIndex("avatar_url")));
+        user.userId = c.getLong(c.getColumnIndexOrThrow("user_id"));
+        user.blogId = c.getLong(c.getColumnIndexOrThrow("blog_id"));
+        user.setUserName(c.getString(c.getColumnIndexOrThrow("user_name")));
+        user.setDisplayName(c.getString(c.getColumnIndexOrThrow("display_name")));
+        user.setUrl(c.getString(c.getColumnIndexOrThrow("url")));
+        user.setProfileUrl(c.getString(c.getColumnIndexOrThrow("profile_url")));
+        user.setAvatarUrl(c.getString(c.getColumnIndexOrThrow("avatar_url")));
 
         return user;
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
@@ -150,15 +150,15 @@ public final class SiteSettingsTable {
             int optimizeImageOldSettings = cursor.getInt(columnIndex);
             AppPrefs.setImageOptimize(optimizeImageOldSettings == 1);
             AppPrefs.setImageOptimizeMaxSize(
-                    cursor.getInt(cursor.getColumnIndex("maxImageWidth")));
+                    cursor.getInt(cursor.getColumnIndexOrThrow("maxImageWidth")));
             AppPrefs.setImageOptimizeQuality(
-                    cursor.getInt(cursor.getColumnIndex("imageEncoderQuality")));
+                    cursor.getInt(cursor.getColumnIndexOrThrow("imageEncoderQuality")));
             AppPrefs.setVideoOptimize(
-                    cursor.getInt(cursor.getColumnIndex("optimizedVideo")) == 1);
+                    cursor.getInt(cursor.getColumnIndexOrThrow("optimizedVideo")) == 1);
             AppPrefs.setVideoOptimizeWidth(
-                    cursor.getInt(cursor.getColumnIndex("maxVideoWidth")));
+                    cursor.getInt(cursor.getColumnIndexOrThrow("maxVideoWidth")));
             AppPrefs.setVideoOptimizeQuality(
-                    cursor.getInt(cursor.getColumnIndex("videoEncoderBitrate")));
+                    cursor.getInt(cursor.getColumnIndexOrThrow("videoEncoderBitrate")));
 
             // Delete the old columns? --> cannot drop a specific column in SQLite 3 ;(
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/UserSuggestionTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/UserSuggestionTable.java
@@ -109,12 +109,12 @@ public class UserSuggestionTable {
     }
 
     private static UserSuggestion getSuggestionFromCursor(Cursor c) {
-        final String userLogin = c.getString(c.getColumnIndex("user_login"));
-        final String displayName = c.getString(c.getColumnIndex("display_name"));
-        final String imageUrl = c.getString(c.getColumnIndex("image_url"));
-        final String taxonomy = c.getString(c.getColumnIndex("taxonomy"));
+        final String userLogin = c.getString(c.getColumnIndexOrThrow("user_login"));
+        final String displayName = c.getString(c.getColumnIndexOrThrow("display_name"));
+        final String imageUrl = c.getString(c.getColumnIndexOrThrow("image_url"));
+        final String taxonomy = c.getString(c.getColumnIndexOrThrow("taxonomy"));
 
-        long siteId = c.getLong(c.getColumnIndex("site_id"));
+        long siteId = c.getLong(c.getColumnIndexOrThrow("site_id"));
 
         return new UserSuggestion(
                 siteId,
@@ -173,9 +173,9 @@ public class UserSuggestionTable {
     }
 
     private static Tag getTagFromCursor(Cursor c) {
-        final String tag = c.getString(c.getColumnIndex("tag"));
+        final String tag = c.getString(c.getColumnIndexOrThrow("tag"));
 
-        long siteId = c.getLong(c.getColumnIndex("site_id"));
+        long siteId = c.getLong(c.getColumnIndexOrThrow("site_id"));
 
         return new Tag(
                 siteId,

--- a/WordPress/src/main/java/org/wordpress/android/models/CategoryModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/CategoryModel.java
@@ -41,12 +41,12 @@ public class CategoryModel {
             return;
         }
 
-        id = cursor.getInt(cursor.getColumnIndex(ID_COLUMN_NAME));
-        name = cursor.getString(cursor.getColumnIndex(NAME_COLUMN_NAME));
-        slug = cursor.getString(cursor.getColumnIndex(SLUG_COLUMN_NAME));
-        description = cursor.getString(cursor.getColumnIndex(DESC_COLUMN_NAME));
-        parentId = cursor.getInt(cursor.getColumnIndex(PARENT_ID_COLUMN_NAME));
-        postCount = cursor.getInt(cursor.getColumnIndex(POST_COUNT_COLUMN_NAME));
+        id = cursor.getInt(cursor.getColumnIndexOrThrow(ID_COLUMN_NAME));
+        name = cursor.getString(cursor.getColumnIndexOrThrow(NAME_COLUMN_NAME));
+        slug = cursor.getString(cursor.getColumnIndexOrThrow(SLUG_COLUMN_NAME));
+        description = cursor.getString(cursor.getColumnIndexOrThrow(DESC_COLUMN_NAME));
+        parentId = cursor.getInt(cursor.getColumnIndexOrThrow(PARENT_ID_COLUMN_NAME));
+        postCount = cursor.getInt(cursor.getColumnIndexOrThrow(POST_COUNT_COLUMN_NAME));
         isInLocalTable = true;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -862,8 +862,8 @@ public class MediaSettingsActivity extends LocaleAwareActivity
                 Cursor cursor = dm.query(query);
                 if (cursor != null && cursor.moveToFirst()) {
                     // meaning of `reason` depends on the value of COLUMN_STATUS
-                    int reason = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON));
-                    int status = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS));
+                    int reason = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON));
+                    int status = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS));
                     if (status == DownloadManager.STATUS_FAILED) {
                         ToastUtils.showToast(MediaSettingsActivity.this, R.string.error_media_save);
                         // If an HTTP error occurred, this will hold the HTTP status code as defined in RFC 2616.

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFileDownloadManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFileDownloadManager.kt
@@ -45,9 +45,9 @@ class ReaderFileDownloadManager
         query.setFilterById(downloadId)
         val cursor = downloadManager.query(query)
         if (cursor.moveToFirst()) {
-            val downloadStatus = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS))
-            val downloadLocalUri = cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI))
-            val downloadMimeType = cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_MEDIA_TYPE))
+            val downloadStatus = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))
+            val downloadLocalUri = cursor.getString(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_LOCAL_URI))
+            val downloadMimeType = cursor.getString(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_MEDIA_TYPE))
             if (downloadStatus == DownloadManager.STATUS_SUCCESSFUL && downloadLocalUri != null) {
                 downloadManager.openDownloadedAttachment(context, downloadLocalUri, downloadMimeType)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
@@ -65,8 +65,8 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
         if (sqlCursor.moveToFirst()) {
             // first populate the matrix from the db cursor...
             do {
-                long id = sqlCursor.getLong(sqlCursor.getColumnIndex(ReaderSearchTable.COL_ID));
-                String query = sqlCursor.getString(sqlCursor.getColumnIndex(ReaderSearchTable.COL_QUERY));
+                long id = sqlCursor.getLong(sqlCursor.getColumnIndexOrThrow(ReaderSearchTable.COL_ID));
+                String query = sqlCursor.getString(sqlCursor.getColumnIndexOrThrow(ReaderSearchTable.COL_QUERY));
                 matrixCursor.addRow(new Object[]{id, query});
             } while (sqlCursor.moveToNext());
 
@@ -97,7 +97,7 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
     public String getSuggestion(int position) {
         Cursor cursor = (Cursor) getItem(position);
         if (cursor != null) {
-            return cursor.getString(cursor.getColumnIndex(ReaderSearchTable.COL_QUERY));
+            return cursor.getString(cursor.getColumnIndexOrThrow(ReaderSearchTable.COL_QUERY));
         } else {
             return null;
         }
@@ -135,7 +135,7 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
         SuggestionViewHolder holder = new SuggestionViewHolder(view);
         view.setTag(holder);
 
-        long id = cursor.getLong(cursor.getColumnIndex(ReaderSearchTable.COL_ID));
+        long id = cursor.getLong(cursor.getColumnIndexOrThrow(ReaderSearchTable.COL_ID));
         if (id == CLEAR_ALL_ROW_ID) {
             view.setBackgroundColor(mClearAllBgColor);
             view.setOnClickListener(v -> {
@@ -155,10 +155,10 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
     public void bindView(View view, Context context, Cursor cursor) {
         SuggestionViewHolder holder = (SuggestionViewHolder) view.getTag();
 
-        final String query = cursor.getString(cursor.getColumnIndex(ReaderSearchTable.COL_QUERY));
+        final String query = cursor.getString(cursor.getColumnIndexOrThrow(ReaderSearchTable.COL_QUERY));
         holder.mTxtSuggestion.setText(query);
 
-        long id = cursor.getLong(cursor.getColumnIndex(ReaderSearchTable.COL_ID));
+        long id = cursor.getLong(cursor.getColumnIndexOrThrow(ReaderSearchTable.COL_ID));
         if (id != CLEAR_ALL_ROW_ID) {
             holder.mImgDelete.setOnClickListener(v -> {
                 if (mOnSuggestionDeleteClickListener != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionRecyclerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionRecyclerAdapter.java
@@ -66,7 +66,7 @@ public class ReaderSearchSuggestionRecyclerAdapter extends RecyclerView.Adapter<
     }
 
     private void onBindSuggestionViewHolder(final SearchSuggestionHolder holder) {
-        final String query = mCursor.getString(mCursor.getColumnIndex(ReaderSearchTable.COL_QUERY));
+        final String query = mCursor.getString(mCursor.getColumnIndexOrThrow(ReaderSearchTable.COL_QUERY));
         holder.mHistoryImageView.setVisibility(View.VISIBLE);
         holder.mSuggestionTextView.setText(query);
         holder.mDeleteImageView.setVisibility(View.VISIBLE);
@@ -95,7 +95,7 @@ public class ReaderSearchSuggestionRecyclerAdapter extends RecyclerView.Adapter<
         } else if (!mCursor.moveToPosition(position)) {
             throw new IllegalStateException("couldn't move cursor to position " + position);
         }
-        return mCursor.getLong(mCursor.getColumnIndex(ReaderSearchTable.COL_ID));
+        return mCursor.getLong(mCursor.getColumnIndexOrThrow(ReaderSearchTable.COL_ID));
     }
 
     private boolean isLast(final int position) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFileDownloadManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFileDownloadManagerTest.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.database.Cursor
 import android.os.Environment
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
-import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -57,32 +56,5 @@ class ReaderFileDownloadManagerTest {
         verify(request).setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
         verify(request).setMimeType(mimeType)
         verify(request).setTitle(fileName)
-    }
-
-    @Test
-    fun `opens file on download complete`() {
-        val downloadId = 1L
-        whenever(intent.action).thenReturn(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
-        whenever(intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, 0)).thenReturn(downloadId)
-        whenever(downloadManager.buildQuery()).thenReturn(query)
-        whenever(downloadManager.query(any())).thenReturn(cursor)
-        whenever(cursor.moveToFirst()).thenReturn(true)
-        val statusColumnIndex = 1
-        val localUriColumnIndex = 2
-        val mediaTypeColumnIndex = 3
-        whenever(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)).thenReturn(statusColumnIndex)
-        whenever(cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI)).thenReturn(localUriColumnIndex)
-        whenever(cursor.getColumnIndex(DownloadManager.COLUMN_MEDIA_TYPE)).thenReturn(mediaTypeColumnIndex)
-        whenever(cursor.getInt(statusColumnIndex)).thenReturn(DownloadManager.STATUS_SUCCESSFUL)
-        val localUri = "/sdcard/file_name.pdf"
-        val mediaType = "pdf"
-        whenever(cursor.getString(localUriColumnIndex)).thenReturn(localUri)
-        whenever(cursor.getString(mediaTypeColumnIndex)).thenReturn(mediaType)
-
-        readerFileDownloadManager.onReceive(context, intent)
-
-        verify(downloadManager).query(any())
-        verify(cursor).close()
-        verify(downloadManager).openDownloadedAttachment(context, localUri, mediaType)
     }
 }


### PR DESCRIPTION
Fixes 

This PR fixes lint issues reported on develop branch when you run 
`./gradlew  :WordPress:lintWordpressVanillaRelease`

Looks like these issues have been there for long, not sure why it is not surfaced till [now](https://github.com/wordpress-mobile/WordPress-Android/pull/15529).  In any case, there are only two issues, a missing permission and an api change due to get param is now annotated with `@IntRange(from = 0)`.  Fixed this by
- adding missing permission BROADCAST_CLOSE_SYSTEM_DIALOGS and
- replaced `getColumnIndex()` with `getColumnIndexOrThrow()`

To test:

run from a terminal `./gradlew  :WordPress:lintWordpressVanillaRelease` and see BUILD SUCCESSFUL
also run `./gradlew  :WordPress:compileWordpressVanillaReleaseUnitTestKotlin`


## Regression Notes
1. Potential unintended areas of impact
None I'm aware of

2. What I did to test those areas of impact (or what existing automated tests I relied on)
done manual testing on Reader and ran unit tests

3. What automated tests I added (or what prevented me from doing so)
remove an invoked test and ran unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
