### PR TITLE
Stats: Fix duplicate `stats_{section}_accessed` events tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -45,8 +45,7 @@ class StatsFragment : DaggerFragment(R.layout.stats_fragment), ScrollableViewIni
     @Inject lateinit var uiHelpers: UiHelpers
     private lateinit var viewModel: StatsViewModel
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
-    private val selectedTabListener: SelectedTabListener
-        get() = SelectedTabListener(viewModel)
+    private lateinit var selectedTabListener: SelectedTabListener
 
     private var restorePreviousSearch = false
 
@@ -84,6 +83,7 @@ class StatsFragment : DaggerFragment(R.layout.stats_fragment), ScrollableViewIni
         statsPager.setPageTransformer(
                 MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
         )
+        selectedTabListener = SelectedTabListener(viewModel)
         TabLayoutMediator(tabLayout, statsPager) { tab, position ->
             tab.text = adapter.getTabTitle(position)
         }.attach()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -143,19 +143,22 @@ class StatsViewModel
         if (!isInitialized || restart) {
             isInitialized = true
 
-            initialSection?.let { statsSectionManager.setSelectedSection(it) }
-
-            val initialGranularity = initialSection?.toStatsGranularity()
-            if (initialGranularity != null && initialSelectedPeriod != null) {
-                selectedDateProvider.setInitialSelectedPeriod(initialGranularity, initialSelectedPeriod)
-            }
-
             // Added today's stats feature config to check whether that card is enabled when stats screen is accessed
             analyticsTracker.track(
                     stat = AnalyticsTracker.Stat.STATS_ACCESSED,
                     site = statsSiteProvider.siteModel,
                     feature = todaysStatsCardFeatureConfig
             )
+
+            initialSection?.let {
+                statsSectionManager.setSelectedSection(it)
+                trackSectionSelected(it)
+            }
+
+            val initialGranularity = initialSection?.toStatsGranularity()
+            if (initialGranularity != null && initialSelectedPeriod != null) {
+                selectedDateProvider.setInitialSelectedPeriod(initialGranularity, initialSelectedPeriod)
+            }
 
             if (launchedFromWidget) {
                 analyticsTracker.track(AnalyticsTracker.Stat.STATS_WIDGET_TAPPED, statsSiteProvider.siteModel)
@@ -227,6 +230,10 @@ class StatsViewModel
 
         listUseCases[statsSection]?.onListSelected()
 
+        trackSectionSelected(statsSection)
+    }
+
+    private fun trackSectionSelected(statsSection: StatsSection) {
         when (statsSection) {
             INSIGHTS -> analyticsTracker.track(STATS_INSIGHTS_ACCESSED)
             DAYS -> analyticsTracker.trackGranular(STATS_PERIOD_DAYS_ACCESSED, StatsGranularity.DAYS)


### PR DESCRIPTION
This PR fixes duplicate `stats_{section}_accessed` events tracking that we noticed in this discussion: p1648128476399289-slack-C011BKNU1V5.

**Details**

Earlier Stats screen's `selectedTabListener` got initialized with a new instance of `SelectedTabListener` every time it was accessed using the `get()` accessor. An attempt to remove it inside `StatsFragment->handleSelectedSection()`would not remove the already added listener as it was a fresh instance and not present in the existing listeners for the tab layout. Multiple listeners caused duplicate events tracking for the section selected (via `onSectionSelect`) as the previous listener was not removed.

The issue existed whenever a non `INSIGHTS` section was requested as a default section like from:
- Views This Week Widget (Default tab: `DAYS`)
- Today's Stats Card (Default tab: `DAYS`)

and then another tab was switched.

This PR fixes it by initializing the selected tab listener only once.

**Scope**

Note that this fix does not track default `INSIGHTS` section selection tracking when the default initial section value is null or `ARG_DESIRED_TIMEFRAME` is not set in the `Intent`, keeping the existing behavior that's present for years. We can create a separate PR to track this event. 

**To test**

1. Open the app. 
2. Enable logging from `Me` -> `App Settings` -> `Privacy Settings` -> `Collect information ON`.
3. Click `Today's Stats Card` on `My Site` tab. 
    (Note that the card is AB tested right now, if you don't see it you can enable from `App Settings` -> `Debug settings` -> `mysite_dashbord_todays_stats_card` ON)
4. Notice that Stats -> `DAY` section is shown.
5. Notice in logs: 
   - `stats_accessed` is tracked (🔵 Tracked: stats_accessed) with properties.
   - `stats_period_accessed` is tracked with value for DAY timeframe (🔵 Tracked: stats_period_accessed , Properties: {"granularity":"days","period":"days"}). 
6. Click `INSIGHTS` tab
7. Notice that `stats_insights_accessed` is tracked only once (🔵 Tracked: stats_insights_accessed).

**Merging Notes**

Targets `release/19.5` branch (p1648181089934229-slack-CC7L49W13)
/cc @AliSoftware 

## Regression Notes
1. Potential unintended areas of impact
Stats event tracking for each section.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
See **To Test** section.

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.