### PR TITLE
Jetpack App: Show all sites and allow site creation 

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -117,6 +117,9 @@ android {
         buildConfigField "boolean", "COMMENTS_SNIPPET", "false"
         buildConfigField "boolean", "READER_COMMENTS_MODERATION", "false"
 
+        // Override these constants in jetpack product flavor to enable/ disable features
+        buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"
+
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
 
@@ -151,6 +154,7 @@ android {
 
             applicationId "com.jetpack.android"
             buildConfigField "boolean", "IS_JETPACK_APP", "true"
+            buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -119,6 +119,7 @@ android {
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"
+        buildConfigField "boolean", "ENABLE_ADD_SELF_HOSTED_SITE", "true"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -155,6 +156,7 @@ android {
             applicationId "com.jetpack.android"
             buildConfigField "boolean", "IS_JETPACK_APP", "true"
             buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"
+            buildConfigField "boolean", "ENABLE_ADD_SELF_HOSTED_SITE", "false"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1379,12 +1379,12 @@ public class ActivityLauncher {
             Activity activity,
             boolean doLoginUpdate,
             ArrayList<Integer> oldSitesIds,
-            boolean isJetpackApp
+            boolean isSiteCreationEnabled
     ) {
         Intent intent = new Intent(activity, LoginEpilogueActivity.class);
         intent.putExtra(LoginEpilogueActivity.EXTRA_DO_LOGIN_UPDATE, doLoginUpdate);
         intent.putIntegerArrayListExtra(LoginEpilogueActivity.ARG_OLD_SITES_IDS, oldSitesIds);
-        if (!isJetpackApp) {
+        if (isSiteCreationEnabled) {
             activity.startActivityForResult(intent, RequestCodes.LOGIN_EPILOGUE);
         } else {
             activity.startActivity(intent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -117,7 +117,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     }
 
     private boolean isNewLoginEpilogueScreenEnabled() {
-        return !mBuildConfigWrapper.isJetpackApp()
+        return mBuildConfigWrapper.isSiteCreationEnabled()
                && !mShowAndReturn;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -50,6 +50,7 @@ import org.wordpress.android.ui.prefs.EmptyViewRecyclerView;
 import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.BuildConfigWrapper;
 import org.wordpress.android.util.DeviceUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
@@ -116,6 +117,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     @Inject Dispatcher mDispatcher;
     @Inject StatsStore mStatsStore;
     @Inject ViewModelProvider.Factory mViewModelFactory;
+    @Inject BuildConfigWrapper mBuildConfigWrapper;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -241,7 +243,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         } else {
             // don't allow editing visibility unless there are multiple wp.com and jetpack sites
             mMenuEdit.setVisible(mSiteStore.getSitesAccessedViaWPComRestCount() > 1);
-            mMenuAdd.setVisible(true);
+            mMenuAdd.setVisible(mBuildConfigWrapper.isSiteCreationEnabled());
         }
 
         // no point showing search if there aren't multiple blogs

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -241,7 +241,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         } else {
             // don't allow editing visibility unless there are multiple wp.com and jetpack sites
             mMenuEdit.setVisible(mSiteStore.getSitesAccessedViaWPComRestCount() > 1);
-            mMenuAdd.setVisible(!BuildConfig.IS_JETPACK_APP);
+            mMenuAdd.setVisible(true);
         }
 
         // no point showing search if there aren't multiple blogs

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -753,16 +753,25 @@ public class SitePickerActivity extends LocaleAwareActivity
         }
     }
 
-    public static void addSite(Activity activity, boolean isSignedInWpCom) {
-        // if user is signed into wp.com use the dialog to enable choosing whether to
-        // create a new wp.com blog or add a self-hosted one
-        if (isSignedInWpCom) {
-            DialogFragment dialog = new AddSiteDialog();
-            dialog.show(activity.getFragmentManager(), AddSiteDialog.ADD_SITE_DIALOG_TAG);
+    public static void addSite(Activity activity, boolean hasAccessToken) {
+        if (hasAccessToken) {
+            if (BuildConfig.IS_JETPACK_APP) {
+                // user is signed into jetpack app, so restrict showing option to add self-hosted site
+                ActivityLauncher.newBlogForResult(activity);
+            } else {
+                // user is signed into wordpress app, so use the dialog to enable choosing whether to
+                // create a new wp.com blog or add a self-hosted one
+                showAddSiteDialog(activity);
+            }
         } else {
-            // user isn't signed into wp.com, so simply enable adding self-hosted
+            // user doesn't have an access token, so simply enable adding self-hosted
             ActivityLauncher.addSelfHostedSiteForResult(activity);
         }
+    }
+
+    private static void showAddSiteDialog(Activity activity) {
+        DialogFragment dialog = new AddSiteDialog();
+        dialog.show(activity.getFragmentManager(), AddSiteDialog.ADD_SITE_DIALOG_TAG);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -757,8 +757,7 @@ public class SitePickerActivity extends LocaleAwareActivity
 
     public static void addSite(Activity activity, boolean hasAccessToken) {
         if (hasAccessToken) {
-            if (BuildConfig.IS_JETPACK_APP) {
-                // user is signed into jetpack app, so restrict showing option to add self-hosted site
+            if (!BuildConfig.ENABLE_ADD_SELF_HOSTED_SITE) {
                 ActivityLauncher.newBlogForResult(activity);
             } else {
                 // user is signed into wordpress app, so use the dialog to enable choosing whether to

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -472,7 +472,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     private boolean isNewLoginEpilogueScreenEnabled() {
-        return !mBuildConfigWrapper.isJetpackApp()
+        return mBuildConfigWrapper.isSiteCreationEnabled()
                && !mShowAndReturn;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -378,7 +378,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     this,
                     getIntent().getBooleanExtra(ARG_DO_LOGIN_UPDATE, false),
                     getIntent().getIntegerArrayListExtra(ARG_OLD_SITES_IDS),
-                    mBuildConfigWrapper.isJetpackApp()
+                    mBuildConfigWrapper.isSiteCreationEnabled()
             );
         } else if (getIntent().getBooleanExtra(ARG_SHOW_SIGNUP_EPILOGUE, false) && savedInstanceState == null) {
             canShowAppRatingPrompt = false;
@@ -1272,7 +1272,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                                 this,
                                 true,
                                 getIntent().getIntegerArrayListExtra(ARG_OLD_SITES_IDS),
-                                mBuildConfigWrapper.isJetpackApp()
+                                mBuildConfigWrapper.isSiteCreationEnabled()
                         );
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -303,7 +303,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                 action.site,
                 CTA_DOMAIN_CREDIT_REDEMPTION
         )
-        is SiteNavigationAction.AddNewSite -> SitePickerActivity.addSite(activity, action.isSignedInWpCom)
+        is SiteNavigationAction.AddNewSite -> SitePickerActivity.addSite(activity, action.hasAccessToken)
         is SiteNavigationAction.ShowQuickStartDialog -> showQuickStartDialog(
                 action.title,
                 action.message,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -52,7 +52,7 @@ sealed class SiteNavigationAction {
     ) : SiteNavigationAction()
 
     data class OpenDomainRegistration(val site: SiteModel) : SiteNavigationAction()
-    data class AddNewSite(val isSignedInWpCom: Boolean) : SiteNavigationAction()
+    data class AddNewSite(val hasAccessToken: Boolean) : SiteNavigationAction()
     data class ShowQuickStartDialog(
         @StringRes val title: Int,
         @StringRes val message: Int,

--- a/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
@@ -19,4 +19,6 @@ class BuildConfigWrapper @Inject constructor() {
     fun isDebugSettingsEnabled(): Boolean = BuildConfig.ENABLE_DEBUG_SETTINGS
 
     val isJetpackApp = BuildConfig.IS_JETPACK_APP
+
+    val isSiteCreationEnabled = BuildConfig.ENABLE_SITE_CREATION
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -6,7 +6,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.jetbrains.annotations.NotNull;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -387,7 +386,6 @@ public class SiteUtils {
     @NonNull
     public static FetchSitesPayload getFetchSitesPayload() {
         ArrayList<SiteFilter> siteFilters = new ArrayList<>();
-        if (BuildConfig.IS_JETPACK_APP) siteFilters.add(SiteFilter.JETPACK);
         return new FetchSitesPayload(siteFilters);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.3.0'
-    wordPressLoginVersion = '0.0.8'
+    wordPressLoginVersion = '79-cd431185a9642fa91a19523606cf44ab322e6917'
     gutenbergMobileVersion = 'v1.71.0'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'


### PR DESCRIPTION
Closes #15916
Depends on https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/79

This PR

- Enables showing all sites (no Jetpack filtering).
- Enables the ability to create a new site.
- Disables adding self-hosted site option while creating a new site.


To test:

1. Install and login to the `Jetpack` app.
2. Notice that all sites are shown on the `Login Epilogue` screen.
3. Click `Done` button.
4. Go to `Site Picker` from `My Site` tab.
5. Notice that all sites are shown on the `Site Picker `screen.
6. Notice that + button exists on top right of the `Site Picker` screen.
7. Click + button.
8. Notice that option to add self-hosted sites does not exists and `wpcom` site creation flow starts with "Choose a design" option.

`TBD - Added to main task` 
- Remove `Quick Start` flow after site creation?

Merging Notes:

- Targets a feature branch that will include similar smaller PRs to enable Jetpack app features.
- Depends on a draft login lib PR removing Jetpack app sites filtering that cannot be merged with `trunk` right now.
- Don't merge the PR yet, I'll take care of the merging.

## Regression Notes
1. Potential unintended areas of impact 
Affected logic in WordPress Android app

2. What I did to test those areas of impact (or what existing automated tests I relied on
Tested manually

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
