### PR TITLE
Bump Aztec version to v1.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = '2.2.0'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.66.0'
+    ext.gutenbergMobileVersion = '4290-75835441d8364c6799c87887a1b727e08efb415b'
     ext.storiesVersion = '1.2.0'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = '2.2.0'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '4290-75835441d8364c6799c87887a1b727e08efb415b'
+    ext.gutenbergMobileVersion = 'v1.68.0-alpha1'
     ext.storiesVersion = '1.2.0'
 
     repositories {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.aztecVersion = 'v1.5.0'
+    ext.aztecVersion = 'v1.5.1'
 }
 
 repositories {


### PR DESCRIPTION
This PR bumps the Aztec version to `v1.5.1` to include the fix https://github.com/wordpress-mobile/AztecEditor-Android/pull/945 for the Gutenberg editor.

To test:
Follow testing instructions from https://github.com/wordpress-mobile/gutenberg-mobile/pull/4290.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
