### PR TITLE
Use line height as a maximum for image rendering.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -760,10 +760,9 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
         txtDate.setText(DateTimeUtils.javaDateToTimeSpan(DateTimeUtils.dateFromIso8601(mComment.getDatePublished()),
                 WordPress.getContext()));
 
-        int maxImageSz = getResources().getDimensionPixelSize(R.dimen.reader_comment_max_image_size);
-        mTxtContent.post(() -> CommentUtils
-                .displayHtmlComment(mTxtContent, mComment.getContent(), maxImageSz, mTxtContent.getLineHeight(),
-                        getString(R.string.comment_unable_to_show_error)));
+        String renderingError = getString(R.string.comment_unable_to_show_error);
+        mTxtContent.post(() -> CommentUtils.displayHtmlComment(mTxtContent, mComment.getContent(),
+                mTxtContent.getWidth(), mTxtContent.getLineHeight(), renderingError));
 
         int avatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_large);
         String avatarUrl = "";

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -761,8 +761,9 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
                 WordPress.getContext()));
 
         int maxImageSz = getResources().getDimensionPixelSize(R.dimen.reader_comment_max_image_size);
-        CommentUtils.displayHtmlComment(mTxtContent, mComment.getContent(), maxImageSz,
-                getString(R.string.comment_unable_to_show_error));
+        mTxtContent.post(() -> CommentUtils
+                .displayHtmlComment(mTxtContent, mComment.getContent(), maxImageSz, mTxtContent.getLineHeight(),
+                        getString(R.string.comment_unable_to_show_error)));
 
         int avatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_large);
         String avatarUrl = "";

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
@@ -17,7 +17,8 @@ public class CommentUtils {
     /*
      * displays comment text as html, including retrieving images
      */
-    public static void displayHtmlComment(TextView textView, String content, int maxImageSize, String errorParseMsg) {
+    public static void displayHtmlComment(TextView textView, String content, int maxImageSize, int maxEmojiSize,
+                                          String errorParseMsg) {
         if (textView == null) {
             return;
         }
@@ -44,7 +45,7 @@ public class CommentUtils {
         // now convert to HTML with an image getter that enforces a max image size
         final Spanned html;
         if (maxImageSize > 0 && content.contains("<img")) {
-            html = HtmlUtils.fromHtml(content, new WPCustomImageGetter(textView, maxImageSize));
+            html = HtmlUtils.fromHtml(content, new WPCustomImageGetter(textView, maxImageSize, maxEmojiSize));
         } else {
             html = HtmlUtils.fromHtml(content);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListUiUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListUiUtils.kt
@@ -18,11 +18,12 @@ import org.wordpress.android.util.getColorFromAttribute
 import javax.inject.Inject
 
 class CommentListUiUtils @Inject constructor() {
-    fun displayHtmlComment(commentContent: String, textView: TextView, maxImageWidth: Int) {
+    fun displayHtmlComment(commentContent: String, textView: TextView, maxImageWidth: Int, maxEmojiWidth: Int) {
         CommentUtils.displayHtmlComment(
                 textView,
                 commentContent,
                 maxImageWidth,
+                maxEmojiWidth,
                 textView.resources.getString(R.string.comment_unable_to_show_error)
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentViewHolder.kt
@@ -27,7 +27,7 @@ class UnifiedCommentViewHolder(
     fun bind(item: Comment) = with(binding) {
         title.text = commentListUiUtils.formatCommentTitle(item.authorName, item.postTitle, title.context)
         comment.post { // we need to know the width of the view for image loading before rendering content
-            commentListUiUtils.displayHtmlComment(item.content, comment, comment.width)
+            commentListUiUtils.displayHtmlComment(item.content, comment, comment.lineHeight)
         }
 
         if (item.isSelected) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentViewHolder.kt
@@ -27,7 +27,7 @@ class UnifiedCommentViewHolder(
     fun bind(item: Comment) = with(binding) {
         title.text = commentListUiUtils.formatCommentTitle(item.authorName, item.postTitle, title.context)
         comment.post { // we need to know the width of the view for image loading before rendering content
-            commentListUiUtils.displayHtmlComment(item.content, comment, comment.lineHeight)
+            commentListUiUtils.displayHtmlComment(item.content, comment, comment.width, comment.lineHeight)
         }
 
         if (item.isSelected) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -330,7 +330,8 @@ public class NotificationsUtils {
         // Note: notifications_max_image_size seems to be the max size an ImageSpan can handle,
         // otherwise it would load blank white
         WPCustomImageGetter imageGetter = new WPCustomImageGetter(textView,
-                context.getResources().getDimensionPixelSize(R.dimen.notifications_max_image_size));
+                context.getResources().getDimensionPixelSize(R.dimen.notifications_max_image_size),
+                textView.getLineHeight());
 
         int indexAdjustment = 0;
         String imagePlaceholder;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -398,10 +398,9 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         }
 
         int maxImageWidth = mContentWidth - indentWidth;
-        commentHolder.mTxtText.post(
-                () -> CommentUtils.displayHtmlComment(commentHolder.mTxtText, comment.getText(), maxImageWidth,
-                        commentHolder.mTxtText.getLineHeight(),
-                        commentHolder.mTxtText.getResources().getString(R.string.comment_unable_to_show_error)));
+        String renderingError = commentHolder.mTxtText.getResources().getString(R.string.comment_unable_to_show_error);
+        CommentUtils.displayHtmlComment(commentHolder.mTxtText, comment.getText(), maxImageWidth,
+                commentHolder.mTxtText.getLineHeight(), renderingError);
 
         // different background for highlighted comment, with optional progress bar
         if (mHighlightCommentId != 0 && mHighlightCommentId == comment.commentId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -398,8 +398,10 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         }
 
         int maxImageWidth = mContentWidth - indentWidth;
-        CommentUtils.displayHtmlComment(commentHolder.mTxtText, comment.getText(), maxImageWidth,
-                commentHolder.mTxtText.getResources().getString(R.string.comment_unable_to_show_error));
+        commentHolder.mTxtText.post(
+                () -> CommentUtils.displayHtmlComment(commentHolder.mTxtText, comment.getText(), maxImageWidth,
+                        commentHolder.mTxtText.getLineHeight(),
+                        commentHolder.mTxtText.getResources().getString(R.string.comment_unable_to_show_error)));
 
         // different background for highlighted comment, with optional progress bar
         if (mHighlightCommentId != 0 && mHighlightCommentId == comment.commentId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentViewHolder.kt
@@ -37,13 +37,15 @@ class CommentViewHolder(
         textCommentDate.text = state.datePublished
         imageManager.loadIntoCircle(imageCommentAvatar, AVATAR, state.avatarUrl)
         authorBadge.visibility = if (state.showAuthorBadge) View.VISIBLE else View.GONE
-
+        textCommentText.post {
+            CommentUtils.displayHtmlComment(
+                    textCommentText,
+                    state.commentText,
+                    threadedCommentsUtils.getMaxWidthForContent(),
+                    textCommentText.lineHeight,
+                    itemView.resources.getString(R.string.comment_unable_to_show_error)
+            )
+        }
         threadedCommentsUtils.setLinksClickable(textCommentText, state.isPrivatePost)
-        CommentUtils.displayHtmlComment(
-                textCommentText,
-                state.commentText,
-                threadedCommentsUtils.getMaxWidthForContent(),
-                itemView.resources.getString(R.string.comment_unable_to_show_error)
-        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentViewHolder.kt
@@ -37,6 +37,7 @@ class CommentViewHolder(
         textCommentDate.text = state.datePublished
         imageManager.loadIntoCircle(imageCommentAvatar, AVATAR, state.avatarUrl)
         authorBadge.visibility = if (state.showAuthorBadge) View.VISIBLE else View.GONE
+
         threadedCommentsUtils.setLinksClickable(textCommentText, state.isPrivatePost)
         CommentUtils.displayHtmlComment(
                 textCommentText,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentViewHolder.kt
@@ -37,15 +37,13 @@ class CommentViewHolder(
         textCommentDate.text = state.datePublished
         imageManager.loadIntoCircle(imageCommentAvatar, AVATAR, state.avatarUrl)
         authorBadge.visibility = if (state.showAuthorBadge) View.VISIBLE else View.GONE
-        textCommentText.post {
-            CommentUtils.displayHtmlComment(
-                    textCommentText,
-                    state.commentText,
-                    threadedCommentsUtils.getMaxWidthForContent(),
-                    textCommentText.lineHeight,
-                    itemView.resources.getString(R.string.comment_unable_to_show_error)
-            )
-        }
         threadedCommentsUtils.setLinksClickable(textCommentText, state.isPrivatePost)
+        CommentUtils.displayHtmlComment(
+                textCommentText,
+                state.commentText,
+                threadedCommentsUtils.getMaxWidthForContent(),
+                textCommentText.lineHeight,
+                itemView.resources.getString(R.string.comment_unable_to_show_error)
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPCustomImageGetter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPCustomImageGetter.kt
@@ -74,7 +74,7 @@ class WPCustomImageGetter @JvmOverloads constructor(
         }
 
         // we need to set a separate width to custom emoji
-        val targetWidth = if (source.contains("wp.com") && source.contains("emojis")) {
+        val targetWidth = if (source.contains(".wp.com") && source.contains("emojis")) {
             maxEmojiWidth
         } else {
             maxWidth

--- a/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPCustomImageGetter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPCustomImageGetter.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType
 import java.lang.ref.WeakReference
-import java.util.HashSet
 import javax.inject.Inject
 
 /**
@@ -21,9 +20,10 @@ import javax.inject.Inject
  *
  * See {@link android.text.Html} for more details.
  */
-class WPCustomImageGetter(
+class WPCustomImageGetter @JvmOverloads constructor(
     textView: TextView,
-    private val maxWidth: Int
+    private val maxWidth: Int,
+    private val maxEmojiWidth: Int = 0
 ) : Html.ImageGetter {
     private val textView: WeakReference<TextView> = WeakReference(textView)
 
@@ -73,12 +73,19 @@ class WPCustomImageGetter(
             source = "http:$source"
         }
 
-        if (maxWidth > 0) {
-            source = PhotonUtils.getPhotonImageUrl(source, maxWidth, 0)
+        // we need to set a separate width to custom emoji
+        val targetWidth = if (source.contains("wp.com") && source.contains("emojis")) {
+            maxEmojiWidth
+        } else {
+            maxWidth
+        }
+
+        if (targetWidth > 0) {
+            source = PhotonUtils.getPhotonImageUrl(source, targetWidth, 0)
         }
 
         return textView.get()?.let {
-            val target = WPRemoteResourceViewTarget(it, maxWidth)
+            val target = WPRemoteResourceViewTarget(it, targetWidth)
             imageManager.loadIntoCustomTarget(target, ImageType.UNKNOWN, source)
             targets.add(target)
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -224,9 +224,6 @@
     <!-- margin to use when indenting comment replies under their parents -->
     <dimen name="reader_comment_indent_per_level">24dp</dimen>
 
-    <!-- max size for images in Reader comments -->
-    <dimen name="reader_comment_max_image_size">160dp</dimen>
-
     <dimen name="reader_comments_actions_height">24dp</dimen>
     <dimen name="reader_comments_content_line_height">24dp</dimen>
     <dimen name="reader_comments_selected_indicator_width">6dp</dimen>


### PR DESCRIPTION
In #16000 we changed the HTML rendered in Site Comment list, and while it definitely works better, some images are getting a bit overblown, like this:

[![Image from Gyazo](https://i.gyazo.com/9596101bf6b6e6e89671530c173420c9.png)](https://gyazo.com/9596101bf6b6e6e89671530c173420c9)

As you can tell this does not work well with some image-based emojis, so I'm limiting the image width to the line height of the TextView. This will reduce the size of regular images as well, but since the comment list is only supposed to give an excerpt of the comment, this is fine.

[![Image from Gyazo](https://i.gyazo.com/6c246576892f3f17ca480cbf3017bcc0.png)](https://gyazo.com/6c246576892f3f17ca480cbf3017bcc0)

To test:
- Using a site with variety of different comments (eg. one of our p2's) confirm that the images are not overblown.

## Regression Notes
1. Potential unintended areas of impact
Images are not visible.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A (layout rendering related changes).

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
