### PR TITLE
[HACK WEEK] Add Dependabot & Dependency Tree Diff Configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,19 @@ jobs:
           name: Create GitHub Release
           command: |
             bundle exec fastlane create_gh_release
-
+  Dependency Tree Diff:
+    executor:
+      name: android/default
+      api-version: "28"
+    steps:
+      - checkout
+      - copy-gradle-properties
+      - run:
+          name: Build dependency diff report
+          command: |
+            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+              ./tools/dependency-tree-diff/dependency-tree-diff.sh
+            fi
 
   Connected Tests:
     parameters:
@@ -348,6 +360,7 @@ workflows:
         - << pipeline.parameters.generate_screenshots >>
         - << pipeline.parameters.release_build >>
     jobs:
+      - Dependency Tree Diff
       - Installable Build:
           filters:
             branches:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       - dependency-name: "com.android.tools.build:gradle"
       # Bumping 1.2.1 to 1.3.0 causes some issues, fist spotted in Reader. For more details, see
       # https://github.com/wordpress-mobile/WordPress-Android/pull/14431
+      # An update related issue has been created to make sure that this gets the needed attention:
+      # https://github.com/wordpress-mobile/WordPress-Android/issues/16132
       - dependency-name: "com.google.android.material:material"
       # Bumping 2.26.3 to 2.27.2 will break the mocks. For more details, see
       # https://github.com/wiremock/wiremock/issues/1345#issuecomment-656060968

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    open-pull-requests-limit: 6
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "bot: dependencies update"
+    reviewers:
+      - "wordpress-mobile/android-developers"
+    ignore:
+      # The Android Gradle Plugin is a dependency that needs to be in sync with other
+      # in-house libraries due to compatibility with composite build.
+      - dependency-name: "com.android.tools.build:gradle"
+      # Bumping 1.2.1 to 1.3.0 causes some issues, fist spotted in Reader. For more details, see
+      # https://github.com/wordpress-mobile/WordPress-Android/pull/14431
+      - dependency-name: "com.google.android.material:material"
+      # Bumping 2.26.3 to 2.27.2 will break the mocks. For more details, see
+      # https://github.com/wiremock/wiremock/issues/1345#issuecomment-656060968
+      - dependency-name: "com.github.tomakehurst:wiremock"
+      # Our libraries that are stored in S3 have a custom versioning scheme which doesn't work with
+      # dependapot.
+      - dependency-name: "org.wordpress:fluxc"
+      - dependency-name: "org.wordpress:utils"
+      - dependency-name: "org.wordpress-mobile.gutenberg-mobile:react-native-gutenberg-bridge"
+      - dependency-name: "org.wordpress:login"
+      - dependency-name: "com.automattic:stories"
+      - dependency-name: "com.automattic.stories:mp4compose"
+      - dependency-name: "com.automattic.stories:photoeditor"
+      - dependency-name: "org.wordpress:aztec"
+      - dependency-name: "org.wordpress.aztec:wordpress-shortcodes"
+      - dependency-name: "org.wordpress.aztec:wordpress-comments"
+      - dependency-name: "org.wordpress.aztec:glide-loader"
+      - dependency-name: "org.wordpress.aztec:picasso-loader"
+      - dependency-name: "com.automattic:about"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -1,3 +1,6 @@
+import se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask
+import se.bjurr.violations.lib.model.SEVERITY
+
 buildscript {
     repositories {
         google()
@@ -528,7 +531,7 @@ if ((file('google-services.json').text) == (file('google-services.json-example')
     println("WARNING: You're using the example google-services.json file. Google login will fail.")
 }
 
-tasks.register("violationCommentsToGitHub", se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask) {
+tasks.register("violationCommentsToGitHub", ViolationCommentsToGitHubTask) {
     repositoryOwner = "wordpress-mobile"
     repositoryName = "WordPress-Android"
     pullRequestId = System.properties['GITHUB_PULLREQUESTID']
@@ -539,7 +542,7 @@ tasks.register("violationCommentsToGitHub", se.bjurr.violations.comments.github.
     createCommentWithAllSingleFileComments = false
     createSingleFileComments = true
     commentOnlyChangedContent = true
-    minSeverity = se.bjurr.violations.lib.model.SEVERITY.INFO //ERROR, INFO, WARN
+    minSeverity = SEVERITY.INFO //ERROR, INFO, WARN
     commentTemplate = """
 **Reporter**: {{violation.reporter}}{{#violation.rule}}\n
 **Rule**: {{violation.rule}}{{/violation.rule}}
@@ -551,6 +554,31 @@ tasks.register("violationCommentsToGitHub", se.bjurr.violations.comments.github.
     violations = [
             ["CHECKSTYLE", ".", ".*/build/.*/checkstyle/.*\\.xml\$", "CheckStyle"],
             ["CHECKSTYLE", ".", ".*/build/.*/detekt/.*\\.xml\$", "Detekt"]
+    ]
+}
+
+tasks.register("dependencyTreeDiffCommentToGitHub", ViolationCommentsToGitHubTask) {
+    repositoryOwner = "wordpress-mobile"
+    repositoryName = "WordPress-Android"
+    pullRequestId = System.properties['GITHUB_PULLREQUESTID']
+    oAuth2Token = System.properties['GITHUB_OAUTH2TOKEN']
+    gitHubUrl = "https://api.github.com/"
+    createCommentWithAllSingleFileComments = true
+    createSingleFileComments = false
+    commentOnlyChangedContent = true
+    commentOnlyChangedFiles = false
+    minSeverity = SEVERITY.INFO
+    commentTemplate = """
+### The PR caused the following dependency changes:
+
+```diff
+{{{violation.message}}}
+```
+
+*Please review and act accordingly*
+"""
+    violations = [
+            ["GENERIC", ".", ".*/build/.*/diff/.*\\.txt\$", "DependenciesDiffChecker"],
     ]
 }
 

--- a/tools/dependency-tree-diff/dependency-tree-diff.sh
+++ b/tools/dependency-tree-diff/dependency-tree-diff.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -eu
+
+TARGET_BRANCH_DEPENDENCIES_FILE="target_branch_dependencies.txt"
+CURRENT_TARGET_BRANCH_DEPENDENCIES_FILE="current_branch_dependencies.txt"
+DIFF_DEPENDENCIES_FOLDER="./build/reports/diff"
+DIFF_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/diff_dependencies.txt"
+CONFIGURATION="wordpressVanillaReleaseRuntimeClasspath"
+DEPENDENCY_TREE_VERSION="1.2.0"
+
+
+git config --global user.email '$( git log --format='%ae' $CIRCLE_SHA1^! )'
+git config --global user.name '$( git log --format='%an' $CIRCLE_SHA1^! )'
+
+prNumber="${CIRCLE_PULL_REQUEST##*/}"
+githubUrl="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$prNumber"
+githubResponse="$(curl "$githubUrl" -H "Authorization: token $GITHUB_API_TOKEN")"
+targetBranch=$(echo "$githubResponse" | tr '\r\n' ' ' | jq '.base.ref' | tr -d '"')
+
+git merge "origin/$targetBranch" --no-edit
+
+if [[ $(git diff --name-status "origin/$targetBranch" | grep ".gradle") ]]; then
+    echo ".gradle files have been changed. Looking for caused dependency changes"
+  else
+    echo ".gradle files haven't been changed. There is no need to run the diff"
+    ./gradlew dependencyTreeDiffCommentToGitHub -DGITHUB_PULLREQUESTID="${CIRCLE_PULL_REQUEST##*/}" -DGITHUB_OAUTH2TOKEN="$GITHUB_API_TOKEN"
+    exit 0
+fi
+
+mkdir -p "$DIFF_DEPENDENCIES_FOLDER"
+
+./gradlew :WordPress:dependencies --configuration $CONFIGURATION > $CURRENT_TARGET_BRANCH_DEPENDENCIES_FILE
+
+git checkout "$targetBranch"
+./gradlew :WordPress:dependencies --configuration $CONFIGURATION > $TARGET_BRANCH_DEPENDENCIES_FILE
+
+# https://github.com/JakeWharton/dependency-tree-diff
+curl -L "https://github.com/JakeWharton/dependency-tree-diff/releases/download/$DEPENDENCY_TREE_VERSION/dependency-tree-diff.jar" -o dependency-tree-diff.jar
+sha=($(sha1sum dependency-tree-diff.jar))
+if [[ $sha != "949394274f37c06ac695b5d49860513e4d16e847" ]]; then
+  echo "dependency-tree-diff.jar file has unexpected sha1"
+  exit 1
+fi
+chmod +x dependency-tree-diff.jar
+./dependency-tree-diff.jar $TARGET_BRANCH_DEPENDENCIES_FILE $CURRENT_TARGET_BRANCH_DEPENDENCIES_FILE > $DIFF_DEPENDENCIES_FILE
+
+if [ -s $DIFF_DEPENDENCIES_FILE ]; then
+  echo "There are changes in dependencies of the project"
+  cat "$DIFF_DEPENDENCIES_FILE"
+else
+  echo "There are no changes in dependencies of the project"
+  rm "$DIFF_DEPENDENCIES_FILE"
+fi
+./gradlew dependencyTreeDiffCommentToGitHub -DGITHUB_PULLREQUESTID="${CIRCLE_PULL_REQUEST##*/}" -DGITHUB_OAUTH2TOKEN="$GITHUB_API_TOKEN" --info

--- a/tools/dependency-tree-diff/dependency-tree-diff.sh
+++ b/tools/dependency-tree-diff/dependency-tree-diff.sh
@@ -11,6 +11,8 @@ DEPENDENCY_TREE_VERSION="1.2.0"
 git config --global user.email '$( git log --format='%ae' $CIRCLE_SHA1^! )'
 git config --global user.name '$( git log --format='%an' $CIRCLE_SHA1^! )'
 
+currentBranch=$(git rev-parse --abbrev-ref HEAD)
+
 prNumber="${CIRCLE_PULL_REQUEST##*/}"
 githubUrl="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$prNumber"
 githubResponse="$(curl "$githubUrl" -H "Authorization: token $GITHUB_API_TOKEN")"
@@ -43,6 +45,7 @@ fi
 chmod +x dependency-tree-diff.jar
 ./dependency-tree-diff.jar $TARGET_BRANCH_DEPENDENCIES_FILE $CURRENT_TARGET_BRANCH_DEPENDENCIES_FILE > $DIFF_DEPENDENCIES_FILE
 
+git checkout "$currentBranch"
 if [ -s $DIFF_DEPENDENCIES_FILE ]; then
   echo "There are changes in dependencies of the project"
   cat "$DIFF_DEPENDENCIES_FILE"


### PR DESCRIPTION
This PR adds [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) and [Dependency Tree Diff](https://github.com/JakeWharton/dependency-tree-diff) tooling and related configuration to this repo. I chose to add both tools in one go because [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) will very much benefit from [Dependency Tree Diff](https://github.com/JakeWharton/dependency-tree-diff) and ultimately help reviewers do their review more effectively.

Also as part of this work I created the following:
- New `bot: dependencies update` label (see [Bot Labels](https://github.com/wordpress-mobile/WordPress-Android/labels?q=bot) query). [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) is going to be using this label (see [dependabot.yml](https://github.com/wordpress-mobile/WordPress-Android/pull/16092/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R8-R9) configuration)
- New `Android Developers` team for the [WordPress Mobile](https://github.com/wordpress-mobile) organization (see [Android Teams](https://github.com/orgs/wordpress-mobile/teams?query=Android) query). [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) is going to be using this team as reviewers (see [dependabot.yml](https://github.com/wordpress-mobile/WordPress-Android/pull/16092/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10-R11) configuration)

-----

As I am mainly copy-pasted the already existing configuration from `WCAndroid`. I tried to be careful with the setup but I might be missing something obvious. As such, I am shamelessly mentioning @wzieba (for on [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates)) and @kidinov (for [Dependency Tree Diff](https://github.com/JakeWharton/dependency-tree-diff)) to help with this review in case I am missing something very obvious. PS: I even copy-pasted your testing instructions... 😅 But, on a more serious note, thank you both for all the work you did already on all that, thus making it so easy for me to follow your lead, you rock! 🪨 

Related `WCAndroid` PRs:
- [Add Dependabot configuration file #3653](https://github.com/woocommerce/woocommerce-android/pull/3653)
- [[HACK] A new CI step to check if dependencies were changed #5420](https://github.com/woocommerce/woocommerce-android/pull/5420)

-----

I'll also publish a P2 post next week (see **NEW**) notifying `WPAndroid` developers about this change and providing more details about the process going forward, mainly (and again) copy-pasting the existing process that is already in place within `WCAndroid`.

Related P2s:
- Android P2 - Surfacing Hidden Change to Pull Requests (dependencies) -> `paqN3M-qo-p2`
- Woo Mobile - Automated code reviews assignment on Github -> `p91TBi-4N0-p2`
- **NEW**: WordPress Mobile Apps: - HACK Week: Dependabot & Dependency Tree Diff -> `pbArwn-41v-p2`
-----

## To test ([Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates)):
- It'll start working after merge. 🤷 

-----

## To test ([Dependency Tree Diff](https://github.com/JakeWharton/dependency-tree-diff)):
- Try to add/remove/change the version of any dependency in the project.
- Push the changes.
- Wait for CI and notice a comment in this PR.
- Revert your change.
- Notice that comment is removed.

PS: You also can reference the below two test related draft PRs to verify correctness:
- #16096
- #16100

-----

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
