### PR TITLE
My Site Dashboard: Tabs - Add "Site Menu" QS step, show QS focus point on tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -48,6 +48,13 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     private val isTabMediatorAttached: Boolean
         get() = tabLayoutMediator?.isAttached == true
 
+    private val viewPagerCallback = object : ViewPager2.OnPageChangeCallback() {
+        override fun onPageSelected(position: Int) {
+            super.onPageSelected(position)
+            viewModel.onTabChanged(position)
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initSoftKeyboard()
@@ -115,6 +122,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     private fun MySiteFragmentBinding.setupViewPager() {
         val adapter = MySiteTabsAdapter(this@MySiteFragment, viewModel.orderedTabTypes)
         viewPager.adapter = adapter
+        viewPager.registerOnPageChangeCallback(viewPagerCallback)
     }
 
     private fun MySiteFragmentBinding.setupActionableEmptyView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -143,16 +143,17 @@ class MySiteViewModel @Inject constructor(
     private val _activeTaskPosition = MutableLiveData<Pair<QuickStartTask, Int>>()
     private val _onShowSwipeRefreshLayout = MutableLiveData<Event<Boolean>>()
 
-    private val tabsUiState = quickStartRepository.onQuickStartSiteMenuStep.switchMap { quickStartSiteMenuStep ->
-        val result = MediatorLiveData<TabsUiState>()
-        /* We want to filter out tabs state livedata update when state is not set in uiModel.
-           Without this check, tabs state livedata merge with state livedata may return a null state
-           when building UiModel. */
-        uiModel.value?.state?.tabsUiState?.let {
-            result.value = it.copy(tabUiStates = it.update(quickStartSiteMenuStep))
-        }
-        result
-    }
+    private val tabsUiState: LiveData<TabsUiState> = quickStartRepository.onQuickStartSiteMenuStep
+            .switchMap { quickStartSiteMenuStep ->
+                val result = MutableLiveData<TabsUiState>()
+                /* We want to filter out tabs state livedata update when state is not set in uiModel.
+                   Without this check, tabs state livedata merge with state livedata may return a null state
+                   when building UiModel. */
+                uiModel.value?.state?.tabsUiState?.let {
+                    result.value = it.copy(tabUiStates = it.update(quickStartSiteMenuStep))
+                }
+                result
+            }
 
     /* Capture and track the site selected event so we can circumvent refreshing sources on resume
        as they're already built on site select. */

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -455,6 +455,7 @@ class MySiteViewModel @Inject constructor(
     }
 
     fun onTabChanged(position: Int) {
+        quickStartRepository.quickStartTaskOrigin = orderedTabTypes[position]
     }
 
     @Suppress("ComplexMethod")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -454,6 +454,9 @@ class MySiteViewModel @Inject constructor(
         }
     }
 
+    fun onTabChanged(position: Int) {
+    }
+
     @Suppress("ComplexMethod")
     private fun onItemClick(action: ListItemAction) {
         selectedSiteRepository.getSelectedSite()?.let { selectedSite ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -140,7 +140,18 @@ class MySiteViewModel @Inject constructor(
     private val _onMediaUpload = MutableLiveData<Event<MediaModel>>()
     private val _activeTaskPosition = MutableLiveData<Pair<QuickStartTask, Int>>()
     private val _onShowSwipeRefreshLayout = MutableLiveData<Event<Boolean>>()
-    private val _tabsUiState = MutableLiveData<TabsUiState>()
+    private val _tabsUiState = quickStartRepository.onQuickStartSiteMenuStep.map { quickStartSiteMenuStep ->
+        val previousTabsUiState = uiModel.value?.state?.tabsUiState
+        previousTabsUiState?.copy(
+                tabUiStates = previousTabsUiState.tabUiStates.map {
+                    if (it.tabType == MySiteTabType.SITE_MENU) {
+                        it.copy(showQuickStartFocusPoint = quickStartSiteMenuStep?.isStarted ?: false)
+                    } else {
+                        it
+                    }
+                }
+        )
+    }
 
     /* Capture and track the site selected event so we can circumvent refreshing sources on resume
        as they're already built on site select. */
@@ -270,6 +281,7 @@ class MySiteViewModel @Inject constructor(
                         tabUiStates = orderedTabTypes.map {
                             TabUiState(
                                     label = UiStringRes(it.stringResId),
+                                    tabType = it,
                                     showQuickStartFocusPoint = false
                             )
                         }
@@ -957,6 +969,7 @@ class MySiteViewModel @Inject constructor(
     ) {
         data class TabUiState(
             val label: UiString,
+            val tabType: MySiteTabType,
             val showQuickStartFocusPoint: Boolean = false
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -478,7 +478,7 @@ class MySiteViewModel @Inject constructor(
     private fun requestSiteMenuStepPendingTask(pendingTask: QuickStartTask) {
         quickStartRepository.clearSiteMenuStep()
         launch {
-            delay(TAB_TRANSITION_DELAY_MS)
+            delay(LIST_SCROLL_DELAY_MS)
             quickStartRepository.setActiveTask(pendingTask)
         }
     }
@@ -1025,6 +1025,6 @@ class MySiteViewModel @Inject constructor(
         const val SITE_NAME_CHANGE_CALLBACK_ID = 1
         const val ARG_QUICK_START_TASK = "ARG_QUICK_START_TASK"
         const val HIDE_WP_ADMIN_GMT_TIME_ZONE = "GMT"
-        const val TAB_TRANSITION_DELAY_MS = 300L
+        const val LIST_SCROLL_DELAY_MS = 500L
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.model.DynamicCardType.GROW_QUICK_START
 import org.wordpress.android.fluxc.store.DynamicCardStore
 import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.CUSTOMIZE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
@@ -25,6 +24,7 @@ import org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartPayload
 import org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartVariant.NEXT_STEPS
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.tabs.MySiteTabType
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.quickstart.QuickStartEvent
@@ -80,16 +80,17 @@ class QuickStartRepository
     private val _activeTask = MutableLiveData<QuickStartTask?>()
     private val _onSnackbar = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val _onQuickStartMySitePrompts = MutableLiveData<Event<QuickStartMySitePrompts>>()
+    private val _onQuickStartSiteMenuStep = MutableLiveData<QuickStartSiteMenuStep?>()
     private var _isQuickStartNoticeShown: Boolean = false
+    private val isMySiteTabsEnabled =
+            mySiteDashboardTabsFeatureConfig.isEnabled() && buildConfigWrapper.isMySiteTabsEnabled
     val onSnackbar = _onSnackbar as LiveData<Event<SnackbarMessageHolder>>
     val onQuickStartMySitePrompts = _onQuickStartMySitePrompts as LiveData<Event<QuickStartMySitePrompts>>
+    val onQuickStartSiteMenuStep = _onQuickStartSiteMenuStep as LiveData<QuickStartSiteMenuStep?>
     val activeTask = _activeTask as LiveData<QuickStartTask?>
     val isQuickStartNoticeShown = _isQuickStartNoticeShown
-    val quickStartOrigin = if (mySiteDashboardTabsFeatureConfig.isEnabled() && buildConfigWrapper.isMySiteTabsEnabled) {
-        QuickStartOrigin.DASHBOARD
-    } else {
-        QuickStartOrigin.ALL
-    }
+    val quickStartOrigin = if (isMySiteTabsEnabled) QuickStartOrigin.DASHBOARD else QuickStartOrigin.ALL
+    var quickStartTaskOrigin = if (isMySiteTabsEnabled) MySiteTabType.DASHBOARD else MySiteTabType.ALL
 
     private var pendingTask: QuickStartTask? = null
 
@@ -103,6 +104,7 @@ class QuickStartRepository
     fun resetTask() {
         clearActiveTask()
         clearPendingTask()
+        clearSiteMenuStep()
     }
 
     fun clearActiveTask() {
@@ -111,6 +113,12 @@ class QuickStartRepository
 
     private fun clearPendingTask() {
         pendingTask = null
+    }
+
+    private fun clearSiteMenuStep() {
+        if (_onQuickStartSiteMenuStep.value != null) {
+            _onQuickStartSiteMenuStep.value = null
+        }
     }
 
     suspend fun getQuickStartTaskTypes(siteLocalId: Int): List<QuickStartTaskType> {
@@ -134,15 +142,19 @@ class QuickStartRepository
     fun setActiveTask(task: QuickStartTask) {
         _activeTask.postValue(task)
         clearPendingTask()
-        if (task == UPDATE_SITE_TITLE) {
-            val shortQuickStartMessage = resourceProvider.getString(
-                    R.string.quick_start_dialog_update_site_title_message_short,
-                    SiteUtils.getSiteNameOrHomeURL(selectedSiteRepository.getSelectedSite())
-            )
-            _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(shortQuickStartMessage.asHtml()))))
-        } else {
-            QuickStartMySitePrompts.getPromptDetailsForTask(task)?.let { activeTutorialPrompt ->
-                _onQuickStartMySitePrompts.postValue(Event(activeTutorialPrompt))
+        when {
+            isSiteMenuStepRequiredForTask(task) -> requestSiteMenuStepForTask(task)
+            task == QuickStartTask.UPDATE_SITE_TITLE -> {
+                val shortQuickStartMessage = resourceProvider.getString(
+                        R.string.quick_start_dialog_update_site_title_message_short,
+                        SiteUtils.getSiteNameOrHomeURL(selectedSiteRepository.getSelectedSite())
+                )
+                _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(shortQuickStartMessage.asHtml()))))
+            }
+            else -> {
+                QuickStartMySitePrompts.getPromptDetailsForTask(task)?.let { activeTutorialPrompt ->
+                    _onQuickStartMySitePrompts.postValue(Event(activeTutorialPrompt))
+                }
             }
         }
     }
@@ -174,6 +186,17 @@ class QuickStartRepository
     ) {
         quickStartStore.setDoneTask(siteLocalId.toLong(), task, true)
         analyticsTrackerWrapper.track(quickStartUtilsWrapper.getTaskCompletedTracker(task))
+    }
+
+    private fun requestSiteMenuStepForTask(task: QuickStartTask) {
+        clearActiveTask()
+        pendingTask = task
+        val shortQuickStartMessage = resourceProvider.getString(
+                R.string.quick_start_site_menu_tab_message_short,
+                resourceProvider.getString(R.string.my_site_menu_tab_title)
+        )
+        _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(shortQuickStartMessage.asHtml()))))
+        _onQuickStartSiteMenuStep.postValue(QuickStartSiteMenuStep(true, task))
     }
 
     fun requestNextStepOfTask(task: QuickStartTask) {
@@ -263,11 +286,23 @@ class QuickStartRepository
         appPrefsWrapper.setLastSkippedQuickStartTask(task)
     }
 
+    private fun isSiteMenuStepRequiredForTask(task: QuickStartTask) =
+            quickStartTaskOrigin == MySiteTabType.DASHBOARD && task.showInSiteMenu()
+
+    private fun QuickStartTask.showInSiteMenu() = when (this) {
+        QuickStartTask.VIEW_SITE,
+        QuickStartTask.ENABLE_POST_SHARING,
+        QuickStartTask.EXPLORE_PLANS -> true
+        else -> false
+    }
+
     enum class QuickStartOrigin {
         SITE_MENU,
         DASHBOARD,
         ALL
     }
+
+    data class QuickStartSiteMenuStep(val isStarted: Boolean, val task: QuickStartTask? = null)
 
     data class QuickStartCategory(
         val taskType: QuickStartTaskType,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -195,7 +195,7 @@ class QuickStartRepository
                 R.string.quick_start_site_menu_tab_message_short,
                 resourceProvider.getString(R.string.my_site_menu_tab_title)
         )
-        _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(shortQuickStartMessage.asHtml()))))
+        _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(htmlCompat.fromHtml(shortQuickStartMessage)))))
         _onQuickStartSiteMenuStep.postValue(QuickStartSiteMenuStep(true, task))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -115,7 +115,7 @@ class QuickStartRepository
         pendingTask = null
     }
 
