### PR TITLE
My Site Dashboard: Tabs - Finalize Tab Labels

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2213,8 +2213,8 @@
     <string name="my_site_quick_actions_title">Quick Links</string>
 
     <!-- My Site - Dashboard -->
-    <string name="my_site_dashboard_tab_title">Dashboard</string>
-    <string name="my_site_menu_tab_title">Menu</string>
+    <string name="my_site_dashboard_tab_title">Home</string>
+    <string name="my_site_menu_tab_title">Site Menu</string>
     <string name="my_site_dashboard_update_error">Couldn\'t update dashboard.</string>
     <string name="my_site_dashboard_stale_message">The dashboard is not updated. Please check your connection and then pull to refresh.</string>
 


### PR DESCRIPTION
Closes #16098

This PR updates tab labels as follows to match tab labels on iOS.

`Menu` -> `Site Menu`
`Dashboard` -> `Home`

<img width=320 src="https://user-images.githubusercontent.com/1405144/158561257-b1ee604c-a213-4b91-9d88-4275d4f2b1b7.jpg"/>

Note that internally they are still referenced as  "site menu" and "dashboard" tabs, with the "dashboard" tab mainly including "dashboard" cards. 

To test:

There's nothing to test as such. Just make sure that the strings are replaced correctly in `strings.xml`.

## Regression Notes - Requires no regression
1. Potential unintended areas of impact n/a


2. What I did to test those areas of impact (or what existing automated tests I relied on) n/a


3. What automated tests I added (or what prevented me from doing so) n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
