### PR TITLE
My Site Dashboard [Phase 2]: Format Date for Scheduled Posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -12,8 +12,11 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBu
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
+import java.text.SimpleDateFormat
+import java.util.Date
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 class PostCardBuilder @Inject constructor(
     private val localeManagerWrapper: LocaleManagerWrapper
 ) {
@@ -97,10 +100,17 @@ class PostCardBuilder @Inject constructor(
     private fun List<PostCardModel>.mapToScheduledPostItems(onPostItemClick: (postId: Int) -> Unit) = map { post ->
         PostItem(
                 title = constructPostTitle(post.title),
-                excerpt = UiStringText(post.date.toString()), // TODO: ashiagr - format date
+                excerpt = UiStringText(constructPostDate(post.date)),
                 featuredImageUrl = post.featuredImage,
                 isTimeIconVisible = true,
                 onClick = { onPostItemClick.invoke(post.id) }
         )
+    }
+
+    private fun constructPostDate(date: Date) =
+            SimpleDateFormat(MONTH_DAY_FORMAT, localeManagerWrapper.getLocale()).format(date)
+
+    companion object {
+        private const val MONTH_DAY_FORMAT = "MMM d"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -11,9 +11,12 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardW
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.LocaleManagerWrapper
 import javax.inject.Inject
 
-class PostCardBuilder @Inject constructor() {
+class PostCardBuilder @Inject constructor(
+    private val localeManagerWrapper: LocaleManagerWrapper
+) {
     fun build(params: PostCardBuilderParams): List<PostCard> = mutableListOf<PostCard>().apply {
         val posts = params.posts
         posts?.hasPublished?.takeIf { !posts.hasDraftsOrScheduledPosts() }

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'develop-6b043a14779528c6badf0a7e54071c32ec2b48ae'
+    fluxCVersion = 'develop-7df10d4eca3c2587309db4ccb03e78dafe94d84b'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Parent: #15200

This PR implements the date excerpt on scheduled posts by formatting the date.

PS: In case you are wondering about Zeplin showing a different date format, this newly date format was discussed and agreed with design, which matches the date format on the posts screen.

-----

Prerequisite:

- Go to `My Site` -> `Me` -> `App Settings` -> `Debug Settings` configuration.
- Turn-on the `MySiteDashboardPhase2FeatureConfig` feature.
- Relaunch the app.

-----

To test:
- If you don't have a scheduled post already, create one.
- Note that on the `My Site` tab, on the `Upcoming scheduled posts` card, any schedule post that is shown within has its date formatted according to the `MMM d` month/day format.
- Also, verify that this date format match the format within the `Posts` screen, and more scecificaly the `SCHEDULED` tab.

-----

Merge instructions:

- [x] Wait for the accompanying [WordPress-FluxC-Android#2207](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2207) PR to be merged.
- [x] Update `fluxcVersion` with the once that includes the above FluxC solution (with either the develop hash or pointing to the newest release). PS: This PR will still show the wrong date until this step is complete.
- [x] Remove the [Status] Not Ready for Merge label.
- [x] Merge this PR.

-----

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` sections above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
