### PR TITLE
Replace jcenter with jcenter-mirror

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -67,7 +67,6 @@ repositories {
             // Required for detekt
             includeVersion "org.jetbrains.kotlinx", "kotlinx-html-jvm", "0.7.2"
             // Required for lintWordpressVanillaRelease
-            includeVersion "org.wordpress", "lint", "1.0.1"
             includeVersion "com.jraska", "falcon", "2.1.1"
         }
     }
@@ -471,7 +470,7 @@ dependencies {
 
     implementation 'com.github.Tenor-Inc:tenor-android-core:0.5.1'
 
-    lintChecks 'org.wordpress:lint:1.0.1'
+    lintChecks 'org.wordpress:lint:1.1.0'
 
     // Firebase
     implementation 'com.google.firebase:firebase-config:19.1.3'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -70,6 +70,7 @@ repositories {
             // Required for detekt
             includeVersion "org.jetbrains.kotlinx", "kotlinx-html-jvm", "0.7.2"
             // Required for lintWordpressVanillaRelease
+            includeVersion "org.wordpress", "lint", "1.0.1"
             includeVersion "com.jraska", "falcon", "2.1.1"
         }
     }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -62,9 +62,6 @@ repositories {
             includeVersion "com.google.android", "flexbox", "2.0.1"
             includeVersion "org.wordpress", "emailchecker2", "1.1.0"
             includeVersion "org.wordpress", "persistentedittext", "1.0.2"
-            includeVersion "org.wordpress", "utils", "1.18.1"
-            includeVersion "org.wordpress", "utils", "1.19.0"
-            includeVersion "org.wordpress", "utils", "1.25"
             includeVersion "org.wordpress", "wellsql-core", "1.6.0"
             includeVersion "org.wordpress", "wellsql", "1.6.0"
             // Required for detekt

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
         maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -48,7 +48,27 @@ repositories {
     }
     google()
     mavenCentral()
-    jcenter()
+    jcenter {
+        content {
+            includeVersion "com.android.volley", "volley", "1.1.1"
+            includeVersion "com.automattic", "rest", "1.0.8"
+            includeVersion "com.google.android.exoplayer", "exoplayer-core", "2.9.3"
+            includeVersion "com.google.android.exoplayer", "exoplayer-dash", "2.9.3"
+            includeVersion "com.google.android.exoplayer", "exoplayer-hls", "2.9.3"
+            includeVersion "com.google.android.exoplayer", "exoplayer-smoothstreaming", "2.9.3"
+            includeVersion "com.google.android.exoplayer", "exoplayer-ui", "2.9.3"
+            includeVersion "com.google.android.exoplayer", "exoplayer", "2.9.3"
+            includeVersion "com.google.android.exoplayer", "extension-okhttp", "2.9.3"
+            includeVersion "com.google.android", "flexbox", "2.0.1"
+            includeVersion "org.wordpress", "emailchecker2", "1.1.0"
+            includeVersion "org.wordpress", "persistentedittext", "1.0.2"
+            includeVersion "org.wordpress", "utils", "1.18.1"
+            includeVersion "org.wordpress", "utils", "1.19.0"
+            includeVersion "org.wordpress", "utils", "1.25"
+            includeVersion "org.wordpress", "wellsql-core", "1.6.0"
+            includeVersion "org.wordpress", "wellsql", "1.6.0"
+        }
+    }
     maven { url "https://www.jitpack.io" }
 }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -67,6 +67,10 @@ repositories {
             includeVersion "org.wordpress", "utils", "1.25"
             includeVersion "org.wordpress", "wellsql-core", "1.6.0"
             includeVersion "org.wordpress", "wellsql", "1.6.0"
+            // Required for detekt
+            includeVersion "org.jetbrains.kotlinx", "kotlinx-html-jvm", "0.7.2"
+            // Required for lintWordpressVanillaRelease
+            includeVersion "com.jraska", "falcon", "2.1.1"
         }
     }
     maven { url "https://www.jitpack.io" }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -48,28 +48,6 @@ repositories {
     }
     google()
     mavenCentral()
