### PR TITLE
Fix for stats endpoints being called twice

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -81,9 +81,9 @@ class StatsFragment : DaggerFragment(R.layout.stats_fragment), ScrollableViewIni
     private fun StatsFragmentBinding.initializeViews(activity: FragmentActivity) {
         val adapter = StatsPagerAdapter(activity)
         statsPager.adapter = adapter
-         statsPager.setPageTransformer(
-                 MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
-         )
+        statsPager.setPageTransformer(
+                MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
+        )
         TabLayoutMediator(tabLayout, statsPager) { tab, position ->
             tab.text = adapter.getTabTitle(position)
         }.attach()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -1,19 +1,19 @@
 package org.wordpress.android.ui.stats.refresh
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.os.Bundle
 import android.view.MotionEvent
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentPagerAdapter
 import androidx.lifecycle.ViewModelProvider
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.widget.MarginPageTransformer
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.google.android.material.tabs.TabLayout.Tab
+import com.google.android.material.tabs.TabLayoutMediator
 import dagger.android.support.DaggerFragment
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -79,9 +79,14 @@ class StatsFragment : DaggerFragment(R.layout.stats_fragment), ScrollableViewIni
     }
 
     private fun StatsFragmentBinding.initializeViews(activity: FragmentActivity) {
-        statsPager.adapter = StatsPagerAdapter(activity, childFragmentManager)
-        tabLayout.setupWithViewPager(statsPager)
-        statsPager.pageMargin = resources.getDimensionPixelSize(R.dimen.margin_extra_large)
+        val adapter = StatsPagerAdapter(activity)
+        statsPager.adapter = adapter
+         statsPager.setPageTransformer(
+                 MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
+         )
+        TabLayoutMediator(tabLayout, statsPager) { tab, position ->
+            tab.text = adapter.getTabTitle(position)
+        }.attach()
         tabLayout.addOnTabSelectedListener(selectedTabListener)
 
         swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
@@ -228,18 +233,15 @@ class StatsFragment : DaggerFragment(R.layout.stats_fragment), ScrollableViewIni
     }
 }
 
-class StatsPagerAdapter(val context: Context, val fm: FragmentManager) : FragmentPagerAdapter(
-        fm,
-        BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT
-) {
-    override fun getCount(): Int = statsSections.size
+class StatsPagerAdapter(val activity: FragmentActivity) : FragmentStateAdapter(activity) {
+    override fun getItemCount(): Int = statsSections.size
 
-    override fun getItem(position: Int): Fragment {
+    override fun createFragment(position: Int): Fragment {
         return StatsListFragment.newInstance(statsSections[position])
     }
 
-    override fun getPageTitle(position: Int): CharSequence? {
-        return context.getString(statsSections[position].titleRes)
+    fun getTabTitle(position: Int): CharSequence {
+        return activity.getString(statsSections[position].titleRes)
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -152,6 +152,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         val nonNullActivity = requireActivity()
         with(StatsListFragmentBinding.bind(view)) {
             binding = this
+            pageContainer.layoutTransition.setAnimateParentHierarchy(false)
             initializeViews(savedInstanceState)
             initializeViewModels(nonNullActivity)
         }

--- a/WordPress/src/main/res/layout/stats_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_fragment.xml
@@ -19,7 +19,7 @@
             android:layout_below="@id/toolbar"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <androidx.viewpager.widget.ViewPager
+            <androidx.viewpager2.widget.ViewPager2
                 android:id="@+id/statsPager"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />

--- a/WordPress/src/main/res/layout/stats_list_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_list_fragment.xml
@@ -26,6 +26,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <LinearLayout
+        android:id="@+id/page_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:animateLayoutChanges="true"


### PR DESCRIPTION
This PR replaces ViewPager with ViewPager2.  Legacy ViewPager is known to be buggy.  Infact, part of the problem seems to be due to onTabSelected invoked inconsistently, on same fragment instantiation that was causing duplicate calls.

Fixes #15906 

To test:

- Setup a debugging proxy like [Charles](https://www.charlesproxy.com/) or [Proxyman](https://proxyman.io/) with your device or emulator as you need to observe network traffic
- Install the app
- Launch app, on My Site, click on Stats from quick links or Stats option below
- Ensure, Stats launches in Insights tab
- Observe network calls and make sure there are no repeated calls to the same endpoint
- Switch to Day, Week, Month and Year tabs and observe network calls.  Ensure there are no repeated calls.

NOTE: By default the ViewPager instantiates next tab fragment offscreen.  So for e.g. when on Insights tab, it instantiates Day fragment and when on Day tab, then Week fragment, so on.  That is to say, You'll see current tab calls plus next tab calls

## Regression Notes
1. Potential unintended areas of impact
Tested all stats tabs variations

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
