### PR TITLE
Integrate gutenberg-mobile release 1.69.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,11 @@
 19.0
 -----
 * [**] Video uploads: video upload is now limited to 5 minutes per video on free plans.
+* [*] Block editor: Give multi-line block names central alignment in inserter [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4343]
+* [**] Block editor: Fix missing translations by refactoring the editor initialization code [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4332]
+* [**] Block editor: Add Jetpack and Layout Grid translations [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4359]
+* [**] Block editor: Fix text formatting mode lost after backspace is used [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4423]
+* [*] Block editor: Add missing translations of unsupported block editor modal [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4410]
 
 18.9
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.2.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = '4438-6ce40f20f16d2cb7b546cadd9e92b6f3c0cd8388'
+    gutenbergMobileVersion = 'v1.69.0'
     storiesVersion = '1.2.0'
     aboutAutomatticVersion = '0.0.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.2.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = 'v1.69.0-alpha2'
+    gutenbergMobileVersion = '4438-6ce40f20f16d2cb7b546cadd9e92b6f3c0cd8388'
     storiesVersion = '1.2.0'
     aboutAutomatticVersion = '0.0.2'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.69.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4438

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.