### PR TITLE
Integrate gutenberg-mobile release 1.69.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.2.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = '4477-59ed92c4552f9f7af3956bddb141463aacaf03ee'
+    gutenbergMobileVersion = 'v1.69.1'
     storiesVersion = '1.2.0'
     aboutAutomatticVersion = '0.0.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.2.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = 'v1.69.0'
+    gutenbergMobileVersion = '4477-59ed92c4552f9f7af3956bddb141463aacaf03ee'
     storiesVersion = '1.2.0'
     aboutAutomatticVersion = '0.0.4'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.69.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4477

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.