### PR TITLE
My Site Dashboard: Tabs - Add fling support for the Dynamic Card rows

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartDynamicCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartDynamicCardViewHolder.kt
@@ -4,6 +4,8 @@ import android.animation.ObjectAnimator
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.os.Parcelable
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.view.ViewGroup
 import androidx.appcompat.widget.TooltipCompat
 import androidx.core.content.ContextCompat
@@ -11,6 +13,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager.HORIZONTAL
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.OnItemTouchListener
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener
 import androidx.recyclerview.widget.RecyclerView.RecycledViewPool
 import org.wordpress.android.R
@@ -20,6 +23,8 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ColorUtils
 import org.wordpress.android.util.viewBinding
+
+private const val Y_BUFFER = 10
 
 class QuickStartDynamicCardViewHolder(
     parent: ViewGroup,
@@ -57,6 +62,7 @@ class QuickStartDynamicCardViewHolder(
     }
 
     fun bind(item: QuickStartDynamicCard) = with(binding) {
+        setOnTouchItemListener()
         currentItem = item
 
         ObjectAnimator.ofInt(quickStartCardProgress, PROGRESS_PROPERTY_NAME, item.progress)
@@ -93,8 +99,53 @@ class QuickStartDynamicCardViewHolder(
         }
     }
 
+    private fun setOnTouchItemListener() = with(binding) {
+        val gestureDetector = GestureDetector(quickStartCardRecyclerView.context, GestureListener())
+        quickStartCardRecyclerView.addOnItemTouchListener(object : OnItemTouchListener {
+            override fun onInterceptTouchEvent(recyclerView: RecyclerView, e: MotionEvent): Boolean {
+                return gestureDetector.onTouchEvent(e)
+            }
+
+            override fun onTouchEvent(recyclerView: RecyclerView, e: MotionEvent) {
+                // NO OP
+            }
+
+            override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+                // NO OP
+            }
+        })
+    }
+
     companion object {
         private const val PROGRESS_PROPERTY_NAME = "progress"
         private const val PROGRESS_DURATION = 600L
+    }
+
+    private inner class GestureListener : GestureDetector.SimpleOnGestureListener() {
+        /**
+         * Capture the DOWN as soon as it's detected to prevent the viewPager from intercepting touch events
+         * We need to do this immediately, because if we don't, then the next move event could potentially
+         * trigger the viewPager to switch tabs
+         */
+        override fun onDown(e: MotionEvent?): Boolean = with(binding) {
+            quickStartCardRecyclerView.parent.requestDisallowInterceptTouchEvent(true)
+            return super.onDown(e)
+        }
+
+        override fun onScroll(
+            e1: MotionEvent?,
+            e2: MotionEvent?,
+            distanceX: Float,
+            distanceY: Float
+        ): Boolean = with(binding) {
+            if (kotlin.math.abs(distanceX) > kotlin.math.abs(distanceY)) {
+                // Detected a horizontal scroll, prevent the viewpager from switching tabs
+                quickStartCardRecyclerView.parent.requestDisallowInterceptTouchEvent(true)
+            } else if (kotlin.math.abs(distanceY) > Y_BUFFER) {
+                // Detected a vertical scroll allow the viewpager to switch tabs
+                quickStartCardRecyclerView.parent.requestDisallowInterceptTouchEvent(false)
+            }
+            return super.onScroll(e1, e2, distanceX, distanceY)
+        }
     }
 }


### PR DESCRIPTION
Fixes #16097 

This PR adds fling support to the Dynamic Card rows. It also prevents the tab from switching while scrolling through the tasks. Utilizes an inner GestureListener class to detect down to prevent the viewpager from intercepting and switching tabs.

**Merge Instructions**
- Ensure that PR #16099 has been merged to trunk
- Remove `Not Ready for Merge` label
- Merge as normal

**To test**
**Prerequisite**
1. Launch the app
2. Go to My Site -> Me -> App Settings -> Debug settings.
4. Enable the `QuickStartDynamicCardsFeatureConfig` flag under the Features in development section.
5. Restart the app
6. Logout followed by a Login
7. Select a site 
8. Select "Show me around" on the quick start prompt dialog

**Dynamic Card - tabs disabled**
1. Launch the app
2. Go to My Site -> Me -> App Settings -> Debug settings.
3. Disable the `MySiteDashboardTabsFeatureConfig` flag under the Features in development section.
5. Restart the app
6. Navigate to My Site view
7. Note the following
     - the dynamic cards are visible within the My Site view
     - the dynamic cards respond to the fling gesture

**Dynamic Card - tabs disabled**
1. Launch the app
2. Go to My Site -> Me -> App Settings -> Debug settings.
3. Enable the `MySiteDashboardTabsFeatureConfig` flag under the Features in development section.
5. Restart the app
6. Navigate to the My Site View -> `MENU` tab
7. Note the following
     - the dynamic cards are visible within the tab
     - the dynamic cards respond to the fling gesture
     - swiping at the end of a dynamic card row doesn't navigate to the `DASHBOARD` tab

## Regression Notes
1. Potential unintended areas of impact
The dynamic cards row is not scrollable

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

4. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
