### PR TITLE
Issue/move whats new to parent category

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -246,9 +246,9 @@ public class AppSettingsFragment extends PreferenceFragment
     }
 
     private void addWhatsNewPreference() {
-        PreferenceCategory aboutTheAppPreferenceCategory =
-                (PreferenceCategory) findPreference(getString(R.string.pref_key_about_section));
-        aboutTheAppPreferenceCategory.addPreference(mWhatsNew);
+        PreferenceScreen preferenceScreen =
+                (PreferenceScreen) findPreference(getString(R.string.pref_key_app_settings_root));
+        preferenceScreen.addPreference(mWhatsNew);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -240,9 +240,9 @@ public class AppSettingsFragment extends PreferenceFragment
     }
 
     private void removeWhatsNewPreference() {
-        PreferenceCategory aboutTheAppPreferenceCategory =
-                (PreferenceCategory) findPreference(getString(R.string.pref_key_about_section));
-        aboutTheAppPreferenceCategory.removePreference(mWhatsNew);
+        PreferenceScreen preferenceScreen =
+                (PreferenceScreen) findPreference(getString(R.string.pref_key_app_settings_root));
+        preferenceScreen.removePreference(mWhatsNew);
     }
 
     private void addWhatsNewPreference() {

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -68,6 +68,10 @@
         android:title="@string/preference_open_device_settings" />
 
     <Preference
+        android:key="@string/pref_key_whats_new"
+        android:title="@string/whats_new_in_version_title" />
+
+    <Preference
         android:key="@string/pref_key_debug_settings"
         app:isPreferenceVisible="false"
         android:title="@string/preference_open_debug_settings" />
@@ -143,10 +147,5 @@
         <Preference
             android:key="@string/pref_key_oss_licenses"
             android:title="@string/open_source_licenses" />
-
-        <Preference
-            android:key="@string/pref_key_whats_new"
-            android:title="@string/whats_new_in_version_title" />
-
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This PR fixes a crash in App Settings related to introduction of unified about screen.

in #15551 FF check to remove About category from app settings was introduced. Unified About screen FF got turned ON now, so the About category is removed. Unintentionally, What's New preference was removed as well, which causes a crash when visiting App Settings with active feature announcement.

This PR moves the What's New preference to the parent screen.

cc @renanferrari @ravishanker 


To test:
- Set build flavor to jalapeno release and set app verstion to pr-15761-build-117882 
- Login to the app with a8c account.
- Navigate to App Settings, and confirm that "Wats New" category is visible and tapping on it shows announcement.

## Regression Notes
1. Potential unintended areas of impact
- "Wats New" might not be visible.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing.

3. What automated tests I added (or what prevented me from doing so)
- Legacy preference screen is not very testable.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
