### PR TITLE
Enable Unified About remote feature flag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -161,7 +161,8 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        if (unifiedAboutFeatureConfig.isEnabled()) {
+        // Temporarily limiting this feature to the WordPress app
+        if (unifiedAboutFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
             recommendTheAppContainer.isVisible = false
             aboutTheAppContainer.isVisible = true
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -481,7 +481,8 @@ public class AppSettingsFragment extends PreferenceFragment
     }
 
     private boolean handleAboutPreferenceClick() {
-        if (mUnifiedAboutFeatureConfig.isEnabled()) {
+        // Temporarily limiting this feature to the WordPress app
+        if (mUnifiedAboutFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
             startActivity(new Intent(getActivity(), UnifiedAboutActivity.class));
         } else {
             startActivity(new Intent(getActivity(), AboutActivity.class));

--- a/WordPress/src/main/java/org/wordpress/android/util/config/UnifiedAboutFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/UnifiedAboutFeatureConfig.kt
@@ -1,23 +1,19 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.UnifiedAboutFeatureConfig.Companion.UNIFIED_ABOUT_REMOTE_FIELD
 import javax.inject.Inject
 
-/**
- * Feature configuration for Unified About Screen
- */
-// TODO: Uncomment the lines @Feature and UNIFIED_ABOUT_REMOTE_FIELD when remote field is configured and
-//  remove line @FeatureInDevelopment and this to-do lines
-@FeatureInDevelopment
+@Feature(UNIFIED_ABOUT_REMOTE_FIELD, true)
 class UnifiedAboutFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
         appConfig,
-        BuildConfig.UNIFIED_ABOUT
-//        UNIFIED_ABOUT_REMOTE_FIELD
+        BuildConfig.UNIFIED_ABOUT,
+        UNIFIED_ABOUT_REMOTE_FIELD
 ) {
     companion object {
-        const val UNIFIED_ABOUT_REMOTE_FIELD = "unified_about_remote_field"
+        const val UNIFIED_ABOUT_REMOTE_FIELD = "unified_about_enabled"
     }
 }

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1631,8 +1631,8 @@
     </style>
 
     <style name="SiteCategoryRowLayout">
-        <item name="android:paddingEnd">@dimen/content_margin_site_row_end</item>
-        <item name="android:paddingStart">@dimen/content_margin_site_row_start</item>
+        <item name="android:paddingEnd">@dimen/margin_extra_large</item>
+        <item name="android:paddingStart">@dimen/margin_extra_large</item>
         <item name="android:foreground">?android:attr/selectableItemBackground</item>
     </style>
 


### PR DESCRIPTION
This PR enables the remote flag for the Unified About feature:

<img width=300 src="https://user-images.githubusercontent.com/830056/143627701-026f625b-4441-4b73-8382-e149e837207f.png"/>

Notes:
- This depends on #15630.
- This PR also limits the feature to the WordPress app, meaning it won't be available to the Jetpack app.
- No release notes were added just yet. We can do so after we make some refinements to the feature.

### To test

1. If the app is already installed, remove it.
1. Use the Jalapeno APK to install the app.
1. Open the app.
1. On the Main screen, tap the Me button.
1. On the Me screen, go to App Settings > Debug settings.
1. On the Debug Settings screen, make sure the "Features" section contains the `unified_about_enabled` option and it is enabled by default.
1. Smoke test the feature using the instructions from #15630.

## Regression Notes
1. Potential unintended areas of impact
Existing items on the Me screen and Jetpack app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
None. This should be done in a follow-up PR soon.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
