### PR TITLE
My Site Dashboard: Phase 2: Metrics - Track Pull to refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -177,7 +177,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
         swipeToRefreshHelper = buildSwipeToRefreshHelper(swipeRefreshLayout) {
             if (NetworkUtils.checkConnection(requireActivity())) {
-                viewModel.refresh()
+                viewModel.refresh(isPullToRefresh = true)
             } else {
                 swipeToRefreshHelper.isRefreshing = false
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_PULL_TO_REFRESH
 import org.wordpress.android.fluxc.model.DynamicCardType
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -477,7 +478,10 @@ class MySiteViewModel @Inject constructor(
         _onNavigation.value = Event(SiteNavigationAction.OpenDomainRegistration(selectedSite))
     }
 
-    fun refresh() = mySiteSourceManager.refresh()
+    fun refresh(isPullToRefresh: Boolean = false) {
+        if (isPullToRefresh) analyticsTrackerWrapper.track(MY_SITE_PULL_TO_REFRESH)
+        mySiteSourceManager.refresh()
+    }
 
     fun onResume(isFirstResume: Boolean) {
         mySiteSourceManager.onResume(isFirstResume)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1357,6 +1357,24 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(showSwipeRefreshLayout.last()).isEqualTo(false)
     }
 
+    @Test
+    fun `given refresh, when invoked as PTR, then pull-to-refresh request is tracked`() {
+        initSelectedSite()
+
+        viewModel.refresh(isPullToRefresh = true)
+
+        verify(analyticsTrackerWrapper).track(Stat.MY_SITE_PULL_TO_REFRESH)
+    }
+
+    @Test
+    fun `given refresh, when not invoked as PTR, then pull-to-refresh request is not tracked`() {
+        initSelectedSite()
+
+        viewModel.refresh()
+
+        verify(analyticsTrackerWrapper, times(0)).track(Stat.MY_SITE_PULL_TO_REFRESH)
+    }
+
     /* CLEARED */
     @Test
     fun `when vm cleared() is invoked, then MySiteSource clear() is invoked`() {

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -817,7 +817,8 @@ public final class AnalyticsTracker {
         EDITOR_BLOCK_INSERTED,
         ABOUT_SCREEN_SHOWN,
         ABOUT_SCREEN_DISMISSED,
-        ABOUT_SCREEN_BUTTON_TAPPED
+        ABOUT_SCREEN_BUTTON_TAPPED,
+        MY_SITE_PULL_TO_REFRESH
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2136,6 +2136,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "about_screen_dismissed";
             case ABOUT_SCREEN_BUTTON_TAPPED:
                 return "about_screen_button_tapped";
+            case MY_SITE_PULL_TO_REFRESH:
+                return "my_site_pull_to_refresh";
         }
         return null;
     }


### PR DESCRIPTION
Fixes #15727 

This PR tracks a user requested PTR as **MY_SITE_PULL_TO_REFRESH** 

**To test:**
- Launch the app
- Navigate to Me -> App Settings -> Debug Settings
- Ensure that the `MySiteDashboardPhase2FeatureConfig` is to set to on
- Restart the app if needed
- Navigate to Me -> App Settings -> Privacy Settings 
- Toggle the "collect information" switch to on
- Navigate to the My Site tab
- Swipe down on the view to initiate the pull-to-refresh
- Navigate to Me -> Help and Support -> Application log
- Note: I: 🔵 Tracked: my_site_pull_to_refresh is shown in the log



## Regression Notes
1. Potential unintended areas of impact N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A
3. What automated tests I added (or what prevented me from doing so)
Added two tests to verify that tracks is called or not called depending on refresh source.

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
