### PR TITLE
remove duplicated WPSupportUtils method

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -479,20 +479,6 @@ public class WPSupportUtils {
         return isElementDisplayed(element);
     }
 
-    public static boolean waitForElementToBeDisplayedWithoutFailure(final ViewInteraction element) {
-        try {
-            waitForConditionToBeTrueWithoutFailure(new Supplier<Boolean>() {
-                @Override
-                public Boolean get() {
-                    return isElementDisplayed(element);
-                }
-            });
-        } catch (Exception e) {
-            // ignore the failure
-        }
-        return isElementDisplayed(element);
-    }
-
     public static void waitForConditionToBeTrue(Supplier<Boolean> supplier) {
         if (supplier.get()) {
             return;


### PR DESCRIPTION
This PR removes a WPSupportUtils method that got duplicated in recently merged PRs ([this](https://github.com/wordpress-mobile/WordPress-Android/pull/15741) and [this](https://github.com/wordpress-mobile/WordPress-Android/pull/15744)) and it's making the build to fail.

The methods are exactly the same, so I just removed one of them.

To test:
Tests must pass on CI.

## Regression Notes
1. Potential unintended areas of impact
This PR could only impact the tests. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
