### PR TITLE
My Site Dashboard - Phase 2 - Update Error Card & Stale Message Style & Copy

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemDecoration.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemDecoration.kt
@@ -18,6 +18,11 @@ class MySiteCardAndItemDecoration(
         val position = parent.getChildAdapterPosition(view)
         if (position < 0) return
         when (parent.adapter?.getItemViewType(position)) {
+            MySiteCardAndItem.Type.INFO_ITEM.ordinal -> {
+                outRect.top = verticalMargin
+                outRect.left = horizontalMargin
+                outRect.right = horizontalMargin
+            }
             MySiteCardAndItem.Type.LIST_ITEM.ordinal,
             MySiteCardAndItem.Type.CATEGORY_HEADER_ITEM.ordinal -> {
                 outRect.left = horizontalMargin

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2220,8 +2220,8 @@
     <string name="my_site_post_card_link_go_to_scheduled_posts">Go to scheduled posts</string>
 
     <!-- My Site - Error Card -->
-    <string name="my_site_error_card_title">Some data wasn\'t loaded</string>
-    <string name="my_site_error_card_subtitle">Couldn\'t display more data about your site right now.</string>
+    <string name="my_site_error_card_title">Some data hasn\'t loaded</string>
+    <string name="my_site_error_card_subtitle">We\'re having trouble loading your site\'s data at the moment.</string>
 
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2204,7 +2204,7 @@
 
     <!-- My Site - Dashboard -->
     <string name="my_site_dashboard_update_error">Couldn\'t update dashboard.</string>
-    <string name="my_site_dashboard_stale_message">Couldn\'t update dashboard. Check your connection and pull to refresh.</string>
+    <string name="my_site_dashboard_stale_message">The dashboard is not updated. Please check your connection and then pull to refresh.</string>
 
     <!-- My Site - Post Card -->
     <string name="my_site_post_card_draft_title">Work on a draft post</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -600,7 +600,7 @@
     </style>
 
     <style name="MySiteInfoItemTextView">
-        <item name="android:textAlignment">center</item>
+        <item name="android:textAlignment">viewStart</item>
         <item name="android:singleLine">false</item>
         <item name="android:textAppearance">?attr/textAppearanceCaption</item>
         <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>


### PR DESCRIPTION
Fixes #15785 

Error Card Before | Error Card After 
-----------|-----------
![error_card_before](https://user-images.githubusercontent.com/1405144/148025920-8c248a67-27e8-49e7-81f5-005d87ed1cae.jpg) | ![error_card_after](https://user-images.githubusercontent.com/1405144/148025711-e32fbaa8-b87c-44e3-a48e-8324e24a4af1.jpg)


Stale Message Before | Stale Message After | Stale Message After (RTL)
-----------|-----------|-----------
![before](https://user-images.githubusercontent.com/1405144/148024195-6ce1a23f-283b-489e-b49b-76996478369d.jpg) | ![after_1](https://user-images.githubusercontent.com/1405144/148025597-1d0ed010-4c10-4a12-a99d-7269a8bd1a2a.jpg) | ![error_card_RTL](https://user-images.githubusercontent.com/1405144/148027532-4d698665-8b46-422f-9efd-ca8757b91d0e.jpg)


To test:

 It is sufficient to 
- Compare updated strings in the `strings.xml` in commits 4fb3f41 (for error card) and 4c2ff9b (for stale message).
- Compare before and after screenshots and review commit 0985613 for stale message style changes.

Merge Instructions:

1. Make sure that the style updates are approved in the design review.
2. Remove `Not Ready for Merge`, `Needs Design Review` labels.
3. Merge the PR.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
