### PR TITLE
Filter media list to call processMediaUri just once

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -68,7 +68,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
             return@filter true
         }
 
-        return processMediaUri(
+        return processMediaUris(
                 allowedUris,
                 site,
                 freshlyTaken,
@@ -77,7 +77,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
                 trackEvent)
     }
 
-    private suspend fun processMediaUri(
+    private suspend fun processMediaUris(
         uriList: List<Uri>,
         site: SiteModel,
         freshlyTaken: Boolean,


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/38287 over at the Gutenberg side.

This PR refactors the code to avoid calling processMediaUri() multiple times when multiple media have been selected.  Cherry picked from this [draft PR](https://github.com/wordpress-mobile/WordPress-Android/pull/15870) by @hypest 

To test:

Test 1

- Add a gallery block in a post
- Add media by selecting 2 photos from the local device gallery
- Observe the gallery block being populated without any additional image blocks to be added after it

Test 2

- Add a video block to a post on a Free Simple site
- Upload a long video (longer than 5mins) from the local device gallery
- Notice that the video is not uploaded and a Toast informs that a paid plan is needed


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
