### PR TITLE
Editor: Handles media from share action

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 19.2
 -----
-
+* [*] Block editor: Fixed an issue in sharing images from other apps [https://github.com/wordpress-mobile/WordPress-Android/pull/15864]
 
 19.1
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -452,11 +452,16 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     private void newPostFromShareAction() {
         Intent intent = getIntent();
-        final String title = intent.getStringExtra(Intent.EXTRA_SUBJECT);
-        final String text = intent.getStringExtra(Intent.EXTRA_TEXT);
-        String content = migrateToGutenbergEditor(AutolinkUtils.autoCreateLinks(text));
-
-        newPostSetup(title, content);
+        String type = intent.getType();
+        if (type != null && (type.startsWith("image") || type.startsWith("video"))) {
+            newPostSetup();
+            setPostMediaFromShareAction();
+        } else {
+            final String title = intent.getStringExtra(Intent.EXTRA_SUBJECT);
+            final String text = intent.getStringExtra(Intent.EXTRA_TEXT);
+            String content = migrateToGutenbergEditor(AutolinkUtils.autoCreateLinks(text));
+            newPostSetup(title, content);
+        }
     }
 
     private void newReblogPostSetup() {
@@ -2471,6 +2476,11 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 return null;
             });
         }
+        setPostMediaFromShareAction();
+    }
+
+    private void setPostMediaFromShareAction() {
+        Intent intent = getIntent();
 
         // Check for shared media
         if (intent.hasExtra(Intent.EXTRA_STREAM)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -452,8 +452,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     private void newPostFromShareAction() {
         Intent intent = getIntent();
-        String type = intent.getType();
-        if (type != null && (type.startsWith("image") || type.startsWith("video"))) {
+        if (isMediaTypeIntent(intent)) {
             newPostSetup();
             setPostMediaFromShareAction();
         } else {
@@ -2485,14 +2484,13 @@ public class EditPostActivity extends LocaleAwareActivity implements
         // Check for shared media
         if (intent.hasExtra(Intent.EXTRA_STREAM)) {
             String action = intent.getAction();
-            String type = intent.getType();
             ArrayList<Uri> sharedUris;
 
             if (Intent.ACTION_SEND_MULTIPLE.equals(action)) {
                 sharedUris = intent.getParcelableArrayListExtra((Intent.EXTRA_STREAM));
             } else {
                 // For a single media share, we only allow images and video types
-                if (type != null && (type.startsWith("image") || type.startsWith("video"))) {
+                if (isMediaTypeIntent(intent)) {
                     sharedUris = new ArrayList<>();
                     sharedUris.add(intent.getParcelableExtra(Intent.EXTRA_STREAM));
                 } else {
@@ -2506,6 +2504,11 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 mEditorMedia.addNewMediaItemsToEditorAsync(sharedUris, false);
             }
         }
+    }
+
+    private boolean isMediaTypeIntent(Intent intent) {
+        String type = intent.getType();
+        return type != null && (type.startsWith("image") || type.startsWith("video"));
     }
 
     private void setFeaturedImageId(final long mediaId, final boolean imagePicked, final boolean isGutenbergEditor) {


### PR DESCRIPTION
Fixes #15735

Adds handling for media from share action.

Notes:
* Reverting https://github.com/wordpress-mobile/WordPress-Android/pull/15697/commits/f241d1ec88d7e0c1d69a9ccaa3dedce29795037c fixes the image sharing issue but reintroduces https://github.com/wordpress-mobile/gutenberg-mobile/issues/4040. I haven't found a cleaner way to resolve both issues at this point.
* Known issue: [when sharing multiple images the images are added twice](https://github.com/wordpress-mobile/WordPress-Android/issues/15873)

To test:

**Share image/video**
1. Open Files and select an image by tapping it.
2. Tap the Share icon in the bottom menu bar.
3. Select WordPress, then choose a site to share to.
4. Select "Add to new post".
5. Verify that the image is successfully added to the post

<details>
<summary>Image sharing</summary>

https://user-images.githubusercontent.com/304044/151398327-cfd2a23d-16ba-42c1-b66a-17cfb78b369b.mp4
</details>

<details>
<summary>Video sharing</summary>

https://user-images.githubusercontent.com/304044/151398260-3bee65f8-6950-4e6a-8c07-bb7e564d3bdf.mp4
</details>

**Share text action**
1. Select some text (e.g. on the browser)
2. Choose the share action on the context menu and select share
3. Select the WordPress app from this PR
4. Select a site
5. Verify that the editor opens with the correct shared content

<details>
<summary>Text sharing</summary>

https://user-images.githubusercontent.com/304044/151398300-ca21c6e1-2886-43e8-8f89-c99f0142f01f.mp4
</details>

## Regression Notes
1. Potential unintended areas of impact
Share functionality

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Relied on existing tests and manually tested the share text action

3. What automated tests I added (or what prevented me from doing so)
The code changes on the EditPostActivity are not easily testable

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
