### PR TITLE
Fixed comment menu rtl visibility.

### DIFF
--- a/WordPress/src/main/res/layout/reader_listitem_comment.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment.xml
@@ -136,8 +136,8 @@
 
                 <RelativeLayout
                     android:id="@+id/comment_action_button_container"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="@dimen/stats_block_icon_size"
+                    android:layout_height="@dimen/stats_block_icon_size"
                     android:background="?android:selectableItemBackgroundBorderless"
                     android:clickable="true"
                     android:focusable="true"
@@ -147,9 +147,8 @@
 
                     <ImageView
                         android:id="@+id/comment_action_button"
-                        android:layout_width="@dimen/stats_block_icon_size"
-                        android:layout_height="@dimen/stats_block_icon_size"
-                        android:layout_centerInParent="true"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
                         android:contentDescription="@string/share_desc"
                         android:scaleType="fitCenter"
                         android:src="@drawable/ic_share_white_24dp"


### PR DESCRIPTION
Fixes #16045 

This PR fixes the visibility of reader comment menu with RTL locales.

To test:
- Change app locale to an RTL one, like Hebrew or Arabic.
- From Reader open post comments list (with some comments).
- Confirm that the Overflow or Share menu button is visible next to each comment.


## Regression Notes
1. Potential unintended areas of impact
Unexpected visual issues.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Confirming the changes visually.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
