### PR TITLE
Stats: Fix `stats_insights_accessed` initial section tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -150,10 +150,8 @@ class StatsViewModel
                     feature = todaysStatsCardFeatureConfig
             )
 
-            initialSection?.let {
-                statsSectionManager.setSelectedSection(it)
-                trackSectionSelected(it)
-            }
+            initialSection?.let { statsSectionManager.setSelectedSection(it) }
+            trackSectionSelected(initialSection ?: INSIGHTS)
 
             val initialGranularity = initialSection?.toStatsGranularity()
             if (initialGranularity != null && initialSelectedPeriod != null) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
@@ -87,7 +88,9 @@ class StatsViewModelTest : BaseUnitTest() {
         viewModel.onSectionSelected(INSIGHTS)
 
         verify(statsSectionManager).setSelectedSection(INSIGHTS)
-        verify(analyticsTracker).track(STATS_INSIGHTS_ACCESSED)
+        /* First one is default insights section selection which is set when no value is passed to vm for
+           initial section */
+        verify(analyticsTracker, times(2)).track(STATS_INSIGHTS_ACCESSED)
     }
 
     @Test


### PR DESCRIPTION
This PR fixes `stats_insights_accessed` initial section tracking when `initialSection` is not passed to `StatsViewModel`.

**Details**

When `initialSection` is not passed to `StatsViewModel`, the default tab selection is not tracked until now (see p1648141247441739/1648128476.399289-slack-C011BKNU1V5). This issue is present for an unknown time (possibly since the beginning of `Stats` implementation). 

Since `INSIGHTS` is the first tab in the `Stats` screen's list of tabs, if `initialSection` is not passed to `StatsViewModel`, we now track the default section as `INSIGHTS` section.

**To test**

Test.1  From `Stats Quick Link`/`Stats Menu` 

1. Open the app. 
2. Enable logging from `Me` -> `App Settings` -> `Privacy Settings` -> `Collect information ON`.
3. Click `Stats Quick Link` or `Stats Menu` from the `My Site` tab
4. Notice that Stats -> `INSIGHTS` section is shown.
5. Notice in logs: 
   - 🔵 Tracked: stats_accessed (with properties)
   - 🔵 Tracked: stats_insights_accessed
6. Toggle to other sections. Return to `INSIGHTS` section.
7.  Notice that logs have below tracking at the end: 
    - 🔵 Tracked: stats_insights_accessed

Test.2 From `Stats Shortcut`

1. Open stats from app's shortcut (right click app icon and click Stats shorcut)
2. Notice that Stats -> `INSIGHTS` section is shown.
3. Notice in logs: 
   - 🔵 Tracked: stats_accessed (with properties)
   - 🔵 Tracked: stats_insights_accessed
  
Test.3 From `Stats Widgets`

1. Add `Stats Views Widget` to the device and select a site to view.
2. Click the widget.
3. Notice that Stats -> `INSIGHTS` section is shown.
5. Notice in logs: 
   - 🔵 Tracked: stats_accessed (with properties)
   - 🔵 Tracked: stats_insights_accessed
   - 🔵 Tracked: stats_widget_tapped (with properties)

**Merging Notes**

Since the initial `INSIGHTS` section is not tracked for an unknown time, and not something that impacted `stats_insights_accessed` event trend since `release/19.3`, let's wait for approval to merge it now or later.

- Make sure that https://github.com/wordpress-mobile/WordPress-Android/pull/16169 is merged.
- Wait for approval to merge to `release/19.5`.
- Remove `Not Ready for Merge` label.
- Merge the PR.

Targets `release/19.5`
/cc @AliSoftware 

## Regression Notes
1. Potential unintended areas of impact
Stats event tracking from Widgets and Shorcuts.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
See **To Test** section.

6. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.