### PR TITLE
Jetpack App: Enable more options

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -122,6 +122,7 @@ android {
         buildConfigField "boolean", "ENABLE_ADD_SELF_HOSTED_SITE", "true"
         buildConfigField "boolean", "ENABLE_SIGNUP", "true"
         buildConfigField "boolean", "ENABLE_READER", "true"
+        buildConfigField "boolean", "ENABLE_CREATE_FAB", "true"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -161,6 +162,7 @@ android {
             buildConfigField "boolean", "ENABLE_ADD_SELF_HOSTED_SITE", "false"
             buildConfigField "boolean", "ENABLE_SIGNUP", "true"
             buildConfigField "boolean", "ENABLE_READER", "true"
+            buildConfigField "boolean", "ENABLE_CREATE_FAB", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -123,6 +123,7 @@ android {
         buildConfigField "boolean", "ENABLE_SIGNUP", "true"
         buildConfigField "boolean", "ENABLE_READER", "true"
         buildConfigField "boolean", "ENABLE_CREATE_FAB", "true"
+        buildConfigField "boolean", "ENABLE_QUICK_ACTION", "true"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -163,6 +164,7 @@ android {
             buildConfigField "boolean", "ENABLE_SIGNUP", "true"
             buildConfigField "boolean", "ENABLE_READER", "true"
             buildConfigField "boolean", "ENABLE_CREATE_FAB", "true"
+            buildConfigField "boolean", "ENABLE_QUICK_ACTION", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -124,6 +124,7 @@ android {
         buildConfigField "boolean", "ENABLE_READER", "true"
         buildConfigField "boolean", "ENABLE_CREATE_FAB", "true"
         buildConfigField "boolean", "ENABLE_QUICK_ACTION", "true"
+        buildConfigField "boolean", "ENABLE_FOLLOWED_SITES_SETTINGS", "true"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -165,6 +166,7 @@ android {
             buildConfigField "boolean", "ENABLE_READER", "true"
             buildConfigField "boolean", "ENABLE_CREATE_FAB", "true"
             buildConfigField "boolean", "ENABLE_QUICK_ACTION", "true"
+            buildConfigField "boolean", "ENABLE_FOLLOWED_SITES_SETTINGS", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -125,6 +125,7 @@ android {
         buildConfigField "boolean", "ENABLE_CREATE_FAB", "true"
         buildConfigField "boolean", "ENABLE_QUICK_ACTION", "true"
         buildConfigField "boolean", "ENABLE_FOLLOWED_SITES_SETTINGS", "true"
+        buildConfigField "boolean", "ENABLE_WHATS_NEW_FEATURE", "true"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -167,6 +168,7 @@ android {
             buildConfigField "boolean", "ENABLE_CREATE_FAB", "true"
             buildConfigField "boolean", "ENABLE_QUICK_ACTION", "true"
             buildConfigField "boolean", "ENABLE_FOLLOWED_SITES_SETTINGS", "true"
+            buildConfigField "boolean", "ENABLE_WHATS_NEW_FEATURE", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -121,6 +121,7 @@ android {
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"
         buildConfigField "boolean", "ENABLE_ADD_SELF_HOSTED_SITE", "true"
         buildConfigField "boolean", "ENABLE_SIGNUP", "true"
+        buildConfigField "boolean", "ENABLE_READER", "true"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -159,6 +160,7 @@ android {
             buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"
             buildConfigField "boolean", "ENABLE_ADD_SELF_HOSTED_SITE", "false"
             buildConfigField "boolean", "ENABLE_SIGNUP", "true"
+            buildConfigField "boolean", "ENABLE_READER", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
 

--- a/WordPress/src/jetpack/res/xml/shortcuts.xml
+++ b/WordPress/src/jetpack/res/xml/shortcuts.xml
@@ -34,7 +34,7 @@
         android:icon="@drawable/ic_shortcut_create_post"
         android:shortcutId="new_post"
         android:shortcutShortLabel="@string/new_post"
-        android:enabled="false">
+        android:enabled="true">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"

--- a/WordPress/src/jetpackJalapeno/res/xml/shortcuts.xml
+++ b/WordPress/src/jetpackJalapeno/res/xml/shortcuts.xml
@@ -34,7 +34,7 @@
         android:icon="@drawable/ic_shortcut_create_post"
         android:shortcutId="new_post"
         android:shortcutShortLabel="@string/new_post"
-        android:enabled="false">
+        android:enabled="true">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"

--- a/WordPress/src/jetpackWasabi/res/xml/shortcuts.xml
+++ b/WordPress/src/jetpackWasabi/res/xml/shortcuts.xml
@@ -34,7 +34,7 @@
         android:icon="@drawable/ic_shortcut_create_post"
         android:shortcutId="new_post"
         android:shortcutShortLabel="@string/new_post"
-        android:enabled="false">
+        android:enabled="true">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -80,7 +80,7 @@ class WPMainNavigationView @JvmOverloads constructor(
 
         // overlay each item with our custom view
         val menuView = getChildAt(0) as BottomNavigationMenuView
-        if (BuildConfig.IS_JETPACK_APP) hideReaderTab()
+        if (!BuildConfig.ENABLE_READER) hideReaderTab()
 
         val inflater = LayoutInflater.from(context)
         for (i in 0 until menu.size()) {
@@ -315,7 +315,7 @@ class WPMainNavigationView @JvmOverloads constructor(
     }
 
     companion object {
-        private val pages = if (BuildConfig.IS_JETPACK_APP) listOf(MY_SITE, NOTIFS) else listOf(MY_SITE, READER, NOTIFS)
+        private val pages = if (BuildConfig.ENABLE_READER) listOf(MY_SITE, READER, NOTIFS) else listOf(MY_SITE, NOTIFS)
 
         private const val TAG_MY_SITE = "tag-mysite"
         private const val TAG_READER = "tag-reader"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -36,7 +36,7 @@ class CardsBuilder @Inject constructor(
     ): List<MySiteCardAndItem> {
         val cards = mutableListOf<MySiteCardAndItem>()
         cards.add(siteInfoCardBuilder.buildSiteInfoCard(siteInfoCardBuilderParams))
-        if (!buildConfigWrapper.isJetpackApp) {
+        if (buildConfigWrapper.isQuickActionEnabled) {
             cards.add(quickActionsCardBuilder.build(quickActionsCardBuilderParams))
         }
         if (domainRegistrationCardBuilderParams.isDomainCreditAvailable) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -358,10 +358,10 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
             }
             else -> titleResId = R.string.notifications_empty_list
         }
-        if (BuildConfig.IS_JETPACK_APP) {
-            showEmptyView(titleResId)
-        } else {
+        if (BuildConfig.ENABLE_READER) {
             showEmptyView(titleResId, descriptionResId, buttonResId)
+        } else {
+            showEmptyView(titleResId)
         }
         actionableEmptyView.image.visibility = if (DisplayUtils.isLandscape(context)) View.GONE else View.VISIBLE
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -296,7 +296,7 @@ public class AppSettingsFragment extends PreferenceFragment
         WhatsNewAnnouncementModel latestAnnouncement = event.getWhatsNewItems().get(0);
         mWhatsNew.setSummary(getString(R.string.version_with_name_param, latestAnnouncement.getAppVersionName()));
         mWhatsNew.setOnPreferenceClickListener(this);
-        if (!BuildConfig.IS_JETPACK_APP) {
+        if (mBuildConfigWrapper.isWhatsNewFeatureEnabled()) {
             addWhatsNewPreference();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -147,7 +147,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         addPreferencesFromResource(R.xml.notifications_settings);
         setHasOptionsMenu(true);
         removeSightAndSoundsForAPI26();
-        removeFollowedBlogsPreferenceForJetpackApp();
+        removeFollowedBlogsPreferenceForIfDisabled();
 
         // Bump Analytics
         if (savedInstanceState == null) {
@@ -169,8 +169,8 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         }
     }
 
-    private void removeFollowedBlogsPreferenceForJetpackApp() {
-        if (mBuildConfigWrapper.isJetpackApp()) {
+    private void removeFollowedBlogsPreferenceForIfDisabled() {
+        if (!mBuildConfigWrapper.isFollowedSitesSettingsEnabled()) {
             PreferenceScreen preferenceScreen =
                 (PreferenceScreen) findPreference(getActivity().getString(R.string.wp_pref_notifications_root));
 

--- a/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
@@ -27,4 +27,6 @@ class BuildConfigWrapper @Inject constructor() {
     val isCreateFabEnabled = BuildConfig.ENABLE_CREATE_FAB
 
     val isQuickActionEnabled = BuildConfig.ENABLE_QUICK_ACTION
+
+    val isFollowedSitesSettingsEnabled = BuildConfig.ENABLE_FOLLOWED_SITES_SETTINGS
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
@@ -29,4 +29,6 @@ class BuildConfigWrapper @Inject constructor() {
     val isQuickActionEnabled = BuildConfig.ENABLE_QUICK_ACTION
 
     val isFollowedSitesSettingsEnabled = BuildConfig.ENABLE_FOLLOWED_SITES_SETTINGS
+
+    val isWhatsNewFeatureEnabled = BuildConfig.ENABLE_WHATS_NEW_FEATURE
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
@@ -25,4 +25,6 @@ class BuildConfigWrapper @Inject constructor() {
     val isSignupEnabled = BuildConfig.ENABLE_SIGNUP
 
     val isCreateFabEnabled = BuildConfig.ENABLE_CREATE_FAB
+
+    val isQuickActionEnabled = BuildConfig.ENABLE_QUICK_ACTION
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
@@ -23,4 +23,6 @@ class BuildConfigWrapper @Inject constructor() {
     val isSiteCreationEnabled = BuildConfig.ENABLE_SITE_CREATION
 
     val isSignupEnabled = BuildConfig.ENABLE_SIGNUP
+
+    val isCreateFabEnabled = BuildConfig.ENABLE_CREATE_FAB
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -204,7 +204,7 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     fun onPageChanged(isOnMySitePageWithValidSite: Boolean, site: SiteModel?) {
-        val showFab = if (buildConfigWrapper.isJetpackApp) false else isOnMySitePageWithValidSite
+        val showFab = if (buildConfigWrapper.isCreateFabEnabled) isOnMySitePageWithValidSite else false
         setMainFabUiState(showFab, site)
     }
 
@@ -224,7 +224,7 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     fun onResume(site: SiteModel?, isOnMySitePageWithValidSite: Boolean) {
-        val showFab = if (buildConfigWrapper.isJetpackApp) false else isOnMySitePageWithValidSite
+        val showFab = if (buildConfigWrapper.isCreateFabEnabled) isOnMySitePageWithValidSite else false
         setMainFabUiState(showFab, site)
 
         checkAndShowFeatureAnnouncementForWordPressApp()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -227,12 +227,11 @@ class WPMainActivityViewModel @Inject constructor(
         val showFab = if (buildConfigWrapper.isCreateFabEnabled) isOnMySitePageWithValidSite else false
         setMainFabUiState(showFab, site)
 
-        checkAndShowFeatureAnnouncementForWordPressApp()
+        checkAndShowFeatureAnnouncement()
     }
 
-    private fun checkAndShowFeatureAnnouncementForWordPressApp() {
-        // Do not proceed with feature announcement check for Jetpack
-        if (!buildConfigWrapper.isJetpackApp) {
+    private fun checkAndShowFeatureAnnouncement() {
+        if (buildConfigWrapper.isWhatsNewFeatureEnabled) {
             launch {
                 val currentVersionCode = buildConfigWrapper.getAppVersionCode()
                 val previousVersionCode = appPrefsWrapper.lastFeatureAnnouncementAppVersionCode

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -101,19 +101,19 @@ class CardsBuilderTest {
     /* QUICK ACTIONS CARD */
 
     @Test
-    fun `when build is Jetpack, then quick action card is not built`() {
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
-        val cards = buildCards()
-
-        assertThat(cards.findQuickActionsCard()).isNull()
-    }
-
-    @Test
-    fun `when build is WordPress, then quick action card is built`() {
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
+    fun `when quick action enabled, then quick action card is built`() {
+        whenever(buildConfigWrapper.isQuickActionEnabled).thenReturn(true)
         val cards = buildCards()
 
         assertThat(cards.findQuickActionsCard()).isNotNull
+    }
+
+    @Test
+    fun `when quick action disabled, then quick action card is not built`() {
+        whenever(buildConfigWrapper.isQuickActionEnabled).thenReturn(false)
+        val cards = buildCards()
+
+        assertThat(cards.findQuickActionsCard()).isNull()
     }
 
     /* QUICK START CARD */

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -584,22 +584,22 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given wordpress app, when app is launched, then feature announcement is shown`() = test {
+    fun `given whats new feature enabled, when app is launched, then feature announcement is shown`() = test {
         whenever(appPrefsWrapper.featureAnnouncementShownVersion).thenReturn(-1)
         whenever(appPrefsWrapper.lastFeatureAnnouncementAppVersionCode).thenReturn(840)
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement(true)).thenReturn(
                 featureAnnouncement
         )
 
-        startViewModelWithDefaultParameters(false)
+        startViewModelWithDefaultParameters(true)
         resumeViewModelWithDefaultParameters()
 
         verify(onFeatureAnnouncementRequestedObserver).onChanged(anyOrNull())
     }
 
     @Test
-    fun `given jetpack app, when app is launched, then feature announcement is not shown`() = test {
-        startViewModelWithDefaultParameters(true)
+    fun `given whats new feature disabled, when app is launched, then feature announcement is not shown`() = test {
+        startViewModelWithDefaultParameters(isWhatsNewFeatureEnabled = false)
         resumeViewModelWithDefaultParameters()
 
         verify(onFeatureAnnouncementRequestedObserver, never()).onChanged(anyOrNull())
@@ -656,10 +656,10 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     private fun startViewModelWithDefaultParameters(
-        isJetpackApp: Boolean = false,
+        isWhatsNewFeatureEnabled: Boolean = true,
         isCreateFabEnabled: Boolean = true
     ) {
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(isJetpackApp)
+        whenever(buildConfigWrapper.isWhatsNewFeatureEnabled).thenReturn(isWhatsNewFeatureEnabled)
         whenever(buildConfigWrapper.isCreateFabEnabled).thenReturn(isCreateFabEnabled)
         viewModel.start(site = initSite(hasFullAccessToContent = true, supportsStories = true))
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -111,7 +111,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     /* FAB VISIBILITY */
 
     @Test
-    fun `given wordpress app, when page changed to my site, then fab is visible`() {
+    fun `given fab enabled, when page changed to my site, then fab is visible`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
@@ -120,7 +120,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given wordpress app, when page changed away from my site, then fab is hidden`() {
+    fun `given fab enabled, when page changed away from my site, then fab is hidden`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
@@ -129,7 +129,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given wordpress app, when my site page is resumed, then fab is visible`() {
+    fun `given fab enabled, when my site page is resumed, then fab is visible`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onResume(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
@@ -138,7 +138,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given wordpress app, when non my site page is resumed, then fab is hidden`() {
+    fun `given fab enabled, when non my site page is resumed, then fab is hidden`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onResume(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
@@ -147,8 +147,8 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given jetpack app, when page changed to my site, then fab is hidden`() {
-        startViewModelWithDefaultParameters(isJetpackApp = true)
+    fun `given fab disabled, when page changed to my site, then fab is hidden`() {
+        startViewModelWithDefaultParameters(isCreateFabEnabled = false)
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
 
@@ -156,8 +156,8 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given jetpack app, when page changed away from my site, then fab is hidden`() {
-        startViewModelWithDefaultParameters(isJetpackApp = true)
+    fun `given fab disabled, when page changed away from my site, then fab is hidden`() {
+        startViewModelWithDefaultParameters(isCreateFabEnabled = false)
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
 
@@ -165,8 +165,8 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given jetpack app, when my site page is resumed, then fab is hidden`() {
-        startViewModelWithDefaultParameters(isJetpackApp = true)
+    fun `given fab disabled, when my site page is resumed, then fab is hidden`() {
+        startViewModelWithDefaultParameters(isCreateFabEnabled = false)
 
         viewModel.onResume(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
 
@@ -174,8 +174,8 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given jetpack app, when non my site page is resumed, then fab is hidden`() {
-        startViewModelWithDefaultParameters(isJetpackApp = true)
+    fun `given fab disabled, when non my site page is resumed, then fab is hidden`() {
+        startViewModelWithDefaultParameters(isCreateFabEnabled = false)
 
         viewModel.onResume(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
 
@@ -185,7 +185,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     /* FAB TOOLTIP VISIBILITY */
 
     @Test
-    fun `given wordpress app, when page changed to my site, then fab tooltip is visible`() {
+    fun `given fab enabled, when page changed to my site, then fab tooltip is visible`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
@@ -194,7 +194,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given wordpress app, when page changed away from my site, then fab tooltip is hidden`() {
+    fun `given fab enabled, when page changed away from my site, then fab tooltip is hidden`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
@@ -203,7 +203,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given wordpress app, when my site page is resumed, then fab tooltip is visible`() {
+    fun `given fab enabled, when my site page is resumed, then fab tooltip is visible`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onResume(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
@@ -212,7 +212,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given wordpress app, when non my site page is resumed, then fab tooltip is hidden`() {
+    fun `given fab enabled, when non my site page is resumed, then fab tooltip is hidden`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onResume(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
@@ -221,8 +221,8 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given jetpack app, when page changed to my site, then fab tooltip is hidden`() {
-        startViewModelWithDefaultParameters(isJetpackApp = true)
+    fun `given fab disabled, when page changed to my site, then fab tooltip is hidden`() {
+        startViewModelWithDefaultParameters(isCreateFabEnabled = false)
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
 
@@ -230,8 +230,8 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given jetpack app, when page changed away from my site, then fab tooltip is hidden`() {
-        startViewModelWithDefaultParameters(isJetpackApp = true)
+    fun `given fab disabled, when page changed away from my site, then fab tooltip is hidden`() {
+        startViewModelWithDefaultParameters(isCreateFabEnabled = false)
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
 
@@ -239,8 +239,8 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given jetpack app, when my site page is resumed, then fab tooltip is hidden`() {
-        startViewModelWithDefaultParameters(isJetpackApp = true)
+    fun `given fab disabled, when my site page is resumed, then fab tooltip is hidden`() {
+        startViewModelWithDefaultParameters(isCreateFabEnabled = false)
 
         viewModel.onResume(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
 
@@ -248,8 +248,8 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given jetpack app, when non my site page is resumed, then fab tooltip is hidden`() {
-        startViewModelWithDefaultParameters(isJetpackApp = true)
+    fun `given fab disabled, when non my site page is resumed, then fab tooltip is hidden`() {
+        startViewModelWithDefaultParameters(isCreateFabEnabled = false)
 
         viewModel.onResume(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
 
@@ -655,8 +655,12 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         assertThat(viewModel.mainActions.value!!.map { it.actionType }).isEqualTo(expectedOrder)
     }
 
-    private fun startViewModelWithDefaultParameters(isJetpackApp: Boolean = false) {
+    private fun startViewModelWithDefaultParameters(
+        isJetpackApp: Boolean = false,
+        isCreateFabEnabled: Boolean = true
+    ) {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(isJetpackApp)
+        whenever(buildConfigWrapper.isCreateFabEnabled).thenReturn(isCreateFabEnabled)
         viewModel.start(site = initSite(hasFullAccessToContent = true, supportsStories = true))
     }
 


### PR DESCRIPTION
Closes #15929

This PR enables Reader, FAB, Quick Actions, Notification Settings, What's New Feature for the `Jetpack` app using `BuildConfig` constants.

To test:

1. Install and log in to the Jetpack app.
2. Notice that
    - Reader tab disabled in #14527 is now present. 4b7206fed4d69768231e0593e1d70581237e61e1
    - FAB disabled in #14553 is now present. 2cf853e6662c622449c4fc6ef6912c6d145702cc
    - Quick Actions card disabled in #14614 is now present. 59613d3d1370364703d6eaeb94df4c8e3f51d456
    - Followed Sites Notification Settings disabled in #14743 is now present. 575e55ec87c966c7558129a663809b565ae97c77
    - What's New Feature disabled in #14771  and #14757 is now present. aec0761b32d635fa25eb2c2083ec7cf859d6d6aa, 45748da
    - Shortcut for new post disabled in #14306 is now present. 1e19bf673fbdea97ec61288ea3bacb8e26432a29

Merging Notes:

Don't merge the PR yet, I'll take care of the merging.

## Regression Notes
1. Potential unintended areas of impact
WordPress App flows.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Updated existing tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
