### PR TITLE
Hide customize insights card

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'trunk-1436f46fc296ede0e65e117bbfced38fa34cec6d'
+    fluxCVersion = '2298-4e21bcd5d88e59854aebe76925aba8a1a308d850'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '2298-4e21bcd5d88e59854aebe76925aba8a1a308d850'
+    fluxCVersion = 'trunk-cb0e4c9565ea52bb8e2ad967d2cd8bf79aed8d8b'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Update [FluxC version to commit version](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2298) for testing

Temporarily hiding customize insights card (see image below for the card that is being removed) due to changed priorities. It will be updated to a new design in the next iteration. 

<img width=320 src="https://user-images.githubusercontent.com/990349/156281311-5ce380f8-74bf-4bd1-94e4-8bafcc8045c4.png" />


Fixes #16020 

To test:

- Make sure, delete any existing app and do a fresh install OR
- Launch app -> Click on Avatar -> Go to Me -> App Settings -> Open device settings ->  Storage and cache -> Clear storage
- Launch app again, Log in if required, then click on Stats either through quick links or **Stats** option below on **My Site**
- Make sure, it is on Insights tab. If not on Insights tab then switch to Insights tab
- Notice that there's no Manage your stats card
- For completeness, compare this version with another version to see Manage your stats cards appears as in image above following above steps



## Regression Notes
1. Potential unintended areas of impact
News card

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
