### PR TITLE
Github Workflow: Add Title and PR url as arguments in the workflow

### DIFF
--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GUTENBERG_MOBILE_VERSION: ${{ github.event.inputs.gutenbergMobileVersion }}
-      PR_TITLE: ${{ github.event.inputs.title }}
+      TITLE: ${{ github.event.inputs.title || 'Automated gutenberg-mobile version update'  }}
       PR_URL: ${{ github.event.inputs.prURL }}
     steps:
       - uses: actions/checkout@v2
@@ -25,11 +25,6 @@ jobs:
       - name: Compute vars
         id: vars
         run: |
-          PR_TITLE_PREFIX = "Automated gutenberg-mobile version update"
-          if [[ $PR_TITLE ]]; then
-            PR_TITLE_PREFIX = $PR_TITLE
-          fi
-          
           # Check if the version contains a "-" character
           if [[ $GUTENBERG_MOBILE_VERSION == *"-"* ]]; then
             # Get the substring up to "-" which should be either "trunk" or the PR number
@@ -37,15 +32,15 @@ jobs:
 
             if [[ "$VERSION_PREFIX" == "trunk" ]]; then
               echo ::set-output name=branch_name::update-gb-mobile-version/for-trunk-update
-              echo ::set-output name=title::"$PR_TITLE_PREFIX for $VERSION_PREFIX"
+              echo ::set-output name=title::"$TITLE for $VERSION_PREFIX"
             else
               echo ::set-output name=branch_name::update-gb-mobile-version/for-pr-$VERSION_PREFIX
-              echo ::set-output name=title::"$PR_TITLE_PREFIX for PR $VERSION_PREFIX"
+              echo ::set-output name=title::"$TITLE for PR $VERSION_PREFIX"
             fi
           else
             # If the version doesn't contain a "-", it should be a tag
             echo ::set-output name=branch_name::update-gb-mobile-version/for-tag-$GUTENBERG_MOBILE_VERSION
-            echo ::set-output name=title::"$PR_TITLE_PREFIX for tag $GUTENBERG_MOBILE_VERSION"
+            echo ::set-output name=title::"$TITLE for tag $GUTENBERG_MOBILE_VERSION"
           fi
 
           echo ::set-output name=commit_message::"Update gutenbergMobileVersion to $GUTENBERG_MOBILE_VERSION - $PR_URL"

--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GUTENBERG_MOBILE_VERSION: ${{ github.event.inputs.gutenbergMobileVersion }}
-      TITLE: ${{ github.event.inputs.title || 'Automated gutenberg-mobile version update'  }}
-      PR_URL: ${{ github.event.inputs.prURL }}
+      PR_TITLE: ${{ github.event.inputs.title || 'Automated gutenberg-mobile version update'  }}
+      GUTENBERG_MOBILE_PR_URL: ${{ github.event.inputs.prURL }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -32,18 +32,18 @@ jobs:
 
             if [[ "$VERSION_PREFIX" == "trunk" ]]; then
               echo ::set-output name=branch_name::update-gb-mobile-version/for-trunk-update
-              echo ::set-output name=title::"$TITLE for $VERSION_PREFIX"
+              echo ::set-output name=title::"$PR_TITLE for $VERSION_PREFIX"
             else
               echo ::set-output name=branch_name::update-gb-mobile-version/for-pr-$VERSION_PREFIX
-              echo ::set-output name=title::"$TITLE for PR $VERSION_PREFIX"
+              echo ::set-output name=title::"$PR_TITLE for PR $VERSION_PREFIX"
             fi
           else
             # If the version doesn't contain a "-", it should be a tag
             echo ::set-output name=branch_name::update-gb-mobile-version/for-tag-$GUTENBERG_MOBILE_VERSION
-            echo ::set-output name=title::"$TITLE for tag $GUTENBERG_MOBILE_VERSION"
+            echo ::set-output name=title::"$PR_TITLE for tag $GUTENBERG_MOBILE_VERSION"
           fi
 
-          echo ::set-output name=commit_message::"Update gutenbergMobileVersion to $GUTENBERG_MOBILE_VERSION - $PR_URL"
+          echo ::set-output name=commit_message::"Update gutenbergMobileVersion to $GUTENBERG_MOBILE_VERSION - $GUTENBERG_MOBILE_PR_URL"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -3,12 +3,18 @@ on:
     inputs:
       gutenbergMobileVersion:
         required: true
+      title:
+        required: false
+      prURL:
+        required: false
 
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest
     env:
       GUTENBERG_MOBILE_VERSION: ${{ github.event.inputs.gutenbergMobileVersion }}
+      PR_TITLE: ${{ github.event.inputs.title }}
+      PR_URL: ${{ github.event.inputs.prURL }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -19,6 +25,11 @@ jobs:
       - name: Compute vars
         id: vars
         run: |
+          PR_TITLE_PREFIX = "Automated gutenberg-mobile version update"
+          if [[ $PR_TITLE ]]; then
+            PR_TITLE_PREFIX = $PR_TITLE
+          fi
+          
           # Check if the version contains a "-" character
           if [[ $GUTENBERG_MOBILE_VERSION == *"-"* ]]; then
             # Get the substring up to "-" which should be either "trunk" or the PR number
@@ -26,17 +37,18 @@ jobs:
 
             if [[ "$VERSION_PREFIX" == "trunk" ]]; then
               echo ::set-output name=branch_name::update-gb-mobile-version/for-trunk-update
-              echo ::set-output name=title::"Automated gutenberg-mobile version update for $VERSION_PREFIX"
+              echo ::set-output name=title::"$PR_TITLE_PREFIX for $VERSION_PREFIX"
             else
               echo ::set-output name=branch_name::update-gb-mobile-version/for-pr-$VERSION_PREFIX
-              echo ::set-output name=title::"Automated gutenberg-mobile version update for PR $VERSION_PREFIX"
+              echo ::set-output name=title::"$PR_TITLE_PREFIX for PR $VERSION_PREFIX"
             fi
           else
             # If the version doesn't contain a "-", it should be a tag
             echo ::set-output name=branch_name::update-gb-mobile-version/for-tag-$GUTENBERG_MOBILE_VERSION
-            echo ::set-output name=title::"Automated gutenberg-mobile version update for tag $GUTENBERG_MOBILE_VERSION"
+            echo ::set-output name=title::"$PR_TITLE_PREFIX for tag $GUTENBERG_MOBILE_VERSION"
           fi
-          echo ::set-output name=commit_message::"Update gutenbergMobileVersion to $GUTENBERG_MOBILE_VERSION"
+
+          echo ::set-output name=commit_message::"Update gutenbergMobileVersion to $GUTENBERG_MOBILE_VERSION - $PR_URL"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
This PR make it possible to add a title and PR url to the generated PR from the workflow.

To test:
I am not sure how to test this except for deploying this change.

## Regression Notes
None that I can think of. 

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
