### PR TITLE
Integrate gutenberg-mobile release 1.72.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 * [*] Notification: Adds Weekly Roundup switch to App info -> Notification menu to disable them for all sites. [https://github.com/wordpress-mobile/WordPress-Android/pull/16118]
 * [*] Block Editor: Add GIF badge for animated GIFs uploaded to Image blocks [https://github.com/WordPress/gutenberg/pull/38996]
 * [*] Block Editor: Small refinement to media upload errors, including centering and tweaking copy. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4597]
-* [*] Block Editor: Pass the ol start and reversed to native RichText too [https://github.com/WordPress/gutenberg/pull/39354]
+* [*] Block Editor: Fix issue with list's starting index and the order [https://github.com/WordPress/gutenberg/pull/39354]
 
 19.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 * [*] Notification: Adds Weekly Roundup switch to App info -> Notification menu to disable them for all sites. [https://github.com/wordpress-mobile/WordPress-Android/pull/16118]
 * [*] Block Editor: Add GIF badge for animated GIFs uploaded to Image blocks [https://github.com/WordPress/gutenberg/pull/38996]
 * [*] Block Editor: Small refinement to media upload errors, including centering and tweaking copy. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4597]
-
+* [*] Block Editor: Pass the ol start and reversed to native RichText too [https://github.com/WordPress/gutenberg/pull/39354]
 
 19.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,8 @@
 
 19.5
 -----
-
+* [*] Block Editor: Add GIF badge for animated GIFs uploaded to Image blocks [https://github.com/WordPress/gutenberg/pull/38996]
+* [*] Block Editor: Small refinement to media upload errors, including centering and tweaking copy. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4597]
 
 19.4
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.4.0'
     wordPressLoginVersion = '0.12.0'
-    gutenbergMobileVersion = 'v1.72.0-alpha5'
+    gutenbergMobileVersion = '4668-2095f19d1a7ed6d52b0f394f9579e66bb4876f0c'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.4.0'
     wordPressLoginVersion = '0.12.0'
-    gutenbergMobileVersion = '4668-2095f19d1a7ed6d52b0f394f9579e66bb4876f0c'
+    gutenbergMobileVersion = 'v1.72.0'
     storiesVersion = '1.2.1'
     aboutAutomatticVersion = '0.0.4'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.72.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR:

https://github.com/wordpress-mobile/gutenberg-mobile/pull/4668

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.