### PR TITLE
Activating the feature flag for comment snippet below reader post.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] Block editor: Preformatted block: Fix an issue where the background color is not showing up for standard themes. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4292]
 * [**] Block editor: Update Gallery Block to default to the new format and auto-convert old galleries to the new format. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4315]
 * [***] Block editor: Highlight text: Enables color customization for specific text within a Paragraph block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4175]
+* [**] Reader: added a comment snippet below the post content; follow the conversation from there, then go to full comments to like and get involved. [https://github.com/wordpress-mobile/WordPress-Android/pull/15705]
 
 18.8
 -----

--- a/WordPress/src/main/java/org/wordpress/android/util/config/CommentsSnippetFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/CommentsSnippetFeatureConfig.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 /**
  * Configuration of the threaded comments below post improvement
  */
-@Feature(COMMENTS_SNIPPET_COMMENTS_REMOTE_FIELD, false)
+@Feature(COMMENTS_SNIPPET_COMMENTS_REMOTE_FIELD, true)
 class CommentsSnippetFeatureConfig
 @Inject constructor(
     appConfig: AppConfig


### PR DESCRIPTION
Fixes #15660, this PR enables the remote feature flag for the comments snippet below reader post content.

Main feature PR: #15663 (check there for full feature description and relevant test steps)

## To test

- Check the unit tests pass
- Remove the app if already installed
- Use the jalapeno apk from this CI to install the WordPress app and check the comment snippet below post content in the reader is available without any need to activate the feature flag
- Smoke test the feature (you can follow the test instructions from [here](https://github.com/wordpress-mobile/WordPress-Android/pull/15663))
- Try to disable the feature flag remotely, restart the app and check you do not have the comment snippet any more.

## Regression Notes
1. Potential unintended areas of impact
Issues in reader post visualisation.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing, relying on already available unit testing and added a few new one.

3. What automated tests I added (or what prevented me from doing so)
Added a few more unit testing.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
