### PR TITLE
Integrate gutenberg-mobile release 1.71.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.3.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = 'v1.71.0'
+    gutenbergMobileVersion = '4574-cd106b810e7b62855d4e46f2b7965b28c3067163'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.3.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = '4574-cd106b810e7b62855d4e46f2b7965b28c3067163'
+    gutenbergMobileVersion = '4574-dc8e2db11ad45321db8cd87d78278c31a1e3a2b0'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.3.0'
     wordPressLoginVersion = '0.0.8'
-    gutenbergMobileVersion = '4574-dc8e2db11ad45321db8cd87d78278c31a1e3a2b0'
+    gutenbergMobileVersion = 'v1.71.1'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 


### PR DESCRIPTION
## Description

This PR incorporates the 1.71.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: [wordpress-mobile/gutenberg-mobile#4574](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4574)

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.