### PR TITLE
My Site Dashboard [Phase 2]: Fix Failing Connected Test due to New API Endpoint

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
@@ -44,7 +44,12 @@ class MySiteSourceManager @Inject constructor(
 
     fun build(coroutineScope: CoroutineScope, siteLocalId: Int?): List<LiveData<out PartialState>> {
         return if (siteLocalId != null) {
-            mySiteSources.map { source -> source.build(coroutineScope, siteLocalId).distinctUntilChanged() }
+            if (mySiteDashboardPhase2FeatureConfig.isEnabled()) {
+                mySiteSources.map { source -> source.build(coroutineScope, siteLocalId).distinctUntilChanged() }
+            } else {
+                mySiteSources.filterNot(CardsSource::class.java::isInstance)
+                        .map { source -> source.build(coroutineScope, siteLocalId).distinctUntilChanged() }
+            }
         } else {
             mySiteSources.filterIsInstance(SiteIndependentSource::class.java)
                     .map { source -> source.build(coroutineScope).distinctUntilChanged() }


### PR DESCRIPTION
Parent: #15498

This PR implements building sources while filtering for cards source. Before this update, although the dashboard cards was not shown on UI, that is when the `Phase 2` feature flag was off, the `CardsSource` was anyway building, thus fetching dashboard cards from the network, persisting and retrieving them from the database. With this update, non of that will happen as the `CardsSource` will be filtered out by the `MySiteSourceManager` to begin with.

-----

To test (`Phase 2` ON):
- Go to `My Site` -> `Me` -> `App Settings` -> `Debug Settings` configuration.
- Turn-on the `MySiteDashboardPhase2FeatureConfig` feature.
- Relaunch the app.
- Note that on the `My Site` tab, the `Dashboard Cards` for `Posts` are being displayed.
- Open `Logcat` and verify that the `D/WordPress-API: CardsStore: fetchCards` is present on the logs.

To test (`Phase 2` OFF):
- Go to `My Site` -> `Me` -> `App Settings` -> `Debug Settings` configuration.
- Turn-off the `MySiteDashboardPhase2FeatureConfig` feature.
- Relaunch the app.
- Note that on the `My Site` tab, the `Dashboard Cards` for `Posts` are not being displayed.
- Open `Logcat` and verify that the `D/WordPress-API: CardsStore: fetchCards` is not present on the logs.
- Also, verify that no network request is being made hitting the `/sites/$site/dashboard/cards` API endpoint, or that no data is persisted on the `wp-android-database/DashboardCards` database table.

To test (Connected Tests):
- Trigger the connected test on this PR.
- Verify all connected tests are successful.

-----

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
