### PR TITLE
Use Automattic-Tracks-Android library from S3 Maven

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -22,6 +22,7 @@ repositories {
             includeGroup "org.wordpress-mobile.gutenberg-mobile"
             includeGroup "com.automattic"
             includeGroup "com.automattic.stories"
+            includeGroup "com.automattic.tracks"
         }
     }
     maven {
@@ -361,7 +362,7 @@ dependencies {
     implementation 'org.wordpress:graphview:3.4.0'
     implementation 'org.wordpress:persistentedittext:1.0.2'
     implementation 'org.wordpress:emailchecker2:1.1.0'
-    implementation "com.github.Automattic:Automattic-Tracks-Android:$tracksVersion"
+    implementation "com.automattic:Automattic-Tracks-Android:$tracksVersion"
     implementation 'com.squareup.okio:okio:2.8.0'
     implementation 'org.apache.commons:commons-text:1.1'
     implementation 'com.airbnb.android:lottie:3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     swipeToRefresh = '1.1.0'
     uCropVersion = '2.2.4'
     lifecycleVersion = '2.2.0'
-    tracksVersion = '2.1.0'
+    tracksVersion = '2.2.0'
     roomVersion = '2.3.0'
 
     coreLibraryDesugaringVersion = '1.1.5'

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -5,18 +5,14 @@ repositories {
         url "https://a8c-libs.s3.amazonaws.com/android"
         content {
             includeGroup "org.wordpress"
-        }
-    }
-    maven {
-        url 'https://jitpack.io'
-        content {
-            includeGroup "com.github.Automattic"
+            includeGroup "com.automattic"
+            includeGroup "com.automattic.tracks"
         }
     }
 }
 
 dependencies {
-    implementation "com.github.Automattic:Automattic-Tracks-Android:$tracksVersion"
+    implementation "com.automattic:Automattic-Tracks-Android:$tracksVersion"
     implementation "org.wordpress:utils:$wordPressUtilsVersion"
 
     lintChecks 'org.wordpress:lint:1.1.0'


### PR DESCRIPTION
This PR updates the `Automattic-Tracks-Android` library dependency so it'll be fetched from S3 Maven instead of Jitpack.

**To test:**

[There are no functionality changes between `2.1.0` & `2.2.0` versions of the library within the tracks module](https://github.com/Automattic/Automattic-Tracks-Android/releases/tag/2.2.0), so as long as the CI is green, I think we should be fine. Making sure the installable build works and checking if the events are properly reported to tracks would be the next steps of testing if the reviewer wants to be extra sure about the change.

**Edit:** Just to be on the safe side, I used the [Network Inspector](https://developer.android.com/studio/debug/network-profiler) to verify that https://public-api.wordpress.com/rest/v1.1/tracks/record was called. I also verified the events were recorded from the `Tracks Live View`.

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
