### PR TITLE
[Tooling] Allow lib localization to be done _after_ release branch cut during code freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -764,8 +764,10 @@ REPOSITORY_NAME = 'WordPress-Android'
   ].freeze
 
   lane :update_frozen_strings_for_translation do |options|
-    FileUtils.mkdir_p(FROZEN_STRINGS_DIR_PATH)
-    FileUtils.cp(MAIN_STRINGS_PATH, FROZEN_STRINGS_DIR_PATH)
+    Dir.chdir('..') do
+      FileUtils.mkdir_p(FROZEN_STRINGS_DIR_PATH)
+      FileUtils.cp(MAIN_STRINGS_PATH, FROZEN_STRINGS_DIR_PATH)
+    end
     git_commit(path: File.join(FROZEN_STRINGS_DIR_PATH, 'strings.xml'), message: 'Freeze strings for translation', allow_nothing_to_commit: true)
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -783,13 +783,10 @@ REPOSITORY_NAME = 'WordPress-Android'
 
   desc 'Merge libraries strings files into the main app one'
   lane :localize_libs do |options|
-    if an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path) then
-      commit_strings(options)
-    end
-  end
+    # Merge `strings.xml` files of libraries that are hosted locally in the repository (in `./libs` folder)
+    an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path)
 
-  desc 'Import strings from binary dependencies'
-  lane :localize_binary_deps do |options|
+    # Merge `strings.xml` files of libraries that are hosted in separate repositories (and linked as binary dependencies with the project)
     binary_imported_libraries.each do |lib|
       download_path = android_download_file_by_version(
         library_name: lib[:name],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -178,7 +178,7 @@ REPOSITORY_NAME = 'WordPress-Android'
     android_completecodefreeze_prechecks(skip_confirm: options[:skip_confirm])
 
     localize_libraries()
-    send_strings_for_translation()
+    update_frozen_strings_for_translation()
 
     ensure_git_status_clean()
     push_to_git_remote
@@ -302,7 +302,7 @@ REPOSITORY_NAME = 'WordPress-Android'
   desc 'Updates a release branch for a new beta release'
   lane :new_beta_release do |options|
     android_betabuild_prechecks(base_version: options[:base_version], skip_confirm: options[:skip_confirm])
-    send_strings_for_translation()
+    update_frozen_strings_for_translation()
     download_translations()
     android_bump_version_beta()
     new_version = android_get_app_version()
@@ -764,10 +764,10 @@ REPOSITORY_NAME = 'WordPress-Android'
     },
   ]
 
-  private_lane :send_strings_for_translation do |options|
-    sh("cd .. && mkdir -p #{update_strings_path} && cp #{main_strings_path} #{update_strings_path} && git add #{update_strings_path}strings.xml")
-    sh('git diff-index --quiet HEAD || git commit -m "Send strings to translation."')
-    sh('git push origin HEAD')
+  lane :update_frozen_strings_for_translation do |options|
+    FileUtils.mkdir_p(update_strings_path)
+    FileUtils.cp(main_strings_path, update_strings_path)
+    git_commit(path: File.join(update_strings_path, 'strings.xml'), message: 'Freeze strings for translation', allow_nothing_to_commit: true)
   end
 
   desc 'Merge libraries strings files into the main app one'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -177,10 +177,11 @@ REPOSITORY_NAME = 'WordPress-Android'
   lane :complete_code_freeze do |options|
     android_completecodefreeze_prechecks(skip_confirm: options[:skip_confirm])
 
-    localize_binary_deps()
-    localize_libs()
+    localize_libraries()
     send_strings_for_translation()
+
     ensure_git_status_clean()
+    push_to_git_remote
 
     new_version = android_get_app_version()
     trigger_release_build(branch_to_build: "release/#{new_version}")
@@ -719,7 +720,7 @@ REPOSITORY_NAME = 'WordPress-Android'
   end
 
 ########################################################################
-# Dependencies handling lanes
+# Libraries Translation Merging
 ########################################################################
   main_strings_path = './WordPress/src/main/res/values/strings.xml'
   update_strings_path = './fastlane/resources/values/'
@@ -769,20 +770,8 @@ REPOSITORY_NAME = 'WordPress-Android'
     sh('git push origin HEAD')
   end
 
