### PR TITLE
My Site Dashboard: Page Behaviours - Loading States - Part 1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class CurrentAvatarSource @Inject constructor(
     private val accountStore: AccountStore
 ) : SiteIndependentSource<CurrentAvatarUrl> {
-    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+    override val refresh = MutableLiveData(true)
 
     override fun build(coroutineScope: CoroutineScope): LiveData<CurrentAvatarUrl> {
         val result = MediatorLiveData<CurrentAvatarUrl>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
@@ -28,7 +28,7 @@ class CurrentAvatarSource @Inject constructor(
             null, true -> {
                 val url = accountStore.account?.avatarUrl.orEmpty()
                 postState(CurrentAvatarUrl(url))
-                onRefreshed()
+                onRefreshedMainThread()
             }
             false -> Unit // Do nothing
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
@@ -28,6 +28,7 @@ class CurrentAvatarSource @Inject constructor(
             null, true -> {
                 val url = accountStore.account?.avatarUrl.orEmpty()
                 postState(CurrentAvatarUrl(url))
+                onRefreshed()
             }
             false -> Unit // Do nothing
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -116,6 +116,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             setupToolbar()
             setupContentViews(savedInstanceState)
             setupObservers()
+            swipeToRefreshHelper.isRefreshing = true
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -560,9 +560,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     private fun hideRefreshIndicatorIfNeeded() {
-        if (swipeToRefreshHelper.isRefreshing) {
-            swipeToRefreshHelper.isRefreshing = viewModel.isRefreshing()
-        }
+        swipeToRefreshHelper.isRefreshing = viewModel.isRefreshing()
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.mysite
 
-import android.os.Looper
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mysite
 
+import android.os.Looper
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -29,7 +30,11 @@ interface MySiteSource<T : PartialState> {
         }
 
         fun onRefreshed() {
-            refresh.value = false
+            if (Looper.getMainLooper().isCurrentThread) { // UI Thread
+                refresh.value = false
+            } else {
+                refresh.postValue(false)
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
@@ -29,12 +29,12 @@ interface MySiteSource<T : PartialState> {
             this@postState.postValue(value)
         }
 
-        fun onRefreshed() {
-            if (Looper.getMainLooper().isCurrentThread) { // UI Thread
-                refresh.value = false
-            } else {
-                refresh.postValue(false)
-            }
+        fun onRefreshedMainThread() {
+            refresh.value = false
+        }
+
+        fun onRefreshedBackgroundThread() {
+            refresh.postValue(false)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
@@ -108,13 +108,15 @@ class MySiteSourceManager @Inject constructor(
     }
 
     private fun refreshAllSources() {
-        allSupportedMySiteSources.filterIsInstance(MySiteRefreshSource::class.java).forEach { it.refresh() }
+        allSupportedMySiteSources.filterIsInstance(MySiteRefreshSource::class.java).forEach {
+            if (it is SiteIndependentSource || selectedSiteRepository.hasSelectedSite()) it.refresh()
+        }
     }
 
     private fun refreshSubsetOfAllSources() {
         selectedSiteSource.updateSiteSettingsIfNecessary()
         currentAvatarSource.refresh()
-        quickStartCardSource.refresh()
+        if (selectedSiteRepository.hasSelectedSite()) quickStartCardSource.refresh()
     }
 
     /* QUICK START */

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
@@ -77,7 +77,12 @@ class MySiteSourceManager @Inject constructor(
 
     fun isRefreshing(): Boolean {
         if (mySiteDashboardPhase2FeatureConfig.isEnabled()) {
-            allSupportedMySiteSources.filterIsInstance(MySiteRefreshSource::class.java).forEach {
+            val source = if (selectedSiteRepository.hasSelectedSite()) {
+                allSupportedMySiteSources
+            } else {
+                siteIndependentSources
+            }
+            source.filterIsInstance(MySiteRefreshSource::class.java).forEach {
                 if (it.isRefreshing() == true) {
                     return true
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -20,7 +20,7 @@ class ScanAndBackupSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase
 ) : MySiteRefreshSource<JetpackCapabilities> {
-    override val refresh = MutableLiveData(selectedSiteRepository.hasSelectedSite())
+    override val refresh = MutableLiveData(true)
 
     fun clear() {
         jetpackCapabilitiesUseCase.clear()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -20,7 +20,7 @@ class ScanAndBackupSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase
 ) : MySiteRefreshSource<JetpackCapabilities> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(selectedSiteRepository.hasSelectedSite())
 
     fun clear() {
         jetpackCapabilitiesUseCase.clear()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -20,7 +20,7 @@ class ScanAndBackupSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase
 ) : MySiteRefreshSource<JetpackCapabilities> {
-    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+    override val refresh = MutableLiveData(true)
 
     fun clear() {
         jetpackCapabilitiesUseCase.clear()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
@@ -48,6 +48,6 @@ class SelectedSiteSource @Inject constructor(
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onSiteChanged(event: OnSiteChanged?) {
         // Handled in WPMainActivity, this observe is only to manage the refresh flag
-        onRefreshed()
+        onRefreshedMainThread()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
@@ -17,7 +17,7 @@ class SelectedSiteSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val dispatcher: Dispatcher
 ) : MySiteRefreshSource<SelectedSite> {
-    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+    override val refresh = MutableLiveData(true)
 
     init {
         dispatcher.register(this)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
@@ -17,7 +17,7 @@ class SelectedSiteSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val dispatcher: Dispatcher
 ) : MySiteRefreshSource<SelectedSite> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(selectedSiteRepository.hasSelectedSite())
 
     init {
         dispatcher.register(this)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -87,8 +87,8 @@ class CardsSource @Inject constructor(
             val error = result.error
             when {
                 error != null -> postState(CardsUpdate(result))
-                model != null -> refresh.postValue(false)
-                else -> refresh.postValue(false)
+                model != null -> onRefreshed()
+                else -> onRefreshed()
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -87,8 +87,8 @@ class CardsSource @Inject constructor(
             val error = result.error
             when {
                 error != null -> postState(CardsUpdate(result))
-                model != null -> onRefreshed()
-                else -> onRefreshed()
+                model != null -> onRefreshedBackgroundThread()
+                else -> onRefreshedBackgroundThread()
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -27,7 +27,7 @@ class CardsSource @Inject constructor(
     private val cardsStore: CardsStore,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : MySiteRefreshSource<CardsUpdate> {
-    override val refresh = MutableLiveData(selectedSiteRepository.hasSelectedSite())
+    override val refresh = MutableLiveData(true)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<CardsUpdate> {
         val result = MediatorLiveData<CardsUpdate>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -27,7 +27,7 @@ class CardsSource @Inject constructor(
     private val cardsStore: CardsStore,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : MySiteRefreshSource<CardsUpdate> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(selectedSiteRepository.hasSelectedSite())
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<CardsUpdate> {
         val result = MediatorLiveData<CardsUpdate>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -24,7 +24,7 @@ class CardsSource @Inject constructor(
     private val cardsStore: CardsStore,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : MySiteRefreshSource<CardsUpdate> {
-    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+    override val refresh = MutableLiveData(true)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<CardsUpdate> {
         val result = MediatorLiveData<CardsUpdate>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
@@ -18,6 +19,8 @@ import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CardsUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import javax.inject.Inject
 import javax.inject.Named
+
+const val REFRESH_DELAY = 500L
 
 class CardsSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
@@ -42,7 +45,7 @@ class CardsSource @Inject constructor(
         if (selectedSite != null && selectedSite.id == siteLocalId) {
             coroutineScope.launch(bgDispatcher) {
                 cardsStore.getCards(selectedSite).collect { result ->
-                    postState(CardsUpdate(result))
+                    postValue(CardsUpdate(result))
                 }
             }
         } else {
@@ -78,9 +81,14 @@ class CardsSource @Inject constructor(
         selectedSite: SiteModel
     ) {
         coroutineScope.launch(bgDispatcher) {
+            delay(REFRESH_DELAY)
             val result = cardsStore.fetchCards(selectedSite)
-            result.error?.let {
-                postState(CardsUpdate(result))
+            val model = result.model
+            val error = result.error
+            when {
+                error != null -> postState(CardsUpdate(result))
+                model != null -> refresh.postValue(false)
+                else -> refresh.postValue(false)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
@@ -34,7 +34,7 @@ class DomainRegistrationSource @Inject constructor(
     private val appLogWrapper: AppLogWrapper,
     private val siteUtils: SiteUtilsWrapper
 ) : MySiteRefreshSource<DomainCreditAvailable> {
-    override val refresh = MutableLiveData(false)
+    override val refresh = MutableLiveData(true)
 
     private val continuations = mutableMapOf<Int, CancellableContinuation<OnPlansFetched>?>()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
@@ -34,7 +34,7 @@ class DomainRegistrationSource @Inject constructor(
     private val appLogWrapper: AppLogWrapper,
     private val siteUtils: SiteUtilsWrapper
 ) : MySiteRefreshSource<DomainCreditAvailable> {
-    override val refresh = MutableLiveData(selectedSiteRepository.hasSelectedSite())
+    override val refresh = MutableLiveData(true)
 
     private val continuations = mutableMapOf<Int, CancellableContinuation<OnPlansFetched>?>()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
@@ -34,7 +34,7 @@ class DomainRegistrationSource @Inject constructor(
     private val appLogWrapper: AppLogWrapper,
     private val siteUtils: SiteUtilsWrapper
 ) : MySiteRefreshSource<DomainCreditAvailable> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(selectedSiteRepository.hasSelectedSite())
 
     private val continuations = mutableMapOf<Int, CancellableContinuation<OnPlansFetched>?>()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
@@ -21,7 +21,7 @@ class QuickStartCardSource @Inject constructor(
     private val quickStartUtilsWrapper: QuickStartUtilsWrapper,
     private val selectedSiteRepository: SelectedSiteRepository
 ) : MySiteRefreshSource<QuickStartUpdate> {
-    override val refresh = MutableLiveData(selectedSiteRepository.hasSelectedSite())
+    override val refresh = MutableLiveData(true)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<QuickStartUpdate> {
         quickStartRepository.resetTask()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
@@ -21,7 +21,7 @@ class QuickStartCardSource @Inject constructor(
     private val quickStartUtilsWrapper: QuickStartUtilsWrapper,
     private val selectedSiteRepository: SelectedSiteRepository
 ) : MySiteRefreshSource<QuickStartUpdate> {
-    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+    override val refresh = MutableLiveData(true)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<QuickStartUpdate> {
         quickStartRepository.resetTask()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
@@ -21,7 +21,7 @@ class QuickStartCardSource @Inject constructor(
     private val quickStartUtilsWrapper: QuickStartUtilsWrapper,
     private val selectedSiteRepository: SelectedSiteRepository
 ) : MySiteRefreshSource<QuickStartUpdate> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(selectedSiteRepository.hasSelectedSite())
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<QuickStartUpdate> {
         quickStartRepository.resetTask()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
@@ -17,7 +17,7 @@ class DynamicCardsSource
     private val dynamicCardStore: DynamicCardStore,
     private val selectedSiteRepository: SelectedSiteRepository
 ) : MySiteRefreshSource<DynamicCardsUpdate> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(selectedSiteRepository.hasSelectedSite())
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DynamicCardsUpdate> {
         val data = MediatorLiveData<DynamicCardsUpdate>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
@@ -17,7 +17,7 @@ class DynamicCardsSource
     private val dynamicCardStore: DynamicCardStore,
     private val selectedSiteRepository: SelectedSiteRepository
 ) : MySiteRefreshSource<DynamicCardsUpdate> {
-    override val refresh = MutableLiveData(selectedSiteRepository.hasSelectedSite())
+    override val refresh = MutableLiveData(true)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DynamicCardsUpdate> {
         val data = MediatorLiveData<DynamicCardsUpdate>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
@@ -17,7 +17,7 @@ class DynamicCardsSource
     private val dynamicCardStore: DynamicCardStore,
     private val selectedSiteRepository: SelectedSiteRepository
 ) : MySiteRefreshSource<DynamicCardsUpdate> {
-    override val refresh: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+    override val refresh = MutableLiveData(true)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DynamicCardsUpdate> {
         val data = MediatorLiveData<DynamicCardsUpdate>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
@@ -65,7 +65,7 @@ class DynamicCardsSource
     private suspend fun callWithSite(function: suspend (Int) -> Unit) {
         selectedSiteRepository.getSelectedSite()?.id?.let { selectedSiteLocalId ->
             function(selectedSiteLocalId)
-            refresh.postValue(true)
+            refresh()
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
@@ -63,6 +63,7 @@ class MySiteSourceManagerTest : BaseUnitTest() {
         selectedSite.value = null
         whenever(siteModel.isUsingWpComRestApi).thenReturn(true)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
+        whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(true)
 
         mySiteSourceManager = MySiteSourceManager(
                 analyticsTrackerWrapper,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
@@ -56,6 +56,7 @@ class MySiteSourceManagerTest : BaseUnitTest() {
     private lateinit var allRefreshedMySiteSourcesExceptCardsSource: List<MySiteSource<*>>
     private lateinit var siteIndependentMySiteSources: List<MySiteSource<*>>
     private lateinit var selectRefreshedMySiteSources: List<MySiteSource<*>>
+    private lateinit var siteDependentMySiteSources: List<MySiteSource<*>>
 
     @InternalCoroutinesApi
     @Before
@@ -109,6 +110,8 @@ class MySiteSourceManagerTest : BaseUnitTest() {
                 quickStartCardSource,
                 currentAvatarSource
         )
+
+        siteDependentMySiteSources = allRefreshedMySiteSources.filterNot(SiteIndependentSource::class.java::isInstance)
     }
 
     /* ON REFRESH */
@@ -158,12 +161,45 @@ class MySiteSourceManagerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given without site local id, when build, then all sources except cards source are built`() {
+    fun `given without site local id, when build, then all site independent sources are built`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
         val coroutineScope = testScope()
 
         mySiteSourceManager.build(coroutineScope, null)
 
         siteIndependentMySiteSources.forEach { verify(it as SiteIndependentSource).build(coroutineScope) }
+    }
+
+    @Test
+    fun `given without site local id, when build, then site dependent sources are not built`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        val coroutineScope = testScope()
+
+        mySiteSourceManager.build(coroutineScope, null)
+
+        siteDependentMySiteSources.forEach { verify(it, times(0)).build(coroutineScope, SITE_LOCAL_ID) }
+    }
+
+    @Test
+    fun `given without site local id, when refresh, then site independent sources are built`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        val coroutineScope = testScope()
+        mySiteSourceManager.build(coroutineScope, null)
+
+        mySiteSourceManager.refresh()
+
+        siteIndependentMySiteSources.forEach { verify(it as SiteIndependentSource).build(coroutineScope) }
+    }
+
+    @Test
+    fun `given without site local id, when refresh, then site dependent sources are not built`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        val coroutineScope = testScope()
+        mySiteSourceManager.build(coroutineScope, null)
+
+        mySiteSourceManager.refresh()
+
+        siteDependentMySiteSources.forEach { verify(it, times(0)).build(coroutineScope, SITE_LOCAL_ID) }
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -153,7 +153,6 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         scanPurchased: Boolean = false,
         backupPurchased: Boolean = false
     ) {
-        whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(hasSelectedSite)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(if (hasSelectedSite) site else null)
         if (hasSelectedSite) {
             whenever(site.siteId).thenReturn(siteRemoteId)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase.JetpackPurchasedProducts
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.JetpackCapabilities
 
+@InternalCoroutinesApi
 class ScanAndBackupSourceTest : BaseUnitTest() {
     @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
     @Mock lateinit var jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase
@@ -28,14 +29,8 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
     private val siteRemoteId = 2L
     private lateinit var isRefreshing: MutableList<Boolean>
 
-    @InternalCoroutinesApi
     @Before
     fun setUp() {
-        scanAndBackupSource = ScanAndBackupSource(
-                TEST_DISPATCHER,
-                selectedSiteRepository,
-                jetpackCapabilitiesUseCase
-        )
         whenever(site.id).thenReturn(siteLocalId)
         whenever(site.isWPCom).thenReturn(false)
         whenever(site.isWPComAtomic).thenReturn(false)
@@ -44,7 +39,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
     @Test
     fun `jetpack capabilities disabled when site not present`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+        initScanAndBackupSource(hasSelectedSite = false)
 
         var result: JetpackCapabilities? = null
         scanAndBackupSource.build(testScope(), siteLocalId).observeForever { result = it }
@@ -55,11 +50,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
     @Test
     fun `jetpack capabilities reloads both scan and backup as true`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        whenever(site.siteId).thenReturn(siteRemoteId)
-        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
-                flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
-        )
+        initScanAndBackupSource(hasSelectedSite = true, scanPurchased = true, backupPurchased = true)
 
         var result: JetpackCapabilities? = null
         scanAndBackupSource.build(testScope(), siteLocalId).observeForever { result = it }
@@ -70,11 +61,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
     @Test
     fun `jetpack capabilities reloads both scan and backup as false`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        whenever(site.siteId).thenReturn(siteRemoteId)
-        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
-                flow { emit(JetpackPurchasedProducts(scan = false, backup = false)) }
-        )
+        initScanAndBackupSource(hasSelectedSite = true, scanPurchased = false, backupPurchased = false)
 
         var result: JetpackCapabilities? = null
         scanAndBackupSource.build(testScope(), siteLocalId).observeForever { result = it }
@@ -85,11 +72,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
     @Test
     fun `Scan not visible on wpcom sites even when Scan product is available`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        whenever(site.siteId).thenReturn(siteRemoteId)
-        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
-                flow { emit(JetpackPurchasedProducts(scan = true, backup = false)) }
-        )
+        initScanAndBackupSource(hasSelectedSite = true, scanPurchased = true, backupPurchased = false)
         whenever(site.isWPCom).thenReturn(true)
 
         var result: JetpackCapabilities? = null
@@ -100,11 +83,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
     @Test
     fun `Scan not visible on atomic sites even when Scan product is available`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        whenever(site.siteId).thenReturn(siteRemoteId)
-        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
-                flow { emit(JetpackPurchasedProducts(scan = true, backup = false)) }
-        )
+        initScanAndBackupSource(hasSelectedSite = true, scanPurchased = true, backupPurchased = false)
         whenever(site.isWPComAtomic).thenReturn(true)
 
         var result: JetpackCapabilities? = null
@@ -115,11 +94,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
     @Test
     fun `Scan visible on non-wpcom sites when Scan product is available and feature flag enabled`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        whenever(site.siteId).thenReturn(siteRemoteId)
-        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
-                flow { emit(JetpackPurchasedProducts(scan = true, backup = false)) }
-        )
+        initScanAndBackupSource(hasSelectedSite = true, scanPurchased = true, backupPurchased = false)
         whenever(site.isWPCom).thenReturn(false)
         whenever(site.isWPComAtomic).thenReturn(false)
 
@@ -131,11 +106,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
     @Test
     fun `when refresh is invoked, then data is refreshed`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        whenever(site.siteId).thenReturn(siteRemoteId)
-        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
-                flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
-        )
+        initScanAndBackupSource(hasSelectedSite = true, scanPurchased = true, backupPurchased = true)
 
         scanAndBackupSource.build(testScope(), siteLocalId).observeForever { }
         scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
@@ -147,6 +118,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
     @Test
     fun `when source is invoked, then refresh is false`() = test {
+        initScanAndBackupSource(hasSelectedSite = true, scanPurchased = true, backupPurchased = true)
         scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
 
         scanAndBackupSource.build(testScope(), siteLocalId)
@@ -156,6 +128,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
     @Test
     fun `when refresh is invoked, then refresh is true`() = test {
+        initScanAndBackupSource(hasSelectedSite = true, scanPurchased = true, backupPurchased = true)
         scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
 
         scanAndBackupSource.refresh()
@@ -165,11 +138,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
     @Test
     fun `when data has been refreshed, then refresh is set to false`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        whenever(site.siteId).thenReturn(siteRemoteId)
-        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
-                flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
-        )
+        initScanAndBackupSource(hasSelectedSite = true, scanPurchased = true, backupPurchased = false)
 
         scanAndBackupSource.build(testScope(), siteLocalId).observeForever { }
         scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
@@ -177,5 +146,25 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         scanAndBackupSource.refresh()
 
         assertThat(isRefreshing.last()).isFalse
+    }
+
+    private suspend fun initScanAndBackupSource(
+        hasSelectedSite: Boolean = true,
+        scanPurchased: Boolean = false,
+        backupPurchased: Boolean = false
+    ) {
+        whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(hasSelectedSite)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(if (hasSelectedSite) site else null)
+        if (hasSelectedSite) {
+            whenever(site.siteId).thenReturn(siteRemoteId)
+            whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
+                    flow { emit(JetpackPurchasedProducts(scan = scanPurchased, backup = backupPurchased)) }
+            )
+        }
+        scanAndBackupSource = ScanAndBackupSource(
+                TEST_DISPATCHER,
+                selectedSiteRepository,
+                jetpackCapabilitiesUseCase
+        )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteSourceTest.kt
@@ -33,7 +33,7 @@ class SelectedSiteSourceTest : BaseUnitTest() {
     fun setUp() {
         site.id = siteLocalId
         whenever(selectedSiteRepository.selectedSiteChange).thenReturn(onSiteChange)
-        source = SelectedSiteSource(selectedSiteRepository, dispatcher)
+        initSelectedSiteSource()
         result = mutableListOf()
         isRefreshing = mutableListOf()
     }
@@ -49,7 +49,7 @@ class SelectedSiteSourceTest : BaseUnitTest() {
 
     @Test
     fun `given selected site, when refresh is invoked, then remote request is dispatched`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        initSelectedSiteSource(hasSelectedSite = true)
 
         source.refresh()
 
@@ -58,7 +58,7 @@ class SelectedSiteSourceTest : BaseUnitTest() {
 
     @Test
     fun `given no selected site, when refresh is invoked, then remote request is not dispatched`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+        initSelectedSiteSource(hasSelectedSite = false)
 
         source.refresh()
 
@@ -66,17 +66,18 @@ class SelectedSiteSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when buildSource is invoked, then refresh is false`() = test {
+    fun `given selected site, when build is invoked, then refresh is true`() = test {
+        initSelectedSiteSource(hasSelectedSite = true)
         source.refresh.observeForever { isRefreshing.add(it) }
 
         source.build(testScope(), siteLocalId).observeForever { result.add(it) }
 
-        assertThat(isRefreshing.last()).isFalse
+        assertThat(isRefreshing.last()).isTrue
     }
 
     @Test
     fun `given selected site, when refresh is invoked, then refresh is true`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        initSelectedSiteSource(hasSelectedSite = true)
         source.refresh.observeForever { isRefreshing.add(it) }
 
         source.refresh()
@@ -86,7 +87,7 @@ class SelectedSiteSourceTest : BaseUnitTest() {
 
     @Test
     fun `given no selected site, when refresh is invoked, then refresh is false`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+        initSelectedSiteSource(hasSelectedSite = false)
         source.refresh.observeForever { isRefreshing.add(it) }
 
         source.refresh()
@@ -104,5 +105,11 @@ class SelectedSiteSourceTest : BaseUnitTest() {
         source.onSiteChanged(OnSiteChanged(1, null))
 
         assertThat(isRefreshing.last()).isFalse
+    }
+
+    private fun initSelectedSiteSource(hasSelectedSite: Boolean = true) {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(if (hasSelectedSite) site else null)
+        whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(hasSelectedSite)
+        source = SelectedSiteSource(selectedSiteRepository, dispatcher)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
@@ -87,7 +87,6 @@ class CardsSourceTest : BaseUnitTest() {
     private fun setUpMocks() {
         whenever(siteModel.id).thenReturn(SITE_LOCAL_ID)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
-        whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(true)
     }
 
     /* GET DATA */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
@@ -41,6 +41,9 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Before
     fun setUp() {
+        site.id = siteLocalId
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(true)
         source = DomainRegistrationSource(
                 TEST_DISPATCHER,
                 dispatcher,
@@ -48,8 +51,6 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
                 appLogWrapper,
                 siteUtils
         )
-        site.id = siteLocalId
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         result = mutableListOf()
         isRefreshing = mutableListOf()
     }
@@ -102,12 +103,12 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when build is invoked, then refresh is false`() = test {
+    fun `when build is invoked, then refresh is true`() = test {
         source.refresh.observeForever { isRefreshing.add(it) }
 
         source.build(testScope(), siteLocalId)
 
-        assertThat(isRefreshing.last()).isFalse
+        assertThat(isRefreshing.first()).isTrue
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
@@ -43,7 +43,6 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
     fun setUp() {
         site.id = siteLocalId
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(true)
         source = DomainRegistrationSource(
                 TEST_DISPATCHER,
                 dispatcher,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
@@ -77,6 +77,10 @@ class QuickStartCardSourceTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Before
     fun setUp() = test {
+        site = SiteModel()
+        site.id = siteLocalId
+        whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         quickStartRepository = QuickStartRepository(
                 TEST_DISPATCHER,
                 quickStartStore,
@@ -107,8 +111,6 @@ class QuickStartCardSourceTest : BaseUnitTest() {
         quickStartRepository.onQuickStartMySitePrompts.observeForever { event ->
             event?.getContentIfNotHandled()?.let { quickStartPrompts.add(it) }
         }
-        site = SiteModel()
-        site.id = siteLocalId
         result = mutableListOf()
         isRefreshing = mutableListOf()
         quickStartCardSource.refresh.observeForever { isRefreshing.add(it) }
@@ -373,7 +375,6 @@ class QuickStartCardSourceTest : BaseUnitTest() {
     private suspend fun initStore(
         nextUncompletedTask: QuickStartTask? = null
     ) {
-        initBuild()
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(dynamicCardStore.getCards(siteLocalId)).thenReturn(
                 DynamicCardsModel(
@@ -405,6 +406,7 @@ class QuickStartCardSourceTest : BaseUnitTest() {
         whenever(quickStartUtilsWrapper.getNextUncompletedQuickStartTask(siteLocalId.toLong()))
                 .thenReturn(nextUncompletedTask)
         whenever(htmlMessageUtils.getHtmlMessageFromStringFormat(anyOrNull())).thenReturn("")
+        initBuild()
     }
 
     private fun initBuild() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
@@ -79,7 +79,6 @@ class QuickStartCardSourceTest : BaseUnitTest() {
     fun setUp() = test {
         site = SiteModel()
         site.id = siteLocalId
-        whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(true)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         quickStartRepository = QuickStartRepository(
                 TEST_DISPATCHER,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
@@ -136,7 +136,6 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     ) {
         whenever(siteModel.id).thenReturn(siteLocalId)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(if (hasSelectedSite) siteModel else null)
-        whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(hasSelectedSite)
         if (hasSelectedSite) {
             val pinnedItem = GROW_QUICK_START
             val dynamicCardTypes = listOf(CUSTOMIZE_QUICK_START, GROW_QUICK_START)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
@@ -26,25 +26,19 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     private lateinit var dynamicCardsSource: DynamicCardsSource
     private val siteLocalId: Int = 1
     private lateinit var isRefreshing: MutableList<Boolean>
+    private val pinnedItem = GROW_QUICK_START
+    private val dynamicCardTypes = listOf(CUSTOMIZE_QUICK_START, GROW_QUICK_START)
 
     @InternalCoroutinesApi
     @Before
-    fun setUp() {
-        dynamicCardsSource = DynamicCardsSource(dynamicCardStore, selectedSiteRepository)
-        whenever(siteModel.id).thenReturn(siteLocalId)
+    fun setUp() = test {
         isRefreshing = mutableListOf()
     }
 
     @Test
-    fun `returns cards from the store`() = test {
-        val pinnedItem = GROW_QUICK_START
-        val dynamicCardTypes = listOf(CUSTOMIZE_QUICK_START, GROW_QUICK_START)
-        whenever(dynamicCardStore.getCards(siteLocalId)).thenReturn(
-                DynamicCardsModel(
-                        pinnedItem,
-                        dynamicCardTypes
-                )
-        )
+    fun `given selected site, when source is build, then cards returned from the store`() = test {
+        initDynamicCardsSource(hasSelectedSite = true)
+
         var result: DynamicCardsUpdate? = null
         dynamicCardsSource.build(testScope(), siteLocalId).observeForever { result = it }
 
@@ -53,8 +47,8 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `hides card when site is present`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
+    fun `given selected site, when hide action done, then card hidden`() = test {
+        initDynamicCardsSource(hasSelectedSite = true)
 
         dynamicCardsSource.hideItem(CUSTOMIZE_QUICK_START)
 
@@ -62,8 +56,8 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `does not hide card when site not present`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+    fun `given no selected site, when hide action done, then card not hidden`() = test {
+        initDynamicCardsSource(hasSelectedSite = false)
 
         dynamicCardsSource.hideItem(GROW_QUICK_START)
 
@@ -71,8 +65,8 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `pins card when site is present`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
+    fun `given selected site, when pin action done, then card is pinned`() = test {
+        initDynamicCardsSource(hasSelectedSite = true)
 
         dynamicCardsSource.pinItem(CUSTOMIZE_QUICK_START)
 
@@ -80,8 +74,8 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `does not pin card when site not present`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+    fun `given no selected site, when pin action done, then card is not pinned`() = test {
+        initDynamicCardsSource(hasSelectedSite = false)
 
         dynamicCardsSource.pinItem(GROW_QUICK_START)
 
@@ -89,8 +83,8 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `unpins when site is present`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
+    fun `given selected site, when unpin action done, then card is unpinned`() = test {
+        initDynamicCardsSource(hasSelectedSite = true)
 
         dynamicCardsSource.unpinItem()
 
@@ -98,8 +92,8 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `does not unpin when site not present`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+    fun `given no selected site, when unpin action done, then card is not unpinned`() = test {
+        initDynamicCardsSource(hasSelectedSite = false)
 
         dynamicCardsSource.unpinItem()
 
@@ -107,7 +101,8 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when source is invoked, then refresh is false`() = test {
+    fun `given selected site, when source is build, then refresh is false`() = test {
+        initDynamicCardsSource(hasSelectedSite = true)
         dynamicCardsSource.refresh.observeForever { isRefreshing.add(it) }
 
         dynamicCardsSource.build(testScope(), siteLocalId)
@@ -116,7 +111,8 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when refresh is invoked, then refresh is true`() = test {
+    fun `given selected site, when refresh is invoked, then refresh is true`() = test {
+        initDynamicCardsSource(hasSelectedSite = true)
         dynamicCardsSource.refresh.observeForever { isRefreshing.add(it) }
 
         dynamicCardsSource.refresh()
@@ -125,20 +121,32 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when data has been refreshed, then refresh is set to false`() = test {
-        val pinnedItem = GROW_QUICK_START
-        val dynamicCardTypes = listOf(CUSTOMIZE_QUICK_START, GROW_QUICK_START)
-        whenever(dynamicCardStore.getCards(siteLocalId)).thenReturn(
-                DynamicCardsModel(
-                        pinnedItem,
-                        dynamicCardTypes
-                )
-        )
+    fun `given selected site, when data has been refreshed, then refresh is set to false`() = test {
+        initDynamicCardsSource(hasSelectedSite = true)
         dynamicCardsSource.refresh.observeForever { isRefreshing.add(it) }
 
         dynamicCardsSource.build(testScope(), siteLocalId).observeForever { }
         dynamicCardsSource.refresh()
 
         assertThat(isRefreshing.last()).isFalse
+    }
+
+    private suspend fun initDynamicCardsSource(
+        hasSelectedSite: Boolean = true
+    ) {
+        whenever(siteModel.id).thenReturn(siteLocalId)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(if (hasSelectedSite) siteModel else null)
+        whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(hasSelectedSite)
+        if (hasSelectedSite) {
+            val pinnedItem = GROW_QUICK_START
+            val dynamicCardTypes = listOf(CUSTOMIZE_QUICK_START, GROW_QUICK_START)
+            whenever(dynamicCardStore.getCards(siteLocalId)).thenReturn(
+                    DynamicCardsModel(
+                            pinnedItem,
+                            dynamicCardTypes
+                    )
+            )
+        }
+        dynamicCardsSource = DynamicCardsSource(dynamicCardStore, selectedSiteRepository)
     }
 }


### PR DESCRIPTION
Parent #15625

Page Behavior (pbArwn-3ny-p2)

This PR displays
- loading indicator on initial site load, 
- no loading indicator when there's no site.

Loading on pull-to-refresh was already functional, so, below `loading states` can be tested with this PR:

State (1) - No data, loading (without shimmer - see p1639483178142800-slack-C0290FLA0RM)
State (2) - Finished loading
State (6) - Refresh or loading with content

Yet to handle:
State (7 + 8) - Refresh fails

## To test

Test loading indicator visibility on initial app load, pull-to-refresh, and site switch for an account with and without sites as follows:

MySiteDashboardPhase2FeatureConfig | With Site | Without Sites 
-- | -- | --
OFF | No | No
ON | Yes | No

## Regression Notes
1. Potential unintended areas of impact
Refresh does not finish and the loading indicator keeps appearing.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested for site + no site scenarios. 

3. What automated tests I added (or what prevented me from doing so)
Fixed existing unit tests in different `my site sources` for the initial loading indicator visibility changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.