### PR TITLE
Update Aztec version to v1.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.wordPressUtilsVersion = '2.2.0'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.68.0-alpha2'
+    ext.gutenbergMobileVersion = 'v1.68.0-alpha3'
     ext.storiesVersion = '1.2.0'
     ext.aboutAutomatticVersion = 'main-c764a2d66273d4c6aeed66bb7a5c75714d88c554'
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.aztecVersion = 'v1.5.1'
+    ext.aztecVersion = 'v1.5.2'
 }
 
 repositories {


### PR DESCRIPTION
This PR updates the Aztec version to `v1.5.2` needed by the latest version of Gutenberg.

To test CI checks should pass

## Regression Notes
1. Potential unintended areas of impact
It's a new formatting feature within the editor that shouldn't affect any other areas.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing in the [Gutenberg](https://github.com/WordPress/gutenberg/pull/36028) implementation.

3. What automated tests I added (or what prevented me from doing so)
N/A 

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
