### PR TITLE
Update customize inisghts card to hint card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ManagementNewsCardUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ManagementNewsCardUseCase.kt
@@ -10,9 +10,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.St
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BigTitle
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.DialogButtons
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ImageItem
 import org.wordpress.android.ui.utils.ListItemInteraction
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Tag
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text
 import org.wordpress.android.ui.stats.refresh.utils.NewsCardHandler
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -35,13 +33,10 @@ class ManagementNewsCardUseCase
     override fun buildLoadingItem(): List<BlockListItem> = listOf()
 
     override fun buildUiModel(domainModel: Boolean): List<BlockListItem> {
-        val highlightedText = resourceProvider.getString(R.string.stats_management_add_new_stats_card)
-        val newsCardMessage = resourceProvider.getString(R.string.stats_management_news_card_message, highlightedText)
+        val newsCardMessage = resourceProvider.getString(R.string.stats_management_news_card_message)
         return listOf(
-                ImageItem(R.drawable.insights_management_feature_image),
-                Tag(R.string.stats_management_new),
                 BigTitle(R.string.stats_manage_your_stats),
-                Text(text = newsCardMessage, bolds = listOf(highlightedText)),
+                Text(text = newsCardMessage),
                 DialogButtons(
                         R.string.stats_management_try_it_now,
                         ListItemInteraction.create(this::onEditInsights),

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/BaseStatsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/viewholders/BaseStatsViewHolder.kt
@@ -1,11 +1,16 @@
 package org.wordpress.android.ui.stats.refresh.lists.viewholders
 
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
+import androidx.core.view.setMargins
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.recyclerview.widget.StaggeredGridLayoutManager.LayoutParams
+import com.google.android.material.card.MaterialCardView
+import org.wordpress.android.R
+import org.wordpress.android.WordPress.getContext
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.LATEST_POST_SUMMARY
 import org.wordpress.android.fluxc.store.StatsStore.ManagementType
 import org.wordpress.android.fluxc.store.StatsStore.StatsType
@@ -25,11 +30,27 @@ abstract class BaseStatsViewHolder(
             ManagementType.CONTROL -> {
                 setFullWidth()
             }
+            ManagementType.NEWS_CARD -> {
+                setCardHint()
+            }
         }
     }
 
     private fun setFullWidth() {
         val layoutParams = itemView.layoutParams as? LayoutParams
         layoutParams?.isFullSpan = true
+    }
+
+    private fun setCardHint() {
+        val card = itemView.findViewById<MaterialCardView>(R.id.stats_list_card)
+
+        val layoutParams = card.layoutParams as? LayoutParams
+        layoutParams?.setMargins(itemView.resources.getDimensionPixelOffset(R.dimen.margin_extra_large))
+
+        val value = TypedValue()
+        itemView.context.theme.resolveAttribute(R.attr.colorOnBackground, value, true)
+        card.setCardBackgroundColor(value.data)
+
+        card.radius = itemView.resources.getDimension(R.dimen.margin_medium)
     }
 }

--- a/WordPress/src/main/res/layout/stats_block_big_title_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_big_title_item.xml
@@ -9,6 +9,7 @@
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text"
         style="@style/StatsBlockBigTitle"
+        android:textColor="?attr/colorOnPrimary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"

--- a/WordPress/src/main/res/layout/stats_block_text_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_text_item.xml
@@ -11,6 +11,7 @@
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text"
         style="@style/StatsBlockText"
+        android:textColor="?attr/colorOnPrimary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"

--- a/WordPress/src/main/res/layout/stats_list_block.xml
+++ b/WordPress/src/main/res/layout/stats_list_block.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/stats_list_card"
     style="@style/WordPress.CardView.Unelevated"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1019,8 +1019,8 @@
     <string name="stats_posting_activity_end_description">You have heard all stats for this period.
         Tapping again will restart from the beginning.</string>
 
-    <string name="stats_manage_your_stats">Manage Your Stats</string>
-    <string name="stats_management_news_card_message">Choose what stats to see, and focus on the data you care most about. Tap %1$s at the bottom of Insights to customise your stats.</string>
+    <string name="stats_manage_your_stats">Customize your experience</string>
+    <string name="stats_management_news_card_message">✨Tap “+” on the top right of the screen to add other stats or re-order your graph.</string>
     <string name="stats_management_try_it_now">Try it now</string>
     <string name="stats_management_dismiss_insights_news_card">Dismiss</string>
     <string name="stats_management_add_new_stats_card">Add new stats card</string>


### PR DESCRIPTION
Updating to new design.

NOTE: This PR is parked for now due to change of priorities.  Customize insights card will be hidden for now in a separate PR

Fixes #16020 

| Before | After |
|---|---|
|![Screenshot_20220302_114621](https://user-images.githubusercontent.com/990349/156273335-08b4cd8a-ecba-4997-b9a0-7b95ed2432a4.png)|![Screenshot_20220302_114056](https://user-images.githubusercontent.com/990349/156273374-43bbebaa-c01a-4877-bbed-ef4e914f6bee.png)|



To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
