### PR TITLE
Fix user able to enter comment edit flow despite lacking permission

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [*] Fixes flickering when changing the preview mode in Page or Site design picker [https://github.com/wordpress-mobile/WordPress-Android/pull/15943]
 * [*] Reader: Admins and Editors can edit comments from Reader [https://github.com/wordpress-mobile/WordPress-Android/pull/15957]
 * [*] Improves the error message shown when trying to create a new site with non-English characters in the domain name [https://github.com/wordpress-mobile/WordPress-Android/pull/15969]
+* [*] Fixed user able to enter comment edit flow despite lacking permission [https://github.com/wordpress-mobile/WordPress-Android/pull/15977]
 
 19.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -1209,7 +1209,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
     }
 
     private boolean canEdit() {
-        return mSite.getHasCapabilityEditOthersPosts();
+        return mSite != null && mSite.getHasCapabilityEditOthersPosts();
     }
 
     private boolean canLike() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -1209,7 +1209,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
     }
 
     private boolean canEdit() {
-        return (mSite != null && canModerate());
+        return mSite.getHasCapabilityEditOthersPosts();
     }
 
     private boolean canLike() {


### PR DESCRIPTION
Fixes #15450 

To test:
**With a role that CAN'T edit comments:**
- Log into the app using an account that has a role that doesn't allow comment editing on a site
- Choose the site and navigate to the My Site tab
- Choose Comments
- Tap a comment from another user on the site to navigate to the "Comments" screen
- Tap the three dots "More" button
- The edit button should NOT appear

**With a role that CAN edit comments:**
- Log into the app using an account that has a role that allow comment editing on a site 
- Choose the site and navigate to the My Site tab
- Choose Comments
- Tap a comment from another user on the site to navigate to the "Comments" screen
- Tap the three dots "More" button
- The edit button should appear and user is able to edit and update the comment

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing in multiple scenarios

3. What automated tests I added (or what prevented me from doing so)
It's not possible to add automated tests to `CommentDetailFragment` at the moment.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
