### PR TITLE
Fix unable to add image to story post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -452,8 +452,9 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
 
     private void getMediaFromDeviceAndTrack(Uri videoUri, int requestCode) {
         final String mimeType = getContentResolver().getType(videoUri);
+        final boolean isVideo = mMediaUtilsWrapper.isVideoMimeType(mimeType);
 
-        if (mSite.getHasFreePlan() && mMediaUtilsWrapper.isVideoMimeType(mimeType)) {
+        if (isVideo && mSite.getHasFreePlan()) {
             if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, videoUri)) {
                 fetchMediaAndDoNext(videoUri, requestCode, mimeType);
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -59,10 +59,23 @@ class AddLocalMediaToPostUseCase @Inject constructor(
 
         if (site.hasFreePlan) {
             uriList.map {
-                val videoDurationAllowed = mediaUtilsWrapper.isVideoFile(it) &&
-                        mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, it)
+                val isVideo = mediaUtilsWrapper.isVideoFile(it)
 
-                if (videoDurationAllowed) {
+                if (isVideo) {
+                    val videoDurationAllowed = mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, it)
+                    if (videoDurationAllowed) {
+                        result = processMediaUri(
+                                uriList,
+                                site,
+                                freshlyTaken,
+                                editorMediaListener,
+                                doUploadAfterAdding,
+                                trackEvent
+                        )
+                    } else {
+                        editorMediaListener.showVideoDurationLimitWarning(it.path.toString())
+                    }
+                } else {
                     result = processMediaUri(
                             uriList,
                             site,
@@ -70,8 +83,6 @@ class AddLocalMediaToPostUseCase @Inject constructor(
                             editorMediaListener,
                             doUploadAfterAdding,
                             trackEvent)
-                } else {
-                    editorMediaListener.showVideoDurationLimitWarning(it.path.toString())
                 }
             }
         } else {


### PR DESCRIPTION
This PR fixes issue with uploading images on Story posts.


To test:

- Select any site with a Free Plan
- Select Media from Quick links or Media under Publish on My Site
- Click on + button on top right hand corner in Media browser and select Choose from device
- Select an image file from media picker and click tick mark
- Notice that a image gets added to the post successfully

For regression, please also check uploading videos and the duration limit still applies by following the steps below.  Thank you.

- Select any site with a Free Plan
- Select Media from Quick links or Media under Publish on My Site
- Click on + button on top right hand corner in Media browser and select Choose from device
- Select a video file longer than 5 minutes in duration from media picker and click tick mark
- Notice that a toast message appears as shown in the first image above
- Try again Selecting a video file shorter than 5 min and notice it uploads without any message
- Also, try uploading a video taken using camera and the notice same rules apply there too
- Try also uploading a video through a Blog post or Story post with Gutenberg video block.
- It should display message as in second image above for free sites if video is longer than 5 minutes.



## Regression Notes
1. Potential unintended areas of impact
Not that I am aware of 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested with image files and video files

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
