### PR TITLE
Integrate gutenberg-mobile release 1.71.0 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] Block editor: Replacing the media for an image set as featured prompts to update the featured image [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3930]
 * [*] Block editor: Fixed an issue in sharing images from other apps [https://github.com/wordpress-mobile/WordPress-Android/pull/15864]
+* [***] Block editor: Font size and line-height support for text-based blocks used in block-based themes [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4519]
 
 19.1
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.3.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = '4543-9375a2a783d70672bad1b66c1a8c96c0464ed16c'
+    gutenbergMobileVersion = '4543-654b3678804156a21ae959c794f02d1aafb21814'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.3.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = '4543-bf4546c6fc1a34499d564cd3ee96d73b06e0bc0d'
+    gutenbergMobileVersion = '4543-9375a2a783d70672bad1b66c1a8c96c0464ed16c'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.3.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = 'v1.71.0-alpha2'
+    gutenbergMobileVersion = '4543-bf4546c6fc1a34499d564cd3ee96d73b06e0bc0d'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.3.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = '4543-654b3678804156a21ae959c794f02d1aafb21814'
+    gutenbergMobileVersion = 'v1.71.0'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.71.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4543/

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.