### PR TITLE
My Site View Model Test: Fix dashboard cards initialisation 

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1994,10 +1994,10 @@ class MySiteViewModelTest : BaseUnitTest() {
         return DashboardCards(
                 cards = mutableListOf<DashboardCard>().apply {
                     if (params.showErrorCard) {
-                        initErrorCard(mockInvocation)
+                        add(initErrorCard(mockInvocation))
                     } else {
-                        initPostCard(mockInvocation)
-                        initTodaysStatsCard(mockInvocation)
+                        add(initPostCard(mockInvocation))
+                        add(initTodaysStatsCard(mockInvocation))
                     }
                 }
         )


### PR DESCRIPTION
This PR fixes dashboard cards initialization in the `MySiteViewModelTest` where the cards were initialized but not added to `DashboardCards.cards`.

For more details, see p1648076275151179-slack-C0290FLA0RM 

To test:

- Add breakpoints at below line and the next line:

https://github.com/wordpress-mobile/WordPress-Android/blob/dbe6f199d00e66a8264cdc46615b715870ff8e15/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt#L1862

- Run tests in the debug mode.
- Wait till the first breakpoint is hit. 
- Resume run till next breakpoint is hit. 
- Notice that `dashboardCards` on the previous line is populated with dashboard cards.

## Regression Notes
1. Potential unintended areas of impact N/A


2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A


3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.