### PR TITLE
Android 12: Security and privacy - Safer component exporting

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -75,7 +75,8 @@
         <activity
             android:name=".ui.WPLaunchActivity"
             android:noHistory="true"
-            android:theme="@style/NoDisplay">
+            android:theme="@style/NoDisplay"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -105,7 +106,8 @@
 
         <activity
             android:name=".ui.accounts.LoginMagicLinkInterceptActivity"
-            android:theme="@style/NoDisplay">
+            android:theme="@style/NoDisplay"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -201,7 +203,8 @@
             android:name=".ui.prefs.notifications.NotificationsSettingsActivity"
             android:configChanges="orientation|screenSize"
             android:theme="@style/WordPress.NoActionBar"
-            android:label="@string/notif_settings_screen_title">
+            android:label="@string/notif_settings_screen_title"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.NOTIFICATION_PREFERENCES" />
@@ -240,7 +243,8 @@
         <activity
             android:name=".ui.posts.EditPostActivity"
             android:theme="@style/WordPress.NoActionBar"
-            android:windowSoftInputMode="stateHidden|adjustResize">
+            android:windowSoftInputMode="stateHidden|adjustResize"
+            android:exported="true">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".ui.posts.PostsListActivity" />
@@ -333,7 +337,8 @@
         <activity
             android:name=".ui.stats.StatsConnectJetpackActivity"
             android:theme="@style/WordPress.NoActionBar" />
-        <activity android:name=".ui.JetpackConnectionResultActivity" android:theme="@style/WordPress.NoActionBar">
+        <activity android:name=".ui.JetpackConnectionResultActivity" android:theme="@style/WordPress.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -384,7 +389,8 @@
         <activity
             android:name=".ui.deeplinks.DeepLinkingIntentReceiverActivity"
             android:theme="@style/WordPress.NoActionBar"
-            android:excludeFromRecents="true">
+            android:excludeFromRecents="true"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -593,7 +599,8 @@
             android:name=".ui.ShareIntentReceiverActivity"
             android:excludeFromRecents="true"
             android:launchMode="singleTask"
-            android:theme="@style/NoDisplay">
+            android:theme="@style/NoDisplay"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
@@ -610,7 +617,8 @@
             android:name=".ui.AddQuickPressShortcutActivity"
             android:label="@string/quickpress_shortcut_activity_label"
             android:theme="@style/WordPress.NoActionBar"
-            android:enabled="@string/widgets_enabled">
+            android:enabled="@string/widgets_enabled"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT" />
 
@@ -917,7 +925,8 @@
         <activity
             android:name=".ui.stats.refresh.lists.widget.views.StatsViewsWidgetConfigureActivity"
             android:label="@string/stats_widget_views_title"
-            android:theme="@style/WordPress.NoActionBar">
+            android:theme="@style/WordPress.NoActionBar"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
@@ -926,7 +935,8 @@
         <activity
             android:name=".ui.stats.refresh.lists.widget.alltime.StatsAllTimeWidgetConfigureActivity"
             android:label="@string/stats_widget_all_time_title"
-            android:theme="@style/WordPress.NoActionBar">
+            android:theme="@style/WordPress.NoActionBar"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
@@ -935,7 +945,8 @@
         <activity
             android:name=".ui.stats.refresh.lists.widget.today.StatsTodayWidgetConfigureActivity"
             android:label="@string/stats_insights_today_stats"
-            android:theme="@style/WordPress.NoActionBar">
+            android:theme="@style/WordPress.NoActionBar"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
@@ -944,7 +955,8 @@
         <activity
             android:name=".ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureActivity"
             android:label="@string/stats_widget_minified_name"
-            android:theme="@style/WordPress.NoActionBar">
+            android:theme="@style/WordPress.NoActionBar"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -862,7 +862,8 @@
             android:value="true" />
 
         <receiver android:name=".ui.notifications.receivers.NotificationsPendingDraftsReceiver"
-            android:enabled="true">
+            android:enabled="true"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
             </intent-filter>
@@ -872,7 +873,8 @@
         <receiver
             android:name=".ui.stats.refresh.lists.widget.views.StatsViewsWidget"
             android:label="@string/stats_widget_weekly_views_name"
-            android:enabled="@string/widgets_enabled">
+            android:enabled="@string/widgets_enabled"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
             </intent-filter>
@@ -884,7 +886,8 @@
         <receiver
             android:name=".ui.stats.refresh.lists.widget.alltime.StatsAllTimeWidget"
             android:label="@string/stats_widget_all_time_insights_name"
-            android:enabled="@string/widgets_enabled">
+            android:enabled="@string/widgets_enabled"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
             </intent-filter>
@@ -896,7 +899,8 @@
         <receiver
             android:name=".ui.stats.refresh.lists.widget.today.StatsTodayWidget"
             android:label="@string/stats_widget_today_insights_name"
-            android:enabled="@string/widgets_enabled">
+            android:enabled="@string/widgets_enabled"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
             </intent-filter>
@@ -908,7 +912,8 @@
         <receiver
             android:name=".ui.stats.refresh.lists.widget.minified.StatsMinifiedWidget"
             android:label="@string/stats_widget_minified_name"
-            android:enabled="@string/widgets_enabled">
+            android:enabled="@string/widgets_enabled"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
             </intent-filter>

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -985,13 +985,16 @@
 
         <service
             android:name=".push.GCMMessageService"
