### PR TITLE
Update Unified About library integration

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -167,7 +167,7 @@
             android:label="@string/about_the_app"
             android:theme="@style/WordPress.NoActionBar.DarkNavbar" />
         <activity
-            android:name=".ui.about.AboutWordPressActivity"
+            android:name=".ui.about.UnifiedAboutActivity"
             android:label="@string/about_the_app"
             android:theme="@style/WordPress.NoActionBar" />
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
@@ -339,7 +339,7 @@ public class ReaderCommentTable {
         comment.isLikedByCurrentUser = SqlUtils.sqlToBool(c.getInt(c.getColumnIndexOrThrow("is_liked")));
         comment.pageNumber = c.getInt(c.getColumnIndexOrThrow("page_number"));
 
-        comment.setShortUrl(c.getString(c.getColumnIndex("short_url")));
+        comment.setShortUrl(c.getString(c.getColumnIndexOrThrow("short_url")));
 
         return comment;
     }

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.JetpackRemoteInstallFragment;
 import org.wordpress.android.ui.ShareIntentReceiverActivity;
 import org.wordpress.android.ui.ShareIntentReceiverFragment;
 import org.wordpress.android.ui.WPWebViewActivity;
+import org.wordpress.android.ui.about.UnifiedAboutActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
@@ -717,6 +718,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(UnifiedCommentsDetailsActivity object);
 
     void inject(UnifiedCommentDetailsFragment object);
