### PR TITLE
Reader - Fix occasional crash on reader interests json parsing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/ParseDiscoverCardsJsonUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/ParseDiscoverCardsJsonUseCase.kt
@@ -9,6 +9,8 @@ import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.models.ReaderTagType.DEFAULT
 import org.wordpress.android.ui.reader.ReaderConstants
+import org.wordpress.android.util.AppLog
+
 import org.wordpress.android.util.JSONUtils
 import javax.inject.Inject
 
@@ -46,7 +48,12 @@ class ParseDiscoverCardsJsonUseCase @Inject constructor() {
         }
         val jsonInterests = interestCardJson.optJSONArray(ReaderConstants.JSON_CARD_DATA) ?: return interestTags
         for (i in 0 until jsonInterests.length()) {
-            interestTags.add(parseInterestTag(jsonInterests.optJSONObject(i)))
+            val interestJSONTag = jsonInterests.optJSONObject(i)
+            if (interestJSONTag != null) {
+                interestTags.add(parseInterestTag(interestJSONTag))
+            } else {
+                AppLog.d(AppLog.T.READER, "Could not find interest JSON tag inside $jsonInterests at index $i")
+            }
         }
         return interestTags
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/ParseDiscoverCardsJsonUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/ParseDiscoverCardsJsonUseCase.kt
@@ -56,13 +56,11 @@ class ParseDiscoverCardsJsonUseCase @Inject constructor(
             if (interestJSONTag != null) {
                 interestTags.add(parseInterestTag(interestJSONTag))
             } else {
+                val errorMsg = "Error parsing reader interests $jsonInterests at index $i."
                 if (BuildConfig.DEBUG) {
-                    throw RuntimeException("Debug build crash on parsing reader interests $jsonInterests")
+                    throw NullPointerException("Debug build crash: $errorMsg")
                 } else {
-                    crashLogging.sendReportWithTag(
-                            exception = NullPointerException("Error parsing reader interests $jsonInterests"),
-                            tag = AppLog.T.READER
-                    )
+                    crashLogging.sendReportWithTag(exception = NullPointerException(errorMsg), tag = AppLog.T.READER)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/ParseDiscoverCardsJsonUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/ParseDiscoverCardsJsonUseCase.kt
@@ -52,15 +52,17 @@ class ParseDiscoverCardsJsonUseCase @Inject constructor(
         }
         val jsonInterests = interestCardJson.optJSONArray(ReaderConstants.JSON_CARD_DATA) ?: return interestTags
         for (i in 0 until jsonInterests.length()) {
-            try {
-                val interestJSONTag = jsonInterests.optJSONObject(i)
+            val interestJSONTag = jsonInterests.optJSONObject(i)
+            if (interestJSONTag != null) {
                 interestTags.add(parseInterestTag(interestJSONTag))
-            } catch (e: NullPointerException) {
+            } else {
                 if (BuildConfig.DEBUG) {
-                    throw RuntimeException("Debug build crash ${e.message} on parsing reader interests $jsonInterests")
+                    throw RuntimeException("Debug build crash on parsing reader interests $jsonInterests")
                 } else {
-                    crashLogging.sendReportWithTag(e, AppLog.T.READER)
-                    AppLog.e(AppLog.T.READER, "Error parsing reader interests $jsonInterests ${e.message}")
+                    crashLogging.sendReportWithTag(
+                            exception = NullPointerException("Error parsing reader interests $jsonInterests"),
+                            tag = AppLog.T.READER
+                    )
                 }
             }
         }


### PR DESCRIPTION
Fixes #15722

I wasn't able to reproduce the crash, however, checking [Sentry logs](https://sentry.io/organizations/a8c/issues/2068869261/), it is evident that the crash occurs when `jsonInterests.optJSONObject(i)` can return a `null` during parsing. I've added a `null` check and added a log to see interests `JSON` content when this happens.

To test:
 - Launch the app.
 - Go to the `Reader - Discover` tab.
 - Follow/ unfollow a few topics using the ⚙️ icon at the top (`Manage Topics & Sites`).
 - Return to `Reader - Discover` tab.
 - Scroll a few pages down. 
 - Notice that the app doesn't crash due to the interests JSON parsing.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**Review Instructions**
Only 1 reviewer is sufficient. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
