### PR TITLE
Update Dagger to 2.41

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     coroutinesVersion = '1.3.9'
     androidxWorkVersion = "2.4.0"
 
-    daggerVersion = '2.29.1'
+    daggerVersion = '2.40.5'
     fluxCVersion = '1.37.0'
 
     appCompatVersion = '1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     coroutinesVersion = '1.3.9'
     androidxWorkVersion = "2.4.0"
 
-    daggerVersion = '2.40.5'
+    daggerVersion = '2.41'
     fluxCVersion = '1.37.0'
 
     appCompatVersion = '1.0.2'


### PR DESCRIPTION
This PR updates `Dagger` to `2.41`.

Except for the bug fixes and `Hilt` (*) related changes, this update has the following changes that is worth noting:
- [2.30](https://github.com/google/dagger/releases/tag/dagger-2.30)
  - `experimentalDaggerErrorMessages` by default.
- [2.31](https://github.com/google/dagger/releases/tag/dagger-2.31)
  - `Assisted Injection` support.
- [2.36](https://github.com/google/dagger/releases/tag/dagger-2.36)
  - Compile time `set binding` validation.
- [2.38](https://github.com/google/dagger/releases/tag/dagger-2.38)
  - `Google Maven` repository for `KSP` artifacts.
- [2.41](https://github.com/google/dagger/releases/tag/dagger-2.41)
  - A [long-standing bug](https://github.com/google/dagger/issues/3136) is now fixed.
  - Slight change  in string format of `bindings`.
  - Improved error messages for unresolvable `deferred types`.
  - Support for `jakarta.inject`.

Non of the above and any other change are breaking building and/or running the app.

`(*)` Since WPAndroid hasn't migrated to `Hilt` just yet (see [here](https://github.com/wordpress-mobile/WordPress-Android/pulls?q=is%3Apr+hilt+is%3Aopen)), any such related changes are excluded from the above notes.

## To test:

- Smoke test the app.

## Regression Notes

1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
