### PR TITLE
Adds permission to allow querying packages in api level 30 and above

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 19.3
 -----
 * [*] Site creation: Fixed bug where sites created within the app were not given the correct time zone, leading to post scheduling issues. [https://github.com/wordpress-mobile/WordPress-Android/pull/15904]
+* [*] Signup/Login: Fixes the check email button functionality on devices with Android 11 and above. [https://github.com/wordpress-mobile/WordPress-Android/pull/15947]
 
 19.2
 -----

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -24,6 +24,9 @@
     <!-- GCM all build types configuration -->
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
+    <!-- Allows querying packages in api level 30 and above (e.g. to check for installed email apps)
+      https://developer.android.com/reference/android/Manifest.permission#QUERY_ALL_PACKAGES -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
 
     <uses-feature
         android:name="android.hardware.camera"


### PR DESCRIPTION
Fixes #15883

[Adds permission to allow querying packages in api level 30 and above](https://developer.android.com/reference/android/Manifest.permission).

Related PR: https://github.com/wordpress-mobile/WordPress-Android/pull/15331

### To test:
_This should be tested on a device with Android 11 (API level 30) and above that has an email client (e.g. Gmail) installed_
1. Press the Signup button on the landing screen of the app (on a fresh install or logged out state)
2. Provide an email
3. On the next screen press the Check email button
4. *Verify* that the email app opens without an error (`Can't detect your email client app`)

**Verify that the functionality does not break on devices with OS older than Android 11**

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
The fix only adds an extra permission to the manifest and does not change 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
