### PR TITLE
[Tooling] Update PlayStore metadata character limits in translator comments

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -52,7 +52,7 @@ msgctxt "short-description"
 msgid "Get powerful security and performance tools in your pocket."
 msgstr ""
 
-#. translators: Multi-paragraph text used to display in the Play Store.
+#. translators: Multi-paragraph text used to display in the Play Store. Limit to 4000 characters including spaces and commas!
 msgctxt "app-store-description"
 msgid ""
 "Get powerful security and performance tools in your pocket with Jetpack for Android.\n"
@@ -66,7 +66,7 @@ msgid ""
 "View the Privacy Notice for California Users at https://automattic.com/privacy/#california-consumer-privacy-act-ccpa.\n"
 msgstr ""
 
-#. App store app name
+#. translators: Title to be displayed in the Play Store. Limit to 30 characters including spaces and commas!
 msgctxt "app-store-name"
 msgid "Jetpack: WP Security & Speed"
 msgstr ""

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -84,7 +84,7 @@ msgctxt "play_store_promo"
 msgid "Easily build your website & blog. Create posts & track analytics from anywhere!"
 msgstr ""
 
-#. translators: Multi-paragraph text used to display in the Play Store.
+#. translators: Multi-paragraph text used to display in the Play Store. Limit to 4000 characters including spaces and commas!
 msgctxt "play_store_desc"
 msgid ""
 "WordPress for Android puts the power of web publishing in your pocket. It’s a website creator and so much more!\n"
@@ -134,7 +134,7 @@ msgid ""
 "California users privacy notice: https://wp.me/Pe4R-d/#california-consumer-privacy-act-ccpa.\n"
 msgstr ""
 
-#. translators: Title to be displayed in the Play Store. Limit to 50 characters including spaces and commas!
+#. translators: Title to be displayed in the Play Store. Limit to 30 characters including spaces and commas!
 msgctxt "play_store_app_title"
 msgid "WordPress – Website Builder"
 msgstr ""


### PR DESCRIPTION
Follow-up of https://github.com/wordpress-mobile/WordPress-Android/pull/16079.

## Why?

I just realized that the hints about character limits that we left to translator in the `.po` file's comments were outdated.

## Context

See discussion in pcbrnV-440-p2#comment-5306 in which I realized — while updating our app title for English locales during last ASO experiment — that the limit for the app's title length in PlayStore have changed from 50 to 30 since last time we edited it (which is why I wasn't able to save my edits last time while applying this ASO experiment).

Given that we are now scaling that experiment and want to apply the new app title to all locales, and thus will have our translators translate the new title next week (which is quite a rare occurrence given that title seldom changes), it is even more important to communicate to them the new, smaller character limit that we have for those fields.