### PR TITLE
Added Several `Contact Support` tests.

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -35,20 +35,10 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="IMPORT_NESTED_CLASSES" value="true" />
-      <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
-      <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
@@ -238,17 +228,10 @@
       </arrangement>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-      <option name="CALL_PARAMETERS_WRAP" value="5" />
-      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_WRAP" value="5" />
-      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="EXTENDS_LIST_WRAP" value="5" />
-      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
       <option name="METHOD_ANNOTATION_WRAP" value="1" />
       <option name="FIELD_ANNOTATION_WRAP" value="1" />
       <option name="ENUM_CONSTANTS_WRAP" value="5" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -35,10 +35,20 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="IMPORT_NESTED_CLASSES" value="true" />
-      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
+      <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
     </JetCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
@@ -228,10 +238,17 @@
       </arrangement>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
-      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_WRAP" value="5" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="EXTENDS_LIST_WRAP" value="5" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
       <option name="METHOD_ANNOTATION_WRAP" value="1" />
       <option name="FIELD_ANNOTATION_WRAP" value="1" />
       <option name="ENUM_CONSTANTS_WRAP" value="5" />

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.e2e;
 
-import androidx.test.espresso.Espresso;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,6 +12,8 @@ import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
 import static org.wordpress.android.support.WPSupportUtils.pressBackUntilElementIsDisplayed;
 
 public class ContactUsTests extends BaseTest {
+    static String senderEmailAddress = "WPcomTest@test.com";
+
     @Before
     public void setUp() {
         logoutIfNecessary();
@@ -31,7 +31,7 @@ public class ContactUsTests extends BaseTest {
                 .chooseContinueWithWpCom()
                 .tapHelp()
                 .assertHelpAndSupportScreenLoaded()
-                .setEmailIfNeeded("WPcomTest@test.com")
+                .setEmailIfNeeded(senderEmailAddress)
                 .openContactUs()
                 .assertContactSupportScreenLoaded()
                 .assertSendButtonDisabled()
@@ -40,14 +40,12 @@ public class ContactUsTests extends BaseTest {
                 .setMessageText("")
                 .assertSendButtonDisabled();
         } finally {
-            Espresso.pressBack();
-            new ContactSupportScreen().deleteUnsentMessageIfNeeded();
+            new ContactSupportScreen().goBackAndDeleteUnsentMessageIfNeeded();
         }
     }
 
     @Test
     public void messageCanBeSent() {
-        String senderEmailAddress = "WPcomTest@test.com";
         String userMessageText = "Please ignore, this is an automated test.";
         String automatedReplyText = "Mobile support will respond as soon as possible, "
                                     + "generally within 48-96 hours. "
@@ -65,8 +63,7 @@ public class ContactUsTests extends BaseTest {
                 .assertUserMessageDelivered(userMessageText)
                 .assertSystemMessageReceived(automatedReplyText);
         } finally {
-            Espresso.pressBack();
-            new ContactSupportScreen().deleteUnsentMessageIfNeeded();
+            new ContactSupportScreen().goBackAndDeleteUnsentMessageIfNeeded();
         }
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -26,18 +26,23 @@ public class ContactUsTests extends BaseTest {
 
     @Test
     public void sendButtonEnabledWhenTextIsEntered() {
-        new LoginFlow()
-            .chooseContinueWithWpCom()
-            .tapHelp()
-            .assertHelpAndSupportScreenLoaded()
-            .setEmailIfNeeded("WPcomTest@test.com")
-            .openContactUs()
-            .assertContactSupportScreenLoaded()
-            .assertSendButtonDisabled()
-            .setMessageText("Hello")
-            .assertSendButtonEnabled()
-            .setMessageText("")
-            .assertSendButtonDisabled();
+        try {
+            new LoginFlow()
+                .chooseContinueWithWpCom()
+                .tapHelp()
+                .assertHelpAndSupportScreenLoaded()
+                .setEmailIfNeeded("WPcomTest@test.com")
+                .openContactUs()
+                .assertContactSupportScreenLoaded()
+                .assertSendButtonDisabled()
+                .setMessageText("Hello")
+                .assertSendButtonEnabled()
+                .setMessageText("")
+                .assertSendButtonDisabled();
+        } finally {
+            Espresso.pressBack();
+            new ContactSupportScreen().deleteUnsentMessageIfNeeded();
+        }
     }
 
     @Test

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -2,6 +2,7 @@ package org.wordpress.android.e2e;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.wordpress.android.R;
 import org.wordpress.android.e2e.flows.LoginFlow;
@@ -41,6 +42,7 @@ public class ContactUsTests extends BaseTest {
         }
     }
 
+    @Ignore("As long as CI does not use gradle.properties from MobileSecrets")
     @Test
     public void messageCanBeSent() {
         String userMessageText = "Please ignore, this is an automated test.";

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -1,0 +1,84 @@
+package org.wordpress.android.e2e;
+
+import androidx.test.espresso.Espresso;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.wordpress.android.R;
+import org.wordpress.android.e2e.flows.LoginFlow;
+import org.wordpress.android.e2e.pages.ContactSupportScreen;
+import org.wordpress.android.support.BaseTest;
+
+import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
+import static org.wordpress.android.support.WPSupportUtils.pressBackUntilElementIsDisplayed;
+
+public class ContactUsTests extends BaseTest {
+    @Before
+    public void setUp() {
+        logoutIfNecessary();
+    }
+
+    @After
+    public void tearDown() {
+        pressBackUntilElementIsDisplayed(R.id.continue_with_wpcom_button);
+    }
+
+    @Test
+    public void sendButtonEnabledWhenTextIsEntered() {
+        new LoginFlow()
+            .chooseContinueWithWpCom()
+            .tapHelp()
+            .assertHelpAndSupportScreenLoaded()
+            .setEmailIfNeeded("WPcomTest@test.com")
+            .openContactUs()
+            .assertContactSupportScreenLoaded()
+            .assertSendButtonDisabled()
+            .setMessageText("Hello")
+            .assertSendButtonEnabled()
+            .setMessageText("")
+            .assertSendButtonDisabled();
+    }
+
+    @Test
+    public void messageCanBeSent() {
+        String senderEmailAddress = "WPcomTest@test.com";
+        String userMessageText = "Please ignore, this is an automated test.";
+        String automatedReplyText = "Mobile support will respond as soon as possible, "
+                                    + "generally within 48-96 hours. "
+                                    + "Please reply with your site address (URL) "
+                                    + "and any additional details we should know.";
+
+        try {
+            new LoginFlow()
+                .chooseContinueWithWpCom()
+                .tapHelp()
+                .setEmailIfNeeded(senderEmailAddress)
+                .openContactUs()
+                .setMessageText(userMessageText)
+                .tapSendButton()
+                .assertUserMessageDelivered(userMessageText)
+                .assertSystemMessageReceived(automatedReplyText);
+        } finally {
+            Espresso.pressBack();
+            new ContactSupportScreen().deleteUnsentMessageIfNeeded();
+        }
+    }
+
+    @Test
+    public void helpCanBeOpenedWhileEnteringEmail() {
+        new LoginFlow()
+                .chooseContinueWithWpCom()
+                .tapHelp()
+                .assertHelpAndSupportScreenLoaded();
+    }
+
+    @Test
+    public void helpCanBeOpenedWhileEnteringPassword() {
+        new LoginFlow()
+                .chooseContinueWithWpCom()
+                .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
+                .tapHelp()
+                .assertHelpAndSupportScreenLoaded();
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -2,7 +2,6 @@ package org.wordpress.android.e2e;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wordpress.android.R;
 import org.wordpress.android.e2e.flows.LoginFlow;
@@ -42,7 +41,6 @@ public class ContactUsTests extends BaseTest {
         }
     }
 
-    @Ignore("As long as CI does not use gradle.properties from MobileSecrets")
     @Test
     public void messageCanBeSent() {
         String userMessageText = "Please ignore, this is an automated test.";

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -12,8 +12,6 @@ import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
 import static org.wordpress.android.support.WPSupportUtils.pressBackUntilElementIsDisplayed;
 
 public class ContactUsTests extends BaseTest {
-    static String senderEmailAddress = "WPcomTest@test.com";
-
     @Before
     public void setUp() {
         logoutIfNecessary();
@@ -31,7 +29,6 @@ public class ContactUsTests extends BaseTest {
                 .chooseContinueWithWpCom()
                 .tapHelp()
                 .assertHelpAndSupportScreenLoaded()
-                .setEmailIfNeeded(senderEmailAddress)
                 .openContactUs()
                 .assertContactSupportScreenLoaded()
                 .assertSendButtonDisabled()
@@ -56,7 +53,6 @@ public class ContactUsTests extends BaseTest {
             new LoginFlow()
                 .chooseContinueWithWpCom()
                 .tapHelp()
-                .setEmailIfNeeded(senderEmailAddress)
                 .openContactUs()
                 .setMessageText(userMessageText)
                 .tapSendButton()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -10,6 +10,7 @@ import androidx.test.rule.ActivityTestRule;
 import org.hamcrest.Matchers;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
+import org.wordpress.android.e2e.pages.HelpAndSupportScreen;
 import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
@@ -127,5 +128,10 @@ public class LoginFlow {
         populateTextField(R.id.input, siteAddress);
         clickOn(R.id.bottom_button);
         return this;
+    }
+
+    public HelpAndSupportScreen tapHelp() {
+        clickOn(onView(withId(R.id.help)));
+        return new HelpAndSupportScreen();
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
@@ -53,6 +53,7 @@ public class ContactSupportScreen {
 
     // Assertions:
     public ContactSupportScreen assertContactSupportScreenLoaded() {
+        waitForElementToBeDisplayedWithoutFailure(textInput);
         textInput.check(matches(isCompletelyDisplayed()));
         sendButton.check(matches(isCompletelyDisplayed()));
         attachButton.check(matches(isCompletelyDisplayed()));

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
@@ -14,33 +14,15 @@ import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.not;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
-import static org.wordpress.android.support.WPSupportUtils.sleep;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 
 public class ContactSupportScreen {
-    // "Contact Support" screen looks differently depending on
-    // "gradle.properties" content (default or from Mobile Secrets).
-    // But the elements tree always contains all elements, some are
-    // just hidden.
-    // Locators below attempt to support both.
-    static ViewInteraction textInput = onView(allOf(
-            isCompletelyDisplayed(),
-            anyOf(
-                    withId(R.id.message_composer_input_text),
-                    withId(R.id.request_message_field)
-            )
-    ));
-    static ViewInteraction sendButton = onView(allOf(
-            isCompletelyDisplayed(),
-            anyOf(
-                    withId(R.id.message_composer_send_btn),
-                    withId(R.id.request_conversations_disabled_menu_ic_send)
-            )
-    ));
+    static ViewInteraction textInput = onView(withId(R.id.message_composer_input_text));
+    static ViewInteraction sendButton = onView(withId(R.id.message_composer_send_btn));
+    static ViewInteraction attachButton = onView(withId(R.id.attachments_indicator_icon));
 
     // Actions:
     public ContactSupportScreen tapSendButton() {
@@ -50,10 +32,6 @@ public class ContactSupportScreen {
 
     public ContactSupportScreen setMessageText(String text) {
         populateTextField(textInput, text);
-        // This sleep serves only one purpose: allowing human to notice
-        // that text was really entered. Especially matters when watching
-        // low-fps test video recordings from CI.
-        sleep();
         return this;
     }
 
@@ -75,8 +53,10 @@ public class ContactSupportScreen {
 
     // Assertions:
     public ContactSupportScreen assertContactSupportScreenLoaded() {
+        waitForElementToBeDisplayedWithoutFailure(textInput);
         textInput.check(matches(isCompletelyDisplayed()));
         sendButton.check(matches(isCompletelyDisplayed()));
+        attachButton.check(matches(isCompletelyDisplayed()));
         return this;
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
@@ -14,15 +14,33 @@ import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.not;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
+import static org.wordpress.android.support.WPSupportUtils.sleep;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 
 public class ContactSupportScreen {
-    static ViewInteraction textInput = onView(withId(R.id.message_composer_input_text));
-    static ViewInteraction sendButton = onView(withId(R.id.message_composer_send_btn));
-    static ViewInteraction attachButton = onView(withId(R.id.attachments_indicator_icon));
+    // "Contact Support" screen looks differently depending on
+    // "gradle.properties" content (default or from Mobile Secrets).
+    // But the elements tree always contains all elements, some are
+    // just hidden.
+    // Locators below attempt to support both.
+    static ViewInteraction textInput = onView(allOf(
+            isCompletelyDisplayed(),
+            anyOf(
+                    withId(R.id.message_composer_input_text),
+                    withId(R.id.request_message_field)
+            )
+    ));
+    static ViewInteraction sendButton = onView(allOf(
+            isCompletelyDisplayed(),
+            anyOf(
+                    withId(R.id.message_composer_send_btn),
+                    withId(R.id.request_conversations_disabled_menu_ic_send)
+            )
+    ));
 
     // Actions:
     public ContactSupportScreen tapSendButton() {
@@ -32,6 +50,10 @@ public class ContactSupportScreen {
 
     public ContactSupportScreen setMessageText(String text) {
         populateTextField(textInput, text);
+        // This sleep serves only one purpose: allowing human to notice
+        // that text was really entered. Especially matters when watching
+        // low-fps test video recordings from CI.
+        sleep();
         return this;
     }
 
@@ -53,10 +75,8 @@ public class ContactSupportScreen {
 
     // Assertions:
     public ContactSupportScreen assertContactSupportScreenLoaded() {
-        waitForElementToBeDisplayedWithoutFailure(textInput);
         textInput.check(matches(isCompletelyDisplayed()));
         sendButton.check(matches(isCompletelyDisplayed()));
-        attachButton.check(matches(isCompletelyDisplayed()));
         return this;
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.e2e.pages;
 
+import androidx.test.espresso.Espresso;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 
@@ -34,7 +35,9 @@ public class ContactSupportScreen {
         return this;
     }
 
-    public HelpAndSupportScreen deleteUnsentMessageIfNeeded() {
+    public HelpAndSupportScreen goBackAndDeleteUnsentMessageIfNeeded() {
+        Espresso.pressBack();
+
         ViewInteraction unsentMessageAlert = onView(
                 withText("Going back will delete your message. "
                          + "Are you sure you want to delete it?"

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
@@ -25,8 +25,7 @@ public class ContactSupportScreen {
     // "Contact Support" screen looks differently depending on
     // "gradle.properties" content (default or from Mobile Secrets).
     // But the elements tree always contains all elements, some are
-    // just hidden.
-    // Locators below attempt to support both.
+    // just hidden. Locators below attempt to support both variants.
     static ViewInteraction textInput = onView(allOf(
             isCompletelyDisplayed(),
             anyOf(

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
@@ -1,0 +1,96 @@
+package org.wordpress.android.e2e.pages;
+
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.espresso.action.ViewActions;
+
+import org.wordpress.android.R;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.not;
+import static org.wordpress.android.support.WPSupportUtils.populateTextField;
+import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
+import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
+
+public class ContactSupportScreen {
+    static ViewInteraction textInput = onView(withId(R.id.message_composer_input_text));
+    static ViewInteraction sendButton = onView(withId(R.id.message_composer_send_btn));
+    static ViewInteraction attachButton = onView(withId(R.id.attachments_indicator_icon));
+
+    // Actions:
+    public ContactSupportScreen tapSendButton() {
+        sendButton.perform(ViewActions.click());
+        return this;
+    }
+
+    public ContactSupportScreen setMessageText(String text) {
+        populateTextField(textInput, text);
+        return this;
+    }
+
+    public HelpAndSupportScreen deleteUnsentMessageIfNeeded() {
+        ViewInteraction unsentMessageAlert = onView(
+                withText("Going back will delete your message. "
+                         + "Are you sure you want to delete it?"
+                ));
+
+        if (waitForElementToBeDisplayedWithoutFailure(unsentMessageAlert)) {
+            onView(withText("Delete"))
+                    .perform(ViewActions.click());
+        }
+
+        return new HelpAndSupportScreen();
+    }
+
+    // Assertions:
+    public ContactSupportScreen assertContactSupportScreenLoaded() {
+        textInput.check(matches(isCompletelyDisplayed()));
+        sendButton.check(matches(isCompletelyDisplayed()));
+        attachButton.check(matches(isCompletelyDisplayed()));
+        return this;
+    }
+
+    public ContactSupportScreen assertSendButtonDisabled() {
+        sendButton.check(matches(not(isEnabled())));
+        return this;
+    }
+
+    public ContactSupportScreen assertSendButtonEnabled() {
+        sendButton.check(matches(isEnabled()));
+        return this;
+    }
+
+    public ContactSupportScreen assertUserMessageDelivered(String messageText) {
+        ViewInteraction userMessageContainer = onView(allOf(
+                withId(R.id.request_user_message_container),
+                hasDescendant(allOf(
+                        withId(R.id.request_user_message_text),
+                        withText(messageText)
+                )),
+                hasDescendant(allOf(
+                        withId(R.id.request_user_message_status),
+                        withText("Delivered")
+                ))
+        ));
+
+        waitForElementToBeDisplayed(userMessageContainer);
+        userMessageContainer.check(matches(isCompletelyDisplayed()));
+        return this;
+    }
+
+    public ContactSupportScreen assertSystemMessageReceived(String messageText) {
+        ViewInteraction systemResponseBubble = onView(allOf(
+                withId(R.id.request_system_message_text),
+                withText(messageText)));
+
+        waitForElementToBeDisplayed(systemResponseBubble);
+        systemResponseBubble.check(matches(isCompletelyDisplayed()));
+        return this;
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
@@ -1,0 +1,63 @@
+package org.wordpress.android.e2e.pages;
+
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.espresso.action.ViewActions;
+
+import org.wordpress.android.R;
+import org.wordpress.android.e2e.flows.LoginFlow;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.*;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+import static org.wordpress.android.support.WPSupportUtils.*;
+
+import static org.hamcrest.Matchers.allOf;
+
+
+public class HelpAndSupportScreen {
+    static ViewInteraction contactUsButton = onView(withId(R.id.contact_us_button));
+    static ViewInteraction FAQButton = onView(withId(R.id.faq_button));
+    static ViewInteraction myTicketsbutton = onView(withId(R.id.my_tickets_button));
+    static ViewInteraction applicationLogButton = onView(withId(R.id.application_log_button));
+    static ViewInteraction applicationVersionText = onView(withId(R.id.applicationVersion));
+    static ViewInteraction emailAddressText = onView(withId(R.id.contactEmailAddress));
+
+
+    public HelpAndSupportScreen assertHelpAndSupportScreenLoaded() {
+        contactUsButton.check(matches(isCompletelyDisplayed()));
+        FAQButton.check(matches(isCompletelyDisplayed()));
+        myTicketsbutton.check(matches(isCompletelyDisplayed()));
+        applicationLogButton.check(matches(isCompletelyDisplayed()));
+        applicationVersionText.check(matches(isCompletelyDisplayed()));
+        emailAddressText.check(matches(isCompletelyDisplayed()));
+        return this;
+    }
+
+    public HelpAndSupportScreen setEmailIfNeeded(String emailAddress) {
+        ViewInteraction emailNotSet = onView(allOf(withId(R.id.contactEmailAddress), withText("Not set")));
+
+        if (isElementCompletelyDisplayed(emailNotSet)) {
+            emailNotSet.perform(ViewActions.click());
+            populateTextField(R.id.support_identity_input_dialog_email_edit_text, emailAddress);
+
+            onView(withText("OK")).perform(ViewActions.click());
+        }
+
+        return this;
+    }
+
+    public ContactSupportScreen openContactUs() {
+        clickOn(contactUsButton);
+        return new ContactSupportScreen();
+    }
+
+    public LoginFlow navigateBack() {
+        Espresso.pressBack();
+        return new LoginFlow();
+    }
+}
+
+

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
@@ -41,14 +41,15 @@ public class HelpAndSupportScreen {
         if (!isElementDisplayed(emailNotSet)) return this;
 
         emailNotSet.perform(ViewActions.click());
-        ViewInteraction emailInput = onView(allOf(
-                withId(R.id.support_identity_input_dialog_email_edit_text)
-        ));
+        ViewInteraction emailInput = onView(withId(R.id.support_identity_input_dialog_email_edit_text));
 
         if (!waitForElementToBeDisplayedWithoutFailure(emailInput)) return this;
 
         populateTextField(emailInput, emailAddress);
-        onView(withText("OK")).perform(ViewActions.click());
+        ViewInteraction okButton = onView(withText("OK"));
+        waitForElementToBeDisplayedWithoutFailure(okButton);
+        okButton.perform(ViewActions.click());
+
         return this;
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
@@ -10,9 +10,10 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
-import static org.wordpress.android.support.WPSupportUtils.isElementCompletelyDisplayed;
+import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.hamcrest.Matchers.allOf;
+import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 
 
 public class HelpAndSupportScreen {
@@ -37,13 +38,17 @@ public class HelpAndSupportScreen {
     public HelpAndSupportScreen setEmailIfNeeded(String emailAddress) {
         ViewInteraction emailNotSet = onView(allOf(withId(R.id.contactEmailAddress), withText("Not set")));
 
-        if (isElementCompletelyDisplayed(emailNotSet)) {
-            emailNotSet.perform(ViewActions.click());
-            populateTextField(R.id.support_identity_input_dialog_email_edit_text, emailAddress);
+        if (!isElementDisplayed(emailNotSet)) return this;
 
-            onView(withText("OK")).perform(ViewActions.click());
-        }
+        emailNotSet.perform(ViewActions.click());
+        ViewInteraction emailInput = onView(allOf(
+                withId(R.id.support_identity_input_dialog_email_edit_text)
+        ));
 
+        if (!waitForElementToBeDisplayedWithoutFailure(emailInput)) return this;
+
+        populateTextField(emailInput, emailAddress);
+        onView(withText("OK")).perform(ViewActions.click());
         return this;
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
@@ -46,8 +46,7 @@ public class HelpAndSupportScreen {
         if (!waitForElementToBeDisplayedWithoutFailure(emailInput)) return this;
 
         populateTextField(emailInput, emailAddress);
-        ViewInteraction okButton = onView(withText("OK"));
-        waitForElementToBeDisplayedWithoutFailure(okButton);
+        ViewInteraction okButton = onView(withId(android.R.id.button1));
         okButton.perform(ViewActions.click());
 
         return this;

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
@@ -17,8 +17,8 @@ import static org.hamcrest.Matchers.allOf;
 
 public class HelpAndSupportScreen {
     static ViewInteraction contactUsButton = onView(withId(R.id.contact_us_button));
-    static ViewInteraction FAQButton = onView(withId(R.id.faq_button));
-    static ViewInteraction myTicketsbutton = onView(withId(R.id.my_tickets_button));
+    static ViewInteraction faqButton = onView(withId(R.id.faq_button));
+    static ViewInteraction myTicketsButton = onView(withId(R.id.my_tickets_button));
     static ViewInteraction applicationLogButton = onView(withId(R.id.application_log_button));
     static ViewInteraction applicationVersionText = onView(withId(R.id.applicationVersion));
     static ViewInteraction emailAddressText = onView(withId(R.id.contactEmailAddress));
@@ -26,8 +26,8 @@ public class HelpAndSupportScreen {
 
     public HelpAndSupportScreen assertHelpAndSupportScreenLoaded() {
         contactUsButton.check(matches(isCompletelyDisplayed()));
-        FAQButton.check(matches(isCompletelyDisplayed()));
-        myTicketsbutton.check(matches(isCompletelyDisplayed()));
+        faqButton.check(matches(isCompletelyDisplayed()));
+        myTicketsButton.check(matches(isCompletelyDisplayed()));
         applicationLogButton.check(matches(isCompletelyDisplayed()));
         applicationVersionText.check(matches(isCompletelyDisplayed()));
         emailAddressText.check(matches(isCompletelyDisplayed()));

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
@@ -10,9 +10,8 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
-import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
-import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 
 
@@ -35,25 +34,27 @@ public class HelpAndSupportScreen {
         return this;
     }
 
-    public HelpAndSupportScreen setEmailIfNeeded(String emailAddress) {
-        ViewInteraction emailNotSet = onView(allOf(withId(R.id.contactEmailAddress), withText("Not set")));
-
-        if (!isElementDisplayed(emailNotSet)) return this;
-
-        emailNotSet.perform(ViewActions.click());
-        ViewInteraction emailInput = onView(withId(R.id.support_identity_input_dialog_email_edit_text));
-
-        if (!waitForElementToBeDisplayedWithoutFailure(emailInput)) return this;
-
-        populateTextField(emailInput, emailAddress);
-        ViewInteraction okButton = onView(withId(android.R.id.button1));
-        okButton.perform(ViewActions.click());
-
-        return this;
-    }
-
     public ContactSupportScreen openContactUs() {
         contactUsButton.perform(ViewActions.click());
+        setEmailIfNeeded("WPcomTest@test.com", "TestUser");
         return new ContactSupportScreen();
+    }
+
+    public void setEmailIfNeeded(String emailAddress, String userName) {
+        ViewInteraction emailInput = onView(withId(R.id.support_identity_input_dialog_email_edit_text));
+
+        if (!waitForElementToBeDisplayedWithoutFailure(emailInput)) {
+            return;
+        }
+
+        populateTextField(emailInput, emailAddress);
+        ViewInteraction nameInput = onView(withId(R.id.support_identity_input_dialog_name_edit_text));
+        populateTextField(nameInput, userName);
+
+        onView(anyOf(
+                withText(android.R.string.ok),
+                withId(android.R.id.button1)
+        ))
+                .perform(ViewActions.click());
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/HelpAndSupportScreen.java
@@ -1,19 +1,17 @@
 package org.wordpress.android.e2e.pages;
 
-import androidx.test.espresso.Espresso;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 
 import org.wordpress.android.R;
-import org.wordpress.android.e2e.flows.LoginFlow;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.*;
+import static androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
-
-import static org.wordpress.android.support.WPSupportUtils.*;
-
+import static org.wordpress.android.support.WPSupportUtils.isElementCompletelyDisplayed;
+import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.hamcrest.Matchers.allOf;
 
 
@@ -50,14 +48,7 @@ public class HelpAndSupportScreen {
     }
 
     public ContactSupportScreen openContactUs() {
-        clickOn(contactUsButton);
+        contactUsButton.perform(ViewActions.click());
         return new ContactSupportScreen();
     }
-
-    public LoginFlow navigateBack() {
-        Espresso.pressBack();
-        return new LoginFlow();
-    }
 }
-
-

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -475,6 +475,20 @@ public class WPSupportUtils {
         return isElementDisplayed(elementID);
     }
 
+    public static boolean waitForElementToBeDisplayedWithoutFailure(final ViewInteraction element) {
+        try {
+            waitForConditionToBeTrueWithoutFailure(new Supplier<Boolean>() {
+                @Override
+                public Boolean get() {
+                    return isElementDisplayed(element);
+                }
+            });
+        } catch (Exception e) {
+            // ignore the failure
+        }
+        return isElementDisplayed(element);
+    }
+
     public static void waitForConditionToBeTrue(Supplier<Boolean> supplier) {
         if (supplier.get()) {
             return;


### PR DESCRIPTION
### Description
Since the ability to contact support is considered one of the most critical, this PR adds several tests:
- `helpCanBeOpenedWhileEnteringPassword`: checks that `Help` button is accessible from the password prompt screen.
- `helpCanBeOpenedWhileEnteringPassword`: checks that `Help` button is accessible from the email prompt screen.
- `sendButtonEnabledWhenTextIsEntered`: checks that `Send` button switches states correctly depending on the entered message text.
- `messageCanBeSent` (disabled, only executable with `gradle.properties` from Mobile Secrets, more [here](https://github.com/wordpress-mobile/WordPress-Android/pull/15744#discussion_r774747829)): sends a message and checks that a certain reply is returned.

### Testing Instructions
- The `Connected Tests-2` CI [job](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/28254/workflows/aeb6e895-16fe-4f54-821b-6e1b1a045e84/jobs/117888/tests) is green, and you can see `helpCanBeOpenedWhileEnteringPassword`, `sendButtonEnabledWhenTextIsEntered `, `helpCanBeOpenedWhileEnteringEmail ` tests included.
- Associated Firebase [execution](https://console.firebase.google.com/u/1/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670/matrices/7792081164030229540/executions/bs.b9b8dc573349240d/test-cases) is also green (Firebase console access is needed to check this).
- Tests run locally (both with default `gradle.properties` and the ones from Mobile Secrets) on `Pixel 2 API 28` (this is the model used on CI).
- [optional] Enable and run `messageCanBeSent` locally with `gradle.properties` from Mobile Secrets.

## Regression Notes
1. Potential unintended areas of impact:
All changes took place in the package related to automated tests. The app behaviour should not be affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on):
I executed all existing automated tests, and the CI is green.

3. What automated tests I added:
I added:
- `sendButtonEnabledWhenTextIsEntered`
- `messageCanBeSent`
- `helpCanBeOpenedWhileEnteringEmail`
- `helpCanBeOpenedWhileEnteringPassword`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.