### PR TITLE
Point to gb-mobile hash with removal of wordpressUtilsVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.2.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = 'v1.70.0-alpha1'
+    gutenbergMobileVersion = '4480-1d26f2c705fd08953b6e2479e799e462c0d40554'
     storiesVersion = '1.2.0'
     aboutAutomatticVersion = '0.0.4'
 


### PR DESCRIPTION
Testing out https://github.com/wordpress-mobile/gutenberg-mobile/pull/4480

### Related PRs

* https://github.com/WordPress/gutenberg/pull/38028
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/4480

### To test:

Nothing in particular. Perhaps smoke testing the editor just to be sure, although that's covered by the E2E tests.

## Regression Notes
1. Potential unintended areas of impact

None, the `utils` library is not used by the gutenberg-mobile code anyway (other than the Aztec wrapper itself, but the PRs here are not removing that dep).

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Triggered the E2E tests here in WPAndroid and in gutenberg-mobile's repo and are green.

3. What automated tests I added (or what prevented me from doing so)

None. No need.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
