### PR TITLE
My Site Dashboard: Phase 2: Metrics - Track "post" site item menu Taps

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -49,6 +49,7 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment.Dyna
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsBuilder
+import org.wordpress.android.ui.mysite.items.SiteItemsTracker
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource
@@ -108,7 +109,8 @@ class MySiteViewModel @Inject constructor(
     private val dynamicCardsBuilder: DynamicCardsBuilder,
     private val mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig,
     private val mySiteSourceManager: MySiteSourceManager,
-    private val cardsTracker: CardsTracker
+    private val cardsTracker: CardsTracker,
+    private val siteItemsTracker: SiteItemsTracker
 ) : ScopedViewModel(mainDispatcher) {
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val _onTechInputDialogShown = MutableLiveData<Event<TextInputDialogModel>>()
@@ -321,6 +323,7 @@ class MySiteViewModel @Inject constructor(
     @Suppress("ComplexMethod")
     private fun onItemClick(action: ListItemAction) {
         selectedSiteRepository.getSelectedSite()?.let { selectedSite ->
+            siteItemsTracker.trackSiteItemClicked(action)
             val navigationAction = when (action) {
                 ListItemAction.ACTIVITY_LOG -> SiteNavigationAction.OpenActivityLog(selectedSite)
                 ListItemAction.BACKUP -> SiteNavigationAction.OpenBackup(selectedSite)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsTracker.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.ui.mysite.items
+
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import javax.inject.Inject
+
+class SiteItemsTracker @Inject constructor(
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+) {
+    enum class Type(val label: String) {
+        POSTS("posts")
+    }
+
+    fun trackSiteItemClicked(listItemAction: ListItemAction) = trackSiteItemClicked(listItemAction.toTypeValue())
+
+    private fun trackSiteItemClicked(type: Type?) {
+        type?.let {
+            analyticsTrackerWrapper.track(Stat.MY_SITE_MENU_ITEM_TAPPED, mapOf(TYPE to it.label))
+        }
+    }
+
+    private fun ListItemAction.toTypeValue(): Type? {
+        return when (this) {
+            ListItemAction.POSTS -> Type.POSTS
+            else -> null
+        }
+    }
+
+    companion object {
+        private const val TYPE = "type"
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -81,6 +81,7 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment.Dyna
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsBuilder
+import org.wordpress.android.ui.mysite.items.SiteItemsTracker
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction
@@ -132,6 +133,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig
     @Mock lateinit var mySiteSourceManager: MySiteSourceManager
     @Mock lateinit var cardsTracker: CardsTracker
+    @Mock lateinit var siteItemsTracker: SiteItemsTracker
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<UiModel>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -274,7 +276,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 dynamicCardsBuilder,
                 mySiteDashboardPhase2FeatureConfig,
                 mySiteSourceManager,
-                cardsTracker
+                cardsTracker,
+                siteItemsTracker
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()
@@ -1191,6 +1194,13 @@ class MySiteViewModelTest : BaseUnitTest() {
         invokeItemClickAction(ListItemAction.STATS)
 
         assertThat(navigationActions).containsExactly(SiteNavigationAction.ConnectJetpackForStats(site))
+    }
+
+    @Test
+    fun `when site item is clicked, then event is tracked`() = test {
+        invokeItemClickAction(ListItemAction.POSTS)
+
+        verify(siteItemsTracker).trackSiteItemClicked(ListItemAction.POSTS)
     }
 
     /* ITEM VISIBILITY */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsTrackerTest.kt
@@ -1,0 +1,45 @@
+package org.wordpress.android.ui.mysite.items
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.ui.mysite.items.SiteItemsTracker.Type
+import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+
+private const val TYPE = "type"
+
+@RunWith(MockitoJUnitRunner::class)
+class SiteItemsTrackerTest {
+    @Mock lateinit var analyticsTracker: AnalyticsTrackerWrapper
+    private lateinit var siteItemsTracker: SiteItemsTracker
+
+    @Before
+    fun setUp() {
+        siteItemsTracker = SiteItemsTracker(analyticsTracker)
+    }
+
+    @Test
+    fun `when site item posts is clicked, then menu item tapped posts is tracked`() {
+        siteItemsTracker.trackSiteItemClicked(ListItemAction.POSTS)
+
+        verifySiteItemClickedTracked(Type.POSTS)
+    }
+
+    @Test
+    fun `given not tracking site item, when site item is clicked, then click is not tracked`() {
+        siteItemsTracker.trackSiteItemClicked(ListItemAction.VIEW_SITE)
+
+        verify(analyticsTracker, times(0)).track(any())
+    }
+
+    private fun verifySiteItemClickedTracked(typeValue: Type) {
+        verify(analyticsTracker).track(Stat.MY_SITE_MENU_ITEM_TAPPED, mapOf(TYPE to typeValue.label))
+    }
+}

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -819,7 +819,8 @@ public final class AnalyticsTracker {
         ABOUT_SCREEN_DISMISSED,
         ABOUT_SCREEN_BUTTON_TAPPED,
         MY_SITE_DASHBOARD_CARD_FOOTER_ACTION_TAPPED,
-        MY_SITE_PULL_TO_REFRESH
+        MY_SITE_PULL_TO_REFRESH,
+        MY_SITE_MENU_ITEM_TAPPED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2140,6 +2140,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "my_site_dashboard_card_footer_action_tapped";
             case MY_SITE_PULL_TO_REFRESH:
                 return "my_site_pull_to_refresh";
+            case MY_SITE_MENU_ITEM_TAPPED:
+                return "my_site_menu_item_tapped";
         }
         return null;
     }


### PR DESCRIPTION
Fixes #15731 

This PR tracks taps on the "Posts" Site Menu Item.

Taps are tracked as **MY_SITE_MENU_ITEM_TAPPED** with the following property:
  **type = “POSTS”**

`SiteItemsTracker` was introduced as a helper class to consolidate the tracking logic. As of this writing, the only menu item that is tracked will be `posts`. This class will be expanded in the near future as we add more cards and we want to compare the difference between a menu item tap vs. a card tap (and even a quick action tap). This is very similar to the newly implemented `CardsTracker` (see #15734).

**To test:**
Setup
- Launch the app
- Navigate to Me -> App Settings -> Debug Settings
- Ensure that the `MySiteDashboardPhase2FeatureConfig` is to set to on
- Restart the app if needed
- Navigate to Me -> App Settings -> Privacy Settings 
- Toggle the "collect information" switch to on
- Navigate to the My Site tab
------------------------

#### Test 1
- Tap on the "posts" site menu item 
- Navigate to Me -> Help and Support -> Application log
- Note that the following is shown in the log
I: 🔵 Tracked: my_site_menu_item_tapped, Properties: {"type":"posts"}
-----------------------

#### Test 2
- Navigate back to My Site tab
- Tap on any other site menu item besides "posts"
- Navigate to Me -> Help and Support -> Application log
- Note that the my_site_menu_item_tapped has not been tracked
-----------------------

## Regression Notes
1. Potential unintended areas of impact N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing
3. What automated tests I added (or what prevented me from doing so)
`SiteItemsTrackerTest`

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
