### PR TITLE
Fix: Show Quickstart focus point when Site Info header Toolbar is collapsed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -156,12 +156,12 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         viewModel.onNavigation.observeEvent(viewLifecycleOwner) { handleNavigationAction(it) }
 
         viewModel.onScrollTo.observeEvent(viewLifecycleOwner) {
-            var scrollTo = it
-            if(it==-1) {
+            var quickStartScrollPosition = it
+            if(quickStartScrollPosition==-1) {
                 appbarMain.setExpanded(true, true)
-                scrollTo = 0
+                quickStartScrollPosition = 0
             }
-            binding?.viewPager?.getCurrentFragment()?.scrollTo(scrollTo)
+            binding?.viewPager?.getCurrentFragment()?.handleScrollTo(quickStartScrollPosition)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -33,10 +33,10 @@ import org.wordpress.android.ui.mysite.tabs.MySiteTabFragment
 import org.wordpress.android.ui.mysite.tabs.MySiteTabsAdapter
 import org.wordpress.android.ui.posts.QuickStartPromptDialogFragment.QuickStartPromptClickInterface
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR
 import org.wordpress.android.util.image.ImageType.USER
-import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.QuickStartFocusPoint
 import javax.inject.Inject
@@ -142,14 +142,23 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     private fun MySiteFragmentBinding.setupObservers() {
-        viewModel.uiModel.observe(viewLifecycleOwner, { uiModel ->
+        viewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
             loadGravatar(uiModel.accountAvatarUrl)
             when (val state = uiModel.state) {
                 is State.SiteSelected -> loadData(state)
                 is State.NoSites -> loadEmptyView(state)
             }
-        })
-        viewModel.onNavigation.observeEvent(viewLifecycleOwner, { handleNavigationAction(it) })
+        }
+        viewModel.onNavigation.observeEvent(viewLifecycleOwner) { handleNavigationAction(it) }
+
+        viewModel.onScrollTo.observeEvent(viewLifecycleOwner) {
+            var scrollTo = it
+            if(it==-1) {
+                appbarMain.setExpanded(true, true)
+                scrollTo = 0
+            }
+            binding?.viewPager?.getCurrentFragment()?.scrollTo(scrollTo)
+        }
     }
 
     private fun MySiteFragmentBinding.loadGravatar(avatarUrl: String) =

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -157,7 +157,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
         viewModel.onScrollTo.observeEvent(viewLifecycleOwner) {
             var quickStartScrollPosition = it
-            if(quickStartScrollPosition==-1) {
+            if (quickStartScrollPosition == -1) {
                 appbarMain.setExpanded(true, true)
                 quickStartScrollPosition = 0
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -474,12 +474,12 @@ class MySiteViewModel @Inject constructor(
         quickStartTask: QuickStartTask,
         position: Int
     ) {
-        if (_activeTaskPosition.value?.first != quickStartTask && isSiteHeaderTask(quickStartTask,position)) {
+        if (_activeTaskPosition.value?.first != quickStartTask && isSiteHeaderQuickStartTask(quickStartTask,position)) {
             _activeTaskPosition.postValue(quickStartTask to position)
         }
     }
 
-    private fun isSiteHeaderTask(quickStartTask: QuickStartTask, position: Int): Boolean {
+    private fun isSiteHeaderQuickStartTask(quickStartTask: QuickStartTask, position: Int): Boolean {
         return if (position == -1 && (quickStartTask == UPDATE_SITE_TITLE || quickStartTask == UPLOAD_SITE_ICON)) true
         else position >= 0
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -269,7 +269,7 @@ class MySiteViewModel @Inject constructor(
         val siteInfo = siteInfoHeaderCardBuilder.buildSiteInfoCard(siteInfoCardBuilderParams)
 
         if (activeTask != null) {
-            scrollToQuickStartTask(
+            scrollToQuickStartTaskIfNecessary(
                     activeTask,
                     getPositionOfQuickStartItem(siteItems)
             )
@@ -470,7 +470,7 @@ class MySiteViewModel @Inject constructor(
         }.toList()
     }
 
-    private fun scrollToQuickStartTask(
+    private fun scrollToQuickStartTaskIfNecessary(
         quickStartTask: QuickStartTask,
         position: Int
     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -474,7 +474,10 @@ class MySiteViewModel @Inject constructor(
         quickStartTask: QuickStartTask,
         position: Int
     ) {
-        if (_activeTaskPosition.value?.first != quickStartTask && isSiteHeaderQuickStartTask(quickStartTask,position)) {
+        if (_activeTaskPosition.value?.first != quickStartTask && isSiteHeaderQuickStartTask(
+                        quickStartTask,
+                        position
+                )) {
             _activeTaskPosition.postValue(quickStartTask to position)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -587,7 +587,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         viewModel.onQuickStartFullScreenDialogDismiss()
     }
 
-    fun scrollTo(scrollTo: Int) {
+    fun handleScrollTo(scrollTo: Int) {
         (binding?.recyclerView?.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(scrollTo, 0)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -67,9 +67,9 @@ import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
 import org.wordpress.android.util.extensions.getColorFromAttribute
+import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.viewmodel.observeEvent
 import java.io.File
 import javax.inject.Inject
@@ -181,9 +181,6 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
                 is State.SiteSelected -> loadData(state)
                 is State.NoSites -> loadEmptyView()
             }
-        })
-        viewModel.onScrollTo.observeEvent(viewLifecycleOwner, {
-            (recyclerView.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(it, 0)
         })
         viewModel.onBasicDialogShown.observeEvent(viewLifecycleOwner, { model ->
             dialogViewModel.showDialog(requireActivity().supportFragmentManager,
@@ -588,5 +585,9 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
 
     override fun onDismiss() {
         viewModel.onQuickStartFullScreenDialogDismiss()
+    }
+
+    fun scrollTo(scrollTo: Int) {
+        (binding?.recyclerView?.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(scrollTo, 0)
     }
 }


### PR DESCRIPTION
Fixes #16153 

After the changes of moving the site header to the toolbar(#16030), the quick start focus point won't be shown for Site Title and Site Icon quick start task if the Site info header toolbar is collapsed. This PR fixes the issue by auto-scrolling to the top and expanding the toolbar if the Quickstart task is either `UPDATE_SITE_TITLE` or `UPLOAD_SITE_ICON`. Please find below the video showing the auto-scroll behaviour 

Video captures:
1. "Site title" QS step (time stamp 0:05)
2.  Auto-scroll (time stamp 0:06)
3. "Site Icon" QS step (time stamp 0:23)
4.  Auto-scroll (time stamp 0:24)
5. "Edit your page" QS step(time stamp 0:45) - Captured this to show the behaviour when the QS step focus point is not inside Site Header. 
6.  No Scroll or the Site Header is not expanded(0:46) 

https://user-images.githubusercontent.com/17463767/160091236-10ae51f4-c6a7-46c3-8965-68ddaf759035.mp4


To test:

Test.1: Regression test Quick Start in single view with tabs disabled

- Launch the app.
- Go to My Site -> Me -> App Settings -> Debug settings.
- Turn off the MySiteDashboardTabsFeatureConfig flag under the Features in development section.
- Restart the app.
- Logout/login and select "Show me around" when the quick start prompt is shown.
- Run tests in [wpandroid-quick-start-testing-instructions.txt](https://github.com/wordpress-mobile/WordPress-Android/files/8246096/wpandroid-quick-start-testing-instructions.txt).
- [ Notice that in **Test 1 - Quick start notice display** or **Test 2 - snackbar action** in the text file, when the Site info header is collapsed and quick start task is **Check your site title or Choose a unique site icon**,  The site info header is expanded and focus point is shown]

Test.2: Quick Start with tabs enabled

- Launch the app.
- Go to My Site -> Me -> App Settings -> Debug settings.
- Turn on the MySiteDashboardTabsFeatureConfig flag under the Features in development section.
- Restart the app.
- Logout/login and select "Show me around" when the quick start prompt is shown.
- Note the "Quick Start" shows in the Dashboard/ Home tab only.
- Run tests in [wpandroid-quick-start-testing-instructions.txt](https://github.com/wordpress-mobile/WordPress-Android/files/8246096/wpandroid-quick-start-testing-instructions.txt).
- [ Notice that in **Test 1 - Quick start notice display** or **Test 2 - snackbar action** in the text file, when the Site info header is collapsed and quick start task is **Check your site title or Choose a unique site icon**,  The site info header is expanded and focus point is shown]

## Review Instructions
- Code review from only one reviewer is sufficient.

## Regression Notes
1. Potential unintended areas of impact
- Quick start focus point not being shown properly 
- Auto-scrolling to the top and the app bar getting expanded for Quickstart tasks other than **Check your site title or Choose a unique site icon**.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual tests 

4. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