-    jcenter {
-        content {
-            includeVersion "com.android.volley", "volley", "1.1.1"
-            includeVersion "com.automattic", "rest", "1.0.8"
-            includeVersion "com.google.android.exoplayer", "exoplayer-core", "2.9.3"
-            includeVersion "com.google.android.exoplayer", "exoplayer-dash", "2.9.3"
-            includeVersion "com.google.android.exoplayer", "exoplayer-hls", "2.9.3"
-            includeVersion "com.google.android.exoplayer", "exoplayer-smoothstreaming", "2.9.3"
-            includeVersion "com.google.android.exoplayer", "exoplayer-ui", "2.9.3"
-            includeVersion "com.google.android.exoplayer", "exoplayer", "2.9.3"
-            includeVersion "com.google.android.exoplayer", "extension-okhttp", "2.9.3"
-            includeVersion "com.google.android", "flexbox", "2.0.1"
-            includeVersion "org.wordpress", "emailchecker2", "1.1.0"
-            includeVersion "org.wordpress", "persistentedittext", "1.0.2"
-            includeVersion "org.wordpress", "wellsql-core", "1.6.0"
-            includeVersion "org.wordpress", "wellsql", "1.6.0"
-            // Required for detekt
-            includeVersion "org.jetbrains.kotlinx", "kotlinx-html-jvm", "0.7.2"
-            // Required for lintWordpressVanillaRelease
-            includeVersion "com.jraska", "falcon", "2.1.1"
-        }
-    }
     maven { url "https://www.jitpack.io" }
 }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -47,8 +47,8 @@ repositories {
         }
     }
     google()
-    jcenter()
     mavenCentral()
+    jcenter()
     maven { url "https://www.jitpack.io" }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,8 @@ buildscript {
                 includeGroup "com.automattic.android"
             }
         }
+        maven { url "https://plugins.gradle.org/m2/" }
         google()
