### PR TITLE
Enable Unified About screen for Jetpack

### DIFF
--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -20,4 +20,7 @@
     <!-- Log out actions in Me -->
     <string name="me_disconnect_from_wordpress_com">Log out of Jetpack</string>
     <string name="sign_out_wpcom_confirm_with_no_changes">Log out of Jetpack?</string>
+
+    <!-- About button in Me -->
+    <string name="me_btn_about">About Jetpack</string>
 </resources>

--- a/WordPress/src/jetpack/res/values/styles_unified_about.xml
+++ b/WordPress/src/jetpack/res/values/styles_unified_about.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="TextAppearance.UnifiedAbout.Header.Title" parent="TextAppearance.MaterialComponents.Headline4">
+        <item name="android:textStyle">bold</item>
+    </style>
+</resources>

--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -44,7 +44,7 @@ class UnifiedAboutViewModel @Inject constructor(
             shareConfigFactory = ::createShareConfig,
             rateUsConfig = RateUsConfig.fromContext(contextProvider.getContext()),
             socialsConfig = SocialsConfig(
-                    twitterUsername = WP_SOCIAL_HANDLE
+                    twitterUsername = if (buildConfig.isJetpackApp) JP_SOCIAL_HANDLE else WP_SOCIAL_HANDLE
             ),
             customItems = listOf(
                     ItemConfig(
@@ -56,14 +56,14 @@ class UnifiedAboutViewModel @Inject constructor(
             legalConfig = LegalConfig(
                     tosUrl = wpUrlUtils.buildTermsOfServiceUrl(contextProvider.getContext()),
                     privacyPolicyUrl = Constants.URL_PRIVACY_POLICY,
-                    acknowledgementsUrl = WP_ACKNOWLEDGEMENTS_URL
+                    acknowledgementsUrl = LICENSES_FILE_URL
             ),
-            onDismiss = ::onDismiss,
             analyticsTracker = AnalyticsConfig(
                     trackScreenShown = unifiedAboutTracker::trackScreenShown,
                     trackScreenDismissed = unifiedAboutTracker::trackScreenDismissed,
                     trackButtonTapped = unifiedAboutTracker::trackButtonTapped
-            )
+            ),
+            onDismiss = ::onDismiss
     )
 
     private suspend fun createShareConfig(): ShareConfig {
@@ -74,7 +74,8 @@ class UnifiedAboutViewModel @Inject constructor(
                 message = when (result) {
                     is Failure -> {
                         AppLog.e(T.MAIN, "Couldn't fetch recommend app template: ${result.error}")
-                        WP_APPS_URL // Returning generic message containing only the apps page URL
+                        // Returning generic message containing only the apps page URL
+                        if (buildConfig.isJetpackApp) JP_APPS_URL else WP_APPS_URL
                     }
                     is Success -> "${result.templateData.message}\n${result.templateData.link}"
                 }
@@ -86,14 +87,19 @@ class UnifiedAboutViewModel @Inject constructor(
     }
 
     private fun onBlogClick() {
-        _onNavigation.postValue(Event(OpenBlog(WP_BLOG_URL)))
+        _onNavigation.postValue(Event(OpenBlog(if (buildConfig.isJetpackApp) JP_BLOG_URL else WP_BLOG_URL)))
     }
 
     companion object {
-        private const val WP_SOCIAL_HANDLE = "wordpress"
-        private const val WP_ACKNOWLEDGEMENTS_URL = "file:///android_asset/licenses.html"
-        private const val WP_APPS_URL = "https://apps.wordpress.com/"
-        private const val WP_BLOG_URL = "https://blog.wordpress.com/"
         private const val BLOG_ITEM_NAME = "blog"
+        private const val LICENSES_FILE_URL = "file:///android_asset/licenses.html"
+
+        private const val WP_SOCIAL_HANDLE = "wordpress"
+        private const val WP_APPS_URL = "https://apps.wordpress.com"
+        private const val WP_BLOG_URL = "https://blog.wordpress.com"
+
+        private const val JP_SOCIAL_HANDLE = "jetpack"
+        private const val JP_APPS_URL = "https://jetpack.com/app"
+        private const val JP_BLOG_URL = "https://jetpack.com/blog"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -161,8 +161,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        // Temporarily limiting this feature to the WordPress app
-        if (unifiedAboutFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
+        if (unifiedAboutFeatureConfig.isEnabled()) {
             recommendTheAppContainer.isVisible = false
             aboutTheAppContainer.isVisible = true
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2406,7 +2406,7 @@
     <string name="invite_links_disable_dialog_message">Once this invite link is disabled, nobody will be able to use it to join your team. Are you sure?</string>
 
     <!--Recommend the app-->
-    <string name="recommend_app_subject">WordPress Apps - Apps for any screen</string>
+    <string name="recommend_app_subject">Automattic Apps - Apps for any screen</string>
     <string name="recommend_app_null_response">No response received</string>
     <string name="recommend_app_bad_format_response">Invalid response received</string>
     <string name="recommend_app_generic_get_template_error">Unknown error fetching recommend app template</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1651,17 +1651,4 @@
         <item name="android:paddingEnd">0dp</item>
         <item name="android:textAlignment">viewStart</item>
     </style>
-
-    <!-- Unified About -->
-    <style name="WordPress.UnifiedAbout" parent="WordPress.NoActionBar">
-        <item name="textAppearanceHeadline4">@style/TextAppearance.UnifiedAbout.Header.Title</item>
-        <item name="textAppearanceHeadline6">@style/TextAppearance.UnifiedAbout.Toolbar.Title</item>
-    </style>
-
-    <style name="TextAppearance.UnifiedAbout.Header.Title" parent="TextAppearance.MaterialComponents.Headline4">
-        <item name="fontFamily">serif</item>
-        <item name="android:textStyle">bold</item>
-    </style>
-
-    <style name="TextAppearance.UnifiedAbout.Toolbar.Title" parent="TextAppearance.App.Toolbar.Title" />
 </resources>

--- a/WordPress/src/main/res/values/styles_unified_about.xml
+++ b/WordPress/src/main/res/values/styles_unified_about.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="WordPress.UnifiedAbout" parent="WordPress.NoActionBar">
+        <item name="textAppearanceHeadline4">@style/TextAppearance.UnifiedAbout.Header.Title</item>
+        <item name="textAppearanceHeadline6">@style/TextAppearance.UnifiedAbout.Toolbar.Title</item>
+    </style>
+
+    <style name="TextAppearance.UnifiedAbout.Header.Title" parent="TextAppearance.MaterialComponents.Headline4">
+        <item name="fontFamily">serif</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.UnifiedAbout.Toolbar.Title" parent="TextAppearance.App.Toolbar.Title" />
+</resources>


### PR DESCRIPTION
This PR enables the Unified About screen for the Jetpack app:

|WordPress|Jetpack|
|----|----|
|![wp](https://user-images.githubusercontent.com/830056/146276620-ec483943-3fff-48ef-8a8b-dec7b95794db.png)|![jp](https://user-images.githubusercontent.com/830056/146276631-3e85e7aa-2ac9-4f79-9cbe-22eb695dbc3e.png)|

Not adding much detail here as I feel the changes are pretty straightforward, but let me know if you need me to clarify anything.

### To test

1. Open the Jetpack app.
1. On the Main screen, tap the Me button.
1. On the Me screen, notice the "About Jetpack" item. Tap it.
1. On the About screen, notice the app information on the Header refers to the Jetpack app.
1. Verify that the About screen styles match the other screens of the app.
1. Smoke test the app and verify that the behavior of each item is correct, including tracking.

Repeat for the WordPress app.

## Regression Notes
1. Potential unintended areas of impact
About screen on the WordPress app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None for now, but I'm planning to do so in a follow-up PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
