### PR TITLE
Update about automattic library to latest v0.0.4

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -58,7 +58,7 @@ class UnifiedAboutViewModel @Inject constructor(
                     privacyPolicyUrl = Constants.URL_PRIVACY_POLICY,
                     acknowledgementsUrl = LICENSES_FILE_URL
             ),
-            analyticsTracker = AnalyticsConfig(
+            analyticsConfig = AnalyticsConfig(
                     trackScreenShown = unifiedAboutTracker::trackScreenShown,
                     trackScreenDismissed = unifiedAboutTracker::trackScreenDismissed,
                     trackButtonTapped = unifiedAboutTracker::trackButtonTapped

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3864,8 +3864,22 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- About -->
     <string name="about_blog">Blog</string>
+    <string name="about_automattic_app_name">About Automattic</string>
     <string name="about_automattic_main_page_title">About %1$s</string>
     <string name="about_automattic_legal_page_title">Legal and More</string>
     <string name="about_automattic_acknowledgements_page_title">Acknowledgements</string>
     <string name="about_automattic_version_label">Version %1$s</string>
+    <string name="about_automattic_share_with_friends">Share with friends</string>
+    <string name="about_automattic_rate_us">Rate us</string>
+    <string name="about_automattic_instagram">Instagram</string>
+    <string name="about_automattic_twitter">Twitter</string>
+    <string name="about_automattic_legal_and_more">Legal and more</string>
+    <string name="about_automattic_family">Automattic family</string>
+    <string name="about_automattic_work_with_us">Work with us</string>
+    <string name="about_automattic_work_from_anywhere">Work from anywhere</string>
+    <string name="about_automattic_terms_of_service">Terms of service</string>
+    <string name="about_automattic_privacy_policy">Privacy policy</string>
+    <string name="about_automattic_california_privacy_notice">California privacy notice</string>
+    <string name="about_automattic_source_code">Source code</string>
+    <string name="about_automattic_acknowledgements">Acknowledgements</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3864,22 +3864,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- About -->
     <string name="about_blog">Blog</string>
-    <string name="about_automattic_app_name">About Automattic</string>
     <string name="about_automattic_main_page_title">About %1$s</string>
     <string name="about_automattic_legal_page_title">Legal and More</string>
     <string name="about_automattic_acknowledgements_page_title">Acknowledgements</string>
     <string name="about_automattic_version_label">Version %1$s</string>
-    <string name="about_automattic_share_with_friends">Share with friends</string>
-    <string name="about_automattic_rate_us">Rate us</string>
-    <string name="about_automattic_instagram">Instagram</string>
-    <string name="about_automattic_twitter">Twitter</string>
-    <string name="about_automattic_legal_and_more">Legal and more</string>
-    <string name="about_automattic_family">Automattic family</string>
-    <string name="about_automattic_work_with_us">Work with us</string>
-    <string name="about_automattic_work_from_anywhere">Work from anywhere</string>
-    <string name="about_automattic_terms_of_service">Terms of service</string>
-    <string name="about_automattic_privacy_policy">Privacy policy</string>
-    <string name="about_automattic_california_privacy_notice">California privacy notice</string>
-    <string name="about_automattic_source_code">Source code</string>
-    <string name="about_automattic_acknowledgements">Acknowledgements</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ ext {
     wordPressLoginVersion = '0.0.8'
     gutenbergMobileVersion = 'v1.69.0'
     storiesVersion = '1.2.0'
-    aboutAutomatticVersion = '0.0.2'
+    aboutAutomatticVersion = '0.0.4'
 
     minSdkVersion = 24
     compileSdkVersion = 31


### PR DESCRIPTION
Updated about automattic library version from 0.0.2 to 0.0.4

This PR updates the about-automattic library version v0.0.2 to v0.0.4 and includes changes from [0.0.3](https://github.com/Automattic/about-automattic-android/releases/tag/0.0.3) and [0.0.4](https://github.com/Automattic/about-automattic-android/releases/tag/0.0.4)

Fixes 30-gh-Automattic/about-automattic-android

To test:

- Use a Samsung device like s10e or z-flip if you have one, otherwise create an emulator with an image like 6.7 Horizontal Fold-in from AVD Manager in AS
- Launch app, On MySite, Go to Me by clicking on avatar on top right hand corner
- Notice About WordPress (second from bottom), click on it to see new Unified About 
- Notice tumbler logo is not cut-off and fits withing the width


## Regression Notes
1. Potential unintended areas of impact
None that is known

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing


3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.