### PR TITLE
fix domains menu appearing for non-jetpack self-hosted site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -165,9 +165,7 @@ class SiteListItemBuilder @Inject constructor(
     }
 
     fun buildDomainsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
-        return if (siteDomainsFeatureConfig.isEnabled() &&
-                site.hasCapabilityManageOptions ||
-                !siteUtilsWrapper.isAccessedViaWPComRest(site)) {
+        return if (hasManageOptionsCapability(site) || isNotAccessedViaWPComRest(site)) {
             ListItem(
                     R.drawable.ic_domains_white_24dp,
                     UiStringRes(R.string.my_site_btn_domains),
@@ -175,6 +173,12 @@ class SiteListItemBuilder @Inject constructor(
             )
         } else null
     }
+
+    private fun hasManageOptionsCapability(site: SiteModel) =
+            siteDomainsFeatureConfig.isEnabled() && site.hasCapabilityManageOptions
+
+    private fun isNotAccessedViaWPComRest(site: SiteModel) =
+            siteDomainsFeatureConfig.isEnabled() && !siteUtilsWrapper.isAccessedViaWPComRest(site)
 
     fun buildSiteSettingsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (site.hasCapabilityManageOptions || !siteUtilsWrapper.isAccessedViaWPComRest(site)) {


### PR DESCRIPTION
Fixes #15654 

This PR fixes domain menu appearing for non-jetpack self-hosted sites which shouldn't appear at all.

To test:

- Use a non-jetpack self-hosted site or create one using jurassic ninja
- Add the site from My Site and see that no domains menu appears under Configuration section

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested before and after the change

3. What automated tests I added (or what prevented me from doing so)
Manual testing

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
