### PR TITLE
Weekly roundup notification channel

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 19.5
 -----
-
+* [*] Notification: Adds Weekly Roundup switch to App info -> Notification menu to disable them for all sites. [https://github.com/wordpress-mobile/WordPress-Android/pull/16118]
 
 19.4
 -----

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -446,6 +446,16 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
             // Register the channel with the system; you can't change the importance
             // or other notification behaviors after this
             notificationManager.createNotificationChannel(transientChannel);
+
+            // Create the WEEKLY ROUNDUP channel (used for weekly roundup notification containing weekly stats)
+            NotificationChannel weeklyRoundupChannel = new NotificationChannel(
+                    getString(R.string.notification_channel_weekly_roundup_id),
+                    getString(R.string.notification_channel_weekly_roundup_title),
+                    NotificationManager.IMPORTANCE_LOW
+            );
+            // Register the channel with the system; you can't change the importance or other notification behaviors
+            // after this
+            notificationManager.createNotificationChannel(weeklyRoundupChannel);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotification.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotification.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.R
 
 data class WeeklyRoundupNotification(
     val id: Int,
-    @StringRes val channel: Int = R.string.notification_channel_reminder_id,
+    @StringRes val channel: Int = R.string.notification_channel_weekly_roundup_id,
     val contentIntentBuilder: () -> PendingIntent,
     val contentTitle: String,
     val contentText: String,

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2921,11 +2921,13 @@
     <string name="notification_channel_important_title">Important</string>
     <string name="notification_channel_transient_title">Transient</string>
     <string name="notification_channel_reminder_title">Reminder</string>
+    <string name="notification_channel_weekly_roundup_title">Weekly Roundup</string>
 
     <string name="notification_channel_normal_id" translatable="false">wpandroid_notification_normal_channel_id</string>
     <string name="notification_channel_important_id" translatable="false">wpandroid_notification_important_channel_id</string>
     <string name="notification_channel_transient_id" translatable="false">wpandroid_notification_transient_channel_id</string>
     <string name="notification_channel_reminder_id" translatable="false">wpandroid_notification_reminder_channel_id</string>
+    <string name="notification_channel_weekly_roundup_id" translatable="false">wpandroid_notification_weekly_roundup_channel_id</string>
 
     <!-- Required by the login library - overwrites the placeholder value with a real channel -->
     <string content_override="true" name="login_notification_channel_id" translatable="false">@string/notification_channel_normal_id</string>


### PR DESCRIPTION
Users can disable weekly roundup notifications for each sites one by one but there was not a switch to disable weekly roundup notifications for all sites.
With this PR, users can disable weekly roundup notifications for all sites from the app info menu.
![Screenshot_20220317_002354](https://user-images.githubusercontent.com/2471769/158693598-352fdf01-da32-4929-81a0-252634e9498b.png)

**To test:**
1. Long-press the WordPress app icon, then tap "i" icon or the "App Info" button on the popup.
2. Tap the "Notifications" button.
3. Switch off "Weekly Roundup".
4. Wait for Monday. No weekly roundup notification should be received.

**Alternatively to manipulate waiting Monday:**
Update the line 31 of [WeeklyRoundupScheduler](https://github.com/wordpress-mobile/WordPress-Android/blob/a2218f0ea74ff4ee996b6266f09b290c43bc6aa1/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupScheduler.kt#L31)
`.setInitialDelay(delay.toMillis(), MILLISECONDS)` -> `.setInitialDelay(30000, MILLISECONDS)` 
to wait 30 seconds after reopening the app.


## Regression Notes
1. Potential unintended areas of impact
Reminder channel shouldn't effect weekly roundup notifications anymore.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually, couldn't see any problem.

3. What automated tests I added (or what prevented me from doing so)


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
