### PR TITLE
Integrate gutenberg-mobile release 1.70.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.2.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = 'v1.70.2'
+    gutenbergMobileVersion = '4565-8e9162135ab039df8abb3b83b6f145ab357926cf'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.2.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = '4565-8e9162135ab039df8abb3b83b6f145ab357926cf'
+    gutenbergMobileVersion = 'v1.70.3'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 


### PR DESCRIPTION
## Description

This PR incorporates the 1.70.3 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: [wordpress-mobile/gutenberg-mobile#4544](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4565)

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.