### PR TITLE
My Site Dashboard: Phase 2: Remove Singleton annotation from My Site Sources

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
@@ -8,9 +8,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.mysite.MySiteSource.SiteIndependentSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class CurrentAvatarSource @Inject constructor(
     private val accountStore: AccountStore
 ) : SiteIndependentSource<CurrentAvatarUrl> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteIconProgressSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteIconProgressSource.kt
@@ -5,9 +5,7 @@ import androidx.lifecycle.map
 import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.ShowSiteIconProgressBar
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class SiteIconProgressSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository
 ) : MySiteSource<ShowSiteIconProgressBar> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -18,9 +18,7 @@ import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CardsUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import javax.inject.Inject
 import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
 class CardsSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val cardsStore: CardsStore,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
@@ -14,9 +14,7 @@ import org.wordpress.android.util.filter
 import org.wordpress.android.util.mapAsync
 import org.wordpress.android.util.merge
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class QuickStartCardSource @Inject constructor(
     private val quickStartRepository: QuickStartRepository,
     private val quickStartStore: QuickStartStore,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
@@ -11,9 +11,7 @@ import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DynamicCardsUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class DynamicCardsSource
 @Inject constructor(
     private val dynamicCardStore: DynamicCardStore,


### PR DESCRIPTION
Parent #15215 

This PR removes the `@Singleton` annotation for the following My Site Sources:
    CardsSource
    CurrentAvatarSource
    DynamicCardsSource
    QuickStartCardSource
    SiteIconProgressSource

### **To test:**
- Smoke test the My Site Tab and make sure that the following functions as expected
- Adding/changing avatar
- Adding/changing site icon
- Post cards are shown when expected
- Quick Start works as expected
- Dynamic cards are shown when the feature flag is on

If additional/detailed test instructions are needed see the following: 
[2021-12-09-test-scenarios.pdf](https://github.com/wordpress-mobile/WordPress-Android/files/7687605/2021-12-09-test-scenarios.pdf)

## Regression Notes
1. Potential unintended areas of impact
My Site Tab doesn't function properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
