### PR TITLE
[Tooling] Improve rename_apk_aab.sh script

### DIFF
--- a/tools/rename_apk_aab.sh
+++ b/tools/rename_apk_aab.sh
@@ -18,13 +18,12 @@ set +o pipefail
 # Usage:
 #   rename_apk_aab.sh [file1.apk] [file2.aab] [...]
 #
-# Without any parameter, applies the rename to every APK/AAB file found in ~/Downloads
+# Without any parameter, applies the rename to every APK/AAB file found at the top level of the ~/Downloads directory
 #
 INPUT_FILES=( "$@" )
 if [[ $# -lt 1 ]]; then
-  IFS=$'\n'
-  INPUT_FILES=( $(find ~/Downloads -name *.apk -o -name *.aab) )
-  unset IFS
+  shopt -s nullglob
+  INPUT_FILES=(~/Downloads/*.{aab,apk})
 fi
 
 

--- a/tools/rename_apk_aab.sh
+++ b/tools/rename_apk_aab.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # This script aims to rename any `.apk` or `.aab` file to `[wpandroid|jpandroid]-{version}[-Signed].apk/aab`
 # depending on the APK/AAB package name, version name and package signature.
@@ -11,7 +11,7 @@
 # no parameter provided – the files will be renamed with a basename appropriate to the ones we use when attaching
 # those files to the GitHub release.
 
-
+set +o pipefail
 
 ### Input Parameters ###
 
@@ -31,9 +31,15 @@ fi
 ##################################
 ### Path to Android tools used ###
 ##################################
-AAPT2=$(ls -1t ${ANDROID_SDK_ROOT:-$ANDROID_HOME}/build-tools/*/aapt2 | head -n1)
-APKSIGNER=$(ls -1t ${ANDROID_SDK_ROOT:-$ANDROID_HOME}/build-tools/*/apksigner | head -n1)
+[[ -d "${ANDROID_SDK_ROOT:-$ANDROID_HOME}" ]] || ( echo "You need to have either \`ANDROID_SDK_ROOT\` or \`ANDROID_HOME\` env var defined, and pointing to your Android SDK installation directory." && exit 1 )
+
+AAPT2=$(ls -1t "${ANDROID_SDK_ROOT:-$ANDROID_HOME}"/build-tools/*/aapt2 | head -n1)
+APKSIGNER=$(ls -1t "${ANDROID_SDK_ROOT:-$ANDROID_HOME}"/build-tools/*/apksigner | head -n1)
 BUNDLETOOL="/usr/local/bin/bundletool"
+
+[[ -x "$AAPT2" ]] || ( echo "Failed to find the \`aapt2\` tool in your \$ANDROID_SDK_ROOT" && exit 1 )
+[[ -x "$APKSIGNER" ]] || ( echo "Failed to find the \`apksigner\` tool in your \$ANDROID_SDK_ROOT" && exit 1 )
+[[ -x "$BUNDLETOOL" ]] || ( echo "Failed to find the \`bundletool\` executable; install it using \`brew install bundletool\`" && exit 1 )
 
 ######################
 ### Helper Methods ###


### PR DESCRIPTION
ℹ️  Note: This PR targets `release/19.2` because this is the branch from which we're more likely to use the script the next time around (during next beta or final release of 19.2).

## Context

The `./tools/rename_apk_aab.sh` script is used by Release Managers to easily and automatically rename `.aab` and `.apk` files downloaded from the Google Play Console (which are always named with the versionCode as the basename, without indication of it the downloaded file is WPAndroid or JPAndroid nor the corresponding versionName it is for) to a more appropriate name (like `wpandroid-<versionName>-Signed.apk`) used to upload the file to the GitHub Release.

## Changes made by this PR

This PR improves the protection against error cases (like when the user does not have the required tools installed) to print helpful error messages and exit rather than accidentally rename `.aab`/`.apk` files to an empty basename.

It also ensures that by default the script only renames the files that are at the top level of the `~/Downloads` folder (where the files you just downloaded from Google Play Console are expected to be), rather than renaming every file in any subfolder of `~/Downloads` (deep traversal) as it was doing before this PR.