### PR TITLE
My Site Dashboard - Phase 2 - Error Card Retry 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -94,7 +94,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                 open val dashboardCardType: DashboardCardType
             ) {
                 data class ErrorCard(
-                    override val dashboardCardType: DashboardCardType = DashboardCardType.ERROR_CARD
+                    override val dashboardCardType: DashboardCardType = DashboardCardType.ERROR_CARD,
+                    val onRetryClick: ListItemInteraction
                 ) : DashboardCard(dashboardCardType)
 
                 sealed class PostCard(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
@@ -41,6 +42,7 @@ sealed class MySiteCardAndItemBuilderParams {
 
     data class DashboardCardsBuilderParams(
         val showErrorCard: Boolean = false,
+        val onErrorRetryClick: () -> Unit,
         val postCardBuilderParams: PostCardBuilderParams
     ) : MySiteCardAndItemBuilderParams()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -271,6 +271,7 @@ class MySiteViewModel @Inject constructor(
                 ),
                 DashboardCardsBuilderParams(
                         showErrorCard = cardsUpdate?.showErrorCard == true,
+                        onErrorRetryClick = this::onDashboardErrorRetry,
                         postCardBuilderParams = PostCardBuilderParams(
                                 posts = cardsUpdate?.cards?.firstOrNull { it is PostsCardModel } as? PostsCardModel,
                                 onPostItemClick = this::onPostItemClick,
@@ -750,6 +751,10 @@ class MySiteViewModel @Inject constructor(
                 else -> Unit // Do nothing
             }
         }
+    }
+
+    private fun onDashboardErrorRetry() {
+        mySiteSourceManager.refresh()
     }
 
     private fun onPostCardFooterLinkClick(postCardType: PostCardType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardsBuilderParams
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardBuilder
+import org.wordpress.android.ui.utils.ListItemInteraction
 import javax.inject.Inject
 
 class CardsBuilder @Inject constructor(
@@ -15,12 +16,14 @@ class CardsBuilder @Inject constructor(
     ): DashboardCards = DashboardCards(
             cards = mutableListOf<DashboardCard>().apply {
                 if (dashboardCardsBuilderParams.showErrorCard) {
-                    add(createErrorCard())
+                    add(createErrorCard(dashboardCardsBuilderParams.onErrorRetryClick))
                 } else {
                     addAll(postCardBuilder.build(dashboardCardsBuilderParams.postCardBuilderParams))
                 }
             }.toList()
     )
 
-    private fun createErrorCard() = ErrorCard()
+    private fun createErrorCard(onErrorRetryClick: () -> Unit) = ErrorCard(
+            onRetryClick = ListItemInteraction.create(onErrorRetryClick)
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/error/ErrorCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/error/ErrorCardViewHolder.kt
@@ -12,5 +12,6 @@ class ErrorCardViewHolder(
         parent.viewBinding(MySiteErrorCardBinding::inflate)
 ) {
     fun bind(card: ErrorCard) = with(binding) {
+        retry.setOnClickListener { card.onRetryClick.click() }
     }
 }

--- a/WordPress/src/main/res/layout/my_site_error_card.xml
+++ b/WordPress/src/main/res/layout/my_site_error_card.xml
@@ -37,6 +37,7 @@
             style="@style/MySiteErrorCardRetry"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_medium_large"
             android:text="@string/retry"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/layout/my_site_error_card.xml
+++ b/WordPress/src/main/res/layout/my_site_error_card.xml
@@ -32,6 +32,17 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/title" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/retry"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="@style/MySiteErrorCardRetry"
+            android:text="@string/retry"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/subtitle" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/layout/my_site_error_card.xml
+++ b/WordPress/src/main/res/layout/my_site_error_card.xml
@@ -34,9 +34,9 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/retry"
+            style="@style/MySiteErrorCardRetry"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            style="@style/MySiteErrorCardRetry"
             android:text="@string/retry"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -786,6 +786,13 @@
         <item name="android:alpha">@dimen/material_emphasis_medium</item>
     </style>
 
+    <style name="MySiteErrorCardRetry" parent="WordPress.Button.Primary">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:layout_marginTop">@dimen/margin_extra_medium_large</item>
+    </style>
+
     <!--My Site Card - Post Item-->
     <style name="MySitePostItemTitle" parent="MySiteCardItemTitle"/>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -774,23 +774,19 @@
     <!--My Site Error Card-->
     <style name="MySiteErrorCardTitle" parent="MySiteCardItemTitle">
         <item name="android:textAlignment">center</item>
-        <item name="android:textSize">@dimen/text_sz_extra_large</item>
+        <item name="android:textSize">@dimen/text_sz_larger</item>
         <item name="android:alpha">@dimen/material_emphasis_medium</item>
     </style>
 
     <style name="MySiteErrorCardSubtitle" parent="MySiteCardItemSubtitle">
         <item name="android:textAlignment">center</item>
-        <item name="android:textSize">@dimen/text_sz_large</item>
+        <item name="android:textSize">@dimen/text_sz_medium</item>
         <item name="android:maxLines">3</item>
-        <item name="android:layout_marginTop">@dimen/margin_extra_large</item>
-        <item name="android:alpha">@dimen/material_emphasis_medium</item>
     </style>
 
     <style name="MySiteErrorCardRetry" parent="WordPress.Button.Primary">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
         <item name="android:textAllCaps">false</item>
-        <item name="android:layout_marginTop">@dimen/margin_extra_medium_large</item>
+        <item name="android:textStyle">normal</item>
     </style>
 
     <!--My Site Card - Post Item-->

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -198,6 +198,7 @@ class CardsBuilderTest {
                         mock()
                 ),
                 dashboardCardsBuilderParams = DashboardCardsBuilderParams(
+                    onErrorRetryClick = mock(),
                     postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock())
                 )
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -85,6 +85,7 @@ class CardsBuilderTest : BaseUnitTest() {
         return cardsBuilder.build(
                 dashboardCardsBuilderParams = DashboardCardsBuilderParams(
                         showErrorCard = showErrorCard,
+                        onErrorRetryClick = { },
                         postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock())
                 )
         )


### PR DESCRIPTION
Parent #15625

This PR adds retry functionality to the dashboard error card and fine-tunes the error card UI.

UI

Light Mode | Dark Mode
------------|------------
![error_card_light](https://user-images.githubusercontent.com/1405144/147232402-1609f595-87d6-4a51-9262-ea8c6e5ff39f.png) | ![error_card_dark](https://user-images.githubusercontent.com/1405144/147232447-72c87b08-2ce0-4d60-be49-d2a0277d9a63.png)

To test:

Prerequisites

- Go to `My Site` -> `Me` -> `App Settings` -> `Test Feature Configuration`.
- Turn the `MySiteDashboardPhase2FeatureConfig` feature flag ON.
- Relaunch the app.

1. Update the `CardsSource.getData(...)` and `CardsSource.fetchCardsAndPostErrorIfAvailable(...)` logic to get the `showErrorCard` to true.
2. Re-install the app.
3. Notice that the error card is displayed with a retry button.
4. Click the retry button.
5. Notice that the `My Site` tab is refreshed. 

**Merge Instructions**
- Make sure that the PR is design-reviewed
- Remove `Needs Design Review` and `Not Ready for Merge` labels
- Merge the PR

## Regression Notes
1. Potential unintended areas of impact
- Changes have a limited scope, only adds a retry button functionality and updates the styles.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- See above.

3. What automated tests I added (or what prevented me from doing so)
- Added unit test to verify refresh action.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
