### PR TITLE
Adds org.wordpress.wellsql to s3 repositories

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -18,6 +18,7 @@ repositories {
             includeGroup "org.wordpress"
             includeGroup "org.wordpress.aztec"
             includeGroup "org.wordpress.fluxc"
+            includeGroup "org.wordpress.wellsql"
             includeGroup "org.wordpress-mobile.gutenberg-mobile"
             includeGroup "com.automattic"
             includeGroup "com.automattic.stories"


### PR DESCRIPTION
With https://github.com/wordpress-mobile/wellsql/pull/20, we started to publish `wellsql` to our S3 Maven repository. This PR updates the S3 repositories to include `org.wordpress.wellsql`, so `> 1.7.0` version of the library can be fetched from there.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
