### PR TITLE
Fix crash when leaving a comment or replying in reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderComment.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderComment.java
@@ -154,11 +154,11 @@ public class ReaderComment {
     }
 
     public String getAuthorEmail() {
-        return mAuthorEmail;
+        return StringUtils.notNullStr(mAuthorName);
     }
 
     public void setAuthorEmail(String authorEmail) {
-        mAuthorEmail = authorEmail;
+        mAuthorEmail = StringUtils.notNullStr(authorEmail);
     }
 
     @Override


### PR DESCRIPTION
In #15957 we introduce a new field in reader comment DB, but I forgot to force its value to be non-nullable string in the Reader Comment model. This caused a crash when submitting a new comment or replying to a comment.

This PR fixes that issue.

To test:
- Navigate to reader and open comments of a post.
- Leave a comment, and confirm that it appears in the list and app is not crashing.
- Reply to a comment, and confirm that reply appears in the list and app is not crashing.

## Regression Notes
1. Potential unintended areas of impact
Very minor change, so none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
Legacy code is not very testable.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