-        jcenter()
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -79,9 +79,27 @@ allprojects {
         google()
         mavenCentral()
         maven { url "https://jitpack.io" }
-        jcenter {
+        maven {
+            url "https://a8c-libs.s3.amazonaws.com/android/jcenter-mirror"
             content {
-                includeVersion "com.andreapivetta.kolor", "kolor", "0.0.2"
+                includeVersion "com.android.volley", "volley", "1.1.1"
+                includeVersion "com.automattic", "rest", "1.0.8"
+                includeVersion "com.google.android.exoplayer", "exoplayer-core", "2.9.3"
+                includeVersion "com.google.android.exoplayer", "exoplayer-dash", "2.9.3"
+                includeVersion "com.google.android.exoplayer", "exoplayer-hls", "2.9.3"
+                includeVersion "com.google.android.exoplayer", "exoplayer-smoothstreaming", "2.9.3"
+                includeVersion "com.google.android.exoplayer", "exoplayer-ui", "2.9.3"
+                includeVersion "com.google.android.exoplayer", "exoplayer", "2.9.3"
+                includeVersion "com.google.android.exoplayer", "extension-okhttp", "2.9.3"
+                includeVersion "com.google.android", "flexbox", "2.0.1"
+                includeVersion "org.wordpress", "emailchecker2", "1.1.0"
+                includeVersion "org.wordpress", "persistentedittext", "1.0.2"
+                includeVersion "org.wordpress", "wellsql-core", "1.6.0"
+                includeVersion "org.wordpress", "wellsql", "1.6.0"
+                // Required for detekt
+                includeVersion "org.jetbrains.kotlinx", "kotlinx-html-jvm", "0.7.2"
+                // Required for lintWordpressVanillaRelease
+                includeVersion "com.jraska", "falcon", "2.1.1"
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ allprojects {
 
     repositories {
         google()
+        mavenCentral()
         jcenter()
         maven { url "https://jitpack.io" }
 

--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,8 @@ allprojects {
                 includeVersion "org.jetbrains.kotlinx", "kotlinx-html-jvm", "0.7.2"
                 // Required for lintWordpressVanillaRelease
                 includeVersion "com.jraska", "falcon", "2.1.1"
+                // Required for ktlint
+                includeVersion "com.andreapivetta.kolor", "kolor", "0.0.2"
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,11 @@ allprojects {
         google()
         mavenCentral()
         maven { url "https://jitpack.io" }
+        jcenter {
+            content {
+                includeVersion "com.andreapivetta.kolor", "kolor", "0.0.2"
+            }
+        }
 
         flatDir {
             dirs '../aars'

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         maven { url "https://jitpack.io" }
 
         flatDir {

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -9,17 +9,9 @@ repositories {
     }
 }
 
-repositories {
-    jcenter {
-        content {
-            includeVersion "org.wordpress", "utils", "1.19.0"
-        }
-    }
-}
-
 dependencies {
     implementation "com.github.Automattic:Automattic-Tracks-Android:$tracksVersion"
-    implementation 'org.wordpress:utils:1.19.0'
+    implementation "org.wordpress:utils:$wordPressUtilsVersion"
 
     lintChecks 'org.wordpress:lint:1.0.1'
 }

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -2,6 +2,12 @@ apply plugin: 'com.android.library'
 
 repositories {
     maven {
+        url "https://a8c-libs.s3.amazonaws.com/android"
+        content {
+            includeGroup "org.wordpress"
+        }
+    }
+    maven {
         url 'https://jitpack.io'
         content {
             includeGroup "com.github.Automattic"

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -9,6 +9,14 @@ repositories {
     }
 }
 
+repositories {
+    jcenter {
+        content {
+            includeVersion "org.wordpress", "utils", "1.19.0"
+        }
+    }
+}
+
 dependencies {
     implementation "com.github.Automattic:Automattic-Tracks-Android:$tracksVersion"
     implementation 'org.wordpress:utils:1.19.0'

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation "com.github.Automattic:Automattic-Tracks-Android:$tracksVersion"
     implementation "org.wordpress:utils:$wordPressUtilsVersion"
 
-    lintChecks 'org.wordpress:lint:1.0.1'
+    lintChecks 'org.wordpress:lint:1.1.0'
 }
 
 android {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -25,11 +25,6 @@ repositories {
     }
     google()
     mavenCentral()
-    jcenter {
-        content {
-            includeVersion "com.android.volley", "volley", "1.1.1"
-        }
-    }
     maven { url "https://www.jitpack.io" }
     maven { url "https://a8c-libs.s3.amazonaws.com/android/hermes-mirror" }
 }

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -92,6 +92,6 @@ dependencies {
 
     implementation 'com.google.code.gson:gson:2.6.2'
 
-    lintChecks 'org.wordpress:lint:1.0.1'
+    lintChecks 'org.wordpress:lint:1.1.0'
 }
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -28,7 +28,6 @@ repositories {
     jcenter {
         content {
             includeVersion "com.android.volley", "volley", "1.1.1"
-            includeVersion "org.wordpress", "utils", "1.25"
         }
     }
     maven { url "https://www.jitpack.io" }
@@ -75,7 +74,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'com.android.volley:volley:1.1.1'
-    implementation 'org.wordpress:utils:1.25'
+    implementation "org.wordpress:utils:$wordPressUtilsVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     api ("$gradle.ext.aztecAndroidAztecPath:$aztecVersion") {
         exclude group: "com.android.volley"

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -24,6 +24,7 @@ repositories {
         }
     }
     google()
+    mavenCentral()
     jcenter()
     maven { url "https://www.jitpack.io" }
     maven { url "https://a8c-libs.s3.amazonaws.com/android/hermes-mirror" }

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -25,7 +25,12 @@ repositories {
     }
     google()
     mavenCentral()
-    jcenter()
+    jcenter {
+        content {
+            includeVersion "com.android.volley", "volley", "1.1.1"
+            includeVersion "org.wordpress", "utils", "1.25"
+        }
+    }
     maven { url "https://www.jitpack.io" }
     maven { url "https://a8c-libs.s3.amazonaws.com/android/hermes-mirror" }
 }

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        jcenter()
         google()
     }
 }

--- a/libs/editor/example/build.gradle
+++ b/libs/editor/example/build.gradle
@@ -8,7 +8,6 @@ repositories {
         }
     }
     google()
-    jcenter()
     maven { url "https://www.jitpack.io" }
 }
 

--- a/libs/editor/example/build.gradle
+++ b/libs/editor/example/build.gradle
@@ -34,7 +34,6 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation project(":WordPressEditor")
-    implementation ('org.wordpress:utils:1.25')
     implementation 'com.android.volley:volley:1.1.1'
 
     // Test libraries

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -9,6 +9,16 @@ android {
     }
 }
 
+repositories {
+    jcenter {
+        content {
+            includeVersion "com.android.volley", "volley", "1.1.1"
+            includeVersion "org.wordpress", "utils", "1.18.1"
+            includeVersion "com.automattic", "rest", "1.0.8"
+        }
+    }
+}
+
 dependencies {
     implementation 'com.android.volley:volley:1.1.1'
 

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -10,6 +10,12 @@ android {
 }
 
 repositories {
+    maven {
+        url "https://a8c-libs.s3.amazonaws.com/android"
+        content {
+            includeGroup "org.wordpress"
+        }
+    }
     jcenter {
         content {
             includeVersion "com.android.volley", "volley", "1.1.1"

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -13,7 +13,6 @@ repositories {
     jcenter {
         content {
             includeVersion "com.android.volley", "volley", "1.1.1"
-            includeVersion "org.wordpress", "utils", "1.18.1"
             includeVersion "com.automattic", "rest", "1.0.8"
         }
     }
@@ -22,7 +21,7 @@ repositories {
 dependencies {
     implementation 'com.android.volley:volley:1.1.1'
 
-    implementation 'org.wordpress:utils:1.18.1'
+    implementation "org.wordpress:utils:$wordPressUtilsVersion"
     implementation ('com.automattic:rest:1.0.8') {
         exclude group: 'com.mcxiaoke.volley'
     }

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -16,12 +16,6 @@ repositories {
             includeGroup "org.wordpress"
         }
     }
-    jcenter {
-        content {
-            includeVersion "com.android.volley", "volley", "1.1.1"
-            includeVersion "com.automattic", "rest", "1.0.8"
-        }
-    }
 }
 
 dependencies {

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -32,6 +32,6 @@ dependencies {
         exclude group: 'com.mcxiaoke.volley'
     }
 
-    lintChecks 'org.wordpress:lint:1.0.1'
+    lintChecks 'org.wordpress:lint:1.1.0'
 }
 


### PR DESCRIPTION
`jcenter` started acting up recently, returning intermittent `403` errors. I initially wanted to limit the dependencies we fetch from `jcenter`, hoping that it'd serve as a roadmap in upgrading our dependencies. However, it seemed like the situation was very dire as I couldn't get a green CI check to get this PR merged. Instead, I ended up creating a `jcenter-mirror` s3 maven and uploading the artifacts we need, so we wouldn't need jcenter at all.

I still wanted to limit the `jcenter-mirror` usage, not that it'd have any new dependencies, so I used the [includeVersion](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.html#includeVersion-java.lang.String-java.lang.String-java.lang.String-) syntax so its usage would be crystal clear.

Please note that I had to upload the artifacts cached in my local environment as I couldn't even download all of them from `jcenter`. However, I cleaned my cache today, so in my opinion it is safe to use these artifacts. Our only other choice is to wait for `jcenter` to return to normal and then try to download the artifacts from there, but I don't see any practical difference between Gradle caching the files and us downloading them manually.

I wanted to refrain from doing any updates in this PR, preferring to do them as separate standalone PRs, however there were 2 instances that made updating as part of this PR somewhat preferable.

* `org.wordpress:lint` was upgraded from `1.0.1` to `1.1.0`. This is [one of our libraries](https://github.com/wordpress-mobile/WordPress-Lint-Android) and `1.1.0` is exactly the same as `1.0.2`. I opted to use a different version when I uploaded this artifact to our S3 maven (not the `jcenter-mirror`) to differentiate them. Unfortunately the project doesn't have any tags to compare `1.0.1` & `1.0.2`, but looking at the recent commits, it looks like a safe upgrade. If there were any issues, it'd happen during the lint task, meaning it won't impact our production code.
* We use very old versions of `org.wordpress:utils` in some of our modules and I admit I still don't have full confidence that we should upgrade them as part of this PR. However, I don't have the old versions cached to upload to `jcenter-mirror` and we need to upgrade these anyway. So, although there is a chance the upgrade could cause issues, I think it's a very negligible one and I am leaning towards including it as part of this PR.

**To test:**
* Green CI should be enough - but smoke testing is always welcome.

## Regression Notes
1. Potential unintended areas of impact
Utils dependency update might cause issues, if there are any breaking changes. However, it's very unlikely in my opinion.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Smoke tested the app. I think the successful build is a much better indication as any breaking issues would more likely to come up as a compile time error.

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
