### PR TITLE
My Site Dashboard: Tabs - Custom view with QS focus point, introduce `TabsUiState`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -23,10 +23,10 @@ import org.wordpress.android.ui.main.SitePickerActivity
 import org.wordpress.android.ui.main.utils.MeGravatarLoader
 import org.wordpress.android.ui.mysite.MySiteViewModel.State
 import org.wordpress.android.ui.mysite.tabs.MySiteTabFragment
+import org.wordpress.android.ui.mysite.tabs.MySiteTabType
 import org.wordpress.android.ui.mysite.tabs.MySiteTabsAdapter
 import org.wordpress.android.ui.posts.QuickStartPromptDialogFragment.QuickStartPromptClickInterface
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.image.ImageType.USER
 import org.wordpress.android.util.setVisible
 import org.wordpress.android.viewmodel.observeEvent
@@ -81,7 +81,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                 }
             }
         }
-        setupTabs(viewModel.tabTitles)
+        setupTabs(viewModel.orderedTabTypes)
         val avatar = root.findViewById<ImageView>(R.id.avatar)
 
         appbarMain.addOnOffsetChangedListener(AppBarLayout.OnOffsetChangedListener { appBarLayout, verticalOffset ->
@@ -102,25 +102,25 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         })
     }
 
-    private fun MySiteFragmentBinding.setupTabs(tabTitles: List<UiString>) {
-        val adapter = MySiteTabsAdapter(this@MySiteFragment, tabTitles)
+    private fun MySiteFragmentBinding.setupTabs(orderedTabTypes: List<MySiteTabType>) {
+        val adapter = MySiteTabsAdapter(this@MySiteFragment, orderedTabTypes)
         viewPager.adapter = adapter
 
         TabLayoutMediator(tabLayout, viewPager) { _, _ -> updateTabs() }.attach()
     }
 
     private fun MySiteFragmentBinding.updateTabs() {
-        viewModel.tabTitles.forEachIndexed { index, tabTitle ->
+        viewModel.orderedTabTypes.forEachIndexed { index, tabType ->
             val tab = tabLayout.getTabAt(index) as TabLayout.Tab
-            updateTab(tab, tabTitle)
+            updateTab(tab, tabType)
         }
     }
 
-    private fun MySiteFragmentBinding.updateTab(tab: TabLayout.Tab, tabTitle: UiString) {
+    private fun MySiteFragmentBinding.updateTab(tab: TabLayout.Tab, tabType: MySiteTabType) {
         val customView = tab.customView ?: createTabCustomView(tab)
         with(customView) {
             val title = findViewById<TextView>(R.id.tab_label)
-            title.text = uiHelpers.getTextOfUiString(requireContext(), tabTitle)
+            title.text = getString(tabType.stringResId)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -2,15 +2,18 @@ package org.wordpress.android.ui.mysite
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
 import android.view.WindowManager
 import android.widget.ImageView
+import android.widget.TextView
 import androidx.appcompat.widget.TooltipCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -103,9 +106,22 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         val adapter = MySiteTabsAdapter(this@MySiteFragment, tabTitles)
         viewPager.adapter = adapter
 
-        TabLayoutMediator(tabLayout, viewPager) { tab, position ->
-            tab.text = uiHelpers.getTextOfUiString(requireContext(), tabTitles[position])
-        }.attach()
+        TabLayoutMediator(tabLayout, viewPager) { _, _ -> updateTabs() }.attach()
+    }
+
+    private fun MySiteFragmentBinding.updateTabs() {
+        viewModel.tabTitles.forEachIndexed { index, tabTitle ->
+            val tab = tabLayout.getTabAt(index) as TabLayout.Tab
+            updateTab(tab, tabTitle)
+        }
+    }
+
+    private fun MySiteFragmentBinding.updateTab(tab: TabLayout.Tab, tabTitle: UiString) {
+        val customView = tab.customView ?: createTabCustomView(tab)
+        with(customView) {
+            val title = findViewById<TextView>(R.id.tab_label)
+            title.text = uiHelpers.getTextOfUiString(requireContext(), tabTitle)
+        }
     }
 
     private fun MySiteFragmentBinding.setupContentViews() {
@@ -176,6 +192,13 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     private fun ViewPager2.getCurrentFragment() =
             this@MySiteFragment.childFragmentManager.findFragmentByTag("f$currentItem") as? MySiteTabFragment
+
+    private fun MySiteFragmentBinding.createTabCustomView(tab: TabLayout.Tab): View {
+        val customView = LayoutInflater.from(context)
+                .inflate(R.layout.my_site_tab_custom_view, tabLayout, false)
+        tab.customView = customView
+        return customView
+    }
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -272,7 +272,6 @@ class MySiteViewModel @Inject constructor(
         )
         // It is okay to use !! here because we are explicitly creating the lists
         return SiteSelected(
-                showTabs = isMySiteTabsEnabled,
                 tabsUiState = TabsUiState(
                         showTabs = isMySiteTabsEnabled,
                         tabUiStates = orderedTabTypes.map {
@@ -940,11 +939,9 @@ class MySiteViewModel @Inject constructor(
     )
 
     sealed class State {
-        abstract val showTabs: Boolean
         abstract val tabsUiState: TabsUiState
 
         data class SiteSelected(
-            override val showTabs: Boolean,
             override val tabsUiState: TabsUiState,
             val cardAndItems: List<MySiteCardAndItem>,
             val siteMenuCardsAndItems: List<MySiteCardAndItem>,
@@ -952,7 +949,6 @@ class MySiteViewModel @Inject constructor(
         ) : State()
 
         data class NoSites(
-            override val showTabs: Boolean = false,
             override val tabsUiState: TabsUiState,
             val shouldShowImage: Boolean
         ) : State()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -70,7 +70,6 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Dismissed
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Negative
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Positive
-import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DisplayUtilsWrapper
@@ -147,11 +146,11 @@ class MySiteViewModel @Inject constructor(
     val isMySiteTabsEnabled: Boolean
         get() = mySiteDashboardTabsFeatureConfig.isEnabled() && buildConfigWrapper.isMySiteTabsEnabled
 
-    val tabTitles: List<UiString>
+    val orderedTabTypes: List<MySiteTabType>
         get() = if (isMySiteTabsEnabled) {
-            listOf(UiStringRes(R.string.my_site_menu_tab_title), UiStringRes(R.string.my_site_dashboard_tab_title))
+            listOf(MySiteTabType.SITE_MENU, MySiteTabType.DASHBOARD)
         } else {
-            listOf(UiStringRes(R.string.my_site_menu_tab_title))
+            listOf(MySiteTabType.ALL)
         }
 
     val onScrollTo: LiveData<Event<Int>> = merge(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabType.kt
@@ -1,9 +1,12 @@
 package org.wordpress.android.ui.mysite.tabs
 
-enum class MySiteTabType(val label: String) {
-    ALL("all"),
-    DASHBOARD("dashboard"),
-    SITE_MENU("site_menu");
+import androidx.annotation.StringRes
+import org.wordpress.android.R
+
+enum class MySiteTabType(val label: String, @StringRes val stringResId: Int) {
+    ALL("all", R.string.my_site_all_tab_title),
+    DASHBOARD("dashboard", R.string.my_site_dashboard_tab_title),
+    SITE_MENU("site_menu", R.string.my_site_menu_tab_title);
 
     override fun toString() = label
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabsAdapter.kt
@@ -2,17 +2,12 @@ package org.wordpress.android.ui.mysite.tabs
 
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import org.wordpress.android.ui.utils.UiString
 
 class MySiteTabsAdapter(
     parent: Fragment,
-    private val tabTitles: List<UiString>
+    private val orderedTabTypes: List<MySiteTabType>
 ) : FragmentStateAdapter(parent) {
-    override fun getItemCount(): Int = tabTitles.size
+    override fun getItemCount(): Int = orderedTabTypes.size
 
-    override fun createFragment(position: Int) = if (position == 0) {
-        MySiteTabFragment.newInstance(MySiteTabType.SITE_MENU)
-    } else {
-        MySiteTabFragment.newInstance(MySiteTabType.DASHBOARD)
-    }
+    override fun createFragment(position: Int) = MySiteTabFragment.newInstance(orderedTabTypes[position])
 }

--- a/WordPress/src/main/res/layout/my_site_tab_custom_view.xml
+++ b/WordPress/src/main/res/layout/my_site_tab_custom_view.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tab_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tab_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="@style/TextAppearance.Design.Tab"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@string/my_site_menu_tab_title"/>
+
+    <org.wordpress.android.widgets.QuickStartFocusPoint
+        android:id="@+id/my_site_tab_quick_start_focus_point"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/quick_start_focus_point_description"
+        android:elevation="@dimen/quick_start_focus_point_elevation"
+        android:gravity="end"
+        android:textAlignment="viewEnd"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:size="small" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2217,6 +2217,7 @@
     <!-- My Site - Dashboard -->
     <string name="my_site_dashboard_tab_title">Home</string>
     <string name="my_site_menu_tab_title">Site Menu</string>
+    <string name="my_site_all_tab_title">All</string>
     <string name="my_site_dashboard_update_error">Couldn\'t update dashboard.</string>
     <string name="my_site_dashboard_stale_message">The dashboard is not updated. Please check your connection and then pull to refresh.</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -371,21 +371,21 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given my site tabs feature flag not enabled, when site is selected, then tabs are not visible`() {
         initSelectedSite(isMySiteDashboardTabsFeatureFlagEnabled = false)
 
-        assertThat((uiModels.last().state as SiteSelected).showTabs).isFalse
+        assertThat((uiModels.last().state as SiteSelected).tabsUiState.showTabs).isFalse
     }
 
     @Test
     fun `given my site tabs build config not enabled, when site is selected, then tabs are not visible`() {
         initSelectedSite(isMySiteDashboardTabsFeatureFlagEnabled = true, isMySiteTabsBuildConfigEnabled = false)
 
-        assertThat((uiModels.last().state as SiteSelected).showTabs).isFalse
+        assertThat((uiModels.last().state as SiteSelected).tabsUiState.showTabs).isFalse
     }
 
     @Test
     fun `given my site tabs build config with flag enabled, when site is selected, then tabs are visible`() {
         initSelectedSite(isMySiteDashboardTabsFeatureFlagEnabled = true, isMySiteTabsBuildConfigEnabled = true)
 
-        assertThat((uiModels.last().state as SiteSelected).showTabs).isTrue
+        assertThat((uiModels.last().state as SiteSelected).tabsUiState.showTabs).isTrue
     }
 
     @Test
@@ -454,7 +454,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `when no site is selected, then tabs are not visible`() {
         onSiteSelected.value = null
 
-        assertThat((uiModels.last().state as NoSites).showTabs).isFalse
+        assertThat((uiModels.last().state as NoSites).tabsUiState.showTabs).isFalse
     }
 
     @Test


### PR DESCRIPTION
Parent #16006

This PR
- Sets custom view for my site tabs to allow showing a QS focus point over `Site Menu` tab in the future.
- Refactors code to update tabs using `TabsUiState`.

/cc @tiagomar (This is mostly a preparatory PR for introducing `Site Menu` QS step with QS focus point in the next PR and can be skipped for testing till that point.)

To test:

Test.1 - Tabs enabled - Tabs UI 

1. Launch the app with a wpcom account having sites.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
3. Turn on the `MySiteDashboardTabsFeatureConfig` flag under the `Features in development` section.
4. Restart the app
5. Logout/login and select "Show me around" when the quick start prompt is shown.
6. Notice that tabs are shown on `My Site` screen with UI same as before.

Optional Tests (covered in adjusted unit tests - c2979fdc67b468576c5b4d3a9c69ba0155ed6c7c)

Test.2 - Tabs disabled

1. Launch the app with a wpcom account having sites.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
3. Turn off the `MySiteDashboardTabsFeatureConfig` flag under the `Features in development` section.
4. Restart the app
5. Logout/login and select "Show me around" when the quick start prompt is shown.
6. Notice that tabs are not shown on `My Site` screen.


Test 3 - Tabs enabled - No Sites

1. Launch the app with a wpcom account having no sites.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
3. Turn on the `MySiteDashboardTabsFeatureConfig` flag under the `Features in development` section.
4. Restart the app.
5. Logout/login.
6. Notice that tabs are not shown on `My Site` screen.

## Regression Notes
1. Potential unintended areas of impact
Tabs don't display as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and automated tested

3. What automated tests I added (or what prevented me from doing so)
Unit tests were updated to reflect the changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
