### PR TITLE
Add Feature Flag for the Site Intent Question Screen

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -117,6 +117,7 @@ android {
         buildConfigField "boolean", "UNIFIED_ABOUT", "false"
         buildConfigField "boolean", "COMMENTS_SNIPPET", "false"
         buildConfigField "boolean", "READER_COMMENTS_MODERATION", "false"
+        buildConfigField "boolean", "SITE_INTENT_QUESTION", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/SiteIntentQuestionFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/SiteIntentQuestionFeatureConfig.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration of the Site Intent Question step in the Site Creation flow
+ */
+@FeatureInDevelopment
+class SiteIntentQuestionFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.SITE_INTENT_QUESTION,
+)

--- a/WordPress/src/main/java/org/wordpress/android/util/config/SiteIntentQuestionFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/SiteIntentQuestionFeatureConfig.kt
@@ -11,5 +11,5 @@ import javax.inject.Inject
 class SiteIntentQuestionFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.SITE_INTENT_QUESTION,
+        BuildConfig.SITE_INTENT_QUESTION
 )


### PR DESCRIPTION
Closes #16018 

## Description

This PR adds the feature config flag for `Site Creation → Site Intent Question`.
We can turn it to a remote feature config when needed by adapting the code (internal ref pbArwn-1kh-p2).

## To Test

1. Launch the app.
2. From `My Site` Go to `Me` -> `App Settings` -> `Debug settings`.
3. **Verify** that `SiteIntentQuestionFeatureConfig` **exists** and is **unchecked** in the `Features in development` section.

## Preview

| <img width="314" src="https://user-images.githubusercontent.com/4588074/156238467-7b6e9360-87d9-42b2-833f-d0d6d30ce4b3.jpg"> |
| --- |


## Regression Notes

1. Potential unintended areas of impact

   ✅ n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)

   ✅ n/a

3. What automated tests I added (or what prevented me from doing so)

   ✅ n/a

---

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.