### PR TITLE
Jetpack app: Enable account creation

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -120,6 +120,7 @@ android {
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"
         buildConfigField "boolean", "ENABLE_ADD_SELF_HOSTED_SITE", "true"
+        buildConfigField "boolean", "ENABLE_SIGNUP", "true"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -157,6 +158,7 @@ android {
             buildConfigField "boolean", "IS_JETPACK_APP", "true"
             buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"
             buildConfigField "boolean", "ENABLE_ADD_SELF_HOSTED_SITE", "false"
+            buildConfigField "boolean", "ENABLE_SIGNUP", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
 

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueViewModel.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueViewModel.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Flow
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step.PROLOGUE
 import org.wordpress.android.ui.accounts.login.LoginPrologueViewModel.ButtonUiState.ContinueWithWpcomButtonState
 import org.wordpress.android.ui.accounts.login.LoginPrologueViewModel.ButtonUiState.EnterYourSiteAddressButtonState
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -26,6 +27,7 @@ import javax.inject.Named
 class LoginPrologueViewModel @Inject constructor(
     private val unifiedLoginTracker: UnifiedLoginTracker,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val buildConfigWrapper: BuildConfigWrapper,
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {
     private val _navigationEvents = MediatorLiveData<Event<LoginNavigationEvents>>()
@@ -44,7 +46,14 @@ class LoginPrologueViewModel @Inject constructor(
 
         _uiState.value = UiState(
                 enterYourSiteAddressButtonState = EnterYourSiteAddressButtonState(::onEnterYourSiteAddressButtonClick),
-                continueWithWpcomButtonState = ContinueWithWpcomButtonState(::onContinueWithWpcomButtonClick)
+                continueWithWpcomButtonState = ContinueWithWpcomButtonState(
+                        title = if (buildConfigWrapper.isSignupEnabled) {
+                            R.string.continue_with_wpcom
+                        } else {
+                            R.string.continue_with_wpcom_no_signup
+                        },
+                        onClick = ::onContinueWithWpcomButtonClick
+                )
         )
     }
 
@@ -71,9 +80,10 @@ class LoginPrologueViewModel @Inject constructor(
         abstract val title: Int
         abstract val onClick: (() -> Unit)
 
-        data class ContinueWithWpcomButtonState(override val onClick: () -> Unit) : ButtonUiState() {
-            override val title = R.string.continue_with_wpcom_no_signup
-        }
+        data class ContinueWithWpcomButtonState(
+            override val title: Int,
+            override val onClick: () -> Unit
+        ) : ButtonUiState()
 
         data class EnterYourSiteAddressButtonState(override val onClick: () -> Unit) : ButtonUiState() {
             override val title = R.string.enter_your_site_address

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -70,6 +70,7 @@ import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.BuildConfigWrapper;
 import org.wordpress.android.util.SelfSignedSSLUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -132,6 +133,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Inject UnifiedLoginTracker mUnifiedLoginTracker;
     @Inject protected SiteStore mSiteStore;
     @Inject protected ViewModelProvider.Factory mViewModelFactory;
+    @Inject BuildConfigWrapper mBuildConfigWrapper;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -158,7 +160,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                     break;
                 case JETPACK_LOGIN_ONLY:
                     mUnifiedLoginTracker.setSource(Source.DEFAULT);
-                    mIsSignupFromLoginEnabled = false;
+                    mIsSignupFromLoginEnabled = mBuildConfigWrapper.isSignupEnabled();
                     loginFromPrologue();
                     break;
                 case WPCOM_LOGIN_ONLY:

--- a/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
@@ -21,4 +21,6 @@ class BuildConfigWrapper @Inject constructor() {
     val isJetpackApp = BuildConfig.IS_JETPACK_APP
 
     val isSiteCreationEnabled = BuildConfig.ENABLE_SITE_CREATION
+
+    val isSignupEnabled = BuildConfig.ENABLE_SIGNUP
 }

--- a/WordPress/src/testJetpack/java/org.wordpress.android/ui.accounts.login/LoginPrologueViewModelTest.kt
+++ b/WordPress/src/testJetpack/java/org.wordpress.android/ui.accounts.login/LoginPrologueViewModelTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.accounts.login
 
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -13,6 +14,7 @@ import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowEmailLoginScr
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowLoginViaSiteAddressScreen
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker
 import org.wordpress.android.ui.accounts.login.LoginPrologueViewModel.UiState
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.Event
 
@@ -20,19 +22,36 @@ import org.wordpress.android.viewmodel.Event
 class LoginPrologueViewModelTest : BaseUnitTest() {
     @Mock lateinit var unifiedLoginTracker: UnifiedLoginTracker
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     private lateinit var viewModel: LoginPrologueViewModel
 
     @Before
     fun setUp() {
-        viewModel = LoginPrologueViewModel(unifiedLoginTracker, analyticsTrackerWrapper, TEST_DISPATCHER)
+        viewModel = LoginPrologueViewModel(
+                unifiedLoginTracker,
+                analyticsTrackerWrapper,
+                buildConfigWrapper,
+                TEST_DISPATCHER
+        )
     }
 
     @Test
-    fun `when view starts, then continue with wpcom button is displayed with correct title`() {
+    fun `given signup disabled, when view starts, then continue with wpcom button is displayed with correct title`() {
+        whenever(buildConfigWrapper.isSignupEnabled).thenReturn(false)
         val observers = init()
 
         assertThat(observers.uiStates.last().continueWithWpcomButtonState.title)
                 .isEqualTo(R.string.continue_with_wpcom_no_signup)
+    }
+
+    @Test
+    fun `given signup enabled, when view starts, then continue with wpcom button is displayed with correct title`() {
+        whenever(buildConfigWrapper.isSignupEnabled).thenReturn(true)
+
+        val observers = init()
+
+        assertThat(observers.uiStates.last().continueWithWpcomButtonState.title)
+                .isEqualTo(R.string.continue_with_wpcom)
     }
 
     @Test


### PR DESCRIPTION
Closes #15922

This PR enables signup using `WordPress.com` in the `Jetpack` app using the `ENABLE_SIGNUP` constant.

To test:
1. Install and login to the `Jetpack` app.
2. Notice that `Log in or signup with WordPress.com` is shown on the `Login Prologue` screen.
3. Signup using a new email.
4. Notice that signup succeeds.

Merging Notes:
- Don't merge the PR yet, I'll take care of the merging.

## Regression Notes
1. Potential unintended areas of impact
WordPress app flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Updated exiting unit tests for Jetpack app `Login Prologue` screen.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
