### PR TITLE
Fix no sites empty view not shown from login epilogue

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 19.3
 -----
 * [*] Site creation: Fixed bug where sites created within the app were not given the correct time zone, leading to post scheduling issues. [https://github.com/wordpress-mobile/WordPress-Android/pull/15904]
+* [*] Login Epilogue: Fixed bug where if no sites available, then new login epilogue screen without clickable sites and with "create new site" is shown instead of no sites empty "My Site" view. [https://github.com/wordpress-mobile/WordPress-Android/pull/15944]
 
 19.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
@@ -44,4 +44,12 @@ class LoginEpilogueViewModel @Inject constructor(
     private fun handleSitesFound() {
         _navigationEvents.postValue(Event(LoginNavigationEvents.CloseWithResultOk))
     }
+
+    fun onLoginEpilogueResume(doLoginUpdate: Boolean) {
+        if (!doLoginUpdate && !siteStore.hasSite()) handleNoSitesFound()
+    }
+
+    fun onLoginFinished(doLoginUpdate: Boolean) {
+        if (doLoginUpdate && !siteStore.hasSite()) handleNoSitesFound()
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -24,6 +25,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.login.LoginBaseFormFragment;
+import org.wordpress.android.ui.accounts.LoginEpilogueViewModel;
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker;
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Click;
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step;
@@ -65,6 +67,8 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     @Inject ImageManager mImageManager;
     @Inject UnifiedLoginTracker mUnifiedLoginTracker;
     @Inject BuildConfigWrapper mBuildConfigWrapper;
+    @Inject ViewModelProvider.Factory mViewModelFactory;
+    @Inject LoginEpilogueViewModel mParentViewModel;
 
     public static LoginEpilogueFragment newInstance(boolean doLoginUpdate, boolean showAndReturn,
                                                     ArrayList<Integer> oldSitesIds) {
@@ -160,6 +164,12 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     }
 
     @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        initViewModel();
+    }
+
+    @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
@@ -167,6 +177,11 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
             AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_EPILOGUE_VIEWED);
             mUnifiedLoginTracker.track(Step.SUCCESS);
         }
+    }
+
+    private void initViewModel() {
+        mParentViewModel = new ViewModelProvider(requireActivity(), mViewModelFactory)
+                .get(LoginEpilogueViewModel.class);
     }
 
     private void initAdapter() {
@@ -301,6 +316,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
             // when from magiclink, we need to complete the login process here (update account and settings)
             doFinishLogin();
         }
+        mParentViewModel.onLoginEpilogueResume(mDoLoginUpdate);
     }
 
     @Override
@@ -382,5 +398,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         endProgress();
         setNewAdapter();
         mSitesList.setAdapter(mAdapter);
+
+        mParentViewModel.onLoginFinished(mDoLoginUpdate);
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
@@ -79,7 +79,40 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
         ).isEmpty()
     }
 
-    /* WordPress app - Eplilogue Screen Close */
+    /* WordPress app - No Sites - Epilogue Screen OnResume Next Time */
+    @Test
+    fun `given wp app with no sites + login update not requested, when screen shown again, then screen is closed`() {
+        init(isJetpackApp = false, hasSite = false, postSignupInterstitialShownEarlier = true)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onLoginEpilogueResume(doLoginUpdate = false)
+
+        assertThat(navigationEvents.first()).isInstanceOf(LoginNavigationEvents.CloseWithResultOk::class.java)
+    }
+
+    @Test
+    fun `given wp app with no sites + login update requested, when screen shown again, then screen is not closed`() {
+        init(isJetpackApp = false, hasSite = false, postSignupInterstitialShownEarlier = true)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onLoginEpilogueResume(doLoginUpdate = true)
+
+        assertThat(
+                navigationEvents.filterIsInstance(LoginNavigationEvents.CloseWithResultOk::class.java)
+        ).isEmpty()
+    }
+
+    @Test
+    fun `given wp app with no site + login update requested, when login finishes, then screen is closed`() {
+        init(isJetpackApp = false, hasSite = false, postSignupInterstitialShownEarlier = true)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onLoginFinished(doLoginUpdate = true)
+
+        assertThat(navigationEvents.first()).isInstanceOf(LoginNavigationEvents.CloseWithResultOk::class.java)
+    }
+
+    /* WordPress app - Epilogue Screen Close On Continue */
     @Test
     fun `given wp app with no sites, when continued from epilogue, then epilogue closes with ok result`() {
         init(isJetpackApp = false, hasSite = false)
@@ -112,7 +145,39 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
         assertThat(navigationEvents.last()).isInstanceOf(LoginNavigationEvents.ShowNoJetpackSites::class.java)
     }
 