-  private_lane :commit_strings do |options|
-    if options[:auto_commit] then
-       sh("cd .. && git add #{main_strings_path}")
-       sh("git commit -m 'Update strings for translation'")
-       sh('git push origin HEAD')
-    else
-      UI.important("Your #{main_strings_path} has changed.")
-      UI.input('Please, review the changes, commit them and press return to continue.')
-    end
-  end
-
-
   desc 'Merge libraries strings files into the main app one'
-  lane :localize_libs do |options|
+  lane :localize_libraries do |options|
     # Merge `strings.xml` files of libraries that are hosted locally in the repository (in `./libs` folder)
     an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path)
 
@@ -793,15 +782,18 @@ REPOSITORY_NAME = 'WordPress-Android'
         import_key: lib[:import_key],
         repository: lib[:repository],
         file_path: lib[:strings_file_path],
-        github_release_prefix: lib[:github_release_prefix])
+        github_release_prefix: lib[:github_release_prefix]
+      )
 
       if download_path.nil?
-        error_message = "Can't download strings file for #{lib[:name]}.\r\n"
-        error_message += "Strings for this library won't get translated.\r\n"
-        error_message += 'Do you want to continue anyway?'
+        error_message = <<~ERROR
+          Can't download strings file for #{lib[:name]}.
+          Strings for this library won't get translated.
+          Do you want to continue anyway?
+        ERROR
         UI.user_error! 'Abort.' unless UI.confirm(error_message)
       else
-        UI.message("Strings.xml file for #{lib[:name]} downloaded to #{download_path}.")
+        UI.message("`strings.xml` file for #{lib[:name]} downloaded to #{download_path}.")
         if lib.key?(:merge_tool)
           sh(lib[:merge_tool], lib[:name], download_path)
         else
@@ -816,8 +808,8 @@ REPOSITORY_NAME = 'WordPress-Android'
       end
     end
 
-    is_repo_clean = ('git status --porcelain').empty?
-    commit_strings(options) unless is_repo_clean
+    # Commit changes
+    git_commit(path: main_strings_path, message: 'Update strings for translation of libraries', allow_nothing_to_commit: true)
   end
 
 ########################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -158,11 +158,6 @@ REPOSITORY_NAME = 'WordPress-Android'
     setbranchprotection(repository: GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository: GHHELPER_REPO, milestone: new_version)
 
-    localize_binary_deps()
-    localize_libs()
-    send_strings_for_translation()
-    ensure_git_status_clean()
-
     UI.message("Jetpack release notes were based on the same ones as WordPress. Don't forget to check #{release_notes_path('jetpack')} and amend them as necessary if any item does not apply for Jetpack before sending them to Editorial.")
   end
 
@@ -181,6 +176,12 @@ REPOSITORY_NAME = 'WordPress-Android'
   desc 'Trigger a release build for a given app after code freeze'
   lane :complete_code_freeze do |options|
     android_completecodefreeze_prechecks(skip_confirm: options[:skip_confirm])
+
+    localize_binary_deps()
+    localize_libs()
+    send_strings_for_translation()
+    ensure_git_status_clean()
+
     new_version = android_get_app_version()
     trigger_release_build(branch_to_build: "release/#{new_version}")
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -813,7 +813,7 @@ REPOSITORY_NAME = 'WordPress-Android'
     end
 
     # Commit changes
-    git_commit(path: MAIN_STRINGS_PATH, message: 'Update strings for translation of libraries', allow_nothing_to_commit: true)
+    git_commit(path: MAIN_STRINGS_PATH, message: 'Merge strings from libraries for translation', allow_nothing_to_commit: true)
   end
 
 ########################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -177,10 +177,10 @@ REPOSITORY_NAME = 'WordPress-Android'
   lane :complete_code_freeze do |options|
     android_completecodefreeze_prechecks(skip_confirm: options[:skip_confirm])
 
-    localize_libraries()
-    update_frozen_strings_for_translation()
+    localize_libraries
+    update_frozen_strings_for_translation
 
-    ensure_git_status_clean()
+    ensure_git_status_clean
     push_to_git_remote
 
     new_version = android_get_app_version()
@@ -302,7 +302,7 @@ REPOSITORY_NAME = 'WordPress-Android'
   desc 'Updates a release branch for a new beta release'
   lane :new_beta_release do |options|
     android_betabuild_prechecks(base_version: options[:base_version], skip_confirm: options[:skip_confirm])
-    update_frozen_strings_for_translation()
+    update_frozen_strings_for_translation
     download_translations()
     android_bump_version_beta()
     new_version = android_get_app_version()
