### PR TITLE
Send proper language tag to Gutenberg

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,8 @@
 19.0
 -----
 
+* [**] Fix handling of Hebrew and Indonesian translations within the editor. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4397]
+
 
 18.9
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.wordPressUtilsVersion = '2.2.0'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.68.0'
+    ext.gutenbergMobileVersion = '4397-ead1c7e7472c3c70a2dd8d4a5549653ea20d6e38'
     ext.storiesVersion = '1.2.0'
     ext.aboutAutomatticVersion = '0.0.2'
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4368

See the [related Gutenberg PR](https://github.com/WordPress/gutenberg/pull/37565) for more information

To test:

## Regression Notes
1. All translations within the Gutenberg editor may be impacted by this change.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the English, French, Hebrew, and Indonesian languages within the editor.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests within Gutenberg to ensure the proper conversions are applied to the localeSlug sent to Gutenberg.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
