### PR TITLE
Update kotlin version to 1.6.0

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -72,7 +72,6 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
             const val FEATURED_IMAGE_THUMBNAIL_SIZE_DP = 40
         }
 
-        @ExperimentalStdlibApi
         override fun onBind(pageItem: PageItem) {
             (pageItem as Page).let { page ->
                 val indentWidth = DisplayUtils.dpToPx(parent.context, 16 * page.indent)
@@ -187,7 +186,6 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
             }
         }
 
-        @ExperimentalStdlibApi
         private fun showSubtitle(inputDate: Date, author: String?, subtitle: Int?, icon: Int?) {
             val date = if (inputDate == Date(0)) Date() else inputDate
             val stringDate = DateTimeUtils.javaDateToTimeSpan(date, parent.context)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -1,3 +1,4 @@
+@file:Suppress("MultiLineIfElse")
 package org.wordpress.android.ui.pages
 
 import android.graphics.drawable.Drawable
@@ -39,7 +40,6 @@ import org.wordpress.android.viewmodel.uistate.ProgressBarUiState.Indeterminate
 import java.util.Date
 import java.util.Locale
 
-@Suppress("MultiLineIfElse")
 sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layout: Int) :
         RecyclerView.ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
     abstract fun onBind(pageItem: PageItem)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
