### PR TITLE
My Site Dashboard: Tabs - Add feature and config flags

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -112,6 +112,7 @@ android {
         buildConfigField "boolean", "UNIFIED_COMMENTS_COMMENT_EDIT", "false"
         buildConfigField "boolean", "MY_SITE_DASHBOARD_PHASE_2", "false"
         buildConfigField "boolean", "MY_SITE_DASHBOARD_TODAYS_STATS_CARD", "false"
+        buildConfigField "boolean", "MY_SITE_DASHBOARD_TABS", "false"
         buildConfigField "boolean", "UNIFIED_COMMENTS_DETAILS", "false"
         buildConfigField "boolean", "UNIFIED_ABOUT", "false"
         buildConfigField "boolean", "COMMENTS_SNIPPET", "false"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -127,6 +127,7 @@ android {
         buildConfigField "boolean", "ENABLE_QUICK_ACTION", "true"
         buildConfigField "boolean", "ENABLE_FOLLOWED_SITES_SETTINGS", "true"
         buildConfigField "boolean", "ENABLE_WHATS_NEW_FEATURE", "true"
+        buildConfigField "boolean", "ENABLE_MY_SITE_DASHBOARD_TABS", "true"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -170,6 +171,7 @@ android {
             buildConfigField "boolean", "ENABLE_QUICK_ACTION", "true"
             buildConfigField "boolean", "ENABLE_FOLLOWED_SITES_SETTINGS", "true"
             buildConfigField "boolean", "ENABLE_WHATS_NEW_FEATURE", "true"
+            buildConfigField "boolean", "ENABLE_MY_SITE_DASHBOARD_TABS", "false"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
 

--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardTabsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardTabsFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration of the 'My Site Dashboard - Tabs' that will display tabs on the 'My Site' screen.
+ */
+@FeatureInDevelopment
+class MySiteDashboardTabsFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.MY_SITE_DASHBOARD_TABS
+)


### PR DESCRIPTION
Closes #15990 

This PR adds the feature and config flags for `My Site Dashboard - Tabs.

1. Launch the app.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
3. Notice that `MySiteDashboardTabsFeatureConfig` exists under `Features in development` section.

<img width=320 src ="https://user-images.githubusercontent.com/506707/155198034-c1d8c0f1-f849-4d7f-9239-057fffd99d8c.png"/>


## Regression Notes
1. Potential unintended areas of impact 🟢 

2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 

3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
