### PR TITLE
Build: Update kotlin and coroutines to 1.5.32 and 1.5.2 respectively (on release branch)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
@@ -29,7 +29,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListI
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.EMPTY_SPACE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.NORMAL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.TextStyle.LIGHT
-import org.wordpress.android.ui.utils.ListItemInteraction.Companion.create
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularStatefulUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
@@ -40,6 +39,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.stats.refresh.utils.getBarWidth
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
+import org.wordpress.android.ui.utils.ListItemInteraction.Companion.create
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
 import javax.inject.Inject
@@ -109,7 +109,7 @@ constructor(
         } else {
             val header = Header(R.string.stats_author_label, R.string.stats_author_views_label)
             items.add(header)
-            val maxViews = domainModel.authors.maxBy { it.views }?.views ?: 0
+            val maxViews = domainModel.authors.maxByOrNull { it.views }?.views ?: 0
             domainModel.authors.forEachIndexed { index, author ->
                 val headerItem = ListItemWithIcon(
                         iconUrl = author.avatarUrl,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
@@ -6,8 +6,8 @@ import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel
-import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType.HOMEPAGE
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType.ATTACHMENT
+import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType.HOMEPAGE
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType.OTHER
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType.PAGE
 import org.wordpress.android.fluxc.model.stats.time.PostAndPageViewsModel.ViewsType.POST
@@ -16,8 +16,8 @@ import org.wordpress.android.fluxc.store.StatsStore.TimeStatsType.POSTS_AND_PAGE
 import org.wordpress.android.fluxc.store.stats.time.PostAndPageViewsStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.stats.StatsConstants.ITEM_TYPE_HOME_PAGE
 import org.wordpress.android.ui.stats.StatsConstants.ITEM_TYPE_ATTACHMENT
+import org.wordpress.android.ui.stats.StatsConstants.ITEM_TYPE_HOME_PAGE
 import org.wordpress.android.ui.stats.StatsConstants.ITEM_TYPE_POST
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPostDetailStats
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPostsAndPages
@@ -30,7 +30,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
-import org.wordpress.android.ui.utils.ListItemInteraction.Companion.create
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularStatelessUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
@@ -40,6 +39,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.stats.refresh.utils.getBarWidth
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
+import org.wordpress.android.ui.utils.ListItemInteraction.Companion.create
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
 import javax.inject.Inject
@@ -112,7 +112,7 @@ constructor(
         } else {
             val header = Header(R.string.stats_posts_and_pages_title_label, R.string.stats_posts_and_pages_views_label)
             items.add(header)
-            val maxViews = domainModel.views.maxBy { it.views }?.views ?: 0
+            val maxViews = domainModel.views.maxByOrNull { it.views }?.views ?: 0
             items.addAll(domainModel.views.mapIndexed { index, viewsModel ->
                 val icon = when (viewsModel.type) {
                     POST -> R.drawable.ic_posts_white_24dp

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TagsAndCategoriesUseCase.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Heade
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.TextStyle.LIGHT
-import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TagsAndCategoriesUseCase.TagsAndCategoriesUiState
@@ -35,6 +34,7 @@ import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.stats.refresh.utils.getBarWidth
+import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
@@ -100,7 +100,7 @@ class TagsAndCategoriesUseCase
                     header
             )
             val tagsList = mutableListOf<BlockListItem>()
-            val maxViews = domainModel.tags.maxBy { it.views }?.views ?: 0
+            val maxViews = domainModel.tags.maxByOrNull { it.views }?.views ?: 0
             domainModel.tags.forEachIndexed { index, tag ->
                 when {
                     tag.items.size == 1 -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -83,7 +83,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         val count = if (columnNumber > MIN_COLUMN_COUNT) columnNumber else MIN_COLUMN_COUNT
         val cutEntries = takeEntriesWithinGraphWidth(count, item.entries)
         val mappedEntries = cutEntries.mapIndexed { index, pair -> toBarEntry(pair, index) }
-        val maxYValue = cutEntries.maxBy { it.value }!!.value
+        val maxYValue = cutEntries.maxByOrNull { it.value }!!.value
         val hasData = item.entries.isNotEmpty() && item.entries.any { it.value > 0 }
         val dataSet = if (hasData) {
             buildDataSet(context, mappedEntries)
@@ -272,7 +272,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     }
 
     private fun getHighlightDataSet(context: Context, cut: List<BarEntry>): BarDataSet? {
-        val maxEntry = cut.maxBy { it.y } ?: return null
+        val maxEntry = cut.maxByOrNull { it.y } ?: return null
         val highlightedDataSet = cut.map {
             BarEntry(it.x, maxEntry.y, it.data)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,7 @@
 buildscript {
-    ext.kotlinVersion = '1.4.20'
-    ext.serializationVersion = '1.0-M1-1.4.0-rc'
+    ext.kotlinVersion = '1.5.32'
+    ext.coroutinesVersion = '1.5.2'
     ext.navComponentVersion = '2.3.5'
-    ext.kotlin_coroutines_version = '1.3.9'
-    ext.coroutinesVersion = '1.3.9'
-    ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '2.2.0'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'


### PR DESCRIPTION
Cherry-pick of the compiler/kotlin fix from https://github.com/wordpress-mobile/WordPress-Android/pull/15646 to also apply it on the `release/18.8` branch.

This fixes the following compilation error which started to appear recently:
```
e: The binary version of its metadata is 1.6.0, expected version is 1.4.2.
```

I am still unsure why [this started to fail building on `release/18.8` branch too today](https://buildkite.com/wordpress-mobile/wordpress-android/builds/2239#60a9417c-2ed9-4188-b0b8-028179b3cadc)… while it _did_ build (locally and on CI, both [Buildkite/lint](https://buildkite.com/wordpress-mobile/wordpress-android/builds/2194#6543643b-e2ec-4f5b-9c3b-daa292a9e421) and [CircleCI/beta rc-1](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/27823/workflows/184d92dd-68f7-4278-af5f-80bb4545f386)) without any issue on Monday… and no new commit was added on `release/18.8` in between. If anyone has any clue, I'm curious.