### PR TITLE
Improve error message for non-English domain names in site creation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] Site creation: Fixed bug where sites created within the app were not given the correct time zone, leading to post scheduling issues. [https://github.com/wordpress-mobile/WordPress-Android/pull/15904]
 * [*] Login Epilogue: Fixed bug where if no sites available, then new login epilogue screen without clickable sites and with "create new site" is shown instead of no sites empty "My Site" view. [https://github.com/wordpress-mobile/WordPress-Android/pull/15944]
 * [*] Fixes flickering when changing the preview mode in Page or Site design picker [https://github.com/wordpress-mobile/WordPress-Android/pull/15943]
+* [*] Improves the error message shown when trying to create a new site with non-English characters in the domain name [https://github.com/wordpress-mobile/WordPress-Android/pull/15969]
 
 19.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,8 +7,8 @@
 * [*] Site creation: Fixed bug where sites created within the app were not given the correct time zone, leading to post scheduling issues. [https://github.com/wordpress-mobile/WordPress-Android/pull/15904]
 * [*] Login Epilogue: Fixed bug where if no sites available, then new login epilogue screen without clickable sites and with "create new site" is shown instead of no sites empty "My Site" view. [https://github.com/wordpress-mobile/WordPress-Android/pull/15944]
 * [*] Fixes flickering when changing the preview mode in Page or Site design picker [https://github.com/wordpress-mobile/WordPress-Android/pull/15943]
-* [*] Improves the error message shown when trying to create a new site with non-English characters in the domain name [https://github.com/wordpress-mobile/WordPress-Android/pull/15969]
 * [*] Reader: Admins and Editors can edit comments from Reader [https://github.com/wordpress-mobile/WordPress-Android/pull/15957]
+* [*] Improves the error message shown when trying to create a new site with non-English characters in the domain name [https://github.com/wordpress-mobile/WordPress-Android/pull/15969]
 
 19.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -111,6 +111,9 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
 
     private fun SiteCreationDomainsScreenBinding.updateContentUiState(contentState: DomainsUiContentState) {
         uiHelpers.updateVisibility(domainListEmptyView, contentState.emptyViewVisibility)
+        if (contentState is DomainsUiContentState.Empty && contentState.message != null) {
+            domainListEmptyViewMessage.text = uiHelpers.getTextOfUiString(requireContext(), contentState.message)
+        }
         uiHelpers.updateVisibility(siteCreationDomainsScreenExample.root, contentState.exampleViewVisibility)
         (recyclerView.adapter as SiteCreationDomainsAdapter).update(contentState.items)
 

--- a/WordPress/src/main/res/layout/site_creation_domains_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_domains_screen.xml
@@ -99,6 +99,7 @@
         app:layout_constraintTop_toTopOf="@+id/recycler_view">
 
         <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/domain_list_empty_view_message"
             style="@style/ActionableEmptyStateTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3170,6 +3170,7 @@
     <string name="site_creation_error_generic_title">There was a problem</string>
     <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>
     <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
+    <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. Only alphanumeric characters are allowed.</string>
     <string name="new_site_creation_unavailable_domain">This domain is unavailable</string>
     <string name="new_site_creation_domain_header_title">Choose a domain</string>
     <string name="new_site_creation_domain_header_subtitle">This is where people will find you on the internet.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -44,11 +44,8 @@ import org.hamcrest.CoreMatchers.`is` as Is
 private const val MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE = 20
 private val ERROR_RESULT_FETCH_QUERY = "error_result_query" to "GENERIC_ERROR"
 private val ERROR_RESULT_FETCH_QUERY_INVALID = "empty_result_query_invalid" to "INVALID_QUERY"
-private val MULTI_RESULT_DOMAIN_FETCH_QUERY = Pair(
-        "multi_result_query",
-        MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE
-)
-private val EMPTY_RESULT_DOMAIN_FETCH_QUERY = Pair("empty_result_query", 0)
+private val MULTI_RESULT_DOMAIN_FETCH_QUERY = "multi_result_query" to MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE
+private val EMPTY_RESULT_DOMAIN_FETCH_QUERY = "empty_result_query" to 0
 
 @InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)


### PR DESCRIPTION
Fixes #13220

This PR proposes a rather quickfix solution for **Improving Error Messaging for non-English characters in Site Creation Flow**.

Following up the discussion in the issue [ #13220](https://github.com/wordpress-mobile/WordPress-Android/issues/13220) and the related conversations on it, I propose we fix this issue by **displaying a less technical error message which is managed in the app** when the user types non alphanumeric characters in the domain input. The main reason for proposing this solution was that it's a **low** priority issue and we may deprecate this screen in the near future  (ref: `pc8HXX-6Z-p2`).

## Context
- PR [#8878](https://github.com/wordpress-mobile/WordPress-Android/pull/8878) introduced the change to treat `SuggestDomainErrorType.INVALID_QUERY` as success and as if we couldn't find any domains for the current domain search query.
  
  >  While testing the site creation flow I found that typing `.` was returning `INVALID_QUERY` error which is not an error we need to specifically handle.
  
  Given the issue we're addressing here, and the fact that the `INVALID_QUERY`  error is also returned when using non-English characters for the domain it made sense for me to handle this error by presenting a message tailored for this case to the user.
  
  In the PR referenced above, the idea was that if needed we can change the message of the empty page:
  
  > We could potentially change the message of the empty page, but I think this is good enough for now.

Technically the solution is not ideal because we model this case as if it is a success in code, because of this any suggestions on how to improve this are more than welcome. I've spent some time exploring different approaches and this was the cleanest one I could come up with in a reasonable amount of time.

I've also explored the option of treating this case as an error in the app, but in my opinion the solution is not optimal, especially because the retry button doesn't help the user in this case.

<details>
<summary>Preview of the current UI for showing errors on this screen</summary>

| <img src="https://user-images.githubusercontent.com/4588074/154340221-0bdbbc3b-76db-4447-9b7c-1c8fceac87b1.png" alt="errors_ui" width="50%"> |
| ---------------------------------------------------- |

</details>

We can also use the error message received from the WP.com public api if that's preferred since it's translated, and it shouldn't be complex.

<details>
<summary>Error Message from WP.com API (The encoded characters are rendered correctly on the device.)</summary>

>  Domain searches only support the following characters (many accents are also allowed): A-Z, a-z, 0-9, -, ., space. You searched for the following unsupported characters: \u0627\u0644\u062c\u0645\u0627\u0639\u0629

</details>

## To Test

1. Start creating a new site using the app (From My Site screen tap the ▼ icon next to the site title)

2. On the Site Picker screen tap on the **+** menu button

3. Select **Create WordPress.com site**

4. Choose any design or tap the **SKIP** menu button (doesn't make a difference for the test)

5. Type `.` or paste`الجماعة`, or type only non alphanumeric characters

6. **Verify** that the text message under the input is:

	> Your search includes characters not supported in WordPress.com domains. Only alphanumeric characters are allowed.

	Note that the message may be misleading during testing, since the message appears only when there are no alphanumeric characters in the search input.
	This fix will mostly impact non-English app users with a non-Latin alphabet on their device keyboard, and the error message is intended to help them with troubleshooting.

## Previews

| Before                                                       | After                               |
| ------------------------------------------------------------ | ----------------------------------- |
| ![before](https://user-images.githubusercontent.com/4588074/154340676-9957541a-be2c-4720-9340-2071f0744627.png) | ![fix_after](https://user-images.githubusercontent.com/4588074/154340727-c2d727f2-01f3-44a6-871a-9f6f5b73e97c.png) |

## Regression Notes

#### 1. Potential unintended areas of impact

- Site creation &rarr; Choose a domain screen (errors or empty list)

#### 2. What I did to test those areas of impact (or what existing automated tests I relied on)

- I tested by inputting  `.`, `الجماعة`, a combination of `الجماعة` and alphanumeric characters.
- I also tested by disabling internet connection and typing random characters in the input field to check that the error UI still works as expected.

#### 3. What automated tests I added (or what prevented me from doing so)

- I updated the existing tests for this screen to check for the generic text message shown when the list is empty.
- I added a unit test to verify the error message for this specific case (when using non-alphanumeric characters in the input):
  `SiteCreationDomainsViewModelTest.verifyNonEmptyUpdateQueryUiStateAfterErrorResponseOfTypeInvalidQuery`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.