### PR TITLE
My Site Dashboard [Phase 2]: Navigate to Edit Post [HACK - DO NOT MERGE]

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -591,10 +591,23 @@ public class ActivityLauncher {
     }
 
     public static void viewCurrentBlogPosts(Context context, SiteModel site) {
-        viewCurrentBlogPostsOfType(context, site, null);
+        viewCurrentBlogPostsOfType(context, site, null, null);
     }
 
-    public static void viewCurrentBlogPostsOfType(Context context, SiteModel site, PostListType postListType) {
+    public static void viewCurrentBlogPostsOfType(
+            Context context,
+            SiteModel site,
+            @Nullable PostListType postListType
+    ) {
+        viewCurrentBlogPostsOfType(context, site, postListType, null);
+    }
+
+    public static void viewCurrentBlogPostsOfType(
+            Context context,
+            SiteModel site,
+            @Nullable PostListType postListType,
+            @Nullable Integer postId
+    ) {
         if (site == null) {
             AppLog.e(T.POSTS, "Site cannot be null when opening posts");
             AnalyticsTracker.track(
@@ -609,7 +622,7 @@ public class ActivityLauncher {
         if (postListType == null) {
             context.startActivity(PostsListActivity.buildIntent(context, site));
         } else {
-            context.startActivity(PostsListActivity.buildIntent(context, site, postListType, false, null));
+            context.startActivity(PostsListActivity.buildIntent(context, site, postListType, false, null, postId));
         }
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_POSTS, site);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -16,9 +16,14 @@ sealed class MySiteCardAndItemBuilderParams {
 
     data class PostCardBuilderParams(
         val posts: PostsCardModel?,
-        val onPostItemClick: (postId: Int) -> Unit,
+        val onPostItemClick: (params: PostItemClickParams) -> Unit,
         val onFooterLinkClick: (postCardType: PostCardType) -> Unit
-    ) : MySiteCardAndItemBuilderParams()
+    ) : MySiteCardAndItemBuilderParams() {
+        data class PostItemClickParams(
+            val postCardType: PostCardType,
+            val postId: Int
+        )
+    }
 
     data class QuickActionsCardBuilderParams(
         val siteModel: SiteModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -321,7 +321,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                     PagePostCreationSourcesDetail.POST_FROM_MY_SITE
             )
         // TODO: ashiagr this is unhandled right now as mocked post is being used which cannot be opened in the editor
-        is SiteNavigationAction.EditPost -> Unit
+        is SiteNavigationAction.EditDraftPost -> Unit
+        is SiteNavigationAction.EditScheduledPost -> Unit
     }
 
     private fun openQuickStartFullScreenDialog(action: SiteNavigationAction.OpenQuickStartFullScreenDialog) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -320,9 +320,20 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                     false,
                     PagePostCreationSourcesDetail.POST_FROM_MY_SITE
             )
-        // TODO: ashiagr this is unhandled right now as mocked post is being used which cannot be opened in the editor
-        is SiteNavigationAction.EditDraftPost -> Unit
-        is SiteNavigationAction.EditScheduledPost -> Unit
+        is SiteNavigationAction.EditDraftPost ->
+            ActivityLauncher.viewCurrentBlogPostsOfType(
+                    requireActivity(),
+                    action.site,
+                    PostListType.DRAFTS,
+                    action.postId
+            )
+        is SiteNavigationAction.EditScheduledPost ->
+            ActivityLauncher.viewCurrentBlogPostsOfType(
+                    requireActivity(),
+                    action.site,
+                    PostListType.SCHEDULED,
+                    action.postId
+            )
     }
 
     private fun openQuickStartFullScreenDialog(action: SiteNavigationAction.OpenQuickStartFullScreenDialog) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
@@ -719,9 +720,9 @@ class MySiteViewModel @Inject constructor(
         analyticsTrackerWrapper.track(Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
     }
 
-    private fun onPostItemClick(postId: Int) {
+    private fun onPostItemClick(params: PostItemClickParams) {
         selectedSiteRepository.getSelectedSite()?.let { site ->
-            _onNavigation.value = Event(SiteNavigationAction.EditPost(site, postId))
+            _onNavigation.value = Event(SiteNavigationAction.EditPost(site, params.postId))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -722,7 +722,13 @@ class MySiteViewModel @Inject constructor(
 
     private fun onPostItemClick(params: PostItemClickParams) {
         selectedSiteRepository.getSelectedSite()?.let { site ->
-            _onNavigation.value = Event(SiteNavigationAction.EditPost(site, params.postId))
+            when (params.postCardType) {
+                PostCardType.DRAFT -> _onNavigation.value =
+                        Event(SiteNavigationAction.EditDraftPost(site, params.postId))
+                PostCardType.SCHEDULED -> _onNavigation.value =
+                        Event(SiteNavigationAction.EditScheduledPost(site, params.postId))
+                else -> Unit // Do nothing
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -59,12 +59,15 @@ sealed class SiteNavigationAction {
         @StringRes val positiveButtonLabel: Int,
         @StringRes val negativeButtonLabel: Int
     ) : SiteNavigationAction()
+
     data class OpenQuickStartFullScreenDialog(
         val type: QuickStartTaskType,
         @StringRes val title: Int
     ) : SiteNavigationAction()
+
     data class OpenDraftsPosts(val site: SiteModel) : SiteNavigationAction()
     data class OpenScheduledPosts(val site: SiteModel) : SiteNavigationAction()
     data class OpenEditorToCreateNewPost(val site: SiteModel) : SiteNavigationAction()
-    data class EditPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
+    data class EditDraftPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
+    data class EditScheduledPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardW
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems.PostItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -83,12 +84,17 @@ class PostCardBuilder @Inject constructor(
 
     private fun PostsCardModel.hasDraftsOrScheduledPosts() = draft.isNotEmpty() || scheduled.isNotEmpty()
 
-    private fun List<PostCardModel>.mapToDraftPostItems(onPostItemClick: (postId: Int) -> Unit) = map { post ->
+    private fun List<PostCardModel>.mapToDraftPostItems(
+        onPostItemClick: (params: PostItemClickParams) -> Unit
+    ) = map { post ->
         PostItem(
                 title = constructPostTitle(post.title),
                 excerpt = constructPostContent(post.content),
                 featuredImageUrl = post.featuredImage,
-                onClick = ListItemInteraction.create(post.id, onPostItemClick)
+                onClick = ListItemInteraction.create(
+                        PostItemClickParams(PostCardType.DRAFT, post.id),
+                        onPostItemClick
+                )
         )
     }
 
@@ -98,13 +104,18 @@ class PostCardBuilder @Inject constructor(
     private fun constructPostContent(content: String) =
             if (content.isEmpty()) UiStringRes(R.string.my_site_no_content_post) else UiStringText(content)
 
-    private fun List<PostCardModel>.mapToScheduledPostItems(onPostItemClick: (postId: Int) -> Unit) = map { post ->
+    private fun List<PostCardModel>.mapToScheduledPostItems(
+        onPostItemClick: (params: PostItemClickParams) -> Unit
+    ) = map { post ->
         PostItem(
                 title = constructPostTitle(post.title),
                 excerpt = UiStringText(constructPostDate(post.date)),
                 featuredImageUrl = post.featuredImage,
                 isTimeIconVisible = true,
-                onClick = ListItemInteraction.create(post.id, onPostItemClick)
+                onClick = ListItemInteraction.create(
+                        PostItemClickParams(PostCardType.SCHEDULED, post.id),
+                        onPostItemClick
+                )
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -100,8 +100,8 @@ class PostListFragment : ViewPagerFragment() {
         mainViewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
                 .get(PostListMainViewModel::class.java)
 
-        mainViewModel.viewLayoutType.observe(viewLifecycleOwner, { optionaLayoutType ->
-            optionaLayoutType?.let { layoutType ->
+        mainViewModel.viewLayoutType.observe(viewLifecycleOwner, { optionalLayoutType ->
+            optionalLayoutType?.let { layoutType ->
                 recyclerView?.removeItemDecoration(itemDecorationCompactLayout)
                 recyclerView?.removeItemDecoration(itemDecorationStandardLayout)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ProgressBar
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -101,7 +100,7 @@ class PostListFragment : ViewPagerFragment() {
         mainViewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
                 .get(PostListMainViewModel::class.java)
 
-        mainViewModel.viewLayoutType.observe(viewLifecycleOwner, Observer { optionaLayoutType ->
+        mainViewModel.viewLayoutType.observe(viewLifecycleOwner, { optionaLayoutType ->
             optionaLayoutType?.let { layoutType ->
                 recyclerView?.removeItemDecoration(itemDecorationCompactLayout)
                 recyclerView?.removeItemDecoration(itemDecorationStandardLayout)
@@ -121,7 +120,7 @@ class PostListFragment : ViewPagerFragment() {
             }
         })
 
-        mainViewModel.authorSelectionUpdated.observe(viewLifecycleOwner, Observer {
+        mainViewModel.authorSelectionUpdated.observe(viewLifecycleOwner, {
             if (it != null) {
                 if (viewModel.updateAuthorFilterIfNotSearch(it)) {
                     recyclerView?.scrollToPosition(0)
@@ -151,7 +150,7 @@ class PostListFragment : ViewPagerFragment() {
 
     private fun initObservers() {
         if (postListType == SEARCH) {
-            mainViewModel.searchQuery.observe(viewLifecycleOwner, Observer {
+            mainViewModel.searchQuery.observe(viewLifecycleOwner, {
                 if (TextUtils.isEmpty(it)) {
                     postListAdapter.submitList(null)
                 }
@@ -159,22 +158,22 @@ class PostListFragment : ViewPagerFragment() {
             })
         }
 
-        viewModel.emptyViewState.observe(viewLifecycleOwner, Observer {
+        viewModel.emptyViewState.observe(viewLifecycleOwner, {
             it?.let { emptyViewState -> updateEmptyViewForState(emptyViewState) }
         })
 
-        viewModel.isFetchingFirstPage.observe(viewLifecycleOwner, Observer {
+        viewModel.isFetchingFirstPage.observe(viewLifecycleOwner, {
             swipeRefreshLayout?.isRefreshing = it == true
         })
 
-        viewModel.pagedListData.observe(viewLifecycleOwner, Observer {
+        viewModel.pagedListData.observe(viewLifecycleOwner, {
             it?.let { pagedListData -> updatePagedListData(pagedListData) }
         })
 
-        viewModel.isLoadingMore.observe(viewLifecycleOwner, Observer {
+        viewModel.isLoadingMore.observe(viewLifecycleOwner, {
             progressLoadMore?.visibility = if (it == true) View.VISIBLE else View.GONE
         })
-        viewModel.scrollToPosition.observe(viewLifecycleOwner, Observer {
+        viewModel.scrollToPosition.observe(viewLifecycleOwner, {
             it?.let { index ->
                 recyclerView?.scrollToPosition(index)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -297,7 +297,6 @@ class PostListFragment : ViewPagerFragment() {
     }
 
     companion object {
-        const val TAG = "post_list_fragment_tag"
         private const val NAVIGATE_TO_EDIT_POST_DELAY_MS = 1000L
 
         @JvmStatic

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -268,12 +268,14 @@ class PostListFragment : ViewPagerFragment() {
         @JvmStatic
         fun newInstance(
             site: SiteModel,
-            postListType: PostListType
+            postListType: PostListType,
+            targetPostId: Int? = null
         ): PostListFragment {
             val fragment = PostListFragment()
             val bundle = Bundle()
             bundle.putSerializable(WordPress.SITE, site)
             bundle.putSerializable(EXTRA_POST_LIST_TYPE, postListType)
+            bundle.putSerializable(EXTRA_TARGET_POST_REMOTE_ID, targetPostId)
             fragment.arguments = bundle
             return fragment
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -182,6 +182,11 @@ class PostListFragment : ViewPagerFragment() {
                 recyclerView?.scrollToPosition(index)
             }
         })
+        viewModel.navigateToPost.observe(viewLifecycleOwner, {
+            it?.let { index ->
+                recyclerView?.layoutManager?.findViewByPosition(index)?.performClick()
+            }
+        })
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -95,7 +95,9 @@ class PostListFragment : ViewPagerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         postListType = requireNotNull(arguments).getSerializable(EXTRA_POST_LIST_TYPE) as PostListType
+
         val targetPostId = requireNotNull(arguments).getSerializable(EXTRA_TARGET_POST_REMOTE_ID) as Int?
+        val targetPostListType = requireNotNull(arguments).getSerializable(EXTRA_TARGET_POST_LIST_TYPE) as PostListType?
 
         if (postListType == SEARCH) {
             recyclerView?.id = R.id.posts_search_recycler_view_id
@@ -147,7 +149,10 @@ class PostListFragment : ViewPagerFragment() {
                 value = mainViewModel.authorSelectionUpdated.value!!,
                 photonWidth = displayWidth - contentSpacing * 2,
                 photonHeight = nonNullActivity.resources.getDimensionPixelSize(R.dimen.reader_featured_image_height),
-                navigateToRemotePostId = targetPostId?.let { RemotePostId(RemoteId(it.toLong())) }
+                navigateToRemotePostId = Pair(
+                        targetPostId?.let { RemotePostId(RemoteId(it.toLong())) },
+                        if (postListType == targetPostListType) targetPostListType else null
+                )
         )
 
         initObservers()
@@ -303,13 +308,15 @@ class PostListFragment : ViewPagerFragment() {
         fun newInstance(
             site: SiteModel,
             postListType: PostListType,
-            targetPostId: Int? = null
+            targetPostId: Int? = null,
+            targetPostListType: PostListType? = null
         ): PostListFragment {
             val fragment = PostListFragment()
             val bundle = Bundle()
             bundle.putSerializable(WordPress.SITE, site)
             bundle.putSerializable(EXTRA_POST_LIST_TYPE, postListType)
             bundle.putSerializable(EXTRA_TARGET_POST_REMOTE_ID, targetPostId)
+            bundle.putSerializable(EXTRA_TARGET_POST_LIST_TYPE, targetPostListType)
             fragment.arguments = bundle
             return fragment
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActionableEmptyView
 import org.wordpress.android.ui.ViewPagerFragment
@@ -32,6 +33,7 @@ import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
 import org.wordpress.android.viewmodel.posts.PagedPostList
 import org.wordpress.android.viewmodel.posts.PostListEmptyUiState
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
+import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.RemotePostId
 import org.wordpress.android.viewmodel.posts.PostListViewModel
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
@@ -92,6 +94,7 @@ class PostListFragment : ViewPagerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         postListType = requireNotNull(arguments).getSerializable(EXTRA_POST_LIST_TYPE) as PostListType
+        val targetPostId = requireNotNull(arguments).getSerializable(EXTRA_TARGET_POST_REMOTE_ID) as Int?
 
         if (postListType == SEARCH) {
             recyclerView?.id = R.id.posts_search_recycler_view_id
@@ -139,10 +142,11 @@ class PostListFragment : ViewPagerFragment() {
 
         // since the MainViewModel has been already started, we need to manually update the authorFilterSelection value
         viewModel.start(
-                postListViewModelConnector,
-                mainViewModel.authorSelectionUpdated.value!!,
+                postListViewModelConnector = postListViewModelConnector,
+                value = mainViewModel.authorSelectionUpdated.value!!,
                 photonWidth = displayWidth - contentSpacing * 2,
-                photonHeight = nonNullActivity.resources.getDimensionPixelSize(R.dimen.reader_featured_image_height)
+                photonHeight = nonNullActivity.resources.getDimensionPixelSize(R.dimen.reader_featured_image_height),
+                navigateToRemotePostId = targetPostId?.let { RemotePostId(RemoteId(it.toLong())) }
         )
 
         initObservers()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -169,9 +169,10 @@ class PostsListActivity : LocaleAwareActivity(),
 
             val actionsShownByDefault = intent.getBooleanExtra(ACTIONS_SHOWN_BY_DEFAULT, false)
             val tabIndex = intent.getIntExtra(TAB_INDEX, PostListType.PUBLISHED.ordinal)
+            val targetPostId = intent.getIntExtra(EXTRA_TARGET_POST_REMOTE_ID, 0).let { if (it != 0) it else null }
 
             setupActionBar()
-            setupContent()
+            setupContent(targetPostId)
             initViewModel(initPreviewState, currentBottomSheetPostId)
             initBloggingReminders()
             initCreateMenuViewModel(tabIndex, actionsShownByDefault)
@@ -188,7 +189,7 @@ class PostsListActivity : LocaleAwareActivity(),
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
-    private fun PostListActivityBinding.setupContent() {
+    private fun PostListActivityBinding.setupContent(targetPostId: Int?) {
         val authorSelectionAdapter = AuthorSelectionAdapter(this@PostsListActivity)
         postListAuthorSelection.adapter = authorSelectionAdapter
 
@@ -221,7 +222,7 @@ class PostsListActivity : LocaleAwareActivity(),
             postListCreateMenuViewModel.onTooltipTapped()
         }
 
-        postsPagerAdapter = PostsPagerAdapter(POST_LIST_PAGES, site, supportFragmentManager)
+        postsPagerAdapter = PostsPagerAdapter(POST_LIST_PAGES, site, targetPostId, supportFragmentManager)
         postPager.adapter = postsPagerAdapter
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -64,6 +64,8 @@ import org.wordpress.android.viewmodel.posts.PostListCreateMenuViewModel
 import javax.inject.Inject
 
 const val EXTRA_TARGET_POST_LOCAL_ID = "targetPostLocalId"
+const val EXTRA_TARGET_POST_REMOTE_ID = "targetPostRemoteId"
+
 const val STATE_KEY_PREVIEW_STATE = "stateKeyPreviewState"
 const val STATE_KEY_BOTTOMSHEET_POST_ID = "stateKeyBottomSheetPostId"
 
@@ -509,7 +511,7 @@ class PostsListActivity : LocaleAwareActivity(),
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         super.onCreateOptionsMenu(menu)
-        menu?.let {
+        menu.let {
             menuInflater.inflate(R.menu.posts_list_toggle_view_layout, it)
             toggleViewLayoutMenuItem = it.findItem(R.id.toggle_post_list_item_layout)
             viewModel.viewLayoutTypeMenuUiState.observe(this, { menuUiState ->
@@ -662,12 +664,14 @@ class PostsListActivity : LocaleAwareActivity(),
         }
 
         @JvmStatic
+        @Suppress("LongParameterList")
         fun buildIntent(
             context: Context,
             site: SiteModel,
             postListType: PostListType,
             actionsShownByDefault: Boolean,
-            notificationType: NotificationType? = null
+            notificationType: NotificationType? = null,
+            targetPostId: Int? = null
         ): Intent {
             val intent = Intent(context, PostsListActivity::class.java)
             intent.putExtra(WordPress.SITE, site)
@@ -675,6 +679,9 @@ class PostsListActivity : LocaleAwareActivity(),
             intent.putExtra(TAB_INDEX, postListType.ordinal)
             if (notificationType != null) {
                 intent.putExtra(ARG_NOTIFICATION_TYPE, notificationType)
+            }
+            if (targetPostId != null) {
+                intent.putExtra(EXTRA_TARGET_POST_REMOTE_ID, targetPostId)
             }
             return intent
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -511,21 +511,19 @@ class PostsListActivity : LocaleAwareActivity(),
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         super.onCreateOptionsMenu(menu)
-        menu.let {
-            menuInflater.inflate(R.menu.posts_list_toggle_view_layout, it)
-            toggleViewLayoutMenuItem = it.findItem(R.id.toggle_post_list_item_layout)
-            viewModel.viewLayoutTypeMenuUiState.observe(this, { menuUiState ->
-                menuUiState?.let {
-                    updateMenuIcon(menuUiState.iconRes, toggleViewLayoutMenuItem)
-                    updateMenuTitle(menuUiState.title, toggleViewLayoutMenuItem)
-                }
-            })
+        menuInflater.inflate(R.menu.posts_list_toggle_view_layout, menu)
+        toggleViewLayoutMenuItem = menu.findItem(R.id.toggle_post_list_item_layout)
+        viewModel.viewLayoutTypeMenuUiState.observe(this, { menuUiState ->
+            menuUiState?.let {
+                updateMenuIcon(menuUiState.iconRes, toggleViewLayoutMenuItem)
+                updateMenuTitle(menuUiState.title, toggleViewLayoutMenuItem)
+            }
+        })
 
-            searchActionButton = it.findItem(R.id.toggle_post_search)
+        searchActionButton = menu.findItem(R.id.toggle_post_search)
 
-            initSearchFragment()
-            binding.initSearchView()
-        }
+        initSearchFragment()
+        binding.initSearchView()
         return true
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -65,6 +65,7 @@ import javax.inject.Inject
 
 const val EXTRA_TARGET_POST_LOCAL_ID = "targetPostLocalId"
 const val EXTRA_TARGET_POST_REMOTE_ID = "targetPostRemoteId"
+const val EXTRA_TARGET_POST_LIST_TYPE = "targetPostListType"
 
 const val STATE_KEY_PREVIEW_STATE = "stateKeyPreviewState"
 const val STATE_KEY_BOTTOMSHEET_POST_ID = "stateKeyBottomSheetPostId"
@@ -169,10 +170,12 @@ class PostsListActivity : LocaleAwareActivity(),
 
             val actionsShownByDefault = intent.getBooleanExtra(ACTIONS_SHOWN_BY_DEFAULT, false)
             val tabIndex = intent.getIntExtra(TAB_INDEX, PostListType.PUBLISHED.ordinal)
+
             val targetPostId = intent.getIntExtra(EXTRA_TARGET_POST_REMOTE_ID, 0).let { if (it != 0) it else null }
+            val targetPostListType = intent.getSerializableExtra(EXTRA_TARGET_POST_LIST_TYPE) as PostListType?
 
             setupActionBar()
-            setupContent(targetPostId)
+            setupContent(targetPostId, targetPostListType)
             initViewModel(initPreviewState, currentBottomSheetPostId)
             initBloggingReminders()
             initCreateMenuViewModel(tabIndex, actionsShownByDefault)
@@ -189,7 +192,10 @@ class PostsListActivity : LocaleAwareActivity(),
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
-    private fun PostListActivityBinding.setupContent(targetPostId: Int?) {
+    private fun PostListActivityBinding.setupContent(
+        targetPostId: Int?,
+        targetPostListType: PostListType?
+    ) {
         val authorSelectionAdapter = AuthorSelectionAdapter(this@PostsListActivity)
         postListAuthorSelection.adapter = authorSelectionAdapter
 
@@ -222,7 +228,13 @@ class PostsListActivity : LocaleAwareActivity(),
             postListCreateMenuViewModel.onTooltipTapped()
         }
 
-        postsPagerAdapter = PostsPagerAdapter(POST_LIST_PAGES, site, targetPostId, supportFragmentManager)
+        postsPagerAdapter = PostsPagerAdapter(
+                POST_LIST_PAGES,
+                site,
+                targetPostId,
+                targetPostListType,
+                supportFragmentManager
+        )
         postPager.adapter = postsPagerAdapter
     }
 
@@ -681,6 +693,7 @@ class PostsListActivity : LocaleAwareActivity(),
             }
             if (targetPostId != null) {
                 intent.putExtra(EXTRA_TARGET_POST_REMOTE_ID, targetPostId)
+                intent.putExtra(EXTRA_TARGET_POST_LIST_TYPE, postListType)
             }
             return intent
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsPagerAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsPagerAdapter.kt
@@ -11,6 +11,7 @@ class PostsPagerAdapter(
     private val pages: List<PostListType>,
     private val site: SiteModel,
     private val targetPostId: Int?,
+    private val targetPostListType: PostListType?,
     val fm: FragmentManager
 ) : FragmentStatePagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
     private val listFragments = mutableMapOf<Int, WeakReference<PostListFragment>>()
@@ -18,7 +19,7 @@ class PostsPagerAdapter(
     override fun getCount(): Int = pages.size
 
     override fun getItem(position: Int): PostListFragment =
-            PostListFragment.newInstance(site, pages[position], targetPostId)
+            PostListFragment.newInstance(site, pages[position], targetPostId, targetPostListType)
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
         val fragment = super.instantiateItem(container, position) as PostListFragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsPagerAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsPagerAdapter.kt
@@ -10,6 +10,7 @@ import java.lang.ref.WeakReference
 class PostsPagerAdapter(
     private val pages: List<PostListType>,
     private val site: SiteModel,
+    private val targetPostId: Int?,
     val fm: FragmentManager
 ) : FragmentStatePagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
     private val listFragments = mutableMapOf<Int, WeakReference<PostListFragment>>()
@@ -17,7 +18,7 @@ class PostsPagerAdapter(
     override fun getCount(): Int = pages.size
 
     override fun getItem(position: Int): PostListFragment =
-            PostListFragment.newInstance(site, pages[position])
+            PostListFragment.newInstance(site, pages[position], targetPostId)
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
         val fragment = super.instantiateItem(container, position) as PostListFragment

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostModel
@@ -47,6 +46,7 @@ import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus
 import org.wordpress.android.viewmodel.posts.PostListEmptyUiState.RefreshError
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
+import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.RemotePostId
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 import javax.inject.Inject
 import javax.inject.Named
@@ -82,6 +82,7 @@ class PostListViewModel @Inject constructor(
     private var photonHeight by Delegates.notNull<Int>()
 
     private var scrollToLocalPostId: LocalPostId? = null
+    private var navigateToRemotePostId: RemotePostId? = null
 
     private val _scrollToPosition = SingleLiveEvent<Int>()
     val scrollToPosition: LiveData<Int> = _scrollToPosition
@@ -129,13 +130,15 @@ class PostListViewModel @Inject constructor(
         postListViewModelConnector: PostListViewModelConnector,
         value: AuthorFilterSelection,
         photonWidth: Int,
-        photonHeight: Int
+        photonHeight: Int,
+        navigateToRemotePostId: RemotePostId?
     ) {
         if (isStarted) {
             return
         }
         this.photonHeight = photonHeight
         this.photonWidth = photonWidth
+        this.navigateToRemotePostId = navigateToRemotePostId
         connector = postListViewModelConnector
 
         isStarted = true

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.Observer
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagedList
 import kotlinx.coroutines.CoroutineDispatcher
@@ -270,7 +269,7 @@ class PostListViewModel @Inject constructor(
     }
 
     init {
-        connectionStatus.observe(lifecycleOwner, Observer {
+        connectionStatus.observe(lifecycleOwner, {
             retryOnConnectionAvailableAfterRefreshError()
         })
         lifecycleOwner.lifecycleRegistry.markState(Lifecycle.State.CREATED)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
+import org.wordpress.android.ui.posts.PostListType
 import org.wordpress.android.ui.posts.PostListType.SEARCH
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.posts.trackPostListAction
@@ -84,7 +85,7 @@ class PostListViewModel @Inject constructor(
     private var photonHeight by Delegates.notNull<Int>()
 
     private var scrollToLocalPostId: LocalPostId? = null
-    private var navigateToRemotePostId: RemotePostId? = null
+    private var navigateToRemotePostId: Pair<RemotePostId?, PostListType?>? = null
 
     private val _scrollToPosition = SingleLiveEvent<Int>()
     val scrollToPosition: LiveData<Int> = _scrollToPosition
@@ -136,7 +137,7 @@ class PostListViewModel @Inject constructor(
         value: AuthorFilterSelection,
         photonWidth: Int,
         photonHeight: Int,
-        navigateToRemotePostId: RemotePostId?
+        navigateToRemotePostId: Pair<RemotePostId?, PostListType?>
     ) {
         if (isStarted) {
             return
@@ -373,8 +374,9 @@ class PostListViewModel @Inject constructor(
     }
 
     private fun checkAndNavigateToPost(data: PagedPostList) {
-        val remotePostId = navigateToRemotePostId
-        if (remotePostId != null) {
+        val remotePostId = navigateToRemotePostId?.first
+        val targetPostListType = navigateToRemotePostId?.second
+        if (remotePostId != null && targetPostListType != null) {
             navigateToPost(data, remotePostId)
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1029,13 +1029,23 @@ class MySiteViewModelTest : BaseUnitTest() {
     /* POST CARD - POST ITEM */
 
     @Test
-    fun `when post item is clicked, then post is opened for edit`() =
+    fun `given draft post card, when post item is clicked, then post is opened for edit draft`() =
             test {
                 initSelectedSite()
 
                 requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.DRAFT, postId))
 
-                assertThat(navigationActions).containsOnly(SiteNavigationAction.EditPost(site, postId))
+                assertThat(navigationActions).containsOnly(SiteNavigationAction.EditDraftPost(site, postId))
+            }
+
+    @Test
+    fun `given scheduled post card, when post item is clicked, then post is opened for edit scheduled`() =
+            test {
+                initSelectedSite()
+
+                requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.SCHEDULED, postId))
+
+                assertThat(navigationActions).containsOnly(SiteNavigationAction.EditScheduledPost(site, postId))
             }
 
     /* ITEM CLICK */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -52,6 +52,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartDynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
@@ -175,7 +176,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private var quickStartTaskTypeItemClickAction: ((QuickStartTaskType) -> Unit)? = null
     private var dynamicCardMoreClick: ((DynamicCardMenuModel) -> Unit)? = null
     private var onPostCardFooterLinkClick: ((postCardType: PostCardType) -> Unit)? = null
-    private var onPostItemClick: ((postId: Int) -> Unit)? = null
+    private var onPostItemClick: ((params: PostItemClickParams) -> Unit)? = null
     private val quickStartCategory: QuickStartCategory
         get() = QuickStartCategory(
                 taskType = QuickStartTaskType.CUSTOMIZE,
@@ -1032,7 +1033,7 @@ class MySiteViewModelTest : BaseUnitTest() {
             test {
                 initSelectedSite()
 
-                requireNotNull(onPostItemClick).invoke(postId)
+                requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.DRAFT, postId))
 
                 assertThat(navigationActions).containsOnly(SiteNavigationAction.EditPost(site, postId))
             }
@@ -1588,7 +1589,9 @@ class MySiteViewModelTest : BaseUnitTest() {
                                 excerpt = UiStringRes(0),
                                 featuredImageUrl = "",
                                 onClick = ListItemInteraction.create {
-                                    (onPostItemClick as (Int) -> Unit).invoke(postId)
+                                    (onPostItemClick as (PostItemClickParams) -> Unit).invoke(
+                                            PostItemClickParams(PostCardType.DRAFT, postId)
+                                    )
                                 }
                         )
                 ),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
@@ -26,7 +26,7 @@ private const val POST_ID = 1
 private const val POST_TITLE = "title"
 private const val POST_CONTENT = "content"
 private const val FEATURED_IMAGE_URL = "featuredImage"
-private val POST_DATE = SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2021-12-06 12:34:56")
+private val POST_DATE = SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2021-12-06 12:34:56")!!
 
 // This class contains placeholder tests until mock data is removed
 @InternalCoroutinesApi

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.FooterLin
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
@@ -42,8 +43,8 @@ class PostCardBuilderTest : BaseUnitTest() {
             date = POST_DATE
     )
 
-    private val onPostCardFooterLinkClick: (PostCardType) -> Unit = {}
-    private val onPostItemClick: (Int) -> Unit = {}
+    private val onPostCardFooterLinkClick: (PostCardType) -> Unit = { }
+    private val onPostItemClick: (params: PostItemClickParams) -> Unit = { }
 
     @Before
     fun setUp() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -72,7 +72,7 @@ class PostListViewModelTest : BaseUnitTest() {
                 DEFAULT_AUTHOR_FILTER,
                 DEFAULT_PHOTON_DIMENSIONS,
                 DEFAULT_PHOTON_DIMENSIONS,
-                null
+                Pair(null, null)
         )
 
         // When
@@ -89,7 +89,7 @@ class PostListViewModelTest : BaseUnitTest() {
                 DEFAULT_AUTHOR_FILTER,
                 DEFAULT_PHOTON_DIMENSIONS,
                 DEFAULT_PHOTON_DIMENSIONS,
-                null
+                Pair(null, null)
         )
 
         val emptyViewStateResults = mutableListOf<PostListEmptyUiState>()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -32,7 +32,7 @@ class PostListViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: PostListViewModel
 
-    @UseExperimental(InternalCoroutinesApi::class)
+    @OptIn(InternalCoroutinesApi::class)
     @Before
     fun setUp() {
         val listStore = mock<ListStore>()
@@ -71,7 +71,8 @@ class PostListViewModelTest : BaseUnitTest() {
                 createPostListViewModelConnector(site = site, postListType = DRAFTS),
                 DEFAULT_AUTHOR_FILTER,
                 DEFAULT_PHOTON_DIMENSIONS,
-                DEFAULT_PHOTON_DIMENSIONS
+                DEFAULT_PHOTON_DIMENSIONS,
+                null
         )
 
         // When
@@ -87,7 +88,8 @@ class PostListViewModelTest : BaseUnitTest() {
                 createPostListViewModelConnector(site = site, postListType = SEARCH),
                 DEFAULT_AUTHOR_FILTER,
                 DEFAULT_PHOTON_DIMENSIONS,
-                DEFAULT_PHOTON_DIMENSIONS
+                DEFAULT_PHOTON_DIMENSIONS,
+                null
         )
 
         val emptyViewStateResults = mutableListOf<PostListEmptyUiState>()
@@ -99,7 +101,7 @@ class PostListViewModelTest : BaseUnitTest() {
         viewModel.search("", 0)
 
         assertThat(emptyViewStateResults.size).isEqualTo(1)
-        assertThat(emptyViewStateResults[0].emptyViewVisible).isTrue()
+        assertThat(emptyViewStateResults[0].emptyViewVisible).isTrue
     }
 
     private companion object {


### PR DESCRIPTION
Parent: #15709

This PR implements this functionality that will allow the user to navigate to the `Edit Post` screen, from the `My Site` screen, through the `Posts` screen.

PS: The PR is marked as `HACK` because of the two `hack` related commits that are trying to bend the paging framework to allow such navigation. @ashiagr and @zwarm I am adding you both as reviewers since I want both your feedback on this PR, its solution and more specifically I want to to focus on the two `hack` related commits. Maybe you can recommend another way of doing that.

-----

Prerequisite:

- Go to `My Site` -> `Me` -> `App Settings` -> `Debug Settings` configuration.
- Turn-on the `MySiteDashboardPhase2FeatureConfig` feature.
- Relaunch the app.

-----

To test:
- If you don't have a draft or scheduled post already, create one.
- Note that on the `My Site` tab, your draft or scheduled posts, if any, are shown.
- Click on a draft or scheduled posts and verify that:
  - First, the `Posts` screen is shown for a second or two.
  - Then, the `Edit Post` screen is launched with the content of the draft or scheduled post that was selected.

The above is testing the happy path. In addition to that please make sure to test any or all other scenarios, ultimately trying to break the solution. For example:
- Before clicking on the draft or scheduled post, update it remotely. Then, verify that by clicking on it, when navigated to the `Edit Post` screen, then you will get the remote updates, instead of the now stale/out-dated local state of the post.
- Enter the `Offline` mode and try to test the solution. You might need to comment out the `CardsSource.postState(...)` for when an error occurs during `cardsStore.fetchCards(selectedSite)` (see line 83). Otherwise, when entering the `Offline` mode, the dashboard feed will disappear. PS: This scenario will be also handling via the ` Handle offline mode` subtask, but it would be great to test it now anyway.

NOTE: It is expected that the `Posts` screen is shown. A subsequent PR, which will handle the full screen post loading, will make sure that the loading experience will be seamless and that the user will never notice the intermediate `Posts` screen.

-----

## Regression Notes
1. Potential unintended areas of impact

Data Loss (⚠️): Due to the nature of the solution, the user can enter into a situation where by clicking on a draft or scheduled post, the `Edit Post` screen will open a stale version of the post, or an unwanted version. At which point, if the user clicks back on a draft post, publishes this draft post, or rescheduled/publishes a scheduled post, then they might experience unintentional data loss.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Extensive manual testing. See `To test` sections above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
