### PR TITLE
My Site: Revert my site bottom spacing

### DIFF
--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -308,7 +308,7 @@
     <dimen name="my_site_blavatar_container_corner_radius">4dp</dimen>
     <dimen name="my_site_blavatar_container_border_width">0.5dp</dimen>
     <dimen name="my_site_blavatar_corner_radius">2dp</dimen>
-    <dimen name="my_site_bottom_spacing">16dp</dimen>
+    <dimen name="my_site_bottom_spacing">64dp</dimen> <!-- added so that the list items are not hidden behind the toast -->
     <dimen name="my_site_name_label_single_line_text_size">20sp</dimen>
     <dimen name="my_site_name_label_double_line_text_size">16sp</dimen>
     <dimen name="my_site_content_area">500dp</dimen>


### PR DESCRIPTION
Bottom padding (updated in commit c0237dbd) is reverted to the previous value to allow enough scrolling so that the list items are not hidden behind the toast. 

Internal Ref: p5T066-2Rr#comment-10829

To test:

1. Follow the Quick Start steps after creating a new site.
2. Tap the “Visit your site” step in the Quick Start so that a snack bar gets displayed.
3. Notice that the list item "View Site" is not hidden behind the snack bar.

<img width=320 src="https://user-images.githubusercontent.com/1405144/145195147-64bf61fc-81a8-4273-8659-b203e707aed1.png">

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
