### PR TITLE
Add empty Site Intent Question screen in site creation flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -206,6 +206,7 @@ import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment
 import org.wordpress.android.ui.sitecreation.previews.SiteCreationPreviewFragment;
 import org.wordpress.android.ui.sitecreation.services.SiteCreationService;
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerFragment;
+import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsFragment;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
 import org.wordpress.android.ui.stats.refresh.StatsActivity;
 import org.wordpress.android.ui.stats.refresh.StatsModule;
@@ -583,6 +584,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(ModalLayoutPickerFragment object);
 
     void inject(HomePagePickerFragment object);
+
+    void inject(SiteCreationIntentsFragment object);
 
     void inject(SubfilterBottomSheetFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -65,6 +65,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM;
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel;
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel;
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerViewModel;
+import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel;
 import org.wordpress.android.ui.stats.refresh.StatsViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.DaysListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsListViewModel;
@@ -249,6 +250,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(HistoryViewModel.class)
     abstract ViewModel historyViewModel(HistoryViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(SiteCreationIntentsViewModel.class)
+    abstract ViewModel siteCreationIntentsViewModel(SiteCreationIntentsViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.INTENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.ui.sitecreation.domains.DomainsScreenListener
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment
@@ -130,6 +131,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
     private fun showStep(target: WizardNavigationTarget<SiteCreationStep, SiteCreationState>) {
         val screenTitle = getScreenTitle(target.wizardStep)
         val fragment = when (target.wizardStep) {
+            INTENTS -> throw Error("SiteCreationIntentsFragment() not implemented")
             SEGMENTS -> HomePagePickerFragment()
             DOMAINS -> SiteCreationDomainsFragment.newInstance(
                     screenTitle

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -19,8 +19,8 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.INTENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.ui.sitecreation.domains.DomainsScreenListener
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment
@@ -33,6 +33,8 @@ import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.Creat
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState.SiteNotInLocalDb
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerFragment
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerViewModel
+import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsFragment
+import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.wizard.WizardNavigationTarget
 import javax.inject.Inject
@@ -48,6 +50,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
     @Inject internal lateinit var uiHelpers: UiHelpers
     private lateinit var mainViewModel: SiteCreationMainVM
     private lateinit var hppViewModel: HomePagePickerViewModel
+    private lateinit var siteCreationIntentsViewModel: SiteCreationIntentsViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -55,6 +58,8 @@ class SiteCreationActivity : LocaleAwareActivity(),
         setContentView(R.layout.site_creation_activity)
         mainViewModel = ViewModelProvider(this, viewModelFactory).get(SiteCreationMainVM::class.java)
         hppViewModel = ViewModelProvider(this, viewModelFactory).get(HomePagePickerViewModel::class.java)
+        siteCreationIntentsViewModel = ViewModelProvider(this, viewModelFactory)
+                .get(SiteCreationIntentsViewModel::class.java)
         mainViewModel.start(savedInstanceState)
         hppViewModel.loadSavedState(savedInstanceState)
 
@@ -131,7 +136,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
     private fun showStep(target: WizardNavigationTarget<SiteCreationStep, SiteCreationState>) {
         val screenTitle = getScreenTitle(target.wizardStep)
         val fragment = when (target.wizardStep) {
-            INTENTS -> throw Error("SiteCreationIntentsFragment() not implemented")
+            INTENTS -> SiteCreationIntentsFragment()
             SEGMENTS -> HomePagePickerFragment()
             DOMAINS -> SiteCreationDomainsFragment.newInstance(
                     screenTitle

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -109,6 +109,12 @@ class SiteCreationActivity : LocaleAwareActivity(),
         mainViewModel.onBackPressedObservable.observe(this, Observer {
             super.onBackPressed()
         })
+        siteCreationIntentsViewModel.onBackButtonPressed.observe(this, Observer {
+            mainViewModel.onBackPressed()
+        })
+        siteCreationIntentsViewModel.onSkipButtonPressed.observe(this, Observer {
+            mainViewModel.onSiteIntentSkipped()
+        })
         hppViewModel.onBackButtonPressed.observe(this, Observer {
             mainViewModel.onBackPressed()
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -95,6 +95,10 @@ class SiteCreationMainVM @Inject constructor(
         outState.putParcelable(KEY_SITE_CREATION_STATE, siteCreationState)
     }
 
+    fun onSiteIntentSkipped() {
+        wizardManager.showNextStep()
+    }
+
     fun onSiteDesignSelected(siteDesign: String) {
         siteCreationState = siteCreationState.copy(siteDesign = siteDesign)
         wizardManager.showNextStep()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -143,7 +143,7 @@ class SiteCreationMainVM @Inject constructor(
         val stepCount = wizardManager.stepsCount
         val firstStep = stepPosition == 1
         val lastStep = stepPosition == stepCount
-        val singleInBetweenStepDomains = wizardManager.stepsCount == 3 && step.name == DOMAINS.name
+        val singleInBetweenStepDomains = step.name == DOMAINS.name
 
         return when {
             firstStep -> ScreenTitleGeneral(R.string.new_site_creation_screen_title_general)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -5,11 +5,12 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 enum class SiteCreationStep : WizardStep {
-    SEGMENTS, DOMAINS, SITE_PREVIEW;
+    SEGMENTS, DOMAINS, SITE_PREVIEW, INTENTS;
 
     companion object {
         fun fromString(input: String): SiteCreationStep {
             return when (input) {
+                "site_creation_intents" -> INTENTS
                 "site_creation_segments" -> SEGMENTS
                 "site_creation_domains" -> DOMAINS
                 "site_creation_site_preview" -> SITE_PREVIEW
@@ -23,6 +24,7 @@ enum class SiteCreationStep : WizardStep {
 class SiteCreationStepsProvider @Inject constructor() {
     fun getSteps(): List<SiteCreationStep> {
         return listOf(
+                SiteCreationStep.fromString("site_creation_intents"),
                 SiteCreationStep.fromString("site_creation_segments"),
                 SiteCreationStep.fromString("site_creation_domains"),
                 SiteCreationStep.fromString("site_creation_site_preview")

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.sitecreation
 
+import org.wordpress.android.util.config.SiteIntentQuestionFeatureConfig
 import org.wordpress.android.util.wizard.WizardStep
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -21,10 +22,20 @@ enum class SiteCreationStep : WizardStep {
 }
 
 @Singleton
-class SiteCreationStepsProvider @Inject constructor() {
+class SiteCreationStepsProvider @Inject constructor(
+    private val siteIntentQuestionFeatureConfig: SiteIntentQuestionFeatureConfig
+) {
     fun getSteps(): List<SiteCreationStep> {
+        if (siteIntentQuestionFeatureConfig.isEnabled()) {
+            return listOf(
+                    SiteCreationStep.fromString("site_creation_intents"),
+                    SiteCreationStep.fromString("site_creation_segments"),
+                    SiteCreationStep.fromString("site_creation_domains"),
+                    SiteCreationStep.fromString("site_creation_site_preview")
+            )
+        }
+
         return listOf(
-                SiteCreationStep.fromString("site_creation_intents"),
                 SiteCreationStep.fromString("site_creation_segments"),
                 SiteCreationStep.fromString("site_creation_domains"),
                 SiteCreationStep.fromString("site_creation_site_preview")

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -1,5 +1,9 @@
 package org.wordpress.android.ui.sitecreation
 
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.INTENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.util.config.SiteIntentQuestionFeatureConfig
 import org.wordpress.android.util.wizard.WizardStep
 import javax.inject.Inject
@@ -7,18 +11,6 @@ import javax.inject.Singleton
 
 enum class SiteCreationStep : WizardStep {
     SEGMENTS, DOMAINS, SITE_PREVIEW, INTENTS;
-
-    companion object {
-        fun fromString(input: String): SiteCreationStep {
-            return when (input) {
-                "site_creation_intents" -> INTENTS
-                "site_creation_segments" -> SEGMENTS
-                "site_creation_domains" -> DOMAINS
-                "site_creation_site_preview" -> SITE_PREVIEW
-                else -> throw IllegalArgumentException("SiteCreationStep not recognized: \$input")
-            }
-        }
-    }
 }
 
 @Singleton
@@ -28,17 +20,17 @@ class SiteCreationStepsProvider @Inject constructor(
     fun getSteps(): List<SiteCreationStep> {
         if (siteIntentQuestionFeatureConfig.isEnabled()) {
             return listOf(
-                    SiteCreationStep.fromString("site_creation_intents"),
-                    SiteCreationStep.fromString("site_creation_segments"),
-                    SiteCreationStep.fromString("site_creation_domains"),
-                    SiteCreationStep.fromString("site_creation_site_preview")
+                    INTENTS,
+                    SEGMENTS,
+                    DOMAINS,
+                    SITE_PREVIEW
             )
         }
 
         return listOf(
-                SiteCreationStep.fromString("site_creation_segments"),
-                SiteCreationStep.fromString("site_creation_domains"),
-                SiteCreationStep.fromString("site_creation_site_preview")
+                SEGMENTS,
+                DOMAINS,
+                SITE_PREVIEW
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -1,0 +1,81 @@
+package org.wordpress.android.ui.sitecreation.verticals
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isInvisible
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.SiteCreationIntentsFragmentBinding
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.DisplayUtilsWrapper
+import javax.inject.Inject
+
+/**
+ * Implements the Site Intent Question UI
+ */
+class SiteCreationIntentsFragment : Fragment() {
+    @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject internal lateinit var uiHelper: UiHelpers
+    @Inject internal lateinit var displayUtils: DisplayUtilsWrapper
+
+    private lateinit var viewModel: SiteCreationIntentsViewModel
+    private var binding: SiteCreationIntentsFragmentBinding? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.site_creation_intents_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
+                .get(SiteCreationIntentsViewModel::class.java)
+
+        val binding = SiteCreationIntentsFragmentBinding.bind(view)
+        with(binding) {
+            this@SiteCreationIntentsFragment.binding = binding
+            setupUi()
+            setupViewModel()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (requireActivity().application as WordPress).component().inject(this)
+    }
+
+    private fun SiteCreationIntentsFragmentBinding.setupUi() {
+        siteCreationIntentsTitlebar.title.isInvisible = !isPhoneLandscape()
+        siteCreationHeaderItem.title.setText(R.string.new_site_creation_intents_header_title)
+        siteCreationHeaderItem.subtitle.setText(R.string.new_site_creation_intents_header_subtitle)
+    }
+
+    private fun SiteCreationIntentsFragmentBinding.setupViewModel() {
+        viewModel.start()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+
+    private fun isPhoneLandscape() = displayUtils.isLandscapeBySize() && !displayUtils.isTablet()
+
+    companion object {
+        const val TAG = "site_creation_intents_fragment_tag"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -18,7 +18,6 @@ import javax.inject.Inject
 /**
  * Implements the Site Intent Question UI
  */
-@Suppress("TooManyFunctions")
 class SiteCreationIntentsFragment : Fragment() {
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject internal lateinit var uiHelper: UiHelpers

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -5,9 +5,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isInvisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.appbar.AppBarLayout
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SiteCreationIntentsFragmentBinding
@@ -60,23 +60,44 @@ class SiteCreationIntentsFragment : Fragment() {
     }
 
     private fun SiteCreationIntentsFragmentBinding.setupUi() {
-        siteCreationIntentsTitlebar.title.isInvisible = !isPhoneLandscape()
+        siteCreationIntentsTitlebar.title.visibility = if (isPhoneLandscape()) View.VISIBLE else View.INVISIBLE
         siteCreationHeaderItem.title.setText(R.string.new_site_creation_intents_header_title)
         siteCreationHeaderItem.subtitle.setText(R.string.new_site_creation_intents_header_subtitle)
     }
 
     private fun SiteCreationIntentsFragmentBinding.setupViewModel() {
+        viewModel.uiState.observe(viewLifecycleOwner) { uiState ->
+            setHeaderVisibility(uiState.isHeaderVisible)
+        }
+
         viewModel.start()
+    }
+
+    private fun SiteCreationIntentsFragmentBinding.setHeaderVisibility(visible: Boolean) {
+        uiHelper.fadeInfadeOutViews(
+                siteCreationIntentsTitlebar.title,
+                siteCreationHeaderItem.title,
+                visible
+        )
     }
 
     private fun SiteCreationIntentsFragmentBinding.setupActionListeners() {
         siteCreationIntentsTitlebar.skipButton.setOnClickListener { viewModel.onSkipPressed() }
         siteCreationIntentsTitlebar.backButton.setOnClickListener { viewModel.onBackPressed() }
+        setScrollListener()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
+    }
+
+    private fun SiteCreationIntentsFragmentBinding.setScrollListener() {
+        val scrollThreshold = resources.getDimension(R.dimen.picker_header_scroll_snap_threshold).toInt()
+        appBarLayout.addOnOffsetChangedListener(AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->
+            viewModel.onAppBarOffsetChanged(verticalOffset, scrollThreshold)
+        })
+        viewModel.onAppBarOffsetChanged(0, scrollThreshold)
     }
 
     private fun isPhoneLandscape() = displayUtils.isLandscapeBySize() && !displayUtils.isTablet()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -18,6 +18,7 @@ import javax.inject.Inject
 /**
  * Implements the Site Intent Question UI
  */
+@Suppress("TooManyFunctions")
 class SiteCreationIntentsFragment : Fragment() {
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject internal lateinit var uiHelper: UiHelpers

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -61,7 +61,7 @@ class SiteCreationIntentsFragment : Fragment() {
     }
 
     private fun SiteCreationIntentsFragmentBinding.setupUi() {
-        siteCreationIntentsTitlebar.title.visibility = if (isPhoneLandscape()) View.VISIBLE else View.INVISIBLE
+        siteCreationIntentsTitlebar.appBarTitle.visibility = if (isPhoneLandscape()) View.VISIBLE else View.INVISIBLE
         siteCreationHeaderItem.title.setText(R.string.new_site_creation_intents_header_title)
         siteCreationHeaderItem.subtitle.setText(R.string.new_site_creation_intents_header_subtitle)
     }
@@ -76,7 +76,7 @@ class SiteCreationIntentsFragment : Fragment() {
 
     private fun SiteCreationIntentsFragmentBinding.setHeaderVisibility(visible: Boolean) {
         uiHelper.fadeInfadeOutViews(
-                siteCreationIntentsTitlebar.title,
+                siteCreationIntentsTitlebar.appBarTitle,
                 siteCreationHeaderItem.title,
                 visible
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -55,11 +55,6 @@ class SiteCreationIntentsFragment : Fragment() {
         }
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        (requireActivity().application as WordPress).component().inject(this)
-    }
-
     private fun SiteCreationIntentsFragmentBinding.setupUi() {
         siteCreationIntentsTitlebar.appBarTitle.isInvisible = !isPhoneLandscape()
         siteCreationHeaderItem.title.setText(R.string.new_site_creation_intents_header_title)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -50,6 +50,7 @@ class SiteCreationIntentsFragment : Fragment() {
             this@SiteCreationIntentsFragment.binding = binding
             setupUi()
             setupViewModel()
+            setupActionListeners()
         }
     }
 
@@ -66,6 +67,11 @@ class SiteCreationIntentsFragment : Fragment() {
 
     private fun SiteCreationIntentsFragmentBinding.setupViewModel() {
         viewModel.start()
+    }
+
+    private fun SiteCreationIntentsFragmentBinding.setupActionListeners() {
+        siteCreationIntentsTitlebar.skipButton.setOnClickListener { viewModel.onSkipPressed() }
+        siteCreationIntentsTitlebar.backButton.setOnClickListener { viewModel.onBackPressed() }
     }
 
     override fun onDestroyView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -5,9 +5,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isInvisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import com.google.android.material.appbar.AppBarLayout
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SiteCreationIntentsFragmentBinding
@@ -61,44 +61,23 @@ class SiteCreationIntentsFragment : Fragment() {
     }
 
     private fun SiteCreationIntentsFragmentBinding.setupUi() {
-        siteCreationIntentsTitlebar.appBarTitle.visibility = if (isPhoneLandscape()) View.VISIBLE else View.INVISIBLE
+        siteCreationIntentsTitlebar.appBarTitle.isInvisible = !isPhoneLandscape()
         siteCreationHeaderItem.title.setText(R.string.new_site_creation_intents_header_title)
         siteCreationHeaderItem.subtitle.setText(R.string.new_site_creation_intents_header_subtitle)
     }
 
-    private fun SiteCreationIntentsFragmentBinding.setupViewModel() {
-        viewModel.uiState.observe(viewLifecycleOwner) { uiState ->
-            setHeaderVisibility(uiState.isHeaderVisible)
-        }
-
+    private fun setupViewModel() {
         viewModel.start()
-    }
-
-    private fun SiteCreationIntentsFragmentBinding.setHeaderVisibility(visible: Boolean) {
-        uiHelper.fadeInfadeOutViews(
-                siteCreationIntentsTitlebar.appBarTitle,
-                siteCreationHeaderItem.title,
-                visible
-        )
     }
 
     private fun SiteCreationIntentsFragmentBinding.setupActionListeners() {
         siteCreationIntentsTitlebar.skipButton.setOnClickListener { viewModel.onSkipPressed() }
         siteCreationIntentsTitlebar.backButton.setOnClickListener { viewModel.onBackPressed() }
-        setScrollListener()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
-    }
-
-    private fun SiteCreationIntentsFragmentBinding.setScrollListener() {
-        val scrollThreshold = resources.getDimension(R.dimen.picker_header_scroll_snap_threshold).toInt()
-        appBarLayout.addOnOffsetChangedListener(AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->
-            viewModel.onAppBarOffsetChanged(verticalOffset, scrollThreshold)
-        })
-        viewModel.onAppBarOffsetChanged(0, scrollThreshold)
     }
 
     private fun isPhoneLandscape() = displayUtils.isLandscapeBySize() && !displayUtils.isTablet()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -47,8 +47,8 @@ class SiteCreationIntentsFragment : Fragment() {
                 .get(SiteCreationIntentsViewModel::class.java)
 
         val binding = SiteCreationIntentsFragmentBinding.bind(view)
+        this.binding = binding
         with(binding) {
-            this@SiteCreationIntentsFragment.binding = binding
             setupUi()
             setupViewModel()
             setupActionListeners()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -1,11 +1,13 @@
 package org.wordpress.android.ui.sitecreation.verticals
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
+import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
@@ -20,11 +22,27 @@ class SiteCreationIntentsViewModel @Inject constructor(
 
     private var isStarted = false
 
+    private val _onSkipButtonPressed = SingleLiveEvent<Unit>()
+    val onSkipButtonPressed: LiveData<Unit> = _onSkipButtonPressed
+
+    private val _onBackButtonPressed = SingleLiveEvent<Unit>()
+    val onBackButtonPressed: LiveData<Unit> = _onBackButtonPressed
+
     fun start() {
         if (isStarted) {
             return
         }
         isStarted = true
         // tracker.trackSiteIntentQuestionViewed()
+    }
+
+    fun onSkipPressed() {
+        // tracker.trackSiteIntentQuestionSkipped()
+        _onSkipButtonPressed.call()
+    }
+
+    fun onBackPressed() {
+        // tracker.trackSiteIntentQuestionCanceled()
+        _onBackButtonPressed.call()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -1,0 +1,30 @@
+package org.wordpress.android.ui.sitecreation.verticals
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.coroutines.CoroutineContext
+
+class SiteCreationIntentsViewModel @Inject constructor(
+    private val tracker: SiteCreationTracker,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+) : ViewModel(), CoroutineScope {
+    private val job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = bgDispatcher + job
+
+    private var isStarted = false
+
+    fun start() {
+        if (isStarted) {
+            return
+        }
+        isStarted = true
+        // tracker.trackSiteIntentQuestionViewed()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -1,20 +1,17 @@
 package org.wordpress.android.ui.sitecreation.verticals
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 class SiteCreationIntentsViewModel @Inject constructor(
-    private val tracker: SiteCreationTracker,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : ViewModel(), CoroutineScope {
     private val job = Job()
@@ -29,26 +26,10 @@ class SiteCreationIntentsViewModel @Inject constructor(
     private val _onBackButtonPressed = SingleLiveEvent<Unit>()
     val onBackButtonPressed: LiveData<Unit> = _onBackButtonPressed
 
-    private val _uiState = MutableLiveData<IntentsUiState>()
-    val uiState: LiveData<IntentsUiState> = _uiState
-
     fun start() {
-        if (isStarted) {
-            return
-        }
+        if (isStarted) return
         isStarted = true
         // tracker.trackSiteIntentQuestionViewed()
-        resetUiState()
-    }
-
-    private fun resetUiState() {
-        updateUiState(
-                IntentsUiState()
-        )
-    }
-
-    private fun updateUiState(uiState: IntentsUiState) {
-        _uiState.value = uiState
     }
 
     fun onSkipPressed() {
@@ -60,16 +41,4 @@ class SiteCreationIntentsViewModel @Inject constructor(
         // tracker.trackSiteIntentQuestionCanceled()
         _onBackButtonPressed.call()
     }
-
-    fun onAppBarOffsetChanged(verticalOffset: Int, scrollThreshold: Int) {
-        val headerShouldBeVisible = verticalOffset < scrollThreshold
-        uiState.value?.let { state ->
-            if (state.isHeaderVisible == headerShouldBeVisible) return // No change
-            updateUiState(state.copy(isHeaderVisible = headerShouldBeVisible))
-        }
-    }
-
-    data class IntentsUiState(
-        val isHeaderVisible: Boolean = false
-    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.sitecreation.verticals
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -28,12 +29,26 @@ class SiteCreationIntentsViewModel @Inject constructor(
     private val _onBackButtonPressed = SingleLiveEvent<Unit>()
     val onBackButtonPressed: LiveData<Unit> = _onBackButtonPressed
 
+    private val _uiState = MutableLiveData<IntentsUiState>()
+    val uiState: LiveData<IntentsUiState> = _uiState
+
     fun start() {
         if (isStarted) {
             return
         }
         isStarted = true
         // tracker.trackSiteIntentQuestionViewed()
+        resetUiState()
+    }
+
+    private fun resetUiState() {
+        updateUiState(
+                IntentsUiState()
+        )
+    }
+
+    private fun updateUiState(uiState: IntentsUiState) {
+        _uiState.value = uiState
     }
 
     fun onSkipPressed() {
@@ -45,4 +60,16 @@ class SiteCreationIntentsViewModel @Inject constructor(
         // tracker.trackSiteIntentQuestionCanceled()
         _onBackButtonPressed.call()
     }
+
+    fun onAppBarOffsetChanged(verticalOffset: Int, scrollThreshold: Int) {
+        val headerShouldBeVisible = verticalOffset < scrollThreshold
+        uiState.value?.let { state ->
+            if (state.isHeaderVisible == headerShouldBeVisible) return // No change
+            updateUiState(state.copy(isHeaderVisible = headerShouldBeVisible))
+        }
+    }
+
+    data class IntentsUiState(
+        val isHeaderVisible: Boolean = false,
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -70,6 +70,6 @@ class SiteCreationIntentsViewModel @Inject constructor(
     }
 
     data class IntentsUiState(
-        val isHeaderVisible: Boolean = false,
+        val isHeaderVisible: Boolean = false
     )
 }

--- a/WordPress/src/main/res/layout/home_page_picker_titlebar.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_titlebar.xml
@@ -38,5 +38,5 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"
-        android:text="@string/hpp_skip_button" />
+        android:text="@string/button_skip" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/site_creation_intents_fragment.xml
+++ b/WordPress/src/main/res/layout/site_creation_intents_fragment.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/layoutPickerBackground"
+    android:fitsSystemWindows="false"
+    android:focusableInTouchMode="true">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/layoutPickerBackground"
+        android:fitsSystemWindows="false">
+        <com.google.android.material.appbar.CollapsingToolbarLayout
+            android:id="@+id/collapsing_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="false"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+            <include
+                android:id="@+id/site_creation_header_item"
+                layout="@layout/site_creation_header_item"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom"
+                android:layout_marginTop="@dimen/toolbar_height" />
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/layoutPickerBackground"
+                android:elevation="0dp"
+                app:layout_collapseMode="pin">
+
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/toolbar_height"
+                    android:layout_marginTop="@dimen/margin_extra_small"
+                    android:orientation="vertical">
+
+                    <include
+                        android:id="@+id/site_creation_intents_titlebar"
+                        layout="@layout/site_creation_intents_titlebar"
+                        android:layout_width="match_parent"
+                        android:layout_gravity="center_vertical"
+                        android:layout_height="wrap_content" />
+
+                </FrameLayout>
+
+            </com.google.android.material.appbar.MaterialToolbar>
+
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/site_creation_intents_titlebar.xml
+++ b/WordPress/src/main/res/layout/site_creation_intents_titlebar.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageButton
+        android:id="@+id/backButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/negative_margin_medium"
+        android:backgroundTint="@color/transparent"
+        android:contentDescription="@string/navigate_back_desc"
+        android:src="@drawable/ic_arrow_left_white_24dp"
+        android:tint="?attr/colorOnSurface" />
+
+    <!--TODO: Rename ModalLayoutPickerHeader style to something more generic. -->
+    <TextView
+        android:id="@+id/title"
+        style="@style/ModalLayoutPickerHeader"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_marginStart="@dimen/siq_title_padding_start"
+        android:layout_marginEnd="0dp"
+        android:text="@string/new_site_creation_intents_header_title" />
+
+    <Button
+        android:id="@+id/skipButton"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:textColor="@color/blue_50"
+        android:textSize="@dimen/text_sz_medium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:text="@string/button_skip" />
+</LinearLayout>

--- a/WordPress/src/main/res/layout/site_creation_intents_titlebar.xml
+++ b/WordPress/src/main/res/layout/site_creation_intents_titlebar.xml
@@ -13,7 +13,6 @@
         android:src="@drawable/ic_arrow_left_white_24dp"
         android:tint="?attr/colorOnSurface" />
 
-    <!--TODO: Rename ModalLayoutPickerHeader style to something more generic. -->
     <TextView
         android:id="@+id/appBarTitle"
         style="@style/ModalLayoutPickerHeader"

--- a/WordPress/src/main/res/layout/site_creation_intents_titlebar.xml
+++ b/WordPress/src/main/res/layout/site_creation_intents_titlebar.xml
@@ -15,7 +15,7 @@
 
     <!--TODO: Rename ModalLayoutPickerHeader style to something more generic. -->
     <TextView
-        android:id="@+id/title"
+        android:id="@+id/appBarTitle"
         style="@style/ModalLayoutPickerHeader"
         android:layout_width="0dp"
         android:layout_weight="1"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -650,6 +650,9 @@
     <dimen name="hpp_button_max_width">244dp</dimen>
     <dimen name="hpp_title_padding_start">@dimen/margin_extra_extra_medium_large</dimen>
 
+    <!-- Site Intent Question -->
+    <dimen name="siq_title_padding_start">@dimen/margin_extra_extra_medium_large</dimen>
+
     <!-- Login Prologue -->
     <dimen name="login_prologue_content_area">320dp</dimen>
     <dimen name="login_prologue_background_circle_size">140dp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3278,7 +3278,6 @@
     <string name="hpp_title">Choose a design</string>
     <string name="hpp_subtitle">Pick your favorite homepage layout. You can edit and customize it later.</string>
     <string name="hpp_choose_button">Choose</string>
-    <string name="hpp_skip_button">Skip</string>
     <string name="hpp_error_title">Layouts not available while offline</string>
     <string name="hpp_error_subtitle">Tap retry when you\'re back online.</string>
     <string name="hpp_retry_error">Please Check your internet connection and retry.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="status_and_visibility">Status &amp; Visibility</string>
 
     <string name="button_not_now">Not now</string>
+    <string name="button_skip">Skip</string>
 
     <string name="at_username">\@%s</string>
 
@@ -3186,6 +3187,8 @@
     <string name="site_creation_fetch_suggestions_error_unknown">There was a problem</string>
     <string name="site_creation_error_generic_title">There was a problem</string>
     <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>
+    <string name="new_site_creation_intents_header_title">What’s your website about?</string>
+    <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type you own</string>
     <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>
     <string name="new_site_creation_unavailable_domain">This domain is unavailable</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
@@ -154,6 +155,13 @@ class SiteCreationMainVMTest {
         whenever(wizardManager.stepPosition(siteCreationStep)).thenReturn(LAST_STEP_INDEX)
         assertThat(viewModel.screenTitleForWizardStep(siteCreationStep))
                 .isInstanceOf(ScreenTitleEmpty::class.java)
+    }
+
+    @Test
+    fun titleForDomainStepIsChooseADomain() {
+        whenever(siteCreationStep.name).thenReturn(SiteCreationStep.DOMAINS.name)
+        assertThat(viewModel.screenTitleForWizardStep(siteCreationStep))
+                .isEqualTo(ScreenTitleGeneral(R.string.new_site_creation_domain_header_title))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -102,6 +102,12 @@ class SiteCreationMainVMTest {
     }
 
     @Test
+    fun onSiteIntentSkippedPropagatedToWizardManager() {
+        viewModel.onSiteIntentSkipped()
+        verify(wizardManager).showNextStep()
+    }
+
+    @Test
     fun backNotSuppressedWhenNotLastStep() {
         whenever(wizardManager.isLastStep()).thenReturn(false)
         viewModel.onBackPressed()


### PR DESCRIPTION
Closes [#16051](https://github.com/wordpress-mobile/WordPress-Android/issues/16051)

## Description

This PR adds a new (currently empty) step to the Site Creation flow, asking the users for their intent before presenting the site design options.

---

### Progress Status
The following checks from the issue acceptance criteria & other considerations are implemented:

- [x] The screen is displayed **only** when the `SITE_INTENT_QUESTION` development feature flag is enabled
  - [x] The screen is displayed as an new step in Site Creation flow
  - [x] The screen is displayed after tapping on 'CREATE A WORDPRESS.COM SITE' in the "Welcome to WordPress" screen.
- [x] Header (Back button, Skip Button, Title & Subtitle) is displayed
  - [x] Skip Button tap → Navigates forward to "Choose a Design" screen
  - [x] Back Button tap → Navigates back to:
    - [x] "Choose site" screen if logged in
    - [x] "Welcome to WordPress" screen if not
- [x] Unit Tests are added where applicable - see 1️⃣ below
- [ ] Events are tracked (Back button pressed, Skip button pressed, Screen viewed) - see 2️⃣ below
- [x] Back button on "Choose a Design" screens navigates back to the "What's your Website about" screen.

**1️⃣ I propose we tackle unit tests in a separate PR.**
There's little logic in the new code, except for firing events and making sure other parts pick them up as expected.

**2️⃣ I'm also proposing we merge this if we find it to be ready.**
We need this PR to progress with #16043 — that PR is responsible for adding the analytics events and it's [currently on hold](https://github.com/wordpress-mobile/WordPress-Android/pull/16043#issuecomment-1059021373) because we need at least the basic UI of the new screen to test it.


## To Test

<details>
<summary><h3>Test the existing flow</h3> (with the feature flag off)</summary>

1. Launch the app
2. From `My Site` screen tap the `⋁` icon next to the site title
3. On the `Choose a site` screen tap the `➕` menu button
4. Select `Create WordPress.com site`
5. **Verify** that you land on the `Choose a design` screen
</details>

### Test the new screen

1. Launch the app
2. Toggle the `SITE_INTENT_QUESTION` feature flag on

   <details>
   <summary>How to toggle the flag</summary>

   1. From `My Site` Go to `Me` → `App Settings` → `Debug settings`
   2. Scroll to `Features in development` section and tap on `SiteIntentQuestionFeatureConfig`
   3. Tap `RESTART THE APP` button
   </details>

3. From `My Site` screen tap the `⋁` icon next to the site title
4. On the `Choose a site` screen tap on `➕` menu button
5. Select `Create WordPress.com site`
6. **Verify** that you land on the `What's your website about?` screen

### Test interactions on the new screen

1. Tap on the `SKIP button`
2. **Verify** that you land on the `Choose a design` screen
3. Tap the `←` button or the device back button
4. **Verify** that you land on the `What's your website about?` screen
5. Tap again the `←` button or the device back button
6. **Verify** that you land on the `Choose a site` screen

<details>
<summary><h3>Test the new screen with a new account</h3></summary>

1. Launch the app
2. Log out ( From `My Site` Go to `Me` → `Log out of WordPress.com` → `LOG OUT` )
3. Tap 'Log in or sign up with WordPress.com`
4. Enter an e-mail address not registered with WordPress.com ([you can use the `+` sign with for Gmail](https://danq.me/2017/09/26/gmail-plus/))
5. Tap `Check Email` & pick an e-mail app
   1. In the e-mail app open the latest e-mail from WordPress.com
   2. Tap `Sign up to WordPress.com`
   3. Tap `Done` on first screen about your profile
   4. Tap `CREATE A WORDPRESS.COM SITE`
   5. **Verify** that you land on the `What's your website about?` screen
   6. Tap the `←` button or the device back button
   7. **Verify** that you land on the `My Site` screen
</details>

## Previews

| Portrait   | Landscape  |
| ---------- | ---------- |
| ![portrait](https://user-images.githubusercontent.com/4588074/158407714-32917ecb-b277-4504-aad2-7f7eb15e941e.jpg) | ![landscape](https://user-images.githubusercontent.com/4588074/158407746-30bb723b-116e-4c9c-a627-be97225e94d8.jpg) |

## Regression Notes

1. Potential unintended areas of impact
   - Existing flow with the feature flag off
   - Other steps in Site Creation when the feature is enabled

8. What I did to test those areas of impact (or what existing automated tests I relied on)
   - Manual Testing
   - Fixed title for the `Choose a domain` screen when the feature is enabled & added a test for it.

9. What automated tests I added (or what prevented me from doing so)
   - **`SiteCreationMainVM`**
      - `titleForDomainStepIsChooseADomain` - referenced above
      - `onSiteIntentSkippedPropagatedToWizardManager` - test the new method for handling the skip button
   - I thought about adding a test for the feature flag in ``
    

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

