### PR TITLE
My Site Dashboard: Phase 2 - Address flicker issue on My Site tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -11,7 +11,6 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartD
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.ListItem
 
-@Suppress("TooManyFunctions")
 class MySiteAdapterDiffCallback(
     private val oldCardAndItems: List<MySiteCardAndItem>,
     private val updatedCardAndItems: List<MySiteCardAndItem>

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -4,13 +4,18 @@ import androidx.recyclerview.widget.DiffUtil
 import org.apache.commons.lang3.NotImplementedException
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems.PostItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard.QuickStartTaskTypeItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartDynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.ListItem
 
+@Suppress("TooManyFunctions")
 class MySiteAdapterDiffCallback(
     private val oldCardAndItems: List<MySiteCardAndItem>,
     private val updatedCardAndItems: List<MySiteCardAndItem>
@@ -37,6 +42,76 @@ class MySiteAdapterDiffCallback(
     }
 
     override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        return oldCardAndItems[oldItemPosition] == updatedCardAndItems[newItemPosition]
+        val oldItem = oldCardAndItems[oldItemPosition]
+        val newItem = updatedCardAndItems[newItemPosition]
+        return when {
+            oldItem is QuickActionsCard && newItem is QuickActionsCard -> areContentsTheSame(oldItem, newItem)
+            oldItem is QuickStartCard && newItem is QuickStartCard -> areContentsTheSame(oldItem, newItem)
+            oldItem is PostCardWithPostItems && newItem is PostCardWithPostItems -> areContentsTheSame(oldItem, newItem)
+            oldItem is PostCardWithoutPostItems && newItem is PostCardWithoutPostItems -> areContentsTheSame(
+                    oldItem,
+                    newItem
+            )
+            else -> oldCardAndItems[oldItemPosition] == updatedCardAndItems[newItemPosition]
+        }
     }
+
+    // QuickActionsCard
+    private fun areContentsTheSame(oldItem: QuickActionsCard, newItem: QuickActionsCard) =
+            oldItem.title == newItem.title &&
+            oldItem.showPages == newItem.showPages &&
+            oldItem.showPagesFocusPoint == newItem.showPagesFocusPoint &&
+            oldItem.showStatsFocusPoint == newItem.showStatsFocusPoint
+
+    // QuickStartCard
+    private fun areContentsTheSame(oldItem: QuickStartCard, newItem: QuickStartCard) =
+            oldItem.moreMenuVisible == newItem.moreMenuVisible &&
+            oldItem.title == newItem.title &&
+            oldItem.activeQuickStartItem == newItem.activeQuickStartItem &&
+            areQuickStartTaskTypeItemsContentsTheSame(oldItem.taskTypeItems, newItem.taskTypeItems)
+
+    // QuickStartTaskTypeItem (List)
+    private fun areQuickStartTaskTypeItemsContentsTheSame(
+        oldList: List<QuickStartTaskTypeItem>,
+        newList: List<QuickStartTaskTypeItem>
+    ): Boolean {
+        oldList.forEachIndexed { index, quickStartTaskTypeItem ->
+            if (!areContentsTheSame(quickStartTaskTypeItem, newList[index])) return false
+        }
+        return true
+    }
+
+    // QuickStartTaskTypeItem
+    private fun areContentsTheSame(oldItem: QuickStartTaskTypeItem, newItem: QuickStartTaskTypeItem) =
+            oldItem.title == newItem.title &&
+                    oldItem.subtitle == newItem.subtitle &&
+                    oldItem.quickStartTaskType == newItem.quickStartTaskType &&
+                    oldItem.titleEnabled == newItem.titleEnabled &&
+                    oldItem.strikeThroughTitle == newItem.strikeThroughTitle
+
+    // PostCardWithPostItems
+    private fun areContentsTheSame(oldItem: PostCardWithPostItems, newItem: PostCardWithPostItems) =
+            oldItem.postCardType == newItem.postCardType &&
+            oldItem.title == newItem.title &&
+            arePostItemsContentsTheSame(oldItem.postItems, newItem.postItems)
+
+    // PostItem (List)
+    private fun arePostItemsContentsTheSame(oldList: List<PostItem>, newList: List<PostItem>): Boolean {
+        oldList.forEachIndexed { index, postItem ->
+            if (!areContentsTheSame(postItem, newList[index])) return false
+        }
+        return true
+    }
+
+    // PostItem
+    private fun areContentsTheSame(oldItem: PostItem, newItem: PostItem) =
+            oldItem.title == newItem.title &&
+            oldItem.excerpt == newItem.excerpt &&
+            oldItem.featuredImageUrl == newItem.featuredImageUrl &&
+            oldItem.isTimeIconVisible == newItem.isTimeIconVisible
+
+    private fun areContentsTheSame(oldItem: PostCardWithoutPostItems, newItem: PostCardWithoutPostItems) =
+            oldItem.postCardType == newItem.postCardType &&
+                    oldItem.title == newItem.title &&
+                    oldItem.excerpt == newItem.excerpt
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -84,10 +84,10 @@ class MySiteAdapterDiffCallback(
     // QuickStartTaskTypeItem
     private fun areContentsTheSame(oldItem: QuickStartTaskTypeItem, newItem: QuickStartTaskTypeItem) =
             oldItem.title == newItem.title &&
-                    oldItem.subtitle == newItem.subtitle &&
-                    oldItem.quickStartTaskType == newItem.quickStartTaskType &&
-                    oldItem.titleEnabled == newItem.titleEnabled &&
-                    oldItem.strikeThroughTitle == newItem.strikeThroughTitle
+            oldItem.subtitle == newItem.subtitle &&
+            oldItem.quickStartTaskType == newItem.quickStartTaskType &&
+            oldItem.titleEnabled == newItem.titleEnabled &&
+            oldItem.strikeThroughTitle == newItem.strikeThroughTitle
 
     // PostCardWithPostItems
     private fun areContentsTheSame(oldItem: PostCardWithPostItems, newItem: PostCardWithPostItems) =
@@ -112,6 +112,6 @@ class MySiteAdapterDiffCallback(
 
     private fun areContentsTheSame(oldItem: PostCardWithoutPostItems, newItem: PostCardWithoutPostItems) =
             oldItem.postCardType == newItem.postCardType &&
-                    oldItem.title == newItem.title &&
-                    oldItem.excerpt == newItem.excerpt
+            oldItem.title == newItem.title &&
+            oldItem.excerpt == newItem.excerpt
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -4,12 +4,8 @@ import androidx.recyclerview.widget.DiffUtil
 import org.apache.commons.lang3.NotImplementedException
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems.PostItem
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard.QuickStartTaskTypeItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartDynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
@@ -41,77 +37,6 @@ class MySiteAdapterDiffCallback(
         }
     }
 
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        val oldItem = oldCardAndItems[oldItemPosition]
-        val newItem = updatedCardAndItems[newItemPosition]
-        return when {
-            oldItem is QuickActionsCard && newItem is QuickActionsCard -> areContentsTheSame(oldItem, newItem)
-            oldItem is QuickStartCard && newItem is QuickStartCard -> areContentsTheSame(oldItem, newItem)
-            oldItem is PostCardWithPostItems && newItem is PostCardWithPostItems -> areContentsTheSame(oldItem, newItem)
-            oldItem is PostCardWithoutPostItems && newItem is PostCardWithoutPostItems -> areContentsTheSame(
-                    oldItem,
-                    newItem
-            )
-            else -> oldCardAndItems[oldItemPosition] == updatedCardAndItems[newItemPosition]
-        }
-    }
-
-    // QuickActionsCard
-    private fun areContentsTheSame(oldItem: QuickActionsCard, newItem: QuickActionsCard) =
-            oldItem.title == newItem.title &&
-            oldItem.showPages == newItem.showPages &&
-            oldItem.showPagesFocusPoint == newItem.showPagesFocusPoint &&
-            oldItem.showStatsFocusPoint == newItem.showStatsFocusPoint
-
-    // QuickStartCard
-    private fun areContentsTheSame(oldItem: QuickStartCard, newItem: QuickStartCard) =
-            oldItem.moreMenuVisible == newItem.moreMenuVisible &&
-            oldItem.title == newItem.title &&
-            oldItem.activeQuickStartItem == newItem.activeQuickStartItem &&
-            areQuickStartTaskTypeItemsContentsTheSame(oldItem.taskTypeItems, newItem.taskTypeItems)
-
-    // QuickStartTaskTypeItem (List)
-    private fun areQuickStartTaskTypeItemsContentsTheSame(
-        oldList: List<QuickStartTaskTypeItem>,
-        newList: List<QuickStartTaskTypeItem>
-    ): Boolean {
-        oldList.forEachIndexed { index, quickStartTaskTypeItem ->
-            if (!areContentsTheSame(quickStartTaskTypeItem, newList[index])) return false
-        }
-        return true
-    }
-
-    // QuickStartTaskTypeItem
-    private fun areContentsTheSame(oldItem: QuickStartTaskTypeItem, newItem: QuickStartTaskTypeItem) =
-            oldItem.title == newItem.title &&
-            oldItem.subtitle == newItem.subtitle &&
-            oldItem.quickStartTaskType == newItem.quickStartTaskType &&
-            oldItem.titleEnabled == newItem.titleEnabled &&
-            oldItem.strikeThroughTitle == newItem.strikeThroughTitle
-
-    // PostCardWithPostItems
-    private fun areContentsTheSame(oldItem: PostCardWithPostItems, newItem: PostCardWithPostItems) =
-            oldItem.postCardType == newItem.postCardType &&
-            oldItem.title == newItem.title &&
-            arePostItemsContentsTheSame(oldItem.postItems, newItem.postItems)
-
-    // PostItem (List)
-    private fun arePostItemsContentsTheSame(oldList: List<PostItem>, newList: List<PostItem>): Boolean {
-        oldList.forEachIndexed { index, postItem ->
-            if (!areContentsTheSame(postItem, newList[index])) return false
-        }
-        return true
-    }
-
-    // PostItem
-    private fun areContentsTheSame(oldItem: PostItem, newItem: PostItem) =
-            oldItem.title == newItem.title &&
-            oldItem.excerpt == newItem.excerpt &&
-            oldItem.featuredImageUrl == newItem.featuredImageUrl &&
-            oldItem.isTimeIconVisible == newItem.isTimeIconVisible
-
-    private fun areContentsTheSame(oldItem: PostCardWithoutPostItems, newItem: PostCardWithoutPostItems) =
-            oldItem.postCardType == newItem.postCardType &&
-            oldItem.title == newItem.title &&
-            oldItem.excerpt == newItem.excerpt
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+            oldCardAndItems[oldItemPosition] == updatedCardAndItems[newItemPosition]
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -106,7 +106,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                     val excerpt: UiString?,
                     val featuredImageUrl: String?,
                     val isTimeIconVisible: Boolean = false,
-                    val onClick: () -> Unit
+                    val onClick: ListItemInteraction
                 )
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardW
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems.PostItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
@@ -87,7 +88,7 @@ class PostCardBuilder @Inject constructor(
                 title = constructPostTitle(post.title),
                 excerpt = constructPostContent(post.content),
                 featuredImageUrl = post.featuredImage,
-                onClick = { onPostItemClick.invoke(post.id) }
+                onClick = ListItemInteraction.create(post.id, onPostItemClick)
         )
     }
 