+
+    void inject(UnifiedAboutActivity object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
@@ -16,9 +16,7 @@ class AboutWordPressActivity : LocaleAwareActivity(), AboutConfigProvider {
         return AboutConfig(
                 headerConfig = HeaderConfig.fromContext(this),
                 shareConfigFactory = ::createShareConfig,
-                rateUsConfig = RateUsConfig(
-                        packageName = "org.wordpress.android"
-                ),
+                rateUsConfig = RateUsConfig.fromContext(this),
                 socialsConfig = SocialsConfig(
                         instagramUsername = WP_SOCIAL_HANDLE,
                         twitterUsername = WP_SOCIAL_HANDLE

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
@@ -9,7 +9,6 @@ import com.automattic.about.model.LegalConfig
 import com.automattic.about.model.RateUsConfig
 import com.automattic.about.model.ShareConfig
 import com.automattic.about.model.SocialsConfig
-import kotlinx.coroutines.delay
 import org.wordpress.android.R
 
 class AboutWordPressActivity : AppCompatActivity(), AboutConfigProvider {
@@ -18,7 +17,6 @@ class AboutWordPressActivity : AppCompatActivity(), AboutConfigProvider {
         return AboutConfig(
                 headerConfig = HeaderConfig.fromContext(this),
                 shareConfigFactory = {
-                    delay(timeMillis = 5000) // Simulate remote call
                     ShareConfig(
                             subject = "WordPress",
                             message = "Hey! Here is a link to download the WordPress app. " +

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
@@ -16,14 +16,7 @@ class AboutWordPressActivity : AppCompatActivity(), AboutConfigProvider {
     override fun getAboutConfig(): AboutConfig {
         return AboutConfig(
                 headerConfig = HeaderConfig.fromContext(this),
-                shareConfigFactory = {
-                    ShareConfig(
-                            subject = "WordPress",
-                            message = "Hey! Here is a link to download the WordPress app. " +
-                                    "I'm really enjoying it and thought you might too!\n" +
-                                    "https://apps.wordpress.com/get?campaign=app_share_link"
-                    )
-                },
+                shareConfigFactory = ::createShareConfig,
                 rateUsConfig = RateUsConfig(
                         packageName = "org.wordpress.android"
                 ),
@@ -44,4 +37,11 @@ class AboutWordPressActivity : AppCompatActivity(), AboutConfigProvider {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.about_word_press_activity)
     }
+
+    private fun createShareConfig() = ShareConfig(
+            subject = "WordPress",
+            message = "Hey! Here is a link to download the WordPress app. " +
+                    "I'm really enjoying it and thought you might too!\n" +
+                    "https://apps.wordpress.com/get?campaign=app_share_link"
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
@@ -21,8 +21,8 @@ class AboutWordPressActivity : LocaleAwareActivity(), AboutConfigProvider {
                         packageName = "org.wordpress.android"
                 ),
                 socialsConfig = SocialsConfig(
-                        instagramUsername = "wordpressdotcom",
-                        twitterUsername = "wordpressdotcom"
+                        instagramUsername = WP_SOCIAL_HANDLE,
+                        twitterUsername = WP_SOCIAL_HANDLE
                 ),
                 legalConfig = LegalConfig(
                         tosUrl = "https://wordpress.com/tos/",
@@ -44,4 +44,8 @@ class AboutWordPressActivity : LocaleAwareActivity(), AboutConfigProvider {
                     "I'm really enjoying it and thought you might too!\n" +
                     "https://apps.wordpress.com/get?campaign=app_share_link"
     )
+
+    companion object {
+        private const val WP_SOCIAL_HANDLE = "wordpressdotcom"
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.about
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import com.automattic.about.model.AboutConfig
 import com.automattic.about.model.AboutConfigProvider
 import com.automattic.about.model.HeaderConfig
@@ -10,8 +9,9 @@ import com.automattic.about.model.RateUsConfig
 import com.automattic.about.model.ShareConfig
 import com.automattic.about.model.SocialsConfig
 import org.wordpress.android.R
+import org.wordpress.android.ui.LocaleAwareActivity
 
-class AboutWordPressActivity : AppCompatActivity(), AboutConfigProvider {
+class AboutWordPressActivity : LocaleAwareActivity(), AboutConfigProvider {
     @SuppressWarnings("RegexpSingleline")
     override fun getAboutConfig(): AboutConfig {
         return AboutConfig(

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/AboutWordPressActivity.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class AboutWordPressActivity : LocaleAwareActivity(), AboutConfigProvider {
-    @SuppressWarnings("RegexpSingleline")
     override fun getAboutConfig(): AboutConfig {
         return AboutConfig(
                 headerConfig = HeaderConfig.fromContext(this),
@@ -46,6 +45,6 @@ class AboutWordPressActivity : LocaleAwareActivity(), AboutConfigProvider {
     )
 
     companion object {
-        private const val WP_SOCIAL_HANDLE = "wordpressdotcom"
+        private const val WP_SOCIAL_HANDLE = "wordpressdotcom" // CHECKSTYLE IGNORE
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutActivity.kt
@@ -11,7 +11,7 @@ import com.automattic.about.model.SocialsConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.LocaleAwareActivity
 
-class AboutWordPressActivity : LocaleAwareActivity(), AboutConfigProvider {
+class UnifiedAboutActivity : LocaleAwareActivity(), AboutConfigProvider {
     override fun getAboutConfig(): AboutConfig {
         return AboutConfig(
                 headerConfig = HeaderConfig.fromContext(this),
@@ -32,7 +32,7 @@ class AboutWordPressActivity : LocaleAwareActivity(), AboutConfigProvider {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.about_word_press_activity)
+        setContentView(R.layout.unified_about_activity)
     }
 
     private fun createShareConfig() = ShareConfig(

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutActivity.kt
@@ -1,16 +1,12 @@
 package org.wordpress.android.ui.about
 
 import android.os.Bundle
-import com.automattic.about.model.AboutConfig
 import com.automattic.about.model.AboutConfigProvider
-import com.automattic.about.model.HeaderConfig
-import com.automattic.about.model.LegalConfig
-import com.automattic.about.model.RateUsConfig
-import com.automattic.about.model.ShareConfig
-import com.automattic.about.model.SocialsConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.ui.about.UnifiedAboutNavigationAction.Dismiss
+import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
 class UnifiedAboutActivity : LocaleAwareActivity(), AboutConfigProvider {
@@ -20,34 +16,13 @@ class UnifiedAboutActivity : LocaleAwareActivity(), AboutConfigProvider {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
         setContentView(R.layout.unified_about_activity)
+
+        viewModel.onNavigation.observeEvent(this) {
+            when (it) {
+                Dismiss -> finish()
+            }
+        }
     }
 
-    override fun getAboutConfig(): AboutConfig {
-        return AboutConfig(
-                headerConfig = HeaderConfig.fromContext(this),
-                shareConfigFactory = ::createShareConfig,
-                rateUsConfig = RateUsConfig.fromContext(this),
-                socialsConfig = SocialsConfig(
-                        instagramUsername = WP_SOCIAL_HANDLE,
-                        twitterUsername = WP_SOCIAL_HANDLE
-                ),
-                legalConfig = LegalConfig(
-                        tosUrl = "https://wordpress.com/tos/",
-                        privacyPolicyUrl = "https://automattic.com/privacy/",
-                        acknowledgementsUrl = "file:///android_asset/licenses.html"
-                ),
-                onDismiss = { onBackPressed() }
-        )
-    }
-
-    private fun createShareConfig() = ShareConfig(
-            subject = "WordPress",
-            message = "Hey! Here is a link to download the WordPress app. " +
-                    "I'm really enjoying it and thought you might too!\n" +
-                    "https://apps.wordpress.com/get?campaign=app_share_link"
-    )
-
-    companion object {
-        private const val WP_SOCIAL_HANDLE = "wordpressdotcom" // CHECKSTYLE IGNORE
-    }
+    override fun getAboutConfig() = viewModel.getAboutConfig()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutActivity.kt
@@ -9,9 +9,19 @@ import com.automattic.about.model.RateUsConfig
 import com.automattic.about.model.ShareConfig
 import com.automattic.about.model.SocialsConfig
 import org.wordpress.android.R
+import org.wordpress.android.WordPress
 import org.wordpress.android.ui.LocaleAwareActivity
+import javax.inject.Inject
 
 class UnifiedAboutActivity : LocaleAwareActivity(), AboutConfigProvider {
+    @Inject lateinit var viewModel: UnifiedAboutViewModel
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (application as WordPress).component().inject(this)
+        setContentView(R.layout.unified_about_activity)
+    }
+
     override fun getAboutConfig(): AboutConfig {
         return AboutConfig(
                 headerConfig = HeaderConfig.fromContext(this),
@@ -28,11 +38,6 @@ class UnifiedAboutActivity : LocaleAwareActivity(), AboutConfigProvider {
                 ),
                 onDismiss = { onBackPressed() }
         )
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.unified_about_activity)
     }
 
     private fun createShareConfig() = ShareConfig(

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutNavigationAction.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.ui.about
+
+sealed class UnifiedAboutNavigationAction {
+    object Dismiss : UnifiedAboutNavigationAction()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -1,9 +1,53 @@
 package org.wordpress.android.ui.about
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.automattic.about.model.AboutConfig
+import com.automattic.about.model.HeaderConfig
+import com.automattic.about.model.LegalConfig
+import com.automattic.about.model.RateUsConfig
+import com.automattic.about.model.ShareConfig
+import com.automattic.about.model.SocialsConfig
+import org.wordpress.android.ui.about.UnifiedAboutNavigationAction.Dismiss
+import org.wordpress.android.viewmodel.ContextProvider
+import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
 class UnifiedAboutViewModel @Inject constructor(
-        // TODO: Add parameters
+    private val contextProvider: ContextProvider
 ) : ViewModel() {
+    private val _onNavigation = MutableLiveData<Event<UnifiedAboutNavigationAction>>()
+    val onNavigation: LiveData<Event<UnifiedAboutNavigationAction>> = _onNavigation
+
+    fun getAboutConfig() = AboutConfig(
+            headerConfig = HeaderConfig.fromContext(contextProvider.getContext()),
+            shareConfigFactory = ::createShareConfig,
+            rateUsConfig = RateUsConfig.fromContext(contextProvider.getContext()),
+            socialsConfig = SocialsConfig(
+                    instagramUsername = WP_SOCIAL_HANDLE,
+                    twitterUsername = WP_SOCIAL_HANDLE
+            ),
+            legalConfig = LegalConfig(
+                    tosUrl = "https://wordpress.com/tos/",
+                    privacyPolicyUrl = "https://automattic.com/privacy/",
+                    acknowledgementsUrl = "file:///android_asset/licenses.html"
+            ),
+            onDismiss = ::onDismiss
+    )
+
+    private fun createShareConfig() = ShareConfig(
+            subject = "WordPress",
+            message = "Hey! Here is a link to download the WordPress app. " +
+                    "I'm really enjoying it and thought you might too!\n" +
+                    "https://apps.wordpress.com/get?campaign=app_share_link"
+    )
+
+    private fun onDismiss() {
+        _onNavigation.postValue(Event(Dismiss))
+    }
+
+    companion object {
+        private const val WP_SOCIAL_HANDLE = "wordpressdotcom" // CHECKSTYLE IGNORE
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -71,7 +71,7 @@ class UnifiedAboutViewModel @Inject constructor(
     }
 
     companion object {
-        private const val WP_SOCIAL_HANDLE = "wordpressdotcom" // CHECKSTYLE IGNORE
+        private const val WP_SOCIAL_HANDLE = "wordpress"
         private const val WP_ACKNOWLEDGEMENTS_URL = "file:///android_asset/licenses.html"
         private const val WP_APPS_URL = "https://apps.wordpress.com/"
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -30,7 +30,7 @@ class UnifiedAboutViewModel @Inject constructor(
     private val contextProvider: ContextProvider,
     private val wpUrlUtils: WpUrlUtilsWrapper,
     private val recommendApiCallsProvider: RecommendApiCallsProvider,
-    private val buildConfig: BuildConfigWrapper,
+    private val buildConfig: BuildConfigWrapper
 ) : ViewModel() {
     private val _onNavigation = MutableLiveData<Event<UnifiedAboutNavigationAction>>()
     val onNavigation: LiveData<Event<UnifiedAboutNavigationAction>> = _onNavigation

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -34,7 +34,7 @@ class UnifiedAboutViewModel @Inject constructor(
             legalConfig = LegalConfig(
                     tosUrl = wpUrlUtils.buildTermsOfServiceUrl(contextProvider.getContext()),
                     privacyPolicyUrl = Constants.URL_PRIVACY_POLICY,
-                    acknowledgementsUrl = "file:///android_asset/licenses.html"
+                    acknowledgementsUrl = WP_ACKNOWLEDGEMENTS_URL
             ),
             onDismiss = ::onDismiss
     )
@@ -52,5 +52,6 @@ class UnifiedAboutViewModel @Inject constructor(
 
     companion object {
         private const val WP_SOCIAL_HANDLE = "wordpressdotcom" // CHECKSTYLE IGNORE
+        private const val WP_ACKNOWLEDGEMENTS_URL = "file:///android_asset/licenses.html"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -40,7 +40,6 @@ class UnifiedAboutViewModel @Inject constructor(
             shareConfigFactory = ::createShareConfig,
             rateUsConfig = RateUsConfig.fromContext(contextProvider.getContext()),
             socialsConfig = SocialsConfig(
-                    instagramUsername = WP_SOCIAL_HANDLE,
                     twitterUsername = WP_SOCIAL_HANDLE
             ),
             legalConfig = LegalConfig(

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -10,12 +10,14 @@ import com.automattic.about.model.RateUsConfig
 import com.automattic.about.model.ShareConfig
 import com.automattic.about.model.SocialsConfig
 import org.wordpress.android.ui.about.UnifiedAboutNavigationAction.Dismiss
+import org.wordpress.android.util.WpUrlUtilsWrapper
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
 class UnifiedAboutViewModel @Inject constructor(
-    private val contextProvider: ContextProvider
+    private val contextProvider: ContextProvider,
+    private val wpUrlUtils: WpUrlUtilsWrapper
 ) : ViewModel() {
     private val _onNavigation = MutableLiveData<Event<UnifiedAboutNavigationAction>>()
     val onNavigation: LiveData<Event<UnifiedAboutNavigationAction>> = _onNavigation
@@ -29,7 +31,7 @@ class UnifiedAboutViewModel @Inject constructor(
                     twitterUsername = WP_SOCIAL_HANDLE
             ),
             legalConfig = LegalConfig(
-                    tosUrl = "https://wordpress.com/tos/",
+                    tosUrl = wpUrlUtils.buildTermsOfServiceUrl(contextProvider.getContext()),
                     privacyPolicyUrl = "https://automattic.com/privacy/",
                     acknowledgementsUrl = "file:///android_asset/licenses.html"
             ),

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -9,6 +9,7 @@ import com.automattic.about.model.LegalConfig
 import com.automattic.about.model.RateUsConfig
 import com.automattic.about.model.ShareConfig
 import com.automattic.about.model.SocialsConfig
+import org.wordpress.android.Constants
 import org.wordpress.android.ui.about.UnifiedAboutNavigationAction.Dismiss
 import org.wordpress.android.util.WpUrlUtilsWrapper
 import org.wordpress.android.viewmodel.ContextProvider
@@ -32,7 +33,7 @@ class UnifiedAboutViewModel @Inject constructor(
             ),
             legalConfig = LegalConfig(
                     tosUrl = wpUrlUtils.buildTermsOfServiceUrl(contextProvider.getContext()),
-                    privacyPolicyUrl = "https://automattic.com/privacy/",
+                    privacyPolicyUrl = Constants.URL_PRIVACY_POLICY,
                     acknowledgementsUrl = "file:///android_asset/licenses.html"
             ),
             onDismiss = ::onDismiss

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.ui.about
+
+import androidx.lifecycle.ViewModel
+import javax.inject.Inject
+
+class UnifiedAboutViewModel @Inject constructor(
+        // TODO: Add parameters
+) : ViewModel() {
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -43,7 +43,7 @@ import org.wordpress.android.networking.GravatarApi
 import org.wordpress.android.networking.GravatarApi.GravatarUploadListener
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
-import org.wordpress.android.ui.about.AboutWordPressActivity
+import org.wordpress.android.ui.about.UnifiedAboutActivity
 import org.wordpress.android.ui.accounts.HelpActivity.Origin.ME_SCREEN_HELP
 import org.wordpress.android.ui.main.MeViewModel.RecommendAppUiState
 import org.wordpress.android.ui.main.WPMainActivity.OnScrollToTopListener
@@ -173,7 +173,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         }
 
         viewModel.showUnifiedAbout.observeEvent(viewLifecycleOwner, {
-            startActivity(Intent(activity, AboutWordPressActivity::class.java))
+            startActivity(Intent(activity, UnifiedAboutActivity::class.java))
         })
 
         viewModel.showDisconnectDialog.observeEvent(viewLifecycleOwner, {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -42,7 +42,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.WhatsNewStore.OnWhatsNewFetched;
 import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewAppId;
 import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewFetchPayload;
-import org.wordpress.android.ui.about.AboutWordPressActivity;
+import org.wordpress.android.ui.about.UnifiedAboutActivity;
 import org.wordpress.android.ui.debug.DebugSettingsActivity;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
@@ -482,7 +482,7 @@ public class AppSettingsFragment extends PreferenceFragment
 
     private boolean handleAboutPreferenceClick() {
         if (mUnifiedAboutFeatureConfig.isEnabled()) {
-            startActivity(new Intent(getActivity(), AboutWordPressActivity.class));
+            startActivity(new Intent(getActivity(), UnifiedAboutActivity.class));
         } else {
             startActivity(new Intent(getActivity(), AboutActivity.class));
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/WpUrlUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/WpUrlUtilsWrapper.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.util
 
+import android.content.Context
 import javax.inject.Inject
 
 class WpUrlUtilsWrapper @Inject constructor() {
     fun isWordPressCom(interceptedUri: String?) = WPUrlUtils.isWordPressCom(interceptedUri)
+    fun buildTermsOfServiceUrl(context: Context): String = WPUrlUtils.buildTermsOfServiceUrl(context)
 }

--- a/WordPress/src/main/res/layout/unified_about_activity.xml
+++ b/WordPress/src/main/res/layout/unified_about_activity.xml
@@ -5,4 +5,4 @@
     android:name="com.automattic.about.ui.AboutFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.about.AboutWordPressActivity" />
+    tools:context=".ui.about.UnifiedAboutActivity" />

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -98,7 +98,7 @@
       <property name="format" value=".*dotcom(?!.*checkstyle ignore)"/>
       <property name="ignoreCase" value="true"/>
       <property name="message" value="You should not use _dotcom_, use _wpcom_ instead"/>
-      <property name="severity" value="warning"/>
+      <property name="severity" value="error"/>
     </module>
 
     <!-- Specific to WordPress -->


### PR DESCRIPTION
This PR introduces a few remaining improvements to the integration of the Unified About library in preparation for release. Here are the main changes:

- The `AboutWordPressActivity` was renamed to `UnifiedAboutActivity`, since we plan to use the same activity to support the Jetpack app as well in the future. 
- All logic necessary to create the `AboutConfig` was moved to a new `UnifiedAboutViewModel`.
- The logic to create the `ShareConfig` now correctly calls the recommend app API.
- The terms of service URL is now localized.
- Other hardcoded URLs were replaced by constants.
- The WP.com Twitter handle (`@wordpressdotcom`) was replaced by the WP.org one (`@wordpress`) and the Instagram handle was removed.
- I have also reverted the change made in 6b34506b94b8c812c7900a89999255472ff7af6c where the severity of a checkstyle rule was downgraded from `error` to `warning`. I found that we didn't need to change that in the first place, we could have a checkstyle suppression comment that looks like this: `// CHECKSTYLE IGNORE`. In the end, this wasn't necessary, since we're changing the social handles anyway.

### To test

**Setup: Enable feature flag**

1. On the Main screen, tap the Me button.
1. On the Me screen, go to App Settings > Debug settings.
1. On the Debug Settings screen, scroll down to the "Features in development" section and tap `UnifiedAboutFeatureConfig` to enable the feature flag.

**1. Share With Friends**

1. Open the Unified About screen.
1. Tap on the "Share With Friends" item.
1. Notice the chooser bottom sheet.
1. Choose an app to share, like an email client.
1. Make sure the subject, text body, and link all look good.

**2. Rate Us**

1. Open the Unified About screen.
1. Tap on the "Rate Us" item.
1. Notice the WordPress page on Google Play.

Note: this won't work for debug versions of the app.

**3. Twitter**
1. Open the Unified About screen.
1. Tap on the "Twitter" item.
1. If you have the Twitter app installed on your device, the system will ask you to choose if you wish to open the link with it or with a browser. If you don't, it will open the browser directly.
1. Notice the WordPress page on Twitter.

**4. Terms of Service**
1. Open the Unified About screen.
1. Tap on the "Legal And More" item.
1. Notice the "Legal And More" screen.
1. Tap on the "Terms Of Service" item.
1. Notice the `https://wordpress.com/tos/` URL is opened on an external browser.
1. Notice how the URL was modified to include the locale tag.

**5. Privacy Policy**
1. Open the Unified About screen.
1. Tap on the "Legal And More" item.
1. Notice the "Legal And More" screen.
1. Tap on the "Privacy Policy" item.
1. Notice the `https://automattic.com/privacy/` URL is opened on an external browser.

**6. Acknowledgments**
1. Open the Unified About screen.
1. Tap on the "Legal And More" item.
1. Notice the "Legal And More" screen.
1. Tap on the "Acknowledgments" item.
1. Notice the `Acknowledgments` screen.

**7. Automattic Family**
1. Open the Unified About screen.
1. Tap on the "Automattic Family" item.
1. Notice the `https://automattic.com/` URL is opened on an external browser.

**8. Work With Us**
1. Open the Unified About screen.
1. Tap on the "Work With Us" item.
1. Notice the `https://automattic.com/work-with-us/` URL is opened on an external browser.

## Regression Notes
1. Potential unintended areas of impact
None that I could think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
None. This should be done in a follow-up PR soon.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
