### PR TITLE
Navigate not logged in user to launch screen from Notification Settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -59,6 +59,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.NotificationsSettings;
 import org.wordpress.android.models.NotificationsSettings.Channel;
 import org.wordpress.android.models.NotificationsSettings.Type;
+import org.wordpress.android.ui.WPLaunchActivity;
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
 import org.wordpress.android.ui.notifications.NotificationEvents;
@@ -183,6 +184,17 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
+
+        boolean isLoggedIn = mAccountStore.hasAccessToken();
+        if (!isLoggedIn) {
+            // Not logged in users can start Notification Settings from App info > Notifications menu.
+            // If there isn't a logged in user, just show the entry screen.
+            Intent intent = new Intent(getContext(), WPLaunchActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+            startActivity(intent);
+            getActivity().finish();
+            return;
+        }
 
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getActivity());
         mDeviceId = settings.getString(NotificationsUtils.WPCOM_PUSH_DEVICE_SERVER_ID, "");


### PR DESCRIPTION
Fixes #16070 

Not logged-in users can open the notification settings screen from App info menu without starting the WordPress app. But this Notification Settings screen is related to the user account, so the screen shouldn't be shown to not logged in user.
This PR navigates not logged-in users from Notification Settings to the launch screen.

Extra neatness could be keeping the user's intent after logging in and navigating them to Notification Settings screen. But it could cause extra problems for some cases. Some other applications (I checked Instagram) are just navigating users to the launch screen as I did in this PR.

**Before:**

https://user-images.githubusercontent.com/2471769/157774046-71634fc3-45be-4fb1-bc35-4e1da31c5dbb.mp4

**After:**

https://user-images.githubusercontent.com/2471769/157774185-d452cfd7-6e99-4d1a-902d-3e0a9e0108ca.mp4

To test:
**Logged out user case**
- Log in to the app.
- Log out from the app.
- Close the app or send it to the background.
- Hold WordPress app icon from the app list. Tap i (info) button. Tap "Notifications". Tap "Additional Settings in the app." (This navigation and button names can be different depending on your device.)
- Launch screen should open.

**Fresh install case**
- Do a fresh install or clear storage of WordPress app from the App info > Storage & cache.
- Hold WordPress app icon from the app list. Tap i (info) button. Tap "Notifications". Tap "Additional Settings in the app." (This navigation and button names can be different depending on your device.)
- Launch screen should open.

## Regression Notes
1. Potential unintended areas of impact
Notification Settings screen should work correctly for all kinds of accounts.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually for different cases explained in testing instructions.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