@@ -103,7 +104,7 @@ class PostCardBuilder @Inject constructor(
                 excerpt = UiStringText(constructPostDate(post.date)),
                 featuredImageUrl = post.featuredImage,
                 isTimeIconVisible = true,
-                onClick = { onPostItemClick.invoke(post.id) }
+                onClick = ListItemInteraction.create(post.id, onPostItemClick)
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostItemViewHolder.kt
@@ -35,6 +35,6 @@ class PostItemViewHolder(
         )
         featuredImage.visibility = if (postItem.featuredImageUrl == null) View.INVISIBLE else View.VISIBLE
         iconTime.setVisible(postItem.isTimeIconVisible)
-        itemView.setOnClickListener { postItem.onClick.invoke() }
+        itemView.setOnClickListener { postItem.onClick.click() }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsCardBuilder.kt
@@ -11,10 +11,10 @@ import javax.inject.Inject
 class QuickActionsCardBuilder @Inject constructor() {
     fun build(params: QuickActionsCardBuilderParams) = QuickActionsCard(
             title = UiStringRes(R.string.my_site_quick_actions_title),
-            onStatsClick = ListItemInteraction.create { params.onQuickActionStatsClick.invoke() },
-            onPagesClick = ListItemInteraction.create { params.onQuickActionPagesClick.invoke() },
-            onPostsClick = ListItemInteraction.create { params.onQuickActionPostsClick.invoke() },
-            onMediaClick = ListItemInteraction.create { params.onQuickActionMediaClick.invoke() },
+            onStatsClick = ListItemInteraction.create(params.onQuickActionStatsClick),
+            onPagesClick = ListItemInteraction.create(params.onQuickActionPagesClick),
+            onPostsClick = ListItemInteraction.create(params.onQuickActionPostsClick),
+            onMediaClick = ListItemInteraction.create(params.onQuickActionMediaClick),
             showPages = params.siteModel.isSelfHostedAdmin || params.siteModel.hasCapabilityEditPages,
             showStatsFocusPoint = params.activeTask == QuickStartTask.CHECK_STATS,
             showPagesFocusPoint = params.activeTask == QuickStartTask.EDIT_HOMEPAGE ||

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
@@ -16,7 +16,7 @@ import kotlin.math.roundToInt
 class QuickStartCardBuilder @Inject constructor() {
     fun build(params: QuickStartCardBuilderParams) = QuickStartCard(
             title = UiStringRes(R.string.quick_start_sites),
-            onRemoveMenuItemClick = ListItemInteraction.create { params.onQuickStartBlockRemoveMenuItemClick.invoke() },
+            onRemoveMenuItemClick = ListItemInteraction.create(params.onQuickStartBlockRemoveMenuItemClick),
             taskTypeItems = params.quickStartCategories.map {
                 buildQuickStartTaskTypeItem(
                         it,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1549,7 +1549,9 @@ class MySiteViewModelTest : BaseUnitTest() {
                                 title = UiStringRes(0),
                                 excerpt = UiStringRes(0),
                                 featuredImageUrl = "",
-                                onClick = { (onPostItemClick as (Int) -> Unit).invoke(postId) }
+                                onClick = ListItemInteraction.create {
+                                    (onPostItemClick as (Int) -> Unit).invoke(postId)
+                                }
                         )
                 ),
                 footerLink = FooterLink(


### PR DESCRIPTION
Fixes #15673  

This PR addresses the flickering issue on the My Site Tab by explicitly comparing contents for the following cards:

- QuickActionsCard
- QuickStartCard
- PostCardsWithPostItems
- PostCardsWithoutPostItems

Before making this adjustment, I added log lines to the `MySiteAdapterDiffCallback` to see where the disconnect was happening. The above cards always returned `false` when `areContentsTheSame` was invoked. 

I thought about adding a `MySiteAdapterDiffCallbackTest` class, but it doesn't look we have any tests (across the app) for testing `areContentsTheSame`. Wdyt?

With this change we shouldn't need to adjust any logic for updating data `onResume` of `MySiteFragment`

**To test:**
Prerequisites
- Launch the app
- Navigate to My Site -> App Settings -> Debug Settings
- Ensure that the `MySiteDashboardPhase2FeatureConfig` is to set to on
- Restart the app if needed

#### Test 1 - PTR
-  Launch the app
- Navigate to the My Site tab
- Swipe down on the view to trigger the refresh
- Note: There is no flickering when the data is refreshed 

#### Test 2 - Switching sites
-  Launch the app
- Navigate to the My Site tab
- Using the site switcher, select a different site 
- Note: The My Site view changes to reflect the newly selected site and there is no flickering. There is still animation to reflect the data has changed for the new site.

#### Test 3 - Return from My Site Tab
-  Launch the app
- Navigate to the My Site tab
- Navigate to another part of the app (Tap a different tab, select a quick action)
- Navigate back to the My Site tab
- Note: There is no flickering 

#### Test 3 - Return from Post update
- Launch the app
- Navigate to a site that has draft post data
- Tap the drafts footer link
- Update the draft post title & save it 
- Navigate back to the My Site tab after the post draft has been uploaded
- Note: The data for the draft post card has changed and there is no flickering. You will still see movement for the updated post.

## Regression Notes
1. Potential unintended areas of impact
My Site Tab flickers and/or cards don't change content

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
