### PR TITLE
Fix snackbar no suitable parent found crash on the Reader tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -912,7 +912,9 @@ public class ReaderPostListFragment extends ViewPagerFragment
                 R.drawable.ic_search_white_24dp
         );
         mSnackbarSequencer.enqueue(
-                new SnackbarItem(new SnackbarItem.Info(mRecyclerView, new UiStringText(title), Snackbar.LENGTH_LONG))
+                new SnackbarItem(
+                        new SnackbarItem.Info(getSnackbarParent(), new UiStringText(title), Snackbar.LENGTH_LONG)
+                )
         );
     }
 


### PR DESCRIPTION
Fixes #15869

This PR fixes a crash while completing the quickstart for the "Grow your audience" -> "Follow other sites" step. The crash seems to have occurred when the `Reader Posts` screen was not laid out and the snackbar referenced a screen element as its parent. This PR now uses an existing `getSnackbarParent()` fn that references coordinator layout or screen's view to fix the issue. 

https://user-images.githubusercontent.com/1405144/151771678-d1fef441-a924-4326-83d4-656f36db79dc.mp4

To test:

- Fresh install the app or clear storage.
- Login with a `wpcom` account and select "Show me around" in the `Quick Start` prompt.
- Select "Grow your audience" -> "Follow other sites" from `Quick Start` card.
- Follow the guided steps. 
- Notice that the crash doesn't occur anymore.

**Review Instructions**

Review from only one reviewer is sufficient.

## Regression Notes
1. Potential unintended areas of impact 🟢 


2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 


3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
