### PR TITLE
[Tooling] Fix rename_apk_aab.sh script (take 2)

### DIFF
--- a/tools/rename_apk_aab.sh
+++ b/tools/rename_apk_aab.sh
@@ -48,9 +48,9 @@ BUNDLETOOL=$(command -v bundletool)
 # Sets PKG, VNAME, VCODE and SIGNED_SUFFIX
 info_for_apk() {
   # Use aapt2 to extract package name, versionCode and versionName
-  INFO_LINE=$($AAPT2 dump badging "$1" | head -n 1)
+  INFO_LINE=$("$AAPT2" dump badging "$1" | head -n 1)
   [[ "$INFO_LINE" =~ name=\'([^\']*)\'[[:blank:]]versionCode=\'([^\']*)\'[[:blank:]]versionName=\'([^\']*)\' ]] && PKG=${BASH_REMATCH[1]} && VCODE=${BASH_REMATCH[2]} && VNAME=${BASH_REMATCH[3]}
-  SIGNED_SUFFIX=$($APKSIGNER verify --print-certs "$1" | grep -qE "(CN=Android, OU=Android, O=Google Inc.)|(O=Automattic Inc.)" && echo "-Signed")
+  SIGNED_SUFFIX=$("$APKSIGNER" verify --print-certs "$1" | grep -qE "(CN=Android, OU=Android, O=Google Inc.)|(O=Automattic Inc.)" && echo "-Signed")
 }
 
 ### Extract info from a single AAB file
@@ -106,7 +106,7 @@ auto_rename_file() {
     NEW_NAME="$BASENAME.aab"
   fi
 
-  echo "$(basename "$1") ==> $NEW_NAME"
+  echo "$(basename "$1") ==> $NEW_NAME (versionCode: $VCODE)"
   mv "$1" "$(dirname "$1")/$NEW_NAME"
 }
 

--- a/tools/rename_apk_aab.sh
+++ b/tools/rename_apk_aab.sh
@@ -34,7 +34,7 @@ fi
 
 AAPT2=$(ls -1t "${ANDROID_SDK_ROOT:-$ANDROID_HOME}"/build-tools/*/aapt2 | head -n1)
 APKSIGNER=$(ls -1t "${ANDROID_SDK_ROOT:-$ANDROID_HOME}"/build-tools/*/apksigner | head -n1)
-BUNDLETOOL="/usr/local/bin/bundletool"
+BUNDLETOOL=$(command -v bundletool)
 
 [[ -x "$AAPT2" ]] || ( echo "Failed to find the \`aapt2\` tool in your \$ANDROID_SDK_ROOT" && exit 1 )
 [[ -x "$APKSIGNER" ]] || ( echo "Failed to find the \`apksigner\` tool in your \$ANDROID_SDK_ROOT" && exit 1 )
@@ -56,9 +56,9 @@ info_for_apk() {
 ### Extract info from a single AAB file
 # Sets PKG, VNAME, VCODE
 info_for_aab() {
-  PKG=$(bundletool dump manifest --bundle "$1" --xpath /manifest/@package)
-  VCODE=$(bundletool dump manifest --bundle "$1" --xpath /manifest/@android:versionCode)
-  VNAME=$(bundletool dump manifest --bundle "$1" --xpath /manifest/@android:versionName)
+  PKG=$("$BUNDLETOOL" dump manifest --bundle "$1" --xpath /manifest/@package)
+  VCODE=$("$BUNDLETOOL" dump manifest --bundle "$1" --xpath /manifest/@android:versionCode)
+  VNAME=$("$BUNDLETOOL" dump manifest --bundle "$1" --xpath /manifest/@android:versionName)
 }
 
 ### Extract info from a single APK or AAB file


### PR DESCRIPTION
Second pass on improving the `rename_apk_aab.sh` tool (see #15959 for recent pass)

 - The way to reference the `bundletool` executable path was not super flexible (hardcoded) and would not have worked on M1 Macs (where `homebrew`'s default installation path is in `/opt/homebrew/bin/` not in `/usr/local/bin`)
 - Added some extra quotes to prevent potential issues with spaces in paths

_PS: Targeting `release/19.2` even though it's not urgent, because that's the branch in which we're most likely to use that script next. Can totally wait for 19.3 if not merged before end of week._