### PR TITLE
Remove remaining subtree doc reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,6 @@
 - [Using Android Resources](using-android-resources.md) - describes how to add or use Android resources like strings and drawables
 - [Localization](localization.md)
 - [Pull Request Guidelines](pull-request-guidelines.md) - branch naming and how to write good pull requests
-- [Subtree'd Library Projects](subtreed-library-projects.md) - how to deal with subtree dependencies
 - [UI Tests](../WordPress/src/androidTest/java/org/wordpress/android/e2e/)
 
 ## Accessibility


### PR DESCRIPTION
Removing a subtree doc reference that was missed in https://github.com/wordpress-mobile/WordPress-Android/pull/15420

To test:
N/A

## Regression Notes
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
