### PR TITLE
Adds: Skeleton classes for Category Detail Screen

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -743,6 +743,10 @@
             android:label="@string/categories"
             android:theme="@style/WordPress.NoActionBar"/>
 
+        <activity
+            android:name=".ui.prefs.categories.detail.CategoryDetailActivity"
+            android:theme="@style/WordPress.NoActionBar"/>
+
         <!-- Services -->
         <service
             android:name=".ui.uploads.UploadService"

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -155,6 +155,7 @@ import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.SiteSettingsTagDetailFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsTagListActivity;
 import org.wordpress.android.ui.prefs.categories.CategoriesListFragment;
+import org.wordpress.android.ui.prefs.categories.detail.CategoryDetailFragment;
 import org.wordpress.android.ui.prefs.homepage.HomepageSettingsDialog;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsFragment;
 import org.wordpress.android.ui.prefs.timezone.SiteSettingsTimezoneBottomSheet;
@@ -694,6 +695,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(BloggingReminderBottomSheetFragment object);
 
     void inject(CategoriesListFragment object);
+
+    void inject(CategoryDetailFragment object);
 
     void inject(LayoutPreviewFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -49,6 +49,7 @@ import org.wordpress.android.ui.posts.PrepublishingViewModel;
 import org.wordpress.android.ui.posts.editor.StorePostViewModel;
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsViewModel;
 import org.wordpress.android.ui.prefs.categories.CategoriesListViewModel;
+import org.wordpress.android.ui.prefs.categories.detail.CategoryDetailViewModel;
 import org.wordpress.android.ui.prefs.homepage.HomepageSettingsViewModel;
 import org.wordpress.android.ui.prefs.timezone.SiteSettingsTimezoneViewModel;
 import org.wordpress.android.ui.reader.ReaderCommentListViewModel;
@@ -576,6 +577,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(CategoriesListViewModel.class)
     abstract ViewModel categoriesViewModel(CategoriesListViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(CategoryDetailViewModel.class)
+    abstract ViewModel categoryDetailViewModel(CategoryDetailViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailActivity.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.ui.prefs.categories.detail
+
+import android.os.Bundle
+import android.view.MenuItem
+import org.wordpress.android.databinding.CategoryDetailActivityBinding
+import org.wordpress.android.ui.LocaleAwareActivity
+
+class CategoryDetailActivity : LocaleAwareActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        with(CategoryDetailActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            setSupportActionBar(toolbarMain)
+            supportActionBar?.let {
+                it.setHomeButtonEnabled(true)
+                it.setDisplayHomeAsUpEnabled(true)
+            }
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailFragment.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.ui.prefs.categories.detail
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.CategoryDetailFragmentBinding
+import org.wordpress.android.fluxc.model.SiteModel
+import javax.inject.Inject
+
+class CategoryDetailFragment : Fragment(R.layout.category_detail_fragment) {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: CategoryDetailViewModel
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initDagger()
+
+        with(CategoryDetailFragmentBinding.bind(view)) {
+            initViewModel(getSite(savedInstanceState))
+        }
+    }
+
+    private fun initDagger() {
+        (requireActivity().application as WordPress).component()?.inject(this)
+    }
+
+    private fun initViewModel(site: SiteModel) {
+        viewModel = ViewModelProvider(this@CategoryDetailFragment, viewModelFactory)
+                .get(CategoryDetailViewModel::class.java)
+        viewModel.start(site)
+    }
+
+    private fun getSite(savedInstanceState: Bundle?): SiteModel {
+        return if (savedInstanceState == null) {
+            requireActivity().intent.getSerializableExtra(WordPress.SITE) as SiteModel
+        } else {
+            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putSerializable(WordPress.SITE, viewModel.siteModel)
+        super.onSaveInstanceState(outState)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModel.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.ui.prefs.categories.detail
+
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+class CategoryDetailViewModel @Inject constructor(
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    private val dispatcher: Dispatcher
+) : ScopedViewModel(bgDispatcher) {
+    private var isStarted = false
+    lateinit var siteModel: SiteModel
+
+    init {
+        dispatcher.register(this)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        dispatcher.unregister(this)
+    }
+
+    fun start(siteModel: SiteModel) {
+        if (isStarted) return
+        isStarted = true
+
+        this.siteModel = siteModel
+    }
+}

--- a/WordPress/src/main/res/layout/category_detail_activity.xml
+++ b/WordPress/src/main/res/layout/category_detail_activity.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container_view"
         android:name="org.wordpress.android.ui.prefs.categories.detail.CategoryDetailFragment"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/category_detail_activity.xml
+++ b/WordPress/src/main/res/layout/category_detail_activity.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <fragment
+        android:id="@+id/fragment_container_view"
+        android:name="org.wordpress.android.ui.prefs.categories.detail.CategoryDetailFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/category_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/category_detail_fragment.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/category_detail"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    >
-
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+    android:layout_height="match_parent" />

--- a/WordPress/src/main/res/layout/category_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/category_detail_fragment.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/category_detail"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModelTest.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.ui.prefs.categories.detail
+
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.Dispatcher
+
+@InternalCoroutinesApi
+class CategoryDetailViewModelTest : BaseUnitTest(){
+    private val dispatcher: Dispatcher = mock()
+
+    private lateinit var viewModel: CategoryDetailViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = CategoryDetailViewModel(TEST_DISPATCHER,dispatcher)
+    }
+
+    @Test
+    fun `sample test`() {
+    } // TODO:
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModelTest.kt
@@ -9,14 +9,14 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.Dispatcher
 
 @InternalCoroutinesApi
-class CategoryDetailViewModelTest : BaseUnitTest(){
+class CategoryDetailViewModelTest : BaseUnitTest() {
     private val dispatcher: Dispatcher = mock()
 
     private lateinit var viewModel: CategoryDetailViewModel
 
     @Before
     fun setUp() {
-        viewModel = CategoryDetailViewModel(TEST_DISPATCHER,dispatcher)
+        viewModel = CategoryDetailViewModel(TEST_DISPATCHER, dispatcher)
     }
 
     @Test


### PR DESCRIPTION
Parent #16058 

To test:
As these are only skeleton classes that are not being called in the UI these cannot be tested from the app. 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
