### PR TITLE
[Tooling] Install drawText when running promo-screenshots job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,9 +279,9 @@ jobs:
           keys:
             - &homebrew-cache-key v2-brew-imagemagick-{{ checksum "Gemfile.lock" }}
       - run:
-          name: Brew Install ImageMagick
+          name: Brew Install ImageMagick & drawText
           command: |
-            brew install pkg-config imagemagick
+            brew install pkg-config imagemagick automattic/build-tools/drawText
             brew cleanup
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,7 @@ jobs:
         type: boolean
         default: true
     macos:
-      xcode: 11.6.0
+      xcode: 13.2.1
     working_directory: /tmp/workspace
     steps:
       - attach_workspace:
@@ -279,7 +279,7 @@ jobs:
           keys:
             - &homebrew-cache-key v2-brew-imagemagick-{{ checksum "Gemfile.lock" }}
       - run:
-          name: Brew Install ImageMagick & drawText
+          name: Brew Install ImageMagick and drawText
           command: |
             brew install pkg-config imagemagick automattic/build-tools/drawText
             brew cleanup


### PR DESCRIPTION
Since `drawText` is not part of `release-toolkit` since the release of `3.0.0`.

See also https://github.com/wordpress-mobile/WordPress-Android/pull/15963

---

### To test…?

Not sure if that will be easy to test (I mean, the right way would be to actually run the whole screenshot suite from A to Z so that it goes thru promo-screenshots… but do we really have the courage to go thru this, especially since I'm not even sure that job and the associated UI tests targets have been kept up-to-date…)
