### PR TITLE
My Site Dashboard - Phase 2 - Fix duplicate Error Snackbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
@@ -12,12 +12,12 @@ import javax.inject.Inject
 class CurrentAvatarSource @Inject constructor(
     private val accountStore: AccountStore
 ) : SiteIndependentSource<CurrentAvatarUrl> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(false)
 
     override fun build(coroutineScope: CoroutineScope): LiveData<CurrentAvatarUrl> {
         val result = MediatorLiveData<CurrentAvatarUrl>()
-        result.refreshData()
         result.addSource(refresh) { result.refreshData(refresh.value) }
+        refresh()
         return result
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -95,9 +95,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     private var binding: MySiteFragmentBinding? = null
 
-    // Capture and track the first `onResume` event so we can circumvent refreshing sources on initial onResume
-    private var isFirstResume = true
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // The following prevents the soft keyboard from leaving a white space when dismissed.
@@ -380,8 +377,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     override fun onResume() {
         super.onResume()
-        viewModel.onResume(isFirstResume)
-        isFirstResume = false
+        viewModel.onResume()
     }
 
     override fun onPause() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
@@ -99,8 +99,8 @@ class MySiteSourceManager @Inject constructor(
         }
     }
 
-    fun onResume(isFirstResume: Boolean) {
-        when (isFirstResume) {
+    fun onResume(isSiteSelected: Boolean) {
+        when (isSiteSelected) {
             true -> refreshSubsetOfAllSources()
             false -> refresh()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -128,7 +128,7 @@ class MySiteViewModel @Inject constructor(
 
     /* Capture and track the site selected event so we can circumvent refreshing sources on resume
        as they're already built on site select. */
-    private var _isSiteSelected = false
+    private var isSiteSelected = false
 
     val onScrollTo: LiveData<Event<Int>> = merge(
             _activeTaskPosition.distinctUntilChanged(),
@@ -152,7 +152,7 @@ class MySiteViewModel @Inject constructor(
 
     val state: LiveData<MySiteUiState> =
             selectedSiteRepository.siteSelected.switchMap { siteLocalId ->
-                _isSiteSelected = true
+                isSiteSelected = true
                 resetShownTrackers()
                 val result = MediatorLiveData<SiteIdToState>()
                 for (newSource in mySiteSourceManager.build(viewModelScope, siteLocalId)) {
@@ -518,8 +518,8 @@ class MySiteViewModel @Inject constructor(
     }
 
     fun onResume() {
-        mySiteSourceManager.onResume(_isSiteSelected)
-        _isSiteSelected = false
+        mySiteSourceManager.onResume(isSiteSelected)
+        isSiteSelected = false
         checkAndShowQuickStartNotice()
         _onShowSwipeRefreshLayout.postValue(Event(mySiteDashboardPhase2FeatureConfig.isEnabled()))
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -126,7 +126,8 @@ class MySiteViewModel @Inject constructor(
     private val _activeTaskPosition = MutableLiveData<Pair<QuickStartTask, Int>>()
     private val _onShowSwipeRefreshLayout = MutableLiveData<Event<Boolean>>()
 
-    // Capture and track the site selected event so we can circumvent refreshing sources on resume as they're already built on site select.
+    /* Capture and track the site selected event so we can circumvent refreshing sources on resume
+       as they're already built on site select. */
     private var _isSiteSelected = false
 
     val onScrollTo: LiveData<Event<Int>> = merge(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -126,8 +126,8 @@ class MySiteViewModel @Inject constructor(
     private val _activeTaskPosition = MutableLiveData<Pair<QuickStartTask, Int>>()
     private val _onShowSwipeRefreshLayout = MutableLiveData<Event<Boolean>>()
 
-    // Capture and track the first `onResume` event so we can circumvent refreshing sources on initial onResume
-    private var _isFirstResume = true
+    // Capture and track the site selected event so we can circumvent refreshing sources on resume as they're already built on site select.
+    private var _isSiteSelected = false
 
     val onScrollTo: LiveData<Event<Int>> = merge(
             _activeTaskPosition.distinctUntilChanged(),
@@ -151,6 +151,7 @@ class MySiteViewModel @Inject constructor(
 
     val state: LiveData<MySiteUiState> =
             selectedSiteRepository.siteSelected.switchMap { siteLocalId ->
+                _isSiteSelected = true
                 resetShownTrackers()
                 val result = MediatorLiveData<SiteIdToState>()
                 for (newSource in mySiteSourceManager.build(viewModelScope, siteLocalId)) {
@@ -516,8 +517,8 @@ class MySiteViewModel @Inject constructor(
     }
 
     fun onResume() {
-        mySiteSourceManager.onResume(_isFirstResume)
-        _isFirstResume = false
+        mySiteSourceManager.onResume(_isSiteSelected)
+        _isSiteSelected = false
         checkAndShowQuickStartNotice()
         _onShowSwipeRefreshLayout.postValue(Event(mySiteDashboardPhase2FeatureConfig.isEnabled()))
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -126,6 +126,9 @@ class MySiteViewModel @Inject constructor(
     private val _activeTaskPosition = MutableLiveData<Pair<QuickStartTask, Int>>()
     private val _onShowSwipeRefreshLayout = MutableLiveData<Event<Boolean>>()
 
+    // Capture and track the first `onResume` event so we can circumvent refreshing sources on initial onResume
+    private var _isFirstResume = true
+
     val onScrollTo: LiveData<Event<Int>> = merge(
             _activeTaskPosition.distinctUntilChanged(),
             quickStartRepository.activeTask
@@ -512,8 +515,9 @@ class MySiteViewModel @Inject constructor(
         mySiteSourceManager.refresh()
     }
 
-    fun onResume(isFirstResume: Boolean) {
-        mySiteSourceManager.onResume(isFirstResume)
+    fun onResume() {
+        mySiteSourceManager.onResume(_isFirstResume)
+        _isFirstResume = false
         checkAndShowQuickStartNotice()
         _onShowSwipeRefreshLayout.postValue(Event(mySiteDashboardPhase2FeatureConfig.isEnabled()))
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -20,7 +20,7 @@ class ScanAndBackupSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase
 ) : MySiteRefreshSource<JetpackCapabilities> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(false)
 
     fun clear() {
         jetpackCapabilitiesUseCase.clear()
@@ -28,8 +28,8 @@ class ScanAndBackupSource @Inject constructor(
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<JetpackCapabilities> {
         val result = MediatorLiveData<JetpackCapabilities>()
-        result.refreshData(coroutineScope, siteLocalId)
         result.addSource(refresh) { result.refreshData(coroutineScope, siteLocalId, refresh.value) }
+        refresh()
         return result
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -24,13 +24,13 @@ class CardsSource @Inject constructor(
     private val cardsStore: CardsStore,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : MySiteRefreshSource<CardsUpdate> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(false)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<CardsUpdate> {
         val result = MediatorLiveData<CardsUpdate>()
         result.getData(coroutineScope, siteLocalId)
-        result.refreshData(coroutineScope, siteLocalId)
         result.addSource(refresh) { result.refreshData(coroutineScope, siteLocalId, refresh.value) }
+        refresh()
         return result
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSource.kt
@@ -34,7 +34,7 @@ class DomainRegistrationSource @Inject constructor(
     private val appLogWrapper: AppLogWrapper,
     private val siteUtils: SiteUtilsWrapper
 ) : MySiteRefreshSource<DomainCreditAvailable> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(false)
 
     private val continuations = mutableMapOf<Int, CancellableContinuation<OnPlansFetched>?>()
 
@@ -48,8 +48,8 @@ class DomainRegistrationSource @Inject constructor(
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DomainCreditAvailable> {
         val data = MediatorLiveData<DomainCreditAvailable>()
-        data.refreshData(coroutineScope, siteLocalId)
         data.addSource(refresh) { data.refreshData(coroutineScope, siteLocalId, refresh.value) }
+        refresh()
         return data
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
@@ -21,7 +21,7 @@ class QuickStartCardSource @Inject constructor(
     private val quickStartUtilsWrapper: QuickStartUtilsWrapper,
     private val selectedSiteRepository: SelectedSiteRepository
 ) : MySiteRefreshSource<QuickStartUpdate> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(false)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<QuickStartUpdate> {
         quickStartRepository.resetTask()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
@@ -17,14 +17,14 @@ class DynamicCardsSource
     private val dynamicCardStore: DynamicCardStore,
     private val selectedSiteRepository: SelectedSiteRepository
 ) : MySiteRefreshSource<DynamicCardsUpdate> {
-    override val refresh = MutableLiveData(true)
+    override val refresh = MutableLiveData(false)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DynamicCardsUpdate> {
         val data = MediatorLiveData<DynamicCardsUpdate>()
-        data.refreshData(coroutineScope, siteLocalId)
         data.addSource(refresh) {
             data.refreshData(coroutineScope, siteLocalId, refresh.value)
         }
+        refresh()
         return data
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSource.kt
@@ -20,12 +20,10 @@ class DynamicCardsSource
     override val refresh = MutableLiveData(false)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<DynamicCardsUpdate> {
-        val data = MediatorLiveData<DynamicCardsUpdate>()
-        data.addSource(refresh) {
-            data.refreshData(coroutineScope, siteLocalId, refresh.value)
-        }
+        val result = MediatorLiveData<DynamicCardsUpdate>()
+        result.addSource(refresh) { result.refreshData(coroutineScope, siteLocalId, refresh.value) }
         refresh()
-        return data
+        return result
     }
 
     private fun MediatorLiveData<DynamicCardsUpdate>.refreshData(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/CurrentAvatarSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/CurrentAvatarSourceTest.kt
@@ -47,12 +47,12 @@ class CurrentAvatarSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when buildSource is invoked, then refresh is false`() = test {
+    fun `when buildSource is invoked, then refresh is true`() = test {
         currentAvatarSource.refresh.observeForever { isRefreshing.add(it) }
 
         currentAvatarSource.build(testScope())
 
-        assertThat(isRefreshing.last()).isFalse
+        assertThat(isRefreshing.last()).isTrue
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
@@ -279,7 +279,7 @@ class MySiteSourceManagerTest : BaseUnitTest() {
     /* ON RESUME */
 
     @Test
-    fun `given not first resume and phase 2 disabled, when on resume, then update site settings if necessary`() {
+    fun `given site not selected and phase 2 disabled, when on resume, then update site settings if necessary`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(false)
 
         mySiteSourceManager.onResume(false)
@@ -288,7 +288,7 @@ class MySiteSourceManagerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given not first resume and phase 2 disabled, when on resume, then refresh quick start`() {
+    fun `given site not selected and phase 2 disabled, when on resume, then refresh quick start`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(false)
 
         mySiteSourceManager.onResume(false)
@@ -297,7 +297,7 @@ class MySiteSourceManagerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given not first resume and phase 2 disabled, when on resume, then refresh current avatar`() {
+    fun `given site not selected and phase 2 disabled, when on resume, then refresh current avatar`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(false)
 
         mySiteSourceManager.onResume(false)
@@ -306,49 +306,49 @@ class MySiteSourceManagerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given first resume and phase 2 disabled, when on resume, then update site settings if necessary`() {
+    fun `given site selected and phase 2 disabled, when on resume, then update site settings if necessary`() {
         mySiteSourceManager.onResume(true)
 
         verify(selectedSiteSource).updateSiteSettingsIfNecessary()
     }
 
     @Test
-    fun `given first resume and phase 2 disabled, when on resume, then refresh quick start`() {
+    fun `given site selected and phase 2 disabled, when on resume, then refresh quick start`() {
         mySiteSourceManager.onResume(true)
 
         verify(quickStartCardSource).refresh()
     }
 
     @Test
-    fun `given first resume and phase 2 disabled, when on resume, then refresh current avatar`() {
+    fun `given site selected and phase 2 disabled, when on resume, then refresh current avatar`() {
         mySiteSourceManager.onResume(true)
 
         verify(currentAvatarSource).refresh()
     }
 
     @Test
-    fun `given first resume and phase 2 enabled, when on resume, then update site settings if necessary`() {
+    fun `given site selected and phase 2 enabled, when on resume, then update site settings if necessary`() {
         mySiteSourceManager.onResume(true)
 
         verify(selectedSiteSource).updateSiteSettingsIfNecessary()
     }
 
     @Test
-    fun `given first resume and phase 2 enabled, when on resume, then refresh quick start`() {
+    fun `given site selected and phase 2 enabled, when on resume, then refresh quick start`() {
         mySiteSourceManager.onResume(true)
 
         verify(quickStartCardSource).refresh()
     }
 
     @Test
-    fun `given first resume and phase 2 enabled, when on resume, then refresh current avatar`() {
+    fun `given site selected and phase 2 enabled, when on resume, then refresh current avatar`() {
         mySiteSourceManager.onResume(true)
 
         verify(currentAvatarSource).refresh()
     }
 
     @Test
-    fun `given first resume and phase 2 enabled, when on resume, then refresh is invoked`() {
+    fun `given site selected and phase 2 enabled, when on resume, then refresh is invoked`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
 
         mySiteSourceManager.onResume(false)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -436,25 +436,23 @@ class MySiteViewModelTest : BaseUnitTest() {
     /* ON RESUME */
     @Test
     fun `given not first resume, when on resume is triggered, then mySiteSourceManager onResume is invoked`() {
-        val firstResume = true
+        viewModel.onResume() // first call
 
-        viewModel.onResume(firstResume)
+        viewModel.onResume() // second call
 
-        verify(mySiteSourceManager).onResume(firstResume)
+        verify(mySiteSourceManager).onResume(false)
     }
 
     @Test
     fun `given first resume, when on resume is triggered, then mySiteSourceManager onResume is invoked`() {
-        val firstResume = false
+        viewModel.onResume()
 
-        viewModel.onResume(firstResume)
-
-        verify(mySiteSourceManager).onResume(firstResume)
+        verify(mySiteSourceManager).onResume(true)
     }
 
     @Test
     fun `when first onResume is triggered, then checkAndShowQuickStartNotice is invoked`() {
-        viewModel.onResume(false)
+        viewModel.onResume()
 
         verify(quickStartRepository).checkAndShowQuickStartNotice()
     }
@@ -1459,8 +1457,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Test
     fun `given not first resume and phase 2 enabled, when on resume, then swipe refresh layout is enabled`() = test {
         init(enableMySiteDashboardConfig = true)
+        viewModel.onResume() // first call
 
-        viewModel.onResume(false)
+        viewModel.onResume() // second call
 
         assertThat(showSwipeRefreshLayout.last()).isEqualTo(true)
     }
@@ -1469,8 +1468,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Test
     fun `given not first resume and phase 2 disabled, when on resume, then swipe refresh layout is disabled`() = test {
         init(enableMySiteDashboardConfig = false)
+        viewModel.onResume() // first call
 
-        viewModel.onResume(false)
+        viewModel.onResume() // second call
 
         assertThat(showSwipeRefreshLayout.last()).isEqualTo(false)
     }
@@ -1480,7 +1480,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given first resume and phase 2 enabled, when on resume, then swipe refresh layout is enabled`() = test {
         init(enableMySiteDashboardConfig = true)
 
-        viewModel.onResume(true)
+        viewModel.onResume()
 
         assertThat(showSwipeRefreshLayout.last()).isEqualTo(true)
     }
@@ -1490,7 +1490,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given first resume and phase 2 disabled, when on resume, then swipe refresh layout is disabled`() = test {
         init(enableMySiteDashboardConfig = false)
 
-        viewModel.onResume(true)
+        viewModel.onResume()
 
         assertThat(showSwipeRefreshLayout.last()).isEqualTo(false)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -117,13 +117,13 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when source is invoked, then refresh is false`() = test {
+    fun `when build is invoked, then refresh is true`() = test {
         initScanAndBackupSource(hasSelectedSite = true, scanPurchased = true, backupPurchased = true)
         scanAndBackupSource.refresh.observeForever { isRefreshing.add(it) }
 
         scanAndBackupSource.build(testScope(), siteLocalId)
 
-        assertThat(isRefreshing.last()).isFalse
+        assertThat(isRefreshing.last()).isTrue
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
@@ -197,7 +197,8 @@ class CardsSourceTest : BaseUnitTest() {
 
         cardSource.build(testScope(), SITE_LOCAL_ID).observeForever { }
 
-        assertThat(result.size).isEqualTo(1)
+        assertThat(result.size).isEqualTo(2)
+        assertThat(result.first()).isFalse
         assertThat(result.last()).isTrue
     }
 
@@ -211,11 +212,12 @@ class CardsSourceTest : BaseUnitTest() {
 
         cardSource.refresh()
 
-        assertThat(result.size).isEqualTo(4)
-        assertThat(result[0]).isTrue // init
-        assertThat(result[1]).isFalse // build(...) -> cardsStore.fetchCards(...) -> success
-        assertThat(result[2]).isTrue // refresh()
-        assertThat(result[3]).isFalse // refreshData(...) -> cardsStore.fetchCards(...) -> success
+        assertThat(result.size).isEqualTo(5)
+        assertThat(result[0]).isFalse // init
+        assertThat(result[1]).isTrue // build(...) -> refresh()
+        assertThat(result[2]).isFalse // build(...) -> cardsStore.fetchCards(...) -> success
+        assertThat(result[3]).isTrue // refresh()
+        assertThat(result[4]).isFalse // refreshData(...) -> cardsStore.fetchCards(...) -> success
     }
 
     @Test
@@ -228,11 +230,12 @@ class CardsSourceTest : BaseUnitTest() {
 
         cardSource.refresh()
 
-        assertThat(result.size).isEqualTo(4)
-        assertThat(result[0]).isTrue // init
-        assertThat(result[1]).isFalse // build(...) -> cardsStore.fetchCards(...) -> success
-        assertThat(result[2]).isTrue // refresh()
-        assertThat(result[3]).isFalse // refreshData(...) -> cardsStore.fetchCards(...) -> success
+        assertThat(result.size).isEqualTo(5)
+        assertThat(result[0]).isFalse // init
+        assertThat(result[1]).isTrue // build(...) -> refresh()
+        assertThat(result[2]).isFalse // build(...) -> cardsStore.fetchCards(...) -> success
+        assertThat(result[3]).isTrue // refresh()
+        assertThat(result[4]).isFalse // refreshData(...) -> cardsStore.fetchCards(...) -> success
     }
 
     @Test
@@ -245,11 +248,12 @@ class CardsSourceTest : BaseUnitTest() {
 
         cardSource.refresh()
 
-        assertThat(result.size).isEqualTo(4)
-        assertThat(result[0]).isTrue // init
-        assertThat(result[1]).isFalse // build(...) -> cardsStore.fetchCards(...) -> error
-        assertThat(result[2]).isTrue // refresh()
-        assertThat(result[3]).isFalse // refreshData(...) -> cardsStore.fetchCards(...) -> error
+        assertThat(result.size).isEqualTo(5)
+        assertThat(result[0]).isFalse // init
+        assertThat(result[1]).isTrue // build(...) -> refresh()
+        assertThat(result[2]).isFalse // build(...) -> cardsStore.fetchCards(...) -> error
+        assertThat(result[3]).isTrue // refresh()
+        assertThat(result[4]).isFalse // refreshData(...) -> cardsStore.fetchCards(...) -> error
     }
 
     /* INVALID SITE */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/domainregistration/DomainRegistrationSourceTest.kt
@@ -107,7 +107,7 @@ class DomainRegistrationSourceTest : BaseUnitTest() {
 
         source.build(testScope(), siteLocalId)
 
-        assertThat(isRefreshing.first()).isTrue
+        assertThat(isRefreshing.last()).isTrue
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
@@ -101,13 +101,13 @@ class DynamicCardsSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given selected site, when source is build, then refresh is false`() = test {
+    fun `given selected site, when source is build, then refresh is true`() = test {
         initDynamicCardsSource(hasSelectedSite = true)
         dynamicCardsSource.refresh.observeForever { isRefreshing.add(it) }
 
         dynamicCardsSource.build(testScope(), siteLocalId)
 
-        assertThat(isRefreshing.last()).isFalse
+        assertThat(isRefreshing.last()).isTrue
     }
 
     @Test


### PR DESCRIPTION
Fixes #15769

This PR fixes the duplicate `Error Snackbar` issue on a site switch.

https://user-images.githubusercontent.com/1405144/148212370-56f32bc5-3817-4e78-b51b-835d0bafc857.mp4

The issue occurred because we refreshed the `My Site Sources` inside `onResume` just after building them on a site switch. For the dashboard cards source, since both build and refresh returned a snackbar error, we started seeing a duplicate snackbar. This PR
- Prevents refreshing all sources after build by invoking `MySiteSourceManager.onResume` with a value `true` every time a site is selected (it can be on the initial fragment resume or site switch). - faf9c25
- Displays a progress bar whenever a source build is invoked (or indirectly a site is selected). - fefc5db

To test:

- Install the app and let at least one dashboard card appear for a site. 
- Inside `FluxC` code, return an error `CardsResult(CardsError(CardsErrorType.GENERIC_ERROR))` from `CardsStore.storeCards`.
- Use `localFluxCPath` inside `WordPress-Android` app.
- Reinstall the app. 
- Notice that the error `snackbar` is shown.
- Switch to a different site, then return to the previous site (for other sites error card might be displayed instead of the snackbar with no dashboard cards entries the db).
- Notice that a progress indicator is shown when a site is switched and the error `snackbar` is shown only once for the site.

## Regression Notes
1. Potential unintended areas of impact
The initial resume scenario (see faf9c25) should work as before. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually. Updated existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
Updated existing unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
