### PR TITLE
My Site Dashboard: Tabs - Hide/Show Tabs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -43,11 +43,11 @@ import org.wordpress.android.ui.comments.CommentDetailFragment;
 import org.wordpress.android.ui.comments.CommentsDetailActivity;
 import org.wordpress.android.ui.comments.EditCommentActivity;
 import org.wordpress.android.ui.comments.unified.EditCancelDialogFragment;
+import org.wordpress.android.ui.comments.unified.UnifiedCommentDetailsFragment;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentListAdapter;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentListFragment;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsActivity;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsDetailsActivity;
-import org.wordpress.android.ui.comments.unified.UnifiedCommentDetailsFragment;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditFragment;
 import org.wordpress.android.ui.debug.cookies.DebugCookiesFragment;
 import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity;
@@ -89,6 +89,8 @@ import org.wordpress.android.ui.mediapicker.MediaPickerFragment;
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment;
 import org.wordpress.android.ui.mysite.MySiteFragment;
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment;
+import org.wordpress.android.ui.mysite.tabs.MySiteDashboardTabFragment;
+import org.wordpress.android.ui.mysite.tabs.MySiteMenuTabFragment;
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity;
 import org.wordpress.android.ui.notifications.NotificationsDetailListFragment;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
@@ -655,6 +657,10 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(ActivityLogTypeFilterFragment object);
 
     void inject(MySiteFragment object);
