### PR TITLE
[Tooling] Fix default branch in Fastfile back to develop

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -114,7 +114,7 @@ import './ScreenshotFastfile'
 Dotenv.load(USER_ENV_FILE_PATH)
 ENV[GHHELPER_REPO = 'wordpress-mobile/WordPress-Android']
 ENV['PROJECT_ROOT_FOLDER'] = File.dirname(File.expand_path(__dir__)) + '/'
-ENV['FL_RELEASE_TOOLKIT_DEFAULT_BRANCH'] = 'trunk'
+ENV['FL_RELEASE_TOOLKIT_DEFAULT_BRANCH'] = 'develop'
 REPOSITORY_NAME = 'WordPress-Android'
 
 ########################################################################


### PR DESCRIPTION
As the migration to trunk hasn't happened just yet.

The PR https://github.com/wordpress-mobile/WordPress-Android/pull/15725 updated the release toolkit to 2.3.0 and set the `FL_RELEASE_TOOLKIT_DEFAULT_BRANCH ` to `trunk`, but wasn't supposed to be merged until the migration occured.

I made the mistake of merging this PR on Friday while wrangling the 18.9 submission, mistakenly thinking the toolkit update would be needed to avoid breaking my submissiojn/release tasks I was too fast in doing so as I should have re-read @oguzkocer 's mention in that PR description about "Please DO NOT merge this PR until the default branch change is applied".

This PR fixes my mistake by changing `FL_RELEASE_TOOLKIT_DEFAULT_BRANCH` to `develop` (until @oguzkocer gets to officially migrate this WPAndroid repo `trunk` later this sprint and change that to `trunk` again once it's ready).