@@ -763,7 +763,10 @@ REPOSITORY_NAME = 'WordPress-Android'
     },
   ].freeze
 
-  lane :update_frozen_strings_for_translation do |options|
+  lane :update_frozen_strings_for_translation do
+    # We need to `cd` to the parent directory because, unlike when calling fastlane actions, commands running directly from the `Fastfile`
+    # (like `FileUtils` calls here) run relative to the `./fastlane` folder, but the `*_DIR_PATH` we use are relative to the repo root.
+    # See: https://docs.fastlane.tools/advanced/fastlane/#directory-behavior
     Dir.chdir('..') do
       FileUtils.mkdir_p(FROZEN_STRINGS_DIR_PATH)
       FileUtils.cp(MAIN_STRINGS_PATH, FROZEN_STRINGS_DIR_PATH)
@@ -772,7 +775,7 @@ REPOSITORY_NAME = 'WordPress-Android'
   end
 
   desc 'Merge libraries strings files into the main app one'
-  lane :localize_libraries do |options|
+  lane :localize_libraries 
     # Merge `strings.xml` files of libraries that are hosted locally in the repository (in `./libs` folder)
     an_localize_libs(app_strings_path: MAIN_STRINGS_PATH, libs_strings_path: LOCAL_LIBRARIES_STRINGS_PATHS)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -722,13 +722,12 @@ REPOSITORY_NAME = 'WordPress-Android'
 ########################################################################
 # Libraries Translation Merging
 ########################################################################
-  main_strings_path = './WordPress/src/main/res/values/strings.xml'
-  update_strings_path = './fastlane/resources/values/'
-  libraries_strings_path = [
+  MAIN_STRINGS_PATH = './WordPress/src/main/res/values/strings.xml'.freeze
+  FROZEN_STRINGS_DIR_PATH = './fastlane/resources/values/'.freeze
+  LOCAL_LIBRARIES_STRINGS_PATHS = [
     { library: "Image Editor", strings_path: "./libs/image-editor/ImageEditor/src/main/res/values/strings.xml", exclusions: [] }
-  ]
-
-  binary_imported_libraries = [
+  ].freeze
+  REMOTE_LIBRARIES_STRINGS_PATHS = [
     {
       name: 'Gutenberg Native',
       import_key: 'gutenbergMobileVersion',
@@ -762,21 +761,21 @@ REPOSITORY_NAME = 'WordPress-Android'
       github_release_prefix: "",
       exclusions: []
     },
-  ]
+  ].freeze
 
   lane :update_frozen_strings_for_translation do |options|
-    FileUtils.mkdir_p(update_strings_path)
-    FileUtils.cp(main_strings_path, update_strings_path)
-    git_commit(path: File.join(update_strings_path, 'strings.xml'), message: 'Freeze strings for translation', allow_nothing_to_commit: true)
+    FileUtils.mkdir_p(FROZEN_STRINGS_DIR_PATH)
+    FileUtils.cp(MAIN_STRINGS_PATH, FROZEN_STRINGS_DIR_PATH)
+    git_commit(path: File.join(FROZEN_STRINGS_DIR_PATH, 'strings.xml'), message: 'Freeze strings for translation', allow_nothing_to_commit: true)
   end
 
   desc 'Merge libraries strings files into the main app one'
   lane :localize_libraries do |options|
     # Merge `strings.xml` files of libraries that are hosted locally in the repository (in `./libs` folder)
-    an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path)
+    an_localize_libs(app_strings_path: MAIN_STRINGS_PATH, libs_strings_path: LOCAL_LIBRARIES_STRINGS_PATHS)
 
     # Merge `strings.xml` files of libraries that are hosted in separate repositories (and linked as binary dependencies with the project)
