### PR TITLE
My Site Dashboard - Stats Card - Add Feature Flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -112,6 +112,7 @@ android {
         buildConfigField "boolean", "RECOMMEND_THE_APP", "false"
         buildConfigField "boolean", "UNIFIED_COMMENTS_COMMENT_EDIT", "false"
         buildConfigField "boolean", "MY_SITE_DASHBOARD_PHASE_2", "false"
+        buildConfigField "boolean", "MY_SITE_DASHBOARD_STATS_CARD", "false"
         buildConfigField "boolean", "UNIFIED_COMMENTS_DETAILS", "false"
         buildConfigField "boolean", "UNIFIED_ABOUT", "false"
         buildConfigField "boolean", "COMMENTS_SNIPPET", "false"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardStatsCardFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardStatsCardFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration of the 'My Site Dashboard - Stats Card' that will add Stats Card on the 'My Site' screen.
+ */
+@FeatureInDevelopment
+class MySiteDashboardStatsCardFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.MY_SITE_DASHBOARD_STATS_CARD
+)


### PR DESCRIPTION
Fixes #15748

This PR adds a feature flag for "My Site Dashboard - Stats Card".

To test:

1. Launch the app.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Test Feature Configuration`.
3. Notice that `MySiteDashboardStatsCardFeatureConfig` exists under `Features in development` section.

<img width=320 src ="https://user-images.githubusercontent.com/1405144/148913318-93d69dee-c422-4cfe-bf51-0fc157b610a4.png"/>

To test:

## Regression Notes
1. Potential unintended areas of impact 🟢 


2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 


3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
