### PR TITLE
Fix for stats endpoints being called twice 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -115,7 +115,6 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
         val nonNullActivity = requireActivity()
         with(StatsViewAllFragmentBinding.bind(view)) {
             this@StatsViewAllFragment.binding = this
-            statsListFragment.pageContainer.layoutTransition.setAnimateParentHierarchy(false)
             with(nonNullActivity as AppCompatActivity) {
                 setSupportActionBar(toolbar)
                 supportActionBar?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -115,6 +115,7 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
         val nonNullActivity = requireActivity()
         with(StatsViewAllFragmentBinding.bind(view)) {
             this@StatsViewAllFragment.binding = this
+            statsListFragment.pageContainer.layoutTransition.setAnimateParentHierarchy(false)
             with(nonNullActivity as AppCompatActivity) {
                 setSupportActionBar(toolbar)
                 supportActionBar?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -152,7 +152,6 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         val nonNullActivity = requireActivity()
         with(StatsListFragmentBinding.bind(view)) {
             binding = this
-            pageContainer.layoutTransition.setAnimateParentHierarchy(false)
             initializeViews(savedInstanceState)
             initializeViewModels(nonNullActivity)
         }

--- a/WordPress/src/main/res/layout/stats_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_fragment.xml
@@ -30,7 +30,6 @@
             android:id="@+id/app_bar_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:animateLayoutChanges="true"
             android:fitsSystemWindows="true">
 
             <com.google.android.material.appbar.MaterialToolbar

--- a/WordPress/src/main/res/layout/stats_list_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_list_fragment.xml
@@ -29,7 +29,6 @@
         android:id="@+id/page_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:animateLayoutChanges="true"
         android:orientation="vertical"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 


### PR DESCRIPTION
The previous fix #15941 fixed most of it.  There were some duplicate calls still happening when you switch to Day tab from Inisghts tab first time.

It is the same animation issue that was fixed on StatsListFragment.  However, StatsListFragment layout is being used as an include on StatsViewAllFragment and it seems to cause the same issue here.

Fixes #15906 

To test:

- Setup a debugging proxy like [Charles](https://www.charlesproxy.com/) or [Proxyman](https://proxyman.io/) with your device or emulator as you need to observe network traffic
- Install the app
- Launch app, on My Site, click on Stats from quick links or Stats option below

Test 1
- Ensure, Stats launches in Insights tab
- Observe network calls and make sure there are no repeated calls to the same endpoint
- Switch to Day tab and observe there are no duplicate calls to the stats endpoints
- Switch to Week, Month and Year tabs and observe network calls. Ensure there are no repeated calls.

Test 2

- Switch to Day tab.  Press back and return to My Site.  Wait for five minutes, Launch stats again
- Ensure, Stats launches in Day tab
- Observe network calls and make sure there are no repeated calls to the same endpoint
- Switch to Week, Month and Year tabs and observe network calls. Ensure there are no repeated calls.


NOTE: By default the ViewPager instantiates next tab fragment offscreen. So for e.g. when on Insights tab, it instantiates Day fragment and when on Day tab, then Week fragment, so on. That is to say, You'll see current tab calls plus next tab calls


## Regression Notes
1. Potential unintended areas of impact
Tested all stats tabs variations


2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
