### PR TITLE
Update Buildkite docker image tag to v1.1.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 docker-container: &docker-container
   plugins:
     - docker#v3.8.0:
-        image: "public.ecr.aws/automattic/android-build-image:311ab824e9fd33ebb71de83c3fd1c328ea84443b"
+        image: "public.ecr.aws/automattic/android-build-image:v1.1.0"
         environment:
           - "CI=true"
 


### PR DESCRIPTION
In https://github.com/wordpress-mobile/WordPress-Android/pull/15115, we have started using a custom hash for the [docker image](https://github.com/wordpress-mobile/docker-android-build-image) to address an issue with the `groovy-all` dependency resolution. In https://github.com/wordpress-mobile/WordPress-Android/pull/15837 we dropped `jcenter` and added `mavenCentral` to our repositories. [It looks like the `groovy-all` dependency is now being resolved to `mavenCentral`](https://scans.gradle.com/s/2jtpiwpshem6u/dependencies?dependencies=groovy-all&expandAll&focusedDependency=WzAsNTEsNDcyNCxbMCwwLFswXV1d), so we no longer need to use the Docker image with the partial cache. Interestingly, I remember failing to fix the issue in #15115 by using `mavenCentral`, however I might have made a mistake in repository order at the time - or maybe the version we are using wasn't available back then 🤷 

Comparing the 2 build times (with & without the partial dependency cache) the results are very similar. The lint task took ~20s longer, but some other tasks took less time, so using the image without the partial cache, which as a reminder was created temporarily, seems like a no-brainer to me. We are still interested in caching some of our dependencies, either in the Docker image or in s3, but we want to do it properly after our centralized dependency versions project.

**To test:**
* This change only impacts CI, so no testing is necessary.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
