### PR TITLE
Temporarily disable option to connect a Facebook account to Publicize

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -27,12 +27,14 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeService;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.services.PublicizeUpdateService;
 import org.wordpress.android.util.AppBarLayoutExtensionsKt;
+import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 
@@ -229,7 +231,11 @@ public class PublicizeListActivity extends LocaleAwareActivity
      */
     @Override
     public void onRequestConnect(PublicizeService service) {
-        showWebViewFragment(service, null);
+        if (isFacebook(service)) {
+            showFacebookWarning();
+        } else {
+            showWebViewFragment(service, null);
+        }
     }
 
     /*
@@ -237,8 +243,12 @@ public class PublicizeListActivity extends LocaleAwareActivity
      */
     @Override
     public void onRequestReconnect(PublicizeService service, PublicizeConnection publicizeConnection) {
-        PublicizeActions.reconnect(publicizeConnection);
-        showWebViewFragment(service, null);
+        if (isFacebook(service)) {
+            showFacebookWarning();
+        } else {
+            PublicizeActions.reconnect(publicizeConnection);
+            showWebViewFragment(service, null);
+        }
     }
 
     /*
@@ -247,6 +257,30 @@ public class PublicizeListActivity extends LocaleAwareActivity
     @Override
     public void onRequestDisconnect(PublicizeConnection publicizeConnection) {
         confirmDisconnect(publicizeConnection);
+    }
+
+    private boolean isFacebook(PublicizeService service) {
+        return service.getId().equals(PublicizeConstants.FACEBOOK_ID);
+    }
+
+    private String getConnectionsUrl(SiteModel site) {
+        return "https://wordpress.com/marketing/connections/" + SiteUtils.getHomeURLOrHostName(site);
+    }
+
+    /*
+     * As of Oct 5, 2021 Facebook has deprecated support for authentication on embedded browsers, so Publicize
+     * connections can't be established through web views anymore (ref: pbArwn-3uU-p2).
+     * This method shows a temporary warning message to the user instead.
+     */
+    private void showFacebookWarning() {
+        new MaterialAlertDialogBuilder(this)
+                .setMessage(R.string.sharing_facebook_warning_message)
+                .setPositiveButton(R.string.sharing_facebook_warning_positive_button,
+                        (dialog, id) -> ActivityLauncher.openUrlExternal(this, getConnectionsUrl(mSite)))
+                .setNegativeButton(R.string.cancel, null)
+                .setCancelable(true)
+                .create()
+                .show();
     }
 
     private void confirmDisconnect(final PublicizeConnection publicizeConnection) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -48,6 +48,8 @@ public class PublicizeListActivity extends LocaleAwareActivity
         PublicizeActions.OnPublicizeActionListener,
         PublicizeServiceAdapter.OnServiceClickListener,
         PublicizeListFragment.PublicizeButtonPrefsListener, ScrollableViewInitializedListener {
+    private static final String WPCOM_CONNECTIONS_URL = "https://wordpress.com/marketing/connections/";
+
     private SiteModel mSite;
     private ProgressDialog mProgressDialog;
     private AppBarLayout mAppBarLayout;
@@ -264,7 +266,7 @@ public class PublicizeListActivity extends LocaleAwareActivity
     }
 
     private String getConnectionsUrl(SiteModel site) {
-        return "https://wordpress.com/marketing/connections/" + SiteUtils.getHomeURLOrHostName(site);
+        return WPCOM_CONNECTIONS_URL + SiteUtils.getHomeURLOrHostName(site);
     }
 
     /*

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2324,7 +2324,7 @@
     <string name="sharing_twitter_message">This will be included in tweets when people share using the Twitter button</string>
     <string name="dialog_title_sharing_facebook_account_must_have_pages">Not Connected</string>
     <string name="sharing_facebook_account_must_have_pages">The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages.</string>
-    <string name="sharing_facebook_warning_message">Connecting a Facebook account via the WordPress app is currently not available, sorry for the inconvenience!\n\nYou can still connect your Facebook account using the web version of WordPress.</string>
+    <string name="sharing_facebook_warning_message">You can connect your Facebook account on the WordPress.com website. When you\'re done, return to the WordPress app to change your Sharing settings.</string>
     <string name="sharing_facebook_warning_positive_button">Go to web</string>
 
     <!--Theme Browser-->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2324,6 +2324,8 @@
     <string name="sharing_twitter_message">This will be included in tweets when people share using the Twitter button</string>
     <string name="dialog_title_sharing_facebook_account_must_have_pages">Not Connected</string>
     <string name="sharing_facebook_account_must_have_pages">The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages.</string>
+    <string name="sharing_facebook_warning_message">Connecting a Facebook account via the WordPress app is currently not available, sorry for the inconvenience!\n\nYou can still connect your Facebook account using the web version of WordPress.</string>
+    <string name="sharing_facebook_warning_positive_button">Go to web</string>
 
     <!--Theme Browser-->
     <string name="current_theme">Current Theme</string>


### PR DESCRIPTION
Fixes #15456

This PR temporarily disables the ability for a user to connect a Facebook account to the Publicize feature through the app. Viewing and disconnecting a Facebook account will still be possible, but connecting will only be available through the web. (internal ref for additional context: pbArwn-3uU-p2)

Note that this is not really a fix for #15456 just yet, but more of a way to temporarily suppress the main error there until we figure out a better solution.

The main change introduced here is that if the user selects the Facebook option on the Sharing screen and then taps the "Connect" button, they will now see a dialog instead of continuing to the usual connection flow. The dialog explains this action is currently unavailable and suggests continuing through the web, as shown in the video below:

https://user-images.githubusercontent.com/830056/150023135-022a021f-48a1-425e-8b90-43d9d16fd9fc.mp4

I also considered hiding or disabling either the Facebook option entirely or just the "Connect" button, but those alternatives didn't seem as clear and flexible as the dialog. As for the dialog itself, I also considered a shorter message like `Sorry, connecting a Facebook account is currently only available through the web version of WordPress.` as well as a different label button like `Continue on the web`. 

I'm adding both the `Needs Copy Review` and `Need Design Review` tags so that we can carefully consider all the appropriate alternatives before we merge this. 

### To test

1. Open the app and select a WP.com or Jetpack site.
1. On the My Site screen, scroll down to the Configuration section.
1. Tap "Sharing".
1. Tap "Facebook".
1. Tap "Connect".
1. Make sure you see the new dialog.
1. Tap "Go to web".
1. Make sure an external browser is opened with the following address: `https://https://wordpress.com/marketing/connections/{currentSiteUrl}`.

## Regression Notes
1. Potential unintended areas of impact
Other Publicize connections.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None. A bigger refactor was out of scope at this moment. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