-    private fun clearSiteMenuStep() {
+    fun clearSiteMenuStep() {
         if (_onQuickStartSiteMenuStep.value != null) {
             _onQuickStartSiteMenuStep.value = null
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -142,6 +142,7 @@ class QuickStartRepository
     fun setActiveTask(task: QuickStartTask) {
         _activeTask.postValue(task)
         clearPendingTask()
+        clearSiteMenuStep()
         when {
             isSiteMenuStepRequiredForTask(task) -> requestSiteMenuStepForTask(task)
             task == QuickStartTask.UPDATE_SITE_TITLE -> {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3076,6 +3076,7 @@
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
     <string name="quick_start_span_start" translatable="false">&lt;span&gt;</string>
     <string name="quick_start_focus_point_description">tap here</string>
+    <string name="quick_start_site_menu_tab_message_short">Tap &lt;b&gt;%1$s&lt;/b&gt; to continue.</string>
 
     <string name="quick_start_card_menu_pin">Pin this</string>
     <string name="quick_start_card_menu_unpin">Unpin this</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -92,6 +92,7 @@ import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartOrigin
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartSiteMenuStep
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuFragment.DynamicCardMenuModel
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsBuilder
@@ -190,6 +191,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private val currentAvatar = MutableLiveData(CurrentAvatarUrl(""))
     private val quickStartUpdate = MutableLiveData(QuickStartUpdate())
     private val activeTask = MutableLiveData<QuickStartTask>()
+    private val quickStartSiteMenuStep = MutableLiveData<QuickStartSiteMenuStep>()
     private val dynamicCards = MutableLiveData(
             DynamicCardsUpdate(
                     cards = listOf(
@@ -274,6 +276,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(mySiteSourceManager.build(any(), anyOrNull())).thenReturn(partialStates)
         whenever(selectedSiteRepository.siteSelected).thenReturn(onSiteSelected)
         whenever(quickStartRepository.activeTask).thenReturn(activeTask)
+        whenever(quickStartRepository.onQuickStartSiteMenuStep).thenReturn(quickStartSiteMenuStep)
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(enableMySiteDashboardConfig)
         viewModel = MySiteViewModel(
                 networkUtilsWrapper,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -20,9 +20,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.DynamicCardStore
 import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_POST_SHARING
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.PUBLISH_POST
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.test
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
@@ -136,11 +133,11 @@ class QuickStartRepositoryTest : BaseUnitTest() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         initStore()
 
-        quickStartRepository.setActiveTask(PUBLISH_POST)
+        quickStartRepository.setActiveTask(QuickStartTask.PUBLISH_POST)
 
         reset(quickStartStore)
 
-        quickStartRepository.completeTask(UPDATE_SITE_TITLE)
+        quickStartRepository.completeTask(QuickStartTask.UPDATE_SITE_TITLE)
 
         verifyZeroInteractions(quickStartStore)
     }
@@ -151,10 +148,10 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     fun `requestNextStepOfTask emits quick start event`() = test {
         initQuickStartInProgress()
 
-        quickStartRepository.setActiveTask(ENABLE_POST_SHARING)
-        quickStartRepository.requestNextStepOfTask(ENABLE_POST_SHARING)
+        quickStartRepository.setActiveTask(QuickStartTask.ENABLE_POST_SHARING)
+        quickStartRepository.requestNextStepOfTask(QuickStartTask.ENABLE_POST_SHARING)
 
-        verify(eventBus).postSticky(QuickStartEvent(ENABLE_POST_SHARING))
+        verify(eventBus).postSticky(QuickStartEvent(QuickStartTask.ENABLE_POST_SHARING))
     }
 
     /* QUICK START REMINDER NOTIFICATION */
@@ -163,9 +160,9 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     fun `given active task != completed task, when task is completed, then reminder notifs are not triggered`() = test {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         initStore()
-        quickStartRepository.setActiveTask(PUBLISH_POST)
+        quickStartRepository.setActiveTask(QuickStartTask.PUBLISH_POST)
 
-        quickStartRepository.completeTask(UPDATE_SITE_TITLE)
+        quickStartRepository.completeTask(QuickStartTask.UPDATE_SITE_TITLE)
 
         verify(quickStartUtilsWrapper, never()).completeTaskAndRemindNextOne(any(), any(), any(), any())
     }
@@ -174,14 +171,14 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     fun `given active task = completed task, when task is completed, then reminder notifs are triggered`() = test {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         initStore()
-        quickStartRepository.setActiveTask(PUBLISH_POST)
+        quickStartRepository.setActiveTask(QuickStartTask.PUBLISH_POST)
 
-        quickStartRepository.completeTask(PUBLISH_POST)
+        quickStartRepository.completeTask(QuickStartTask.PUBLISH_POST)
 
         verify(quickStartUtilsWrapper).completeTaskAndRemindNextOne(
-                PUBLISH_POST,
+                QuickStartTask.PUBLISH_POST,
                 site,
-                QuickStartEvent(PUBLISH_POST),
+                QuickStartEvent(QuickStartTask.PUBLISH_POST),
                 contextProvider.getContext()
         )
     }
@@ -190,7 +187,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given uncompleted task exists, when show quick start notice is triggered, then snackbar is shown`() = test {
-        initStore(nextUncompletedTask = PUBLISH_POST)
+        initStore(nextUncompletedTask = QuickStartTask.PUBLISH_POST)
 
         quickStartRepository.checkAndShowQuickStartNotice()
 
@@ -209,23 +206,23 @@ class QuickStartRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `when show quick start notice dismissed using swipe-to-dismiss action, then the task is skipped`() = test {
-        initStore(nextUncompletedTask = PUBLISH_POST)
+        initStore(nextUncompletedTask = QuickStartTask.PUBLISH_POST)
         quickStartRepository.checkAndShowQuickStartNotice()
 
         snackbars.last().onDismissAction.invoke(Callback.DISMISS_EVENT_SWIPE)
 
-        verify(appPrefsWrapper).setLastSkippedQuickStartTask(PUBLISH_POST)
+        verify(appPrefsWrapper).setLastSkippedQuickStartTask(QuickStartTask.PUBLISH_POST)
     }
 
     @Test
     fun `when show quick start notice dismissed using non swipe-to-dismiss action, then the task is not skipped`() =
             test {
-                initStore(nextUncompletedTask = PUBLISH_POST)
+                initStore(nextUncompletedTask = QuickStartTask.PUBLISH_POST)
                 quickStartRepository.checkAndShowQuickStartNotice()
 
                 snackbars.last().onDismissAction.invoke(Callback.DISMISS_EVENT_ACTION)
 
-                verify(appPrefsWrapper, never()).setLastSkippedQuickStartTask(PUBLISH_POST)
+                verify(appPrefsWrapper, never()).setLastSkippedQuickStartTask(QuickStartTask.PUBLISH_POST)
             }
 
     private fun initQuickStartInProgress() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -96,6 +96,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
         site.id = siteLocalId
     }
 
+    /* QUICK START SKIP */
+
     @Test
     fun `when quick start is skipped, then all quick start tasks for the selected site are set to done`() = test {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
@@ -127,6 +129,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 verify(quickStartStore).setQuickStartNotificationReceived(siteLocalId.toLong(), true)
             }
 
+    /* QUICK START COMPLETE TASK */
+
     @Test
     fun `completeTask does not marks active task as done if it is different`() = test {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
@@ -141,6 +145,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
         verifyZeroInteractions(quickStartStore)
     }
 
+    /* QUICK START REQUEST NEXT STEP */
+
     @Test
     fun `requestNextStepOfTask emits quick start event`() = test {
         initQuickStartInProgress()
@@ -150,6 +156,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
 
         verify(eventBus).postSticky(QuickStartEvent(ENABLE_POST_SHARING))
     }
+
+    /* QUICK START REMINDER NOTIFICATION */
 
     @Test
     fun `given active task != completed task, when task is completed, then reminder notifs are not triggered`() = test {
@@ -177,6 +185,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 contextProvider.getContext()
         )
     }
+
+    /* QUICK START NOTICE */
 
     @Test
     fun `given uncompleted task exists, when show quick start notice is triggered, then snackbar is shown`() = test {


### PR DESCRIPTION
Parent #16006

This PR adds `Site Menu` QS step when needed, displays QS focus point on the tab, and requests pending QS task on tab change. 
The "Site Menu" QS step is needed when QS task starts from `Dashboard`/ `Home` tab but the corresponding menu item is present on the `Site Menu` tab. In this case, an intermediate step is introduced that instructs users to tap `Site Menu` tab to continue.  

Video captures:

- "Site Menu" QS step (timstamp 0:23)
- Auto-scroll (on continue from "Site Menu" QS step (timstamp 0:26)
- FAB (timstamp 0:38)
- Integration from other parts of the app (timestamp 0.13 - Homepage, 0.31 - Publicize, 0.47 - Reader)

https://user-images.githubusercontent.com/1405144/159706819-c79d6d8e-2087-48ed-bf6b-ed679ad96a7c.mp4

To test:

**Test.1: Regression test Quick Start in single view with tabs disabled**

1. Launch the app.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
3. Turn off the `MySiteDashboardTabsFeatureConfig` flag under the `Features in development` section.
4. Restart the app.
5. Logout/login and select "Show me around" when the quick start prompt is shown.
6. Run tests in [wpandroid-quick-start-testing-instructions.txt](https://github.com/wordpress-mobile/WordPress-Android/files/8246096/wpandroid-quick-start-testing-instructions.txt).

**Test.2: Quick Start with tabs enabled**
1. Launch the app.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
3. Turn on the `MySiteDashboardTabsFeatureConfig` flag under the `Features in development` section.
4. Restart the app.
5. Logout/login and select "Show me around" when the quick start prompt is shown.
6. Note the "Quick Start" shows in the `Dashboard`/ `Home` tab only. 
7. Run tests in [wpandroid-quick-start-testing-instructions.txt](https://github.com/wordpress-mobile/WordPress-Android/files/8246096/wpandroid-quick-start-testing-instructions.txt).
[ Notice that in `Test 1 - Quick start notice display` in the text file, when quick start task is available only on `Site Menu` tab, `Site Menu` tab shows QS focus point. On clicking the tab, the focus point should disappear and the appropriate site menu item should get QS focus point.]

**Review Instructions**

Code review from only one reviewer is sufficient.

## Regression Notes
1. Potential unintended areas of impact
Quick start actions/tasks don't work as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and automated tested

3. What automated tests I added (or what prevented me from doing so)
Unit tests were updated to reflect refactoring efforts

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
