### PR TITLE
Put back Share with friends under Me

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 * [**] Block editor: Fix text formatting mode lost after backspace is used [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4423]
 * [*] Block editor: Add missing translations of unsupported block editor modal [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4410]
 * [***] My Site: Introduced cards based dashboard feed with posts card [https://github.com/wordpress-mobile/WordPress-Android/issues/15198]
+* [*] Me: Put back the "Share WordPress with a friend" on the Me screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/15818]
 
 18.9
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -162,15 +162,14 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         }
 
         if (unifiedAboutFeatureConfig.isEnabled()) {
-            recommendTheAppContainer.isVisible = false
             aboutTheAppContainer.isVisible = true
 
             rowAboutTheApp.setOnClickListener {
                 viewModel.showUnifiedAbout()
             }
-        } else {
-            initRecommendUiState()
         }
+
+        initRecommendUiState()
 
         viewModel.showUnifiedAbout.observeEvent(viewLifecycleOwner, {
             startActivity(Intent(activity, UnifiedAboutActivity::class.java))


### PR DESCRIPTION
Based on the analysis of tracks on new about feature.  It was suggested to put back Share with friends under Me

| Before | After |
|---|---|
| ![device-2022-01-13-095842](https://user-images.githubusercontent.com/990349/149237311-7306b063-4730-4f85-a366-28ea6c62de58.png) | ![device-2022-01-13-095745](https://user-images.githubusercontent.com/990349/149237342-d12713e9-d717-4443-8791-01949f7bd6c2.png) |


Fixes #

To test:

* Build and run
* Navigate to the Me screen (tap the avatar in the top right of the My Site screen)
* See the "Share WordPress with a friend" above About WordPress as in after image above
* Click on Share WordPress with a friend and a share sheet pops out and are able to share

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
