### PR TITLE
Integrate gutenberg-mobile release 1.68.0-alpha1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.wordPressUtilsVersion = '2.2.0'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.68.0-alpha2'
+    ext.gutenbergMobileVersion = '4342-7d41854fe9584539570467e692201a61bd8ce13a'
     ext.storiesVersion = '1.2.0'
     ext.aboutAutomatticVersion = 'main-c764a2d66273d4c6aeed66bb7a5c75714d88c554'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.68.0-alpha1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4342

Release Submission Checklist

Not applicable.