### PR TITLE
Update login lib tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.4.0'
-    wordPressLoginVersion = 'trunk-6c8cd2f3c3873f3beca9309cae18c196df24eb84'
+    wordPressLoginVersion = '0.11.1'
     gutenbergMobileVersion = 'v1.71.1'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'


### PR DESCRIPTION
This PR updates the login lib version (to point tag instead of a trunk hash) for a beta fix (included in https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/82) as suggested in the below discussions:

https://github.com/wordpress-mobile/WordPress-Android/pull/16025#issuecomment-1056775330
p1646220997389879/1646134574.562459-slack-CC7L49W13

Cc @AliSoftware 

To test:

Make sure that the tests from https://github.com/wordpress-mobile/WordPress-Android/pull/16025 pass. 

## Regression Notes
1. Potential unintended areas of impact N/A


2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A


3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.