-            tools:ignore="ExportedService">
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+        <!-- FirebaseInstanceIdService performs security checks at runtime,
+        no need for explicit permissions despite exported="true" -->
         <service
             android:name=".push.InstanceIDService"
+            android:exported="true"
             tools:ignore="ExportedService">
             <intent-filter>
                 <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -266,7 +266,8 @@
         <activity-alias
             android:name=".ui.posts.PostsActivity"
             android:enabled="true"
-            android:targetActivity=".ui.WPLaunchActivity">
+            android:targetActivity=".ui.WPLaunchActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>
@@ -492,7 +493,8 @@
             />
         <activity-alias
             android:name=".WPComPostReaderActivity"
-            android:targetActivity=".ui.reader.ReaderPostPagerActivity">
+            android:targetActivity=".ui.reader.ReaderPostPagerActivity"
+            android:exported="true">
             <intent-filter>
                 <data
                     android:host="wordpress.com"


### PR DESCRIPTION
Closes #16064

This PR explicitly declares the `android:exported` attribute in the manifest for activities, services, and receivers including an intent filter as part of ([behavior changes: safer component exporting](https://developer.android.com/about/versions/12/behavior-changes-12#exported) for `Android 12 - Target SDK Version 31`.

Note: These changes were simple to be addressed, can exist with the existing `targetSdkVersion=30` and so the PR targets `trunk`.

### Review Instructions

1. Review from only one reviewer is sufficient.
2. Targets a future milestone, so there's no rush to review it.

### Details

--------
#### Activities & Activity Alias 86f33073a240602b4c726e7a6a11394e44e54f12 & 86f33073a240602b4c726e7a6a11394e44e54f12

A. `android:exported` is set to `true` for

1. Launchable activities/ activity-alias
(error shown if `exported` set to false: `A launchable activity must be exported as of Android 12, which also makes it available to other apps.`)

    `WPLaunchActivity`
    `PostsActivity` (alias)

4. Activities supporting `ACTION_VIEW` 
(error shown if `exported` set to false: `Activity supporting ACTION_VIEW is not exported`)

    `LoginMagicLinkInterceptActivity`
    `NotificationsSettingsActivity`
    `EditPostActivity`
    `JetpackConnectionResultActivity`
    `DeepLinkingIntentReceiverActivity`
    `WPComPostReaderActivity` (alias)

5. `AddQuickPressShortcutActivity` (accessed using widgets) 
(if `exported` set to false, app crashes with logs)

        E/StartActivityParams: Unable to send back result
        android.app.PendingIntent$CanceledException
        at android.app.PendingIntent.send(PendingIntent.java:959)
        at android.app.PendingIntent.send(PendingIntent.java:806)
        at com.android.launcher3.proxy.StartActivityParams.deliverResult(SourceFile:2)
        at com.android.launcher3.proxy.ProxyActivityStarter.onActivityResult(SourceFile:2)
        at android.app.Activity.dispatchActivityResult(Activity.java:8381)
        at android.app.ActivityThread.deliverResults(ActivityThread.java:5294)

B. `android:exported` is set to `false` for     

1. Stats widgets configure activities

    `StatsViewsWidgetConfigureActivity`
    `StatsAllTimeWidgetConfigureActivity`
    `StatsTodayWidgetConfigureActivity`
    `StatsMinifiedWidgetConfigureActivity`

2. `ShareIntentReceiverActivity`

    **Testing Instructions** (for activities with`android:exported=false`)

    TestB.1: Stats widgets configure activities

    1. Long press app icon 
    2. Select widgets
    4. Choose a widget corresponding to activities listed in `B.1 `and place it on the device screen
    6. Tap on the widget
    7. Make sure that the activity is created properly

    <img height="480" src="https://user-images.githubusercontent.com/1405144/157443423-161dd567-39e2-49a0-aa32-f194a572bc98.png"/>

    TestB.2: Share intent receiver activity

    1. Publish a post (optionally include an image) and put the app to the background so that post published notification is shown
    2. Click the Share action button from the notification
    4. Complete the action
    6. Make sure there are no crashes

    <img height="480" src="https://user-images.githubusercontent.com/1405144/157442380-64a099a5-5b39-4df6-852c-df6947dc2d36.png"/>

--------

#### Services 89f8b6f7c3bc23ac270ed498160ef46657d8924a

`android:exported` for below services is set based on their respective documentation:     

`GCMMessageService`:  https://firebase.google.com/docs/cloud-messaging/android/client#manifest
`InstanceIDService`: https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceIdService

--------

#### Receivers 534eb3b

1. `android:exported` is set to `false` for Stats widget providers based on [the below guideline](https://developer.android.com/guide/topics/appwidgets/#Manifest):

    > The component should not be exported unless a separate process needs to broadcast to your AppWidgetProvider, which is usually not the case.     

    `StatsViewsWidget`
    `StatsAllTimeWidget`
    `StatsTodayWidget`
    `StatsMinifiedWidget`

2. `NotificationsPendingDraftsReceiver` - this receiver is triggered when a draft is scheduled from the app and notification is enabled for it. It doesn't look like we need to export it considering no external process need to broadcast to it.
Note that currently these notifications are not shown due to an existing bug: https://github.com/wordpress-mobile/WordPress-Android/issues/14240 

--------

## Regression Notes
1. Potential unintended areas of impact 
Push notifications (needs to be tested well)

3. What I did to test those areas of impact (or what existing automated tests I relied on)
See notes and testing instructions

5. What automated tests I added (or what prevented me from doing so) - N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
