### PR TITLE
My Site Dashboard [Phase 2]: Enable Feature Flag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardPhase2FeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardPhase2FeatureConfig.kt
@@ -1,17 +1,26 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig.Companion.MY_SITE_DASHBOARD_PHASE_2
 import javax.inject.Inject
 
 /**
  * Configuration of the 'My Site Dashboard - Phase 2', which amongst others includes the new 'Dashboard Post Cards'
  * that will be added on the 'My Site' screen.
  */
-@FeatureInDevelopment
+@Feature(
+        remoteField = MY_SITE_DASHBOARD_PHASE_2,
+        defaultValue = true
+)
 class MySiteDashboardPhase2FeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
         appConfig,
-        BuildConfig.MY_SITE_DASHBOARD_PHASE_2
-)
+        BuildConfig.MY_SITE_DASHBOARD_PHASE_2,
+        MY_SITE_DASHBOARD_PHASE_2
+) {
+    companion object {
+        const val MY_SITE_DASHBOARD_PHASE_2 = "my_site_dashboard_phase_2"
+    }
+}


### PR DESCRIPTION
Fixes #15713

This PR enables the feature flag for the Onboarding Improvements: Existing Users feature.

-----

To test:

- Clear app data to make sure all feature flags are set to default.
- Open the app.
- Make sure that the `Dashboard Feed` is shown within the `My Site` tab, for the `Posts` card(s).
- In more detail, make sure that at least one of the below `Posts` cards is shown:
  - `Create First`
  - `Create Next`
  - `Draft`
  - `Scheduled`

-----

Merge instructions:
- [x] Wait for the #15762 PR to get merged.
- [x] (Optional) Wait for the #15768 PR to get created, reviewed and then merged.
- [x] Remove the `[Status] Not Ready for Merge` label.
- [x] Merge this PR.

-----

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

N/A

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
