### PR TITLE
Fix self hosted crash in Plugin Browser

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
@@ -336,7 +336,11 @@ class PluginBrowserViewModel @Inject constructor(
             return
         }
 
-        site = requireNotNull(mSiteStore.getSiteBySiteId(site.siteId))
+        site = if (site.isJetpackConnected && site.isUsingWpComRestApi) {
+            requireNotNull(mSiteStore.getSiteBySiteId(site.siteId))
+        } else {
+            requireNotNull(mSiteStore.getSiteByLocalId(site.id))
+        }
     }
 
     // Keeping the data up to date

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
@@ -336,7 +336,7 @@ class PluginBrowserViewModel @Inject constructor(
             return
         }
 
-        site = if (site.isJetpackConnected && site.isUsingWpComRestApi) {
+        site = if (site.isUsingWpComRestApi) {
             requireNotNull(mSiteStore.getSiteBySiteId(site.siteId))
         } else {
             requireNotNull(mSiteStore.getSiteByLocalId(site.id))


### PR DESCRIPTION
Fixes #15145 

This one was tricky.

In a situation where the user is managing a self-hosted site alongside wpcom/jetpack sites, the crash will occur if `OnSiteChanged` even gets emitted when the user is in Plugin Browser (self-hosted site need to be selected).

The crash happens when we try to get a fresh site from the store using a local site ID, where remote ID is expected. (self-hosted sites only have local IDs)

The crash does not happen when you have only self-hosted sites in the app, since `OnSiteChanged` event will always contain an Error, and will not reach the offending code.

Fix addresses this by requesting a fresh site using local ID for self-hosted sites and remote ID for wpcom/jetpack sites.

The issue is hard to reproduce because the timing of `OnSiteChanged` is unpredictable. I assume this happens on the initial app launch when the site fetch call is delayed because of throttling, and the user navigates to the Plugin browser before the call is finished.

You can force the original crash and confirm that the issue is resolved by calling `mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(SiteUtils.getFetchSitesPayload()));` somewhere in the Plugin browser (eg, in `submitSearch` method of `PluginBrowserViewModel` 🤷 ).

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
