### PR TITLE
Workflow: Simplify the PR Title so that it comes from the event

### DIFF
--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GUTENBERG_MOBILE_VERSION: ${{ github.event.inputs.gutenbergMobileVersion }}
-      PR_TITLE: ${{ github.event.inputs.title || 'Automated gutenberg-mobile version update'  }}
+      PR_TITLE: ${{ github.event.inputs.title || 'Automated gutenberg-mobile version update for ' +  ${{ github.event.inputs.gutenbergMobileVersion }}   }}
       PR_BODY: ${{ github.event.inputs.body || 'This PR incorporates changes from [gutenberg-mobile repo](https://github.com/wordpress-mobile/gutenberg-mobile).' }} 
       GUTENBERG_MOBILE_PR_URL: ${{ github.event.inputs.prURL }}
     steps:
@@ -35,17 +35,14 @@ jobs:
 
             if [[ "$VERSION_PREFIX" == "trunk" ]]; then
               echo ::set-output name=branch_name::update-gb-mobile-version/for-trunk-update
-              echo ::set-output name=title::"$PR_TITLE for $VERSION_PREFIX"
             else
               echo ::set-output name=branch_name::update-gb-mobile-version/for-pr-$VERSION_PREFIX
-              echo ::set-output name=title::"$PR_TITLE for PR $VERSION_PREFIX"
             fi
           else
             # If the version doesn't contain a "-", it should be a tag
             echo ::set-output name=branch_name::update-gb-mobile-version/for-tag-$GUTENBERG_MOBILE_VERSION
-            echo ::set-output name=title::"$PR_TITLE for tag $GUTENBERG_MOBILE_VERSION"
           fi
-
+          echo ::set-output name=title::"$PR_TITLE"
           echo ::set-output name=commit_message::"Update gutenbergMobileVersion to $GUTENBERG_MOBILE_VERSION"
           echo ::set-output name=pr_description::"##Description \n $PR_BODY \n\n Related Changes: $GUTENBERG_MOBILE_PR_URL"
       - name: Create Pull Request


### PR DESCRIPTION
Continue to improve the PR title that is generated by the workflow. 

Similar to https://github.com/wordpress-mobile/WordPress-Android/pull/15693 

To test:

Deploy and run the script in https://github.com/wordpress-mobile/gutenberg-mobile/pull/4353

## Regression Notes
None that I can think of. 


PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
