### PR TITLE
Separate buildscript dependency versions in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,51 @@
+ext {
+    coroutinesVersion = '1.5.2'
+    wordPressUtilsVersion = '2.2.0'
+    wordPressLoginVersion = '0.0.8'
+    gutenbergMobileVersion = 'v1.68.0'
+    storiesVersion = '1.2.0'
+    aboutAutomatticVersion = '0.0.2'
+
+    minSdkVersion = 24
+    compileSdkVersion = 31
+    targetSdkVersion = 30
+
+    coroutinesVersion = '1.3.9'
+    androidxWorkVersion = "2.4.0"
+
+    daggerVersion = '2.29.1'
+    fluxCVersion = '1.32.0'
+
+    appCompatVersion = '1.0.2'
+    coreVersion = '1.3.2'
+    lifecycleVersion = '2.2.0'
+    constraintLayoutVersion = '1.1.3'
+    materialVersion = '1.2.1'
+    preferenceVersion = '1.1.0'
+    swipeToRefresh = '1.1.0'
+    uCropVersion = '2.2.4'
+    lifecycleVersion = '2.2.0'
+    tracksVersion = '2.1.0'
+    roomVersion = '2.3.0'
+
+    coreLibraryDesugaringVersion = '1.1.5'
+
+    exoPlayerVersion = '2.9.3'
+
+    // testing
+    jUnitVersion = '4.13'
+    androidxTestVersion = '1.1.0'
+    androidxArchCoreVersion = '2.0.0'
+    assertJVersion = '3.11.1'
+    espressoVersion = '3.1.0'
+    mockitoCoreVersion = "3.3.3"
+    nhaarmanMockitoVersion = "2.2.0"
+}
+
 buildscript {
     ext.kotlinVersion = '1.5.32'
-    ext.coroutinesVersion = '1.5.2'
     ext.navComponentVersion = '2.3.5'
-    ext.wordPressUtilsVersion = '2.2.0'
-    ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.68.0'
-    ext.storiesVersion = '1.2.0'
-    ext.aboutAutomatticVersion = '0.0.2'
 
     repositories {
         maven {
@@ -119,43 +157,6 @@ buildScan {
         // Otherwise CI might shut down before it's uploaded
         uploadInBackground = false
     }
-}
-
-ext {
-    minSdkVersion = 24
-    compileSdkVersion = 31
-    targetSdkVersion = 30
-
-    coroutinesVersion = '1.3.9'
-    androidxWorkVersion = "2.4.0"
-
-    daggerVersion = '2.29.1'
-    fluxCVersion = '1.32.0'
-
-    appCompatVersion = '1.0.2'
-    coreVersion = '1.3.2'
-    lifecycleVersion = '2.2.0'
-    constraintLayoutVersion = '1.1.3'
-    materialVersion = '1.2.1'
-    preferenceVersion = '1.1.0'
-    swipeToRefresh = '1.1.0'
-    uCropVersion = '2.2.4'
-    lifecycleVersion = '2.2.0'
-    tracksVersion = '2.1.0'
-    roomVersion = '2.3.0'
-
-    coreLibraryDesugaringVersion = '1.1.5'
-
-    exoPlayerVersion = '2.9.3'
-
-    // testing
-    jUnitVersion = '4.13'
-    androidxTestVersion = '1.1.0'
-    androidxArchCoreVersion = '2.0.0'
-    assertJVersion = '3.11.1'
-    espressoVersion = '3.1.0'
-    mockitoCoreVersion = "3.3.3"
-    nhaarmanMockitoVersion = "2.2.0"
 }
 
 // Onboarding and dev env setup tasks


### PR DESCRIPTION
This PR prepares the repository for an easier transition to the Plugin DSL which is being worked on in #15314.

In `build.gradle` we are currently adding the dependency versions in both `buildscript` block as well as a separate `ext` block. `buildscript` is not the correct place to add these versions unless the version is utilized in the `buildscript`. So, this PR moves all the dependency versions from `buildscript` except for `kotlinVersion`, `navComponentVersion` & `detektVersion` as they are used within the `buildscript` block. It also moves the `ext` block to the top of the file as that's where the developers are currently used to updating some dependencies such as `fluxCVersion`, `gutenbergMobileVersion` etc. We'll move these dependency versions to a TOML file early 2022, so I am leaving it as unchanged as I can.

In #15314, we'll move all the dependency versions within the `buildscript` block to the `settings.gradle` file as part of the Plugin DSL and remove the `buildscript` block completely.

**To test:**
* CI checks should be enough

## Regression Notes
1. Potential unintended areas of impact
Dependencies not being found during build

2. What I did to test those areas of impact (or what existing automated tests I relied on)
It's a compilation time regression, so no testing is necessary

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
