### PR TITLE
Scroll to new stats insights card when added

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -124,7 +124,9 @@ class BaseListUseCase(
                                 }
                             }
                 }
-                mutableScrollTo.postValue(Event(visibleTypes.last()))
+                if (!refresh) {
+                    mutableScrollTo.postValue(Event(visibleTypes.last()))
+                }
             }
         } else {
             mutableSnackbarMessage.postValue(R.string.stats_site_not_loaded_yet)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -77,6 +77,9 @@ class BaseListUseCase(
     private val mutableListSelected = SingleLiveEvent<Unit>()
     val listSelected: LiveData<Unit> = mutableListSelected
 
+    private val mutableScrollTo = MutableLiveData<Event<StatsType>>()
+    val scrollTo: LiveData<Event<StatsType>> = mutableScrollTo
+
     suspend fun loadData() {
         loadData(refresh = false, forced = false)
     }
@@ -121,6 +124,7 @@ class BaseListUseCase(
                                 }
                             }
                 }
+                mutableScrollTo.postValue(Event(visibleTypes.last()))
             }
         } else {
             mutableSnackbarMessage.postValue(R.string.stats_site_not_loaded_yet)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import org.wordpress.android.R
@@ -190,9 +191,13 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
             }
         })
 
-        viewModel.scrollToNewCard.observeEvent(viewLifecycleOwner, { statsType ->
+        viewModel.scrollToNewCard.observeEvent(viewLifecycleOwner, {
             (recyclerView.adapter as? StatsBlockAdapter)?.let { adapter ->
-                recyclerView.smoothScrollToPosition(adapter.positionOf(statsType))
+                adapter.registerAdapterDataObserver(object : AdapterDataObserver() {
+                    override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+                        layoutManager?.smoothScrollToPosition(recyclerView, null, adapter.itemCount)
+                    }
+                })
             }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -189,6 +189,12 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
                 recyclerView.smoothScrollToPosition(adapter.positionOf(statsType))
             }
         })
+
+        viewModel.scrollToNewCard.observeEvent(viewLifecycleOwner, { statsType ->
+            (recyclerView.adapter as? StatsBlockAdapter)?.let { adapter ->
+                recyclerView.smoothScrollToPosition(adapter.positionOf(statsType))
+            }
+        })
     }
 
     private fun StatsListFragmentBinding.showUiModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -82,6 +82,8 @@ abstract class StatsListViewModel(
 
     val scrollTo = newsCardHandler?.scrollTo
 
+    val scrollToNewCard = statsUseCase.scrollTo
+
     override fun onCleared() {
         statsUseCase.onCleared()
         super.onCleared()


### PR DESCRIPTION
This PR improves scrolling to new stats card/s when added through insights management option.


https://user-images.githubusercontent.com/990349/152288113-530945dc-0e33-4387-bdc5-3196d735756b.mov


Fixes #15878 

To test:

- Launch app, then click on Stats either through quick links or Stats option on My Site
- Scroll down if necessary, to find `(+) Add new stats card item` and click on it. It should open **Add New Card** screen
- Select a card or cards and hit save
- It should land back on insights tab where the new card/s added and visible above the fold with animation

NOTE: you might need a site with already some stats cards in insights tab, otherwise you might see an empty stats view! In that case please add some cards and check after that.


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
manual testing

3. What automated tests I added (or what prevented me from doing so)
existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
