### PR TITLE
[Tooling] Fix syntax error in Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -787,7 +787,7 @@ REPOSITORY_NAME = 'WordPress-Android'
   end
 
   desc 'Merge libraries strings files into the main app one'
-  lane :localize_libraries 
+  lane :localize_libraries do
     # Merge `strings.xml` files of libraries that are hosted locally in the repository (in `./libs` folder)
     an_localize_libs(app_strings_path: MAIN_STRINGS_PATH, libs_strings_path: LOCAL_LIBRARIES_STRINGS_PATHS)
 


### PR DESCRIPTION
I apparently missed a `do` while refactoring the `Fastfile` via #15966 ([here](https://github.com/wordpress-mobile/WordPress-Android/pull/15966/files#diff-dff4b99d4e651ab9d7597876ec8dbe92aa934e42c0fb55f4aadd6c106fc96688R778))

```
$ fl code_freeze
…
[12:22:38]:     1018:	    File.join(project_root, 'build', "#{prefix}-#{version['name']}.aab")
[12:22:38]:     1019:	  end
[12:22:38]:  => 1020:	end

[!] Syntax error in your Fastfile on line 1020: Fastfile:1020: syntax error, unexpected `end', expecting end-of-input
```
Unfortunately, that issue wasn't caught earlier by CI (as I'd have expected).

Not sure why since I expect a couple of CI jobs to run the `bundle exec fastlane …` command, and any syntax error in there like this one should have made the whole thing fail, just like I had above 🤔  Or maybe, because this is Android, we don't run any `fastlane` command on CI in that many occasions after all (as opposed to iOS), hence why it was missed?