### PR TITLE
My Site Dashboard - Phase2: Fix indefinite spinner on app close then reopen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
@@ -32,6 +32,7 @@ class SelectedSiteSource @Inject constructor(
         siteLocalId: Int
     ) = selectedSiteRepository.selectedSiteChange
             .filter { it == null || it.id == siteLocalId }
+            .apply { onRefreshedMainThread() }
             .map { SelectedSite(it) }
 
     override fun refresh() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteSourceTest.kt
@@ -66,13 +66,15 @@ class SelectedSiteSourceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given selected site, when build is invoked, then refresh is true`() = test {
+    fun `given selected site, when build is invoked, then refresh changes from true to false`() = test {
         initSelectedSiteSource(hasSelectedSite = true)
         source.refresh.observeForever { isRefreshing.add(it) }
 
+        assertThat(isRefreshing.last()).isTrue
+
         source.build(testScope(), siteLocalId).observeForever { result.add(it) }
 
-        assertThat(isRefreshing.last()).isTrue
+        assertThat(isRefreshing.last()).isFalse
     }
 
     @Test


### PR DESCRIPTION
Fixes #15767 

This PR stops the refreshing indicator from showing indefinitely when closing the application (using the back press/swipe) and then re-opening.

**To test:**
- Launch the app.
- Verify that the pull-to-refresh appears for a second or two, and then disappears.
- Tap the device back button or swipe the app closed
- Re-open the app
- Note: The pull-to-refresh indicator appears and then disappears.

## Regression Notes
1. Potential unintended areas of impact 
The refreshing indicator remains visible

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual

3. What automated tests I added (or what prevented me from doing so)
Updated unit test to verify resetting the refresh property

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
