### PR TITLE
Page/Site design picker: Fixes flickering when changing the preview mode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [*] Comment editor: Notification comments support in the new editor [https://github.com/wordpress-mobile/WordPress-Android/pull/15884]
 * [*] Site creation: Fixed bug where sites created within the app were not given the correct time zone, leading to post scheduling issues. [https://github.com/wordpress-mobile/WordPress-Android/pull/15904]
 * [*] Login Epilogue: Fixed bug where if no sites available, then new login epilogue screen without clickable sites and with "create new site" is shown instead of no sites empty "My Site" view. [https://github.com/wordpress-mobile/WordPress-Android/pull/15944]
+* [*] Fixes flickering when changing the preview mode in Page or Site design picker [https://github.com/wordpress-mobile/WordPress-Android/pull/15943]
 
 19.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.view.Gravity.CENTER_HORIZONTAL
 import android.view.LayoutInflater
 import android.view.View
@@ -34,6 +35,7 @@ import javax.inject.Inject
 
 private const val INITIAL_SCALE = 90
 private const val JS_EVALUATION_DELAY = 250L
+private const val JS_READY_CALLBACK_ID = 926L
 
 abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
     @Inject lateinit var displayUtilsWrapper: DisplayUtilsWrapper
@@ -127,8 +129,16 @@ abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
                 setWebViewWidth(view, width)
                 val widthScript = context?.getString(R.string.web_preview_width_script, width)
                 if (widthScript != null) {
-                    Handler().postDelayed({
-                        view.evaluateJavascript(widthScript) { viewModel.onPreviewLoaded() }
+                    Handler(Looper.getMainLooper()).postDelayed({
+                        view.evaluateJavascript(widthScript) {
+                            view.postVisualStateCallback(JS_READY_CALLBACK_ID, object : WebView.VisualStateCallback() {
+                                override fun onComplete(requestId: Long) {
+                                    if (JS_READY_CALLBACK_ID == requestId) {
+                                        viewModel.onPreviewLoaded()
+                                    }
+                                }
+                            })
+                        }
                     }, JS_EVALUATION_DELAY)
                 }
             }


### PR DESCRIPTION
Fixes #13952

## Description
Fixes flickering when changing the preview mode in the Page and Site design pickers by accounting for the rendering delay before updating the webview loading state.

## To test
### Site Design Picker
1. Start the site creation flow (e.g. Choose site > Add button)
2. Select the Create WordPress.com site option
3. Select a design
4. Press Preview
5. Press the preview mode button at the top right of the screen
6. **Verify** that the current preview mode does not flash before the selected mode renders

### Page Layout Picker
1. Press the Fab ➕ icon at the *My Site* screen
2. Choose *Site Page*
3. Select a layout
4. Press Preview
5. Press the preview mode button at the top right of the screen
6. **Verify** that the current preview mode does not flash before the selected mode renders


<details>
<summary>Before</summary>

https://user-images.githubusercontent.com/304044/153589175-53021f24-55ac-4e45-8a87-a17d16d18d91.mp4
</details>

<details>
<summary>After</summary>

https://user-images.githubusercontent.com/304044/153589219-0bfe300b-28ee-4fd6-936a-c730d9081c38.mp4
</details>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and relied on existing tests (`ModalLayoutPickerViewModelTest`, `HomePagePickerViewModelTest`)

3. What automated tests I added (or what prevented me from doing so)
The fix involves a UI improvement for which a stable test might not be possible

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
