### PR TITLE
[Notification section] Read all notifications when the user clicks on the ✔️ button

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -486,6 +486,7 @@ dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$coreLibraryDesugaringVersion"
 
     implementation "com.google.android.exoplayer:exoplayer:$exoPlayerVersion"
+    implementation "app.cash.turbine:turbine:$turbine_version"
 }
 
 configurations.all {

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -33,6 +33,7 @@ import org.wordpress.android.ui.main.MeViewModel;
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel;
 import org.wordpress.android.ui.mysite.MySiteViewModel;
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel;
+import org.wordpress.android.ui.notifications.NotificationListViewModel;
 import org.wordpress.android.ui.people.PeopleInviteViewModel;
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel;
 import org.wordpress.android.ui.plans.PlansViewModel;
@@ -584,4 +585,9 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ConversationNotificationsViewModel.class)
     abstract ViewModel conversationNotificationsViewModel(ConversationNotificationsViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(NotificationListViewModel.class)
+    abstract ViewModel notificationListViewModel(NotificationListViewModel viewModel);
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationListViewModel.kt
@@ -1,0 +1,58 @@
+package org.wordpress.android.ui.notifications
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.collect
+import org.wordpress.android.R
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+class NotificationListViewModel @Inject constructor(
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val notificationUseCase: NotificationsUseCase,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+) : ScopedViewModel(mainDispatcher) {
+
+    private var isStarted: Boolean = false
+    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
+    fun start() {
+        if (isStarted) return
+        isStarted = true
+
+        _snackbarEvents.addSource(notificationUseCase.snackbarEvents) { event ->
+            _snackbarEvents.value = event
+        }
+    }
+
+    fun onClickReadAllNotifications() {
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+            launch(bgDispatcher) {
+                _snackbarEvents.value = Event(SnackbarMessageHolder(UiStringRes(R.string.no_network_message)))
+            }
+        } else {
+            launch(bgDispatcher) {
+                notificationUseCase.requestNotifications()
+                notificationUseCase.uiStateFlow.collect {
+                    when (it) {
+                        NotificationsUseCase.UiState.InitialState -> Unit
+                        is NotificationsUseCase.UiState.NotesReceived -> notificationUseCase.setAllNotesAsRead(it.notes)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsUseCase.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.ui.notifications
+
+import android.text.TextUtils
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.greenrobot.eventbus.EventBus
+import org.json.JSONException
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.datasets.NotificationsTable
+import org.wordpress.android.models.Note
+import org.wordpress.android.networking.RestClientUtils
+import org.wordpress.android.ui.notifications.utils.NotificationsActions
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.viewmodel.Event
+import java.util.*
+import javax.inject.Inject
+
+class NotificationsUseCase @Inject constructor() {
+
+    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
+    private val _uiStateFlow = MutableStateFlow<UiState>(UiState.InitialState)
+    val uiStateFlow = _uiStateFlow.asStateFlow()
+
+    sealed class UiState() {
+        object InitialState : UiState()
+        class NotesReceived(val notes: List<Note>) : UiState()
+    }
+
+    fun requestNotifications() {
+        val params: MutableMap<String, String> = HashMap()
+        params["number"] = "200"
+        params["num_note_items"] = "20"
+        params["fields"] = RestClientUtils.NOTIFICATION_FIELDS
+        if (!TextUtils.isEmpty(Locale.getDefault().toString())) {
+            params["locale"] = Locale.ENGLISH.toString().lowercase()
+        }
+        WordPress.getRestClientUtilsV1_1().getNotifications(params, {
+            if (it == null) {
+                _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiString.UiStringRes(R.string.error_notif_generic))))
+            } else {
+                try {
+                    _uiStateFlow.value = UiState.NotesReceived(NotificationsActions.parseNotes(it))
+                } catch (e: JSONException) {
+                    _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiString.UiStringRes(R.string.error_notif_generic))))
+                }
+            }
+        }, {
+            _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiString.UiStringRes(R.string.error_notif_generic))))
+        })
+    }
+
+    fun setAllNotesAsRead(noteList: List<Note>) {
+        for (note in noteList) {
+            if (note.isUnread) {
+                NotificationsActions.markNoteAsRead(note)
+                note.setRead()
+                NotificationsTable.saveNote(note)
+                EventBus.getDefault().post(NotificationEvents.NotificationsChanged())
+            }
+        }
+        _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiString.UiStringRes(R.string.mark_all_notifications_read_success))))
+    }
+}

--- a/WordPress/src/main/res/menu/notifications_list_menu.xml
+++ b/WordPress/src/main/res/menu/notifications_list_menu.xml
@@ -3,6 +3,12 @@
       xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/read_all_notifications"
+        android:icon="@drawable/ic_checkmark_white_24dp"
+        android:title="@string/read_all_notifications"
+        app:showAsAction="always"/>
+
+    <item
         android:id="@+id/notifications_settings"
         android:icon="@drawable/ic_cog_white_24dp"
         android:title="@string/notification_settings"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1418,6 +1418,9 @@
     <string name="notifications_tab_title_comments">Comments</string>
     <string name="notifications_tab_title_follows">Follows</string>
     <string name="notifications_tab_title_likes">Likes</string>
