### PR TITLE
Issue/16122 add blogging prompt option to reminders

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -119,6 +119,7 @@ android {
         buildConfigField "boolean", "COMMENTS_SNIPPET", "false"
         buildConfigField "boolean", "READER_COMMENTS_MODERATION", "false"
         buildConfigField "boolean", "SITE_INTENT_QUESTION", "false"
+        buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAdapter.kt
@@ -7,7 +7,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Caption
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.HighEmphasisText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Illustration
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.IncludePromptSwitched
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.PromptSwitch
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.MediumEmphasisText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.TimeItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Tip
@@ -51,7 +51,7 @@ class BloggingRemindersAdapter @Inject constructor(private val uiHelpers: UiHelp
             is DayButtonsViewHolder -> holder.onBind(item as DayButtons, payloads.firstOrNull() as? DayButtonsPayload)
             is TipViewHolder -> holder.onBind(item as Tip)
             is TimeViewHolder -> holder.onBind(item as TimeItem)
-            is IncludePromptSwitchViewHolder -> holder.onBind(item as IncludePromptSwitched)
+            is IncludePromptSwitchViewHolder -> holder.onBind(item as PromptSwitch)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAdapter.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.CAP
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.DAY_BUTTONS
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.HIGH_EMPHASIS_TEXT
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.ILLUSTRATION
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.INCLUDE_PROMPT_SWITCH
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.PROMPT_SWITCH
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.LOW_EMPHASIS_TEXT
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.NOTIFICATION_TIME
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.TIP
@@ -26,7 +26,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.Ca
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.DayButtonsViewHolder
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.HighEmphasisTextViewHolder
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.IllustrationViewHolder
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.IncludePromptSwitchViewHolder
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.PromptSwitchViewHolder
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.MediumEmphasisTextViewHolder
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.TimeViewHolder
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.TipViewHolder
@@ -51,7 +51,7 @@ class BloggingRemindersAdapter @Inject constructor(private val uiHelpers: UiHelp
             is DayButtonsViewHolder -> holder.onBind(item as DayButtons, payloads.firstOrNull() as? DayButtonsPayload)
             is TipViewHolder -> holder.onBind(item as Tip)
             is TimeViewHolder -> holder.onBind(item as TimeItem)
-            is IncludePromptSwitchViewHolder -> holder.onBind(item as PromptSwitch)
+            is PromptSwitchViewHolder -> holder.onBind(item as PromptSwitch)
         }
     }
 
@@ -65,7 +65,7 @@ class BloggingRemindersAdapter @Inject constructor(private val uiHelpers: UiHelp
             DAY_BUTTONS -> DayButtonsViewHolder(parent, uiHelpers)
             TIP -> TipViewHolder(parent, uiHelpers)
             NOTIFICATION_TIME -> TimeViewHolder(parent, uiHelpers)
-            INCLUDE_PROMPT_SWITCH -> IncludePromptSwitchViewHolder(parent)
+            PROMPT_SWITCH -> PromptSwitchViewHolder(parent)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAdapter.kt
@@ -2,11 +2,12 @@ package org.wordpress.android.ui.bloggingreminders
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Caption
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersDiffCallback.DayButtonsPayload
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Caption
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.HighEmphasisText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Illustration
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.IncludePromptSwitched
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.MediumEmphasisText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.TimeItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Tip
@@ -16,6 +17,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.CAP
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.DAY_BUTTONS
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.HIGH_EMPHASIS_TEXT
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.ILLUSTRATION
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.INCLUDE_PROMPT_SWITCH
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.LOW_EMPHASIS_TEXT
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.NOTIFICATION_TIME
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.TIP
@@ -24,6 +26,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.Ca
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.DayButtonsViewHolder
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.HighEmphasisTextViewHolder
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.IllustrationViewHolder
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.IncludePromptSwitchViewHolder
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.MediumEmphasisTextViewHolder
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.TimeViewHolder
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.TipViewHolder
@@ -48,6 +51,7 @@ class BloggingRemindersAdapter @Inject constructor(private val uiHelpers: UiHelp
             is DayButtonsViewHolder -> holder.onBind(item as DayButtons, payloads.firstOrNull() as? DayButtonsPayload)
             is TipViewHolder -> holder.onBind(item as Tip)
             is TimeViewHolder -> holder.onBind(item as TimeItem)
+            is IncludePromptSwitchViewHolder -> holder.onBind(item as IncludePromptSwitched)
         }
     }
 
@@ -61,6 +65,7 @@ class BloggingRemindersAdapter @Inject constructor(private val uiHelpers: UiHelp
             DAY_BUTTONS -> DayButtonsViewHolder(parent, uiHelpers)
             TIP -> TipViewHolder(parent, uiHelpers)
             NOTIFICATION_TIME -> TimeViewHolder(parent, uiHelpers)
+            INCLUDE_PROMPT_SWITCH -> IncludePromptSwitchViewHolder(parent)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersItem.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.CAP
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.DAY_BUTTONS
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.HIGH_EMPHASIS_TEXT
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.ILLUSTRATION
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.INCLUDE_PROMPT_SWITCH
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.LOW_EMPHASIS_TEXT
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.NOTIFICATION_TIME
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.TIP
@@ -23,6 +24,7 @@ sealed class BloggingRemindersItem(val type: Type) {
         DAY_BUTTONS,
         TIP,
         NOTIFICATION_TIME,
+        INCLUDE_PROMPT_SWITCH,
     }
 
     data class Illustration(@DrawableRes val illustration: Int) : BloggingRemindersItem(ILLUSTRATION)
@@ -56,6 +58,11 @@ sealed class BloggingRemindersItem(val type: Type) {
         val time: UiString,
         val onClick: ListItemInteraction
     ) : BloggingRemindersItem(NOTIFICATION_TIME)
+
+    data class IncludePromptSwitched(
+        val isToggled: Boolean,
+        val onClick: ListItemInteraction
+    ) : BloggingRemindersItem(INCLUDE_PROMPT_SWITCH)
 
     data class Tip(val title: UiString, val message: UiString) : BloggingRemindersItem(TIP)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersItem.kt
@@ -6,7 +6,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.CAP
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.DAY_BUTTONS
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.HIGH_EMPHASIS_TEXT
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.ILLUSTRATION
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.INCLUDE_PROMPT_SWITCH
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.PROMPT_SWITCH
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.LOW_EMPHASIS_TEXT
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.NOTIFICATION_TIME
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Type.TIP
@@ -24,7 +24,7 @@ sealed class BloggingRemindersItem(val type: Type) {
         DAY_BUTTONS,
         TIP,
         NOTIFICATION_TIME,
-        INCLUDE_PROMPT_SWITCH,
+        PROMPT_SWITCH,
     }
 
     data class Illustration(@DrawableRes val illustration: Int) : BloggingRemindersItem(ILLUSTRATION)
@@ -62,7 +62,7 @@ sealed class BloggingRemindersItem(val type: Type) {
     data class PromptSwitch(
         val isToggled: Boolean,
         val onClick: ListItemInteraction
-    ) : BloggingRemindersItem(INCLUDE_PROMPT_SWITCH)
+    ) : BloggingRemindersItem(PROMPT_SWITCH)
 
     data class Tip(val title: UiString, val message: UiString) : BloggingRemindersItem(TIP)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersItem.kt
@@ -59,7 +59,7 @@ sealed class BloggingRemindersItem(val type: Type) {
         val onClick: ListItemInteraction
     ) : BloggingRemindersItem(NOTIFICATION_TIME)
 
-    data class IncludePromptSwitched(
+    data class PromptSwitch(
         val isToggled: Boolean,
         val onClick: ListItemInteraction
     ) : BloggingRemindersItem(INCLUDE_PROMPT_SWITCH)

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
@@ -10,7 +10,8 @@ data class BloggingRemindersUiModel(
     val siteId: Int,
     val enabledDays: Set<DayOfWeek> = setOf(),
     val hour: Int,
-    val minute: Int
+    val minute: Int,
+    val isPromptIncluded: Boolean = true // TODO: get a real value here when implemented
 ) {
     fun getNotificationTime(): CharSequence =
             LocalTime.of(hour, minute).format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewHolder.kt
@@ -25,8 +25,8 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButto
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.EmphasizedText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.HighEmphasisText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Illustration
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.IncludePromptSwitched
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.MediumEmphasisText
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.PromptSwitch
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.TimeItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Tip
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Title
@@ -176,7 +176,7 @@ sealed class BloggingRemindersViewHolder<T : ViewBinding>(protected val binding:
             BloggingRemindersViewHolder<BloggingRemindersPromptSwitchBinding>(
                     parentView.viewBinding(BloggingRemindersPromptSwitchBinding::inflate)
             ) {
-        fun onBind(item: IncludePromptSwitched) = with(binding) {
+        fun onBind(item: PromptSwitch) = with(binding) {
             includePromptSwitch.isChecked = item.isToggled
             includePromptSwitch.setOnCheckedChangeListener { _, _ -> item.onClick.click() }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewHolder.kt
@@ -178,7 +178,7 @@ sealed class BloggingRemindersViewHolder<T : ViewBinding>(protected val binding:
             ) {
         fun onBind(item: IncludePromptSwitched) = with(binding) {
             includePromptSwitch.isChecked = item.isToggled
-            includePromptSwitch.setOnCheckedChangeListener { _, _ ->  item.onClick.click()}
+            includePromptSwitch.setOnCheckedChangeListener { _, _ -> item.onClick.click() }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewHolder.kt
@@ -172,7 +172,7 @@ sealed class BloggingRemindersViewHolder<T : ViewBinding>(protected val binding:
         }
     }
 
-    class IncludePromptSwitchViewHolder(parentView: ViewGroup) :
+    class PromptSwitchViewHolder(parentView: ViewGroup) :
             BloggingRemindersViewHolder<BloggingRemindersPromptSwitchBinding>(
                     parentView.viewBinding(BloggingRemindersPromptSwitchBinding::inflate)
             ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewHolder.kt
@@ -12,18 +12,20 @@ import androidx.viewbinding.ViewBinding
 import org.wordpress.android.databinding.BloggingRemindersCaptionBinding
 import org.wordpress.android.databinding.BloggingRemindersDayButtonsBinding
 import org.wordpress.android.databinding.BloggingRemindersIllustrationBinding
+import org.wordpress.android.databinding.BloggingRemindersPromptSwitchBinding
 import org.wordpress.android.databinding.BloggingRemindersTextHighEmphasisBinding
 import org.wordpress.android.databinding.BloggingRemindersTextMediumEmphasisBinding
 import org.wordpress.android.databinding.BloggingRemindersTimeBinding
 import org.wordpress.android.databinding.BloggingRemindersTipBinding
 import org.wordpress.android.databinding.BloggingRemindersTitleBinding
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Caption
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersDiffCallback.DayButtonsPayload
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Caption
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons.DayItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.EmphasizedText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.HighEmphasisText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Illustration
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.IncludePromptSwitched
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.MediumEmphasisText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.TimeItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Tip
@@ -167,6 +169,16 @@ sealed class BloggingRemindersViewHolder<T : ViewBinding>(protected val binding:
         fun onBind(item: TimeItem) = with(binding) {
             uiHelpers.setTextOrHide(timeButton, item.time)
             timeItem.setOnClickListener { item.onClick.click() }
+        }
+    }
+
+    class IncludePromptSwitchViewHolder(parentView: ViewGroup) :
+            BloggingRemindersViewHolder<BloggingRemindersPromptSwitchBinding>(
+                    parentView.viewBinding(BloggingRemindersPromptSwitchBinding::inflate)
+            ) {
+        fun onBind(item: IncludePromptSwitched) = with(binding) {
+            includePromptSwitch.isChecked = item.isToggled
+            includePromptSwitch.setOnCheckedChangeListener { _, _ ->  item.onClick.click()}
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Scr
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Screen.SELECTION
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import org.wordpress.android.util.merge
 import org.wordpress.android.util.perform
 import org.wordpress.android.viewmodel.Event
@@ -29,7 +30,6 @@ import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.workers.reminder.ReminderConfig.WeeklyReminder
 import org.wordpress.android.workers.reminder.ReminderScheduler
 import java.time.DayOfWeek
-import java.util.ArrayList
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -69,7 +69,7 @@ class BloggingRemindersViewModel @Inject constructor(
                 PROLOGUE -> prologueBuilder.buildUiItems()
                 PROLOGUE_SETTINGS -> prologueBuilder.buildUiItemsForSettings()
                 SELECTION -> daySelectionBuilder.buildSelection(
-                        bloggingRemindersModel, this::selectDay, this::selectTime
+                        bloggingRemindersModel, this::selectDay, this::selectTime, this::togglePromptSwitch
                 )
                 EPILOGUE -> epilogueBuilder.buildUiItems(bloggingRemindersModel)
             }
@@ -147,6 +147,11 @@ class BloggingRemindersViewModel @Inject constructor(
 
     fun selectTime() {
         _isTimePickerShowing.value = Event(true)
+    }
+
+    private fun togglePromptSwitch() {
+        val currentState = _bloggingRemindersModel.value!!
+        _bloggingRemindersModel.value = currentState.copy(isPromptIncluded = !currentState.isPromptIncluded)
     }
 
     fun onChangeTime(hour: Int, minute: Int) {
@@ -254,9 +259,9 @@ class BloggingRemindersViewModel @Inject constructor(
             WeeklyReminder(this.enabledDays)
 
     enum class Screen(val trackingName: String) {
-        PROLOGUE("main"),
-        PROLOGUE_SETTINGS("main"),
-        SELECTION("day_picker"),
+        PROLOGUE("main"), // displayed after post is published
+        PROLOGUE_SETTINGS("main"),  // displayed from Site Settings before showing cadence selector
+        SELECTION("day_picker"), // cadence selector
         EPILOGUE("all_set")
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -22,7 +22,6 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Scr
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Screen.SELECTION
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
-import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import org.wordpress.android.util.merge
 import org.wordpress.android.util.perform
 import org.wordpress.android.viewmodel.Event
@@ -180,9 +179,11 @@ class BloggingRemindersViewModel @Inject constructor(
                             bloggingRemindersModel.siteId,
                             bloggingRemindersModel.hour,
                             bloggingRemindersModel.minute,
-                            bloggingRemindersModel.toReminderConfig())
+                            bloggingRemindersModel.toReminderConfig()
+                    )
                     analyticsTracker.trackRemindersScheduled(
-                            daysCount, bloggingRemindersModel.getNotificationTime24hour())
+                            daysCount, bloggingRemindersModel.getNotificationTime24hour()
+                    )
                 } else {
                     reminderScheduler.cancelBySiteId(bloggingRemindersModel.siteId)
                     analyticsTracker.trackRemindersCancelled()
@@ -260,7 +261,7 @@ class BloggingRemindersViewModel @Inject constructor(
 
     enum class Screen(val trackingName: String) {
         PROLOGUE("main"), // displayed after post is published
-        PROLOGUE_SETTINGS("main"),  // displayed from Site Settings before showing cadence selector
+        PROLOGUE_SETTINGS("main"), // displayed from Site Settings before showing cadence selector
         SELECTION("day_picker"), // cadence selector
         EPILOGUE("all_set")
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -149,8 +149,9 @@ class BloggingRemindersViewModel @Inject constructor(
     }
 
     private fun togglePromptSwitch() {
-        val currentState = _bloggingRemindersModel.value!!
-        _bloggingRemindersModel.value = currentState.copy(isPromptIncluded = !currentState.isPromptIncluded)
+        _bloggingRemindersModel.value?.let { currentState ->
+            _bloggingRemindersModel.value = currentState.copy(isPromptIncluded = !currentState.isPromptIncluded)
+        }
     }
 
     fun onChangeTime(hour: Int, minute: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
@@ -6,8 +6,8 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButto
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons.DayItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.EmphasizedText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Illustration
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.IncludePromptSwitched
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.MediumEmphasisText
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.PromptSwitch
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.TimeItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Tip
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Title
@@ -64,7 +64,7 @@ class DaySelectionBuilder
 
             if (bloggingPromptsFeatureConfig.isEnabled()) {
                 selectionList.add(
-                        IncludePromptSwitched(
+                        PromptSwitch(
                                 bloggingRemindersModel.isPromptIncluded,
                                 ListItemInteraction.create(onPromptSwitchToggled)
                         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButto
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons.DayItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.EmphasizedText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Illustration
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.IncludePromptSwitched
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.MediumEmphasisText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.TimeItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Tip
@@ -15,6 +16,7 @@ import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import java.time.DayOfWeek
 import java.time.format.TextStyle.SHORT
 import javax.inject.Inject
@@ -23,12 +25,14 @@ class DaySelectionBuilder
 @Inject constructor(
     private val daysProvider: DaysProvider,
     private val dayLabelUtils: DayLabelUtils,
-    private val localeManagerWrapper: LocaleManagerWrapper
+    private val localeManagerWrapper: LocaleManagerWrapper,
+    private val bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig
 ) {
     fun buildSelection(
         bloggingRemindersModel: BloggingRemindersUiModel?,
         onSelectDay: (DayOfWeek) -> Unit,
-        onSelectTime: () -> Unit
+        onSelectTime: () -> Unit,
+        onPromptSwitchToggled: () -> Unit,
     ): List<BloggingRemindersItem> {
         val daysOfWeek = daysProvider.getDaysOfWeekByLocale()
         val text = dayLabelUtils.buildNTimesLabel(bloggingRemindersModel)
@@ -54,7 +58,18 @@ class DaySelectionBuilder
             selectionList.add(
                     TimeItem(
                             UiStringText(bloggingRemindersModel.getNotificationTime()),
-                            ListItemInteraction.create(onSelectTime)))
+                            ListItemInteraction.create(onSelectTime)
+                    )
+            )
+
+            if (bloggingPromptsFeatureConfig.isEnabled()) {
+                selectionList.add(
+                        IncludePromptSwitched(
+                                bloggingRemindersModel.isPromptIncluded,
+                                ListItemInteraction.create(onPromptSwitchToggled)
+                        )
+                )
+            }
         }
 
         selectionList.add(

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
@@ -89,7 +89,11 @@ class DaySelectionBuilder
             true
         }
         val buttonText = if (isFirstTimeFlow) {
-            R.string.blogging_reminders_notify_me
+            if (bloggingPromptsFeatureConfig.isEnabled()) {
+                string.blogging_prompt_set_reminders
+            } else {
+                string.blogging_reminders_notify_me
+            }
         } else {
             R.string.blogging_reminders_update
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
@@ -32,7 +32,7 @@ class DaySelectionBuilder
         bloggingRemindersModel: BloggingRemindersUiModel?,
         onSelectDay: (DayOfWeek) -> Unit,
         onSelectTime: () -> Unit,
-        onPromptSwitchToggled: () -> Unit,
+        onPromptSwitchToggled: () -> Unit
     ): List<BloggingRemindersItem> {
         val daysOfWeek = daysProvider.getDaysOfWeekByLocale()
         val text = dayLabelUtils.buildNTimesLabel(bloggingRemindersModel)

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/PrologueBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/PrologueBuilder.kt
@@ -42,7 +42,6 @@ class PrologueBuilder
                     HighEmphasisText(UiStringRes(R.string.set_up_blogging_reminders_message))
             )
         }
-
     }
 
     fun buildPrimaryButton(

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/PrologueBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/PrologueBuilder.kt
@@ -7,23 +7,42 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Title
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.UiState.PrimaryButton
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import javax.inject.Inject
 
 class PrologueBuilder
-@Inject constructor() {
+@Inject constructor(private val bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig) {
     fun buildUiItems(): List<BloggingRemindersItem> {
-        return listOf(Illustration(R.drawable.img_illustration_celebration_150dp),
-                Title(UiStringRes(R.string.set_your_blogging_reminders_title)),
-                HighEmphasisText(UiStringRes(R.string.post_publishing_set_up_blogging_reminders_message))
-        )
+        return if (bloggingPromptsFeatureConfig.isEnabled()) {
+            listOf(
+                    Illustration(R.drawable.img_illustration_celebration_150dp),
+                    Title(UiStringRes(R.string.set_your_blogging_prompts_title)),
+                    HighEmphasisText(UiStringRes(R.string.post_publishing_set_up_blogging_prompts_message))
+            )
+        } else {
+            listOf(
+                    Illustration(R.drawable.img_illustration_celebration_150dp),
+                    Title(UiStringRes(R.string.set_your_blogging_reminders_title)),
+                    HighEmphasisText(UiStringRes(R.string.post_publishing_set_up_blogging_reminders_message))
+            )
+        }
     }
 
     fun buildUiItemsForSettings(): List<BloggingRemindersItem> {
-        return listOf(
-                Illustration(R.drawable.img_illustration_celebration_150dp),
-                Title(UiStringRes(R.string.set_your_blogging_reminders_title)),
-                HighEmphasisText(UiStringRes(R.string.set_up_blogging_reminders_message))
-        )
+        return if (bloggingPromptsFeatureConfig.isEnabled()) {
+            listOf(
+                    Illustration(R.drawable.img_illustration_celebration_150dp),
+                    Title(UiStringRes(R.string.set_your_blogging_prompts_title)),
+                    HighEmphasisText(UiStringRes(R.string.post_publishing_set_up_blogging_prompts_message))
+            )
+        } else {
+            listOf(
+                    Illustration(R.drawable.img_illustration_celebration_150dp),
+                    Title(UiStringRes(R.string.set_your_blogging_reminders_title)),
+                    HighEmphasisText(UiStringRes(R.string.set_up_blogging_reminders_message))
+            )
+        }
+
     }
 
     fun buildPrimaryButton(

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -101,6 +101,7 @@ import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
+import org.wordpress.android.util.config.BloggingPromptsFeatureConfig;
 import org.wordpress.android.util.config.BloggingRemindersFeatureConfig;
 import org.wordpress.android.util.config.ManageCategoriesFeatureConfig;
 import org.wordpress.android.widgets.WPSnackbar;
@@ -184,6 +185,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Inject ZendeskHelper mZendeskHelper;
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject BloggingRemindersFeatureConfig mBloggingRemindersFeatureConfig;
+    @Inject BloggingPromptsFeatureConfig mBloggingPromptsFeatureConfig;
     @Inject ManageCategoriesFeatureConfig mManageCategoriesFeatureConfig;
     @Inject UiHelpers mUiHelpers;
 
@@ -1209,6 +1211,10 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (!mBloggingRemindersFeatureConfig.isEnabled()) {
             removeBloggingRemindersSettings();
         } else {
+            if (mBloggingPromptsFeatureConfig.isEnabled()) {
+                mBloggingRemindersPref.setTitle(R.string.site_settings_blogging_reminders_and_prompts_title);
+            }
+
             mBloggingRemindersViewModel = new ViewModelProvider(getAppCompatActivity(), mViewModelFactory)
                     .get(BloggingRemindersViewModel.class);
             BloggingReminderUtils.observeBottomSheet(
@@ -1935,7 +1941,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     /**
      * This removes all preferences from the General preference group, except for Blogging Reminders – in practice it
      * is removed as well, but then added back.
-     *
+     * <p>
      * In the future, we should consider either moving the Blogging Reminders preference to its own group or
      * replace this approach with something more scalable and efficient.
      */

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsFeatureConfig.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.BloggingPromptsFeatureConfig.Companion.BLOGGING_PROMPTS_REMOTE_FIELD
+import javax.inject.Inject
+
+@Feature(BLOGGING_PROMPTS_REMOTE_FIELD, false)
+class BloggingPromptsFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.BLOGGING_PROMPTS,
+        BLOGGING_PROMPTS_REMOTE_FIELD
+) {
+    companion object {
+        const val BLOGGING_PROMPTS_REMOTE_FIELD = "blogging_prompts_remote_field"
+    }
+}

--- a/WordPress/src/main/res/layout/blogging_reminders_prompt_switch.xml
+++ b/WordPress/src/main/res/layout/blogging_reminders_prompt_switch.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
+    android:background="?attr/selectableItemBackground">
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/include_prompt_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/prompt_switch_subtitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:text="@string/blogging_reminders_include_prompt_subtitle"
+        app:layout_constraintEnd_toStartOf="@+id/include_prompt_switch"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/prompt_switch_title" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/prompt_switch_title"
+        style="@style/TextAppearance.Compat.Notification"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_large"
+        android:text="@string/blogging_reminders_include_prompt_title"
+        app:layout_constraintEnd_toStartOf="@+id/include_prompt_switch"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@+id/bottom_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="@dimen/margin_large"
+        android:background="@color/gray_5"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/prompt_switch_subtitle" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/WordPress/src/main/res/layout/blogging_reminders_prompt_switch.xml
+++ b/WordPress/src/main/res/layout/blogging_reminders_prompt_switch.xml
@@ -22,7 +22,7 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
-        android:text="@string/blogging_reminders_include_prompt_subtitle"
+        android:text="@string/blogging_reminders_prompt_subtitle"
         app:layout_constraintEnd_toStartOf="@+id/include_prompt_switch"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/prompt_switch_title" />
@@ -35,7 +35,7 @@
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
         android:layout_marginTop="@dimen/margin_large"
-        android:text="@string/blogging_reminders_include_prompt_title"
+        android:text="@string/blogging_reminders_prompt_title"
         app:layout_constraintEnd_toStartOf="@+id/include_prompt_switch"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/WordPress/src/main/res/layout/blogging_reminders_time.xml
+++ b/WordPress/src/main/res/layout/blogging_reminders_time.xml
@@ -6,7 +6,6 @@
     android:background="?attr/selectableItemBackground"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
     android:layout_marginTop="@dimen/margin_extra_large" >
 
     <View

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3893,8 +3893,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_reminders_notification_time">Notification time</string>
     <string name="set_your_blogging_prompts_title">Become a better writer by building a habit</string>
     <string name="post_publishing_set_up_blogging_prompts_message">Posting regularly attracts new readers. Tell us when you want to write and we\'ll send you a reminder!</string>
-    <string name="blogging_reminders_include_prompt_title">Include daily prompt</string>
-    <string name="blogging_reminders_include_prompt_subtitle">Reminder will include a daily prompt</string>
+    <string name="blogging_reminders_prompt_title">Include daily prompt</string>
+    <string name="blogging_reminders_prompt_subtitle">Reminder will include a daily prompt</string>
 
     <!-- Stats module disabled error view -->
     <string name="stats_disabled_title">Looking for stats?</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -627,6 +627,7 @@
     <string name="site_settings_timezone_title">Timezone</string>
     <string name="site_settings_timezone_subtitle">Choose a city in your timezone</string>
     <string name="site_settings_blogging_reminders_title">Blogging reminders</string>
+    <string name="site_settings_blogging_reminders_and_prompts_title">Reminders and prompts</string>
     <string name="site_settings_posts_per_page_title">Posts per page</string>
     <string name="site_settings_format_entry_custom">Custom</string>
     <string name="site_settings_format_hint_custom">Custom format</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3892,9 +3892,10 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_reminders_tip_message">Posting regularly can help keep your readers engaged, and attract new visitors to your site.</string>
     <string name="blogging_reminders_notification_time">Notification time</string>
     <string name="set_your_blogging_prompts_title">Become a better writer by building a habit</string>
-    <string name="post_publishing_set_up_blogging_prompts_message">Posting regularly attracts new readers. Tell us when you want to write and we\'ll send you a reminder!</string>
+    <string name="post_publishing_set_up_blogging_prompts_message">Posting regularly attracts new readers. Tell us when you want to write and we\’ll send you a reminder!</string>
     <string name="blogging_reminders_prompt_title">Include daily prompt</string>
     <string name="blogging_reminders_prompt_subtitle">Reminder will include a daily prompt</string>
+    <string name="blogging_prompt_set_reminders">Set reminders</string>
 
     <!-- Stats module disabled error view -->
     <string name="stats_disabled_title">Looking for stats?</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3891,6 +3891,10 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_reminders_tip">Tip</string>
     <string name="blogging_reminders_tip_message">Posting regularly can help keep your readers engaged, and attract new visitors to your site.</string>
     <string name="blogging_reminders_notification_time">Notification time</string>
+    <string name="set_your_blogging_prompts_title">Become a better writer by building a habit</string>
+    <string name="post_publishing_set_up_blogging_prompts_message">Posting regularly attracts new readers. Tell us when you want to write and we\'ll send you a reminder!</string>
+    <string name="blogging_reminders_include_prompt_title">Include daily prompt</string>
+    <string name="blogging_reminders_include_prompt_subtitle">Reminder will include a daily prompt</string>
 
     <!-- Stats module disabled error view -->
     <string name="stats_disabled_title">Looking for stats?</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
@@ -136,7 +136,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     fun `date selection selected`() = test {
         val model = initEmptyStore()
         val daySelectionScreen = listOf<BloggingRemindersItem>()
-        whenever(daySelectionBuilder.buildSelection(eq(model), any(), any())).thenReturn(daySelectionScreen)
+        whenever(daySelectionBuilder.buildSelection(eq(model), any(), any(), any())).thenReturn(daySelectionScreen)
         whenever(bloggingRemindersStore.hasModifiedBloggingReminders(siteId)).thenReturn(true)
 
         viewModel.onBlogSettingsItemClicked(siteId)
@@ -463,7 +463,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
                                     }
                     )
             )
-        }.whenever(daySelectionBuilder).buildSelection(any(), any(), any())
+        }.whenever(daySelectionBuilder).buildSelection(any(), any(), any(), any())
 
         doAnswer {
             val model = it.getArgument<BloggingRemindersUiModel>(0)

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
@@ -166,6 +166,23 @@ class DaySelectionBuilderTest {
     }
 
     @Test
+    fun `primary button shows a different label when blogging prompt FF is on`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+
+        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute)
+
+        val primaryButton = daySelectionBuilder.buildPrimaryButton(bloggingRemindersModel, true, onConfirm)
+
+        assertThat(primaryButton).isEqualTo(
+                PrimaryButton(
+                        UiStringRes(R.string.blogging_prompt_set_reminders),
+                        true,
+                        Companion.create(bloggingRemindersModel, onConfirm)
+                )
+        )
+    }
+
+    @Test
     fun `click on primary button confirm selection`() {
         val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
@@ -196,7 +196,6 @@ class DaySelectionBuilderTest {
         assertThat(potentialSwitches.size).isEqualTo(1)
     }
 
-
     @Test
     fun `include prompt switch is not visible when days are not selected`() {
         val bloggingRemindersModel = BloggingRemindersUiModel(1, hour = hour, minute = minute)

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButto
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.EmphasizedText
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Illustration
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.MediumEmphasisText
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.PromptSwitch
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Title
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.UiState.PrimaryButton
 import org.wordpress.android.ui.utils.ListItemInteraction
@@ -21,6 +22,7 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import java.time.DayOfWeek
 import java.time.DayOfWeek.SUNDAY
 import java.time.DayOfWeek.WEDNESDAY
@@ -32,26 +34,38 @@ class DaySelectionBuilderTest {
     @Mock lateinit var daysProvider: DaysProvider
     @Mock lateinit var dayLabelUtils: DayLabelUtils
     @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
+    @Mock lateinit var bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig
     private lateinit var daySelectionBuilder: DaySelectionBuilder
     private var daySelected: DayOfWeek? = null
     private var confirmed = false
+    private var promptSwitchToggled = false
     private val hour = 10
     private val minute = 0
     private val onSelectDay: (DayOfWeek) -> Unit = {
         daySelected = it
     }
     private val onSelectTime: () -> Unit = {}
+    private val onPromptSwitchToggled: () -> Unit = {
+        promptSwitchToggled = true
+    }
     private val onConfirm: (BloggingRemindersUiModel?) -> Unit = {
         confirmed = true
     }
 
     @Before
     fun setUp() {
-        daySelectionBuilder = DaySelectionBuilder(daysProvider, dayLabelUtils, localeManagerWrapper)
+        daySelectionBuilder = DaySelectionBuilder(
+                daysProvider,
+                dayLabelUtils,
+                localeManagerWrapper,
+                bloggingPromptsFeatureConfig
+        )
         whenever(daysProvider.getDaysOfWeekByLocale()).thenReturn(DayOfWeek.values().toList())
         whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
         daySelected = null
         confirmed = false
+        promptSwitchToggled = false
     }
 
     @Test
@@ -61,7 +75,12 @@ class DaySelectionBuilderTest {
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
                 .thenReturn(dayLabel)
 
-        val uiModel = daySelectionBuilder.buildSelection(bloggingRemindersModel, onSelectDay, onSelectTime)
+        val uiModel = daySelectionBuilder.buildSelection(
+                bloggingRemindersModel,
+                onSelectDay,
+                onSelectTime,
+                onPromptSwitchToggled
+        )
 
         assertModel(uiModel, setOf(), dayLabel)
     }
@@ -76,7 +95,8 @@ class DaySelectionBuilderTest {
         val uiModel = daySelectionBuilder.buildSelection(
                 bloggingRemindersModel,
                 onSelectDay,
-                onSelectTime
+                onSelectTime,
+                onPromptSwitchToggled
         )
 
         assertModel(uiModel, setOf(WEDNESDAY, SUNDAY), dayLabel)
@@ -87,7 +107,12 @@ class DaySelectionBuilderTest {
         val bloggingRemindersModel = BloggingRemindersUiModel(1, hour = hour, minute = minute)
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel)).thenReturn(UiStringText("Once a week"))
 
-        val uiModel = daySelectionBuilder.buildSelection(bloggingRemindersModel, onSelectDay, onSelectTime)
+        val uiModel = daySelectionBuilder.buildSelection(
+                bloggingRemindersModel,
+                onSelectDay,
+                onSelectTime,
+                onPromptSwitchToggled
+        )
 
         DayOfWeek.values().forEachIndexed { index, day ->
             uiModel.clickOnDayItem(index)
@@ -149,6 +174,107 @@ class DaySelectionBuilderTest {
         primaryButton.onClick.click()
 
         assertThat(confirmed).isTrue()
+    }
+
+    @Test
+    fun `include prompt switch is visible when days are selected`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+
+        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute)
+        val dayLabel = UiStringText("Twice a week")
+        whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
+                .thenReturn(dayLabel)
+
+        val uiModel = daySelectionBuilder.buildSelection(
+                bloggingRemindersModel,
+                onSelectDay,
+                onSelectTime,
+                onPromptSwitchToggled
+        )
+
+        val potentialSwitches = uiModel.filterIsInstance<PromptSwitch>()
+        assertThat(potentialSwitches.size).isEqualTo(1)
+    }
+
+
+    @Test
+    fun `include prompt switch is not visible when days are not selected`() {
+        val bloggingRemindersModel = BloggingRemindersUiModel(1, hour = hour, minute = minute)
+        val dayLabel = UiStringText("Not set")
+        whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
+                .thenReturn(dayLabel)
+
+        val uiModel = daySelectionBuilder.buildSelection(
+                bloggingRemindersModel,
+                onSelectDay,
+                onSelectTime,
+                onPromptSwitchToggled
+        )
+
+        val potentialSwitches = uiModel.filterIsInstance<PromptSwitch>()
+        assertThat(potentialSwitches.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `single include prompt switch is visible when FF is on`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+
+        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute)
+        val dayLabel = UiStringText("Twice a week")
+        whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
+                .thenReturn(dayLabel)
+
+        val uiModel = daySelectionBuilder.buildSelection(
+                bloggingRemindersModel,
+                onSelectDay,
+                onSelectTime,
+                onPromptSwitchToggled
+        )
+
+        val potentialSwitches = uiModel.filterIsInstance<PromptSwitch>()
+        assertThat(potentialSwitches.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `include prompt switch is not visible when FF is off`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
+
+        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute)
+        val dayLabel = UiStringText("Twice a week")
+        whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
+                .thenReturn(dayLabel)
+
+        val uiModel = daySelectionBuilder.buildSelection(
+                bloggingRemindersModel,
+                onSelectDay,
+                onSelectTime,
+                onPromptSwitchToggled
+        )
+
+        val potentialSwitches = uiModel.filterIsInstance<PromptSwitch>()
+        assertThat(potentialSwitches.isEmpty()).isTrue()
+    }
+
+    @Test
+    fun `click on a prompt switch toggles the prompt state`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+
+        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute)
+        val dayLabel = UiStringText("Twice a week")
+        whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
+                .thenReturn(dayLabel)
+
+        val uiModel = daySelectionBuilder.buildSelection(
+                bloggingRemindersModel,
+                onSelectDay,
+                onSelectTime,
+                onPromptSwitchToggled
+        )
+
+        val switch = uiModel.find { it is PromptSwitch }
+        (switch as PromptSwitch).onClick.click()
+
+        assertThat(promptSwitchToggled).isTrue()
     }
 
     private fun assertModel(

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/PrologueBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/PrologueBuilderTest.kt
@@ -56,7 +56,6 @@ class PrologueBuilderTest {
         assertBloggingPromptsModel(uiModel)
     }
 
-
     @Test
     fun `builds correct UI model for settings when prompts feature is on`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/PrologueBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/PrologueBuilderTest.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.ui.bloggingreminders
 
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.HighEmphasisText
@@ -12,9 +14,11 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Title
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.UiState.PrimaryButton
 import org.wordpress.android.ui.utils.ListItemInteraction.Companion
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 
 @RunWith(MockitoJUnitRunner::class)
 class PrologueBuilderTest {
+    @Mock lateinit var bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig
     private lateinit var prologueBuilder: PrologueBuilder
     private var confirmed = false
 
@@ -24,15 +28,42 @@ class PrologueBuilderTest {
 
     @Before
     fun setUp() {
-        prologueBuilder = PrologueBuilder()
+        prologueBuilder = PrologueBuilder(bloggingPromptsFeatureConfig)
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
         confirmed = false
     }
 
     @Test
-    fun `builds UI model with no selected days`() {
+    fun `builds correct UI model`() {
         val uiModel = prologueBuilder.buildUiItems()
 
-        assertModel(uiModel)
+        assertUiModel(uiModel)
+    }
+
+    @Test
+    fun `builds correct UI model for settings`() {
+        val uiModel = prologueBuilder.buildUiItemsForSettings()
+
+        assertUiModelForSettings(uiModel)
+    }
+
+    @Test
+    fun `builds correct UI model when prompts feature is on`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+
+        val uiModel = prologueBuilder.buildUiItems()
+
+        assertBloggingPromptsModel(uiModel)
+    }
+
+
+    @Test
+    fun `builds correct UI model for settings when prompts feature is on`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+
+        val uiModel = prologueBuilder.buildUiItemsForSettings()
+
+        assertBloggingPromptsModel(uiModel) // currently it's same as regular UI model
     }
 
     @Test
@@ -58,7 +89,7 @@ class PrologueBuilderTest {
         assertThat(confirmed).isTrue()
     }
 
-    private fun assertModel(
+    private fun assertUiModel(
         uiModel: List<BloggingRemindersItem>
     ) {
         assertThat(uiModel[0]).isEqualTo(Illustration(R.drawable.img_illustration_celebration_150dp))
@@ -66,6 +97,30 @@ class PrologueBuilderTest {
         assertThat(uiModel[2]).isEqualTo(
                 HighEmphasisText(
                         UiStringRes(R.string.post_publishing_set_up_blogging_reminders_message)
+                )
+        )
+    }
+
+    private fun assertUiModelForSettings(
+        uiModel: List<BloggingRemindersItem>
+    ) {
+        assertThat(uiModel[0]).isEqualTo(Illustration(R.drawable.img_illustration_celebration_150dp))
+        assertThat(uiModel[1]).isEqualTo(Title(UiStringRes(R.string.set_your_blogging_reminders_title)))
+        assertThat(uiModel[2]).isEqualTo(
+                HighEmphasisText(
+                        UiStringRes(R.string.set_up_blogging_reminders_message)
+                )
+        )
+    }
+
+    private fun assertBloggingPromptsModel(
+        uiModel: List<BloggingRemindersItem>
+    ) {
+        assertThat(uiModel[0]).isEqualTo(Illustration(R.drawable.img_illustration_celebration_150dp))
+        assertThat(uiModel[1]).isEqualTo(Title(UiStringRes(R.string.set_your_blogging_prompts_title)))
+        assertThat(uiModel[2]).isEqualTo(
+                HighEmphasisText(
+                        UiStringRes(R.string.post_publishing_set_up_blogging_prompts_message)
                 )
         )
     }


### PR DESCRIPTION
Fixes #16122

This PR adds a blogging prompt Feature Flag, and adds a blogging prompt specific UI to cadence settings when the feature flag is on.

[![Image from Gyazo](https://i.gyazo.com/13171796b7138e676d4e3ad0e881f0af.png)](https://gyazo.com/13171796b7138e676d4e3ad0e881f0af)

[![Image from Gyazo](https://i.gyazo.com/807f10744a667a13e583a35ae97741e3.png)](https://gyazo.com/807f10744a667a13e583a35ae97741e3)

To test:
- You want to compare the changes alongside a current version from the trunk.
- Perform a clean install of wasabi build variant.
- Navigate to App Settings -> Debug settings and enable `blogging_prompts_remote_field` option.
- Navigate back to My Site screen.
- Tap on + button and crate a new new post. After post is published you should see the blogging reminder prologue. (will appear only on first publish)
- Confirm that the copy in the prologue matches provided screenshots/design.
- Proceed to blogging prompts cadence settings.
- Select a day, and confirm that the "Include prompt" switch is present, and operates correctly.
- Confirm that the primary button label says "Set reminders" and not "Notify me" (it will say "Update" if you already set reminder before).
- Navigate to Site Settings and confirm that `Blogging reminders` now reads `Reminders and prompts`.
- Tap on the `Reminders and prompts` and confirm that prologue copy is same as prologue after posting.

## Regression Notes
1. Potential unintended areas of impact
- Wrong copy is visible when FF is off.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and new automated tests.

4. What automated tests I added (or what prevented me from doing so)
Tests for ff behavior.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
