### PR TITLE
My Site Dashboard - Post Card - Adjust TextView Width

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostItemViewHolder.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.posts
 
-import android.view.View
 import android.view.ViewGroup
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -33,7 +32,7 @@ class PostItemViewHolder(
                         UIDimenRes(R.dimen.my_site_post_item_image_corner_radius)
                 )
         )
-        featuredImage.visibility = if (postItem.featuredImageUrl == null) View.INVISIBLE else View.VISIBLE
+        featuredImage.setVisible(postItem.featuredImageUrl != null)
         iconTime.setVisible(postItem.isTimeIconVisible)
         itemView.setOnClickListener { postItem.onClick.click() }
     }


### PR DESCRIPTION
Parent: #15198

This PR adjusts `My Site Dashboard` post items's text view to take the space previously left empty for the featured image as suggested in beta testing here: p5T066-2Vl-p2#comment-10987

<img width=320 src="https://user-images.githubusercontent.com/1405144/149918001-5e66ac32-4df0-4e34-86d0-8a12f6f61062.jpg"/>


To test:

1. Launch the app. 
2. Login with a wpcom account.
3. Go to My Site screen.
4. Create a draft post with a long title and content. 
5. Notice that the title and content text fill the space previously left empty for the featured image. 


## Regression Notes
1. Potential unintended areas of impact 🟢 


2. What I did to test those areas of impact (or what existing automated tests I relied on)  🟢 


3. What automated tests I added (or what prevented me from doing so)  🟢 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.