### PR TITLE
[Tooling] Extract translation checks in dedicated lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -361,24 +361,7 @@ REPOSITORY_NAME = 'WordPress-Android'
     android_finalize_prechecks(skip_confirm: options[:skip_confirm])
     configure_apply(force: is_ci)
 
-    UI.message('Checking app strings translation status...')
-    check_translation_progress(
-      glotpress_url: 'https://translate.wordpress.org/projects/apps/android/dev/',
-      abort_on_violations: false
-    )
-
-    UI.message('Checking WordPress release notes strings translation status...')
-    check_translation_progress(
-      glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:gp_url],
-      abort_on_violations: false
-    )
-
-    UI.message('Checking Jetpack release notes strings translation status...')
-    check_translation_progress(
-      glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:gp_url],
-      abort_on_violations: false
-    )
-
+    check_translations_coverage()
     download_translations()
 
     android_bump_version_final_release()
@@ -393,6 +376,30 @@ REPOSITORY_NAME = 'WordPress-Android'
 
     # Trigger release build
     trigger_release_build(branch_to_build: "release/#{version['name']}")
+  end
+
+  lane :check_translations_coverage do |options|
+    UI.message('Checking app strings translation status...')
+    check_translation_progress(
+      glotpress_url: 'https://translate.wordpress.org/projects/apps/android/dev/',
+      abort_on_violations: false,
+      skip_confirm: options[:skip_confirm] || false
+    )
+
+    UI.message('Checking WordPress release notes strings translation status...')
+    check_translation_progress(
+      glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:gp_url],
+      abort_on_violations: false,
+      skip_confirm: options[:skip_confirm] || false
+    )
+
+    UI.message('Checking Jetpack release notes strings translation status...')
+    check_translation_progress(
+      glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:gp_url],
+      abort_on_violations: false,
+      skip_confirm: options[:skip_confirm] || false
+    )
+
   end
 
   #####################################################################################


### PR DESCRIPTION
This change simply extracts the various calls to `check_translation_progress` (on the app strings + WP release notes + JP release notes), reporting GlotPress % for each Mag16 locale, into its own lane, so that we can call it easily as a stand-alone check.

This is useful if we want for example to check the progress of the translations in the middle of the sprint (without waiting for the `finalize_release` to check coverage) and report to our Excellence Wrangler if a brand new beta (especially ones made close to the submission day) already has everything translated (and ready to be tested in advance) or not yet.


_PS: I've targeted the `release/19.0` branch because it could be a useful lane to use as the sprint end approaches. But in practice there's no rush to this change and it's totally ok if it misses the end of sprint and lands only later in `trunk`._