### PR TITLE
Comment snippet: tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedListNavigationEvent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedListNavigationEvent.kt
@@ -1,12 +1,15 @@
 package org.wordpress.android.ui.engagement
 
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource
+
 sealed class EngagedListNavigationEvent(val closeUserProfileIfOpened: Boolean = true) {
     data class PreviewSiteByUrl(val siteUrl: String, val source: String) : EngagedListNavigationEvent()
     data class PreviewSiteById(val siteId: Long, val source: String) : EngagedListNavigationEvent()
     data class PreviewCommentInReader(
         val siteId: Long,
         val commentPostId: Long,
-        val postOrCommentId: Long
+        val postOrCommentId: Long,
+        val source: ThreadedCommentsActionSource
     ) : EngagedListNavigationEvent()
     data class PreviewPostInReader(val siteId: Long, val postId: Long) : EngagedListNavigationEvent()
     data class OpenUserProfileBottomSheet(

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
@@ -163,7 +163,8 @@ class EngagedPeopleListFragment : Fragment() {
                             event.siteId,
                             event.commentPostId,
                             event.postOrCommentId,
-                            mUnifiedThreadedCommentsFeatureConfig.isEnabled()
+                            mUnifiedThreadedCommentsFeatureConfig.isEnabled(),
+                            event.source.sourceDescription
                     )
                 }
                 is PreviewPostInReader -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModel.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.engagement.ListScenarioType.LOAD_COMMENT_LIKES
 import org.wordpress.android.ui.engagement.ListScenarioType.LOAD_POST_LIKES
 import org.wordpress.android.ui.engagement.PreviewBlogByUrlSource.LIKED_COMMENT_USER_HEADER
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.COMMENT_LIKE_NOTIFICATION
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.utils.UiString
@@ -274,7 +275,7 @@ class EngagedPeopleListViewModel @Inject constructor(
         _onNavigationEvent.value = Event(
                 if (commentPostId > 0) {
                     if (readerUtilsWrapper.postAndCommentExists(siteId, commentPostId, postOrCommentId)) {
-                        PreviewCommentInReader(siteId, commentPostId, postOrCommentId)
+                        PreviewCommentInReader(siteId, commentPostId, postOrCommentId, COMMENT_LIKE_NOTIFICATION)
                     } else {
                         PreviewSiteByUrl(siteUrl, LIKED_COMMENT_USER_HEADER.sourceDescription)
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -54,6 +54,7 @@ import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveCli
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource;
 import org.wordpress.android.ui.reader.tracker.ReaderTracker;
 import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.util.AppBarLayoutExtensionsKt;
@@ -533,7 +534,8 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
                 siteId,
                 postId,
                 commentId,
-                mUnifiedThreadedCommentsFeatureConfig.isEnabled()
+                mUnifiedThreadedCommentsFeatureConfig.isEnabled(),
+                ThreadedCommentsActionSource.COMMENT_NOTIFICATION.getSourceDescription()
         );
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -55,6 +55,7 @@ import org.wordpress.android.ui.notifications.blocks.UserNoteBlock.OnGravatarCli
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import org.wordpress.android.ui.reader.ReaderActivityLauncher
 import org.wordpress.android.ui.reader.actions.ReaderPostActions
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.COMMENT_NOTIFICATION
 import org.wordpress.android.ui.reader.services.ReaderCommentService
 import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.util.AppLog
@@ -242,7 +243,8 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
                 ReaderActivityLauncher.showReaderComments(
                         activity, note.siteId.toLong(), note.postId.toLong(),
                         note.commentId,
-                        mUnifiedThreadedCommentsFeatureConfig.isEnabled()
+                        mUnifiedThreadedCommentsFeatureConfig.isEnabled(),
+                        COMMENT_NOTIFICATION.sourceDescription
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
@@ -25,6 +25,8 @@ import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.reader.ReaderActivityLauncher
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.ACTIVITY_LOG_DETAIL
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.stats.StatsViewType.FOLLOWERS
@@ -66,7 +68,7 @@ class FormattableContentClickHandler @Inject constructor(
                 // Load the comment in the reader list if it exists, otherwise show a webview
                 val postId = clickedSpan.postId ?: clickedSpan.rootId ?: 0
                 if (ReaderUtils.postAndCommentExists(siteId, postId, id)) {
-                    showReaderCommentsList(activity, siteId, postId, id)
+                    showReaderCommentsList(activity, siteId, postId, id, ACTIVITY_LOG_DETAIL)
                 } else {
                     showWebViewActivityForUrl(activity, clickedSpan.url, rangeType)
                 }
@@ -150,13 +152,20 @@ class FormattableContentClickHandler @Inject constructor(
         ReaderActivityLauncher.showReaderLikingUsers(activity, blogId, postId)
     }
 
-    private fun showReaderCommentsList(activity: FragmentActivity, siteId: Long, postId: Long, commentId: Long) {
+    private fun showReaderCommentsList(
+        activity: FragmentActivity,
+        siteId: Long,
+        postId: Long,
+        commentId: Long,
+        source: ThreadedCommentsActionSource
+    ) {
         ReaderActivityLauncher.showReaderComments(
                 activity,
                 siteId,
                 postId,
                 commentId,
-                unifiedThreadedCommentsFeatureConfig.isEnabled()
+                unifiedThreadedCommentsFeatureConfig.isEnabled(),
+                source.sourceDescription
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -193,8 +193,12 @@ public class ReaderActivityLauncher {
     /*
      * show comments for the passed Ids
      */
-    public static void showReaderComments(Context context, long blogId, long postId, boolean isNewThreadedComment) {
-        showReaderComments(context, blogId, postId, null, 0, null, isNewThreadedComment);
+    public static void showReaderComments(Context context,
+                                          long blogId,
+                                          long postId,
+                                          boolean isNewThreadedComment,
+                                          String source) {
+        showReaderComments(context, blogId, postId, null, 0, null, isNewThreadedComment, source);
     }
 
 
@@ -206,7 +210,8 @@ public class ReaderActivityLauncher {
         long blogId,
         long postId,
         long commentId,
-        boolean isNewThreadedComment
+        boolean isNewThreadedComment,
+        String source
     ) {
         showReaderComments(
                 context,
@@ -215,7 +220,8 @@ public class ReaderActivityLauncher {
                 DirectOperation.COMMENT_JUMP,
                 commentId,
                 null,
-                isNewThreadedComment
+                isNewThreadedComment,
+                source
         );
     }
 
@@ -230,7 +236,7 @@ public class ReaderActivityLauncher {
      * @param interceptedUri  URI to fall back into (i.e. to be able to open in external browser)
      */
     public static void showReaderComments(Context context, long blogId, long postId, DirectOperation
-            directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment) {
+            directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment, String source) {
         Intent intent = createShowReaderCommentsIntent(
                 context,
                 blogId,
@@ -238,22 +244,24 @@ public class ReaderActivityLauncher {
                 directOperation,
                 commentId,
                 interceptedUri,
-                isNewThreadedComment
+                isNewThreadedComment,
+                source
         );
         context.startActivity(intent);
     }
 
     public static void showReaderCommentsForResult(
             Fragment fragment,
-           long blogId,
-           long postId,
-           boolean isNewThreadedComment
+            long blogId,
+            long postId,
+            boolean isNewThreadedComment,
+            String source
     ) {
-        showReaderCommentsForResult(fragment, blogId, postId, null, 0, null, isNewThreadedComment);
+        showReaderCommentsForResult(fragment, blogId, postId, null, 0, null, isNewThreadedComment, source);
     }
 
     public static void showReaderCommentsForResult(Fragment fragment, long blogId, long postId, DirectOperation
-            directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment) {
+            directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment, String source) {
         Intent intent = createShowReaderCommentsIntent(
                 fragment.getContext(),
                 blogId,
@@ -261,13 +269,14 @@ public class ReaderActivityLauncher {
                 directOperation,
                 commentId,
                 interceptedUri,
-                isNewThreadedComment
+                isNewThreadedComment,
+                source
         );
         fragment.startActivityForResult(intent, RequestCodes.READER_FOLLOW_CONVERSATION);
     }
 
     private static Intent createShowReaderCommentsIntent(Context context, long blogId, long postId, DirectOperation
-            directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment) {
+            directOperation, long commentId, String interceptedUri, boolean isNewThreadedComment, String source) {
         Intent intent = new Intent(
                 context,
                 isNewThreadedComment ? ThreadedCommentsActivity.class : ReaderCommentListActivity.class
@@ -277,6 +286,7 @@ public class ReaderActivityLauncher {
         intent.putExtra(ReaderConstants.ARG_DIRECT_OPERATION, directOperation);
         intent.putExtra(ReaderConstants.ARG_COMMENT_ID, commentId);
         intent.putExtra(ReaderConstants.ARG_INTERCEPTED_URI, interceptedUri);
+        intent.putExtra(ReaderConstants.ARG_SOURCE, source);
 
         return intent;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -62,6 +62,7 @@ import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderCommentActions;
 import org.wordpress.android.ui.reader.actions.ReaderPostActions;
 import org.wordpress.android.ui.reader.adapters.ReaderCommentAdapter;
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource;
 import org.wordpress.android.ui.reader.services.ReaderCommentService;
 import org.wordpress.android.ui.reader.tracker.ReaderTracker;
 import org.wordpress.android.ui.reader.viewmodels.ConversationNotificationsViewModel;
@@ -136,6 +137,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     private long mCommentId;
     private int mRestorePosition;
     private String mInterceptedUri;
+    private String mSource;
 
     @Inject AccountStore mAccountStore;
     @Inject UiHelpers mUiHelpers;
@@ -247,7 +249,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
             mEditComment.setAdapter(mSuggestionAdapter);
         }
 
-        mReaderTracker.trackPost(AnalyticsTracker.Stat.READER_ARTICLE_COMMENTS_OPENED, mPost);
+        mReaderTracker.trackPost(AnalyticsTracker.Stat.READER_ARTICLE_COMMENTS_OPENED, mPost, mSource);
 
         ImageView buttonExpand = findViewById(R.id.button_expand);
         buttonExpand.setOnClickListener(
@@ -370,6 +372,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
             mRestorePosition = savedInstanceState.getInt(ReaderConstants.KEY_RESTORE_POSITION);
             mHasUpdatedComments = savedInstanceState.getBoolean(KEY_HAS_UPDATED_COMMENTS);
             mInterceptedUri = savedInstanceState.getString(ReaderConstants.ARG_INTERCEPTED_URI);
+            mSource = savedInstanceState.getString(ReaderConstants.ARG_SOURCE);
         } else {
             mBlogId = getIntent().getLongExtra(ReaderConstants.ARG_BLOG_ID, 0);
             mPostId = getIntent().getLongExtra(ReaderConstants.ARG_POST_ID, 0);
@@ -377,9 +380,10 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
                     .getSerializableExtra(ReaderConstants.ARG_DIRECT_OPERATION);
             mCommentId = getIntent().getLongExtra(ReaderConstants.ARG_COMMENT_ID, 0);
             mInterceptedUri = getIntent().getStringExtra(ReaderConstants.ARG_INTERCEPTED_URI);
+            mSource = getIntent().getStringExtra(ReaderConstants.ARG_SOURCE);
         }
 
-        mConversationViewModel.start(mBlogId, mPostId);
+        mConversationViewModel.start(mBlogId, mPostId, ThreadedCommentsActionSource.READER_THREADED_COMMENTS);
     }
 
     @Override
@@ -592,6 +596,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
         outState.putLong(KEY_REPLY_TO_COMMENT_ID, mReplyToCommentId);
         outState.putBoolean(KEY_HAS_UPDATED_COMMENTS, mHasUpdatedComments);
         outState.putString(ReaderConstants.ARG_INTERCEPTED_URI, mInterceptedUri);
+        outState.putString(ReaderConstants.ARG_SOURCE, mSource);
 
         super.onSaveInstanceState(outState);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFollowCommentsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFollowCommentsHandler.kt
@@ -13,6 +13,7 @@ import javax.inject.Named
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
 import org.wordpress.android.R
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.Failure
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FollowCommentsNotAllowed
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FollowStateChanged
@@ -37,9 +38,10 @@ class ReaderFollowCommentsHandler @Inject constructor(
         blogId: Long,
         postId: Long,
         askSubscribe: Boolean,
+        source: ThreadedCommentsActionSource,
         onSuccessSnackbarAction: (() -> Unit)?
     ) {
-        readerCommentsFollowUseCase.setMySubscriptionToPost(blogId, postId, askSubscribe)
+        readerCommentsFollowUseCase.setMySubscriptionToPost(blogId, postId, askSubscribe, source)
                 .flowOn(bgDispatcher).collect { state ->
             manageState(state, onSuccessSnackbarAction)
         }
@@ -56,9 +58,10 @@ class ReaderFollowCommentsHandler @Inject constructor(
         blogId: Long,
         postId: Long,
         askEnable: Boolean,
+        source: ThreadedCommentsActionSource,
         onSuccessSnackbarAction: (() -> Unit)? = null
     ) {
-        readerCommentsFollowUseCase.setEnableByPushNotifications(blogId, postId, askEnable)
+        readerCommentsFollowUseCase.setEnableByPushNotifications(blogId, postId, askEnable, source)
                 .flowOn(bgDispatcher).collect { state ->
                     manageState(state, onSuccessSnackbarAction)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -83,6 +83,8 @@ import org.wordpress.android.ui.reader.adapters.FACE_ITEM_LEFT_OFFSET_DIMEN
 import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter
 import org.wordpress.android.ui.reader.adapters.ReaderPostLikersAdapter
 import org.wordpress.android.ui.reader.adapters.TrainOfFacesItem
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.DIRECT_OPERATION
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.READER_POST_DETAILS_COMMENTS
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
@@ -492,7 +494,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         val interceptedUri = bundle?.getString(ReaderConstants.ARG_INTERCEPTED_URI)
 
         if (commentsSnippetFeatureConfig.isEnabled()) {
-            conversationViewModel.start(blogId, postId)
+            conversationViewModel.start(blogId, postId, READER_POST_DETAILS_COMMENTS)
         }
         viewModel.start(isRelatedPost = isRelatedPost, isFeed = isFeed, interceptedUri = interceptedUri)
     }
@@ -762,7 +764,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                     this@ReaderPostDetailFragment,
                     blogId,
                     postId,
-                    mUnifiedThreadedCommentsFeatureConfig.isEnabled()
+                    mUnifiedThreadedCommentsFeatureConfig.isEnabled(),
+                    this.source.sourceDescription
             )
 
             is ReaderNavigationEvents.ShowNoSitesToReblog -> ReaderActivityLauncher.showNoSiteToReblog(activity)
@@ -784,10 +787,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                 showRelatedPostDetail(postId = this.postId, blogId = this.blogId)
 
             is ReaderNavigationEvents.ReplaceRelatedPostDetailsWithHistory ->
-                replaceRelatedPostDetailWithHistory(
-                        postId = this.postId,
-                        blogId = this.blogId
-                )
+                replaceRelatedPostDetailWithHistory(postId = this.postId, blogId = this.blogId)
 
             is ReaderNavigationEvents.ShowPostInWebView -> showPostInWebView(post)
             is ReaderNavigationEvents.ShowEngagedPeopleList -> {
@@ -1419,7 +1419,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                         ReaderActivityLauncher.showReaderComments(
                                 activity, it.blogId, it.postId,
                                 directOperation, commentId.toLong(), viewModel.interceptedUri,
-                                mUnifiedThreadedCommentsFeatureConfig.isEnabled()
+                                mUnifiedThreadedCommentsFeatureConfig.isEnabled(),
+                                DIRECT_OPERATION.sourceDescription
                         )
                     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -90,6 +90,7 @@ import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionRecyclerAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSiteSearchAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSiteSearchAdapter.SiteSearchAdapterListener;
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource;
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEditorForReblog;
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog;
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab;
@@ -2619,7 +2620,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
                         requireContext(),
                         post.blogId,
                         post.postId,
-                        mUnifiedThreadedCommentsFeatureConfig.isEnabled()
+                        mUnifiedThreadedCommentsFeatureConfig.isEnabled(),
+                        ThreadedCommentsActionSource.READER_POST_CARD.getSourceDescription()
                 );
                 break;
             case TOGGLE_SEEN_STATUS:

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/comments/ThreadedCommentsActionSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/comments/ThreadedCommentsActionSource.kt
@@ -1,0 +1,32 @@
+package org.wordpress.android.ui.reader.comments
+
+import org.wordpress.android.ui.reader.tracker.ReaderTracker.Companion.SOURCE_DISCOVER
+import org.wordpress.android.ui.reader.tracker.ReaderTracker.Companion.SOURCE_POST_DETAIL
+import org.wordpress.android.ui.reader.tracker.ReaderTracker.Companion.SOURCE_POST_DETAIL_COMMENT_SNIPPET
+
+enum class ThreadedCommentsActionSource(val sourceDescription: String) {
+    READER_POST_CARD("reader_post_card"),
+    READER_POST_DETAILS("reader_post_details"),
+    READER_POST_DETAILS_COMMENTS("reader_post_details_comments"),
+    READER_THREADED_COMMENTS("reader_threaded_comments"),
+    COMMENT_NOTIFICATION("comment_notification"),
+    MY_SITE_COMMENT("my_site_comment"),
+    COMMENT_LIKE_NOTIFICATION("comment_like_notification"),
+    ACTIVITY_LOG_DETAIL("activity_log_detail"),
+    DIRECT_OPERATION("direct_operation"),
+    UNKNOWN("unknown");
+
+    companion object {
+        fun mapReaderPostSource(source: String): ThreadedCommentsActionSource {
+            return if (source.equals(SOURCE_POST_DETAIL)) {
+                READER_POST_DETAILS
+            } else if (source.equals(SOURCE_POST_DETAIL_COMMENT_SNIPPET)) {
+                READER_POST_DETAILS_COMMENTS
+            } else if (source.equals(SOURCE_DISCOVER)) {
+                READER_POST_CARD
+            } else {
+                UNKNOWN
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/comments/ThreadedCommentsActionSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/comments/ThreadedCommentsActionSource.kt
@@ -10,7 +10,7 @@ enum class ThreadedCommentsActionSource(val sourceDescription: String) {
     READER_POST_DETAILS_COMMENTS("reader_post_details_comments"),
     READER_THREADED_COMMENTS("reader_threaded_comments"),
     COMMENT_NOTIFICATION("comment_notification"),
-    MY_SITE_COMMENT("my_site_comment"),
+    MY_SITE_COMMENT("my_site_comment"), // TODO: currently not used but we could want to mimic iOS here
     COMMENT_LIKE_NOTIFICATION("comment_like_notification"),
     ACTIVITY_LOG_DETAIL("activity_log_detail"),
     DIRECT_OPERATION("direct_operation"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/comments/ThreadedCommentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/comments/ThreadedCommentsFragment.kt
@@ -353,7 +353,7 @@ class ThreadedCommentsFragment : Fragment(R.layout.threaded_comments_fragment), 
             }
         })
 
-        conversationViewModel.start(blogId, postId)
+        conversationViewModel.start(blogId, postId, ThreadedCommentsActionSource.READER_THREADED_COMMENTS)
     }
 
     override fun onCollapse(result: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.ReaderActivityLauncher
 import org.wordpress.android.ui.reader.ReaderActivityLauncher.OpenUrlType
 import org.wordpress.android.ui.reader.ReaderPostWebViewCachingFragment
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.READER_POST_CARD
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.EmptyUiState
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEditorForReblog
@@ -131,7 +132,8 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
                 context,
                 event.blogId,
                 event.postId,
-                mUnifiedThreadedCommentsFeatureConfig.isEnabled()
+                mUnifiedThreadedCommentsFeatureConfig.isEnabled(),
+                READER_POST_CARD.sourceDescription
         )
         is ShowNoSitesToReblog -> ReaderActivityLauncher.showNoSiteToReblog(activity)
         is ShowSitePickerForResult -> ActivityLauncher.showSitePickerForResult(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -8,13 +8,18 @@ import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
 import org.wordpress.android.ui.engagement.HeaderData
 import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource
 
 sealed class ReaderNavigationEvents {
     data class ShowPostDetail(val post: ReaderPost) : ReaderNavigationEvents()
     data class SharePost(val post: ReaderPost) : ReaderNavigationEvents()
     data class OpenPost(val post: ReaderPost) : ReaderNavigationEvents()
     data class ShowPostsByTag(val tag: ReaderTag) : ReaderNavigationEvents()
-    data class ShowReaderComments(val blogId: Long, val postId: Long) : ReaderNavigationEvents()
+    data class ShowReaderComments(
+        val blogId: Long,
+        val postId: Long,
+        val source: ThreadedCommentsActionSource
+    ) : ReaderNavigationEvents()
     object ShowNoSitesToReblog : ReaderNavigationEvents()
     data class ShowSitePickerForResult(val preselectedSite: SiteModel, val post: ReaderPost, val mode: SitePickerMode) :
             ReaderNavigationEvents()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommendedBlogsCardUiState.ReaderRecommendedBlogUiState
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.SharePost
@@ -183,7 +184,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
             LIKE -> handleLikeClicked(post, source)
             BOOKMARK -> handleBookmarkClicked(post, isBookmarkList, source)
             REBLOG -> handleReblogClicked(post)
-            COMMENTS -> handleCommentsClicked(post.postId, post.blogId)
+            COMMENTS -> handleCommentsClicked(post.postId, post.blogId, source)
             REPORT_POST -> handleReportPostClicked(post)
             TOGGLE_SEEN_STATUS -> handleToggleSeenStatusClicked(post, source)
             SPACER_NO_ACTION -> Unit // Do nothing
@@ -491,8 +492,12 @@ class ReaderPostCardActionsHandler @Inject constructor(
         }
     }
 
-    private fun handleCommentsClicked(postId: Long, blogId: Long) {
-        _navigationEvents.postValue(Event(ShowReaderComments(blogId, postId)))
+    private fun handleCommentsClicked(postId: Long, blogId: Long, source: String) {
+        _navigationEvents.postValue(Event(ShowReaderComments(
+                blogId,
+                postId,
+                ThreadedCommentsActionSource.mapReaderPostSource(source)
+        )))
     }
 
     private fun prepareEnableNotificationSnackbarAction(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCase.kt
@@ -127,7 +127,7 @@ class ReaderCommentsFollowUseCase @Inject constructor(
                 blogId,
                 postId,
                 post,
-                properties // TODOD
+                properties
         )
     }
 
@@ -193,7 +193,7 @@ class ReaderCommentsFollowUseCase @Inject constructor(
                 blogId,
                 postId,
                 readerPostTableWrapper.getBlogPost(blogId, postId, true),
-                properties // TODOD
+                properties
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCase.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.reader.FollowConversationStatusFlags
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsAction.DISABLE_PUSH_NOTIFICATION
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsAction.ENABLE_PUSH_NOTIFICATION
@@ -72,11 +73,13 @@ class ReaderCommentsFollowUseCase @Inject constructor(
     suspend fun setMySubscriptionToPost(
         blogId: Long,
         postId: Long,
-        subscribe: Boolean
+        subscribe: Boolean,
+        source: ThreadedCommentsActionSource
     ): Flow<FollowCommentsState> = flow {
         val properties = mutableMapOf<String, Any?>()
 
         properties.addFollowAction(subscribe)
+        properties.addFollowActionSource(source)
 
         emit(FollowCommentsState.Loading)
 
@@ -124,17 +127,19 @@ class ReaderCommentsFollowUseCase @Inject constructor(
                 blogId,
                 postId,
                 post,
-                properties
+                properties // TODOD
         )
     }
 
     suspend fun setEnableByPushNotifications(
         blogId: Long,
         postId: Long,
-        enable: Boolean
+        enable: Boolean,
+        source: ThreadedCommentsActionSource
     ): Flow<FollowCommentsState> = flow {
         val properties = mutableMapOf<String, Any?>()
         properties.addEnablePushNotificationAction(enable)
+        properties.addFollowActionSource(source)
 
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             emit(FollowCommentsState.FollowStateChanged(
@@ -188,7 +193,7 @@ class ReaderCommentsFollowUseCase @Inject constructor(
                 blogId,
                 postId,
                 readerPostTableWrapper.getBlogPost(blogId, postId, true),
-                properties
+                properties // TODOD
         )
     }
 
@@ -265,9 +270,17 @@ class ReaderCommentsFollowUseCase @Inject constructor(
         return this
     }
 
+    private fun MutableMap<String, Any?>.addFollowActionSource(
+        source: ThreadedCommentsActionSource
+    ): MutableMap<String, Any?> {
+        this[FOLLOW_COMMENT_ACTION_SOURCE] = source.sourceDescription
+        return this
+    }
+
     companion object {
         private const val FOLLOW_COMMENT_ACTION = "follow_action"
         private const val FOLLOW_COMMENT_ACTION_RESULT = "follow_action_result"
         private const val FOLLOW_COMMENT_ACTION_ERROR = "follow_action_error"
+        private const val FOLLOW_COMMENT_ACTION_SOURCE = "source"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModel.kt
@@ -14,6 +14,8 @@ import org.wordpress.android.ui.reader.FollowCommentsUiStateType.LOADING
 import org.wordpress.android.ui.reader.FollowCommentsUiStateType.VISIBLE_WITH_STATE
 import org.wordpress.android.ui.reader.FollowConversationStatusFlags
 import org.wordpress.android.ui.reader.ReaderFollowCommentsHandler
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.UNKNOWN
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.Failure
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FlagsMappedState
@@ -52,15 +54,17 @@ class ConversationNotificationsViewModel @Inject constructor(
 
     private var blogId: Long = 0
     private var postId: Long = 0
+    private var source: ThreadedCommentsActionSource = UNKNOWN
 
     data class ShowBottomSheetData(val show: Boolean, val isReceivingNotifications: Boolean = false)
 
-    fun start(blogId: Long, postId: Long) {
+    fun start(blogId: Long, postId: Long, source: ThreadedCommentsActionSource) {
         if (isStarted) return
         isStarted = true
 
         this.blogId = blogId
         this.postId = postId
+        this.source = source
 
         _updateFollowStatus.value = FollowCommentsNotAllowed
 
@@ -87,6 +91,7 @@ class ConversationNotificationsViewModel @Inject constructor(
                     blogId,
                     postId,
                     enable,
+                    source,
                     getSnackbarAction(fromSnackbar, enable)
             )
         }
@@ -150,6 +155,7 @@ class ConversationNotificationsViewModel @Inject constructor(
                     blogId,
                     postId,
                     askSubscribe,
+                    source,
                     if (askSubscribe) ::enablePushNotificationsFromSnackbarAction else null
             )
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFollowCommentsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFollowCommentsHandlerTest.kt
@@ -14,6 +14,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.test
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.READER_THREADED_COMMENTS
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FollowStateChanged
@@ -80,13 +81,18 @@ class ReaderFollowCommentsHandlerTest {
                 userMessage = userMessage
         )
 
-        whenever(readerCommentsFollowUseCase.setMySubscriptionToPost(blogId, postId, true)).thenReturn(
+        whenever(readerCommentsFollowUseCase.setMySubscriptionToPost(
+                blogId,
+                postId,
+                true,
+                READER_THREADED_COMMENTS
+        )).thenReturn(
                 flow { emit(state) }
         )
 
         setupObservers()
 
-        followCommentsHandler.handleFollowCommentsClicked(blogId, postId, true, null)
+        followCommentsHandler.handleFollowCommentsClicked(blogId, postId, true, READER_THREADED_COMMENTS, null)
 
         requireNotNull(uiState).let {
             assertThat(it).isEqualTo(state)
@@ -110,13 +116,24 @@ class ReaderFollowCommentsHandlerTest {
                 userMessage = userMessage
         )
 
-        whenever(readerCommentsFollowUseCase.setMySubscriptionToPost(blogId, postId, true)).thenReturn(
+        whenever(readerCommentsFollowUseCase.setMySubscriptionToPost(
+                blogId,
+                postId,
+                true,
+                READER_THREADED_COMMENTS
+        )).thenReturn(
                 flow { emit(state) }
         )
 
         setupObservers()
 
-        followCommentsHandler.handleFollowCommentsClicked(blogId, postId, true, snackbarAction)
+        followCommentsHandler.handleFollowCommentsClicked(
+                blogId,
+                postId,
+                true,
+                READER_THREADED_COMMENTS,
+                snackbarAction
+        )
 
         requireNotNull(uiState).let {
             assertThat(it).isEqualTo(state)
@@ -142,13 +159,24 @@ class ReaderFollowCommentsHandlerTest {
                 forcePushNotificationsUpdate = true
         )
 
-        whenever(readerCommentsFollowUseCase.setEnableByPushNotifications(blogId, postId, true)).thenReturn(
+        whenever(readerCommentsFollowUseCase.setEnableByPushNotifications(
+                blogId,
+                postId,
+                true,
+                READER_THREADED_COMMENTS
+        )).thenReturn(
                 flow { emit(state) }
         )
 
         setupObservers()
 
-        followCommentsHandler.handleEnableByPushNotificationsClicked(blogId, postId, true, snackbarAction)
+        followCommentsHandler.handleEnableByPushNotificationsClicked(
+                blogId,
+                postId,
+                true,
+                READER_THREADED_COMMENTS,
+                snackbarAction
+        )
 
         requireNotNull(uiState).let {
             assertThat(it).isEqualTo(state)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
@@ -257,7 +257,11 @@ class ReaderPostDetailUiStateBuilderTest {
             isCommentsOpen = true
         }
 
-        val snippetUiState = builder.buildCommentSnippetUiState(Loading, dummySourceReaderPost, dummyonCommentSnippetClicked)
+        val snippetUiState = builder.buildCommentSnippetUiState(
+                Loading,
+                dummySourceReaderPost,
+                dummyonCommentSnippetClicked
+        )
 
         assertThat(snippetUiState.showFollowConversation).isTrue()
     }
@@ -289,7 +293,11 @@ class ReaderPostDetailUiStateBuilderTest {
             add(comment)
         }
 
-        val snippetUiState = builder.buildCommentSnippetUiState(CommentSnippetData(comments = commentsList), dummySourceReaderPost, dummyonCommentSnippetClicked)
+        val snippetUiState = builder.buildCommentSnippetUiState(
+                CommentSnippetData(comments = commentsList),
+                dummySourceReaderPost,
+                dummyonCommentSnippetClicked
+        )
 
         assertThat(snippetUiState.snippetItems.first().type).isEqualTo(COMMENT)
         assertThat(snippetUiState.snippetItems[1].type).isEqualTo(BUTTON)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.reader
 
+import android.content.Context
+import android.content.res.Resources
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
@@ -11,9 +13,13 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
+import org.wordpress.android.models.ReaderComment
+import org.wordpress.android.models.ReaderCommentList
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.test
 import org.wordpress.android.ui.reader.discover.ReaderPostUiStateBuilder
@@ -22,10 +28,14 @@ import org.wordpress.android.ui.reader.models.ReaderSimplePostList
 import org.wordpress.android.ui.reader.utils.FeaturedImageUtils
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.utils.ThreadedCommentsUtils
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.CommentSnippetState.CommentSnippetData
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.CommentSnippetState.Loading
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState.ExcerptFooterUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState.ReaderPostFeaturedImageUiState
 import org.wordpress.android.ui.reader.views.ReaderPostDetailsHeaderViewUiStateBuilder
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.BUTTON
+import org.wordpress.android.ui.reader.views.uistates.CommentItemType.COMMENT
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.HtmlUtilsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -36,6 +46,7 @@ import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.GravatarUtilsWrapper
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.util.Date
 
 @InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -51,6 +62,8 @@ class ReaderPostDetailUiStateBuilderTest {
     @Mock lateinit var displayUtilsWrapper: DisplayUtilsWrapper
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var contextProvider: ContextProvider
+    @Mock lateinit var context: Context
+    @Mock lateinit var resources: Resources
     @Mock lateinit var htmlUtilsWrapper: HtmlUtilsWrapper
     @Mock lateinit var htmlMessageUtils: HtmlMessageUtils
     @Mock lateinit var readerSimplePost: ReaderSimplePost
@@ -65,6 +78,7 @@ class ReaderPostDetailUiStateBuilderTest {
         this.blogName = "blog name"
     }
     private val dummyOnRelatedPostItemClicked: (Long, Long, Boolean) -> Unit = { _, _, _ -> }
+    private val dummyonCommentSnippetClicked: (Long, Long) -> Unit = { _, _ -> }
     private val dummyFeaturedImageUrl = "/image/url"
     private val dummyVisitPostLinkText = "visit post"
     private val dummyDisplayPixelHeight = 100
@@ -235,6 +249,51 @@ class ReaderPostDetailUiStateBuilderTest {
 
                 assertThat(relatedPostsUiState.cards?.first()?.featuredImageUrl).isNull()
             }
+
+    @Test
+    fun `follow conversation shown if post isWP and comments are open`() {
+        dummySourceReaderPost.apply {
+            isExternal = false
+            isCommentsOpen = true
+        }
+
+        val snippetUiState = builder.buildCommentSnippetUiState(Loading, dummySourceReaderPost, dummyonCommentSnippetClicked)
+
+        assertThat(snippetUiState.showFollowConversation).isTrue()
+    }
+
+    @Test
+    fun `snippet contains comment and button`() {
+        dummySourceReaderPost.apply {
+            isExternal = false
+            isCommentsOpen = true
+        }
+
+        whenever(contextProvider.getContext()).thenReturn(context)
+        whenever(context.resources).thenReturn(resources)
+        whenever(resources.getDimensionPixelSize(anyInt())).thenReturn(10)
+
+        whenever(dateTimeUtilsWrapper.dateFromIso8601(anyString())).thenReturn(Date())
+        whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(anyOrNull())).thenReturn("")
+
+        whenever(gravatarUtilsWrapper.fixGravatarUrl(anyString(), anyInt())).thenReturn("")
+
+        val comment = ReaderComment().apply {
+            authorName = ""
+            published = "2021-12-08T16:58:20-08:00"
+            authorAvatar = "https://avatar"
+            text = "test"
+        }
+
+        val commentsList = ReaderCommentList().apply {
+            add(comment)
+        }
+
+        val snippetUiState = builder.buildCommentSnippetUiState(CommentSnippetData(comments = commentsList), dummySourceReaderPost, dummyonCommentSnippetClicked)
+
+        assertThat(snippetUiState.snippetItems.first().type).isEqualTo(COMMENT)
+        assertThat(snippetUiState.snippetItems[1].type).isEqualTo(BUTTON)
+    }
 
     private fun buildRelatedPostsUiState(
         relatedPosts: ReaderSimplePostList = dummyRelatedPosts,

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCaseTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.R
 import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.test
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.READER_THREADED_COMMENTS
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.Failure
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FollowCommentsNotAllowed
@@ -127,7 +128,7 @@ class ReaderCommentsFollowUseCaseTest {
     fun `setMySubscriptionToPost emits expected state when no network`() = test {
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
 
-        val flow = followCommentsUseCase.setMySubscriptionToPost(blogId, postId, true)
+        val flow = followCommentsUseCase.setMySubscriptionToPost(blogId, postId, true, READER_THREADED_COMMENTS)
 
         assertThat(flow.toList()).isEqualTo(
                 listOf(Loading, Failure(blogId, postId, UiStringRes(R.string.error_network_connection)))
@@ -139,7 +140,7 @@ class ReaderCommentsFollowUseCaseTest {
         whenever(postSubscribersApiCallsProvider.subscribeMeToPost(anyLong(), anyLong()))
                 .thenReturn(PostSubscribersCallResult.Success(true, false))
 
-        val flow = followCommentsUseCase.setMySubscriptionToPost(blogId, postId, true)
+        val flow = followCommentsUseCase.setMySubscriptionToPost(blogId, postId, true, READER_THREADED_COMMENTS)
 
         assertThat(flow.toList()).isEqualTo(listOf(
                 Loading,
@@ -162,7 +163,7 @@ class ReaderCommentsFollowUseCaseTest {
 
         whenever(postSubscribersApiCallsProvider.unsubscribeMeFromPost(anyLong(), anyLong())).thenReturn(failure)
 
-        val flow = followCommentsUseCase.setMySubscriptionToPost(blogId, postId, false)
+        val flow = followCommentsUseCase.setMySubscriptionToPost(blogId, postId, false, READER_THREADED_COMMENTS)
 
         assertThat(flow.toList()).isEqualTo(listOf(
                 Loading,
@@ -174,7 +175,7 @@ class ReaderCommentsFollowUseCaseTest {
     fun `setEnableByPushNotifications emits expected state when no network`() = test {
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
 
-        val flow = followCommentsUseCase.setEnableByPushNotifications(blogId, postId, true)
+        val flow = followCommentsUseCase.setEnableByPushNotifications(blogId, postId, true, READER_THREADED_COMMENTS)
 
         assertThat(flow.toList()).isEqualTo(listOf(FollowStateChanged(
                         blogId = blogId,
@@ -192,7 +193,7 @@ class ReaderCommentsFollowUseCaseTest {
         whenever(postSubscribersApiCallsProvider.managePushNotificationsForPost(anyLong(), anyLong(), eq(true)))
                 .thenReturn(PostSubscribersCallResult.Success(true, true))
 
-        val flow = followCommentsUseCase.setEnableByPushNotifications(blogId, postId, true)
+        val flow = followCommentsUseCase.setEnableByPushNotifications(blogId, postId, true, READER_THREADED_COMMENTS)
 
         assertThat(flow.toList()).isEqualTo(listOf(
                 FollowStateChanged(
@@ -214,7 +215,7 @@ class ReaderCommentsFollowUseCaseTest {
         whenever(postSubscribersApiCallsProvider.managePushNotificationsForPost(anyLong(), anyLong(), eq(true)))
                 .thenReturn(PostSubscribersCallResult.Failure(errorMessage))
 
-        val flow = followCommentsUseCase.setEnableByPushNotifications(blogId, postId, true)
+        val flow = followCommentsUseCase.setEnableByPushNotifications(blogId, postId, true, READER_THREADED_COMMENTS)
 
         assertThat(flow.toList()).isEqualTo(listOf(
                 FollowStateChanged(

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModelTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.reader.FollowCommentsUiStateType
 import org.wordpress.android.ui.reader.FollowCommentsUiStateType.VISIBLE_WITH_STATE
 import org.wordpress.android.ui.reader.FollowConversationUiState
 import org.wordpress.android.ui.reader.ReaderFollowCommentsHandler
+import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.READER_THREADED_COMMENTS
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FollowStateChanged
 import org.wordpress.android.viewmodel.Event
@@ -89,7 +90,13 @@ class ConversationNotificationsViewModelTest : BaseUnitTest() {
         doAnswer {
             stateChanged = FollowStateChanged(blogId, postId, true, false)
             followStatusUpdate.postValue(stateChanged)
-        }.whenever(followCommentsHandler).handleFollowCommentsClicked(eq(blogId), eq(postId), eq(true), anyOrNull())
+        }.whenever(followCommentsHandler).handleFollowCommentsClicked(
+                eq(blogId),
+                eq(postId),
+                eq(true),
+                eq(READER_THREADED_COMMENTS),
+                anyOrNull()
+        )
 
         setupObserversAndStart()
 
@@ -115,7 +122,13 @@ class ConversationNotificationsViewModelTest : BaseUnitTest() {
         doAnswer {
             stateChanged = FollowStateChanged(blogId, postId, false, false)
             followStatusUpdate.postValue(stateChanged)
-        }.whenever(followCommentsHandler).handleFollowCommentsClicked(blogId, postId, false, null)
+        }.whenever(followCommentsHandler).handleFollowCommentsClicked(
+                blogId,
+                postId,
+                false,
+                READER_THREADED_COMMENTS,
+                null
+        )
 
         setupObserversAndStart()
 
@@ -141,7 +154,13 @@ class ConversationNotificationsViewModelTest : BaseUnitTest() {
         doAnswer {
             stateChanged = FollowStateChanged(blogId, postId, true, true)
             followStatusUpdate.postValue(stateChanged)
-        }.whenever(followCommentsHandler).handleEnableByPushNotificationsClicked(blogId, postId, true, null)
+        }.whenever(followCommentsHandler).handleEnableByPushNotificationsClicked(
+                blogId,
+                postId,
+                true,
+                READER_THREADED_COMMENTS,
+                null
+        )
 
         setupObserversAndStart()
 
@@ -162,6 +181,6 @@ class ConversationNotificationsViewModelTest : BaseUnitTest() {
             uiState = it
         }
 
-        viewModel.start(blogId, postId)
+        viewModel.start(blogId, postId, READER_THREADED_COMMENTS)
     }
 }


### PR DESCRIPTION
Part of #15660

This PR:
- adds source property for:
   - `comment_follow_conversation` (every follow/unfollow and even push action)
   🔵 Tracked: comment_follow_conversation, Properties: { "source":"reader_post_details_comments" }
   🔵 Tracked: comment_follow_conversation, Properties: { "source":"reader_threaded_comments" }
   - `reader_article_comments_opened`:
       - On a Reader post card, tap the comment button: 
       🔵 Tracked: reader_article_comments_opened, Properties: {"source":"reader_post_card"}     
       - In Reader post details, tap the comment button on the bottom toolbar.
       🔵 Tracked: reader_article_comments_opened, Properties: {"source":"reader_post_details"}
       - In Reader post details, tap the button in the Comments snippet
       🔵 Tracked: reader_article_comments_opened, Properties: {"source":"reader_post_details_comments"}
       - In Notifications > Comments, tap a notification's header that displays threaded comments.
       🔵 Tracked: reader_article_comments_opened, Properties: {"source":"comment_notification"}       
       - For a comment go to Notifications > Likes > detail > notification header. 
       🔵 Tracked: reader_article_comments_opened, Properties: {"source":"comment_like_notification"}
       - Go to My Site > Activity Log > Comment activity > tap the word Comment.
       🔵 Tracked: reader_article_comments_opened, Properties: {"source":"reader_post_details_comments"}
       - Open with the app a link to like a comment from an email notification
       🔵 Tracked: reader_article_comments_opened, Properties: {"source":"direct_operation"}
       
- adds a bit of unit testing

NOTE 1: the MY_SITE_COMMENT is currently not used but we  could want to mimic iOS here ([1](https://github.com/wordpress-mobile/WordPress-iOS/pull/17638), [2](https://github.com/wordpress-mobile/WordPress-iOS/pull/17651))
NOTE 2: if the comment thread is not in the cache yet you get a webview

## To test
- Check the unit tests are green
- Check you get the tracking as per description above

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
NA

3. What automated tests I added (or what prevented me from doing so)
Added a few unit test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
