### PR TITLE
Update fastlane release toolkit default branch to trunk

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -114,7 +114,7 @@ import './ScreenshotFastfile'
 Dotenv.load(USER_ENV_FILE_PATH)
 ENV[GHHELPER_REPO = 'wordpress-mobile/WordPress-Android']
 ENV['PROJECT_ROOT_FOLDER'] = File.dirname(File.expand_path(__dir__)) + '/'
-ENV['FL_RELEASE_TOOLKIT_DEFAULT_BRANCH'] = 'develop'
+ENV['FL_RELEASE_TOOLKIT_DEFAULT_BRANCH'] = 'trunk'
 REPOSITORY_NAME = 'WordPress-Android'
 
 ########################################################################


### PR DESCRIPTION
This PR updates the release toolkit default branch in the release branch in preparation of the default branch change on Monday. This is a smaller subset of the changes we are making in https://github.com/wordpress-mobile/WordPress-Android/pull/15652 against `develop`.

Please approve this PR, but **do not merge it**.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
