### PR TITLE
Making comment service able to fetch a reduced set of comments.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -13,6 +13,9 @@ public class ReaderConstants {
     // max # top-level comments to request when updating comments
     public static final int READER_MAX_COMMENTS_TO_REQUEST = 20;
 
+    // # top-level comments to request when updating comments snippet in post details
+    public static final int READER_COMMENTS_TO_REQUEST_FOR_POST_SNIPPET = 1;
+
     public static final int READER_MAX_USERS_TO_DISPLAY = 500; // max # users to show in ReaderUserListActivity
     public static final long READER_AUTO_UPDATE_DELAY_MINUTES = 10; // 10 minute delay between automatic updates
     public static final int READER_MAX_RECOMMENDED_TO_REQUEST = 20; // max # of recommended blogs to request

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -17,6 +17,11 @@ import org.wordpress.android.util.StringUtils;
  * Reader-related EventBus event classes
  */
 public class ReaderEvents {
+    public enum UpdateCommentsScenario {
+        COMMENT_SNIPPET,
+        GENERIC
+    }
+
     private ReaderEvents() {
         throw new AssertionError();
     }
@@ -188,17 +193,61 @@ public class ReaderEvents {
     }
 
     public static class UpdateCommentsStarted {
+        private final UpdateCommentsScenario mScenario;
+        private final long mBlogId;
+        private final long mPostId;
+
+        public UpdateCommentsStarted(UpdateCommentsScenario scenario, long blogId, long postId) {
+            mScenario = scenario;
+            mBlogId = blogId;
+            mPostId = postId;
+        }
+
+        public UpdateCommentsScenario getScenario() {
+            return mScenario;
+        }
+
+        public long getBlogId() {
+            return mBlogId;
+        }
+
+        public long getPostId() {
+            return mPostId;
+        }
     }
 
     public static class UpdateCommentsEnded {
         private final ReaderActions.UpdateResult mResult;
+        private final UpdateCommentsScenario mScenario;
+        private final long mBlogId;
+        private final long mPostId;
 
-        public UpdateCommentsEnded(ReaderActions.UpdateResult result) {
+        public UpdateCommentsEnded(
+                ReaderActions.UpdateResult result,
+                UpdateCommentsScenario scenario,
+                long blogId,
+                long postId
+        ) {
             mResult = result;
+            mScenario = scenario;
+            mBlogId = blogId;
+            mPostId = postId;
         }
 
         public ReaderActions.UpdateResult getResult() {
             return mResult;
+        }
+
+        public UpdateCommentsScenario getScenario() {
+            return mScenario;
+        }
+
+        public long getBlogId() {
+            return mBlogId;
+        }
+
+        public long getPostId() {
+            return mPostId;
         }
     }
 


### PR DESCRIPTION
Part of  #15660

This PR makes the comment service used to fetch comments content for a post, able to fetch a page lenght suitable for comment snippet scenario (namely only 1 comment is fetched).

## To test
In this PR we want to check that the service behaviour didn't change. Side test with a previous version of the app that the threaded comments in the reader behaves as before (comment number, comment content, pagination etc...). Smoke test like, reply and whatever interaction you may think of with comments :) 

## Regression Notes
1. Potential unintended areas of impact
Reader threaded comments fetching

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Logic checking and manual testing.

3. What automated tests I added (or what prevented me from doing so)
The code logic is in a service and not easy to automated test. Refactor of that service was not in scope here.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
