### PR TITLE
[Gutenberg] Integrate alpha version `v1.69.0-alpha2`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.2.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = 'v1.69.0-alpha1'
+    gutenbergMobileVersion = 'v1.69.0-alpha2'
     storiesVersion = '1.2.0'
     aboutAutomatticVersion = '0.0.2'
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.aztecVersion = 'v1.5.2'
+    ext.aztecVersion = 'v1.5.3'
 }
 
 repositories {


### PR DESCRIPTION
The purpose of this PR is to integrate the latest changes from Gutenberg Mobile via the alpha version `v1.69.0-alpha2`, and update the Aztec version of WordPressEditor library to `v1.5.3` as it's required by the changes.

**Changes:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/4423
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/4414 (the changes of this PR were merged along the previous one)

## Regression Notes
1. Potential unintended areas of impact
All changes should only affect the editor hence, I don't foresee any other unintended areas of impact.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Both PRs have been manually tested.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
