### PR TITLE
My Site Dashboard: Phase 2 - Reorder quick start dynamic card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -228,7 +228,7 @@ class MySiteViewModel @Inject constructor(
         scanAvailable: Boolean,
         cards: CardsResult<List<CardModel>>?
     ): List<MySiteCardAndItem> {
-        val cards = cardsBuilder.build(
+        val cardsResult = cardsBuilder.build(
                 DomainRegistrationCardBuilderParams(
                         isDomainCreditAvailable = isDomainCreditAvailable,
                         domainRegistrationClick = this::domainRegistrationClick
@@ -278,7 +278,7 @@ class MySiteViewModel @Inject constructor(
                         onClick = this::onItemClick
                 )
         )
-        return orderForDisplay(cards, dynamicCards, siteItems)
+        return orderForDisplay(cardsResult, dynamicCards, siteItems)
     }
 
     private fun buildNoSiteState(): NoSites {
@@ -296,7 +296,7 @@ class MySiteViewModel @Inject constructor(
         return if (indexOfPostsCard == -1) {
             cards + dynamicCards + siteItems
         } else {
-            return mutableListOf<MySiteCardAndItem>().apply {
+            mutableListOf<MySiteCardAndItem>().apply {
                 addAll(cards)
                 addAll(indexOfPostsCard, dynamicCards)
                 addAll(siteItems)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.dashboard.CardsStore.CardsResult
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
@@ -226,58 +227,81 @@ class MySiteViewModel @Inject constructor(
         backupAvailable: Boolean,
         scanAvailable: Boolean,
         cards: CardsResult<List<CardModel>>?
-    ) = cardsBuilder.build(
-            DomainRegistrationCardBuilderParams(
-                    isDomainCreditAvailable = isDomainCreditAvailable,
-                    domainRegistrationClick = this::domainRegistrationClick
-            ),
-            PostCardBuilderParams(
-                    posts = cards?.model?.firstOrNull { it is PostsCardModel } as? PostsCardModel,
-                    onPostItemClick = this::onPostItemClick,
-                    onFooterLinkClick = this::onPostCardFooterLinkClick
-            ),
-            QuickActionsCardBuilderParams(
-                    siteModel = site,
-                    activeTask = activeTask,
-                    onQuickActionStatsClick = this::quickActionStatsClick,
-                    onQuickActionPagesClick = this::quickActionPagesClick,
-                    onQuickActionPostsClick = this::quickActionPostsClick,
-                    onQuickActionMediaClick = this::quickActionMediaClick
-            ),
-            QuickStartCardBuilderParams(
-                    quickStartCategories = quickStartCategories,
-                    onQuickStartBlockRemoveMenuItemClick = this::onQuickStartBlockRemoveMenuItemClick,
-                    onQuickStartTaskTypeItemClick = this::onQuickStartTaskTypeItemClick
-            ),
-            SiteInfoCardBuilderParams(
-                    site = site,
-                    showSiteIconProgressBar = showSiteIconProgressBar,
-                    titleClick = this::titleClick,
-                    iconClick = this::iconClick,
-                    urlClick = this::urlClick,
-                    switchSiteClick = this::switchSiteClick,
-                    activeTask = activeTask
-            )
-    ) + dynamicCardsBuilder.build(
-            quickStartCategories,
-            pinnedDynamicCard,
-            visibleDynamicCards,
-            this::onDynamicCardMoreClick,
-            this::onQuickStartTaskCardClick
-    ) + siteItemsBuilder.build(
-            SiteItemsBuilderParams(
-                    site = site,
-                    activeTask = activeTask,
-                    backupAvailable = backupAvailable,
-                    scanAvailable = scanAvailable,
-                    onClick = this::onItemClick
-            )
-    )
+    ): List<MySiteCardAndItem> {
+        val cards = cardsBuilder.build(
+                DomainRegistrationCardBuilderParams(
+                        isDomainCreditAvailable = isDomainCreditAvailable,
+                        domainRegistrationClick = this::domainRegistrationClick
+                ),
+                PostCardBuilderParams(
+                        posts = cards?.model?.firstOrNull { it is PostsCardModel } as? PostsCardModel,
+                        onPostItemClick = this::onPostItemClick,
+                        onFooterLinkClick = this::onPostCardFooterLinkClick
+                ),
+                QuickActionsCardBuilderParams(
+                        siteModel = site,
+                        activeTask = activeTask,
+                        onQuickActionStatsClick = this::quickActionStatsClick,
+                        onQuickActionPagesClick = this::quickActionPagesClick,
+                        onQuickActionPostsClick = this::quickActionPostsClick,
+                        onQuickActionMediaClick = this::quickActionMediaClick
+                ),
+                QuickStartCardBuilderParams(
+                        quickStartCategories = quickStartCategories,
+                        onQuickStartBlockRemoveMenuItemClick = this::onQuickStartBlockRemoveMenuItemClick,
+                        onQuickStartTaskTypeItemClick = this::onQuickStartTaskTypeItemClick
+                ),
+                SiteInfoCardBuilderParams(
+                        site = site,
+                        showSiteIconProgressBar = showSiteIconProgressBar,
+                        titleClick = this::titleClick,
+                        iconClick = this::iconClick,
+                        urlClick = this::urlClick,
+                        switchSiteClick = this::switchSiteClick,
+                        activeTask = activeTask
+                )
+        )
+        val dynamicCards = dynamicCardsBuilder.build(
+                quickStartCategories,
+                pinnedDynamicCard,
+                visibleDynamicCards,
+                this::onDynamicCardMoreClick,
+                this::onQuickStartTaskCardClick
+        )
+
+        val siteItems = siteItemsBuilder.build(
+                SiteItemsBuilderParams(
+                        site = site,
+                        activeTask = activeTask,
+                        backupAvailable = backupAvailable,
+                        scanAvailable = scanAvailable,
+                        onClick = this::onItemClick
+                )
+        )
+        return orderForDisplay(cards, dynamicCards, siteItems)
+    }
 
     private fun buildNoSiteState(): NoSites {
         // Hide actionable empty view image when screen height is under specified min height.
         val shouldShowImage = displayUtilsWrapper.getDisplayPixelHeight() >= MIN_DISPLAY_PX_HEIGHT_NO_SITE_IMAGE
         return NoSites(shouldShowImage)
+    }
+
+    private fun orderForDisplay(
+        cards: List<MySiteCardAndItem>,
+        dynamicCards: List<MySiteCardAndItem>,
+        siteItems: List<MySiteCardAndItem>
+    ): List<MySiteCardAndItem> {
+        val indexOfPostsCard = cards.indexOfFirst { it is PostCard }
+        return if (indexOfPostsCard == -1) {
+            cards + dynamicCards + siteItems
+        } else {
+            return mutableListOf<MySiteCardAndItem>().apply {
+                addAll(cards)
+                addAll(indexOfPostsCard, dynamicCards)
+                addAll(siteItems)
+            }.toList()
+        }
     }
 
     private fun scrollToQuickStartTaskIfNecessary(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1377,7 +1377,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @InternalCoroutinesApi
     @Test
-    fun `given post cards exist, when cardAndItems list is ordered, then dynamic cards precede the post cards`(){
+    fun `given post cards exist, when cardAndItems list is ordered, then dynamic cards precede the post cards`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
         initSelectedSite(isQuickStartDynamicCardEnabled = true)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.CardsResult
 import org.wordpress.android.test
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems.PostItem
@@ -1364,6 +1365,28 @@ class MySiteViewModelTest : BaseUnitTest() {
         verify(mySiteSourceManager).clear()
     }
 
+    /* ORDERED LIST */
+    @InternalCoroutinesApi
+    @Test
+    fun `given no post cards exist, when cardAndItems list is ordered, then dynamic card follow all cards`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(false)
+        initSelectedSite(isQuickStartDynamicCardEnabled = true)
+
+        assertThat(getLastItems().last()).isInstanceOf(DynamicCard::class.java)
+    }
+
+    @InternalCoroutinesApi
+    @Test
+    fun `given post cards exist, when cardAndItems list is ordered, then dynamic cards precede the post cards`(){
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        initSelectedSite(isQuickStartDynamicCardEnabled = true)
+
+        val postCardIndex = getLastItems().indexOfFirst { it is PostCard }
+        val dynamicCardIndex = getLastItems().indexOfFirst { it is DynamicCard }
+
+        assertThat(dynamicCardIndex).isLessThan(postCardIndex)
+    }
+
     private fun findQuickActionsCard() = getLastItems().find { it is QuickActionsCard } as QuickActionsCard?
 
     private fun findQuickStartDynamicCard() = getLastItems().find { it is DynamicCard } as DynamicCard?
@@ -1430,7 +1453,22 @@ class MySiteViewModelTest : BaseUnitTest() {
             val domainRegistrationCard = initDomainRegistrationCard(it)
             val quickStartCard = initQuickStartCard(it)
             val postCard = initPostCard(it)
-            listOf<MySiteCardAndItem>(siteInfoCard, quickActionsCard, domainRegistrationCard, quickStartCard, postCard)
+            if (mySiteDashboardPhase2FeatureConfig.isEnabled()) {
+                listOf<MySiteCardAndItem>(
+                        siteInfoCard,
+                        quickActionsCard,
+                        domainRegistrationCard,
+                        quickStartCard,
+                        postCard
+                )
+            } else {
+                listOf<MySiteCardAndItem>(
+                        siteInfoCard,
+                        quickActionsCard,
+                        domainRegistrationCard,
+                        quickStartCard
+                )
+            }
         }.whenever(cardsBuilder).build(
                 domainRegistrationCardBuilderParams = any(),
                 postCardBuilderParams = any(),


### PR DESCRIPTION
Parent #15625 

This PR slots the quick start `DynamicCard` into the proper position within the MySiteCardAndItems list. The functionality was moved to a separate method, so it is clear that the order is being changed. As of this writing, that position is directly preceding the Post Card if one exists or following the existing cards if a post card doesn't exist. Note: The `CardsBuilder.build` still manages the order of the cards themselves.

**To test:**
#### Test 1
- Launch the app
- Select a site with quick start in progress
- Navigate to My Site -> App Settings -> Debug Settings
- Ensure that the `MySiteDashboardPhase2FeatureConfig` is to set to on
- Ensure that the `QuickStartDynamicCardsFeatureConfig` is to set to on
- Restart the app if needed
- Navigate to the My Site tab
- Note: The dynamic cards are shown in the slot immediately above the first post card

#### Test 2
- Launch the app
- Select a site with quick start in progress
- Navigate to My Site -> App Settings -> Debug Settings
- Ensure that the `MySiteDashboardPhase2FeatureConfig` is to set to off
- Ensure that the `QuickStartDynamicCardsFeatureConfig` is to set to on
- Restart the app if needed
- Navigate to the My Site tab
- Note: The dynamic cards are shown in the slot immediately below the other cards (a.k.a. before the menu items)

## Regression Notes
1. Potential unintended areas of impact
The dynamic cards are incorrectly ordered in the my site view

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
Added two tests to `MySiteViewModelTest`

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
