### PR TITLE
My Site Dashboard - Phase 2 - Fix nested scrolling

### DIFF
--- a/WordPress/src/main/res/layout/my_site_post_card_with_post_items.xml
+++ b/WordPress/src/main/res/layout/my_site_post_card_with_post_items.xml
@@ -22,6 +22,7 @@
             android:id="@+id/post_items"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:nestedScrollingEnabled="false"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Parent #15625

This PR fixes scrolling behavior by disabling nested scrolling for the post items in a post card.

### To test

Prerequisite:

- Go to `My Site` -> `Me` -> `App Settings` -> `Test Feature Configuration`.
- Turn the `MySiteDashboardPhase2FeatureConfig` feature flag ON.
- Relaunch the app.


1. Select a site with a few `draft` or `scheduled` posts.
2. Scroll the list by dragging a post item from the `draft` or `scheduled` post card.
3. Notice that the list scrolls, unlike the previous state where the list did not scroll due to the nested scrolling enabled state.  

## Regression Notes
1. Potential unintended areas of impact
N/A 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A 

3. What automated tests I added (or what prevented me from doing so)
N/A 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
