### PR TITLE
Build: Remove Duplicate Coroutines Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 ext {
-    coroutinesVersion = '1.5.2'
     wordPressUtilsVersion = '2.4.0'
     wordPressLoginVersion = '0.12.0'
     gutenbergMobileVersion = 'v1.71.3'
@@ -10,7 +9,7 @@ ext {
     compileSdkVersion = 31
     targetSdkVersion = 30
 
-    coroutinesVersion = '1.3.9'
+    coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'


### PR DESCRIPTION
After running `./gradlew WordPress:dependencies` before and after the change, it seems that the older `1.3.9` version was also overriding the newer `1.5.2` version, which is expected as the older `1.3.9` version has been declared last.

As such, in addition to removing the duplicate coroutines version, this PR also fixes this `1.3.9` vs. `1.5.2` version inconsistency.

To test:
- Smoke test the app.

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
