### PR TITLE
Hotfix for gallery block duplicates issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -68,7 +68,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
             return@filter true
         }
 
-        return processMediaUri(
+        return processMediaUris(
                 allowedUris,
                 site,
                 freshlyTaken,
@@ -77,7 +77,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
                 trackEvent)
     }
 
-    private suspend fun processMediaUri(
+    private suspend fun processMediaUris(
         uriList: List<Uri>,
         site: SiteModel,
         freshlyTaken: Boolean,


### PR DESCRIPTION
This PR cherry picks changes from #15872  as an hotfix for 19.0 to address issues https://github.com/WordPress/gutenberg/issues/38287 and #15873 

Fixes #15873 and https://github.com/WordPress/gutenberg/issues/38287


To test:

Test 1

- Add a gallery block in a post
- Add media by selecting 2 photos from the local device gallery
- Observe the gallery block being populated without any additional image blocks to be added after it

Test 2

- Add a video block to a post on a Free Simple site
- Upload a long video (longer than 5mins) from the local device gallery
- Notice that the video is not uploaded and a Toast informs that a paid plan is needed


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
