### PR TITLE
[Tooling] Update release-toolkit to 3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.4)
       rexml
-    activesupport (5.2.6)
+    activesupport (5.2.6.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -30,6 +30,8 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     bigdecimal (1.4.4)
+    buildkit (1.4.5)
+      sawyer (>= 0.6)
     chroma (0.2.0)
     claide (1.0.3)
     colored (1.2)
@@ -110,9 +112,10 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (2.3.0)
+    fastlane-plugin-wpmreleasetoolkit (3.0.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
+      buildkit (~> 1.4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
@@ -124,7 +127,7 @@ GEM
       rake (>= 12.3, < 14.0)
       rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
-    git (1.9.1)
+    git (1.10.2)
       rchardet (~> 1.8)
     google-apis-androidpublisher_v3 (0.13.0)
       google-apis-core (>= 0.4, < 2.a)
@@ -168,7 +171,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.8.11)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.6.1)
@@ -188,10 +191,10 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    octokit (4.21.0)
+    octokit (4.22.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.13.10)
+    oj (3.13.11)
     optimist (3.0.1)
     options (2.3.2)
     optparse (0.1.1)
@@ -204,7 +207,7 @@ GEM
     public_suffix (4.0.6)
     racc (1.6.0)
     rake (13.0.6)
-    rake-compiler (1.1.6)
+    rake-compiler (1.1.9)
       rake
     rchardet (1.8.0)
     representable (3.1.1)
@@ -264,7 +267,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 2.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 3.0)
   nokogiri
   rmagick (~> 4.1)
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -7,4 +7,4 @@ group :screenshots, optional: true do
 end
 
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', branch: 'trunk'
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 2.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 3.0'


### PR DESCRIPTION
As it says on the tin.

@jkmassel I expected to also have to update the CI config file (`.circleci/config.yml`) to install `drawText` via homebrew for the `promo-screenshots` job [here](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/.circleci/config.yml#L282-L285) — as per [those instructions from the release-toolkit 3.0 update](https://github.com/wordpress-mobile/release-toolkit/pull/312/files#diff-e39c28e5e33301e7a94a866a62ffce85b4a42cadaa201837879de70cfeeaefd3R32), since that's the main breaking change that we need to adapt to when going thru that major version bump in clients.

But… I was unable to install it as brew tells me that there's no such formulae:
```
$ brew install automattic/build-tools/drawText
==> Tapping automattic/build-tools
Cloning into '/usr/local/Homebrew/Library/Taps/automattic/homebrew-build-tools'...
remote: Enumerating objects: 131, done.
remote: Counting objects: 100% (131/131), done.
remote: Compressing objects: 100% (129/129), done.
remote: Total 131 (delta 77), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (131/131), 5.54 MiB | 3.23 MiB/s, done.
Resolving deltas: 100% (77/77), done.
Tapped 3 formulae (15 files, 5.6MB).

Warning: No available formula or cask with the name "automattic/build-tools/drawtext". Did you mean automattic/build-tools/hostmgr?
```
And indeed I [can't find the formula in our brew tap](https://github.com/automattic/homebrew-build-tools) (nor a PR to add it)

What am I missing?