-    /* Jetpack app - Eplilogue Screen Close */
+    @Test
+    fun `given jp app with no sites + login update not requested, when screen shown, then no jp sites shown`() {
+        init(isJetpackApp = true, hasSite = false)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onLoginEpilogueResume(doLoginUpdate = false)
+
+        assertThat(navigationEvents.first()).isInstanceOf(LoginNavigationEvents.ShowNoJetpackSites::class.java)
+    }
+
+    @Test
+    fun `given jp app with no sites + login update requested, when screen shown, then no jp sites not shown`() {
+        init(isJetpackApp = true, hasSite = false)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onLoginEpilogueResume(doLoginUpdate = true)
+
+        assertThat(
+                navigationEvents.filterIsInstance(LoginNavigationEvents.ShowNoJetpackSites::class.java)
+        ).isEmpty()
+    }
+
+    @Test
+    fun `given jp app with no site + login update requested, when login finishes, then no jp sites shown`() {
+        init(isJetpackApp = true, hasSite = false)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onLoginFinished(doLoginUpdate = true)
+
+        assertThat(navigationEvents.first()).isInstanceOf(LoginNavigationEvents.ShowNoJetpackSites::class.java)
+    }
+
+    /* Jetpack app - Epilogue Screen Close On Continue */
     @Test
     fun `given jetpack app with sites, when continued from epilogue, then screen closes with ok result`() {
         init(isJetpackApp = true, hasSite = true)


### PR DESCRIPTION
Fixes #15494

## Description

If the app is _freshly installed_ and no sites are present, then `PostSignupInterstitial` screen is shown with the welcome message. But after logout and re-login, currently, the new `LoginEpilogue` screen (without any site and with an option to create a new site) is displayed instead of the empty `My Site` screen. There is no on-screen option to dismiss the new `LoginEpilogue` screen.

This PR fixes the no sites empty view not shown issue after _logout-> login path_ by closing the screen if no sites are found, `WPMainActivity` that already exists in the back stack is shown with an empty `MySite` tab and option to add site. 

The Jetpack app continues with the `ShowNoJetpackSites` action, however, this behavior will change once all sites are shown and site creation is enabled (see #15915). 

Note: It seems that on `magic link login`, the epilogue screen waits for [login to finish where it fetches the sites](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/blob/c37055807bf279cba2a975161e4d8f3ba42b137b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java#L288). In this scenario, we close the screen after the sites are fetched and still no sites are found.

To test:

**WordPress App**

1. Fresh install the app.
2. Signup with a new email without assigning a password.
3. Notice that `PostSignupInterstitial` screen is displayed.
4. Click `Not right now` option.
5. Go to `My Site` tab and log out from the `Me` profile settings.
6. Re-login using the same email address (since the password is not assigned, you'll get a magic link for login).
7. Notice that an empty `My Site` tab is displayed with `Add new site` button.
8. Logout and assign a password to the account on the web.
9. Re-login to the app using email + password.
10. Notice that an empty `My Site` tab is displayed with `Add new site` button.
11. Create a new site.
12. Logout and re-login.
13. Notice that the `LoginEpilogue` screen is displayed with a list of sites and an option to `Create a new site`.
14. Tap on a site on the `LoginEpilogue` screen.
15. Notice that the `My Site` tab is shown for the selected site.

**Jetpack App**

No Sites
1. Login using an account without any `Jetpack` sites.
2. Notice that `No Jetpack Sites` screen is displayed.

With Sites
1. Login using an account with `Jetpack` sites.
2. Notice that the `LoginEpilogue` screen is displayed with a list of sites and `Done` option.
3. Tap on a site on the `LoginEpilogue` screen.
4. Notice that the `My Site` tab is shown for the selected site.

## Regression Notes
1. Potential unintended areas of impact
Login flows.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for the fix.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
