### PR TITLE
Fixes event tracking when selecting an avatar from the signup epilogue screen

### DIFF
--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1292,7 +1292,7 @@ public class AnalyticsTrackerNosara extends Tracker {
             case SIGNUP_EMAIL_BUTTON_TAPPED:
                 return "signup_email_button_tapped";
             case SIGNUP_EMAIL_EPILOGUE_GRAVATAR_CROPPED:
-                return "signup_email_epilogue_gravatar_cropped:";
+                return "signup_email_epilogue_gravatar_cropped";
             case SIGNUP_EMAIL_EPILOGUE_GRAVATAR_GALLERY_PICKED:
                 return "signup_email_epilogue_gallery_picked";
             case SIGNUP_EMAIL_EPILOGUE_GRAVATAR_SHOT_NEW:


### PR DESCRIPTION
Fixes #12536

To test:

1. Signup with an email
2. Tap the avatar "+" button at the Epilogue screen
3. Select an image and crop it as necessary
4. **Verify** that the event is tracked correctly like `🔵 Tracked: signup_email_epilogue_gravatar_cropped` and no error is produced in the log.

<details>
<summary>error before the fix</summary>

```
2022-03-11 10:57:50.361 12960-12960/org.wordpress.android.beta E/NosaraClient: Cannot create the event: wpandroid_signup_email_epilogue_gravatar_cropped:
    com.automattic.android.tracks.Exceptions.EventNameException: Event name must match: ^(([a-z0-9]+)_){2}([a-z0-9_]+)$
        at com.automattic.android.tracks.Event.checkEventName(Event.java:82)
        at com.automattic.android.tracks.Event.<init>(Event.java:41)
        at com.automattic.android.tracks.TracksClient.track(TracksClient.java:425)
        at com.automattic.android.tracks.TracksClient.track(TracksClient.java:414)
        at org.wordpress.android.analytics.AnalyticsTrackerNosara.track(AnalyticsTrackerNosara.java:536)
        at org.wordpress.android.analytics.AnalyticsTrackerNosara.track(AnalyticsTrackerNosara.java:41)
        at org.wordpress.android.analytics.AnalyticsTracker.track(AnalyticsTracker.java:861)
        at org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment.onActivityResult(SignupEpilogueFragment.java:407)
        at androidx.fragment.app.FragmentManager$9.onActivityResult(FragmentManager.java:2905)
        at androidx.fragment.app.FragmentManager$9.onActivityResult(FragmentManager.java:2885)
        at androidx.activity.result.ActivityResultRegistry.doDispatch(ActivityResultRegistry.java:392)
        at androidx.activity.result.ActivityResultRegistry.dispatchResult(ActivityResultRegistry.java:351)
        at androidx.activity.ComponentActivity.onActivityResult(ComponentActivity.java:638)
        at androidx.fragment.app.FragmentActivity.onActivityResult(FragmentActivity.java:164)
        at android.app.Activity.dispatchActivityResult(Activity.java:8388)
        at android.app.ActivityThread.deliverResults(ActivityThread.java:5361)
        at android.app.ActivityThread.handleSendResult(ActivityThread.java:5407)
        at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:67)
        at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2253)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7870)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)

```
</details>

## Regression Notes
1. Potential unintended areas of impact
N/A

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

7. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
