### PR TITLE
Category Listing Screen - Retry Logic 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModel.kt
@@ -4,6 +4,7 @@ import androidx.annotation.DrawableRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.R
@@ -27,6 +28,8 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
+
+private const val RETRY_DELAY = 300L
 
 class CategoriesListViewModel @Inject constructor(
     private val getCategoriesUseCase: GetCategoriesUseCase,
@@ -55,7 +58,9 @@ class CategoriesListViewModel @Inject constructor(
 
         this.siteModel = siteModel
         getCategoriesFromDb()
-        fetchCategoriesFromNetwork(isInvokedFromInit = true)
+        launch {
+            fetchCategoriesFromNetwork(isInvokedFromInit = true)
+        }
     }
 
     private fun getCategoriesFromDb() {
@@ -66,13 +71,18 @@ class CategoriesListViewModel @Inject constructor(
         }
     }
 
-    private fun fetchCategoriesFromNetwork(isInvokedFromInit: Boolean = false) {
+    private fun onRetryClicked() {
+        launch { fetchCategoriesFromNetwork(false) }
+    }
+
+    private suspend fun fetchCategoriesFromNetwork(isInvokedFromInit: Boolean = false) {
+        if (!isInvokedFromInit) {
+            _uiState.postValue(Loading)
+            delay(RETRY_DELAY)
+        }
         if (networkUtilsWrapper.isNetworkAvailable()) {
-            if (!isInvokedFromInit) _uiState.value = Loading
-            launch {
-                getCategoriesUseCase.fetchSiteCategories(siteModel)
-            }
-        } else if (_uiState.value is Loading) _uiState.value = NoConnection(::fetchCategoriesFromNetwork)
+            getCategoriesUseCase.fetchSiteCategories(siteModel)
+        } else if (_uiState.value is Loading) _uiState.postValue(NoConnection(::onRetryClicked))
     }
 
     @SuppressWarnings("unused")
@@ -92,7 +102,7 @@ class CategoriesListViewModel @Inject constructor(
 
     private fun processFetchCategoriesCallback(event: OnTaxonomyChanged) {
         if (event.isError) {
-            if (_uiState.value is Loading) _uiState.value = GenericError(::fetchCategoriesFromNetwork)
+            if (_uiState.value is Loading) _uiState.value = GenericError(::onRetryClicked)
             return
         }
         launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModel.kt
@@ -72,7 +72,7 @@ class CategoriesListViewModel @Inject constructor(
     }
 
     private fun onRetryClicked() {
-        launch { fetchCategoriesFromNetwork(false) }
+        launch { fetchCategoriesFromNetwork() }
     }
 
     private suspend fun fetchCategoriesFromNetwork(isInvokedFromInit: Boolean = false) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModelTest.kt
@@ -86,8 +86,7 @@ class CategoriesListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given no items in db with internet available, when vm starts, then list of items from network is displayed`() {
-        whenever(getCategoriesUseCase.getSiteCategories(siteModel))
-                .thenReturn(arrayListOf(), mock())
+        whenever(getCategoriesUseCase.getSiteCategories(siteModel)).thenReturn(arrayListOf(), mock())
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
 
         viewModel.start(siteModel)
@@ -101,8 +100,7 @@ class CategoriesListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given no items in db and api error occurs, when vm starts, then error is displayed`() {
-        whenever(getCategoriesUseCase.getSiteCategories(siteModel))
-                .thenReturn(arrayListOf())
+        whenever(getCategoriesUseCase.getSiteCategories(siteModel)).thenReturn(arrayListOf())
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
         viewModel.start(siteModel)
 
@@ -115,8 +113,7 @@ class CategoriesListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given error occurs, when retry is invoked, then loading is displayed`() {
-        whenever(networkUtilsWrapper.isNetworkAvailable())
-                .thenReturn(true)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
         viewModel.start(siteModel)
 
         viewModel.onTaxonomyChanged(getGenericTaxonomyError())
@@ -128,8 +125,7 @@ class CategoriesListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given api error occurs, when retry is invoked on no network, then no network is displayed`() {
-        whenever(networkUtilsWrapper.isNetworkAvailable())
-                .thenReturn(true).thenReturn(false)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true).thenReturn(false)
         viewModel.start(siteModel)
 
         viewModel.onTaxonomyChanged(getGenericTaxonomyError())
@@ -152,8 +148,7 @@ class CategoriesListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given network available, when retry is invoked, then list of items from network is displayed`() {
-        whenever(getCategoriesUseCase.getSiteCategories(siteModel))
-                .thenReturn(arrayListOf(), mock())
+        whenever(getCategoriesUseCase.getSiteCategories(siteModel)).thenReturn(arrayListOf(), mock())
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false).thenReturn(true)
         viewModel.start(siteModel)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModelTest.kt
@@ -150,6 +150,20 @@ class CategoriesListViewModelTest : BaseUnitTest() {
         assertTrue(uiStates.last() is NoConnection)
     }
 
+    @Test
+    fun `given network available, when retry is invoked, then no connection error is displayed`() {
+        whenever(getCategoriesUseCase.getSiteCategories(siteModel))
+                .thenReturn(arrayListOf(), mock())
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false).thenReturn(true)
+        viewModel.start(siteModel)
+
+        (uiStates.last() as NoConnection).action.invoke()
+
+        verify(getCategoriesUseCase, times(1)).fetchSiteCategories(siteModel)
+        viewModel.onTaxonomyChanged(getTaxonomyChangedCallback())
+        assertTrue(uiStates.last() is Content)
+    }
+
     private fun getGenericTaxonomyError(): OnTaxonomyChanged {
         val taxonomyChanged = OnTaxonomyChanged(0)
         taxonomyChanged.causeOfChange = FETCH_CATEGORIES

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModelTest.kt
@@ -151,7 +151,7 @@ class CategoriesListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given network available, when retry is invoked, then no connection error is displayed`() {
+    fun `given network available, when retry is invoked, then list of items from network is displayed`() {
         whenever(getCategoriesUseCase.getSiteCategories(siteModel))
                 .thenReturn(arrayListOf(), mock())
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false).thenReturn(true)


### PR DESCRIPTION
Fixes #15550 

Fixes the following scenario's in `CategoriesListFragment` 

- Show loading screen when retry button is clicked on Error state 
- In error state(`NoConnection` or `GenericError`), If no internet available and retry is button is clicked, Show no Network error

Updates

`CategoriesListViewModel`
- Adds retry logic with a delay to show the loading state 

`CategoriesListViewModelTest`
- Adds tests for the retry logic in `CategoriesListViewModel`


### To test:
These Scenarios can be tested using the Unit tests in `CategoriesListViewModelTest`

- Show loading screen when retry button is clicked on Error state - test
`given error occurs, when retry is invoked, then loading is displayed`
- In error state(`NoConnection` or `GenericError`), If no internet available and retry is button is clicked, Show no Network error.  
     - `given api error occurs, when retry is invoked on no network, then no network is displayed`
     - `given no network, when retry is invoked, then no connection error is displayed`
- When retry is invoked and internet is available, Show content 
    - `given network available, when retry is invoked, then list of items from network is displayed`

## Regression Notes
1. Potential unintended areas of impact
Categories not showing the correct state 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Checked if the unit tests for that area still pass, Manual testing. 

3. What automated tests I added (or what prevented me from doing so)
Unit tests 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
