### PR TITLE
Integrate gutenberg-mobile release 1.69.0-alpha1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.2.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = 'v1.68.0'
+    gutenbergMobileVersion = '4422-5b2fab1deae1509959ea1d301e2ce9a5de291831'
     storiesVersion = '1.2.0'
     aboutAutomatticVersion = '0.0.2'
 


### PR DESCRIPTION
:warning: DO NOT MERGE - This PR is for pre-release smoke testing and will be deleted.

## Description
This PR incorporates the 1.69.0-alpha1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4422

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.