### PR TITLE
My Site Dashboard: Page Behaviours - Error States - Part 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
@@ -27,8 +27,7 @@ class CurrentAvatarSource @Inject constructor(
         when (isRefresh) {
             null, true -> {
                 val url = accountStore.account?.avatarUrl.orEmpty()
-                postState(CurrentAvatarUrl(url))
-                onRefreshedMainThread()
+                setState(CurrentAvatarUrl(url))
             }
             false -> Unit // Do nothing
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
@@ -28,6 +28,11 @@ interface MySiteSource<T : PartialState> {
             this@postState.postValue(value)
         }
 
+        fun MediatorLiveData<T>.setState(value: T) {
+            refresh.value = false
+            this@setState.value = value
+        }
+
         fun onRefreshedMainThread() {
             refresh.value = false
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
@@ -26,7 +26,7 @@ data class MySiteUiState(
     val quickStartCategories: List<QuickStartCategory> = listOf(),
     val pinnedDynamicCard: DynamicCardType? = null,
     val visibleDynamicCards: List<DynamicCardType> = listOf(),
-    val cards: CardsResult<List<CardModel>>? = null
+    val cardsUpdate: CardsUpdate? = null
 ) {
     sealed class PartialState {
         data class CurrentAvatarUrl(val url: String) : PartialState()
@@ -65,7 +65,7 @@ data class MySiteUiState(
                     pinnedDynamicCard = partialState.pinnedDynamicCard,
                     visibleDynamicCards = partialState.cards
             )
-            is CardsUpdate -> this.copy(cards = partialState.cards)
+            is CardsUpdate -> this.copy(cardsUpdate = partialState)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
@@ -46,7 +46,7 @@ data class MySiteUiState(
         data class CardsUpdate(
             val cards: List<CardModel>? = null,
             val showErrorCard: Boolean = false,
-            val showSnackbarError: Boolean = false
+            var showSnackbarError: Boolean = false
         ) : PartialState()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
@@ -51,7 +51,7 @@ data class MySiteUiState(
     }
 
     fun update(partialState: PartialState): MySiteUiState {
-        val uiState = updateSnackbarStatusToShowOnlyOnce(partialState) ?: this
+        val uiState = updateSnackbarStatusToShowOnlyOnce(partialState)
 
         return when (partialState) {
             is CurrentAvatarUrl -> uiState.copy(currentAvatarUrl = partialState.url)
@@ -75,6 +75,7 @@ data class MySiteUiState(
     }
 
     private fun updateSnackbarStatusToShowOnlyOnce(partialState: PartialState) =
-            this.copy(cardsUpdate = this.cardsUpdate?.copy(showSnackbarError = false))
-                    .takeIf { partialState !is CardsUpdate }
+            if (partialState !is CardsUpdate) {
+                this.copy(cardsUpdate = this.cardsUpdate?.copy(showSnackbarError = false))
+            } else this
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
@@ -4,7 +4,6 @@ import org.wordpress.android.fluxc.model.DynamicCardType
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
-import org.wordpress.android.fluxc.store.dashboard.CardsStore.CardsResult
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CardsUpdate
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DomainCreditAvailable
@@ -44,7 +43,7 @@ data class MySiteUiState(
             val cards: List<DynamicCardType>
         ) : PartialState()
 
-        data class CardsUpdate(val cards: CardsResult<List<CardModel>>) : PartialState()
+        data class CardsUpdate(val cards: List<CardModel>?) : PartialState()
     }
 
     fun update(partialState: PartialState): MySiteUiState {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
@@ -43,7 +43,11 @@ data class MySiteUiState(
             val cards: List<DynamicCardType>
         ) : PartialState()
 
-        data class CardsUpdate(val cards: List<CardModel>?) : PartialState()
+        data class CardsUpdate(
+            val cards: List<CardModel>? = null,
+            val showErrorCard: Boolean = false,
+            val showSnackbarError: Boolean = false
+        ) : PartialState()
     }
 
     fun update(partialState: PartialState): MySiteUiState {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
@@ -46,29 +46,35 @@ data class MySiteUiState(
         data class CardsUpdate(
             val cards: List<CardModel>? = null,
             val showErrorCard: Boolean = false,
-            var showSnackbarError: Boolean = false
+            val showSnackbarError: Boolean = false
         ) : PartialState()
     }
 
     fun update(partialState: PartialState): MySiteUiState {
+        val uiState = updateSnackbarStatusToShowOnlyOnce(partialState) ?: this
+
         return when (partialState) {
-            is CurrentAvatarUrl -> this.copy(currentAvatarUrl = partialState.url)
-            is SelectedSite -> this.copy(site = partialState.site)
-            is ShowSiteIconProgressBar -> this.copy(showSiteIconProgressBar = partialState.showSiteIconProgressBar)
-            is DomainCreditAvailable -> this.copy(isDomainCreditAvailable = partialState.isDomainCreditAvailable)
-            is JetpackCapabilities -> this.copy(
+            is CurrentAvatarUrl -> uiState.copy(currentAvatarUrl = partialState.url)
+            is SelectedSite -> uiState.copy(site = partialState.site)
+            is ShowSiteIconProgressBar -> uiState.copy(showSiteIconProgressBar = partialState.showSiteIconProgressBar)
+            is DomainCreditAvailable -> uiState.copy(isDomainCreditAvailable = partialState.isDomainCreditAvailable)
+            is JetpackCapabilities -> uiState.copy(
                     scanAvailable = partialState.scanAvailable,
                     backupAvailable = partialState.backupAvailable
             )
-            is QuickStartUpdate -> this.copy(
+            is QuickStartUpdate -> uiState.copy(
                     activeTask = partialState.activeTask,
                     quickStartCategories = partialState.categories
             )
-            is DynamicCardsUpdate -> this.copy(
+            is DynamicCardsUpdate -> uiState.copy(
                     pinnedDynamicCard = partialState.pinnedDynamicCard,
                     visibleDynamicCards = partialState.cards
             )
-            is CardsUpdate -> this.copy(cardsUpdate = partialState)
+            is CardsUpdate -> uiState.copy(cardsUpdate = partialState)
         }
     }
+
+    private fun updateSnackbarStatusToShowOnlyOnce(partialState: PartialState) =
+            this.copy(cardsUpdate = this.cardsUpdate?.copy(showSnackbarError = false))
+                    .takeIf { partialState !is CardsUpdate }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -171,7 +171,7 @@ class MySiteViewModel @Inject constructor(
             cardsUpdate
     ) ->
         val state = if (site != null) {
-            cardsUpdate?.showSnackbarError?.takeIf { it }?.let { cardsUpdate.handleCardsUpdateForSnackbarError() }
+            cardsUpdate?.checkAndShowSnackbarError()
             buildSiteSelectedStateAndScroll(
                     site,
                     showSiteIconProgressBar,
@@ -190,9 +190,11 @@ class MySiteViewModel @Inject constructor(
         UiModel(currentAvatarUrl.orEmpty(), state)
     }
 
-    private fun CardsUpdate.handleCardsUpdateForSnackbarError() {
-        _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.my_site_dashboard_update_error))))
-        this.showSnackbarError = false
+    private fun CardsUpdate.checkAndShowSnackbarError() {
+        if (showSnackbarError) {
+            _onSnackbarMessage
+                    .postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.my_site_dashboard_update_error))))
+        }
     }
 
     @Suppress("LongParameterList")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -17,12 +17,10 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_PULL_TO_REF
 import org.wordpress.android.fluxc.model.DynamicCardType
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.dashboard.CardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
-import org.wordpress.android.fluxc.store.dashboard.CardsStore.CardsResult
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
@@ -36,6 +34,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStart
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteItemsBuilderParams
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState
+import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CardsUpdate
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.NoSites
 import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
@@ -169,7 +168,7 @@ class MySiteViewModel @Inject constructor(
             quickStartCategories,
             pinnedDynamicCard,
             visibleDynamicCards,
-            cards
+            cardsUpdate
     ) ->
         val state = if (site != null) {
             buildSiteSelectedStateAndScroll(
@@ -182,7 +181,7 @@ class MySiteViewModel @Inject constructor(
                     visibleDynamicCards,
                     backupAvailable,
                     scanAvailable,
-                    cards
+                    cardsUpdate
             )
         } else {
             buildNoSiteState()
@@ -201,7 +200,7 @@ class MySiteViewModel @Inject constructor(
         visibleDynamicCards: List<DynamicCardType>,
         backupAvailable: Boolean,
         scanAvailable: Boolean,
-        cards: CardsResult<List<CardModel>>?
+        cardsUpdate: CardsUpdate?
     ): SiteSelected {
         val siteItems = buildSiteSelectedState(
                 site,
@@ -213,7 +212,7 @@ class MySiteViewModel @Inject constructor(
                 visibleDynamicCards,
                 backupAvailable,
                 scanAvailable,
-                cards
+                cardsUpdate
         )
         scrollToQuickStartTaskIfNecessary(
                 activeTask,
@@ -233,7 +232,7 @@ class MySiteViewModel @Inject constructor(
         visibleDynamicCards: List<DynamicCardType>,
         backupAvailable: Boolean,
         scanAvailable: Boolean,
-        cards: CardsResult<List<CardModel>>?
+        cardsUpdate: CardsUpdate?
     ): List<MySiteCardAndItem> {
         val cardsResult = cardsBuilder.build(
                 SiteInfoCardBuilderParams(
@@ -264,7 +263,8 @@ class MySiteViewModel @Inject constructor(
                 ),
                 DashboardCardsBuilderParams(
                         postCardBuilderParams = PostCardBuilderParams(
-                                posts = cards?.model?.firstOrNull { it is PostsCardModel } as? PostsCardModel,
+                                posts = cardsUpdate?.cards?.model
+                                        ?.firstOrNull { it is PostsCardModel } as? PostsCardModel,
                                 onPostItemClick = this::onPostItemClick,
                                 onFooterLinkClick = this::onPostCardFooterLinkClick
                         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -171,6 +171,7 @@ class MySiteViewModel @Inject constructor(
             cardsUpdate
     ) ->
         val state = if (site != null) {
+            cardsUpdate?.showSnackbarError?.takeIf { it }?.let { handleCardsUpdateForSnackbarError() }
             buildSiteSelectedStateAndScroll(
                     site,
                     showSiteIconProgressBar,
@@ -187,6 +188,10 @@ class MySiteViewModel @Inject constructor(
             buildNoSiteState()
         }
         UiModel(currentAvatarUrl.orEmpty(), state)
+    }
+
+    private fun handleCardsUpdateForSnackbarError() {
+        _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.my_site_dashboard_update_error))))
     }
 
     @Suppress("LongParameterList")
@@ -262,6 +267,7 @@ class MySiteViewModel @Inject constructor(
                         onQuickStartTaskTypeItemClick = this::onQuickStartTaskTypeItemClick
                 ),
                 DashboardCardsBuilderParams(
+                        showErrorCard = cardsUpdate?.showErrorCard == true,
                         postCardBuilderParams = PostCardBuilderParams(
                                 posts = cardsUpdate?.cards?.firstOrNull { it is PostsCardModel } as? PostsCardModel,
                                 onPostItemClick = this::onPostItemClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -263,8 +263,7 @@ class MySiteViewModel @Inject constructor(
                 ),
                 DashboardCardsBuilderParams(
                         postCardBuilderParams = PostCardBuilderParams(
-                                posts = cardsUpdate?.cards?.model
-                                        ?.firstOrNull { it is PostsCardModel } as? PostsCardModel,
+                                posts = cardsUpdate?.cards?.firstOrNull { it is PostsCardModel } as? PostsCardModel,
                                 onPostItemClick = this::onPostItemClick,
                                 onFooterLinkClick = this::onPostCardFooterLinkClick
                         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -171,7 +171,7 @@ class MySiteViewModel @Inject constructor(
             cardsUpdate
     ) ->
         val state = if (site != null) {
-            cardsUpdate?.showSnackbarError?.takeIf { it }?.let { handleCardsUpdateForSnackbarError() }
+            cardsUpdate?.showSnackbarError?.takeIf { it }?.let { cardsUpdate.handleCardsUpdateForSnackbarError() }
             buildSiteSelectedStateAndScroll(
                     site,
                     showSiteIconProgressBar,
@@ -190,8 +190,9 @@ class MySiteViewModel @Inject constructor(
         UiModel(currentAvatarUrl.orEmpty(), state)
     }
 
-    private fun handleCardsUpdateForSnackbarError() {
+    private fun CardsUpdate.handleCardsUpdateForSnackbarError() {
         _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.my_site_dashboard_update_error))))
+        this.showSnackbarError = false
     }
 
     @Suppress("LongParameterList")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -45,7 +45,7 @@ class CardsSource @Inject constructor(
         if (selectedSite != null && selectedSite.id == siteLocalId) {
             coroutineScope.launch(bgDispatcher) {
                 cardsStore.getCards(selectedSite).collect { result ->
-                    postValue(CardsUpdate(result))
+                    postValue(CardsUpdate(result.model))
                 }
             }
         } else {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2209,6 +2209,9 @@
     <string name="my_site_bottom_sheet_add_story">Story post</string>
     <string name="my_site_quick_actions_title">Quick Links</string>
 
+    <!-- My Site - Dashboard -->
+    <string name="my_site_dashboard_update_error">Couldn\'t update dashboard.</string>
+
     <!-- My Site - Post Card -->
     <string name="my_site_post_card_draft_title">Work on a draft post</string>
     <string name="my_site_post_card_scheduled_title">Upcoming scheduled posts</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteUiStateTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteUiStateTest.kt
@@ -1,0 +1,44 @@
+package org.wordpress.android.ui.mysite
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
+import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CardsUpdate
+import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.QuickStartUpdate
+
+@RunWith(MockitoJUnitRunner::class)
+class MySiteUiStateTest : BaseUnitTest() {
+    @Mock lateinit var postsCardModel: PostsCardModel
+    private lateinit var mySiteUiState: MySiteUiState
+
+    @Before
+    fun setUp() {
+        mySiteUiState = MySiteUiState()
+    }
+
+    @Test
+    fun `given cards update with snackbar, when ui state is updated with cards update, then snackbar shown`() {
+        val partialState = CardsUpdate(cards = listOf(postsCardModel), showSnackbarError = true)
+
+        val updatedUiState = mySiteUiState.update(partialState)
+
+        assertThat(updatedUiState.cardsUpdate?.showSnackbarError).isTrue
+    }
+
+    @Test
+    fun `given cards update with snackbar, when ui state is updated with different update, then snackbar not shown`() {
+        val cardsUpdate = CardsUpdate(cards = listOf(postsCardModel), showSnackbarError = true)
+        val quickStartUpdate = QuickStartUpdate()
+
+        var updatedUiState = mySiteUiState.update(cardsUpdate)
+        updatedUiState = updatedUiState.update(quickStartUpdate)
+
+        assertThat(updatedUiState.cardsUpdate?.showSnackbarError).isFalse
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -212,7 +212,6 @@ class MySiteViewModelTest : BaseUnitTest() {
                                     )
                             )
                     )
-
             )
     )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -36,7 +36,6 @@ import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel.Post
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
-import org.wordpress.android.fluxc.store.dashboard.CardsStore.CardsResult
 import org.wordpress.android.test
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.FooterLink
@@ -190,31 +189,30 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     private val cardsUpdate = MutableLiveData(
             CardsUpdate(
-                    CardsResult(
-                            listOf(
-                                    PostsCardModel(
-                                            hasPublished = true,
-                                            draft = listOf(
-                                                    PostCardModel(
-                                                            id = 1,
-                                                            title = "draft",
-                                                            content = "content",
-                                                            featuredImage = "featuredImage",
-                                                            date = Date()
-                                                    )
-                                            ),
-                                            scheduled = listOf(
-                                                    PostCardModel(
-                                                            id = 2,
-                                                            title = "scheduled",
-                                                            content = "",
-                                                            featuredImage = null,
-                                                            date = Date()
-                                                    )
+                    cards = listOf(
+                            PostsCardModel(
+                                    hasPublished = true,
+                                    draft = listOf(
+                                            PostCardModel(
+                                                    id = 1,
+                                                    title = "draft",
+                                                    content = "content",
+                                                    featuredImage = "featuredImage",
+                                                    date = Date()
+                                            )
+                                    ),
+                                    scheduled = listOf(
+                                            PostCardModel(
+                                                    id = 2,
+                                                    title = "scheduled",
+                                                    content = "",
+                                                    featuredImage = null,
+                                                    date = Date()
                                             )
                                     )
                             )
                     )
+
             )
     )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1074,6 +1074,18 @@ class MySiteViewModelTest : BaseUnitTest() {
                 )
             }
 
+    @Test
+    fun `given show snackbar not in cards update, when dashboard cards updated, then dashboard snackbar not shown`() =
+            test {
+                initSelectedSite()
+
+                cardsUpdate.value = cardsUpdate.value?.copy(showSnackbarError = false)
+
+                assertThat(snackbars).doesNotContain(
+                        SnackbarMessageHolder(UiStringRes(R.string.my_site_dashboard_update_error))
+                )
+            }
+
     /* ITEM CLICK */
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1075,19 +1075,6 @@ class MySiteViewModelTest : BaseUnitTest() {
                 )
             }
 
-    @Test
-    fun `given dashboard snackbar once shown, when a different partial state is updated, then snackbar not re-shown`() =
-            test {
-                initSelectedSite()
-                cardsUpdate.value = cardsUpdate.value?.copy(showSnackbarError = true)
-                snackbars.clear()
-
-                quickStartUpdate.value = QuickStartUpdate()
-
-                assertThat(snackbars).isEmpty()
-                assertThat(cardsUpdate.value?.showSnackbarError).isFalse
-            }
-
     /* ITEM CLICK */
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1061,6 +1061,33 @@ class MySiteViewModelTest : BaseUnitTest() {
                 assertThat(navigationActions).containsOnly(SiteNavigationAction.EditScheduledPost(site, postId))
             }
 
+    /* DASHBOARD ERROR SNACKBAR */
+
+    @Test
+    fun `given show snackbar in cards update, when dashboard cards updated, then dashboard snackbar shown`() =
+            test {
+                initSelectedSite()
+
+                cardsUpdate.value = cardsUpdate.value?.copy(showSnackbarError = true)
+
+                assertThat(snackbars).containsOnly(
+                        SnackbarMessageHolder(UiStringRes(R.string.my_site_dashboard_update_error))
+                )
+            }
+
+    @Test
+    fun `given dashboard snackbar once shown, when a different partial state is updated, then snackbar not re-shown`() =
+            test {
+                initSelectedSite()
+                cardsUpdate.value = cardsUpdate.value?.copy(showSnackbarError = true)
+                snackbars.clear()
+
+                quickStartUpdate.value = QuickStartUpdate()
+
+                assertThat(snackbars).isEmpty()
+                assertThat(cardsUpdate.value?.showSnackbarError).isFalse
+            }
+
     /* ITEM CLICK */
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -988,7 +988,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         verify(mySiteSourceManager).onQuickStartMenuInteraction(DynamicCardMenuInteraction.Remove(id))
     }
 
-    /* POST CARDS */
+    /* DASHBOARD POST CARD - FOOTER LINK */
 
     @Test
     fun `given create first card, when footer link is clicked, then editor is opened to create new post`() =
@@ -1039,7 +1039,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.SCHEDULED)
     }
 
-    /* POST CARD - POST ITEM */
+    /* DASHBOARD POST CARD - POST ITEM */
 
     @Test
     fun `given draft post card, when post item is clicked, then post is opened for edit draft`() =

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
@@ -70,9 +70,6 @@ class CardsSourceTest : BaseUnitTest() {
     private val apiError = CardsResult<List<CardModel>>(
             error = CardsError(CardsErrorType.API_ERROR)
     )
-    private val genericError = CardsResult<List<CardModel>>(
-            error = CardsError(CardsErrorType.GENERIC_ERROR)
-    )
 
     @Before
     fun setUp() {
@@ -138,7 +135,7 @@ class CardsSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given error, when build is invoked, then error data is also loaded (network)`() = test {
+    fun `given error, when build is invoked, then error snackbar is also shown (network)`() = test {
         val result = mutableListOf<CardsUpdate>()
         whenever(cardsStore.getCards(siteModel)).thenReturn(flowOf(data))
         whenever(cardsStore.fetchCards(siteModel)).thenReturn(apiError)
@@ -147,7 +144,7 @@ class CardsSourceTest : BaseUnitTest() {
         cardSource.build(testScope(), SITE_LOCAL_ID).observeForever { it?.let { result.add(it) } }
 
         assertThat(result.size).isEqualTo(1)
-        assertThat(result.first()).isEqualTo(CardsUpdate(apiError))
+        assertThat(result.first()).isEqualTo(CardsUpdate(cards = data.model, showSnackbarError = true))
     }
 
     @Test
@@ -176,7 +173,7 @@ class CardsSourceTest : BaseUnitTest() {
 
         assertThat(result.size).isEqualTo(2)
         assertThat(result.first()).isEqualTo(CardsUpdate(data.model))
-        assertThat(result.last()).isEqualTo(CardsUpdate(apiError))
+        assertThat(result.last()).isEqualTo(CardsUpdate(cards = data.model, showSnackbarError = true))
     }
 
     /* IS REFRESHING */
@@ -246,7 +243,7 @@ class CardsSourceTest : BaseUnitTest() {
     /* INVALID SITE */
 
     @Test
-    fun `given invalid site, when build is invoked, then error data is loaded`() = test {
+    fun `given invalid site, when build is invoked, then error card is shown`() = test {
         val invalidSiteLocalId = 2
         val result = mutableListOf<CardsUpdate>()
         cardSource.refresh.observeForever { }
@@ -254,11 +251,11 @@ class CardsSourceTest : BaseUnitTest() {
         cardSource.build(testScope(), invalidSiteLocalId).observeForever { it?.let { result.add(it) } }
 
         assertThat(result.size).isEqualTo(1)
-        assertThat(result.first()).isEqualTo(CardsUpdate(genericError))
+        assertThat(result.first()).isEqualTo(CardsUpdate(showErrorCard = true))
     }
 
     @Test
-    fun `given invalid site, when refresh is invoked, then error data is loaded`() = test {
+    fun `given invalid site, when refresh is invoked, then error card is shown`() = test {
         val invalidSiteLocalId = 2
         val result = mutableListOf<CardsUpdate>()
         cardSource.refresh.observeForever { }
@@ -267,7 +264,7 @@ class CardsSourceTest : BaseUnitTest() {
         cardSource.refresh()
 
         assertThat(result.size).isEqualTo(2)
-        assertThat(result.first()).isEqualTo(CardsUpdate(genericError))
-        assertThat(result.last()).isEqualTo(CardsUpdate(genericError))
+        assertThat(result.first()).isEqualTo(CardsUpdate(showErrorCard = true))
+        assertThat(result.last()).isEqualTo(CardsUpdate(showErrorCard = true))
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
@@ -109,7 +109,7 @@ class CardsSourceTest : BaseUnitTest() {
         cardSource.build(testScope(), SITE_LOCAL_ID).observeForever { it?.let { result.add(it) } }
 
         assertThat(result.size).isEqualTo(1)
-        assertThat(result.first()).isEqualTo(CardsUpdate(data))
+        assertThat(result.first()).isEqualTo(CardsUpdate(data.model))
     }
 
     /* REFRESH DATA */
@@ -134,7 +134,7 @@ class CardsSourceTest : BaseUnitTest() {
         cardSource.build(testScope(), SITE_LOCAL_ID).observeForever { it?.let { result.add(it) } }
 
         assertThat(result.size).isEqualTo(1)
-        assertThat(result.first()).isEqualTo(CardsUpdate(data))
+        assertThat(result.first()).isEqualTo(CardsUpdate(data.model))
     }
 
     @Test
@@ -161,7 +161,7 @@ class CardsSourceTest : BaseUnitTest() {
         cardSource.refresh()
 
         assertThat(result.size).isEqualTo(1)
-        assertThat(result.first()).isEqualTo(CardsUpdate(data))
+        assertThat(result.first()).isEqualTo(CardsUpdate(data.model))
     }
 
     @Test
@@ -175,7 +175,7 @@ class CardsSourceTest : BaseUnitTest() {
         cardSource.refresh()
 
         assertThat(result.size).isEqualTo(2)
-        assertThat(result.first()).isEqualTo(CardsUpdate(data))
+        assertThat(result.first()).isEqualTo(CardsUpdate(data.model))
         assertThat(result.last()).isEqualTo(CardsUpdate(apiError))
     }
 


### PR DESCRIPTION
Parent #15625

Page Behavior (pbArwn-3ny-p2)

This PR 
- Displays `dashboard error card` when there are no dashboard content cards and there's an error [State 2 in the Page Behaviour P2 post].
- Displays `dashboard snackbar error` when there are dashboard cards and there's an error [State 6 in the Page Behaviour P2 post].
- Prevents the snackbar from displaying multiple times whenever there's a partial state update. 

Error Card | Snackbar Error
-----------|--------------
![error_card](https://user-images.githubusercontent.com/1405144/147215241-37eb347a-b103-4756-bdae-d8e30a35543e.png) | ![snackbar_error](https://user-images.githubusercontent.com/1405144/147215277-9ae73f1f-8fd0-4b38-9533-8cb86bca98aa.png)

To test:

Prerequisites

- Go to `My Site` -> `Me` -> `App Settings` -> `Test Feature Configuration`.
- Turn the `MySiteDashboardPhase2FeatureConfig` feature flag ON.
- Relaunch the app.

To return an error from the API might be tricky so the solution can be verified using `CardsSourceTest`, `MySiteViewModelTest` and `MySiteUiStateTest` tests in 6bb16bd, e7a7c5a and 2c956e6.

It can also be verified by updating the `CardsSource.getData(...)` and `CardsSource.fetchCardsAndPostErrorIfAvailable(...)` logic to get the `showErrorCard` to true or to get the `showSnackbarError` to true.

Notes:
- Ignore all styling for the error card.

## Regression Notes
1. Potential unintended areas of impact
Since the PR mainly touches dashboard cards source logic, it might impact the existing dashboard post cards display logic. Whenever there's an error, and dashboard cards exist in the local cache, then those cards should keep displaying. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
See above.

3. What automated tests I added (or what prevented me from doing so)
Updated unit tests for `CardsSource` and `MySiteViewModel` touching this logic.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
