### PR TITLE
My Site Dashboard [Phase 2]: Navigate to Posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -16,9 +16,14 @@ sealed class MySiteCardAndItemBuilderParams {
 
     data class PostCardBuilderParams(
         val posts: PostsCardModel?,
-        val onPostItemClick: (postId: Int) -> Unit,
+        val onPostItemClick: (params: PostItemClickParams) -> Unit,
         val onFooterLinkClick: (postCardType: PostCardType) -> Unit
-    ) : MySiteCardAndItemBuilderParams()
+    ) : MySiteCardAndItemBuilderParams() {
+        data class PostItemClickParams(
+            val postCardType: PostCardType,
+            val postId: Int
+        )
+    }
 
     data class QuickActionsCardBuilderParams(
         val siteModel: SiteModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -321,7 +321,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                     PagePostCreationSourcesDetail.POST_FROM_MY_SITE
             )
         // TODO: ashiagr this is unhandled right now as mocked post is being used which cannot be opened in the editor
-        is SiteNavigationAction.EditPost -> Unit
+        is SiteNavigationAction.EditDraftPost -> Unit
+        is SiteNavigationAction.EditScheduledPost -> Unit
     }
 
     private fun openQuickStartFullScreenDialog(action: SiteNavigationAction.OpenQuickStartFullScreenDialog) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -320,9 +320,12 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                     false,
                     PagePostCreationSourcesDetail.POST_FROM_MY_SITE
             )
-        // TODO: ashiagr this is unhandled right now as mocked post is being used which cannot be opened in the editor
-        is SiteNavigationAction.EditDraftPost -> Unit
-        is SiteNavigationAction.EditScheduledPost -> Unit
+        // The below navigation is temporary and as such not utilizing the 'action.postId' in order to navigate to the
+        // 'Edit Post' screen. Instead, it fallbacks to navigating to the 'Posts' screen and targeting a specific tab.
+        is SiteNavigationAction.EditDraftPost ->
+            ActivityLauncher.viewCurrentBlogPostsOfType(requireActivity(), action.site, PostListType.DRAFTS)
+        is SiteNavigationAction.EditScheduledPost ->
+            ActivityLauncher.viewCurrentBlogPostsOfType(requireActivity(), action.site, PostListType.SCHEDULED)
     }
 
     private fun openQuickStartFullScreenDialog(action: SiteNavigationAction.OpenQuickStartFullScreenDialog) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
@@ -719,9 +720,9 @@ class MySiteViewModel @Inject constructor(
         analyticsTrackerWrapper.track(Stat.QUICK_START_REQUEST_DIALOG_NEGATIVE_TAPPED)
     }
 
