### PR TITLE
Manually update `version.properties` for 19.1.1 hotfix

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -2,7 +2,7 @@
 
 # Version Information for Vanilla / Release builds
 versionName=19.1.1
-versionCode=1167
+versionCode=1168
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
 alpha.versionName=alpha-341

--- a/version.properties
+++ b/version.properties
@@ -1,8 +1,8 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=19.1
-versionCode=1165
+versionName=19.1.1
+versionCode=1167
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
 alpha.versionName=alpha-341


### PR DESCRIPTION
I only updated the values for the main build, not the `alpha` one, as it was done in the 19.0.1 hotfix: fd74624836dcfcaafbcb1ee1ab594f648d1171f3