### PR TITLE
[Gutenberg] Update gesture handler and reanimated libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.4.0'
     wordPressLoginVersion = 'trunk-a229c42dc36badcc39f7be3d3ad5231bb031eee9'
-    gutenbergMobileVersion = '4615-4a8ef81f3e79ffbe72b2040b04afb689cff18891'
+    gutenbergMobileVersion = 'v1.72.0-alpha3'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.4.0'
     wordPressLoginVersion = 'trunk-a229c42dc36badcc39f7be3d3ad5231bb031eee9'
-    gutenbergMobileVersion = 'v1.71.1'
+    gutenbergMobileVersion = '4615-1cefffe9925b3cb15bad992b0940a8d5356061b2'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.4.0'
     wordPressLoginVersion = 'trunk-a229c42dc36badcc39f7be3d3ad5231bb031eee9'
-    gutenbergMobileVersion = '4615-1cefffe9925b3cb15bad992b0940a8d5356061b2'
+    gutenbergMobileVersion = '4615-4a8ef81f3e79ffbe72b2040b04afb689cff18891'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 


### PR DESCRIPTION
**Gutenberg Mobile PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/4615

This PR updates the Gutenberg Mobile reference to add newer versions of the following libraries, which are native dependencies of Gutenberg:
- `react-native-gesture-handler`
- `react-native-reanimated`

**NOTE:** This PR will be merged into `gutenberg/1.72.0-changes` branch instead of `trunk` due we don't know on which Gutenberg Mobile release will be incorporated, therefore all native changes should be put on hold until the next release is planned.

To test:
Follow testing instructions from https://github.com/WordPress/gutenberg/pull/39098.

## Regression Notes
1. Potential unintended areas of impact
It should only impact the editor hence, I don't foresee any potential unintended areas of impact.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
