### PR TITLE
Merge release/19.5 to fix typo in string

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3191,7 +3191,7 @@
     <string name="site_creation_error_generic_title">There was a problem</string>
     <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>
     <string name="new_site_creation_intents_header_title">What’s your website about?</string>
-    <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type you own</string>
+    <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type your own</string>
     <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>
     <string name="new_site_creation_unavailable_domain">This domain is unavailable</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -3191,7 +3191,7 @@
     <string name="site_creation_error_generic_title">There was a problem</string>
     <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>
     <string name="new_site_creation_intents_header_title">What’s your website about?</string>
-    <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type you own</string>
+    <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type your own</string>
     <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>
     <string name="new_site_creation_unavailable_domain">This domain is unavailable</string>


### PR DESCRIPTION
One of our polyglots (@kharissulistiyo) helpfully flagged a typo in one of our string (introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/16103, so cc-ing @ovitrif for proofreading), [and reported it in the WordPress.org Slack](https://wordpress.slack.com/archives/C02RP50LK/p1647941697618019).

This PR simply fixes the typo:
 - In the original English `strings.xml` file — which is constantly updated with new strings by developers during the development of new features on `trunk`
 - In the `fastlane/resources/values/strings.xml` — which contains the strings we froze on Monday alongside the code freeze of 19.5; those are the ones getting imported by GlotPress, to be translated during the sprint in which 19.5 is frozen to be beta-tested and translated (without risking being impacted by features in development in the meantime)
