### PR TITLE
Comments snippet under post.

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -116,6 +116,7 @@ android {
         buildConfigField "boolean", "UNIFIED_COMMENTS_DETAILS", "false"
         buildConfigField "boolean", "UNIFIED_THREADED_COMMENTS", "false"
         buildConfigField "boolean", "UNIFIED_ABOUT", "false"
+        buildConfigField "boolean", "COMMENTS_SNIPPET", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
@@ -5,6 +5,8 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
 
+import androidx.annotation.Nullable;
+
 import org.wordpress.android.models.ReaderComment;
 import org.wordpress.android.models.ReaderCommentList;
 import org.wordpress.android.models.ReaderPost;
@@ -138,6 +140,30 @@ public class ReaderCommentTable {
         String[] args = {Long.toString(post.blogId), Long.toString(post.postId)};
         Cursor c = ReaderDatabase.getReadableDb().rawQuery(
                 "SELECT * FROM tbl_comments WHERE blog_id=? AND post_id=? ORDER BY timestamp", args);
+        try {
+            ReaderCommentList comments = new ReaderCommentList();
+            if (c.moveToFirst()) {
+                do {
+                    comments.add(getCommentFromCursor(c));
+                } while (c.moveToNext());
+            }
+            return comments;
+        } finally {
+            SqlUtils.closeCursor(c);
+        }
+    }
+
+    @Nullable
+    public static ReaderCommentList getCommentsForPostSnippet(ReaderPost post, int limit) {
+        if (post == null) {
+            return new ReaderCommentList();
+        }
+
+        String[] args = {Long.toString(post.blogId), Long.toString(post.postId), Integer.toString(limit)};
+        Cursor c = ReaderDatabase.getReadableDb().rawQuery(
+                "SELECT * FROM tbl_comments WHERE blog_id=? AND post_id=? AND parent_id=0 ORDER BY timestamp LIMIT ?",
+                args
+        );
         try {
             ReaderCommentList comments = new ReaderCommentList();
             if (c.moveToFirst()) {

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -180,6 +180,7 @@ import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
 import org.wordpress.android.ui.reader.ReaderSearchActivity;
 import org.wordpress.android.ui.reader.ReaderSubsActivity;
 import org.wordpress.android.ui.reader.SubfilterBottomSheetFragment;
+import org.wordpress.android.ui.reader.adapters.CommentSnippetAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderBlogAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderCommentAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
@@ -720,6 +721,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(UnifiedCommentDetailsFragment object);
 
     void inject(UnifiedAboutActivity object);
+
+    void inject(CommentSnippetAdapter object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -73,4 +73,7 @@ public class RequestCodes {
 
     // Reader Interests
     public static final int READER_INTERESTS = 9001;
+
+    // Comments related
+    public static final int READER_FOLLOW_CONVERSATION = 10000;
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/FollowConversationUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/FollowConversationUiState.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.reader
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
-const val FOLLOW_COMMENTS_UI_STATE_FLAGS_KEY = "follow-comments-ui-state-flags-key"
+const val FOLLOW_CONVERSATION_UI_STATE_FLAGS_KEY = "follow-conversation-ui-state-flags-key"
 
 data class FollowConversationUiState(
     val flags: FollowConversationStatusFlags,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -11,6 +11,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.ActivityOptionsCompat;
+import androidx.fragment.app.Fragment;
 
 import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
@@ -230,6 +231,38 @@ public class ReaderActivityLauncher {
      */
     public static void showReaderComments(Context context, long blogId, long postId, DirectOperation
             directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment) {
+        Intent intent = createShowReaderCommentsIntent(
+                context,
+                blogId,
+                postId,
+                directOperation,
+                commentId,
+                interceptedUri,
+                isNewThreadedComment
+        );
+        context.startActivity(intent);
+    }
+
+    public static void showReaderCommentsForResult(Fragment fragment, long blogId, long postId, boolean isNewThreadedComment) {
+        showReaderCommentsForResult(fragment, blogId, postId, null, 0, null, isNewThreadedComment);
+    }
+
+    public static void showReaderCommentsForResult(Fragment fragment, long blogId, long postId, DirectOperation
+            directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment) {
+        Intent intent = createShowReaderCommentsIntent(
+                fragment.getContext(),
+                blogId,
+                postId,
+                directOperation,
+                commentId,
+                interceptedUri,
+                isNewThreadedComment
+        );
+        fragment.startActivityForResult(intent, RequestCodes.READER_FOLLOW_CONVERSATION);
+    }
+
+    private static Intent createShowReaderCommentsIntent(Context context, long blogId, long postId, DirectOperation
+            directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment) {
         Intent intent = new Intent(
                 context,
                 isNewThreadedComment ? ThreadedCommentsActivity.class : ReaderCommentListActivity.class
@@ -239,7 +272,8 @@ public class ReaderActivityLauncher {
         intent.putExtra(ReaderConstants.ARG_DIRECT_OPERATION, directOperation);
         intent.putExtra(ReaderConstants.ARG_COMMENT_ID, commentId);
         intent.putExtra(ReaderConstants.ARG_INTERCEPTED_URI, interceptedUri);
-        context.startActivity(intent);
+
+        return intent;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -231,7 +231,7 @@ public class ReaderActivityLauncher {
      */
     public static void showReaderComments(Context context, long blogId, long postId, DirectOperation
             directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment) {
-        Intent intent = createShowReaderCommentsIntent(
+        Intent intent = buildShowReaderCommentsIntent(
                 context,
                 blogId,
                 postId,
@@ -254,7 +254,7 @@ public class ReaderActivityLauncher {
 
     public static void showReaderCommentsForResult(Fragment fragment, long blogId, long postId, DirectOperation
             directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment) {
-        Intent intent = createShowReaderCommentsIntent(
+        Intent intent = buildShowReaderCommentsIntent(
                 fragment.getContext(),
                 blogId,
                 postId,
@@ -266,7 +266,7 @@ public class ReaderActivityLauncher {
         fragment.startActivityForResult(intent, RequestCodes.READER_FOLLOW_CONVERSATION);
     }
 
-    private static Intent createShowReaderCommentsIntent(Context context, long blogId, long postId, DirectOperation
+    private static Intent buildShowReaderCommentsIntent(Context context, long blogId, long postId, DirectOperation
             directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment) {
         Intent intent = new Intent(
                 context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -243,7 +243,12 @@ public class ReaderActivityLauncher {
         context.startActivity(intent);
     }
 
-    public static void showReaderCommentsForResult(Fragment fragment, long blogId, long postId, boolean isNewThreadedComment) {
+    public static void showReaderCommentsForResult(
+            Fragment fragment,
+           long blogId,
+           long postId,
+           boolean isNewThreadedComment
+    ) {
         showReaderCommentsForResult(fragment, blogId, postId, null, 0, null, isNewThreadedComment);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -94,7 +94,7 @@ import javax.inject.Inject;
 import static org.wordpress.android.ui.CommentFullScreenDialogFragment.RESULT_REPLY;
 import static org.wordpress.android.ui.CommentFullScreenDialogFragment.RESULT_SELECTION_END;
 import static org.wordpress.android.ui.CommentFullScreenDialogFragment.RESULT_SELECTION_START;
-import static org.wordpress.android.ui.reader.FollowConversationUiStateKt.FOLLOW_COMMENTS_UI_STATE_FLAGS_KEY;
+import static org.wordpress.android.ui.reader.FollowConversationUiStateKt.FOLLOW_CONVERSATION_UI_STATE_FLAGS_KEY;
 import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
 import kotlin.Unit;
@@ -500,7 +500,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
                             bellItem.setVisible(uiState.getFlags().isBellMenuVisible());
 
                             setResult(RESULT_OK, new Intent().putExtra(
-                                    FOLLOW_COMMENTS_UI_STATE_FLAGS_KEY,
+                                    FOLLOW_CONVERSATION_UI_STATE_FLAGS_KEY,
                                     uiState.getFlags()
                             ));
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -499,7 +499,10 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
                             followItem.setVisible(uiState.getFlags().isFollowMenuVisible());
                             bellItem.setVisible(uiState.getFlags().isBellMenuVisible());
 
-                            setResult(RESULT_OK, new Intent().putExtra(FOLLOW_COMMENTS_UI_STATE_FLAGS_KEY, uiState.getFlags()));
+                            setResult(
+                                    RESULT_OK,
+                                    new Intent().putExtra(FOLLOW_COMMENTS_UI_STATE_FLAGS_KEY, uiState.getFlags())
+                            );
                         }
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -481,7 +481,9 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
     private fun initViewModel(binding: ReaderFragmentPostDetailBinding, savedInstanceState: Bundle?) {
         viewModel = ViewModelProvider(this, viewModelFactory).get(ReaderPostDetailViewModel::class.java)
-        conversationViewModel = ViewModelProvider(this, viewModelFactory).get(ConversationNotificationsViewModel::class.java)
+        conversationViewModel = ViewModelProvider(this, viewModelFactory).get(
+                ConversationNotificationsViewModel::class.java
+        )
 
         viewModel.uiState.observe(viewLifecycleOwner, {
             uiHelpers.updateVisibility(binding.textError, it.errorVisible)
@@ -537,7 +539,6 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                 manageFollowConversationUiState(uiState, binding)
             })
 
-
             viewModel.commentSnippetState.observe(viewLifecycleOwner, { state ->
                 manageCommentSnippetUiState(state)
             })
@@ -559,7 +560,10 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         viewModel.start(isRelatedPost = isRelatedPost, isFeed = isFeed, interceptedUri = interceptedUri)
     }
 
-    private fun manageFollowConversationUiState(uiState: FollowConversationUiState, binding: ReaderFragmentPostDetailBinding) {
+    private fun manageFollowConversationUiState(
+        uiState: FollowConversationUiState,
+        binding: ReaderFragmentPostDetailBinding
+    ) {
         if (!isAdded) return
 
         with(binding) {
@@ -640,10 +644,13 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         with(requireActivity()) {
             if (this.isFinishing) return@with
 
-            commentsSnippetContainer.visibility = if (commentsSnippetFeatureConfig.isEnabled()) View.VISIBLE else View.GONE
+            commentsSnippetContainer.visibility = if (commentsSnippetFeatureConfig.isEnabled()) {
+                View.VISIBLE
+            } else {
+                View.GONE
+            }
             followConversationContainer.visibility = if (state.showFollowConversation) View.VISIBLE else View.GONE
             commentsNumTitle.text = readerUtilsWrapper.getTextForCommentSnippet(state.commentsNumber)
-
 
             setupCommentSnippetAdapter(this, state.snippetItems)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1181,16 +1181,17 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         val resultListener = ReaderActions.UpdateResultListener { result ->
             val post = viewModel.post
             if (isAdded && post != null) {
+                if (commentsSnippetFeatureConfig.isEnabled()) {
+                    conversationViewModel.onUpdatePost(post.blogId, post.postId)
+                    viewModel.onRefreshCommentsData(post.blogId, post.postId)
+                }
+
                 // if the post has changed, reload it from the db and update the like/comment counts
                 if (result.isNewOrChanged) {
                     viewModel.post = ReaderPostTable.getBlogPost(post.blogId, post.postId, false)
                     viewModel.post?.let {
                         if (likesEnhancementsFeatureConfig.isEnabled()) {
                             viewModel.onRefreshLikersData(it)
-                        }
-                        if (commentsSnippetFeatureConfig.isEnabled()) {
-                            conversationViewModel.onUpdatePost(it.blogId, it.postId)
-                            viewModel.onRefreshCommentsData(it.blogId, it.postId, it.numReplies)
                         }
                         viewModel.onUpdatePost(it)
                     }
@@ -1484,7 +1485,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                         viewModel.onRefreshLikersData(it)
                     }
                     if (commentsSnippetFeatureConfig.isEnabled()) {
-                        viewModel.onRefreshCommentsData(it.blogId, it.postId, it.numReplies)
+                        viewModel.onRefreshCommentsData(it.blogId, it.postId)
                     }
                     viewModel.onRelatedPostsRequested(it)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -648,12 +648,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         with(requireActivity()) {
             if (this.isFinishing) return@with
 
-            commentsSnippetContainer.visibility = if (commentsSnippetFeatureConfig.isEnabled()) {
-                View.VISIBLE
-            } else {
-                View.GONE
-            }
-            followConversationContainer.visibility = if (state.showFollowConversation) View.VISIBLE else View.GONE
+            uiHelpers.updateVisibility(commentsSnippetContainer, commentsSnippetFeatureConfig.isEnabled())
+            uiHelpers.updateVisibility(followConversationContainer, state.showFollowConversation)
             commentsNumTitle.text = readerUtilsWrapper.getTextForCommentSnippet(state.commentsNumber)
 
             setupCommentSnippetAdapter(this, state.snippetItems)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1250,7 +1250,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             RequestCodes.READER_FOLLOW_CONVERSATION -> {
                 if (resultCode == Activity.RESULT_OK && commentsSnippetFeatureConfig.isEnabled() && data != null) {
                     val flags = data.getParcelableExtra<FollowConversationStatusFlags>(
-                            FOLLOW_COMMENTS_UI_STATE_FLAGS_KEY
+                            FOLLOW_CONVERSATION_UI_STATE_FLAGS_KEY
                     )
                     flags?.let {
                         conversationViewModel.onUserNavigateFromComments(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.reader
 
 import android.app.Activity
 import android.app.DownloadManager
+import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
@@ -32,11 +33,13 @@ import androidx.core.graphics.BlendModeColorFilterCompat
 import androidx.core.graphics.BlendModeCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.Factory
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.facebook.shimmer.ShimmerFrameLayout
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -75,6 +78,7 @@ import org.wordpress.android.ui.reader.ReaderPostPagerActivity.DirectOperation
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.actions.ReaderActions
 import org.wordpress.android.ui.reader.actions.ReaderPostActions
+import org.wordpress.android.ui.reader.adapters.CommentSnippetAdapter
 import org.wordpress.android.ui.reader.adapters.FACE_ITEM_LEFT_OFFSET_DIMEN
 import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter
 import org.wordpress.android.ui.reader.adapters.ReaderPostLikersAdapter
@@ -89,7 +93,9 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
 import org.wordpress.android.ui.reader.viewholders.PostLikerItemDecorator
+import org.wordpress.android.ui.reader.viewmodels.ConversationNotificationsViewModel
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.CommentSnippetUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.TrainOfFacesUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ErrorUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.LoadingUiState
@@ -101,6 +107,7 @@ import org.wordpress.android.ui.reader.views.ReaderWebView
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderCustomViewListener
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewPageFinishedListener
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewUrlClickListener
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AppLog
@@ -113,6 +120,7 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.WPPermissionUtils.READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE
 import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
+import org.wordpress.android.util.config.CommentsSnippetFeatureConfig
 import org.wordpress.android.util.config.LikesEnhancementsFeatureConfig
 import org.wordpress.android.util.config.UnifiedThreadedCommentsFeatureConfig
 import org.wordpress.android.util.getColorFromAttribute
@@ -162,6 +170,11 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private lateinit var likeEmptyStateText: TextView
     private lateinit var likeFacesRecycler: RecyclerView
 
+    private lateinit var commentsSnippetContainer: View
+    private lateinit var followConversationContainer: View
+    private lateinit var commentsNumTitle: TextView
+    private lateinit var commentSnippetRecycler: RecyclerView
+
     private lateinit var excerptFooter: ViewGroup
     private lateinit var textExcerptFooter: TextView
 
@@ -187,6 +200,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private var fileForDownload: String? = null
 
     private lateinit var viewModel: ReaderPostDetailViewModel
+    private lateinit var conversationViewModel: ConversationNotificationsViewModel
 
     @Inject internal lateinit var accountStore: AccountStore
     @Inject internal lateinit var siteStore: SiteStore
@@ -203,6 +217,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     @Inject lateinit var likesEnhancementsFeatureConfig: LikesEnhancementsFeatureConfig
     @Inject lateinit var contextProvider: ContextProvider
     @Inject lateinit var mUnifiedThreadedCommentsFeatureConfig: UnifiedThreadedCommentsFeatureConfig
+    @Inject lateinit var commentsSnippetFeatureConfig: CommentsSnippetFeatureConfig
 
     private val mSignInClickListener = View.OnClickListener {
         EventBus.getDefault()
@@ -287,6 +302,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         initScrollView(view)
         initWebView(view)
         initLikeFacesTrain(view)
+        initCommentSnippetView(view)
         initExcerptFooter(view)
         initRelatedPostsView(view)
         initLayoutFooter(view)
@@ -304,7 +320,14 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         val swipeToRefreshOffset = resources.getDimensionPixelSize(R.dimen.toolbar_content_offset)
         swipeRefreshLayout.setProgressViewOffset(false, 0, swipeToRefreshOffset)
 
-        swipeToRefreshHelper = buildSwipeToRefreshHelper(swipeRefreshLayout) { if (isAdded) updatePost() }
+        swipeToRefreshHelper = buildSwipeToRefreshHelper(swipeRefreshLayout) {
+            if (isAdded) {
+                if (commentsSnippetFeatureConfig.isEnabled()) {
+                    conversationViewModel.onRefresh()
+                }
+                updatePost()
+            }
+        }
     }
 
     private fun initAppBar(view: View) {
@@ -356,6 +379,13 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         likeFacesRecycler = view.findViewById(R.id.likes_recycler)
         likeProgressBar = view.findViewById(R.id.progress_bar)
         likeEmptyStateText = view.findViewById(R.id.empty_state_text)
+    }
+
+    private fun initCommentSnippetView(view: View) {
+        commentsSnippetContainer = view.findViewById(R.id.comments_snippet)
+        commentsNumTitle = view.findViewById(R.id.comments_number_title)
+        followConversationContainer = view.findViewById(R.id.follow_conversation_container)
+        commentSnippetRecycler = view.findViewById(R.id.comments_recycler)
     }
 
     private fun initExcerptFooter(view: View) {
@@ -414,6 +444,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         val binding = ReaderFragmentPostDetailBinding.bind(view)
 
         initLikeFacesRecycler(savedInstanceState)
+        initCommentSnippetRecycler(savedInstanceState)
         initViewModel(binding, savedInstanceState)
         restoreState(savedInstanceState)
         setHasOptionsMenu(true)
@@ -437,8 +468,20 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         likeFacesRecycler.layoutManager = layoutManager
     }
 
+    private fun initCommentSnippetRecycler(savedInstanceState: Bundle?) {
+        if (!commentsSnippetFeatureConfig.isEnabled()) return
+        val layoutManager = LinearLayoutManager(activity)
+
+        savedInstanceState?.getParcelable<Parcelable>(ReaderPostDetailFragment.KEY_COMMENTS_SNIPPET_LIST_STATE)?.let {
+            layoutManager.onRestoreInstanceState(it)
+        }
+
+        commentSnippetRecycler.layoutManager = layoutManager
+    }
+
     private fun initViewModel(binding: ReaderFragmentPostDetailBinding, savedInstanceState: Bundle?) {
         viewModel = ViewModelProvider(this, viewModelFactory).get(ReaderPostDetailViewModel::class.java)
+        conversationViewModel = ViewModelProvider(this, viewModelFactory).get(ConversationNotificationsViewModel::class.java)
 
         viewModel.uiState.observe(viewLifecycleOwner, {
             uiHelpers.updateVisibility(binding.textError, it.errorVisible)
@@ -460,6 +503,46 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             })
         }
 
+        if (commentsSnippetFeatureConfig.isEnabled()) {
+            conversationViewModel.snackbarEvents.observe(viewLifecycleOwner, { event ->
+                if (!isAdded) return@observe
+
+                val fm: FragmentManager = childFragmentManager
+                val bottomSheet =
+                        fm.findFragmentByTag(NOTIFICATIONS_BOTTOM_SHEET_TAG) as? CommentNotificationsBottomSheetFragment
+                if (bottomSheet != null) return@observe
+                event.applyIfNotHandled {
+                    this.showSnackbar(binding)
+                }
+            })
+
+            conversationViewModel.showBottomSheetEvent.observeEvent(viewLifecycleOwner, { showBottomSheetData ->
+                if (!isAdded) return@observeEvent
+
+                val fm: FragmentManager = childFragmentManager
+                var bottomSheet =
+                        fm.findFragmentByTag(NOTIFICATIONS_BOTTOM_SHEET_TAG) as? CommentNotificationsBottomSheetFragment
+                if (showBottomSheetData.show && bottomSheet == null) {
+                    bottomSheet = CommentNotificationsBottomSheetFragment.newInstance(
+                            showBottomSheetData.isReceivingNotifications,
+                            true
+                    )
+                    bottomSheet.show(fm, NOTIFICATIONS_BOTTOM_SHEET_TAG)
+                } else if (!showBottomSheetData.show && bottomSheet != null) {
+                    bottomSheet.dismiss()
+                }
+            })
+
+            conversationViewModel.updateFollowUiState.observe(viewLifecycleOwner, { uiState ->
+                manageFollowConversationUiState(uiState, binding)
+            })
+
+
+            viewModel.commentSnippetState.observe(viewLifecycleOwner, { state ->
+                manageCommentSnippetUiState(state)
+            })
+        }
+
         viewModel.refreshPost.observeEvent(viewLifecycleOwner, {} /* Do nothing */)
 
         viewModel.snackbarEvents.observeEvent(viewLifecycleOwner, { it.showSnackbar(binding) })
@@ -470,7 +553,46 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         val isFeed = bundle?.getBoolean(ReaderConstants.ARG_IS_FEED) ?: false
         val interceptedUri = bundle?.getString(ReaderConstants.ARG_INTERCEPTED_URI)
 
+        if (commentsSnippetFeatureConfig.isEnabled()) {
+            conversationViewModel.start(blogId, postId)
+        }
         viewModel.start(isRelatedPost = isRelatedPost, isFeed = isFeed, interceptedUri = interceptedUri)
+    }
+
+    private fun manageFollowConversationUiState(uiState: FollowConversationUiState, binding: ReaderFragmentPostDetailBinding) {
+        if (!isAdded) return
+
+        with(binding) {
+            val bellItem = commentsSnippet.bellIcon
+            val followContainer = commentsSnippet.followConversationContainer
+
+            val shimmerView: ShimmerFrameLayout = commentsSnippet.shimmerViewContainer
+            val followText = commentsSnippet.followConversation
+            followText.setOnClickListener(
+                    if (uiState.onFollowTapped != null) {
+                        View.OnClickListener { uiState.onFollowTapped.invoke() }
+                    } else {
+                        null
+                    }
+            )
+            bellItem.setOnClickListener {
+                uiState.onManageNotificationsTapped.invoke()
+            }
+            followContainer.isEnabled = uiState.flags.isMenuEnabled
+            followText.isEnabled = uiState.flags.isMenuEnabled
+            bellItem.isEnabled = uiState.flags.isMenuEnabled
+            if (uiState.flags.showMenuShimmer) {
+                if (!shimmerView.isShimmerVisible) {
+                    shimmerView.showShimmer(true)
+                } else if (!shimmerView.isShimmerStarted) {
+                    shimmerView.startShimmer()
+                }
+            } else {
+                shimmerView.hideShimmer()
+            }
+            shimmerView.visibility = if (uiState.flags.isFollowMenuVisible) View.VISIBLE else View.GONE
+            bellItem.visibility = if (uiState.flags.isBellMenuVisible) View.VISIBLE else View.GONE
+        }
     }
 
     private fun manageLikesUiState(state: TrainOfFacesUiState) {
@@ -510,6 +632,34 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                 viewModel.onLikeFacesClicked()
             }
         }
+    }
+
+    private fun manageCommentSnippetUiState(state: CommentSnippetUiState) {
+        if (!isAdded) return
+
+        with(requireActivity()) {
+            if (this.isFinishing) return@with
+
+            commentsSnippetContainer.visibility = if (commentsSnippetFeatureConfig.isEnabled()) View.VISIBLE else View.GONE
+            followConversationContainer.visibility = if (state.showFollowConversation) View.VISIBLE else View.GONE
+            commentsNumTitle.text = readerUtilsWrapper.getTextForCommentSnippet(state.commentsNumber)
+
+
+            setupCommentSnippetAdapter(this, state.snippetItems)
+        }
+    }
+
+    private fun setupCommentSnippetAdapter(context: Context, items: List<CommentSnippetItemState>) {
+        val adapter = commentSnippetRecycler.adapter as? CommentSnippetAdapter ?: CommentSnippetAdapter(
+                context,
+                viewModel.post
+        ).also {
+            commentSnippetRecycler.adapter = it
+        }
+
+        val recyclerViewState = commentSnippetRecycler.layoutManager?.onSaveInstanceState()
+        adapter.loadData(items)
+        commentSnippetRecycler.layoutManager?.onRestoreInstanceState(recyclerViewState)
     }
 
     private fun setupLikeFacesTrain(items: List<TrainOfFacesItem>, loading: Boolean, shouldSkipAnimation: Boolean) {
@@ -597,8 +747,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             is ReaderNavigationEvents.ShowReportPost ->
                 ReaderActivityLauncher.openUrl(context, readerUtilsWrapper.getReportPostUrl(url), OpenUrlType.INTERNAL)
 
-            is ReaderNavigationEvents.ShowReaderComments -> ReaderActivityLauncher.showReaderComments(
-                    context,
+            is ReaderNavigationEvents.ShowReaderComments -> ReaderActivityLauncher.showReaderCommentsForResult(
+                    this@ReaderPostDetailFragment,
                     blogId,
                     postId,
                     mUnifiedThreadedCommentsFeatureConfig.isEnabled()
@@ -842,6 +992,12 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             outState.putString(ReaderConstants.KEY_ERROR_MESSAGE, errorMessage)
         }
 
+        if (commentsSnippetFeatureConfig.isEnabled()) {
+            commentSnippetRecycler?.layoutManager?.let {
+                outState.putParcelable(KEY_COMMENTS_SNIPPET_LIST_STATE, it.onSaveInstanceState())
+            }
+        }
+
         super.onSaveInstanceState(outState)
     }
 
@@ -915,6 +1071,9 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         localRelatedPostsView.visibility = View.GONE
         if (likesEnhancementsFeatureConfig.isEnabled()) {
             likeFacesTrain.visibility = View.GONE
+        }
+        if (commentsSnippetFeatureConfig.isEnabled()) {
+            commentsSnippetContainer.visibility = View.GONE
         }
 
         // clear the webView - otherwise it will remain scrolled to where the user scrolled to
@@ -1022,6 +1181,10 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                         if (likesEnhancementsFeatureConfig.isEnabled()) {
                             viewModel.onRefreshLikersData(it)
                         }
+                        if (commentsSnippetFeatureConfig.isEnabled()) {
+                            conversationViewModel.onUpdatePost(it.blogId, it.postId)
+                            viewModel.onRefreshCommentsData(it.blogId, it.postId, it.numReplies)
+                        }
                         viewModel.onUpdatePost(it)
                     }
                 }
@@ -1071,6 +1234,20 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                             SelectedSiteRepository.UNAVAILABLE
                     ) ?: SelectedSiteRepository.UNAVAILABLE
                     viewModel.onReblogSiteSelected(siteLocalId)
+                }
+            }
+            RequestCodes.READER_FOLLOW_CONVERSATION -> {
+                if (resultCode == Activity.RESULT_OK) {
+                    if (commentsSnippetFeatureConfig.isEnabled()) {
+                        data?.let {
+                            val flags = data.getParcelableExtra<FollowConversationStatusFlags>(
+                                    FOLLOW_COMMENTS_UI_STATE_FLAGS_KEY
+                            )
+                            flags?.let {
+                                conversationViewModel.onUserNavigateFromComments(it)
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -1181,6 +1358,10 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         if (postSlugsResolutionUnderway) {
             AppLog.w(T.READER, "reader post detail > post request already running")
             return
+        }
+
+        if (commentsSnippetFeatureConfig.isEnabled()) {
+            conversationViewModel.onUpdatePost(blogId, postId)
         }
 
         viewModel.onShowPost(blogId = blogId, postId = postId)
@@ -1298,6 +1479,9 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                 viewModel.post?.let {
                     if (likesEnhancementsFeatureConfig.isEnabled()) {
                         viewModel.onRefreshLikersData(it)
+                    }
+                    if (commentsSnippetFeatureConfig.isEnabled()) {
+                        viewModel.onRefreshCommentsData(it.blogId, it.postId, it.numReplies)
                     }
                     viewModel.onRelatedPostsRequested(it)
                 }
@@ -1495,6 +1679,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
     companion object {
         private const val KEY_LIKERS_LIST_STATE = "likers_list_state"
+        private const val KEY_COMMENTS_SNIPPET_LIST_STATE = "comments_snippet_list_state"
+        private const val NOTIFICATIONS_BOTTOM_SHEET_TAG = "NOTIFICATIONS_BOTTOM_SHEET_TAG"
 
         fun newInstance(blogId: Long, postId: Long): ReaderPostDetailFragment {
             return newInstance(false, blogId, postId, null, 0, false, null, null, false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilder.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.reader
 
 import dagger.Reusable
 import org.wordpress.android.R
+import org.wordpress.android.R.dimen
+import org.wordpress.android.R.string
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType
@@ -10,12 +12,24 @@ import org.wordpress.android.ui.reader.models.ReaderSimplePost
 import org.wordpress.android.ui.reader.models.ReaderSimplePostList
 import org.wordpress.android.ui.reader.utils.FeaturedImageUtils
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.reader.utils.ThreadedCommentsUtils
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.CommentSnippetState
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.CommentSnippetState.CommentSnippetData
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.CommentSnippetState.Empty
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.CommentSnippetState.Failure
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.CommentSnippetState.Loading
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.CommentSnippetUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState.ExcerptFooterUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState.ReaderPostFeaturedImageUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState.RelatedPostsUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState.RelatedPostsUiState.ReaderRelatedPostUiState
 import org.wordpress.android.ui.reader.views.ReaderPostDetailsHeaderViewUiStateBuilder
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState.ButtonState
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState.CommentState
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState.LoadingState
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState.TextMessage
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.HtmlUtilsWrapper
 import org.wordpress.android.ui.utils.UiDimen.UIDimenRes
@@ -23,7 +37,11 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.DisplayUtilsWrapper
+import org.wordpress.android.util.GravatarUtilsWrapper
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
@@ -41,6 +59,9 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
     private val contextProvider: ContextProvider,
     private val htmlUtilsWrapper: HtmlUtilsWrapper,
     private val htmlMessageUtils: HtmlMessageUtils,
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
+    private val gravatarUtilsWrapper: GravatarUtilsWrapper,
+    private val threadedCommentsUtils: ThreadedCommentsUtils,
     resourceProvider: ResourceProvider
 ) {
     private val relatedPostFeaturedImageWidth: Int = resourceProvider
@@ -87,6 +108,86 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
             headerLabel = buildRelatedPostsHeaderLabel(blogName = sourcePost.blogName, isGlobal = isGlobal),
             railcarJsonStrings = relatedPosts.map { it.railcarJson }
     )
+
+    fun buildCommentSnippetUiState(
+        commentSnippetState: CommentSnippetState,
+        post: ReaderPost?,
+        onCommentSnippetClicked: (Long, Long) -> Unit
+    ): CommentSnippetUiState {
+        return post?.let { readerPost ->
+            AppLog.d(T.READER, "buildCommentSnippetUiState -> post was not null")
+
+            CommentSnippetUiState(
+                    commentsNumber = readerPost.numReplies,
+                    showFollowConversation = readerPost.isWP && readerPost.isCommentsOpen,
+                    snippetItems = getSnippetItems(commentSnippetState, post, onCommentSnippetClicked)
+            )
+        } ?: run {
+            AppLog.d(T.READER, "buildCommentSnippetUiState -> post was null")
+            CommentSnippetUiState(
+                    snippetItems = listOf(LoadingState),
+                    showFollowConversation = false,
+                    commentsNumber = 0
+            )
+        }
+    }
+
+    private fun getSnippetItems(
+        commentSnippetState: CommentSnippetState,
+        readerPost: ReaderPost,
+        onCommentSnippetClicked: (Long, Long) -> Unit
+    ): List<CommentSnippetItemState> {
+        return when(commentSnippetState) {
+            is CommentSnippetData -> commentSnippetState.comments.map { readerComment ->
+                CommentState(
+                        authorName = readerComment.authorName,
+                        datePublished = dateTimeUtilsWrapper.javaDateToTimeSpan(
+                                dateTimeUtilsWrapper.dateFromIso8601(
+                                        readerComment.published
+                                )
+                        ),
+                        avatarUrl = gravatarUtilsWrapper.fixGravatarUrl(
+                                readerComment.authorAvatar,
+                                contextProvider.getContext().resources.getDimensionPixelSize(dimen.avatar_sz_extra_small)
+                        ),
+                        showAuthorBadge = readerComment.authorId == readerPost.authorId,
+                        commentText = readerComment.text,
+                        isPrivatePost = threadedCommentsUtils.isPrivatePost(readerPost),
+                        blogId = readerComment.blogId,
+                        postId = readerComment.postId,
+                        commentId = readerComment.commentId
+                )
+            } + ButtonState(
+                    buttonText = UiStringRes(string.reader_comments_view_all),
+                    postId = readerPost.postId,
+                    blogId = readerPost.blogId,
+                    onCommentSnippetClicked = onCommentSnippetClicked
+            )
+            is Empty -> {
+                listOf<CommentSnippetItemState>(
+                        TextMessage(commentSnippetState.message)
+                ) + if (readerPost.isCommentsOpen) {
+                    listOf<CommentSnippetItemState>(ButtonState(
+                            buttonText = UiStringRes(string.reader_comments_be_first_to_comment),
+                            postId = readerPost.postId,
+                            blogId = readerPost.blogId,
+                            onCommentSnippetClicked = onCommentSnippetClicked))
+                } else {
+                    listOf<CommentSnippetItemState>()
+                }
+            }
+            is Failure -> listOf(
+                    TextMessage(commentSnippetState.message),
+                    ButtonState(
+                            buttonText = UiStringRes(string.reader_comments_view_all),
+                            postId = readerPost.postId,
+                            blogId = readerPost.blogId,
+                            onCommentSnippetClicked = onCommentSnippetClicked
+                    )
+            )
+            Loading -> listOf(LoadingState)
+        }
+    }
 
     private fun mapRelatedPostToUiState(
         post: ReaderSimplePost,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilder.kt
@@ -137,7 +137,7 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
         readerPost: ReaderPost,
         onCommentSnippetClicked: (Long, Long) -> Unit
     ): List<CommentSnippetItemState> {
-        return when(commentSnippetState) {
+        return when (commentSnippetState) {
             is CommentSnippetData -> commentSnippetState.comments.map { readerComment ->
                 CommentState(
                         authorName = readerComment.authorName,
@@ -148,7 +148,9 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
                         ),
                         avatarUrl = gravatarUtilsWrapper.fixGravatarUrl(
                                 readerComment.authorAvatar,
-                                contextProvider.getContext().resources.getDimensionPixelSize(dimen.avatar_sz_extra_small)
+                                contextProvider.getContext().resources.getDimensionPixelSize(
+                                        dimen.avatar_sz_extra_small
+                                )
                         ),
                         showAuthorBadge = readerComment.authorId == readerPost.authorId,
                         commentText = readerComment.text,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/CommentSnippetAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/CommentSnippetAdapter.kt
@@ -1,0 +1,72 @@
+package org.wordpress.android.ui.reader.adapters
+
+import android.content.Context
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView.Adapter
+import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.ui.reader.tracker.ReaderTracker
+import org.wordpress.android.ui.reader.utils.ThreadedCommentsUtils
+import org.wordpress.android.ui.reader.viewholders.CommentButtonViewHolder
+import org.wordpress.android.ui.reader.viewholders.CommentMessageViewHolder
+import org.wordpress.android.ui.reader.viewholders.CommentViewHolder
+import org.wordpress.android.ui.reader.viewholders.CommentsLoadingViewHolder
+import org.wordpress.android.ui.reader.viewholders.CommentsSnippetViewHolder
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.BUTTON
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.COMMENT
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.LOADING
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.TEXT_MESSAGE
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.image.ImageManager
+import javax.inject.Inject
+
+class CommentSnippetAdapter constructor(
+    context: Context,
+    val post: ReaderPost?
+) : Adapter<CommentsSnippetViewHolder<*>>() {
+    @Inject lateinit var threadedCommentsUtils: ThreadedCommentsUtils
+    @Inject lateinit var imageManager: ImageManager
+    @Inject lateinit var accountStore: AccountStore
+    @Inject lateinit var readerTracker: ReaderTracker
+    @Inject lateinit var uiHelpers: UiHelpers
+
+    private var itemsList = listOf<CommentSnippetItemState>()
+    private var contentWidth: Int
+
+    init {
+        (context.applicationContext as WordPress).component().inject(this)
+        // calculate the max width of comment content
+        contentWidth = threadedCommentsUtils.getMaxWidthForContent()
+    }
+
+    fun loadData(items: List<CommentSnippetItemState>) {
+        val diffResult = DiffUtil.calculateDiff(
+                CommentSnippetAdatperDiffCallback(itemsList, items)
+        )
+        itemsList = items
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CommentsSnippetViewHolder<*> {
+        return when (viewType) {
+            LOADING.ordinal -> CommentsLoadingViewHolder(parent)
+            COMMENT.ordinal -> CommentViewHolder(parent, imageManager, threadedCommentsUtils)
+            BUTTON.ordinal -> CommentButtonViewHolder(parent, uiHelpers)
+            TEXT_MESSAGE.ordinal -> CommentMessageViewHolder(parent, uiHelpers)
+            else -> throw IllegalArgumentException("Unexpected ViewHolder in CommentSnippetAdapter: $viewType")
+        }
+    }
+
+    override fun getItemViewType(position: Int) = itemsList[position].type.ordinal
+
+    override fun getItemCount(): Int {
+        return itemsList.size
+    }
+
+    override fun onBindViewHolder(holder: CommentsSnippetViewHolder<*>, position: Int) {
+        holder.onBind(itemsList[position])
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/CommentSnippetAdatperDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/CommentSnippetAdatperDiffCallback.kt
@@ -1,0 +1,40 @@
+package org.wordpress.android.ui.reader.adapters
+
+import androidx.recyclerview.widget.DiffUtil
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.BUTTON
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.COMMENT
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.LOADING
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.TEXT_MESSAGE
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState
+
+class CommentSnippetAdatperDiffCallback(
+    private val oldItems: List<CommentSnippetItemState>,
+    private val newItems: List<CommentSnippetItemState>
+) : DiffUtil.Callback() {
+    override fun getOldListSize(): Int {
+        return oldItems.size
+    }
+
+    override fun getNewListSize(): Int {
+        return newItems.size
+    }
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val oldItem = oldItems[oldItemPosition]
+        val newItem = newItems[newItemPosition]
+        return if (oldItem.type == newItem.type) {
+            when (oldItem.type) {
+                LOADING -> true
+                COMMENT, BUTTON, TEXT_MESSAGE -> oldItem == newItem
+            }
+        } else {
+            false
+        }
+    }
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val oldItem = oldItems[oldItemPosition]
+        val newItem = newItems[newItemPosition]
+        return oldItem == newItem
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
@@ -398,6 +398,7 @@ class ReaderTracker @Inject constructor(
         const val SOURCE_SITE_PREVIEW = "site_preview"
         const val SOURCE_TAG_PREVIEW = "tag_preview"
         const val SOURCE_POST_DETAIL = "post_detail"
+        const val SOURCE_POST_DETAIL_COMMENT_SNIPPET = "post_detail_comment_snippet"
         const val SOURCE_COMMENT = "comment"
         const val SOURCE_USER = "user"
         const val SOURCE_STATS = "stats"

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -190,6 +190,18 @@ public class ReaderUtils {
         }
     }
 
+    public static String getTextForCommentSnippet(Context context, int numComments) {
+        switch (numComments) {
+            case 0:
+                return context.getString(R.string.comments);
+            case 1:
+                return context.getString(R.string.reader_short_comment_count_one);
+            default:
+                String count = FormatUtils.formatInt(numComments);
+                return String.format(context.getString(R.string.reader_short_comment_count_multi), count);
+        }
+    }
+
     /*
      * returns true if a ReaderPost and ReaderComment exist for the passed Ids
      */

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
@@ -53,4 +53,9 @@ class ReaderUtilsWrapper @Inject constructor(
         postId: Long,
         commentId: Long
     ) = ReaderUtils.commentExists(blogId, postId, commentId)
+
+    fun getTextForCommentSnippet(numComments: Int): String? = ReaderUtils.getTextForCommentSnippet(
+            appContext,
+            numComments
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
@@ -15,6 +15,7 @@ import javax.inject.Inject
  *
  */
 @Reusable
+@Suppress("TooManyFunctions")
 class ReaderUtilsWrapper @Inject constructor(
     private val appContext: Context,
     private val tagUpdateClientUtilsProvider: TagUpdateClientUtilsProvider

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentButtonViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentButtonViewHolder.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.reader.viewholders
+
+import android.view.ViewGroup
+import org.wordpress.android.databinding.ReaderListitemCommentButtonBinding
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState.ButtonState
+import org.wordpress.android.ui.utils.UiHelpers
+
+class CommentButtonViewHolder(
+    parent: ViewGroup,
+    val uiHelpers: UiHelpers
+) : CommentsSnippetViewHolder<ReaderListitemCommentButtonBinding>(
+        parent,
+        ReaderListitemCommentButtonBinding::inflate
+) {
+    override fun onBind(itemUiState: CommentSnippetItemState) = with(binding) {
+        val state = itemUiState as ButtonState
+
+        commentActionButton.text = uiHelpers.getTextOfUiString(itemView.context, state.buttonText)
+
+        commentActionButton.setOnClickListener { state.onCommentSnippetClicked.invoke(state.postId, state.blogId) }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentMessageViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentMessageViewHolder.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.ui.reader.viewholders
+
+import android.view.ViewGroup
+import org.wordpress.android.databinding.ReaderListitemCommentMessageBinding
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState.TextMessage
+import org.wordpress.android.ui.utils.UiHelpers
+
+class CommentMessageViewHolder(
+    parent: ViewGroup,
+    val uiHelpers: UiHelpers
+) : CommentsSnippetViewHolder<ReaderListitemCommentMessageBinding>(
+        parent,
+        ReaderListitemCommentMessageBinding::inflate
+) {
+    override fun onBind(itemUiState: CommentSnippetItemState) = with(binding) {
+        val state = itemUiState as TextMessage
+
+        textEmpty.text = uiHelpers.getTextOfUiString(itemView.context, state.message)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentViewHolder.kt
@@ -1,0 +1,50 @@
+package org.wordpress.android.ui.reader.viewholders
+
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
+import org.wordpress.android.R
+import org.wordpress.android.databinding.ReaderListitemCommentBinding
+import org.wordpress.android.ui.comments.CommentUtils
+import org.wordpress.android.ui.reader.utils.ThreadedCommentsUtils
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState.CommentState
+import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.image.ImageType.AVATAR
+
+class CommentViewHolder(
+    parent: ViewGroup,
+    private val imageManager: ImageManager,
+    private val threadedCommentsUtils: ThreadedCommentsUtils
+) : CommentsSnippetViewHolder<ReaderListitemCommentBinding>(
+        parent,
+        ReaderListitemCommentBinding::inflate
+) {
+    override fun onBind(itemUiState: CommentSnippetItemState) = with(binding) {
+        val state = itemUiState as CommentState
+
+        shareCommentButton.visibility = View.GONE
+        actionsContainer.visibility = View.GONE
+        divider.visibility = View.GONE
+
+        val readerSpacing = itemView.resources.getDimensionPixelSize(R.dimen.reader_detail_margin)
+
+        val params = commentBodyContainer.layoutParams as MarginLayoutParams
+        params.marginStart = readerSpacing
+        params.marginEnd = readerSpacing
+        commentBodyContainer.layoutParams = params
+
+        textCommentAuthor.text = state.authorName
+        textCommentDate.text = state.datePublished
+        imageManager.loadIntoCircle(imageCommentAvatar, AVATAR, state.avatarUrl)
+        authorBadge.visibility = if (state.showAuthorBadge) View.VISIBLE else View.GONE
+
+        threadedCommentsUtils.setLinksClickable(textCommentText, state.isPrivatePost)
+        CommentUtils.displayHtmlComment(
+                textCommentText,
+                state.commentText,
+                threadedCommentsUtils.getMaxWidthForContent(),
+                itemView.resources.getString(R.string.comment_unable_to_show_error)
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentsLoadingViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentsLoadingViewHolder.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.ui.reader.viewholders
+
+import android.view.ViewGroup
+import org.wordpress.android.databinding.ReaderListitemCommentLoadingBinding
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState
+
+class CommentsLoadingViewHolder(
+    parent: ViewGroup
+) : CommentsSnippetViewHolder<ReaderListitemCommentLoadingBinding>(
+        parent,
+        ReaderListitemCommentLoadingBinding::inflate
+) {
+    override fun onBind(itemUiState: CommentSnippetItemState) = with(binding) {
+        // nothing to do actually
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentsSnippetViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentsSnippetViewHolder.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.ui.reader.viewholders
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
+import org.wordpress.android.ui.reader.views.uistates.CommentSnippetItemState
+
+abstract class CommentsSnippetViewHolder<T : ViewBinding>(
+    internal val parent: ViewGroup,
+    inflateBinding: (LayoutInflater, ViewGroup, Boolean) -> T,
+    protected val binding: T = inflateBinding(LayoutInflater.from(parent.context), parent, false)
+) : RecyclerView.ViewHolder(binding.root) {
+    abstract fun onBind(itemUiState: CommentSnippetItemState)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -925,7 +925,7 @@ class ReaderPostDetailViewModel @Inject constructor(
                 }
                 FAILED -> {
                     lastRenderedRepliesData = null
-                    if (networkUtilsWrapper.isNetworkAvailable()) {
+                    if (!networkUtilsWrapper.isNetworkAvailable()) {
                         CommentSnippetState.Failure(UiStringRes(R.string.no_network_message))
                     } else {
                         CommentSnippetState.Failure(UiStringRes(R.string.reader_comments_fetch_failure))

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -254,7 +254,7 @@ class ReaderPostDetailViewModel @Inject constructor(
                         )
                     }
                     if (commentsSnippetFeatureConfig.isEnabled()) {
-                        onRefreshCommentsData(post.blogId, post.postId, post.numReplies)
+                        onRefreshCommentsData(post.blogId, post.postId)
                     }
                     updatePostActions(post)
                 }
@@ -286,21 +286,28 @@ class ReaderPostDetailViewModel @Inject constructor(
         }
     }
 
-    fun onRefreshCommentsData(blogId: Long, postId: Long, numReplies: Int) {
+    fun onRefreshCommentsData(blogId: Long, postId: Long) {
         if (!commentsSnippetFeatureConfig.isEnabled()) return
-        val isRepliesDataChanged = lastRenderedRepliesData?.isMatchingPostCommentsStatus(
-                blogId,
-                postId,
-                numReplies
-        ) ?: true
 
-        if (!isRepliesDataChanged) return
+        val post = readerPostTableWrapper.getBlogPost(blogId, postId, true)
 
-        ReaderCommentService.startServiceForCommentSnippet(
-                contextProvider.getContext(),
-                blogId,
-                postId
-        )
+        post?.let {
+            val isRepliesDataChanged = lastRenderedRepliesData?.isMatchingPostCommentsStatus(
+                    it.blogId,
+                    it.postId,
+                    it.numReplies
+            ) ?: true
+
+            if (!isRepliesDataChanged) return
+
+            ReaderCommentService.startServiceForCommentSnippet(
+                    contextProvider.getContext(),
+                    blogId,
+                    postId
+            )
+
+        }
+
     }
 
     fun onRefreshLikersData(post: ReaderPost, isLikingAction: Boolean = false) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -286,7 +286,11 @@ class ReaderPostDetailViewModel @Inject constructor(
 
     fun onRefreshCommentsData(blogId: Long, postId: Long, numReplies: Int) {
         if (!commentsSnippetFeatureConfig.isEnabled()) return
-        val isRepliesDataChanged = lastRenderedRepliesData?.isMatchingPostCommentsStatus(blogId, postId, numReplies) ?: true
+        val isRepliesDataChanged = lastRenderedRepliesData?.isMatchingPostCommentsStatus(
+                blogId,
+                postId,
+                numReplies
+        ) ?: true
 
         if (!isRepliesDataChanged) return
 
@@ -867,10 +871,10 @@ class ReaderPostDetailViewModel @Inject constructor(
     fun onEventMainThread(event: UpdateCommentsStarted?) {
         if (!commentsSnippetFeatureConfig.isEnabled()) return
         if (
-                event == null
-                || event.scenario != COMMENT_SNIPPET
-                || post?.blogId != event.blogId
-                || post?.postId != event.postId
+                event == null ||
+                event.scenario != COMMENT_SNIPPET ||
+                post?.blogId != event.blogId ||
+                post?.postId != event.postId
         ) {
             return
         }
@@ -883,11 +887,11 @@ class ReaderPostDetailViewModel @Inject constructor(
     fun onEventMainThread(event: UpdateCommentsEnded?) {
         if (!commentsSnippetFeatureConfig.isEnabled()) return
         if (
-                event == null
-                || event.scenario != COMMENT_SNIPPET
-                || event.result == null
-                || post?.blogId != event.blogId
-                || post?.postId != event.postId
+                event == null ||
+                event.scenario != COMMENT_SNIPPET ||
+                event.result == null ||
+                post?.blogId != event.blogId ||
+                post?.postId != event.postId
         ) {
             return
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -305,9 +305,7 @@ class ReaderPostDetailViewModel @Inject constructor(
                     blogId,
                     postId
             )
-
         }
-
     }
 
     fun onRefreshLikersData(post: ReaderPost, isLikingAction: Boolean = false) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/uistates/CommentSnippetItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/uistates/CommentSnippetItemState.kt
@@ -1,0 +1,41 @@
+package org.wordpress.android.ui.reader.views.uistates
+
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.BUTTON
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.COMMENT
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.LOADING
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.TEXT_MESSAGE
+import org.wordpress.android.ui.utils.UiString
+
+enum class CommentItemType {
+    LOADING,
+    COMMENT,
+    BUTTON,
+    TEXT_MESSAGE
+}
+
+sealed class CommentSnippetItemState(open val type: CommentItemType) {
+    object LoadingState : CommentSnippetItemState(LOADING)
+
+    data class CommentState(
+        val authorName: String,
+        val datePublished: String,
+        val avatarUrl: String,
+        val showAuthorBadge: Boolean,
+        val commentText: String,
+        val isPrivatePost: Boolean,
+        val blogId: Long,
+        val postId: Long,
+        val commentId: Long
+    ) : CommentSnippetItemState(COMMENT)
+
+    data class ButtonState(
+        val buttonText: UiString,
+        val postId: Long,
+        val blogId: Long,
+        val onCommentSnippetClicked: (Long, Long) -> Unit
+    ) : CommentSnippetItemState(BUTTON)
+
+    data class TextMessage(
+        val message: UiString
+    ) : CommentSnippetItemState(TEXT_MESSAGE)
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/CommentsSnippetFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/CommentsSnippetFeatureConfig.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.CommentsSnippetFeatureConfig.Companion.COMMENTS_SNIPPET_COMMENTS_REMOTE_FIELD
+import javax.inject.Inject
+
+/**
+ * Configuration of the threaded comments below post improvement
+ */
+@Feature(COMMENTS_SNIPPET_COMMENTS_REMOTE_FIELD, false)
+class CommentsSnippetFeatureConfig
+@Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.COMMENTS_SNIPPET,
+        COMMENTS_SNIPPET_COMMENTS_REMOTE_FIELD
+) {
+    companion object {
+        const val COMMENTS_SNIPPET_COMMENTS_REMOTE_FIELD = "comments_snippet_remote_field"
+    }
+}

--- a/WordPress/src/main/res/color/option_disabled_selector_primary.xml
+++ b/WordPress/src/main/res/color/option_disabled_selector_primary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?android:attr/colorPrimary" android:state_enabled="true" />
+    <item android:alpha="@dimen/material_emphasis_disabled" android:color="?android:attr/colorPrimary" />
+</selector>

--- a/WordPress/src/main/res/color/option_disabled_selector_primary.xml
+++ b/WordPress/src/main/res/color/option_disabled_selector_primary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="?android:attr/colorPrimary" android:state_enabled="true" />
-    <item android:alpha="@dimen/material_emphasis_disabled" android:color="?android:attr/colorPrimary" />
+    <item android:color="?attr/colorPrimary" android:state_enabled="true" />
+    <item android:alpha="@dimen/material_emphasis_disabled" android:color="?attr/colorPrimary" />
 </selector>

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -55,11 +55,18 @@
                         android:layout_height="wrap_content"
                         android:layout_below="@+id/layout_post_detail_content" />
 
+                    <include
+                        android:id="@+id/comments_snippet"
+                        layout="@layout/reader_post_comments_snippet"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@+id/liker_faces_container" />
+
                     <LinearLayout
                         android:id="@+id/container_related_posts"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_below="@+id/liker_faces_container"
+                        android:layout_below="@+id/comments_snippet"
                         android:orientation="vertical"
                         android:layout_alignEnd="@+id/layout_post_detail_content"
                         android:layout_alignStart="@+id/layout_post_detail_content"

--- a/WordPress/src/main/res/layout/reader_listitem_comment.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment.xml
@@ -130,6 +130,7 @@
                         app:layout_constraintBottom_toBottomOf="@+id/image_comment_avatar"
                         app:layout_constraintStart_toEndOf="@+id/image_comment_avatar"
                         app:layout_constraintTop_toBottomOf="@+id/text_comment_author"
+                        app:layout_constraintEnd_toEndOf="parent"
                         tools:text="Apr 30 2021" />
                 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WordPress/src/main/res/layout/reader_listitem_comment_button.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment_button.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@android:color/transparent"
+    android:foregroundGravity="center"
+    android:paddingStart="@dimen/reader_detail_margin"
+    android:paddingEnd="@dimen/reader_detail_margin">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/comment_action_button"
+        style="@style/WordPress.Invite.Button.Secondary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/reader_comments_view_all"/>
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/reader_listitem_comment_loading.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment_loading.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@android:color/transparent"
+    android:foregroundGravity="center"
+    android:padding="@dimen/reader_detail_margin">
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminate="true"
+        android:progressTint="?attr/colorPrimary"
+        android:visibility="visible"/>
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/reader_listitem_comment_message.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment_message.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@android:color/transparent"
+    android:foregroundGravity="center"
+    android:padding="@dimen/reader_detail_margin">
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/text_empty"
+        style="@style/ReaderTextView.EmptyList"
+        android:text="@string/reader_empty_comments"
+        android:textColor="?attr/wpColorOnSurfaceMedium"
+        android:visibility="visible"
+        app:fixWidowWords="true" />
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/reader_post_comments_snippet.xml
+++ b/WordPress/src/main/res/layout/reader_post_comments_snippet.xml
@@ -31,7 +31,7 @@
         app:layout_constraintBottom_toBottomOf="@+id/comments_number_title"
         app:layout_constraintTop_toTopOf="@+id/comments_number_title"
         android:orientation="horizontal"
-        android:animateLayoutChanges="true">
+        android:animateLayoutChanges="false">
 
         <com.facebook.shimmer.ShimmerFrameLayout
             android:id="@+id/shimmer_view_container"

--- a/WordPress/src/main/res/layout/reader_post_comments_snippet.xml
+++ b/WordPress/src/main/res/layout/reader_post_comments_snippet.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/comments_snippet_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:visibility="gone"
+    tools:visibility="visible">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/comments_number_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minHeight="45dp"
+        android:gravity="center_vertical"
+        android:layout_marginStart="@dimen/reader_detail_margin"
+        android:text="@string/comments"
+        style="@style/ReaderTextView.Post.Title.Detail"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/divider"/>
+
+    <LinearLayout
+        android:id="@+id/follow_conversation_container"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_marginEnd="@dimen/reader_detail_margin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/comments_number_title"
+        app:layout_constraintTop_toTopOf="@+id/comments_number_title"
+        android:orientation="horizontal"
+        android:animateLayoutChanges="true">
+
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/shimmer_view_container"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            app:shimmer_auto_start="false">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/follow_conversation"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:textAppearance="?attr/textAppearanceCaption"
+                android:textColor="@color/option_disabled_selector_primary"
+                android:gravity="center"
+                android:text="@string/reader_comments_follow_conversation"/>
+
+        </com.facebook.shimmer.ShimmerFrameLayout>
+
+        <ImageView
+            android:id="@+id/bell_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="?attr/selectableItemBackground"
+            android:padding="@dimen/margin_large"
+            android:src="@drawable/ic_notifications_white_24dp"
+            app:tint="@color/primary"
+            android:contentDescription="@string/reader_btn_follow_conversation_settings"/>
+
+    </LinearLayout>
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/list_divider_height"
+        android:layout_marginStart="@dimen/reader_detail_margin"
+        android:layout_marginEnd="@dimen/reader_detail_margin"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:background="?attr/wpColorSurfaceSecondary"
+        android:visibility="visible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/comments_number_title"
+        app:layout_constraintBottom_toTopOf="@+id/comments_recycler_container"/>
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/comments_recycler_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/divider"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/comments_recycler"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/reader_post_comments_snippet.xml
+++ b/WordPress/src/main/res/layout/reader_post_comments_snippet.xml
@@ -76,7 +76,7 @@
         app:layout_constraintTop_toBottomOf="@+id/comments_number_title"
         app:layout_constraintBottom_toTopOf="@+id/comments_recycler_container"/>
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <LinearLayout
         android:id="@+id/comments_recycler_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2106,6 +2106,11 @@
     <string name="reader_empty_saved_posts_description">Tap %s to save a post to your list.</string>
     <string name="reader_empty_saved_posts_content_description">Tap the Add to Save Posts button to save a post to your list.</string>
     <string name="reader_empty_comments">No comments yet</string>
+    <string name="reader_comments_fetch_failure">There was an error getting comments</string>
+    <string name="reader_comments_post_fetch_failure">There was an error getting post data</string>
+    <string name="reader_comments_view_all">View all comments</string>
+    <string name="reader_comments_be_first_to_comment">Be the first to comment</string>
+    <string name="reader_comments_follow_conversation">Follow Conversation</string>
     <string name="reader_empty_posts_in_blog">This site is empty</string>
     <string name="reader_empty_search_title">No results found</string>
     <string name="reader_empty_search_description">No results found for %s for your language</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.reader.models.ReaderSimplePost
 import org.wordpress.android.ui.reader.models.ReaderSimplePostList
 import org.wordpress.android.ui.reader.utils.FeaturedImageUtils
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.reader.utils.ThreadedCommentsUtils
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState.ExcerptFooterUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState.ReaderPostFeaturedImageUiState
@@ -30,7 +31,9 @@ import org.wordpress.android.ui.utils.HtmlUtilsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.DisplayUtilsWrapper
+import org.wordpress.android.util.GravatarUtilsWrapper
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
 
@@ -50,7 +53,10 @@ class ReaderPostDetailUiStateBuilderTest {
     @Mock lateinit var contextProvider: ContextProvider
     @Mock lateinit var htmlUtilsWrapper: HtmlUtilsWrapper
     @Mock lateinit var htmlMessageUtils: HtmlMessageUtils
-    @Mock private lateinit var readerSimplePost: ReaderSimplePost
+    @Mock lateinit var readerSimplePost: ReaderSimplePost
+    @Mock lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
+    @Mock lateinit var gravatarUtilsWrapper: GravatarUtilsWrapper
+    @Mock lateinit var threadedCommentsUtils: ThreadedCommentsUtils
     private lateinit var dummyRelatedPosts: ReaderSimplePostList
 
     private var dummySourceReaderPost = ReaderPost().apply {
@@ -76,6 +82,9 @@ class ReaderPostDetailUiStateBuilderTest {
                 contextProvider,
                 htmlUtilsWrapper,
                 htmlMessageUtils,
+                dateTimeUtilsWrapper,
+                gravatarUtilsWrapper,
+                threadedCommentsUtils,
                 resourceProvider
         )
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -96,7 +96,9 @@ import org.wordpress.android.ui.utils.UiDimen.UIDimenRes
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.EventBusWrapper
+import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.WpUrlUtilsWrapper
+import org.wordpress.android.util.config.CommentsSnippetFeatureConfig
 import org.wordpress.android.util.config.LikesEnhancementsFeatureConfig
 import org.wordpress.android.util.image.ImageType.BLAVATAR_CIRCULAR
 import org.wordpress.android.viewmodel.ContextProvider
@@ -137,6 +139,8 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
     @Mock private lateinit var contextProvider: ContextProvider
     @Mock private lateinit var engagementUtils: EngagementUtils
     @Mock private lateinit var htmlMessageUtils: HtmlMessageUtils
+    @Mock private lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    @Mock private lateinit var commentsSnippetFeatureConfig: CommentsSnippetFeatureConfig
 
     private val fakePostFollowStatusChangedFeed = MutableLiveData<FollowStatusChanged>()
     private val fakeRefreshPostFeed = MutableLiveData<Event<Unit>>()
@@ -176,7 +180,10 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
                 getLikesHandler,
                 likesEnhancementsFeatureConfig,
                 engagementUtils,
-                htmlMessageUtils
+                htmlMessageUtils,
+                contextProvider,
+                networkUtilsWrapper,
+                commentsSnippetFeatureConfig
         )
         whenever(readerGetPostUseCase.get(any(), any(), any())).thenReturn(Pair(readerPost, false))
         whenever(readerPostCardActionsHandler.followStatusUpdated).thenReturn(fakePostFollowStatusChangedFeed)


### PR DESCRIPTION
Part of #15660

There are a few files involved in this PR but nearly half of them are simple ViewHolders and layout related files, so hopefully it's good enough to review.

This PR does the following:
 - Introduces a COMMENTS_SNIPPET feature flag (that must be activated to test the feature)
 - Introduces the comments snippet below post content. This shows first comment if present and gives access to view all comments. Also `follow conversation` is possible from here.

A few special cases to consider:

| Post with comments and comments are closed: no Follow Conversation present | ![image](https://user-images.githubusercontent.com/47797566/145261074-c35fd5f9-48aa-4aa0-b1f0-28007645a480.png) |
|---|---|
| Post with comments and comments opened: Follow Conversation present | ![image](https://user-images.githubusercontent.com/47797566/145261226-e9d0d361-21cb-44ef-b686-2fadcfff24fa.png) |
| Post without comments and comments are closed: no Follow Conversation and closed comment label | ![image](https://user-images.githubusercontent.com/47797566/145261372-b0e1246e-1be5-427e-900b-3f499e028670.png) |
| Post without comments and comments opened: Follow Conversation and No comments yet label | ![image](https://user-images.githubusercontent.com/47797566/145261658-e3268485-ac27-4bb3-a226-c80c1b71a7a9.png) |


There are a few bits that can be unit tested but unit test is being added in a separate PR. Also tracking is being added in a separate PR.

## To test
- Check you do not have the comment snippet when the FF is off and it's there when the FF is on
- Check the special cases reported in the images above
- Check you can open the threaded comment view by tapping on the button (View all comments or Be the first to comment depending on the scenario)
- Check you can Follow/Unfollow by email or by push notification. Smoke test the feature (should behave the same as in the threaded comments)
- Try to rotate the screen and check no visual issues happen
- Smoke test the Post Detail screen (follow site, like post, save for later, whatever you can thing ok :) )

## Regression Notes
1. Potential unintended areas of impact
The feature is still behind a feature flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
The feature is still behind a feature flag.

3. What automated tests I added (or what prevented me from doing so)
The feature is still behind a feature flag and a few more automated tests are being submitted with a dedicated PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