+    <string name="read_all_notifications">Read all notifications</string>
+    <string name="mark_all_notifications_read_success">All notifications marked as read</string>
+
 
     <!-- Notification Settings -->
     <string name="notification_settings">Notification Settings</string>
@@ -1892,6 +1895,7 @@
     <string name="error_browser_no_network">Unable to load this page right now.</string>
     <string name="error_network_connection">Check your network connection and try again.</string>
     <string name="error_update_site_title_network">Couldn\'t update site title. Check your network connection and try again.</string>
+    <string name="error_notif_generic">We couldn\'t complete this action. Please try again.</string>
 
     <!-- Post Error -->
     <string name="error_unknown_post">Could not find the post on the server</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/notifications/NotificationListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/notifications/NotificationListViewModelTest.kt
@@ -1,0 +1,85 @@
+package org.wordpress.android.ui.notifications
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.test
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.Event
+
+@InternalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class NotificationListViewModelTest {
+    @Rule
+    @JvmField
+    val rule = InstantTaskExecutorRule()
+
+    @Mock
+    lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+
+    @Mock
+    lateinit var notificationUseCase: NotificationsUseCase
+
+    private lateinit var notificationListViewModel: NotificationListViewModel
+
+    private val snackbarEvents = MutableLiveData<Event<SnackbarMessageHolder>>()
+    private var holder: SnackbarMessageHolder? = null
+
+    @Before
+    fun setUp() {
+        whenever(notificationUseCase.snackbarEvents).thenReturn(snackbarEvents)
+        notificationListViewModel = NotificationListViewModel(
+            networkUtilsWrapper = networkUtilsWrapper,
+            notificationUseCase = notificationUseCase,
+            bgDispatcher = TEST_DISPATCHER,
+            mainDispatcher = TEST_DISPATCHER
+        )
+        notificationListViewModel.snackbarEvents.observeForever {
+            it.applyIfNotHandled {
+                holder = this
+            }
+        }
+        notificationListViewModel.start()
+    }
+
+    @Test
+    fun `User clicks onClickReadAllNotifications and internet is not available`() = test() {
+        // GIVEN
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        // WHEN
+        notificationListViewModel.onClickReadAllNotifications()
+
+        // THEN
+        requireNotNull(holder).let {
+            Assertions.assertThat(it.message).isEqualTo(UiString.UiStringRes(R.string.no_network_message))
+        }
+    }
+
+    @Test
+    fun `User clicks onClickReadAllNotifications and requestNotifications is called`() = test() {
+        // GIVEN
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(notificationUseCase.uiStateFlow).thenReturn(MutableStateFlow(NotificationsUseCase.UiState.InitialState))
+
+        // WHEN
+        notificationListViewModel.onClickReadAllNotifications()
+
+        // THEN
+        verify(notificationUseCase).requestNotifications()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/notifications/NotificationsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/notifications/NotificationsUseCaseTest.kt
@@ -1,0 +1,61 @@
+package org.wordpress.android.ui.notifications
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import app.cash.turbine.test
+import org.assertj.core.api.Assertions
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
+import org.wordpress.android.test
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.utils.UiString
+
+@RunWith(MockitoJUnitRunner::class)
+class NotificationsUseCaseTest {
+    @Rule
+    @JvmField
+    val rule = InstantTaskExecutorRule()
+
+    private lateinit var notificationsUseCase: NotificationsUseCase
+
+    private var holder: SnackbarMessageHolder? = null
+
+    @Before
+    fun setUp() {
+        notificationsUseCase = NotificationsUseCase()
+        notificationsUseCase.snackbarEvents.observeForever {
+            it.applyIfNotHandled {
+                holder = this
+            }
+        }
+    }
+
+    @Test
+    fun `When NotificationUseCase starts, InitialState is the state of UiState`() = test() {
+        // GIVEN
+        // WHEN
+        notificationsUseCase.uiStateFlow.test {
+            // THEN
+            assertEquals(awaitItem(), NotificationsUseCase.UiState.InitialState)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `When the user setAllNotesAsRead with no notifications, the snackbar is called`() = test() {
+        // GIVEN
+        // WHEN
+        notificationsUseCase.setAllNotesAsRead(listOf())
+
+        // THEN
+        requireNotNull(holder).let {
+            Assertions.assertThat(it.message)
+                .isEqualTo(UiString.UiStringRes(R.string.mark_all_notifications_read_success))
+        }
+
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,7 @@ ext {
     espressoVersion = '3.1.0'
     mockitoCoreVersion = "3.3.3"
     nhaarmanMockitoVersion = "2.2.0"
+    turbine_version = "0.7.0"
 }
 
 // Onboarding and dev env setup tasks


### PR DESCRIPTION
## Fixes #15710

Some automatticians [commented](https://github.com/wordpress-mobile/WordPress-iOS/issues/17135) they wanted to have a button next to the settings icons to read all notifications on iOS. @khaykov Suggested me to do the same on Android, so this PR adds that functionality including unit testing files.

## To test:
- Go to the notification screen
- Click on the ✔️ button
- Verify all notifications are marked as read
- Read the message "All notifications marked as read" from a SnackBar

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
I have added `NotificationListViewModelTest` and `NotificationsUseCaseTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
