### PR TITLE
Issue/15890 hide comment snippet on self hosted sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1482,7 +1482,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                     if (likesEnhancementsFeatureConfig.isEnabled()) {
                         viewModel.onRefreshLikersData(it)
                     }
-                    if (commentsSnippetFeatureConfig.isEnabled() && !it.isExternal) {
+                    if (commentsSnippetFeatureConfig.isEnabled()) {
                         viewModel.onRefreshCommentsData(it.blogId, it.postId)
                     }
                     viewModel.onRelatedPostsRequested(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1482,7 +1482,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                     if (likesEnhancementsFeatureConfig.isEnabled()) {
                         viewModel.onRefreshLikersData(it)
                     }
-                    if (commentsSnippetFeatureConfig.isEnabled()) {
+                    if (commentsSnippetFeatureConfig.isEnabled() && !it.isExternal) {
                         viewModel.onRefreshCommentsData(it.blogId, it.postId)
                     }
                     viewModel.onRelatedPostsRequested(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModel.kt
@@ -5,14 +5,15 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
+import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
-import org.wordpress.android.ui.reader.FollowConversationUiState
 import org.wordpress.android.ui.reader.FollowCommentsUiStateType.DISABLED
 import org.wordpress.android.ui.reader.FollowCommentsUiStateType.GONE
 import org.wordpress.android.ui.reader.FollowCommentsUiStateType.LOADING
 import org.wordpress.android.ui.reader.FollowCommentsUiStateType.VISIBLE_WITH_STATE
 import org.wordpress.android.ui.reader.FollowConversationStatusFlags
+import org.wordpress.android.ui.reader.FollowConversationUiState
 import org.wordpress.android.ui.reader.ReaderFollowCommentsHandler
 import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource
 import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.UNKNOWN
@@ -32,6 +33,7 @@ import javax.inject.Named
 @Suppress("TooManyFunctions")
 class ConversationNotificationsViewModel @Inject constructor(
     private val followCommentsHandler: ReaderFollowCommentsHandler,
+    private val readerPostTableWrapper: ReaderPostTableWrapper,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(bgDispatcher) {
     private var isStarted = false
@@ -164,7 +166,15 @@ class ConversationNotificationsViewModel @Inject constructor(
     private fun getFollowConversationStatus(isInit: Boolean) {
         followStatusGetJob?.cancel()
         followStatusGetJob = launch(bgDispatcher) {
-            followCommentsHandler.handleFollowCommentsStatusRequest(blogId, postId, isInit)
+            val post = readerPostTableWrapper.getBlogPost(
+                    blogId,
+                    postId,
+                    true
+            )
+
+            if (post != null && !post.isExternal) {
+                followCommentsHandler.handleFollowCommentsStatusRequest(blogId, postId, isInit)
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModel.kt
@@ -172,8 +172,10 @@ class ConversationNotificationsViewModel @Inject constructor(
                     true
             )
 
-            if (post != null && !post.isExternal) {
-                followCommentsHandler.handleFollowCommentsStatusRequest(blogId, postId, isInit)
+            post?.let {
+                if (!post.isExternal) {
+                    followCommentsHandler.handleFollowCommentsStatusRequest(blogId, postId, isInit)
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -293,7 +293,8 @@ class ReaderPostDetailViewModel @Inject constructor(
 
         val post = readerPostTableWrapper.getBlogPost(blogId, postId, true)
         post?.let {
-            if(post.isExternal) return
+            if (post.isExternal) return
+
             val isRepliesDataChanged = lastRenderedRepliesData?.isMatchingPostCommentsStatus(
                     it.blogId,
                     it.postId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -255,7 +255,7 @@ class ReaderPostDetailViewModel @Inject constructor(
                                 true
                         )
                     }
-                    if (commentsSnippetFeatureConfig.isEnabled()) {
+                    if (commentsSnippetFeatureConfig.isEnabled() && !post.isExternal) {
                         onRefreshCommentsData(post.blogId, post.postId)
                     }
                     updatePostActions(post)
@@ -292,8 +292,8 @@ class ReaderPostDetailViewModel @Inject constructor(
         if (!commentsSnippetFeatureConfig.isEnabled()) return
 
         val post = readerPostTableWrapper.getBlogPost(blogId, postId, true)
-
         post?.let {
+            if(post.isExternal) return
             val isRepliesDataChanged = lastRenderedRepliesData?.isMatchingPostCommentsStatus(
                     it.blogId,
                     it.postId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -293,21 +293,21 @@ class ReaderPostDetailViewModel @Inject constructor(
 
         val post = readerPostTableWrapper.getBlogPost(blogId, postId, true)
         post?.let {
-            if (post.isExternal) return
+            if (!post.isExternal) {
+                val isRepliesDataChanged = lastRenderedRepliesData?.isMatchingPostCommentsStatus(
+                        it.blogId,
+                        it.postId,
+                        it.numReplies
+                ) ?: true
 
-            val isRepliesDataChanged = lastRenderedRepliesData?.isMatchingPostCommentsStatus(
-                    it.blogId,
-                    it.postId,
-                    it.numReplies
-            ) ?: true
+                if (!isRepliesDataChanged) return
 
-            if (!isRepliesDataChanged) return
-
-            readerCommentServiceStarterWrapper.startServiceForCommentSnippet(
-                    contextProvider.getContext(),
-                    blogId,
-                    postId
-            )
+                readerCommentServiceStarterWrapper.startServiceForCommentSnippet(
+                        contextProvider.getContext(),
+                        blogId,
+                        postId
+                )
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -255,7 +255,7 @@ class ReaderPostDetailViewModel @Inject constructor(
                                 true
                         )
                     }
-                    if (commentsSnippetFeatureConfig.isEnabled() && !post.isExternal) {
+                    if (commentsSnippetFeatureConfig.isEnabled()) {
                         onRefreshCommentsData(post.blogId, post.postId)
                     }
                     updatePostActions(post)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModelTest.kt
@@ -4,8 +4,11 @@ import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -14,6 +17,8 @@ import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
+import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.test
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.FollowCommentsUiStateType
@@ -28,6 +33,7 @@ import org.wordpress.android.viewmodel.Event
 @InternalCoroutinesApi
 class ConversationNotificationsViewModelTest : BaseUnitTest() {
     @Mock lateinit var followCommentsHandler: ReaderFollowCommentsHandler
+    @Mock lateinit var readerPostTableWrapper: ReaderPostTableWrapper
 
     private lateinit var viewModel: ConversationNotificationsViewModel
     private val blogId = 100L
@@ -36,13 +42,18 @@ class ConversationNotificationsViewModelTest : BaseUnitTest() {
     private var followStatusUpdate = MutableLiveData<FollowCommentsState>()
     private var uiState: FollowConversationUiState? = null
 
+    private val internalPost = ReaderPost().also { it.isExternal = false }
+    private val externalPost = ReaderPost().also { it.isExternal = true }
+
     @Before
     fun setUp() {
         whenever(followCommentsHandler.snackbarEvents).thenReturn(snackbarEvents)
         whenever(followCommentsHandler.followStatusUpdate).thenReturn(followStatusUpdate)
+        whenever(readerPostTableWrapper.getBlogPost(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(internalPost)
 
         viewModel = ConversationNotificationsViewModel(
                 followCommentsHandler,
+                readerPostTableWrapper,
                 TEST_DISPATCHER
         )
     }
@@ -174,6 +185,14 @@ class ConversationNotificationsViewModelTest : BaseUnitTest() {
             assertThat(it.flags.type).isEqualTo(VISIBLE_WITH_STATE)
             assertThat(it.flags.isReceivingNotifications).isTrue()
         }
+    }
+
+    @Test
+    fun `followCommentsHandler is not called for external posts`() = runBlocking {
+        whenever(readerPostTableWrapper.getBlogPost(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(externalPost)
+        setupObserversAndStart()
+
+        verify(followCommentsHandler, never()).handleFollowCommentsStatusRequest(anyOrNull(), anyOrNull(), anyOrNull())
     }
 
     private fun setupObserversAndStart() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -976,6 +977,22 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
         }
     }
 
+    @Test
+    fun `onRefreshCommentsData does not start comment snippet service for external posts`() {
+        val externalPost = createDummyReaderPost(1, isWpComPost = false)
+        whenever(
+                readerPostTableWrapper.getBlogPost(
+                        anyOrNull(),
+                        anyOrNull(),
+                        anyOrNull()
+                )
+        ).thenReturn(externalPost)
+
+        viewModel.onRefreshCommentsData(1,1)
+
+        verify(readerCommentServiceStarterWrapper, never()).startServiceForCommentSnippet(anyOrNull(), anyOrNull(), anyOrNull())
+    }
+
     private fun <T> testWithoutLocalPost(block: suspend CoroutineScope.() -> T) {
         test {
             whenever(readerGetPostUseCase.get(any(), any(), any())).thenReturn(Pair(null, false))
@@ -983,16 +1000,17 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
         }
     }
 
-    private fun createDummyReaderPost(id: Long, isWpComPost: Boolean = true): ReaderPost = ReaderPost().apply {
-        this.postId = id
-        this.blogId = id * 100
-        this.feedId = id * 1000
-        this.title = "DummyPost"
-        this.featuredVideo = id.toString()
-        this.featuredImage = "/featured_image/$id/url"
-        this.isExternal = !isWpComPost
-        this.numReplies = 1
-    }
+    private fun createDummyReaderPost(id: Long, isWpComPost: Boolean = true): ReaderPost =
+            ReaderPost().apply {
+                this.postId = id
+                this.blogId = id * 100
+                this.feedId = id * 1000
+                this.title = "DummyPost"
+                this.featuredVideo = id.toString()
+                this.featuredImage = "/featured_image/$id/url"
+                this.isExternal = !isWpComPost
+                this.numReplies = 1
+            }
 
     private fun createDummyReaderPostCommentSnippetList(): ReaderCommentList =
             ReaderCommentList().apply {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -988,9 +988,13 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
                 )
         ).thenReturn(externalPost)
 
-        viewModel.onRefreshCommentsData(1,1)
+        viewModel.onRefreshCommentsData(1, 1)
 
-        verify(readerCommentServiceStarterWrapper, never()).startServiceForCommentSnippet(anyOrNull(), anyOrNull(), anyOrNull())
+        verify(readerCommentServiceStarterWrapper, never()).startServiceForCommentSnippet(
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull()
+        )
     }
 
     private fun <T> testWithoutLocalPost(block: suspend CoroutineScope.() -> T) {


### PR DESCRIPTION
Fixes #15890

This PR disables network requests for conversation following status (it was causing an error toast) and comment snippet for self hosted sites (this prevents snippet from becoming visible).

To test:
- From reader open post on self-hosted site. Confirm that there is no error toasts and comment snippet is not visible.
- Open wpcom post and confirm that comment snippet is visible.
- Open wpcom post with closed comments, and confirm that the comment snippet is visible.


## Regression Notes
1. Potential unintended areas of impact
Comment Snippet is not visible when expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + added automated tests.

3. What automated tests I added (or what prevented me from doing so)
Added test that confirm that the comment snippet service is not started for external posts (this prevents any interaction with UI observer of snippet, which keep it hidden).
Added a test that prevents checking status of follow conversation for external posts.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