-    private fun onPostItemClick(postId: Int) {
+    private fun onPostItemClick(params: PostItemClickParams) {
         selectedSiteRepository.getSelectedSite()?.let { site ->
-            _onNavigation.value = Event(SiteNavigationAction.EditPost(site, postId))
+            _onNavigation.value = Event(SiteNavigationAction.EditPost(site, params.postId))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -722,7 +722,13 @@ class MySiteViewModel @Inject constructor(
 
     private fun onPostItemClick(params: PostItemClickParams) {
         selectedSiteRepository.getSelectedSite()?.let { site ->
-            _onNavigation.value = Event(SiteNavigationAction.EditPost(site, params.postId))
+            when (params.postCardType) {
+                PostCardType.DRAFT -> _onNavigation.value =
+                        Event(SiteNavigationAction.EditDraftPost(site, params.postId))
+                PostCardType.SCHEDULED -> _onNavigation.value =
+                        Event(SiteNavigationAction.EditScheduledPost(site, params.postId))
+                else -> Unit // Do nothing
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -59,12 +59,15 @@ sealed class SiteNavigationAction {
         @StringRes val positiveButtonLabel: Int,
         @StringRes val negativeButtonLabel: Int
     ) : SiteNavigationAction()
+
     data class OpenQuickStartFullScreenDialog(
         val type: QuickStartTaskType,
         @StringRes val title: Int
     ) : SiteNavigationAction()
+
     data class OpenDraftsPosts(val site: SiteModel) : SiteNavigationAction()
     data class OpenScheduledPosts(val site: SiteModel) : SiteNavigationAction()
     data class OpenEditorToCreateNewPost(val site: SiteModel) : SiteNavigationAction()
-    data class EditPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
+    data class EditDraftPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
+    data class EditScheduledPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardW
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems.PostItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -83,12 +84,17 @@ class PostCardBuilder @Inject constructor(
 
     private fun PostsCardModel.hasDraftsOrScheduledPosts() = draft.isNotEmpty() || scheduled.isNotEmpty()
 
-    private fun List<PostCardModel>.mapToDraftPostItems(onPostItemClick: (postId: Int) -> Unit) = map { post ->
+    private fun List<PostCardModel>.mapToDraftPostItems(
+        onPostItemClick: (params: PostItemClickParams) -> Unit
+    ) = map { post ->
         PostItem(
                 title = constructPostTitle(post.title),
                 excerpt = constructPostContent(post.content),
                 featuredImageUrl = post.featuredImage,
-                onClick = ListItemInteraction.create(post.id, onPostItemClick)
+                onClick = ListItemInteraction.create(
+                        PostItemClickParams(PostCardType.DRAFT, post.id),
+                        onPostItemClick
+                )
         )
     }
 
@@ -98,13 +104,18 @@ class PostCardBuilder @Inject constructor(
     private fun constructPostContent(content: String) =
             if (content.isEmpty()) UiStringRes(R.string.my_site_no_content_post) else UiStringText(content)
 
-    private fun List<PostCardModel>.mapToScheduledPostItems(onPostItemClick: (postId: Int) -> Unit) = map { post ->
+    private fun List<PostCardModel>.mapToScheduledPostItems(
+        onPostItemClick: (params: PostItemClickParams) -> Unit
+    ) = map { post ->
         PostItem(
                 title = constructPostTitle(post.title),
                 excerpt = UiStringText(constructPostDate(post.date)),
                 featuredImageUrl = post.featuredImage,
                 isTimeIconVisible = true,
-                onClick = ListItemInteraction.create(post.id, onPostItemClick)
+                onClick = ListItemInteraction.create(
+                        PostItemClickParams(PostCardType.SCHEDULED, post.id),
+                        onPostItemClick
+                )
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1029,13 +1029,23 @@ class MySiteViewModelTest : BaseUnitTest() {
     /* POST CARD - POST ITEM */
 
     @Test
-    fun `when post item is clicked, then post is opened for edit`() =
+    fun `given draft post card, when post item is clicked, then post is opened for edit draft`() =
             test {
                 initSelectedSite()
 
                 requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.DRAFT, postId))
 
-                assertThat(navigationActions).containsOnly(SiteNavigationAction.EditPost(site, postId))
+                assertThat(navigationActions).containsOnly(SiteNavigationAction.EditDraftPost(site, postId))
+            }
+
+    @Test
+    fun `given scheduled post card, when post item is clicked, then post is opened for edit scheduled`() =
+            test {
+                initSelectedSite()
+
+                requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.SCHEDULED, postId))
+
+                assertThat(navigationActions).containsOnly(SiteNavigationAction.EditScheduledPost(site, postId))
             }
 
     /* ITEM CLICK */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -52,6 +52,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartDynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
@@ -175,7 +176,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private var quickStartTaskTypeItemClickAction: ((QuickStartTaskType) -> Unit)? = null
     private var dynamicCardMoreClick: ((DynamicCardMenuModel) -> Unit)? = null
     private var onPostCardFooterLinkClick: ((postCardType: PostCardType) -> Unit)? = null
-    private var onPostItemClick: ((postId: Int) -> Unit)? = null
+    private var onPostItemClick: ((params: PostItemClickParams) -> Unit)? = null
     private val quickStartCategory: QuickStartCategory
         get() = QuickStartCategory(
                 taskType = QuickStartTaskType.CUSTOMIZE,
@@ -1032,7 +1033,7 @@ class MySiteViewModelTest : BaseUnitTest() {
             test {
                 initSelectedSite()
 
-                requireNotNull(onPostItemClick).invoke(postId)
+                requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.DRAFT, postId))
 
                 assertThat(navigationActions).containsOnly(SiteNavigationAction.EditPost(site, postId))
             }
@@ -1588,7 +1589,9 @@ class MySiteViewModelTest : BaseUnitTest() {
                                 excerpt = UiStringRes(0),
                                 featuredImageUrl = "",
                                 onClick = ListItemInteraction.create {
-                                    (onPostItemClick as (Int) -> Unit).invoke(postId)
+                                    (onPostItemClick as (PostItemClickParams) -> Unit).invoke(
+                                            PostItemClickParams(PostCardType.DRAFT, postId)
+                                    )
                                 }
                         )
                 ),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
@@ -26,7 +26,7 @@ private const val POST_ID = 1
 private const val POST_TITLE = "title"
 private const val POST_CONTENT = "content"
 private const val FEATURED_IMAGE_URL = "featuredImage"
-private val POST_DATE = SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2021-12-06 12:34:56")
+private val POST_DATE = SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse("2021-12-06 12:34:56")!!
 
 // This class contains placeholder tests until mock data is removed
 @InternalCoroutinesApi

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.FooterLin
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
@@ -42,8 +43,8 @@ class PostCardBuilderTest : BaseUnitTest() {
             date = POST_DATE
     )
 
-    private val onPostCardFooterLinkClick: (PostCardType) -> Unit = {}
-    private val onPostItemClick: (Int) -> Unit = {}
+    private val onPostCardFooterLinkClick: (PostCardType) -> Unit = { }
+    private val onPostItemClick: (params: PostItemClickParams) -> Unit = { }
 
     @Before
     fun setUp() {


### PR DESCRIPTION
Parent: #15709

This PR implements this functionality that will allow the user to navigate to the `Posts` screen.

PS: The PR is overtakes the previous #15720 hacky PR and as such the whole #15709 issue overall. The decision to not proceed with this solution was made within [this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/15723#issuecomment-996762177).

-----

Prerequisite:

- Go to `My Site` -> `Me` -> `App Settings` -> `Debug Settings` configuration.
- Turn-on the `MySiteDashboardPhase2FeatureConfig` feature.
- Relaunch the app.

-----

To test:
- If you don't have a draft or scheduled post already, create one.
- Note that on the `My Site` tab, your draft or scheduled posts, if any, are shown.
- Click on a draft or scheduled posts and verify that the `Posts` screen is shown, navigating you on the draft or scheduled tab correspondingly.

-----

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` sections above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
