### PR TITLE
My Site Dashboard - Phase 2 - Hide dashboard cards: jetpack app, non wpcom sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
@@ -31,7 +31,8 @@ class MySiteSourceManager @Inject constructor(
     cardsSource: CardsSource,
     siteIconProgressSource: SiteIconProgressSource,
     private val mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig,
-    private val buildConfigWrapper: BuildConfigWrapper
+    private val buildConfigWrapper: BuildConfigWrapper,
+    private val selectedSiteRepository: SelectedSiteRepository
 ) {
     private val mySiteSources: List<MySiteSource<*>> = listOf(
             selectedSiteSource,
@@ -44,9 +45,14 @@ class MySiteSourceManager @Inject constructor(
             cardsSource
     )
 
+    private val showDashboardCards: Boolean
+        get() = mySiteDashboardPhase2FeatureConfig.isEnabled() &&
+                !buildConfigWrapper.isJetpackApp &&
+                selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi == true
+
     fun build(coroutineScope: CoroutineScope, siteLocalId: Int?): List<LiveData<out PartialState>> {
         return if (siteLocalId != null) {
-            if (mySiteDashboardPhase2FeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp) {
+            if (showDashboardCards) {
                 mySiteSources.map { source ->
                     source.build(coroutineScope, siteLocalId)
                             .addDistinctUntilChangedIfNeeded(!mySiteDashboardPhase2FeatureConfig.isEnabled())

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.Dyn
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction.Pin
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction.Unpin
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsSource
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
 import javax.inject.Inject
@@ -29,7 +30,8 @@ class MySiteSourceManager @Inject constructor(
     private val selectedSiteSource: SelectedSiteSource,
     cardsSource: CardsSource,
     siteIconProgressSource: SiteIconProgressSource,
-    private val mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig
+    private val mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig,
+    private val buildConfigWrapper: BuildConfigWrapper
 ) {
     private val mySiteSources: List<MySiteSource<*>> = listOf(
             selectedSiteSource,
@@ -44,7 +46,7 @@ class MySiteSourceManager @Inject constructor(
 
     fun build(coroutineScope: CoroutineScope, siteLocalId: Int?): List<LiveData<out PartialState>> {
         return if (siteLocalId != null) {
-            if (mySiteDashboardPhase2FeatureConfig.isEnabled()) {
+            if (mySiteDashboardPhase2FeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp) {
                 mySiteSources.map { source ->
                     source.build(coroutineScope, siteLocalId)
                             .addDistinctUntilChangedIfNeeded(!mySiteDashboardPhase2FeatureConfig.isEnabled())


### PR DESCRIPTION
Parent #15625 

This PR hides dashboard cards feed in the `Jetpack` app and for `non wpcom sites` (accessed using login using existing site).

To test:

**Test 1 Jetpack app**

1. Install and launch Jetpack app. 
2. Go to `My Site` -> `Me` -> `App Settings` -> `Test Feature Configuration`.
3. Turn the `MySiteDashboardPhase2FeatureConfig` feature flag ON.
4. Relaunch the app.
5. Notice that dashboard cards are not visible.
6. Pull-to refresh.
7. Notice that the refresh completes without any issues.

**Test 2 Non wpcom site**

1. Install and launch WordPress app.
2. Login using a jurassic ninja site.
3. Go to `My Site` -> `Me` -> `App Settings` -> `Test Feature Configuration`.
4. Turn the `MySiteDashboardPhase2FeatureConfig` feature flag ON.
5. Relaunch the app.
6. Notice that dashboard cards are not visible.
7. Pull-to refresh.
8. Notice that the refresh completes without any issues.

**Test 3 WordPress app - wpcom site**

1. Install and launch WordPress app.
2. Login using wordpress.com account having at least 1 site
3. Go to `My Site` -> `Me` -> `App Settings` -> `Test Feature Configuration`.
4. Turn the `MySiteDashboardPhase2FeatureConfig` feature flag ON.
5. Relaunch the app.
6. Notice that dashboard cards are visible.
7. Pull-to refresh.
8. Notice that the refresh completes without any issues.


## Regression Notes
1. Potential unintended areas of impact
The dashboard cards feed in the WordPress app should be visible.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for scenarios where dashboard cards were hidden.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
