### PR TITLE
Quick Start: Remove dead pixels around snackbars

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -537,11 +537,11 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     private fun showSnackbar(holder: SnackbarMessageHolder) {
-        activity?.let { parent ->
+        activity?.let {
             snackbarSequencer.enqueue(
                     SnackbarItem(
                             info = Info(
-                                    view = parent.findViewById(R.id.coordinator),
+                                    view = requireView(),
                                     textRes = holder.message,
                                     duration = holder.duration,
                                     isImportant = holder.isImportant


### PR DESCRIPTION
#15461

<img width="320" alt="Screenshot 2021-11-24 at 12 45 48 PM" src="https://user-images.githubusercontent.com/1405144/143192339-07d94f75-18c7-4f9a-89b9-a1975c016437.png">

Cc @osullivanchris 

To test:

1. Follow the "Quick Start" steps after creating a new site.
2. Tap any "Quick Start" task (e.g. "Edit your homepage") so that a snackbar gets displayed.
3. Notice that the "Quick Start" snackbar doesn't have any dead pixels around it.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