+
+    void inject(MySiteDashboardTabFragment object);
+
+    void inject(MySiteMenuTabFragment object);
 
     void inject(BackupDownloadActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -33,6 +33,8 @@ import org.wordpress.android.ui.main.MeViewModel;
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel;
 import org.wordpress.android.ui.mysite.MySiteViewModel;
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel;
+import org.wordpress.android.ui.mysite.tabs.MySiteDashboardTabViewModel;
+import org.wordpress.android.ui.mysite.tabs.MySiteMenuTabViewModel;
 import org.wordpress.android.ui.people.PeopleInviteViewModel;
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel;
 import org.wordpress.android.ui.plans.PlansViewModel;
@@ -471,6 +473,16 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(MySiteViewModel.class)
     abstract ViewModel mySiteViewModel(MySiteViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(MySiteDashboardTabViewModel.class)
+    abstract ViewModel mySiteDashboardTabViewModel(MySiteDashboardTabViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(MySiteMenuTabViewModel.class)
+    abstract ViewModel mySiteMenuTabViewModel(MySiteMenuTabViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -201,8 +201,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             loadGravatar(uiModel.accountAvatarUrl)
             hideRefreshIndicatorIfNeeded()
             when (val state = uiModel.state) {
-                is State.SiteSelected -> loadData(state.cardAndItems)
-                is State.NoSites -> loadEmptyView(state.shouldShowImage)
+                is State.SiteSelected -> loadData(state)
+                is State.NoSites -> loadEmptyView(state)
             }
         })
         viewModel.onScrollTo.observeEvent(viewLifecycleOwner, {
@@ -542,22 +542,24 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         AnalyticsTracker.track(AnalyticsTracker.Stat.QUICK_START_REQUEST_VIEWED)
     }
 
-    private fun MySiteFragmentBinding.loadData(cardAndItems: List<MySiteCardAndItem>) {
+    private fun MySiteFragmentBinding.loadData(state: State.SiteSelected) {
+        tabLayout.setVisible(state.showTabs)
         recyclerView.setVisible(true)
         actionableEmptyView.setVisible(false)
         viewModel.setActionableEmptyViewGone(actionableEmptyView.isVisible) {
             actionableEmptyView.setVisible(false)
         }
-        (recyclerView.adapter as? MySiteAdapter)?.loadData(cardAndItems)
+        (recyclerView.adapter as? MySiteAdapter)?.loadData(state.cardAndItems)
     }
 
-    private fun MySiteFragmentBinding.loadEmptyView(shouldShowEmptyViewImage: Boolean) {
+    private fun MySiteFragmentBinding.loadEmptyView(state: State.NoSites) {
+        tabLayout.setVisible(state.showTabs)
         recyclerView.setVisible(false)
         viewModel.setActionableEmptyViewVisible(actionableEmptyView.isVisible) {
             actionableEmptyView.setVisible(true)
-            actionableEmptyView.image.setVisible(shouldShowEmptyViewImage)
+            actionableEmptyView.image.setVisible(state.shouldShowImage)
         }
-        actionableEmptyView.image.setVisible(shouldShowEmptyViewImage)
+        actionableEmptyView.image.setVisible(state.shouldShowImage)
     }
 
     private fun showSnackbar(holder: SnackbarMessageHolder) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -15,6 +15,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.tabs.TabLayoutMediator
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity
@@ -40,6 +41,7 @@ import org.wordpress.android.ui.mysite.MySiteViewModel.State
 import org.wordpress.android.ui.mysite.SiteIconUploadHandler.ItemUploadedModel
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel
+import org.wordpress.android.ui.mysite.tabs.MySiteTabsAdapter
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
@@ -54,6 +56,7 @@ import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MAIN
@@ -128,7 +131,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                 }
             }
         }
-
+        setupTabs(viewModel.tabTitles)
         val avatar = root.findViewById<ImageView>(R.id.avatar)
 
         appbarMain.addOnOffsetChangedListener(AppBarLayout.OnOffsetChangedListener { appBarLayout, verticalOffset ->
@@ -147,6 +150,15 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                 avatar.scaleY = newScale
             }
         })
+    }
+
+    private fun MySiteFragmentBinding.setupTabs(tabTitles: List<UiString>) {
+        val adapter = MySiteTabsAdapter(this@MySiteFragment, tabTitles)
+        viewPager.adapter = adapter
+
+        TabLayoutMediator(tabLayout, viewPager) { tab, position ->
+            tab.text = uiHelpers.getTextOfUiString(requireContext(), tabTitles[position])
+        }.attach()
     }
 
     private fun MySiteFragmentBinding.setupContentViews(savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -67,6 +67,7 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Dismissed
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Negative
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Positive
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DisplayUtilsWrapper
@@ -80,6 +81,7 @@ import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
+import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.util.experiments.LandOnTheEditorABExperiment
 import org.wordpress.android.util.filter
@@ -123,7 +125,8 @@ class MySiteViewModel @Inject constructor(
     private val cardsTracker: CardsTracker,
     private val siteItemsTracker: SiteItemsTracker,
     private val domainRegistrationCardShownTracker: DomainRegistrationCardShownTracker,
-    private val buildConfigWrapper: BuildConfigWrapper
+    private val buildConfigWrapper: BuildConfigWrapper,
+    private val mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
 ) : ScopedViewModel(mainDispatcher) {
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val _onTechInputDialogShown = MutableLiveData<Event<TextInputDialogModel>>()
@@ -137,6 +140,16 @@ class MySiteViewModel @Inject constructor(
     /* Capture and track the site selected event so we can circumvent refreshing sources on resume
        as they're already built on site select. */
     private var isSiteSelected = false
+
+    private val isMySiteTabsEnabled: Boolean
+        get() = mySiteDashboardTabsFeatureConfig.isEnabled() && buildConfigWrapper.isMySiteTabsEnabled
+
+    val tabTitles: List<UiString>
+        get() = if (isMySiteTabsEnabled) {
+            listOf(UiStringRes(R.string.my_site_menu_tab_title), UiStringRes(R.string.my_site_dashboard_tab_title))
+        } else {
+            listOf(UiStringRes(R.string.my_site_menu_tab_title))
+        }
 
     val onScrollTo: LiveData<Event<Int>> = merge(
             _activeTaskPosition.distinctUntilChanged(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -259,7 +259,7 @@ class MySiteViewModel @Inject constructor(
                 activeTask,
                 siteItems.indexOfFirst { it.activeQuickStartItem }
         )
-        return SiteSelected(siteItems)
+        return SiteSelected(showTabs = isMySiteTabsEnabled, cardAndItems = siteItems)
     }
 
     @Suppress("LongParameterList")
@@ -362,7 +362,7 @@ class MySiteViewModel @Inject constructor(
         // Hide actionable empty view image when screen height is under specified min height.
         val shouldShowImage = !buildConfigWrapper.isJetpackApp &&
                 displayUtilsWrapper.getDisplayPixelHeight() >= MIN_DISPLAY_PX_HEIGHT_NO_SITE_IMAGE
-        return NoSites(shouldShowImage)
+        return NoSites(shouldShowImage = shouldShowImage)
     }
 
     private fun orderForDisplay(
@@ -879,8 +879,9 @@ class MySiteViewModel @Inject constructor(
     )
 
     sealed class State {
-        data class SiteSelected(val cardAndItems: List<MySiteCardAndItem>) : State()
-        data class NoSites(val shouldShowImage: Boolean) : State()
+        abstract val showTabs: Boolean
+        data class SiteSelected(override val showTabs: Boolean, val cardAndItems: List<MySiteCardAndItem>) : State()
+        data class NoSites(override val showTabs: Boolean = false, val shouldShowImage: Boolean) : State()
     }
 
     data class TextInputDialogModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDashboardTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDashboardTabFragment.kt
@@ -1,0 +1,36 @@
+package org.wordpress.android.ui.mysite.tabs
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import javax.inject.Inject
+
+class MySiteDashboardTabFragment : Fragment(R.layout.my_site_dashboard_tab_fragment) {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: MySiteDashboardTabViewModel
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initDagger()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initViewModel()
+    }
+
+    private fun initDagger() {
+        (requireActivity().application as WordPress).component().inject(this)
+    }
+
+    private fun initViewModel() {
+        viewModel = ViewModelProvider(this, viewModelFactory).get(MySiteDashboardTabViewModel::class.java)
+    }
+
+    companion object {
+        fun newInstance() = MySiteDashboardTabFragment()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDashboardTabViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDashboardTabViewModel.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.mysite.tabs
+
+import androidx.lifecycle.ViewModel
+import javax.inject.Inject
+
+class MySiteDashboardTabViewModel @Inject constructor() : ViewModel()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteMenuTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteMenuTabFragment.kt
@@ -1,0 +1,36 @@
+package org.wordpress.android.ui.mysite.tabs
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import javax.inject.Inject
+
+class MySiteMenuTabFragment : Fragment(R.layout.my_site_menu_tab_fragment) {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: MySiteMenuTabViewModel
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initDagger()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initViewModel()
+    }
+
+    private fun initDagger() {
+        (requireActivity().application as WordPress).component().inject(this)
+    }
+
+    private fun initViewModel() {
+        viewModel = ViewModelProvider(this, viewModelFactory).get(MySiteMenuTabViewModel::class.java)
+    }
+
+    companion object {
+        fun newInstance() = MySiteMenuTabFragment()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteMenuTabViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteMenuTabViewModel.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.mysite.tabs
+
+import androidx.lifecycle.ViewModel
+import javax.inject.Inject
+
+class MySiteMenuTabViewModel @Inject constructor() : ViewModel()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabsAdapter.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.ui.mysite.tabs
+
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import org.wordpress.android.ui.utils.UiString
+
+class MySiteTabsAdapter(
+    parent: Fragment,
+    private val tabTitles: List<UiString>
+) : FragmentStateAdapter(parent) {
+    override fun getItemCount(): Int = tabTitles.size
+
+    override fun createFragment(position: Int): Fragment {
+        return if (position == 0) {
+            MySiteMenuTabFragment.newInstance()
+        } else {
+            MySiteDashboardTabFragment.newInstance()
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
@@ -31,4 +31,6 @@ class BuildConfigWrapper @Inject constructor() {
     val isFollowedSitesSettingsEnabled = BuildConfig.ENABLE_FOLLOWED_SITES_SETTINGS
 
     val isWhatsNewFeatureEnabled = BuildConfig.ENABLE_WHATS_NEW_FEATURE
+
+    val isMySiteTabsEnabled = BuildConfig.ENABLE_MY_SITE_DASHBOARD_TABS
 }

--- a/WordPress/src/main/res/layout/my_site_dashboard_tab_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_dashboard_tab_fragment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/text_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Tab" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -8,7 +8,7 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/prominent_toolbar_height"
+        android:layout_height="wrap_content"
         android:fitsSystemWindows="true"
         app:liftOnScroll="false">
 
@@ -16,18 +16,33 @@
             android:id="@+id/collapsing_toolbar"
             style="@style/WordPress.CollapsedToolbarLayout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="@dimen/prominent_toolbar_height"
             app:title="@string/my_site_section_screen_title">
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar_main"
                 android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
+                android:layout_height="@dimen/toolbar_height"
                 app:layout_collapseMode="pin"
                 app:theme="@style/WordPress.ActionBar" />
         </com.google.android.material.appbar.CollapsingToolbarLayout>
 
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:layout_gravity="bottom"
+            android:visibility="gone"
+            app:layout_scrollFlags="scroll|enterAlways"
+            tools:text="@string/my_site_menu_tab_title"/>
+
     </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/view_pager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/my_site_menu_tab_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_menu_tab_fragment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/text_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Tab" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2213,6 +2213,8 @@
     <string name="my_site_quick_actions_title">Quick Links</string>
 
     <!-- My Site - Dashboard -->
+    <string name="my_site_dashboard_tab_title">Dashboard</string>
+    <string name="my_site_menu_tab_title">Menu</string>
     <string name="my_site_dashboard_update_error">Couldn\'t update dashboard.</string>
     <string name="my_site_dashboard_stale_message">The dashboard is not updated. Please check your connection and then pull to refresh.</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -367,6 +367,27 @@ class MySiteViewModelTest : BaseUnitTest() {
     /* SITE STATE */
 
     @Test
+    fun `given my site tabs feature flag not enabled, when site is selected, then tabs are not visible`() {
+        initSelectedSite(isMySiteDashboardTabsFeatureFlagEnabled = false)
+
+        assertThat((uiModels.last().state as SiteSelected).showTabs).isFalse
+    }
+
+    @Test
+    fun `given my site tabs build config not enabled, when site is selected, then tabs are not visible`() {
+        initSelectedSite(isMySiteDashboardTabsFeatureFlagEnabled = true, isMySiteTabsBuildConfigEnabled = false)
+
+        assertThat((uiModels.last().state as SiteSelected).showTabs).isFalse
+    }
+
+    @Test
+    fun `given my site tabs build config with flag enabled, when site is selected, then tabs are visible`() {
+        initSelectedSite(isMySiteDashboardTabsFeatureFlagEnabled = true, isMySiteTabsBuildConfigEnabled = true)
+
+        assertThat((uiModels.last().state as SiteSelected).showTabs).isTrue
+    }
+
+    @Test
     fun `model is empty with no selected site`() {
         onSiteSelected.value = null
         currentAvatar.value = CurrentAvatarUrl("")
@@ -427,6 +448,13 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* EMPTY VIEW */
+
+    @Test
+    fun `when no site is selected, then tabs are not visible`() {
+        onSiteSelected.value = null
+
+        assertThat((uiModels.last().state as NoSites).showTabs).isFalse
+    }
 
     @Test
     fun `given wp app, when no site is selected and screen height is higher than 600 pixels, show empty view image`() {
@@ -1688,6 +1716,8 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     private fun initSelectedSite(
+        isMySiteDashboardTabsFeatureFlagEnabled: Boolean = false,
+        isMySiteTabsBuildConfigEnabled: Boolean = false,
         isQuickStartDynamicCardEnabled: Boolean = false,
         isQuickStartInProgress: Boolean = false,
         showStaleMessage: Boolean = false
@@ -1699,6 +1729,8 @@ class MySiteViewModelTest : BaseUnitTest() {
         quickStartUpdate.value = QuickStartUpdate(
                 categories = if (isQuickStartInProgress) listOf(quickStartCategory) else emptyList()
         )
+        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsFeatureFlagEnabled)
+        whenever(buildConfigWrapper.isMySiteTabsEnabled).thenReturn(isMySiteTabsBuildConfigEnabled)
         onSiteSelected.value = siteLocalId
         onSiteChange.value = site
         selectedSite.value = SelectedSite(site)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -114,6 +114,7 @@ import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
+import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.util.experiments.LandOnTheEditorABExperiment
 import org.wordpress.android.viewmodel.ContextProvider
@@ -152,6 +153,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var siteItemsTracker: SiteItemsTracker
     @Mock lateinit var domainRegistrationCardShownTracker: DomainRegistrationCardShownTracker
     @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
+    @Mock lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<UiModel>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -301,7 +303,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 cardsTracker,
                 siteItemsTracker,
                 domainRegistrationCardShownTracker,
-                buildConfigWrapper
+                buildConfigWrapper,
+                mySiteDashboardTabsFeatureConfig
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/tabs/MySiteDashboardTabViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/tabs/MySiteDashboardTabViewModelTest.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.ui.mysite.tabs
+
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.BaseUnitTest
+
+@RunWith(MockitoJUnitRunner::class)
+class MySiteDashboardTabViewModelTest : BaseUnitTest()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/tabs/MySiteDashboardTabViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/tabs/MySiteDashboardTabViewModelTest.kt
@@ -1,8 +1,13 @@
 package org.wordpress.android.ui.mysite.tabs
 
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.BaseUnitTest
 
 @RunWith(MockitoJUnitRunner::class)
-class MySiteDashboardTabViewModelTest : BaseUnitTest()
+class MySiteDashboardTabViewModelTest : BaseUnitTest() {
+    @Test
+    fun `dummy test`() {
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/tabs/MySiteMenuTabViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/tabs/MySiteMenuTabViewModelTest.kt
@@ -1,8 +1,13 @@
 package org.wordpress.android.ui.mysite.tabs
 
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.BaseUnitTest
 
 @RunWith(MockitoJUnitRunner::class)
-class MySiteMenuTabViewModelTest : BaseUnitTest()
+class MySiteMenuTabViewModelTest : BaseUnitTest() {
+    @Test
+    fun `dummy test`() {
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/tabs/MySiteMenuTabViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/tabs/MySiteMenuTabViewModelTest.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.ui.mysite.tabs
+
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.BaseUnitTest
+
+@RunWith(MockitoJUnitRunner::class)
+class MySiteMenuTabViewModelTest : BaseUnitTest()


### PR DESCRIPTION
Parent #16001

This PR 
- Adds tabs on the `MySiteFragment` and shows/ hides them based on `MySiteDashboardTabsFeatureConfig`, `BuildConfig.ENABLE_MY_SITE_DASHBOARD_TABS` and `SiteSelected`/ `NoSites` states. 
- Associates a `ViewPager` with the `TabLayout`.
- Inits blank `fragments` and `VMs`, `VM tests` for each tab.

<img width=320 src="https://user-images.githubusercontent.com/1405144/155984442-233bcdcf-f18b-4a91-9822-258ecb5881ec.jpg"/>

To test:

1. Launch the app
2. Select a wp com site 
3. Navigate to My Site -> App Settings -> Debug Settings
4. Ensure that the `MySiteDashboardTabsFeatureConfig` is to set to OFF
5. Navigate to the My Site tab (restart the app if needed)
6. Notice that tabs are not visible
7. Navigate again to My Site -> App Settings -> Debug Settings
8. Ensure that the `MySiteDashboardTabsFeatureConfig` is to set to ON
9. Navigate to the My Site tab (restart the app if needed)
10. Notice that tabs are visible
11. Logout and login with an account with no sites
12. Notice that tabs are not visible
13. Toggle `BuildConfig.ENABLE_MY_SITE_DASHBOARD_TABS` to `false` in `build.gradle` for the selected build variant
14. Relaunch the app
15. Logout and login with a wpcom account with sites, and repeat steps 7-9
16. Notice that tabs are not visible

Note: Currently tabs ordering is not taken into account. 

## Regression Notes
1. Potential unintended areas of impact
My Site header layout.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests covering `MySiteDashboardTabsFeatureConfig`, `BuildConfig.ENABLE_MY_SITE_DASHBOARD_TABS` and `SiteSelected`/ `NoSites` states.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
