### PR TITLE
Fixes draft posts when published later do not update to latest date

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsUtils.kt
@@ -40,7 +40,7 @@ class PostSettingsUtils
             } else if (postUtilsWrapper.isPublishDateInTheFuture(postModel.dateCreated)) {
                 labelToUse = resourceProvider.getString(R.string.schedule_for, formattedDate)
             } else {
-                labelToUse = resourceProvider.getString(R.string.publish_on, formattedDate)
+                labelToUse = resourceProvider.getString(R.string.immediately)
             }
         } else if (postUtilsWrapper.shouldPublishImmediatelyOptionBeAvailable(status)) {
             labelToUse = resourceProvider.getString(R.string.immediately)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -142,12 +142,9 @@ class StorePostViewModel
                         updateFromEditor.content
                 )
 
-                // only makes sense to change the publish date and locally changed date if the Post was actually changed
-                if (postTitleOrContentChanged) {
-                    postRepository.updatePublishDateIfShouldBePublishedImmediately(
-                            postModel
-                    )
-                }
+                postRepository.updatePublishDateIfShouldBePublishedImmediately(
+                        postModel
+                )
 
                 postTitleOrContentChanged
             }


### PR DESCRIPTION
Drafts when published later if no edits made will publish with the date created and not updated to latest because of condition post title or content is not changed.

Fixes #15244 

To test:

Test 1
- Launch app, on My Site tap on FAB(+) button, tap on Blog post
- Add a title (in Add title block), and in Start writing.. note the current time (e.g. 5:16pm)
- Tap on ⠇on top right hand corner and choose Save to save draft
- Wait for a few minutes and open the draft created above from DRAFTS tab
- Tap on PUBLISH. **Verify that Publish Date is set to Immediately**
- Tap on PUBLISH NOW button at the bottom
- Open the Posts again from My Site, find the Post created above in PUBLISHED tab
- Tap on ⠇on top right hand corner and choose Post settings.  **Verify Publish Date is set to latest time**

Test 2

- You may test to verify with another version of the app to verify the difference following steps on the issue #15244 

## Regression Notes
1. Potential unintended areas of impact
Tested drafts and no drafts

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually and existing unit tests

3. What automated tests I added (or what prevented me from doing so)
Ran existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
