### PR TITLE
Update event bus to v3.3.1

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -335,7 +335,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-auth:18.1.0'
     implementation 'com.android.installreferrer:installreferrer:2.2'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
-    implementation 'org.greenrobot:eventbus:3.2.0'
+    implementation 'org.greenrobot:eventbus:3.3.0'
     implementation ('com.automattic:rest:1.0.8') {
         exclude group: 'com.mcxiaoke.volley'
     }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -335,7 +335,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-auth:18.1.0'
     implementation 'com.android.installreferrer:installreferrer:2.2'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
-    implementation 'org.greenrobot:eventbus:3.3.0'
+    implementation 'org.greenrobot:eventbus:3.3.1'
     implementation ('com.automattic:rest:1.0.8') {
         exclude group: 'com.mcxiaoke.volley'
     }


### PR DESCRIPTION
This PR updates event bus to v3.3.1. The main change is that the new version doesn't depend on the support library.
https://github.com/greenrobot/EventBus/releases/tag/V3.3.0
https://github.com/greenrobot/EventBus/releases/tag/V3.3.1

To test:
Smoke test the app

## Regression Notes
1. Potential unintended areas of impact
The whole app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Smoke tested the app - I expect it to either no work anywhere or work everywhere

3. What automated tests I added (or what prevented me from doing so)
The existing tests should cover it

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
