### PR TITLE
Fixes my site icon indeterminate progress

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [**] Login: improved error messages for login with self-hosted sites. [https://github.com/wordpress-mobile/WordPress-Android/pull/15919]
 * [*] Reader: nested comments with missing parent are now hidden from the comment list [https://github.com/wordpress-mobile/WordPress-Android/pull/15993]
+* [*] My Site: Fixes indeterminate progress bar in site icon when cancelling editing [https://github.com/wordpress-mobile/WordPress-Android/pull/15958]
 
 19.3
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -610,13 +610,10 @@ class MySiteViewModel @Inject constructor(
         analyticsTrackerWrapper.track(stat)
         val imageUri = Uri.parse(iconUrl)?.let { UriWrapper(it) }
         if (imageUri != null) {
-            selectedSiteRepository.showSiteIconProgressBar(true)
             launch(bgDispatcher) {
                 val fetchMedia = wpMediaUtilsWrapper.fetchMediaToUriWrapper(imageUri)
                 if (fetchMedia != null) {
                     _onNavigation.postValue(Event(SiteNavigationAction.OpenCropActivity(fetchMedia)))
-                } else {
-                    selectedSiteRepository.showSiteIconProgressBar(false)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -636,13 +636,10 @@ class MySiteViewModel @Inject constructor(
         analyticsTrackerWrapper.track(stat)
         val imageUri = Uri.parse(iconUrl)?.let { UriWrapper(it) }
         if (imageUri != null) {
-            selectedSiteRepository.showSiteIconProgressBar(true)
             launch(bgDispatcher) {
                 val fetchMedia = wpMediaUtilsWrapper.fetchMediaToUriWrapper(imageUri)
                 if (fetchMedia != null) {
                     _onNavigation.postValue(Event(SiteNavigationAction.OpenCropActivity(fetchMedia)))
-                } else {
-                    selectedSiteRepository.showSiteIconProgressBar(false)
                 }
             }
         }


### PR DESCRIPTION
Fixes #13155

To test:
- My Site -> Change site icon.
- Select an image and tap on confirm.
- In the Edit Photo screen tap on the top left x icon and check that the default/previous icon is shown.
- No indeterminate progress bar on icon.

**Before:**
https://user-images.githubusercontent.com/29736284/154083329-fad29b9e-ff71-404c-8558-d09760c6e181.mp4

**After:**
https://user-images.githubusercontent.com/29736284/154081646-3968cd13-7d12-4bc4-be5b-fb5bb6adf92d.mp4

## Regression Notes
1. Potential unintended areas of impact
- Fixed `site icon progress`, did not find a case where it may misbehave.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual tests

3. What automated tests I added (or what prevented me from doing so)
- Changes do not require extra tests nor do they affect existing.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
