### PR TITLE
Update the format sytext in github workflow

### DIFF
--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
       - name: Update Gutenberg Mobile Version
         run: |
-          sed -i '' -E "s/gutenbergMobileVersion = '(.*)'/gutenbergMobileVersion = '$GUTENBERG_MOBILE_VERSION'/" build.gradle
+          sed -i '' -E "s/gutenbergMobileVersion = '(.*)'/gutenbergMobileVersion = '{$GUTENBERG_MOBILE_VERSION}'/" build.gradle
       - name: Compute vars
         id: vars
         run: |

--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -18,8 +18,9 @@ jobs:
       PR_TITLE: ${{ github.event.inputs.title || format('Automated gutenberg-mobile version update for {0} !', github.event.inputs.gutenbergMobileVersion ) }}
       PR_BODY: ${{ github.event.inputs.body || format('This PR incorporates changes from {0}.', github.event.inputs.prURL ) }}
       GUTENBERG_MOBILE_PR_URL: ${{ github.event.inputs.prURL }}
-
-      run: |
+    steps:
+      - name: create PR Description
+        run: |
           PR_DESCRIPTION=$(cat << EOF
           ## Description
           
@@ -29,8 +30,9 @@ jobs:
 
           EOF
           )
-          echo "::set-output name=pr_description::$PR_DESCRIPTION"
-    steps:
+          echo "::set-output name=description::$PR_DESCRIPTION"
+        id: pr_description
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -63,5 +65,5 @@ jobs:
           title: ${{ steps.vars.outputs.title }}
           branch: ${{ steps.vars.outputs.branch_name }}
           labels: gutenberg-mobile
-          body: ${{ steps.vars.outputs.pr_description }}
+          body: ${{ steps.pr_description.outputs.description }}
           delete-branch: true

--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GUTENBERG_MOBILE_VERSION: ${{ github.event.inputs.gutenbergMobileVersion }}
-      PR_TITLE: ${{ github.event.inputs.title || format('{ Automated gutenberg-mobile version update for {0} ! }', github.event.inputs.gutenbergMobileVersion ) }}
-      PR_BODY: ${{ github.event.inputs.body || format( '{ This PR incorporates changes from {0}. }', github.event.inputs.prURL ) }}
+      PR_TITLE: ${{ github.event.inputs.title || format('Automated gutenberg-mobile version update for {0} !', github.event.inputs.gutenbergMobileVersion ) }}
+      PR_BODY: ${{ github.event.inputs.body || format('This PR incorporates changes from {0}.', github.event.inputs.prURL ) }}
       GUTENBERG_MOBILE_PR_URL: ${{ github.event.inputs.prURL }}
 
       run: |

--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
       - name: Update Gutenberg Mobile Version
         run: |
-          sed -i '' -E "s/gutenbergMobileVersion = '(.*)'/gutenbergMobileVersion = '{$GUTENBERG_MOBILE_VERSION}'/" build.gradle
+          sed -i "s/gutenbergMobileVersion = '.*'/gutenbergMobileVersion = '$GUTENBERG_MOBILE_VERSION'/g" build.gradle
       - name: Compute vars
         id: vars
         run: |

--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -19,7 +19,7 @@ jobs:
       PR_BODY: ${{ github.event.inputs.body || format('This PR incorporates changes from {0}.', github.event.inputs.prURL ) }}
       GUTENBERG_MOBILE_PR_URL: ${{ github.event.inputs.prURL }}
     steps:
-      - name: create PR Description
+      - name: Create PR Description
         run: |
           PR_DESCRIPTION=$(cat << EOF
           ## Description
@@ -30,6 +30,9 @@ jobs:
 
           EOF
           )
+          PR_DESCRIPTION="${PR_DESCRIPTION//'%'/'%25'}"
+          PR_DESCRIPTION="${PR_DESCRIPTION//$'\n'/'%0A'}"
+          PR_DESCRIPTION="${PR_DESCRIPTION//$'\r'/'%0D'}"
           echo "::set-output name=description::$PR_DESCRIPTION"
         id: pr_description
 


### PR DESCRIPTION
Similar to https://github.com/wordpress-mobile/WordPress-Android/pull/15791 

This PR tries to fix the generated PR description that gets generated by the workflow.

To test:
Visit https://github.com/wordpress-mobile/WordPress-Android/actions/workflows/automated-version-update-pr.yml
Set the Worflow to use the following

branch: fix/github-workflow-update-format
gutenbergMobileVersion: 4350-930a73b8a6c964df202603f619099943714ab32d
title: Gutenberg Mobile https://github.com/wordpress-mobile/gutenberg-mobile/pull/4350
prURL: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4350

leave body empty.
See

<img width="400" alt="Screen Shot 2022-01-04 at 3 19 30 PM" src="https://user-images.githubusercontent.com/115071/148137020-2c2ec0ab-21fa-47d8-9dad-fc740ee65b5e.png">

The result of this this is the following PR. 
https://github.com/wordpress-mobile/WordPress-Android/pull/15793


🤞   that it works? 


## Regression Notes
1. Potential unintended areas of impact
none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
none.

3. What automated tests I added (or what prevented me from doing so)
none.
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
