### PR TITLE
Add blog item to About screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutActivity.kt
@@ -4,8 +4,10 @@ import android.os.Bundle
 import com.automattic.about.model.AboutConfigProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.about.UnifiedAboutNavigationAction.Dismiss
+import org.wordpress.android.ui.about.UnifiedAboutNavigationAction.OpenBlog
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -19,7 +21,8 @@ class UnifiedAboutActivity : LocaleAwareActivity(), AboutConfigProvider {
 
         viewModel.onNavigation.observeEvent(this) {
             when (it) {
-                Dismiss -> finish()
+                is Dismiss -> finish()
+                is OpenBlog -> ActivityLauncher.openUrlExternal(this, it.url)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutNavigationAction.kt
@@ -2,4 +2,5 @@ package org.wordpress.android.ui.about
 
 sealed class UnifiedAboutNavigationAction {
     object Dismiss : UnifiedAboutNavigationAction()
+    data class OpenBlog(val url: String) : UnifiedAboutNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -60,9 +60,9 @@ class UnifiedAboutViewModel @Inject constructor(
             ),
             onDismiss = ::onDismiss,
             analyticsTracker = AnalyticsConfig(
-                    trackScreenShown = ::trackScreenShown,
-                    trackScreenDismissed = ::trackScreenDismissed,
-                    trackButtonTapped = ::trackButtonTapped
+                    trackScreenShown = unifiedAboutTracker::trackScreenShown,
+                    trackScreenDismissed = unifiedAboutTracker::trackScreenDismissed,
+                    trackButtonTapped = unifiedAboutTracker::trackButtonTapped
             )
     )
 
@@ -95,17 +95,5 @@ class UnifiedAboutViewModel @Inject constructor(
         private const val WP_APPS_URL = "https://apps.wordpress.com/"
         private const val WP_BLOG_URL = "https://blog.wordpress.com/"
         private const val BLOG_ITEM_NAME = "blog"
-    }
-
-    private fun trackScreenShown(screen: String) {
-        unifiedAboutTracker.trackScreenShown(screen = screen)
-    }
-
-    private fun trackScreenDismissed(screen: String) {
-        unifiedAboutTracker.trackScreenDismissed(screen = screen)
-    }
-
-    private fun trackButtonTapped(button: String) {
-        unifiedAboutTracker.trackButtonTapped(button = button)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import com.automattic.about.model.AboutConfig
 import com.automattic.about.model.AnalyticsConfig
 import com.automattic.about.model.HeaderConfig
+import com.automattic.about.model.ItemConfig
 import com.automattic.about.model.LegalConfig
 import com.automattic.about.model.RateUsConfig
 import com.automattic.about.model.ShareConfig
@@ -18,6 +19,7 @@ import org.wordpress.android.models.recommend.RecommendApiCallsProvider.Recommen
 import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendCallResult.Failure
 import org.wordpress.android.models.recommend.RecommendApiCallsProvider.RecommendCallResult.Success
 import org.wordpress.android.ui.about.UnifiedAboutNavigationAction.Dismiss
+import org.wordpress.android.ui.about.UnifiedAboutNavigationAction.OpenBlog
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.BuildConfigWrapper
@@ -43,6 +45,13 @@ class UnifiedAboutViewModel @Inject constructor(
             rateUsConfig = RateUsConfig.fromContext(contextProvider.getContext()),
             socialsConfig = SocialsConfig(
                     twitterUsername = WP_SOCIAL_HANDLE
+            ),
+            customItems = listOf(
+                    ItemConfig(
+                            name = BLOG_ITEM_NAME,
+                            title = contextProvider.getContext().getString(R.string.about_blog),
+                            onClick = ::onBlogClick
+                    )
             ),
             legalConfig = LegalConfig(
                     tosUrl = wpUrlUtils.buildTermsOfServiceUrl(contextProvider.getContext()),
@@ -76,10 +85,16 @@ class UnifiedAboutViewModel @Inject constructor(
         _onNavigation.postValue(Event(Dismiss))
     }
 
+    private fun onBlogClick() {
+        _onNavigation.postValue(Event(OpenBlog(WP_BLOG_URL)))
+    }
+
     companion object {
         private const val WP_SOCIAL_HANDLE = "wordpress"
         private const val WP_ACKNOWLEDGEMENTS_URL = "file:///android_asset/licenses.html"
         private const val WP_APPS_URL = "https://apps.wordpress.com/"
+        private const val WP_BLOG_URL = "https://blog.wordpress.com/"
+        private const val BLOG_ITEM_NAME = "blog"
     }
 
     private fun trackScreenShown(screen: String) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3849,4 +3849,7 @@ translators: Block name. %s: The localized block name -->
     <string name="weekly_roundup">Weekly Roundup</string>
     <string name="weekly_roundup_notification_title">Weekly Roundup: %s</string>
     <string name="weekly_roundup_notification_text">Your site got %1$d views, %2$d likes, %3$d comments.</string>
+
+    <!-- About -->
+    <string name="about_blog">Blog</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.68.0-alpha2'
     ext.storiesVersion = '1.2.0'
-    ext.aboutAutomatticVersion = '20-b0e8c9446a359885c8655a2d911283e28e633138'
+    ext.aboutAutomatticVersion = 'main-61cb99923ffab35d8ef9ae6d356accbfc3a2bf4a'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.68.0-alpha2'
     ext.storiesVersion = '1.2.0'
-    ext.aboutAutomatticVersion = 'main-c764a2d66273d4c6aeed66bb7a5c75714d88c554'
+    ext.aboutAutomatticVersion = '20-b0e8c9446a359885c8655a2d911283e28e633138'
 
     repositories {
         maven {


### PR DESCRIPTION
This PR adds a custom "Blog" item to the Unified About screen. Tapping this item opens `blog.wordpress.com` in an external browser:

https://user-images.githubusercontent.com/830056/145261072-2653284d-44bd-4fd4-a9ec-97d054b646e4.mp4

Note: I'm adding the "Not Ready for Merge" label here as we still need to update the About library version once this PR gets merged: 20-gh-Automattic/about-automattic-android

### Main changes

- Added a new `OpenBlog` navigation action containing a `url` parameter, and the necessary logic to open it in an external browser. (6f79bcfacb77893f3e65e29c4798b198a6d950a4, 25993d2180535a8d69909a8e838817e2d1ff5a75)
- Updated the `AboutConfig` to provide a single item list containing an `ItemConfig` object corresponding to the new "Blog" item, including the logic to post the navigation action with the right URL when tapping the item. (d13f96affa90a9eb2f9010b91004bf35ed92b6aa)
    - Note: The provided blog URL is currently a simple constant, but since this is done through the view model, we have enough flexibility to switch it based on some logic in the future, such as providing a different link for the Jetpack app, for example. 
- I also did a bit of a clean up on the tracking functions, but that's unrelated to other changes. (81acc47125b9ac0d4610ca90c8062e1b92fd50ba)

### To test

1. On the Main screen, tap the Me button.
1. On the Me screen, tap the About WordPress item.
1. On the About screen, notice the new "Blog" item.
1. Tap on it.
1. Notice the `https://blog.wordpress.com` URL is opened in an external browser.
1. On `logcat`, notice the following message: 

```
🔵 Tracked: about_screen_button_tapped, Properties: {"button":"blog"}
```

## Regression Notes
1. Potential unintended areas of impact
None that I could think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None at this time, but we should consider adding some tests to the library.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.