### PR TITLE
Upgrade wordPressUtilsVersion to 2.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 ext {
     coroutinesVersion = '1.5.2'
-    wordPressUtilsVersion = '2.2.0'
+    wordPressUtilsVersion = '2.3.0'
     wordPressLoginVersion = '0.0.8'
     gutenbergMobileVersion = 'v1.70.0'
     storiesVersion = '1.2.1'


### PR DESCRIPTION
This PR updates the utils library to its latest version. The main goal for this change is that we match the version that `gutenberg-mobile` projects use [which recently was updated it to the latest version](https://github.com/WordPress/gutenberg/pull/38142).

[Here is the full changelog for utils' `2.2.0...2.3.0`.](https://github.com/wordpress-mobile/WordPress-Utils-Android/compare/2.2.0...2.3.0)

**To test:**
Smoke test the app.

## Regression Notes
1. Potential unintended areas of impact
Looking at the changes in the library I can't think of any meaningful ones.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Smoke tested the app

3. What automated tests I added (or what prevented me from doing so)
Ran all the UI tests so it'd act as a smoke test.

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
