### PR TITLE
My Site Dashboard: Tabs - Display `QuickStartCard` based on `QuickStartOrigin`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -366,20 +366,20 @@ class MySiteViewModel @Inject constructor(
                 ),
                 MySiteTabType.SITE_MENU to orderForDisplay(
                         infoItem,
-                        cardsResult.filterNot { getCardTypeFiltersForTab(MySiteTabType.SITE_MENU).contains(it.type) },
+                        cardsResult.filterNot { getCardTypeExclusionFiltersForTab(MySiteTabType.SITE_MENU).contains(it.type) },
                         dynamicCards,
                         siteItems
                 ),
                 MySiteTabType.DASHBOARD to orderForDisplay(
                         infoItem,
-                        cardsResult.filterNot { getCardTypeFiltersForTab(MySiteTabType.DASHBOARD).contains(it.type) },
+                        cardsResult.filterNot { getCardTypeExclusionFiltersForTab(MySiteTabType.DASHBOARD).contains(it.type) },
                         listOf(),
                         listOf()
                 )
         )
     }
 
-    private fun getCardTypeFiltersForTab(tabType: MySiteTabType) = when (tabType) {
+    private fun getCardTypeExclusionFiltersForTab(tabType: MySiteTabType) = when (tabType) {
         MySiteTabType.SITE_MENU -> mutableListOf<Type>().apply {
             add(Type.DASHBOARD_CARDS)
             if (quickStartRepository.quickStartOrigin == QuickStartOrigin.DASHBOARD) add(Type.QUICK_START_CARD)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -348,13 +348,13 @@ class MySiteViewModel @Inject constructor(
         )
 
         val siteItems = siteItemsBuilder.build(
-                    SiteItemsBuilderParams(
-                            site = site,
-                            activeTask = activeTask,
-                            backupAvailable = backupAvailable,
-                            scanAvailable = scanAvailable,
-                            onClick = this::onItemClick
-                    )
+                SiteItemsBuilderParams(
+                        site = site,
+                        activeTask = activeTask,
+                        backupAvailable = backupAvailable,
+                        scanAvailable = scanAvailable,
+                        onClick = this::onItemClick
+                )
         )
 
         return mapOf(
@@ -366,13 +366,17 @@ class MySiteViewModel @Inject constructor(
                 ),
                 MySiteTabType.SITE_MENU to orderForDisplay(
                         infoItem,
-                        cardsResult.filterNot { getCardTypeExclusionFiltersForTab(MySiteTabType.SITE_MENU).contains(it.type) },
+                        cardsResult.filterNot {
+                            getCardTypeExclusionFiltersForTab(MySiteTabType.SITE_MENU).contains(it.type)
+                        },
                         dynamicCards,
                         siteItems
                 ),
                 MySiteTabType.DASHBOARD to orderForDisplay(
                         infoItem,
-                        cardsResult.filterNot { getCardTypeExclusionFiltersForTab(MySiteTabType.DASHBOARD).contains(it.type) },
+                        cardsResult.filterNot {
+                            getCardTypeExclusionFiltersForTab(MySiteTabType.DASHBOARD).contains(it.type)
+                        },
                         listOf(),
                         listOf()
                 )
@@ -924,12 +928,14 @@ class MySiteViewModel @Inject constructor(
 
     sealed class State {
         abstract val showTabs: Boolean
+
         data class SiteSelected(
             override val showTabs: Boolean,
             val cardAndItems: List<MySiteCardAndItem>,
             val siteMenuCardsAndItems: List<MySiteCardAndItem>,
             val dashboardCardsAndItems: List<MySiteCardAndItem>
         ) : State()
+
         data class NoSites(override val showTabs: Boolean = false, val shouldShowImage: Boolean) : State()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -366,20 +366,20 @@ class MySiteViewModel @Inject constructor(
                 ),
                 MySiteTabType.SITE_MENU to orderForDisplay(
                         infoItem,
-                        cardsResult.filterNot { getFilteredCardTypesForTab(MySiteTabType.SITE_MENU).contains(it.type) },
+                        cardsResult.filterNot { getCardTypeFiltersForTab(MySiteTabType.SITE_MENU).contains(it.type) },
                         dynamicCards,
                         siteItems
                 ),
                 MySiteTabType.DASHBOARD to orderForDisplay(
                         infoItem,
-                        cardsResult.filterNot { getFilteredCardTypesForTab(MySiteTabType.DASHBOARD).contains(it.type) },
+                        cardsResult.filterNot { getCardTypeFiltersForTab(MySiteTabType.DASHBOARD).contains(it.type) },
                         listOf(),
                         listOf()
                 )
         )
     }
 
-    private fun getFilteredCardTypesForTab(tabType: MySiteTabType) = when (tabType) {
+    private fun getCardTypeFiltersForTab(tabType: MySiteTabType) = when (tabType) {
         MySiteTabType.SITE_MENU -> mutableListOf<Type>().apply {
             add(Type.DASHBOARD_CARDS)
             if (quickStartRepository.quickStartOrigin == QuickStartOrigin.DASHBOARD) add(Type.QUICK_START_CARD)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -28,9 +28,9 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.SiteInfoCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.InfoItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardsBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.InfoItemBuilderParams
@@ -55,6 +55,7 @@ import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartOrigin
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment.DynamicCardMenuModel
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsBuilder
@@ -365,17 +366,28 @@ class MySiteViewModel @Inject constructor(
                 ),
                 MySiteTabType.SITE_MENU to orderForDisplay(
                         infoItem,
-                        cardsResult.filterNot { it is DashboardCards }.toList(),
+                        cardsResult.filterNot { getFilteredCardTypesForTab(MySiteTabType.SITE_MENU).contains(it.type) },
                         dynamicCards,
                         siteItems
                 ),
                 MySiteTabType.DASHBOARD to orderForDisplay(
                         infoItem,
-                        cardsResult.filterNot { it is QuickStartCard }.toList(),
+                        cardsResult.filterNot { getFilteredCardTypesForTab(MySiteTabType.DASHBOARD).contains(it.type) },
                         listOf(),
                         listOf()
                 )
         )
+    }
+
+    private fun getFilteredCardTypesForTab(tabType: MySiteTabType) = when (tabType) {
+        MySiteTabType.SITE_MENU -> mutableListOf<Type>().apply {
+            add(Type.DASHBOARD_CARDS)
+            if (quickStartRepository.quickStartOrigin == QuickStartOrigin.DASHBOARD) add(Type.QUICK_START_CARD)
+        }
+        MySiteTabType.DASHBOARD -> mutableListOf<Type>().apply {
+            if (quickStartRepository.quickStartOrigin == QuickStartOrigin.SITE_MENU) add(Type.QUICK_START_CARD)
+        }
+        MySiteTabType.ALL -> emptyList()
     }
 
     private fun onTodaysStatsCardFooterLinkClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.Event
@@ -65,7 +66,8 @@ class QuickStartRepository
     private val htmlCompat: HtmlCompatWrapper,
     private val quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig,
     private val contextProvider: ContextProvider,
-    private val htmlMessageUtils: HtmlMessageUtils
+    private val htmlMessageUtils: HtmlMessageUtils,
+    mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
 ) : CoroutineScope {
     private val job: Job = Job()
     override val coroutineContext: CoroutineContext
@@ -81,6 +83,11 @@ class QuickStartRepository
     val onQuickStartMySitePrompts = _onQuickStartMySitePrompts as LiveData<Event<QuickStartMySitePrompts>>
     val activeTask = _activeTask as LiveData<QuickStartTask?>
     val isQuickStartNoticeShown = _isQuickStartNoticeShown
+    val quickStartOrigin = if (mySiteDashboardTabsFeatureConfig.isEnabled()) {
+        QuickStartOrigin.DASHBOARD
+    } else {
+        QuickStartOrigin.ALL
+    }
 
     private var pendingTask: QuickStartTask? = null
 
@@ -252,6 +259,12 @@ class QuickStartRepository
     private fun onQuickStartNoticeNegativeAction(task: QuickStartTask) {
         analyticsTrackerWrapper.track(Stat.QUICK_START_TASK_DIALOG_NEGATIVE_TAPPED)
         appPrefsWrapper.setLastSkippedQuickStartTask(task)
+    }
+
+    enum class QuickStartOrigin {
+        SITE_MENU,
+        DASHBOARD,
+        ALL
     }
 
     data class QuickStartCategory(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
@@ -67,6 +68,7 @@ class QuickStartRepository
     private val quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig,
     private val contextProvider: ContextProvider,
     private val htmlMessageUtils: HtmlMessageUtils,
+    buildConfigWrapper: BuildConfigWrapper,
     mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
 ) : CoroutineScope {
     private val job: Job = Job()
@@ -83,7 +85,7 @@ class QuickStartRepository
     val onQuickStartMySitePrompts = _onQuickStartMySitePrompts as LiveData<Event<QuickStartMySitePrompts>>
     val activeTask = _activeTask as LiveData<QuickStartTask?>
     val isQuickStartNoticeShown = _isQuickStartNoticeShown
-    val quickStartOrigin = if (mySiteDashboardTabsFeatureConfig.isEnabled()) {
+    val quickStartOrigin = if (mySiteDashboardTabsFeatureConfig.isEnabled() && buildConfigWrapper.isMySiteTabsEnabled) {
         QuickStartOrigin.DASHBOARD
     } else {
         QuickStartOrigin.ALL

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -91,6 +91,7 @@ import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartOrigin
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment.DynamicCardMenuModel
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsBuilder
@@ -1706,10 +1707,21 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given selected site, when dashboard cards and items, then qs card not exists`() {
+    fun `given selected site with dashboard qs origin, when dashboard cards and items, then qs card exists`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
         setUpSiteItemBuilder()
-        initSelectedSite()
+        initSelectedSite(quickStartOrigin = QuickStartOrigin.DASHBOARD)
+
+        val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
+
+        assertThat(items.filterIsInstance(QuickStartCard::class.java)).isNotEmpty
+    }
+
+    @Test
+    fun `given selected site with site menu qs origin, when dashboard cards and items, then qs card not exists`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        setUpSiteItemBuilder()
+        initSelectedSite(quickStartOrigin = QuickStartOrigin.SITE_MENU)
 
         val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
 
@@ -1739,14 +1751,25 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given selected site, when site menu cards and items, then qs card exists`() {
+    fun `given selected site with dashboard qs origin, when site menu cards and items, then qs card not exists`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
         setUpSiteItemBuilder()
-        initSelectedSite()
+        initSelectedSite(quickStartOrigin = QuickStartOrigin.DASHBOARD)
 
         val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
 
-        assertThat(items.filterIsInstance(QuickStartCard::class.java)).isNotEmpty()
+        assertThat(items.filterIsInstance(QuickStartCard::class.java)).isEmpty()
+    }
+
+    @Test
+    fun `given selected site with site menu qs origin, when site menu cards and items, then qs card exists`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        setUpSiteItemBuilder()
+        initSelectedSite(quickStartOrigin = QuickStartOrigin.SITE_MENU)
+
+        val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
+
+        assertThat(items.filterIsInstance(QuickStartCard::class.java)).isNotEmpty
     }
 
     private fun findQuickActionsCard() = getLastItems().find { it is QuickActionsCard } as QuickActionsCard?
@@ -1800,7 +1823,8 @@ class MySiteViewModelTest : BaseUnitTest() {
         isMySiteTabsBuildConfigEnabled: Boolean = false,
         isQuickStartDynamicCardEnabled: Boolean = false,
         isQuickStartInProgress: Boolean = false,
-        showStaleMessage: Boolean = false
+        showStaleMessage: Boolean = false,
+        quickStartOrigin: QuickStartOrigin = QuickStartOrigin.ALL
     ) {
         setUpDynamicCardsBuilder(isQuickStartDynamicCardEnabled)
         whenever(
@@ -1811,6 +1835,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         )
         whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsFeatureFlagEnabled)
         whenever(buildConfigWrapper.isMySiteTabsEnabled).thenReturn(isMySiteTabsBuildConfigEnabled)
+        whenever(quickStartRepository.quickStartOrigin).thenReturn(quickStartOrigin)
         onSiteSelected.value = siteLocalId
         onSiteChange.value = site
         selectedSite.value = SelectedSite(site)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1686,6 +1686,16 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given selected site with all qs origin, when all cards and items, then qs cards exists`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        initSelectedSite(quickStartOrigin = QuickStartOrigin.ALL)
+
+        val items = (uiModels.last().state as SiteSelected).cardAndItems
+
+        assertThat(items.filterIsInstance(QuickStartCard::class.java)).isNotEmpty
+    }
+
+    @Test
     fun `given selected site, when dashboard cards and items, then dashboard cards exists`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
         initSelectedSite()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1674,7 +1674,6 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* STATE LISTS */
-    @InternalCoroutinesApi
     @Test
     fun `given site select exists, then cardAndItem lists are not empty`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
@@ -1685,33 +1684,69 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(getSiteMenuTabLastItems().isNotEmpty())
     }
 
-    @InternalCoroutinesApi
     @Test
-    fun `given selected site, when dashboard cards and items, then list does not contain quick start or list items`() {
+    fun `given selected site, when dashboard cards and items, then dashboard cards exists`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
-        setUpSiteItemBuilder()
-        initSelectedSite(isQuickStartDynamicCardEnabled = false)
+        initSelectedSite()
 
         val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
 
-        items.forEach {
-            assertThat(it).isNotInstanceOf(ListItem::class.java)
-            assertThat(it).isNotInstanceOf(QuickStartCard::class.java)
-        }
+        assertThat(items.filterIsInstance(DashboardCards::class.java)).isNotEmpty
     }
 
-    @InternalCoroutinesApi
     @Test
-    fun `given selected site, when site menu cards and items, then list does not contain dashboard cards`() {
+    fun `given selected site, when dashboard cards and items, then list items not exist`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
         setUpSiteItemBuilder()
-        initSelectedSite(isQuickStartDynamicCardEnabled = false)
+        initSelectedSite()
+
+        val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
+
+        assertThat(items.filterIsInstance(ListItem::class.java)).isEmpty()
+    }
+
+    @Test
+    fun `given selected site, when dashboard cards and items, then qs card not exists`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        setUpSiteItemBuilder()
+        initSelectedSite()
+
+        val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
+
+        assertThat(items.filterIsInstance(QuickStartCard::class.java)).isEmpty()
+    }
+
+    @Test
+    fun `given selected site, when site menu cards and items, then dashboard cards not exist`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        setUpSiteItemBuilder()
+        initSelectedSite()
 
         val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
 
-        items.forEach {
-            assertThat(it).isNotInstanceOf(DashboardCards::class.java)
-        }
+        assertThat(items.filterIsInstance(DashboardCards::class.java)).isEmpty()
+    }
+
+    @Test
+    fun `given selected site, when site menu cards and items, then list items exist`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        setUpSiteItemBuilder()
+        initSelectedSite()
+
+        val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
+
+        assertThat(items.filterIsInstance(ListItem::class.java)).isNotEmpty
+    }
+
+    @Test
+    fun `given selected site, when site menu cards and items, then qs card exists`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        setUpSiteItemBuilder()
+        initSelectedSite()
+
+        val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
+
+        assertThat(items.filterIsInstance(QuickStartCard::class.java)).isNotEmpty()
     }
 
     private fun findQuickActionsCard() = getLastItems().find { it is QuickActionsCard } as QuickActionsCard?

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.quickstart.QuickStartTaskDetails.PUBLISH_POST_TU
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails.SHARE_SITE_TUTORIAL
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
@@ -65,6 +66,7 @@ class QuickStartCardSourceTest : BaseUnitTest() {
     @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
     @Mock lateinit var contextProvider: ContextProvider
     @Mock lateinit var htmlMessageUtils: HtmlMessageUtils
+    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
     private lateinit var site: SiteModel
     private lateinit var quickStartRepository: QuickStartRepository
@@ -97,6 +99,7 @@ class QuickStartCardSourceTest : BaseUnitTest() {
                 quickStartDynamicCardsFeatureConfig,
                 contextProvider,
                 htmlMessageUtils,
+                buildConfigWrapper,
                 mySiteDashboardTabsFeatureConfig
         )
         quickStartCardSource = QuickStartCardSource(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
@@ -46,6 +46,7 @@ import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -64,6 +65,7 @@ class QuickStartCardSourceTest : BaseUnitTest() {
     @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
     @Mock lateinit var contextProvider: ContextProvider
     @Mock lateinit var htmlMessageUtils: HtmlMessageUtils
+    @Mock lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
     private lateinit var site: SiteModel
     private lateinit var quickStartRepository: QuickStartRepository
     private lateinit var quickStartCardSource: QuickStartCardSource
@@ -94,7 +96,8 @@ class QuickStartCardSourceTest : BaseUnitTest() {
                 htmlCompat,
                 quickStartDynamicCardsFeatureConfig,
                 contextProvider,
-                htmlMessageUtils
+                htmlMessageUtils,
+                mySiteDashboardTabsFeatureConfig
         )
         quickStartCardSource = QuickStartCardSource(
                 quickStartRepository,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -52,6 +53,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
     @Mock lateinit var contextProvider: ContextProvider
     @Mock lateinit var htmlMessageUtils: HtmlMessageUtils
+    @Mock lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
     private lateinit var site: SiteModel
     private lateinit var quickStartRepository: QuickStartRepository
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -75,7 +77,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 htmlCompat,
                 quickStartDynamicCardsFeatureConfig,
                 contextProvider,
-                htmlMessageUtils
+                htmlMessageUtils,
+                mySiteDashboardTabsFeatureConfig
         )
         snackbars = mutableListOf()
         quickStartPrompts = mutableListOf()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts
 import org.wordpress.android.ui.utils.HtmlMessageUtils
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
@@ -53,6 +54,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     @Mock lateinit var quickStartDynamicCardsFeatureConfig: QuickStartDynamicCardsFeatureConfig
     @Mock lateinit var contextProvider: ContextProvider
     @Mock lateinit var htmlMessageUtils: HtmlMessageUtils
+    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
     private lateinit var site: SiteModel
     private lateinit var quickStartRepository: QuickStartRepository
@@ -78,6 +80,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 quickStartDynamicCardsFeatureConfig,
                 contextProvider,
                 htmlMessageUtils,
+                buildConfigWrapper,
                 mySiteDashboardTabsFeatureConfig
         )
         snackbars = mutableListOf()


### PR DESCRIPTION
Parent #16006

This PR introduces `QuickStartOrigin` and displays `QuickStartCard` on a tab based on the set origin. When tabs are enabled, `QuickStartOrigin` is initially set to `DASHBOARD`.

Known Issues:
- Currently, `QuickStartOrigin` needs to be updated programmatically in the code to decide which tab `QuickStartCard` should be displayed. A settings screen will be added in the future that will decide the initial tab and set the `QuickStartOrigin` accordingly.
- While on `Dashboard` (renamed to `Home`) tab, the notification dot is not shown on the menu tab.

To test:

Test.1 Tabs disabled

1. Launch the app.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug` settings.
3. Turn off the `MySiteDashboardTabsFeatureConfig` flag under the Features in development section.
4. Restart the app
5. Logout/login and select "Show me around" when the quick start prompt is shown.
6. Note that tabs are not displayed.
7. `QuickStartCard` is displayed.

Test.1 Tabs enabled, `QuickStartOrigin - DASHBOARD`

1. Launch the app.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug` settings.
3. Turn on the `MySiteDashboardTabsFeatureConfig` flag under the Features in development section.
4. Restart the app
5. Logout/login and select "Show me around" when the quick start prompt is shown.
6. Note that tabs are displayed.
7. Note that `QuickStartCard` is displayed on the `Dashboard` (renamed to `Home`) tab only.

Test.3 Tabs enabled, `QuickStartOrigin - SITE_MENU`

1. Change `QuickStartOrigin` from `DASHBOARD` to `SITE_MENU` in the code:

https://github.com/wordpress-mobile/WordPress-Android/blob/d783f1df462d60438181804bb7527c80c7829093/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt#L87

2. Reinstall the app with `MySiteDashboardTabsFeatureConfig` flag still turned on.
3. Note that `Quick Start Card` is displayed on the `Site Menu` tab only.

## Review Instructions
- Review from only one reviewer is sufficient.

## Regression Notes
1. Potential unintended areas of impact
Quick start actions/tasks don't work as expected

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and automated tested

5. What automated tests I added (or what prevented me from doing so)
Unit tests were updated to reflect the changes/

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
