### PR TITLE
MSD: Remove "No Content" text for an empty excerpt in a draft post card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -102,7 +102,7 @@ class PostCardBuilder @Inject constructor(
             if (title.isEmpty()) UiStringRes(R.string.my_site_untitled_post) else UiStringText(title)
 
     private fun constructPostContent(content: String) =
-            if (content.isEmpty()) UiStringRes(R.string.my_site_no_content_post) else UiStringText(content)
+            content.takeIf { it.isNotEmpty() }?.let { UiStringText(content) }
 
     private fun List<PostCardModel>.mapToScheduledPostItems(
         onPostItemClick: (params: PostItemClickParams) -> Unit

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2210,7 +2210,6 @@
     <string name="my_site_post_card_draft_title">Work on a draft post</string>
     <string name="my_site_post_card_scheduled_title">Upcoming scheduled posts</string>
     <string name="my_site_untitled_post">Untitled</string>
-    <string name="my_site_no_content_post">No Content</string>
     <string name="my_site_create_first_post_title">Create your first post</string>
     <string name="my_site_create_first_post_excerpt">Posts appear on your blog page in reverse chronological order. It\'s time to share your ideas with the world!</string>
     <string name="my_site_create_next_post_title">Create your next post</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
@@ -269,7 +269,7 @@ class PostCardBuilderTest : BaseUnitTest() {
 
         val postsCard = buildPostsCard(posts).filterDraftPostCard()?.postItems?.first()
 
-        assertThat(postsCard?.excerpt).isEqualTo(UiStringRes(R.string.my_site_no_content_post))
+        assertThat(postsCard?.excerpt).isNull()
     }
 
     @Test


### PR DESCRIPTION
Fixes #15850

This PR removes `No Content` text for an empty excerpt in a `draft` post card on `My Site Dashboard`.

<img width=320 src="https://user-images.githubusercontent.com/1405144/150773184-83f200ac-b149-41f4-8a3d-ce47651a523f.jpg"/>

To test:

1. Create a draft post.
2. Add a non-featured image to the post and nothing else to it.
3. Go to `My Site Dashboard`.
4. Notice that the `No Content` is not shown in the corresponding draft post card.
5. Add a featured image to the post. 
6. Notice that the featured image is shown but `No Content` is still not shown in the corresponding draft post card. This matches the behavior on the `Posts Screen - Post Item`.

## Regression Notes
1. Potential unintended areas of impact 
See `To test`


2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 


3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
