### PR TITLE
Fixes: Jetpack App Auto-dismiss keyboard when the error screen is displayed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [**] Login: improved error messages for login with self-hosted sites. [https://github.com/wordpress-mobile/WordPress-Android/pull/15919]
 * [*] Reader: nested comments with missing parent are now hidden from the comment list [https://github.com/wordpress-mobile/WordPress-Android/pull/15993]
 * [*] My Site: Fixes indeterminate progress bar in site icon when cancelling editing [https://github.com/wordpress-mobile/WordPress-Android/pull/15958]
+* [*] Jetpack App: Fixes Keyboard shown in error message screen . [https://github.com/wordpress-mobile/WordPress-Android/pull/16038]
 
 19.3
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorFragment.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowSignInForResu
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step
 import org.wordpress.android.ui.utils.HtmlMessageUtils
+import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
@@ -55,6 +56,7 @@ class LoginSiteCheckErrorFragment : Fragment(R.layout.jetpack_login_empty_view) 
         initBackPressHandler()
         initViewModel()
         with(JetpackLoginEmptyViewBinding.bind(view)) {
+            ActivityUtils.hideKeyboardForced(view)
             initErrorMessageView()
             initClickListeners()
         }


### PR DESCRIPTION
Fixes #16023

Before
While logging in via site address in the Jetpack app using a site that leads to the error screen with the message “need to have the Jetpack plugin installed…”, the keyboard covers the error.

After the fix 
While logging in via site address in the Jetpack app, when the error screen is displayed, the keyboard is dismissed.


https://user-images.githubusercontent.com/17463767/156517650-3afe622a-6e97-4eb4-bf7a-45f90518ca58.mp4


To test:
1. Open Jetpack app.
2. Click "Enter your existing site address" on the Landing screen.
3. Enter a self-hosted site (without Jetpack) on the Log In screen.
4. Click Continue.
5. Notice that the keyboard is not shown and one can read the message

Tested on: **Oneplus nord, Android 11**

## Regression Notes
1. Potential unintended areas of impact
- Error message not being displayed properly 
- If the user dismissed the keyboard on login, then after navigating to the error screen. App will crash

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
