### PR TITLE
Merge release/19.4 after code-freeze

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+19.5
+-----
+
+
 19.4
 -----
 * [***] Block editor: Support for multiple color palettes [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4537]

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,10 +1,9 @@
 * [***] Block editor: Support for multiple color palettes [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4537]
 * [*] Allows choosing email app during signup and login [https://github.com/wordpress-mobile/WordPress-Android/pull/15979]
-* [**] Login: improved error messages for login with self-hosted sites. [https://github.com/wordpress-mobile/WordPress-Android/pull/15919]
 * [*] Reader: nested comments with missing parent are now hidden from the comment list [https://github.com/wordpress-mobile/WordPress-Android/pull/15993]
 * [*] Fixed an issue which prevented uploading of captured photos after an orientation change. [https://github.com/wordpress-mobile/WordPress-Android/pull/16037]
 * [*] My Site: Fixes indeterminate progress bar in site icon when cancelling editing [https://github.com/wordpress-mobile/WordPress-Android/pull/15958]
 * [*] Stats: Re-organized the default view in Insights, presenting more interesting data at a glance [https://github.com/wordpress-mobile/WordPress-Android/pull/16036]
-* [*] Jetpack App: Fixes Keyboard shown in error message screen . [https://github.com/wordpress-mobile/WordPress-Android/pull/16038]
-* [*] Jetpack App: Fixes an issue where the logout button needs to be pressed twice. [https://github.com/wordpress-mobile/WordPress-Android/pull/16041]
+* [*] Fixes Keyboard shown in error message screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/16038]
+* [*] Fixes an issue where the logout button needs to be pressed twice. [https://github.com/wordpress-mobile/WordPress-Android/pull/16041]
 

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,5 +1,10 @@
-- Sign up through WordPress.com and create sites in Jetpack
-- Use the Reader in Jetpack
-- See notifications in new comment editor
-- Get a fix for the flickering Page/Site preview
-- Keep editor story blocks from closing when memory is low
+* [***] Block editor: Support for multiple color palettes [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4537]
+* [*] Allows choosing email app during signup and login [https://github.com/wordpress-mobile/WordPress-Android/pull/15979]
+* [**] Login: improved error messages for login with self-hosted sites. [https://github.com/wordpress-mobile/WordPress-Android/pull/15919]
+* [*] Reader: nested comments with missing parent are now hidden from the comment list [https://github.com/wordpress-mobile/WordPress-Android/pull/15993]
+* [*] Fixed an issue which prevented uploading of captured photos after an orientation change. [https://github.com/wordpress-mobile/WordPress-Android/pull/16037]
+* [*] My Site: Fixes indeterminate progress bar in site icon when cancelling editing [https://github.com/wordpress-mobile/WordPress-Android/pull/15958]
+* [*] Stats: Re-organized the default view in Insights, presenting more interesting data at a glance [https://github.com/wordpress-mobile/WordPress-Android/pull/16036]
+* [*] Jetpack App: Fixes Keyboard shown in error message screen . [https://github.com/wordpress-mobile/WordPress-Android/pull/16038]
+* [*] Jetpack App: Fixes an issue where the logout button needs to be pressed twice. [https://github.com/wordpress-mobile/WordPress-Android/pull/16041]
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,7 +1,10 @@
-- No email button in signup when email app is unavailable
-- Notifications in new comment editor
-- Correct time zone for sites created in app
-- Bug fixes for empty “My Site” view and Page/Site preview
-- Reader comment editing for Admins/Editors
-- Low memory doesn’t affect editor story blocks
-- Better error text for new site URLs with non-English characters
+* [***] Block editor: Support for multiple color palettes [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4537]
+* [*] Allows choosing email app during signup and login [https://github.com/wordpress-mobile/WordPress-Android/pull/15979]
+* [**] Login: improved error messages for login with self-hosted sites. [https://github.com/wordpress-mobile/WordPress-Android/pull/15919]
+* [*] Reader: nested comments with missing parent are now hidden from the comment list [https://github.com/wordpress-mobile/WordPress-Android/pull/15993]
+* [*] Fixed an issue which prevented uploading of captured photos after an orientation change. [https://github.com/wordpress-mobile/WordPress-Android/pull/16037]
+* [*] My Site: Fixes indeterminate progress bar in site icon when cancelling editing [https://github.com/wordpress-mobile/WordPress-Android/pull/15958]
+* [*] Stats: Re-organized the default view in Insights, presenting more interesting data at a glance [https://github.com/wordpress-mobile/WordPress-Android/pull/16036]
+* [*] Jetpack App: Fixes Keyboard shown in error message screen . [https://github.com/wordpress-mobile/WordPress-Android/pull/16038]
+* [*] Jetpack App: Fixes an issue where the logout button needs to be pressed twice. [https://github.com/wordpress-mobile/WordPress-Android/pull/16041]
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -5,6 +5,4 @@
 * [*] Fixed an issue which prevented uploading of captured photos after an orientation change. [https://github.com/wordpress-mobile/WordPress-Android/pull/16037]
 * [*] My Site: Fixes indeterminate progress bar in site icon when cancelling editing [https://github.com/wordpress-mobile/WordPress-Android/pull/15958]
 * [*] Stats: Re-organized the default view in Insights, presenting more interesting data at a glance [https://github.com/wordpress-mobile/WordPress-Android/pull/16036]
-* [*] Jetpack App: Fixes Keyboard shown in error message screen . [https://github.com/wordpress-mobile/WordPress-Android/pull/16038]
-* [*] Jetpack App: Fixes an issue where the logout button needs to be pressed twice. [https://github.com/wordpress-mobile/WordPress-Android/pull/16041]
 

--- a/WordPress/metadata/release_notes_short.txt
+++ b/WordPress/metadata/release_notes_short.txt
@@ -1,6 +1,0 @@
-- Notifications in new comment editor
-- Correct time zone for sites created in app
-- Reader comment editing for Admins/Editors
-- Low memory doesn’t affect editor story blocks
-- Error text for new site URLs with non-English characters
-- Assorted bug fixes and design improvements

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.4.0'
-    wordPressLoginVersion = 'trunk-6c8cd2f3c3873f3beca9309cae18c196df24eb84'
+    wordPressLoginVersion = '0.12.0'
     gutenbergMobileVersion = 'v1.71.3'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
@@ -14,7 +14,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'trunk-40cf317d1872205b9c55f76a82da975e1447fe9c'
+    fluxCVersion = '1.37.0'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2213,6 +2213,8 @@
     <string name="my_site_quick_actions_title">Quick Links</string>
 
     <!-- My Site - Dashboard -->
+    <string name="my_site_dashboard_tab_title">Dashboard</string>
+    <string name="my_site_menu_tab_title">Menu</string>
     <string name="my_site_dashboard_update_error">Couldn\'t update dashboard.</string>
     <string name="my_site_dashboard_stale_message">The dashboard is not updated. Please check your connection and then pull to refresh.</string>
 
@@ -2806,6 +2808,10 @@
     <string name="login_find_your_connected_email">Find your connected email</string>
     <string name="login_checking_site_address">Checking site address</string>
     <string name="login_error_while_adding_site">Error while adding site. Error code: %s</string>
+    <string name="login_error_xml_rpc_services_disabled">XML-RPC services are disabled on this site.</string>
+    <string name="login_error_xml_rpc_cannot_read_site">Unable to read the WordPress site at that URL. Tap on help icon to view the FAQ.</string>
+    <string name="login_error_xml_rpc_cannot_read_site_auth_required">XML-RPC calls seem blocked on this site (error code 401). If attempt to login fails tap on help icon to view the FAQ.</string>
+    <string name="login_error_xml_rpc_auth_error_communicating">There was a problem communicating with the site. An HTTP error code 401 was returned.</string>
     <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
     <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
     <string name="login_invalid_site_url">Please enter a complete website address, like example.com.</string>
@@ -2813,6 +2819,7 @@
     <string name="login_empty_password">Please enter a password</string>
     <string name="login_empty_2fa">Please enter a verification code</string>
     <string name="login_email_client_not_found">Can\'t detect your email client app</string>
+    <string name="login_select_email_client">Which email app do you use?</string>
     <string name="login_epilogue_mysites_one">My site</string>
     <string name="login_epilogue_mysites_other">My sites</string>
     <string name="login_epilogue_mysites_heading">Choose a site to open</string>
@@ -3180,7 +3187,7 @@
     <string name="site_creation_error_generic_title">There was a problem</string>
     <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>
     <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
-    <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. Only alphanumeric characters are allowed.</string>
+    <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>
     <string name="new_site_creation_unavailable_domain">This domain is unavailable</string>
     <string name="new_site_creation_domain_header_title">Choose a domain</string>
     <string name="new_site_creation_domain_header_subtitle">This is where people will find you on the internet.</string>

--- a/version.properties
+++ b/version.properties
@@ -1,9 +1,9 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=19.3
-versionCode=1178
+versionName=19.4-rc-1
+versionCode=1179
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
-alpha.versionName=alpha-346
-alpha.versionCode=1177
+alpha.versionName=alpha-347
+alpha.versionCode=1180


### PR DESCRIPTION
- [X] New empty entry created in `RELEASE-NOTES.txt` for next iteration.
- [x] `{jetpack_}metadata/release_notes.txt` extracted for WordPress and Jetpack.
- [x] `WordPress/jetpack_metadata/release_notes.txt` audited to remove any item not applicable for Jetpack. — ℹ️  see f6ad46ea81b62c57e0cb0774f944d607f49c1f77
- [x] Internal dependencies (FluxC, Login. Stories. About…) bumped to a new stable version in `build.gradle` if necessary.
- [x] `WordPress/src/main/res/values/strings.xml` updated with strings from binary dependencies. — ℹ️  no new strings from libs
- [x] New strings frozen/copied into `fastlane/resources/values/strings.xml`.
- [x] Version bumped in `version.properties`