### PR TITLE
My Site Dashboard: Phase 2: Relocate init and clear functions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -22,6 +22,10 @@ class ScanAndBackupSource @Inject constructor(
 ) : MySiteRefreshSource<JetpackCapabilities> {
     override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
+    fun clear() {
+        jetpackCapabilitiesUseCase.clear()
+    }
+
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<JetpackCapabilities> {
         val result = MediatorLiveData<JetpackCapabilities>()
         result.refreshData(coroutineScope, siteLocalId)
@@ -59,9 +63,5 @@ class ScanAndBackupSource @Inject constructor(
         } else {
             postState(JetpackCapabilities(scanAvailable = false, backupAvailable = false))
         }
-    }
-
-    fun clear() {
-        jetpackCapabilitiesUseCase.clear()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
@@ -19,6 +19,14 @@ class SelectedSiteSource @Inject constructor(
 ) : MySiteRefreshSource<SelectedSite> {
     override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
 
+    init {
+        dispatcher.register(this)
+    }
+
+    fun clear() {
+        dispatcher.unregister(this)
+    }
+
     override fun build(
         coroutineScope: CoroutineScope,
         siteLocalId: Int
@@ -35,14 +43,6 @@ class SelectedSiteSource @Inject constructor(
     }
 
     fun updateSiteSettingsIfNecessary() = selectedSiteRepository.updateSiteSettingsIfNecessary()
-
-    init {
-        dispatcher.register(this)
-    }
-
-    fun clear() {
-        dispatcher.unregister(this)
-    }
 
     @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)


### PR DESCRIPTION
Parent #15215 

This PR addresses relocates the `init()` and `clear()` functions to immediately follow the field definitions. As requested in this [comment](https://github.com/wordpress-mobile/WordPress-Android/pull/15645#discussion_r761819048).

To test:
There is nothing to test in this PR

## Regression Notes
1. Potential unintended areas of impact N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A
3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
