### PR TITLE
My Site Dashboard - Stats Card - Enable Feature

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardTodaysStatsCardFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardTodaysStatsCardFeatureConfig.kt
@@ -1,16 +1,25 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig.Companion.MY_SITE_DASHBOARD_TODAYS_STATS_CARD
 import javax.inject.Inject
 
 /**
- * Configuration of the 'My Site Dashboard - Stats Card' that will add Stats Card on the 'My Site' screen.
+ * Configuration of the 'My Site Dashboard - Today's Stats Card' that will add the card on the 'My Site' screen.
  */
-@FeatureInDevelopment
+@Feature(
+        remoteField = MY_SITE_DASHBOARD_TODAYS_STATS_CARD,
+        defaultValue = true
+)
 class MySiteDashboardTodaysStatsCardFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
         appConfig,
-        BuildConfig.MY_SITE_DASHBOARD_TODAYS_STATS_CARD
-)
+        BuildConfig.MY_SITE_DASHBOARD_TODAYS_STATS_CARD,
+        MY_SITE_DASHBOARD_TODAYS_STATS_CARD
+) {
+    companion object {
+        const val MY_SITE_DASHBOARD_TODAYS_STATS_CARD = "my_site_dashboard_todays_stats_card"
+    }
+}


### PR DESCRIPTION
Closes #15752 

This PR enables the remote flag for the `My Site Dashboard - Today's Stats Card` feature.

To test:

1. Clear app data.
2. Open the app.
3. Make sure you don't manually activate the feature flag.
4. Go to `My Site` and notice that `Today's Stats `card exists.

Note: This flag will be overridden using `Firebase Remote Config` condition. See p1645013610195379-slack-C0290FLA0RM for more details. I've created a remote config flag in the Firebase console with the target users' condition. It is still in draft mode and will be published on Monday. But this should not block this PR from merging.

## Regression Notes
1. Potential unintended areas of impact N/A


2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A


3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.