### PR TITLE
Remove is_fse_active, is_fse_eligible fields from mock responses

### DIFF
--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/jetpack_rest_v11_me_sites.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/jetpack_rest_v11_me_sites.json
@@ -217,8 +217,6 @@
           },
           "launch_status": false,
           "site_migration": null,
-          "is_fse_active": false,
-          "is_fse_eligible": false,
           "is_core_site_editor_enabled": false,
           "updates": {
             "wordpress": 0,
@@ -425,8 +423,6 @@
           },
           "launch_status": false,
           "site_migration": null,
-          "is_fse_active": false,
-          "is_fse_eligible": false,
           "is_core_site_editor_enabled": false,
           "updates": {
             "wordpress": 0,
@@ -639,8 +635,6 @@
           },
           "launch_status": false,
           "site_migration": null,
-          "is_fse_active": false,
-          "is_fse_eligible": false,
           "is_core_site_editor_enabled": false,
           "updates": {
             "wordpress": 0,

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_sites.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_sites.json
@@ -154,8 +154,6 @@
                       },
                       "launch_status": "unlaunched",
                       "site_migration": null,
-                      "is_fse_active": false,
-                      "is_fse_eligible": false,
                       "is_core_site_editor_enabled": false
                     }, {
                       "ID": 181851495,
@@ -298,8 +296,6 @@
                       },
                       "launch_status": "unlaunched",
                       "site_migration": null,
-                      "is_fse_active": false,
-                      "is_fse_eligible": false,
                       "is_core_site_editor_enabled": false
                     }, {
                       "ID": 181977606,
@@ -440,8 +436,6 @@
                       },
                       "launch_status": false,
                       "site_migration": null,
-                      "is_fse_active": false,
-                      "is_fse_eligible": false,
                       "is_core_site_editor_enabled": false
                     }
             ]

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_sites_post_125073.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_sites_post_125073.json
@@ -761,8 +761,6 @@
                         },
                         "launch_status": false,
                         "site_migration": null,
-                        "is_fse_active": false,
-                        "is_fse_eligible": false,
                         "is_core_site_editor_enabled": false,
                         "is_wpcom_atomic": false
                     },

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_sites_post_439.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_sites_post_439.json
@@ -661,8 +661,6 @@
                         },
                         "launch_status": false,
                         "site_migration": null,
-                        "is_fse_active": false,
-                        "is_fse_eligible": false,
                         "is_core_site_editor_enabled": false,
                         "is_wpcom_atomic": false
                     },

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_sites_post_441.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_sites_post_441.json
@@ -761,8 +761,6 @@
                         },
                         "launch_status": false,
                         "site_migration": null,
-                        "is_fse_active": false,
-                        "is_fse_eligible": false,
                         "is_core_site_editor_enabled": false,
                         "is_wpcom_atomic": false
                     },

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_sites_post_related_125073.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_sites_post_related_125073.json
@@ -118,8 +118,6 @@
                                 },
                                 "launch_status": "launched",
                                 "site_migration": null,
-                                "is_fse_active": false,
-                                "is_fse_eligible": false,
                                 "is_core_site_editor_enabled": false,
                                 "is_wpcom_atomic": false
                             }
@@ -313,8 +311,6 @@
                                 },
                                 "launch_status": "launched",
                                 "site_migration": null,
-                                "is_fse_active": false,
-                                "is_fse_eligible": false,
                                 "is_core_site_editor_enabled": false,
                                 "is_wpcom_atomic": false
                             }

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_sites_post_related_441.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_sites_post_related_441.json
@@ -118,8 +118,6 @@
                                 },
                                 "launch_status": "launched",
                                 "site_migration": null,
-                                "is_fse_active": false,
-                                "is_fse_eligible": false,
                                 "is_core_site_editor_enabled": false,
                                 "is_wpcom_atomic": false
                             }
@@ -313,8 +311,6 @@
                                 },
                                 "launch_status": "launched",
                                 "site_migration": null,
-                                "is_fse_active": false,
-                                "is_fse_eligible": false,
                                 "is_core_site_editor_enabled": false,
                                 "is_wpcom_atomic": false
                             }

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v11_sites_181851495.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v11_sites_181851495.json
@@ -179,8 +179,6 @@
             },
             "launch_status": "unlaunched",
             "site_migration": null,
-            "is_fse_active": false,
-            "is_fse_eligible": false,
             "is_core_site_editor_enabled": false
         }
     }


### PR DESCRIPTION
This PR removes `is_fse_active`, `is_fse_eligible` fields from the mock responses as they're being removed in the site endpoint as part of D76032-code.

Related discussion: p1646345126209259-slack-C02QANACA

To test:
There's nothing to test as such. Make sure that all references to these fields are removed from the mock responses.

Merge instructions:

1. Wait for D76032-code to be deployed.
2. Remove not ready for merge label.
3. Merge the PR. 

## Regression Notes
1. Potential unintended areas of impact N/A


2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A


3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.