### PR TITLE
My Site Dashboard [Phase 2]: Load Handling while Navigating to Edit Post [DO NOT MERGE]

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostLoadingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostLoadingDialogFragment.kt
@@ -1,0 +1,30 @@
+package org.wordpress.android.ui.posts
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import androidx.appcompat.app.AppCompatDialog
+import androidx.appcompat.app.AppCompatDialogFragment
+import org.wordpress.android.R
+
+class PostLoadingDialogFragment : AppCompatDialogFragment() {
+    override fun getTheme() = R.style.WordPress_FullscreenDialog
+
+    override fun setupDialog(dialog: Dialog, style: Int) {
+        (dialog as AppCompatDialog).supportRequestWindowFeature(Window.FEATURE_NO_TITLE)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.post_loading_dialog_fragment, container, false)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+        dialog.setCanceledOnTouchOutside(false)
+        dialog.setCancelable(false)
+        return dialog
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -108,6 +108,7 @@ class PostsListActivity : LocaleAwareActivity(),
     private var restorePreviousSearch = false
 
     private var progressDialog: ProgressDialog? = null
+    private var loadingDialog: PostLoadingDialogFragment? = null
 
     private var onPageChangeListener: OnPageChangeListener = object : OnPageChangeListener {
         override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}
@@ -170,6 +171,11 @@ class PostsListActivity : LocaleAwareActivity(),
             val actionsShownByDefault = intent.getBooleanExtra(ACTIONS_SHOWN_BY_DEFAULT, false)
             val tabIndex = intent.getIntExtra(TAB_INDEX, PostListType.PUBLISHED.ordinal)
             val targetPostId = intent.getIntExtra(EXTRA_TARGET_POST_REMOTE_ID, 0).let { if (it != 0) it else null }
+
+            if (targetPostId != null) {
+                loadingDialog = PostLoadingDialogFragment()
+                loadingDialog?.show(supportFragmentManager, TAG_POST_LOADING_DIALOG)
+            }
 
             setupActionBar()
             setupContent(targetPostId)
@@ -459,6 +465,11 @@ class PostsListActivity : LocaleAwareActivity(),
         postListCreateMenuViewModel.onResume()
     }
 
+    override fun onStop() {
+        loadingDialog?.dismiss()
+        super.onStop()
+    }
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 
@@ -654,6 +665,8 @@ class PostsListActivity : LocaleAwareActivity(),
         private const val BLOGGING_REMINDERS_FRAGMENT_TAG = "blogging_reminders_fragment_tag"
         private const val ACTIONS_SHOWN_BY_DEFAULT = "actions_shown_by_default"
         private const val TAB_INDEX = "tab_index"
+
+        private const val TAG_POST_LOADING_DIALOG = "TAG_POST_LOADING_DIALOG"
 
         @JvmStatic
         fun buildIntent(context: Context, site: SiteModel): Intent {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -459,7 +459,7 @@ class PostsListActivity : LocaleAwareActivity(),
         }
     }
 
-    public override fun onResume() {
+    override fun onResume() {
         super.onResume()
         ActivityId.trackLastActivity(ActivityId.POSTS)
         postListCreateMenuViewModel.onResume()

--- a/WordPress/src/main/res/layout/post_loading_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/post_loading_dialog_fragment.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingEnd="@dimen/margin_extra_large"
+    android:paddingStart="@dimen/margin_extra_large">
+
+    <!-- NOTE: The bottom margin is arbitrary set to '27dp' in order to much the exact location of
+     progress bar on the 'Edit Post` screen so that it appears to be the same progress bar. -->
+    <ProgressBar
+        android:id="@+id/post_loading_progress"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:indeterminate="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/post_loading_text" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/post_loading_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="27dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginStart="20dp"
+        android:text="@string/post_loading_dialog_text"
+        android:textAlignment="center"
+        android:textAppearance="?attr/textAppearanceHeadline6"
+        app:layout_constraintBottom_toTopOf="@id/post_loading_progress"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3120,6 +3120,7 @@
     <string name="error_unknown_page_type">Unknown page format</string>
 
     <!-- Posts -->
+    <string name="post_loading_dialog_text">Loading post</string>
     <string name="post_list_author">Post author</string>
     <string name="post_list_tab_published_posts">Published</string>
     <string name="post_list_tab_drafts">Drafts</string>


### PR DESCRIPTION
Parent: #15709

This PR sits on top of the previous #15720 PR and completes this part of the flow by adding the extra full screen post loading dialog in it, before showing the `Edit Post` screen, while waiting within the intermediate `Posts` screen.

-----

Prerequisite:

- Go to `My Site` -> `Me` -> `App Settings` -> `Debug Settings` configuration.
- Turn-on the `MySiteDashboardPhase2FeatureConfig` feature.
- Relaunch the app.

-----

To test:
- If you don't have a draft or scheduled post already, create one.
- Note that on the `My Site` tab, your draft or scheduled posts, if any, are shown.
- Click on a draft or scheduled posts and verify that:
  - First, the `Posts` screen is no longer shown.
  - Second, instead of the `Posts` screen, a full screen `Post Loading Dialog` is now shown.
  - Then, the `Edit Post` screen is launched with the content of the draft or scheduled post that was selected.

NOTE: The position of progress bar of the full screen `Post Loading Dialog` and the `Edit Post` screen match. As such, this creates the illusion that this is a same progress bar.

-----

Merge instructions:

- Wait for the previous #15720 PR to be merged.
- Remove the `[Status] Not Ready for Merge` label.
- Wait for the @osullivanchris to do a design review of this flow, including the previous #15720 PR.
- Remove the `[Status] Needs Design Review` label.
- Merge this PR.

-----

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` sections above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
