### PR TITLE
My Site Dashboard: Phase 2: Metrics - Track Post Card Item Tapped

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -760,6 +760,7 @@ class MySiteViewModel @Inject constructor(
 
     private fun onPostItemClick(params: PostItemClickParams) {
         selectedSiteRepository.getSelectedSite()?.let { site ->
+            cardsTracker.trackPostItemClicked(params.postCardType)
             when (params.postCardType) {
                 PostCardType.DRAFT -> _onNavigation.value =
                         Event(SiteNavigationAction.EditDraftPost(site, params.postId))

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -29,9 +29,23 @@ class CardsTracker @Inject constructor(
         trackCardFooterLinkClicked(Type.POST.label, postCardType.toSubtypeValue().label)
     }
 
+    fun trackPostItemClicked(postCardType: PostCardType) {
+        trackCardPostItemClicked(Type.POST.label, postCardType.toSubtypeValue().label)
+    }
+
     private fun trackCardFooterLinkClicked(type: String, subtype: String) {
         analyticsTrackerWrapper.track(
                 Stat.MY_SITE_DASHBOARD_CARD_FOOTER_ACTION_TAPPED,
+                mapOf(
+                        TYPE to type,
+                        SUBTYPE to subtype
+                )
+        )
+    }
+
+    private fun trackCardPostItemClicked(type: String, subtype: String) {
+        analyticsTrackerWrapper.track(
+                Stat.MY_SITE_DASHBOARD_CARD_ITEM_TAPPED,
                 mapOf(
                         TYPE to type,
                         SUBTYPE to subtype

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1105,6 +1105,15 @@ class MySiteViewModelTest : BaseUnitTest() {
                 assertThat(navigationActions).containsOnly(SiteNavigationAction.EditScheduledPost(site, postId))
             }
 
+    @Test
+    fun `given post card, when item is clicked, then event is tracked`() = test {
+        initSelectedSite()
+
+        requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.SCHEDULED, postId))
+
+        verify(cardsTracker).trackPostItemClicked(PostCardType.SCHEDULED)
+    }
+
     /* DASHBOARD ERROR SNACKBAR */
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -54,12 +54,36 @@ class CardsTrackerTest {
         verifyFooterLinkClickedTracked(Type.POST, PostSubtype.SCHEDULED)
     }
 
+    @Test
+    fun `when post draft item is clicked, then post item event is tracked`() {
+        cardsTracker.trackPostItemClicked(PostCardType.DRAFT)
+
+        verifyPostItemClickedTracked(Type.POST, PostSubtype.DRAFT)
+    }
+
+    @Test
+    fun `when post scheduled item is clicked, then post item event is tracked`() {
+        cardsTracker.trackPostItemClicked(PostCardType.SCHEDULED)
+
+        verifyPostItemClickedTracked(Type.POST, PostSubtype.SCHEDULED)
+    }
+
     private fun verifyFooterLinkClickedTracked(
         typeValue: Type,
         subtypeValue: PostSubtype
     ) {
         verify(analyticsTracker).track(
                 Stat.MY_SITE_DASHBOARD_CARD_FOOTER_ACTION_TAPPED,
+                mapOf(TYPE to typeValue.label, SUBTYPE to subtypeValue.label)
+        )
+    }
+
+    private fun verifyPostItemClickedTracked(
+        typeValue: Type,
+        subtypeValue: PostSubtype
+    ) {
+        verify(analyticsTracker).track(
+                Stat.MY_SITE_DASHBOARD_CARD_ITEM_TAPPED,
                 mapOf(TYPE to typeValue.label, SUBTYPE to subtypeValue.label)
         )
     }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -821,7 +821,8 @@ public final class AnalyticsTracker {
         MY_SITE_DASHBOARD_CARD_FOOTER_ACTION_TAPPED,
         MY_SITE_PULL_TO_REFRESH,
         MY_SITE_MENU_ITEM_TAPPED,
-        MY_SITE_DASHBOARD_CARD_SHOWN
+        MY_SITE_DASHBOARD_CARD_SHOWN,
+        MY_SITE_DASHBOARD_CARD_ITEM_TAPPED,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2144,6 +2144,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "my_site_menu_item_tapped";
             case MY_SITE_DASHBOARD_CARD_SHOWN:
                 return "my_site_dashboard_card_shown";
+            case MY_SITE_DASHBOARD_CARD_ITEM_TAPPED:
+                return "my_site_dashboard_card_item_tapped";
         }
         return null;
     }


### PR DESCRIPTION
Fixes #15730 

This PR tracks taps on the Post Item Link

Taps are tracked as **MY_SITE_DASHBOARD_CARD_ITEM_TAPPED** with the following properties:
- type = “post”
- sub_type = “drafts”, “scheduled”

**To test:**
Setup
- Launch the app
- Navigate to Me -> App Settings -> Debug Settings
- Ensure that the `MySiteDashboardPhase2FeatureConfig` is to set to on
- Restart the app if needed
- Navigate to Me -> App Settings -> Privacy Settings 
- Toggle the "collect information" switch to on
- Navigate to the My Site tab
------------------------
- Select a site that has draft posts
- Tap on an individual post item from within the "Drafts" card
- Navigate to Me -> Help and Support -> Application log
- Note that the following is shown in the log
I: 🔵 Tracked: my_site_dashboard_card_item_tapped, Properties: {"type":"post","subtype":"draft"}
-----------------------
- Select a site that has scheduled posts
- Tap on an individual post item from within the "Scheduled" card
- Navigate to Me -> Help and Support -> Application log
- Note that the following is shown in the log
I: 🔵 Tracked: my_site_dashboard_card_item_tapped, Properties: {"type":"post","subtype":"scheduled"}

## Regression Notes
1. Potential unintended areas of impact N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)
CardsTrackerTests and MySiteViewModelTests were updated

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
