### PR TITLE
Zendesk: Fix invisible `Start a conversation` button issue

### DIFF
--- a/WordPress/src/main/res/layout/zs_activity_request_list_scene_empty.xml
+++ b/WordPress/src/main/res/layout/zs_activity_request_list_scene_empty.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/request_list_swipe_refresh_layout_empty"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <androidx.legacy.widget.Space
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <include layout="@layout/zs_activity_request_list_empty_logo" />
+
+        <TextView
+            android:id="@+id/request_list_description_empty"
+            style="@style/ZendeskSdkTheme.Light.Request.Message.Text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="64dp"
+            android:layout_marginLeft="64dp"
+            android:layout_marginEnd="64dp"
+            android:layout_marginRight="64dp"
+            android:gravity="center"
+            android:text="@string/request_list_empty_text"
+            android:textSize="16sp" />
+
+        <Button
+            android:id="@+id/request_list_empty_start_conversation"
+            style="@style/ZendeskRequestListButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingLeft="16dp"
+            android:paddingTop="10dp"
+            android:paddingRight="16dp"
+            android:paddingBottom="10dp"
+            android:text="@string/request_list_empty_start_conversation" />
+
+        <androidx.legacy.widget.Space
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <ImageView
+            android:id="@+id/request_list_zendesk_logo_empty"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|center_horizontal"
+            android:layout_marginBottom="24dp"
+            android:contentDescription="@string/zs_general_referrer_logo_label_accessibility"
+            android:padding="8dp"
+            app:srcCompat="@drawable/zs_zendesk_product_logo" />
+
+    </LinearLayout>
+
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -122,17 +122,6 @@
         <item name="android:background">?android:attr/listDivider</item>
     </style>
 
-    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
-        <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
-        <item name="android:statusBarColor">@color/primary_dark</item>
-        <item name="titleTextColor">?attr/colorOnSurface</item>
-        <item name="toolbarNavigationButtonStyle">
-            @style/Widget.AppCompat.Toolbar.Button.Navigation
-        </item>
-        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
-        <item name="android:navigationBarColor">@android:color/black</item>
-    </style>
-
     <style name="WordPress.SnackbarButton" parent="Widget.MaterialComponents.Button.TextButton.Snackbar">
         <item name="android:textColor">?attr/colorSecondaryVariant</item>
     </style>

--- a/WordPress/src/main/res/values-night/styles_zendesk.xml
+++ b/WordPress/src/main/res/values-night/styles_zendesk.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
+        <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
+        <item name="android:statusBarColor">@color/primary_dark</item>
+        <item name="titleTextColor">?attr/colorOnSurface</item>
+        <item name="toolbarNavigationButtonStyle">
+            @style/Widget.AppCompat.Toolbar.Button.Navigation
+        </item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+    </style>
+</resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -204,17 +204,6 @@
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
-        <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
-        <item name="android:statusBarColor">?attr/colorPrimaryDark</item>
-        <item name="titleTextColor">?attr/colorOnSurface</item>
-        <item name="toolbarNavigationButtonStyle">
-            @style/Widget.AppCompat.Toolbar.Button.Navigation
-        </item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:navigationBarColor">@android:color/black</item>
-    </style>
-
     <style name="WordPress.Stories.Immersive" parent="WordPress.NoActionBar">
         <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:immersive">true</item>

--- a/WordPress/src/main/res/values/styles_zendesk.xml
+++ b/WordPress/src/main/res/values/styles_zendesk.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
+        <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
+        <item name="android:statusBarColor">?attr/colorPrimaryDark</item>
+        <item name="titleTextColor">?attr/colorOnSurface</item>
+        <item name="toolbarNavigationButtonStyle">
+            @style/Widget.AppCompat.Toolbar.Button.Navigation
+        </item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+    </style>
+</resources>

--- a/WordPress/src/main/res/values/styles_zendesk.xml
+++ b/WordPress/src/main/res/values/styles_zendesk.xml
@@ -10,4 +10,13 @@
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:navigationBarColor">@android:color/black</item>
     </style>
+
+    <!-- Zendesk Styles Override -->
+
+    <style name="ZendeskRequestListButton" parent="@style/Widget.MaterialComponents.Button">
+        <item name="android:textColor">@color/zs_request_list_white</item>
+        <item name="android:textSize">@dimen/text_sz_medium</item>
+        <item name="backgroundTint">@null</item> <!-- This is done so that the custom background is not tinted. See https://git.io/JyEnY -->
+        <item name="android:background">@color/colorPrimary</item>
+    </style>
 </resources>


### PR DESCRIPTION
Fixes #15503

This PR makes minimal changes to show the invisible `Start a conversation` Zendesk button.

<img width="320" src="https://user-images.githubusercontent.com/1405144/147557530-fcfd3753-107c-4773-a81f-9153e7c97593.png"/>

##### Note that the PR doesn't attempt to fix the dark/ light mode theming issues (#11111). Cc @malinajirka, @khaykov.

To test:

1. Open the app.
2. Make sure you are not logged in or you are logged in with an account which doesn't have any support tickets.
3. Go to the Support section (eg. Login with WordPress.com -> Tap on "?" icon in the toolbar.
4. Tap on `My Tickets`.
5. Notice "Start a conversation" button is visible.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
