### PR TITLE
Update About screen theme

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 18.9
 -----
-
+* [*] Added new About screen where the user can rate and share the app, visit our Twitter profile and blog, view other apps, and more. [https://github.com/wordpress-mobile/WordPress-Android/pull/15631]
 
 18.8
 -----

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -169,7 +169,7 @@
         <activity
             android:name=".ui.about.UnifiedAboutActivity"
             android:label="@string/about_the_app"
-            android:theme="@style/WordPress.NoActionBar" />
+            android:theme="@style/WordPress.UnifiedAbout" />
         <activity
             android:name=".ui.prefs.BlogPreferencesActivity"
             android:configChanges="orientation|screenSize"

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1647,4 +1647,17 @@
         <item name="android:paddingEnd">0dp</item>
         <item name="android:textAlignment">viewStart</item>
     </style>
+
+    <!-- Unified About -->
+    <style name="WordPress.UnifiedAbout" parent="WordPress.NoActionBar">
+        <item name="textAppearanceHeadline4">@style/TextAppearance.UnifiedAbout.Header.Title</item>
+        <item name="textAppearanceHeadline6">@style/TextAppearance.UnifiedAbout.Toolbar.Title</item>
+    </style>
+
+    <style name="TextAppearance.UnifiedAbout.Header.Title" parent="TextAppearance.MaterialComponents.Headline4">
+        <item name="fontFamily">serif</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.UnifiedAbout.Toolbar.Title" parent="TextAppearance.App.Toolbar.Title" />
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.68.0'
     ext.storiesVersion = '1.2.0'
-    ext.aboutAutomatticVersion = '21-9b1783356b263d0746b4859570af2f6484f44a80'
+    ext.aboutAutomatticVersion = 'main-9df59764f7cf2a7161826e102384cd04e2cfdaad'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.68.0-alpha3'
     ext.storiesVersion = '1.2.0'
-    ext.aboutAutomatticVersion = 'main-61cb99923ffab35d8ef9ae6d356accbfc3a2bf4a'
+    ext.aboutAutomatticVersion = '21-9b1783356b263d0746b4859570af2f6484f44a80'
 
     repositories {
         maven {


### PR DESCRIPTION
This PR upgrades the Unified About library to enable custom theme support (refer to [this](https://github.com/Automattic/about-automattic-android/pull/21) for more details) and then adds a custom theme to `UnifiedAboutActivity` in order to change the font styles used there to match the rest of the app:

<img width=300 src="https://user-images.githubusercontent.com/830056/145500701-5d951465-a777-4870-b552-cd891bfead5f.png"/>

Notes: 
- I'm adding the "Not Ready for Merge" label here as we still need to update the About library version once [this PR](https://github.com/Automattic/about-automattic-android/pull/21) gets merged.
- This PR also adds a release note item referring to the release of the Unified About screen. It technically happened on `18.8`, but we missed that one.

### To test

1. On the Main screen, tap the Me button.
1. On the Me screen, tap the About WordPress item.
1. On the About screen, notice how the text style on the App Bar and the Header now match the rest of the app.
1. Switch to dark mode and verify that the screen is still following the style defined by the Unified About design spec.

## Regression Notes
1. Potential unintended areas of impact
None that I could think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None at this time, but we should consider adding some tests to the library.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.