-    binary_imported_libraries.each do |lib|
+    REMOTE_LIBRARIES_STRINGS_PATHS.each do |lib|
       download_path = android_download_file_by_version(
         library_name: lib[:name],
         import_key: lib[:import_key],
@@ -797,19 +796,19 @@ REPOSITORY_NAME = 'WordPress-Android'
         if lib.key?(:merge_tool)
           sh(lib[:merge_tool], lib[:name], download_path)
         else
-          lib_to_merge = [ {
+          lib_to_merge = [{
             library: lib[:name],
             strings_path: download_path,
             exclusions: lib[:exclusions]
           }]
-          an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: lib_to_merge)
+          an_localize_libs(app_strings_path: MAIN_STRINGS_PATH, libs_strings_path: lib_to_merge)
         end
         File.delete(download_path) if File.exist?(download_path)
       end
     end
 
     # Commit changes
-    git_commit(path: main_strings_path, message: 'Update strings for translation of libraries', allow_nothing_to_commit: true)
+    git_commit(path: MAIN_STRINGS_PATH, message: 'Update strings for translation of libraries', allow_nothing_to_commit: true)
   end
 
 ########################################################################


### PR DESCRIPTION
## Why?

Currently, our release scenario for WPAndroid requires us to:
 - First update a couple of libraries (the one that contains strings) to a stable tag _first_
 - Only then, run `fastlane code_freeze`, which cuts the `release/*` branch, then calls the lane localizating the libraries (merging their `strings.xml` files with the main one), which requires those libs to be on a tag (and not on a `trunk-<sha1>` type of version)

This means that we unfortunately have to do those version bumps of the libraries to stable versions… on `trunk`, before the code freeze branch was created.

## Changes in this PR

This PR moves the steps calling the library localization logic from `code_freeze` to `complete_code_freeze`, so that we can now:
 - Call `code_freeze` even / regardless of if the libraries are not yet on a stable version number
 - Then bump the libraries to a stable version number at that stage, making those bumps happen in `release/*` branch post-cut, instead of them happening in `trunk`
 - Then call `complete_code_freeze` to do the library localization, then freeze the strings for GlotPress import, then trigger the CI

This PR also takes the occasion of doing some small cleaning on those library-related translation lanes:

 - Merge both the `localize_libs` and `localize_binary_dependencies` into a single `localize_libraries` lane (now that the `localze_libs` was a one-liner + given we always want to do the merge for both local and remote libs at the same time anyway, never separately)
 - This also allowed us to only make a single `git push` just before we trigger the CI build, instead of two previously
 - Removed the `:commit_strings` private lane, and replace it with a direct call to the built-in `git_commit` fastlane action (with a clearer git message as well)
 - Rename the `send_strings_for_translation` to `update_frozen_strings_for_translation` which I felt was a more accurate name for it (as it does not really send/upload the strings to Glotpress as the previous name suggested, but only updates the `strings.xml` file that we "freeze" during code-freeze for GlotPress to import via a cron later)
 - Rename some of the constants used in `localize_libraries` with clearer name, and using uppercases (as per Ruby conventions)

## To Test

 - Create a test branch from this one (`git checkout tooling/code-freeze-libs-l10n && git checkout -b test-15966`). 
 - ✏️  Update `build.gradle` to point all relevant libraries to tags instead of sha1s
    - Especially currently `wordPressLoginVersion` is currently pointing on a `trunk-sha1` version, so update it to `'0.0.9'` instead.
    - The actual tag you use does not really matter as long as it exists on GitHub (we won't be compiling the app during this test, so no worries about the tag you use not having the latest changes, those versions will only be used to download the `strings.xml` files from a tag on GitHub)
 - 💻  Run `bundle exec fastlane localize_libraries` and check it runs without crashing
 - 🕵️  Confirm that the lane did not push any new commit after it ran —because it did not find any new strings from our libraries since last time we ran it during last code freeze
 - ✏️  Point `aboutAutomatticVersion = '0.0.2'`, in order to use a version that had different `strings.xml` back then.
 - 💻  Run `bundle exec fastlane localize_libraries` again
 - 🕵️  Confirm that this time the lane created a new commit with message "Update strings for translation of libraries" and which adds the couple of `about_automattic_*` strings to `WordPress/src/main/res/values/strings.xml` (strings that were since deleted in `0.0.3` & `0.0.4`, but were there back in `0.0.2`)
 - Run `bundle exec fastlane update_frozen_strings_for_translation`
 - 🕵️  Confirm that the lane created a commit with message "Freeze strings for translations", which updates the `fastlane/resources/values/strings.xml` file so that it is a copy of the `WordPress/src/main/res/values/strings.xml` file
    - It should at least have the same changes as the one you saw from the previous commit updating the `about_automattic_*` keys
    - But it will also have new keys added to `trunk` since the last code freeze (currently, `error_edit_notification` is one of such new key for example)
 - 🧹  Delete your test branch

### Related change in Release Scenario

Corresponding in our mobile toolbox to update the WPAndroid scenario accordingly: 244-gh-Automattic/mobile-toolbox