@@ -109,7 +109,7 @@ constructor(
         } else {
             val header = Header(R.string.stats_author_label, R.string.stats_author_views_label)
             items.add(header)
-            val maxViews = domainModel.authors.maxBy { it.views }?.views ?: 0
+            val maxViews = domainModel.authors.maxByOrNull { it.views }?.views ?: 0
             domainModel.authors.forEachIndexed { index, author ->
                 val headerItem = ListItemWithIcon(
                         iconUrl = author.avatarUrl,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
@@ -112,7 +112,7 @@ constructor(
         } else {
             val header = Header(R.string.stats_posts_and_pages_title_label, R.string.stats_posts_and_pages_views_label)
             items.add(header)
-            val maxViews = domainModel.views.maxBy { it.views }?.views ?: 0
+            val maxViews = domainModel.views.maxByOrNull { it.views }?.views ?: 0
             items.addAll(domainModel.views.mapIndexed { index, viewsModel ->
                 val icon = when (viewsModel.type) {
                     POST -> R.drawable.ic_posts_white_24dp

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCase.kt
@@ -54,7 +54,6 @@ class MostPopularInsightsUseCase
         return listOf(buildTitle(), Empty())
     }
 
-    @ExperimentalStdlibApi
     override fun buildUiModel(domainModel: InsightsMostPopularModel): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
         items.add(buildTitle())

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
@@ -100,7 +100,7 @@ class TagsAndCategoriesUseCase
                     header
             )
             val tagsList = mutableListOf<BlockListItem>()
-            val maxViews = domainModel.tags.maxBy { it.views }?.views ?: 0
+            val maxViews = domainModel.tags.maxByOrNull { it.views }?.views ?: 0
             domainModel.tags.forEachIndexed { index, tag ->
                 when {
                     tag.items.size == 1 -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -83,7 +83,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         val count = if (columnNumber > MIN_COLUMN_COUNT) columnNumber else MIN_COLUMN_COUNT
         val cutEntries = takeEntriesWithinGraphWidth(count, item.entries)
         val mappedEntries = cutEntries.mapIndexed { index, pair -> toBarEntry(pair, index) }
-        val maxYValue = cutEntries.maxBy { it.value }!!.value
+        val maxYValue = cutEntries.maxByOrNull { it.value }!!.value
         val hasData = item.entries.isNotEmpty() && item.entries.any { it.value > 0 }
         val dataSet = if (hasData) {
             buildDataSet(context, mappedEntries)
@@ -272,7 +272,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     }
 
     private fun getHighlightDataSet(context: Context, cut: List<BarEntry>): BarDataSet? {
-        val maxEntry = cut.maxBy { it.y } ?: return null
+        val maxEntry = cut.maxByOrNull { it.y } ?: return null
         val highlightedDataSet = cut.map {
             BarEntry(it.x, maxEntry.y, it.data)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
@@ -15,7 +15,6 @@ class DateUtils @Inject constructor(
     private val contextProvider: ContextProvider,
     private val localeManagerWrapper: LocaleManagerWrapper
 ) {
-    @ExperimentalStdlibApi
     fun getWeekDay(dayOfTheWeek: Int): String {
         val c = Calendar.getInstance()
         c.firstDayOfWeek = Calendar.MONDAY

--- a/WordPress/src/main/java/org/wordpress/android/util/StringExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/StringExtensions.kt
@@ -13,7 +13,6 @@ import java.util.Locale
  *
  * The [capitalizeWithLocaleWithoutLint] is chosen to communicate this issue with the caller.
  */
-@ExperimentalStdlibApi
 @SuppressLint("DefaultLocale")
 fun String.capitalizeWithLocaleWithoutLint(locale: Locale): String {
     return this.capitalize(locale)

--- a/WordPress/src/test/java/org/wordpress/android/CoroutinesUtils.kt
+++ b/WordPress/src/test/java/org/wordpress/android/CoroutinesUtils.kt
@@ -28,7 +28,6 @@ fun testScope() = CoroutineScope(Unconfined)
 
 @InternalCoroutinesApi
 private class TestDispatcher : CoroutineDispatcher(), Delay {
-    @InternalCoroutinesApi
     override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
         continuation.resume(Unit)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilderTest.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.jetpack.restore.builders
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -27,7 +26,6 @@ private const val SERVER_CREDS_MSG_WITH_CLICKABLE_LINK =
         "<a href=\"$SERVER_CREDS_LINK\">Enter your server credentials&lt</a> " +
                 "to enable one click site restores from backups."
 
-@InternalCoroutinesApi
 class RestoreStateListItemBuilderTest : BaseUnitTest() {
     private lateinit var builder: RestoreStateListItemBuilder
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/AddExistingMediaToPostUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/AddExistingMediaToPostUseCaseTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
-import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,7 +18,6 @@ import org.wordpress.android.test
 import org.wordpress.android.ui.posts.editor.EditorTracker
 
 @RunWith(MockitoJUnitRunner::class)
-@UseExperimental(InternalCoroutinesApi::class)
 class AddExistingMediaToPostUseCaseTest : BaseUnitTest() {
     @Test
     fun `addMediaToEditor called on all models returned from loadMediaByRemoteId`() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCaseTest.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.ui.posts.editor.media.GetMediaModelUseCase.CreateMe
 import org.wordpress.android.ui.posts.editor.media.OptimizeMediaUseCase.OptimizeMediaResult
 
 @RunWith(MockitoJUnitRunner::class)
-@UseExperimental(InternalCoroutinesApi::class)
+@OptIn(InternalCoroutinesApi::class)
 class AddLocalMediaToPostUseCaseTest : BaseUnitTest() {
     @Test
     fun `addNewMediaToEditorAsync returns true on success`() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
@@ -35,7 +35,7 @@ import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 
-@UseExperimental(InternalCoroutinesApi::class)
+@OptIn(InternalCoroutinesApi::class)
 class EditorMediaTest : BaseUnitTest() {
     @Test
     fun `advertiseImageOptimisationAndAddMedia shows dialog when shouldAdvertiseImageOptimization is true`() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/GetMediaModelUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/GetMediaModelUseCaseTest.kt
@@ -24,7 +24,7 @@ import org.wordpress.android.util.MediaUtilsWrapper
 import java.io.File
 
 @RunWith(MockitoJUnitRunner::class)
-@UseExperimental(InternalCoroutinesApi::class)
+@OptIn(InternalCoroutinesApi::class)
 class GetMediaModelUseCaseTest : BaseUnitTest() {
     @Test
     fun `loadMediaByLocalId loads models from db and returns them`() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/OptimizeMediaUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/OptimizeMediaUseCaseTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.android.ui.posts.editor.EditorTracker
 import org.wordpress.android.util.MediaUtilsWrapper
 
 @RunWith(MockitoJUnitRunner::class)
-@UseExperimental(InternalCoroutinesApi::class)
+@OptIn(InternalCoroutinesApi::class)
 class OptimizeMediaUseCaseTest : BaseUnitTest() {
     @Test
     fun `Uri filtered out when getRealPathFromURI returns null`() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCaseTest.kt
@@ -44,7 +44,6 @@ class MostPopularInsightsUseCaseTest : BaseUnitTest() {
     private val hour = 20
     private val highestHourPercent = 25.5
     private val hourString = "8:00 PM"
-    @ExperimentalStdlibApi
     @InternalCoroutinesApi
     @Before
     fun setUp() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaTest.kt
@@ -27,7 +27,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.viewmodel.Event
 
-@UseExperimental(InternalCoroutinesApi::class)
+@OptIn(InternalCoroutinesApi::class)
 class StoryEditorMediaTest : BaseUnitTest() {
     @Test
     fun `advertiseImageOptimisationAndAddMedia shows dialog when shouldAdvertiseImageOptimization is true`() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -21,7 +21,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions
 import org.junit.Rule
 import org.junit.Test
@@ -495,7 +494,6 @@ class UploadStarterTest {
         whenever(pageStore.getPagesWithLocalChanges(siteModel)).thenReturn(listOf())
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     private fun createUploadStarter(
         connectionStatus: LiveData<ConnectionStatus> = createConnectionStatusLiveData(null),
         uploadServiceFacade: UploadServiceFacade = this.uploadServiceFacade,

--- a/WordPress/src/test/java/org/wordpress/android/util/NoDelayCoroutineDispatcher.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/NoDelayCoroutineDispatcher.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.InternalCoroutinesApi
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 
-@UseExperimental(InternalCoroutinesApi::class)
+@OptIn(InternalCoroutinesApi::class)
 class NoDelayCoroutineDispatcher : CoroutineDispatcher(), Delay {
     override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
         continuation.resume(Unit)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/history/HistoryViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/history/HistoryViewModelTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -74,7 +73,6 @@ class HistoryViewModelTest {
         assertThat(viewModel.listStatus.value).isEqualTo(HistoryListStatus.DONE)
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     private fun createHistoryVieWModel() = HistoryViewModel(
             dispatcher = dispatcher,
             resourceProvider = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -32,7 +32,7 @@ class PostListViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: PostListViewModel
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     @Before
     fun setUp() {
         val listStore = mock<ListStore>()

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,11 @@ buildscript {
     }
 
     dependencies {
+        // Fixes "R8: Unexpected error during rewriting of Kotlin metadata for class ..." issue in AGP
+        // See: https://issuetracker.google.com/issues/194915678
+        classpath 'com.android.tools:r8:3.0.73'
         classpath 'com.android.tools.build:gradle:4.2.2'
+
         classpath 'com.automattic.android:fetchstyle:1.1'
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,7 @@
 buildscript {
-    ext.kotlinVersion = '1.4.20'
-    ext.serializationVersion = '1.0-M1-1.4.0-rc'
+    ext.kotlinVersion = '1.6.0'
     ext.navComponentVersion = '2.3.5'
-    ext.kotlin_coroutines_version = '1.3.9'
-    ext.coroutinesVersion = '1.3.9'
-    ext.kotlin_ktx_version = '1.2.0'
+    ext.coroutinesVersion = '1.5.2'
     ext.wordPressUtilsVersion = '2.2.0'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
@@ -132,7 +129,7 @@ ext {
     coroutinesVersion = '1.3.9'
     androidxWorkVersion = "2.4.0"
 
-    daggerVersion = '2.29.1'
+    daggerVersion = '2.40.3'
     fluxCVersion = '1.31.0'
 
     appCompatVersion = '1.0.2'

--- a/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigCheckBuilder.kt
+++ b/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigCheckBuilder.kt
@@ -11,7 +11,6 @@ import com.squareup.kotlinpoet.TypeSpec
 import java.util.Locale
 
 class RemoteConfigCheckBuilder(private val remoteFeatures: List<TypeName>) {
-    @ExperimentalStdlibApi
     fun getContent(): FileSpec {
         val remoteFeaturesWithNames = remoteFeatures.map {
             it.toString()

--- a/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigProcessor.kt
+++ b/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigProcessor.kt
@@ -16,7 +16,6 @@ import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
 import javax.tools.Diagnostic.Kind
 
-@ExperimentalStdlibApi
 @AutoService(Processor::class) // For registering the service
 @SupportedSourceVersion(SourceVersion.RELEASE_8) // to support Java 8
 @SupportedAnnotationTypes(


### PR DESCRIPTION
This PR updates kotlin to the latest version `1.6.0`. We had some failures related to the kotlin version today in #15641 and instead of addressing that with a temporary solution, I decided to put in the time to update to the latest version. Here is a summary of the changes:

* Updates `kotlinVersion` to `1.6.0` & `coroutinesVersion` to `1.5.2`
* Updates `daggerVersion` to `2.40.3` to fix build errors due to kotlin version update
* Specifies `com.android.tools:r8` version to fix this issue: https://issuetracker.google.com/issues/194915678
* Replaces deprecated [maxBy](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/max-by.html) with `maxByOrNull`
* Removes `ExperimentalStdlibApi` annotation as it's no longer necessary in our case
* Removes `InternalCoroutinesApi` & `ExperimentalCoroutinesApi` annotations from a few classes where they weren't necessary (I don't think I got them all, but I didn't want to sink more time into this PR)
* Replaces deprecated [UseExperimental](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-use-experimental/) with `OptIn`

**To test:**
Smoke test the app. It's unlikely that these changes will have any impact on the application as the changes should be limited to compilation. Unfortunately there is no good way to verify that, so I think all we can do is smoke test the app and address anything that might come up in the future.

## Regression Notes
1. Potential unintended areas of impact
* Compile errors that might not be covered by our regular CI integration (such as release builds)
* Possibly some issues in the app, but I think this is very unlikely and there is no specific area to focus

2. What I did to test those areas of impact (or what existing automated tests I relied on)
* Smoke tested the app and mainly focused on getting successful builds in CI & local environment.

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
