### PR TITLE
[Tooling] Allow `upload_to_play_store` to retry on Google API failure

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -576,17 +576,29 @@ REPOSITORY_NAME = 'WordPress-Android'
     aab_file_path = bundle_file_path(app, version)
 
     if File.exist? aab_file_path then
-      upload_to_play_store(
-        package_name: package_name,
-        aab: aab_file_path,
-        track: options[:track],
-        release_status: 'draft',
-        skip_upload_metadata: true,
-        skip_upload_changelogs: true,
-        skip_upload_images: true,
-        skip_upload_screenshots: true,
-        json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
-      )
+      retry_count = 2
+      begin
+        upload_to_play_store(
+          package_name: package_name,
+          aab: aab_file_path,
+          track: options[:track],
+          release_status: 'draft',
+          skip_upload_metadata: true,
+          skip_upload_changelogs: true,
+          skip_upload_images: true,
+          skip_upload_screenshots: true,
+          json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
+        )
+      rescue FastlaneCore::Interface::FastlaneError => ex
+        # Sometimes the upload fails randomly with a "Google Api Error: Invalid request - This Edit has been deleted.".
+        # It seems one reason might be a race condition when we do multiple edits at the exact same time (WP alpha, WP beta, JP beta). Retrying usually fixes it
+        if ex.message.start_with?('Google Api Error') && (retry_count -= 1) > 0
+          UI.error "Upload failed with Google API error. Retrying in 2mn..."
+          sleep(120)
+          retry
+        end
+        raise
+      end
     else
       UI.error("Unable to find a build artifact at #{aab_file_path}")
     end


### PR DESCRIPTION
This is a PR to workaround a Google API error we encounter randomly when trying to upload new builds to the PlayStore in parallel

⚠️  Note: I've made this PR target `release/19.2` because it's most likely that the next time we will use this lane will be during release duties of `19.2`

### Context

When we build a new alpha/beta or the final release and try to upload it to the PlayStore, sometimes the build ends failing on the very last step with this error message ([example](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/28983/workflows/9dfcdff2-5b0a-44bd-ad7a-b3257c65f0f5/jobs/118953)):

```
[…]
| 17   | Switch to upload_build_to_play_store lane                     | 0           |
| 💥   | upload_to_play_store                                          | 31          |
+------+---------------------------------------------------------------+-------------+

[09:49:27]: fastlane finished with errors

[!] Google Api Error: Invalid request - This Edit has been deleted.

Exited with code exit status 1
```

Retrying the build ("Rerun from failed"on CircleCI) typically fixes it every time.

### Why

We are not entirely sure why this happens, but it seems a bit random and likely due to something of a race condition happening between CI and the Google API.

There's an [old GitHub Issue on fastlane about it](https://github.com/fastlane/fastlane/issues/13689), but it has been auto-closed and likely won't be fixed anytime soon. [One of the comment in this issue](https://github.com/fastlane/fastlane/issues/13689#issuecomment-439217502) suggests that the issue might happen when we try to run the lane in parallel. Given that we indeed parallelized the build-and-upload of WP alpha, WP beta and JP beta, it seems quite likely that there could be a race condition there with each trying to do an "Edit" at roughly the same time.

An "Edit" on PlayStore API is like a transaction in a DB: the API requires you top [begin an Edit](https://github.com/fastlane/fastlane/blob/master/supply/lib/supply/uploader.rb#L7), then make your changes, then [commit the Edit](https://github.com/fastlane/fastlane/blob/master/supply/lib/supply/uploader.rb#L43) to validate them; so indeed it seems likely that the job for WP alpha opens an Edit, and the one for WP beta also opens one, inherently cancelling the WP-alpha one, leading to the error.

On the other hand, I've seen cases where the **very first** of the 3 jobs is the one that fails (see the order of the messages in the Slack notifications ref. p1644832168536729-slack-C5ALGJYEP ), which makes me wonder if that situation above is really what's happening

### Workaround

In any case, since retrying the job makes it pass, I've decided to implement an auto-retry mechanism on the upload step itself, to avoid us having to be surprised by the error notification, have to re-run the job manually (only when the other 2 have finished because the UI to "rerun from failed" needs so), and also only retry the upload (instead of having to restart the whole build again).

This might not be perfect (it's only a workaround, after all), but seems an easy enough to implement (as opposed to having to implement some semaphore mechanism to sync the build or completely split and rearrange the job dependencies just for this) and hopefully enough to reduce the amount of those API errors in the future.