### PR TITLE
Improve error message when registering internationalized domain names

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3180,7 +3180,7 @@
     <string name="site_creation_error_generic_title">There was a problem</string>
     <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>
     <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
-    <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. Only alphanumeric characters are allowed.</string>
+    <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>
     <string name="new_site_creation_unavailable_domain">This domain is unavailable</string>
     <string name="new_site_creation_domain_header_title">Choose a domain</string>
     <string name="new_site_creation_domain_header_subtitle">This is where people will find you on the internet.</string>


### PR DESCRIPTION
Fixes [#13220](https://github.com/wordpress-mobile/WordPress-Android/issues/13220)

The error message shown when searching for domain names with characters that are not in the Latin alphabet appeared to be confusing by relying on the "alphanumeric" keyword.

In an internal discussion (ref: p5T066-31e-p2#comment-11444) it was suggested to make it more clear in order to avoid confusion.

### To Test
1. Start creating a new site using the app (From My Site screen tap the ▼ icon next to the site title)
2. On the Site Picker screen tap on the ➕ menu button
3. Select **Create WordPress.com site**
4. Choose any design or tap the **SKIP** menu button
5. Type `.` or any word with non-Latin characters
6. **Verify** that the text message under the input is:
   > Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9, –, ..

## Previews

| Before | After |
| --- | --- |
| ![fix_before](https://user-images.githubusercontent.com/4588074/155769430-c33e5c9c-8e3c-42d5-a0fd-ee7d463b0044.png) | ![fix_after](https://user-images.githubusercontent.com/4588074/155769459-6515a364-c13b-4ecb-bf72-9c298a0bddbc.png) |

## Regression Notes

1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.