### PR TITLE
Merge release/19.5 (19.5-rc-2 + new screenshot copies)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,8 @@ fastlane/report.xml
 fastlane/README.md
 fastlane/metadata/android/screenshots.html
 fastlane/metadata/android/*/images/
+fastlane/jetpack_metadata/android/screenshots.html
+fastlane/jetpack_metadata/android/*/images/
 fastlane/screenshots
 default.profraw
 

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -125,99 +125,57 @@ msgctxt "play_store_app_title"
 msgid "WordPress – Website Builder"
 msgstr ""
 
-#. translators: This is a promo message that will be attached on top of the first screenshot in the Play Store.
+#. translators: This is a promo message that will be attached on top of the 1st screenshot in the Play Store.
 #. No specified characters limit here, but try to keep as short as the source one.
 msgctxt "play_store_screenshot_1"
-msgid "The world’s most popular website builder"
+msgid "Create and update your website from anywhere."
 msgstr ""
 
-#. translators: This is a promo message that will be attached on top of the second screenshot in the Play Store.
+#. translators: This is a promo message that will be attached on top of the 3rd screenshot in the Play Store.
 #. No specified characters limit here, but try to keep as short as the source one.
 msgctxt "play_store_screenshot_2"
-msgid "Create a site or start a blog"
+msgid "Create a site or start a blog."
 msgstr ""
 
-#. translators: This is a promo message that will be attached on top of the third screenshot in the Play Store.
+#. translators: This is a promo message that will be attached on top of the 4th screenshot in the Play Store.
 #. No specified characters limit here, but try to keep as short as the source one.
 msgctxt "play_store_screenshot_3"
-msgid "Discover new reads"
+msgid "Discover new reads."
 msgstr ""
 
-#. translators: This is a promo message that will be attached on top of the fourth screenshot in the Play Store.
+#. translators: This is a promo message that will be attached on top of the 5th screenshot in the Play Store.
 #. No specified characters limit here, but try to keep as short as the source one.
 msgctxt "play_store_screenshot_4"
-msgid "Build an audience"
+msgid "Build an audience."
 msgstr ""
 
-#. translators: This is a promo message that will be attached on top of the fifth screenshot in the Play Store.
+#. translators: This is a promo message that will be attached on top of the 6th screenshot in the Play Store.
 #. No specified characters limit here, but try to keep as short as the source one.
 msgctxt "play_store_screenshot_5"
-msgid "Keep tabs on your site"
+msgid "Keep tabs on your site."
 msgstr ""
 
-#. translators: This is a promo message that will be attached on top of the fifth screenshot in the Play Store.
+#. translators: This is a promo message that will be attached on top of the 7th screenshot in the Play Store.
 #. No specified characters limit here, but try to keep as short as the source one.
 msgctxt "play_store_screenshot_6"
-msgid "Reply in real time"
+msgid "Reply in real time."
 msgstr ""
 
-#. translators: This is a promo message that will be attached on top of the fifth screenshot in the Play Store.
+#. translators: This is a promo message that will be attached on top of the 8th screenshot in the Play Store.
 #. No specified characters limit here, but try to keep as short as the source one.
 msgctxt "play_store_screenshot_7"
-msgid "Upload on the go"
+msgid "Upload on the go."
 msgstr ""
 
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_1"
-msgid ""
-"<strong>Create</strong> beautiful\n"
-"posts and pages\n"
+#. translators: This is a promo message that will be attached on top of the 9th screenshot in the Play Store.
+#. No specified characters limit here, but try to keep as short as the source one.
+msgctxt "play_store_screenshot_8"
+msgid "Create immersive fullscreen stories."
 msgstr ""
 
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_2"
-msgid ""
-"<strong>Track</strong> what your\n"
-"visitors love\n"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_3"
-msgid ""
-"<strong>Check</strong> what's\n"
-"happening in real-time\n"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_4"
-msgid ""
-"<strong>Share</strong>\n"
-"from anywhere\n"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_5"
-msgid ""
-"<strong>Capture</strong> ideas\n"
-"on the go\n"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_6"
-msgid "<strong>Write</strong> without compromises"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot_7"
-msgid ""
-"<strong>Build</strong> and manage\n"
-"your website\n"
+#. translators: This is a promo message that will be attached on top of the 10th screenshot in the Play Store.
+#. No specified characters limit here, but try to keep as short as the source one.
+msgctxt "play_store_screenshot_9"
+msgid "Stay engaged with blogging reminders."
 msgstr ""
 

--- a/WordPress/metadata/enhanced_screenshot_1.html
+++ b/WordPress/metadata/enhanced_screenshot_1.html
@@ -1,2 +1,0 @@
-<strong>Create</strong> beautiful
-posts and pages

--- a/WordPress/metadata/enhanced_screenshot_2.html
+++ b/WordPress/metadata/enhanced_screenshot_2.html
@@ -1,2 +1,0 @@
-<strong>Track</strong> what your
-visitors love

--- a/WordPress/metadata/enhanced_screenshot_3.html
+++ b/WordPress/metadata/enhanced_screenshot_3.html
@@ -1,2 +1,0 @@
-<strong>Check</strong> what's
-happening in real-time

--- a/WordPress/metadata/enhanced_screenshot_4.html
+++ b/WordPress/metadata/enhanced_screenshot_4.html
@@ -1,2 +1,0 @@
-<strong>Share</strong>
-from anywhere

--- a/WordPress/metadata/enhanced_screenshot_5.html
+++ b/WordPress/metadata/enhanced_screenshot_5.html
@@ -1,2 +1,0 @@
-<strong>Capture</strong> ideas
-on the go

--- a/WordPress/metadata/enhanced_screenshot_6.html
+++ b/WordPress/metadata/enhanced_screenshot_6.html
@@ -1,1 +1,0 @@
-<strong>Write</strong> without compromises

--- a/WordPress/metadata/enhanced_screenshot_7.html
+++ b/WordPress/metadata/enhanced_screenshot_7.html
@@ -1,2 +1,0 @@
-<strong>Build</strong> and manage
-your website

--- a/WordPress/metadata/screenshot_1.txt
+++ b/WordPress/metadata/screenshot_1.txt
@@ -1,1 +1,1 @@
-The world’s most popular website builder
+Create and update your website from anywhere.

--- a/WordPress/metadata/screenshot_2.txt
+++ b/WordPress/metadata/screenshot_2.txt
@@ -1,1 +1,1 @@
-Create a site or start a blog
+Create a site or start a blog.

--- a/WordPress/metadata/screenshot_3.txt
+++ b/WordPress/metadata/screenshot_3.txt
@@ -1,1 +1,1 @@
-Discover new reads
+Discover new reads.

--- a/WordPress/metadata/screenshot_4.txt
+++ b/WordPress/metadata/screenshot_4.txt
@@ -1,1 +1,1 @@
-Build an audience
+Build an audience.

--- a/WordPress/metadata/screenshot_5.txt
+++ b/WordPress/metadata/screenshot_5.txt
@@ -1,1 +1,1 @@
-Keep tabs on your site
+Keep tabs on your site.

--- a/WordPress/metadata/screenshot_6.txt
+++ b/WordPress/metadata/screenshot_6.txt
@@ -1,1 +1,1 @@
-Reply in real time
+Reply in real time.

--- a/WordPress/metadata/screenshot_7.txt
+++ b/WordPress/metadata/screenshot_7.txt
@@ -1,1 +1,1 @@
-Upload on the go
+Upload on the go.

--- a/WordPress/metadata/screenshot_8.txt
+++ b/WordPress/metadata/screenshot_8.txt
@@ -1,0 +1,1 @@
+Create immersive fullscreen stories.

--- a/WordPress/metadata/screenshot_9.txt
+++ b/WordPress/metadata/screenshot_9.txt
@@ -1,0 +1,1 @@
+Stay engaged with blogging reminders.

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -45,8 +45,7 @@ class StatsFragment : DaggerFragment(R.layout.stats_fragment), ScrollableViewIni
     @Inject lateinit var uiHelpers: UiHelpers
     private lateinit var viewModel: StatsViewModel
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
-    private val selectedTabListener: SelectedTabListener
-        get() = SelectedTabListener(viewModel)
+    private lateinit var selectedTabListener: SelectedTabListener
 
     private var restorePreviousSearch = false
 
@@ -84,6 +83,7 @@ class StatsFragment : DaggerFragment(R.layout.stats_fragment), ScrollableViewIni
         statsPager.setPageTransformer(
                 MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
         )
+        selectedTabListener = SelectedTabListener(viewModel)
         TabLayoutMediator(tabLayout, statsPager) { tab, position ->
             tab.text = adapter.getTabTitle(position)
         }.attach()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -150,10 +150,8 @@ class StatsViewModel
                     feature = todaysStatsCardFeatureConfig
             )
 
-            initialSection?.let {
-                statsSectionManager.setSelectedSection(it)
-                trackSectionSelected(it)
-            }
+            initialSection?.let { statsSectionManager.setSelectedSection(it) }
+            trackSectionSelected(initialSection ?: INSIGHTS)
 
             val initialGranularity = initialSection?.toStatsGranularity()
             if (initialGranularity != null && initialSelectedPeriod != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -143,19 +143,22 @@ class StatsViewModel
         if (!isInitialized || restart) {
             isInitialized = true
 
-            initialSection?.let { statsSectionManager.setSelectedSection(it) }
-
-            val initialGranularity = initialSection?.toStatsGranularity()
-            if (initialGranularity != null && initialSelectedPeriod != null) {
-                selectedDateProvider.setInitialSelectedPeriod(initialGranularity, initialSelectedPeriod)
-            }
-
             // Added today's stats feature config to check whether that card is enabled when stats screen is accessed
             analyticsTracker.track(
                     stat = AnalyticsTracker.Stat.STATS_ACCESSED,
                     site = statsSiteProvider.siteModel,
                     feature = todaysStatsCardFeatureConfig
             )
+
+            initialSection?.let {
+                statsSectionManager.setSelectedSection(it)
+                trackSectionSelected(it)
+            }
+
+            val initialGranularity = initialSection?.toStatsGranularity()
+            if (initialGranularity != null && initialSelectedPeriod != null) {
+                selectedDateProvider.setInitialSelectedPeriod(initialGranularity, initialSelectedPeriod)
+            }
 
             if (launchedFromWidget) {
                 analyticsTracker.track(AnalyticsTracker.Stat.STATS_WIDGET_TAPPED, statsSiteProvider.siteModel)
@@ -227,6 +230,10 @@ class StatsViewModel
 
         listUseCases[statsSection]?.onListSelected()
 
+        trackSectionSelected(statsSection)
+    }
+
+    private fun trackSectionSelected(statsSection: StatsSection) {
         when (statsSection) {
             INSIGHTS -> analyticsTracker.track(STATS_INSIGHTS_ACCESSED)
             DAYS -> analyticsTracker.trackGranular(STATS_PERIOD_DAYS_ACCESSED, StatsGranularity.DAYS)

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-11 18:54:08+0000
+Translation-Revision-Date: 2022-03-24 17:54:07+0000
 Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n % 100 >= 3 && n % 100 <= 10) ? 3 : ((n % 100 >= 11 && n % 100 <= 99) ? 4 : 5))));
 Generator: GlotPress/3.0.0-alpha.2
 Language: ar
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">قد يصعب على الأشخاص قراءة تركيبة الألوان هذه. حاول استخدام لون خلفية أغمق و/أو لون نص أكثر إشراقًا.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">قد يصعب على الأشخاص قراءة تركيبة الألوان هذه. حاول استخدام لون خلفية أغمق و/أو لون نص أكثر إشراقًا.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">فشل في إدراج وسائط.\nانقر للحصول على مزيد من المعلومات.</string>
+    <string name="new_site_creation_intents_header_subtitle">اختيار موضوع من القائمة الواردة أدناه أو كتابة موضوعك الخاص</string>
+    <string name="new_site_creation_intents_header_title">ما الذي يدور موقعك حوله؟</string>
+    <string name="notification_channel_weekly_roundup_title">موجز أسبوعي</string>
+    <string name="my_site_dashboard_tab_title">الرئيسية</string>
+    <string name="adding_cat">إضافة تصنيف</string>
     <string name="login_select_email_client">ما تطبيق البريد الإلكتروني الذي تستخدمه؟</string>
     <string name="login_error_xml_rpc_auth_error_communicating">حدثت مشكلة في أثناء الاتصال بالموقع. تم إرجاع رمز خطأ HTTP رقم 401.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">تبدو استدعاءات XML-RPC محظورة على هذا الموقع (رمز الخطأ 401). إذا فشلت محاولة تسجيل الدخول، فانقر على أيقونة المساعدة لعرض الأسئلة المتداولة.</string>
     <string name="login_error_xml_rpc_cannot_read_site">يتعذر قراءة موقع WordPress على معرف URL ذلك. انقر على أيقونة المساعدة لعرض الأسئلة المتداولة.</string>
     <string name="login_error_xml_rpc_services_disabled">خدمات XML-RPC غير مفعلة في هذا الموقع.</string>
-    <string name="my_site_menu_tab_title">القائمة</string>
-    <string name="my_site_dashboard_tab_title">لوحة التحكم</string>
+    <string name="my_site_menu_tab_title">قائمة الموقع</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">يتضمن بحثك أحرف غير مدعومة في نطاقات ووردبريس.كوم. يُسمح بالأحرف الآتية: من A إلى Z، ومن a إلى z، ومن 0 إلى 9.</string>
     <string name="my_site_todays_stat_card_title">إحصاءات اليوم</string>
     <string name="my_site_error_within_card_subtitle">تحقَّق من اتصالك بالإنترنت وقم بتحديث الصفحة.</string>
@@ -317,6 +324,7 @@ Language: ar
     <string name="gutenberg_native_preview_page">معاينة الصفحة</string>
     <string name="gutenberg_native_preview_post">معاينة المقالة</string>
     <string name="gutenberg_native_retry">أعد المحاولة</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">واحد</string>
     <string name="gutenberg_native_no_preview_available">لا توجد معاينة متاحة</string>
     <string name="gutenberg_native_s_link">%s رابط</string>
@@ -699,7 +707,6 @@ Language: ar
     <string name="login_prologue_third_subtitle_one">أُعجب &lt;b&gt;Madison Ruiz&lt;/b&gt; بمقالتك</string>
     <string name="login_prologue_third_subtitle_two">لقد تلقيت &lt;b&gt;50 إعجاب&lt;/b&gt; على موقعك اليوم</string>
     <string name="login_prologue_third_subtitle_three">قام &lt;b&gt;Johan Brandt&lt;/b&gt; بالردّ على مقالتك</string>
-    <string name="hpp_skip_button">تخطي</string>
     <string name="hpp_choose_button">اختيار</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">تم فتح قائمة المكوّن القابلة للتمرير. حدد مكوّنًا.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">تم قفل قائمة المكوّن القابلة للتمرير.</string>
@@ -1204,7 +1211,6 @@ Language: ar
     <string name="gutenberg_native_move_block_up_from_row_1_s_to_row_2_s">نقل المكوِّن إلى أعلى من الصف %1$s إلى الصف %2$s</string>
     <string name="gutenberg_native_move_block_down_from_row_1_s_to_row_2_s">نقل المكوِّن إلى أسفل من الصف %1$s إلى الصف %2$s</string>
     <string name="gutenberg_native_help_icon">أيقونة المساعدة</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">فشلت عملية إدراج وسائط.\nيرجى النقر على الخيارات.</string>
     <string name="gutenberg_native_link_inserted">تمّ إدراج الرابط</string>
     <string name="gutenberg_native_move_block_down">تحريك المكوّن لأسفل</string>
     <string name="gutenberg_native_image_caption_s">تسمية توضيحية للصورة. %s</string>
@@ -2545,6 +2551,7 @@ Language: ar
     <string name="comments_empty_list_filtered_trashed">لا توجد تعليقات موضوعة في سلة المهملات</string>
     <string name="comments_empty_list_filtered_pending">لا توجد تعليقات في قائمة الإنتظار</string>
     <string name="comments_empty_list_filtered_approved">لا توجد تعليقات تمّت الموافقة عليها</string>
+    <string name="button_skip">تخطي</string>
     <string name="xmlrpc_missing_method_error">تعذر الاتصال. طرق XML-RPC غير موجودة على الخادم.</string>
     <string name="post_format_status">الحالة</string>
     <string name="alignment_center">وسط</string>

--- a/WordPress/src/main/res/values-bg/strings.xml
+++ b/WordPress/src/main/res/values-bg/strings.xml
@@ -370,6 +370,7 @@ Language: bg
     <string name="me_btn_app_settings">Настройки на приложението</string>
     <string name="editor_remove_failed_uploads">Премахване на неуспешно качените файлове</string>
     <string name="site_settings_advanced_header">Разширени</string>
+    <string name="button_skip">Пропускане</string>
     <string name="xmlrpc_missing_method_error">Грешка при свързването. Задължителни XML-RPC методи липсват на този сървър.</string>
     <string name="post_format_status">Състояние</string>
     <string name="post_format_video">Видео клип</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -11,8 +11,6 @@ Language: cs_CZ
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Zdá se, že volání XML-RPC jsou na tomto webu blokována (kód chyby 401). Pokud se pokus o přihlášení nezdaří, klepněte na ikonu nápovědy pro zobrazení FAQ.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Nelze číst WordPress web na této adrese URL. Klepnutím na ikonu nápovědy zobrazíte FAQ.</string>
     <string name="login_error_xml_rpc_services_disabled">Služby publikačního protokolu XML-RPC nejsou na tomto webu povoleny.</string>
-    <string name="my_site_menu_tab_title">Menu</string>
-    <string name="my_site_dashboard_tab_title">Nástěnka</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Vaše vyhledávání obsahuje znaky, které nejsou podporovány v doménách WordPress.com. Jsou povoleny pouze alfanumerické znaky: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Zkontrolujte připojení k internetu a obnovte stránku.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Přejít na statistiky</string>
@@ -699,7 +697,6 @@ Language: cs_CZ
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; lajkoval váš příspěvek</string>
     <string name="login_prologue_third_subtitle_two">Dnes jste na svém webu obdrželi &lt;b&gt;50 lajků&lt;/b&gt;</string>
     <string name="login_prologue_third_subtitle_three">&lt;b&gt;Johan Brandt&lt;/b&gt; odpověděl na váš příspěvek</string>
-    <string name="hpp_skip_button">Přeskočit</string>
     <string name="hpp_choose_button">Vybrat</string>
     <string name="hpp_subtitle">Vyberte si své oblíbené rozvržení domovské stránky. Později jej můžete upravit a přizpůsobit.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Nabídka rolovatelného bloku uzavřena.</string>
@@ -1204,7 +1201,6 @@ Language: cs_CZ
     <string name="gutenberg_native_move_block_up_from_row_1_s_to_row_2_s">Přesunout blok nahoru z řádku %1$s do řádku %2$s</string>
     <string name="gutenberg_native_navigate_up">Přejděte nahoru</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Poslední změnu vrátíte dvojitým klepnutím</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Vložení média se nezdařilo .\nKlepněte na nastavení.</string>
     <string name="gutenberg_native_help_icon">Ikona nápovědy</string>
     <string name="gutenberg_native_hide_keyboard">Skrýt klávesnici</string>
     <string name="gutenberg_native_image_caption_s">Titulek obrázku. %s</string>
@@ -2545,6 +2541,7 @@ Language: cs_CZ
     <string name="comments_empty_list_filtered_trashed">Žádné komentáře v koši</string>
     <string name="comments_empty_list_filtered_pending">Žádné komentáře nečekají na schválení</string>
     <string name="comments_empty_list_filtered_approved">Žádné schválené komentáře</string>
+    <string name="button_skip">Přeskočit</string>
     <string name="xmlrpc_missing_method_error">Nelze se připojit. Požadované metody XML-RPC chybí na serveru.</string>
     <string name="post_format_status">Aktualita</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-cy/strings.xml
+++ b/WordPress/src/main/res/values-cy/strings.xml
@@ -147,6 +147,7 @@ Language: cy_GB
     <string name="start_over">Cychwyn Eto</string>
     <string name="editor_remove_failed_uploads">Tynnu llwythi sydd wedi methu</string>
     <string name="site_settings_advanced_header">Uwch</string>
+    <string name="button_skip">Hepgor</string>
     <string name="xmlrpc_missing_method_error">Doedd dim modd cysylltu. Mae\'r dulliau XML-RPC angenrheidiol ar goll o\'r gweinydd.</string>
     <string name="post_format_status">Statws</string>
     <string name="post_format_video">Fideo</string>

--- a/WordPress/src/main/res/values-da/strings.xml
+++ b/WordPress/src/main/res/values-da/strings.xml
@@ -44,6 +44,7 @@ Language: da_DK
     <string name="site_settings_export_content_title">Eksporter indhold</string>
     <string name="contact_support">Kontakt support</string>
     <string name="site_settings_advanced_header">Avanceret</string>
+    <string name="button_skip">Spring over</string>
     <string name="alignment_center">Centreret</string>
     <string name="post_format_video">Video</string>
     <string name="post_format_status">Status</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-09 14:54:08+0000
+Translation-Revision-Date: 2022-03-23 07:26:47+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: de
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Diese Farbkombination ist unter Umständen für manche Menschen schwer lesbar. Wähle eine hellere Hintergrundfarbe und/oder eine dunklere Textfarbe.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Diese Farbkombination ist unter Umständen für manche Menschen schwer lesbar. Wähle eine dunklere Hintergrundfarbe und/oder eine hellere Textfarbe.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Das Einfügen des Mediums ist fehlgeschlagen.\nTippe für weitere Informationen.</string>
+    <string name="new_site_creation_intents_header_title">Worum wird es auf deiner Website gehen?</string>
+    <string name="new_site_creation_intents_header_subtitle">Wähle ein Thema aus der folgenden Liste oder gib ein eigenes Thema ein</string>
+    <string name="adding_cat">Kategorie wird hinzugefügt</string>
+    <string name="my_site_dashboard_tab_title">Startseite</string>
+    <string name="notification_channel_weekly_roundup_title">Wöchentliche Zusammenfassung</string>
     <string name="login_select_email_client">Welche E-Mail-Anwendung verwendest du?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Bei der Kommunikation mit der Website ist ein Problem aufgetreten. Es wurde ein HTTP-Fehlercode 401 zurückgegeben.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">XML-RPC-Anrufe sind auf dieser Website anscheinend blockiert (Fehlercode 401). Wenn der Anmeldeversuch fehlschlägt, tippe auf das Hilfe-Icon, um die FAQ anzuzeigen.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Unter dieser URL kann keine WordPress-Website gefunden werden. Tippe auf das Hilfe-Icon, um die FAQ anzuzeigen.</string>
-    <string name="my_site_dashboard_tab_title">Dashboard</string>
-    <string name="my_site_menu_tab_title">Menü</string>
     <string name="login_error_xml_rpc_services_disabled">Der XML-RPC-Service wurde auf dieser Website deaktiviert.</string>
+    <string name="my_site_menu_tab_title">Website-Menü</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Deine Suche beinhaltet Zeichen, die in Domains von WordPress.com nicht unterstützt werden. Die folgenden Zeichen sind erlaubt: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Überprüfe deine Internetverbindung und lade die Seite neu.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Gehe zu den Statistiken</string>
@@ -151,7 +158,7 @@ Language: de
     <string name="gutenberg_native_embed_block_previews_are_coming_soon">Vorschauen für Einbettungen-Blöcke sind demnächst verfügbar</string>
     <string name="weekly_roundup">Wöchentliche Zusammenfassung</string>
     <string name="gutenberg_native_embed_options">Einbettungsoptionen</string>
-    <string name="gutenberg_native_double_tap_to_view_embed_options">Zum Anzeigen der Einbettungsoptionen zweimal tippen</string>
+    <string name="gutenberg_native_double_tap_to_view_embed_options">Zum Anzeigen der Einbettungsoptionen zweimal tippen.</string>
     <string name="quick_start_list_create_site_message">Website erstellt! Schließe eine weitere Aufgabe ab.</string>
     <string name="like_faces_you_plus_others_like_text">&lt;a href=\"\"&gt;Dir und %1$s Blogger&lt;/a&gt; gefällt das.</string>
     <string name="like_faces_others_like_text">&lt;a href=\"\"&gt;%1$s Blogger&lt;/a&gt; gefällt das.</string>
@@ -317,6 +324,7 @@ Language: de
     <string name="gutenberg_native_preview_page">Seitenvorschau</string>
     <string name="gutenberg_native_preview_post">Beitragsvorschau</string>
     <string name="gutenberg_native_retry">Erneut versuchen</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Eins</string>
     <string name="gutenberg_native_no_preview_available">Keine Vorschau verfügbar</string>
     <string name="gutenberg_native_s_link">%s Link</string>
@@ -701,7 +709,6 @@ Language: de
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; gefällt dein Beitrag</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Scrollbares Block-Menü geöffnet. Wähle einen Block aus.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Scrollbares Block-Menü geschlossen.</string>
-    <string name="hpp_skip_button">Überspringen</string>
     <string name="hpp_choose_button">Auswählen</string>
     <string name="hpp_subtitle">Wähle ein Layout für deine Startseite aus, das dir gefällt. Du kannst es später bearbeiten und anpassen.</string>
     <string name="hpp_title">Wähle ein Design</string>
@@ -998,9 +1005,9 @@ Language: de
     <string name="photo_picker_video_title">Video auswählen</string>
     <string name="photo_picker_photo_or_video_title">Medien auswählen</string>
     <string name="site_picker_ask_site_select">Die Website konnte nicht ausgewählt werden. Bitte versuche es erneut.</string>
-    <string name="error_failed_to_load_into_file">Laden in die Datei fehlgeschlagen, bitte versuche es erneut. </string>
     <string name="feature_announcement_find_out_mode">Mehr erfahren</string>
     <string name="preview_image_thumbnail_description">Vorschau des Vorschaubilds</string>
+    <string name="error_failed_to_load_into_file">Laden in die Datei fehlgeschlagen, bitte versuche es erneut.</string>
     <string name="copy_text">Kopieren</string>
     <string name="button_insert">Einfügen</string>
     <string name="whats_new_in_version_title">Was ist neu?</string>
@@ -1209,7 +1216,6 @@ Language: de
     <string name="gutenberg_native_hide_keyboard">Tastatur ausblenden</string>
     <string name="gutenberg_native_help_icon">Hilfe-Icon</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Zum Rückgängigmachen der letzten Änderung zweimal tippen</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Das Einfügen von Medien ist fehlgeschlagen.\nFür Optionen bitte hier tippen.</string>
     <string name="gutenberg_native_link_text">Linktext</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Zum Umschalten der Einstellung zweimal tippen</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Zum Auswählen eines Bilds zweimal tippen</string>
@@ -2545,6 +2551,7 @@ Language: de
     <string name="comments_empty_list_filtered_trashed">Keine gelöschten Kommentare</string>
     <string name="comments_empty_list_filtered_pending">Keine ausstehenden Kommentare</string>
     <string name="comments_empty_list_filtered_approved">Keine genehmigten Kommentare</string>
+    <string name="button_skip">Überspringen</string>
     <string name="xmlrpc_missing_method_error">Konnte nicht verbinden. Die benötigte XML-RPC Methoden sind nicht auf dem Server vorhanden.</string>
     <string name="post_format_status">Status</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-el/strings.xml
+++ b/WordPress/src/main/res/values-el/strings.xml
@@ -718,6 +718,7 @@ Language: el_GR
     <string name="site_settings_advanced_header">Προχωρημένες</string>
     <string name="comments_empty_list_filtered_pending">Δεν υπάρχουν Εκκρεμή σχόλια</string>
     <string name="comments_empty_list_filtered_approved">Δεν υπάρχουν Εγκεκριμένα σχόλια</string>
+    <string name="button_skip">Παράβλεψη</string>
     <string name="xmlrpc_missing_method_error">Αδυναμία σύνδεσης. Οι απαιτούμενες μέθοδοι XML-RPC απουσιάζουν από το διακομιστή.</string>
     <string name="post_format_status">Κατάσταση</string>
     <string name="post_format_video">Βίντεο</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -1273,6 +1273,7 @@ Language: en_AU
     <string name="comments_empty_list_filtered_trashed">No trashed comments</string>
     <string name="comments_empty_list_filtered_pending">No pending comments</string>
     <string name="comments_empty_list_filtered_approved">No approved comments</string>
+    <string name="button_skip">Skip</string>
     <string name="xmlrpc_missing_method_error">Couldn\'t connect. Required XML-RPC methods are missing on the server.</string>
     <string name="post_format_status">Status</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -11,8 +11,6 @@ Language: en_CA
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">XML-RPC calls seem blocked on this site (error code 401). If attempt to login fails tap on help icon to view the FAQ.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Unable to read the WordPress site at that URL. Tap on help icon to view the FAQ.</string>
     <string name="login_error_xml_rpc_services_disabled">XML-RPC services are disabled on this site.</string>
-    <string name="my_site_menu_tab_title">Menu</string>
-    <string name="my_site_dashboard_tab_title">Dashboard</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>
     <string name="error_edit_notification">An error occurred while updating the notification content</string>
     <string name="my_site_error_within_card_subtitle">Check your internet connection and refresh the page.</string>
@@ -701,7 +699,6 @@ Language: en_CA
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; liked your post</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Scrollable block menu opened. Select a block.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Scrollable block menu closed.</string>
-    <string name="hpp_skip_button">Skip</string>
     <string name="hpp_choose_button">Choose</string>
     <string name="hpp_subtitle">Pick your favourite homepage layout. You can edit and customize it later.</string>
     <string name="hpp_title">Choose a design</string>
@@ -1208,7 +1205,6 @@ Language: en_CA
     <string name="gutenberg_native_image_caption_s">Image caption. %s</string>
     <string name="gutenberg_native_hide_keyboard">Hide keyboard</string>
     <string name="gutenberg_native_help_icon">Help icon</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Failed to insert media.\nPlease tap for options.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Double tap to undo last change</string>
     <string name="gutenberg_native_link_text">Link text</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Double tap to toggle setting</string>
@@ -2545,6 +2541,7 @@ Language: en_CA
     <string name="comments_empty_list_filtered_trashed">No trashed comments</string>
     <string name="comments_empty_list_filtered_pending">No pending comments</string>
     <string name="comments_empty_list_filtered_approved">No approved comments</string>
+    <string name="button_skip">Skip</string>
     <string name="xmlrpc_missing_method_error">Couldn\'t connect. Required XML-RPC methods are missing on the server.</string>
     <string name="post_format_status">Status</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-07 21:34:17+0000
+Translation-Revision-Date: 2022-03-22 14:15:55+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: en_GB
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">This colour combination may be hard for people to read. Try using a brighter background colour and/or a darker text colour.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">This colour combination may be hard for people to read. Try using a darker background colour and/or a brighter text colour.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Failed to insert media.\nTap for more info.</string>
+    <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type your own</string>
+    <string name="new_site_creation_intents_header_title">What’s your website about?</string>
+    <string name="notification_channel_weekly_roundup_title">Weekly Roundup</string>
+    <string name="my_site_dashboard_tab_title">Home</string>
+    <string name="adding_cat">Adding category</string>
     <string name="login_select_email_client">Which email app do you use?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">There was a problem communicating with the site. An HTTP error code 401 was returned.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">XML-RPC calls seem blocked on this site (error code 401). If attempt to log in fails, tap on help icon to view the FAQ.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Unable to read the WordPress site at that URL. Tap on help icon to view the FAQ.</string>
     <string name="login_error_xml_rpc_services_disabled">XML-RPC services are disabled on this site.</string>
-    <string name="my_site_menu_tab_title">Menu</string>
-    <string name="my_site_dashboard_tab_title">Dashboard</string>
+    <string name="my_site_menu_tab_title">Site Menu</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Check your internet connection and refresh the page.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Go to stats</string>
@@ -317,6 +324,7 @@ Language: en_GB
     <string name="gutenberg_native_preview_post">Preview post</string>
     <string name="gutenberg_native_preview_page">Preview page</string>
     <string name="gutenberg_native_retry">Retry</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">One</string>
     <string name="gutenberg_native_no_preview_available">No preview available</string>
     <string name="gutenberg_native_text_color">Text colour</string>
@@ -701,7 +709,6 @@ Language: en_GB
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; liked your post</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Scrollable block menu opened. Select a block.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Scrollable block menu closed.</string>
-    <string name="hpp_skip_button">Skip</string>
     <string name="hpp_choose_button">Choose</string>
     <string name="hpp_subtitle">Pick your favourite homepage layout. You can edit and customise it later.</string>
     <string name="hpp_title">Choose a design</string>
@@ -1209,7 +1216,6 @@ Language: en_GB
     <string name="gutenberg_native_image_caption_s">Image caption. %s</string>
     <string name="gutenberg_native_hide_keyboard">Hide keyboard</string>
     <string name="gutenberg_native_help_icon">Help icon</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Failed to insert media.\nPlease tap for options.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Double tap to undo last change</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Double tap to toggle setting</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Double tap to select an image</string>
@@ -2545,6 +2551,7 @@ Language: en_GB
     <string name="comments_empty_list_filtered_trashed">No binned comments</string>
     <string name="comments_empty_list_filtered_pending">No pending comments</string>
     <string name="comments_empty_list_filtered_approved">No approved comments</string>
+    <string name="button_skip">Skip</string>
     <string name="xmlrpc_missing_method_error">Couldn\'t connect. Required XML-RPC methods are missing on the server.</string>
     <string name="alignment_center">Centre</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-08 05:30:02+0000
+Translation-Revision-Date: 2022-03-22 13:39:41+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: es_CO
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Esta combinación de color puede ser difícil de leer para la gente. Intenta usar un color de fondo más claro y/o un color de texto más oscuro.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Esta combinación de color puede ser difícil de leer para la gente. Intenta usar un color de fondo más oscuro y/o un color de texto más claro.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Fallo al insertar los medios.\nToca para más información.</string>
+    <string name="new_site_creation_intents_header_subtitle">Elige una temática de las listadas a continuación o escribe la tuya propia</string>
+    <string name="new_site_creation_intents_header_title">¿De qué trata tu web?</string>
+    <string name="notification_channel_weekly_roundup_title">Resumen semanal</string>
+    <string name="my_site_dashboard_tab_title">Inicio</string>
+    <string name="adding_cat">Añadir categorías</string>
     <string name="login_select_email_client">¿Qué aplicación de correo electrónico usas?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Ha habido un problema al comunicar con el sitio. Se ha devuelto un código de error HTTP 401.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Las llamadas XML-RPC parecen bloqueadas en este sitio (código de error 401). Si el intento de acceso falla, toca en el icono de ayuda para ver las FAQ.</string>
     <string name="login_error_xml_rpc_cannot_read_site">No se ha podido leer el sitio WordPress en esa URL. Toca en el icono de ayuda para ver las FAQ.</string>
     <string name="login_error_xml_rpc_services_disabled">Los servicios XML-RPC están desactivados en este sitio.</string>
-    <string name="my_site_menu_tab_title">Menú</string>
-    <string name="my_site_dashboard_tab_title">Escritorio</string>
+    <string name="my_site_menu_tab_title">Menú del sitio</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Tu búsqueda incluye caracteres no compatibles en los dominios de WordPress.com. Se permiten los siguientes caracteres: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Comprueba tu conexión a Internet y actualiza la página.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Ir a las estadísticas</string>
@@ -317,6 +324,7 @@ Language: es_CO
     <string name="gutenberg_native_preview_post">Previsualizar la entrada</string>
     <string name="gutenberg_native_preview_page">Previsualizar la página</string>
     <string name="gutenberg_native_retry">Reintentar</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Uno</string>
     <string name="gutenberg_native_no_preview_available">Vista previa no disponible</string>
     <string name="gutenberg_native_text_color">Color del texto</string>
@@ -701,7 +709,6 @@ Language: es_CO
     <string name="login_prologue_third_subtitle_one">A &lt;b&gt;Madison Ruíz&lt;/b&gt; le ha gustado tu entrada</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Se ha abierto el menú de bloques desplazable. Selecciona un bloque.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Se ha cerrado el menú de bloques desplazable.</string>
-    <string name="hpp_skip_button">Omitir</string>
     <string name="hpp_choose_button">Elegir</string>
     <string name="hpp_subtitle">Elige el diseño de página de inicio que prefieras. Puedes personalizarlo o cambiarlo más tarde.</string>
     <string name="hpp_title">Elige un diseño</string>
@@ -1209,7 +1216,6 @@ Language: es_CO
     <string name="gutenberg_native_image_caption_s">Leyenda de la imagen. %s</string>
     <string name="gutenberg_native_hide_keyboard">Ocultar el teclado</string>
     <string name="gutenberg_native_help_icon">Icono de ayuda</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Fallo al insertar los medios.\nPor favor, toca para ver las opciones.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Toca dos veces para deshacer el último cambio</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Toca dos veces para alternar los ajustes</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Toca dos veces para seleccionar una imagen</string>
@@ -2545,6 +2551,7 @@ Language: es_CO
     <string name="comments_empty_list_filtered_trashed">No hay comentarios en la papelera</string>
     <string name="comments_empty_list_filtered_pending">No hay comentarios pendientes</string>
     <string name="comments_empty_list_filtered_approved">No hay comentarios aprobados</string>
+    <string name="button_skip">Saltar</string>
     <string name="xmlrpc_missing_method_error">No se pudo conectar. Los métodos requeridos en el XML-RPC faltan en el servidor.</string>
     <string name="alignment_center">Centrado</string>
     <string name="post_format_video">Vídeo</string>

--- a/WordPress/src/main/res/values-es-rMX/strings.xml
+++ b/WordPress/src/main/res/values-es-rMX/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-02-08 13:49:51+0000
+Translation-Revision-Date: 2022-03-22 14:04:07+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: es_MX
@@ -127,7 +127,6 @@ Language: es_MX
     <string name="login_prologue_third_subtitle_three">&lt;b&gt;Juan Gómez&lt;/b&gt; ha respondido en tu entrada</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Se ha abierto el menú de bloques desplazable. Selecciona un bloque.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Se ha cerrado el menú de bloques desplazable.</string>
-    <string name="hpp_skip_button">Omitir</string>
     <string name="hpp_choose_button">Elegir</string>
     <string name="hpp_subtitle">Elige tu layout favorito de página de inicio. Puedes editarlo y personalizarlo más tarde.</string>
     <string name="hpp_title">Elige un diseño</string>
@@ -622,7 +621,6 @@ Language: es_MX
     <string name="gutenberg_native_image_caption_s">Leyenda de la imagen. %s</string>
     <string name="gutenberg_native_hide_keyboard">Ocultar teclado</string>
     <string name="gutenberg_native_help_icon">Icono de ayuda</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Fallo al insertar los medios.\nPor favor, toca para ver las opciones.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Toca dos veces para deshacer el último cambio</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Toca dos veces para alternar los ajustes</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Toca dos veces para seleccionar una imagen</string>
@@ -1943,6 +1941,7 @@ Language: es_MX
     <string name="comments_empty_list_filtered_trashed">No hay comentarios en la papelera</string>
     <string name="comments_empty_list_filtered_pending">No hay comentarios pendientes</string>
     <string name="comments_empty_list_filtered_approved">No hay comentarios aprobados</string>
+    <string name="button_skip">Saltar</string>
     <string name="xmlrpc_missing_method_error">No se pudo conectar. Los métodos requeridos en el XML-RPC faltan en el servidor.</string>
     <string name="alignment_center">Centrado</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-08 05:30:53+0000
+Translation-Revision-Date: 2022-03-22 13:39:50+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: es_VE
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Esta combinación de color puede ser difícil de leer para la gente. Intenta usar un color de fondo más claro y/o un color de texto más oscuro.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Esta combinación de color puede ser difícil de leer para la gente. Intenta usar un color de fondo más oscuro y/o un color de texto más claro.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Fallo al insertar los medios.\nToca para más información.</string>
+    <string name="new_site_creation_intents_header_subtitle">Elige una temática de las listadas a continuación o escribe la tuya propia</string>
+    <string name="new_site_creation_intents_header_title">¿De qué trata tu web?</string>
+    <string name="notification_channel_weekly_roundup_title">Resumen semanal</string>
+    <string name="my_site_dashboard_tab_title">Inicio</string>
+    <string name="adding_cat">Añadir categorías</string>
     <string name="login_select_email_client">¿Qué aplicación de correo electrónico usas?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Ha habido un problema al comunicar con el sitio. Se ha devuelto un código de error HTTP 401.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Las llamadas XML-RPC parecen bloqueadas en este sitio (código de error 401). Si el intento de acceso falla, toca en el icono de ayuda para ver las FAQ.</string>
     <string name="login_error_xml_rpc_cannot_read_site">No se ha podido leer el sitio WordPress en esa URL. Toca en el icono de ayuda para ver las FAQ.</string>
     <string name="login_error_xml_rpc_services_disabled">Los servicios XML-RPC están desactivados en este sitio.</string>
-    <string name="my_site_menu_tab_title">Menú</string>
-    <string name="my_site_dashboard_tab_title">Escritorio</string>
+    <string name="my_site_menu_tab_title">Menú del sitio</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Tu búsqueda incluye caracteres no compatibles en los dominios de WordPress.com. Se permiten los siguientes caracteres: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Comprueba tu conexión a Internet y actualiza la página.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Ir a las estadísticas</string>
@@ -317,6 +324,7 @@ Language: es_VE
     <string name="gutenberg_native_preview_post">Previsualizar la entrada</string>
     <string name="gutenberg_native_preview_page">Previsualizar la página</string>
     <string name="gutenberg_native_retry">Reintentar</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Uno</string>
     <string name="gutenberg_native_no_preview_available">Vista previa no disponible.</string>
     <string name="gutenberg_native_text_color">Color del texto</string>
@@ -701,7 +709,6 @@ Language: es_VE
     <string name="login_prologue_third_subtitle_one">A &lt;b&gt;Madison Ruíz&lt;/b&gt; le ha gustado tu entrada</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Se ha abierto el menú de bloques desplazable. Selecciona un bloque.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Se ha cerrado el menú de bloques desplazable.</string>
-    <string name="hpp_skip_button">Omitir</string>
     <string name="hpp_choose_button">Elegir</string>
     <string name="hpp_subtitle">Elige el diseño de página de inicio que prefieras. Puedes personalizarlo o cambiarlo más tarde.</string>
     <string name="hpp_title">Elige un diseño</string>
@@ -1209,7 +1216,6 @@ Language: es_VE
     <string name="gutenberg_native_image_caption_s">Leyenda de la imagen. %s</string>
     <string name="gutenberg_native_hide_keyboard">Ocultar el teclado</string>
     <string name="gutenberg_native_help_icon">Icono de ayuda</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Fallo al insertar los medios.\nPor favor, toca para ver las opciones.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Toca dos veces para deshacer el último cambio</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Toca dos veces para alternar los ajustes</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Toca dos veces para seleccionar una imagen</string>
@@ -2545,6 +2551,7 @@ Language: es_VE
     <string name="comments_empty_list_filtered_trashed">No hay comentarios en la papelera</string>
     <string name="comments_empty_list_filtered_pending">No hay comentarios pendientes</string>
     <string name="comments_empty_list_filtered_approved">No hay comentarios aprobados</string>
+    <string name="button_skip">Saltar</string>
     <string name="xmlrpc_missing_method_error">No se pudo conectar. Los métodos requeridos en el XML-RPC faltan en el servidor.</string>
     <string name="alignment_center">Centrado</string>
     <string name="post_format_video">Vídeo</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-08 05:29:21+0000
+Translation-Revision-Date: 2022-03-22 13:39:29+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: es
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Esta combinación de color puede ser difícil de leer para la gente. Intenta usar un color de fondo más claro y/o un color de texto más oscuro.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Fallo al insertar los medios.\nToca para más información.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Esta combinación de color puede ser difícil de leer para la gente. Intenta usar un color de fondo más oscuro y/o un color de texto más claro.</string>
+    <string name="new_site_creation_intents_header_title">¿De qué trata tu web?</string>
+    <string name="new_site_creation_intents_header_subtitle">Elige una temática de las listadas a continuación o escribe la tuya propia</string>
+    <string name="adding_cat">Añadir categorías</string>
+    <string name="my_site_dashboard_tab_title">Inicio</string>
+    <string name="notification_channel_weekly_roundup_title">Resumen semanal</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Ha habido un problema al comunicar con el sitio. Se ha devuelto un código de error HTTP 401.</string>
     <string name="login_select_email_client">¿Qué aplicación de correo electrónico usas?</string>
     <string name="login_error_xml_rpc_cannot_read_site">No se ha podido leer el sitio WordPress en esa URL. Toca en el icono de ayuda para ver las FAQ.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Las llamadas XML-RPC parecen bloqueadas en este sitio (código de error 401). Si el intento de acceso falla, toca en el icono de ayuda para ver las FAQ.</string>
-    <string name="my_site_dashboard_tab_title">Escritorio</string>
-    <string name="my_site_menu_tab_title">Menú</string>
     <string name="login_error_xml_rpc_services_disabled">Los servicios XML-RPC están desactivados en este sitio.</string>
+    <string name="my_site_menu_tab_title">Menú del sitio</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Tu búsqueda incluye caracteres no compatibles en los dominios de WordPress.com. Se permiten los siguientes caracteres: A–Z, a–z, 0–9.</string>
     <string name="error_edit_notification">Ha ocurrido un error al actualizar el contenido del aviso</string>
     <string name="my_site_todays_stat_card_title">Estadísticas de hoy</string>
@@ -317,6 +324,7 @@ Language: es
     <string name="gutenberg_native_preview_page">Previsualizar la página</string>
     <string name="gutenberg_native_preview_post">Previsualizar la entrada</string>
     <string name="gutenberg_native_retry">Reintentar</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Uno</string>
     <string name="gutenberg_native_no_preview_available">Vista previa no disponible</string>
     <string name="gutenberg_native_s_link">Enlace %s</string>
@@ -701,7 +709,6 @@ Language: es
     <string name="login_prologue_third_subtitle_three">&lt;b&gt;Juan Gómez&lt;/b&gt; ha respondido en tu entrada</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Se ha abierto el menú de bloques desplazable. Selecciona un bloque.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Se ha cerrado el menú de bloques desplazable.</string>
-    <string name="hpp_skip_button">Omitir</string>
     <string name="hpp_choose_button">Elegir</string>
     <string name="hpp_subtitle">Elige el diseño de página de inicio que prefieras. Puedes personalizarlo o cambiarlo más tarde.</string>
     <string name="hpp_title">Elige un diseño</string>
@@ -1208,7 +1215,6 @@ Language: es
     <string name="gutenberg_native_image_caption_s">Leyenda de la imagen. %s</string>
     <string name="gutenberg_native_hide_keyboard">Ocultar el teclado</string>
     <string name="gutenberg_native_help_icon">Icono de ayuda</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Fallo al insertar los medios.\nPor favor, toca para ver las opciones.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Toca dos veces para deshacer el último cambio</string>
     <string name="gutenberg_native_link_text">Texto del enlace</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Toca dos veces para alternar los ajustes</string>
@@ -2545,6 +2551,7 @@ Language: es
     <string name="comments_empty_list_filtered_trashed">No hay comentarios en la papelera</string>
     <string name="comments_empty_list_filtered_pending">No hay comentarios pendientes</string>
     <string name="comments_empty_list_filtered_approved">No hay comentarios aprobados</string>
+    <string name="button_skip">Saltar</string>
     <string name="xmlrpc_missing_method_error">No se pudo conectar. Los métodos requeridos en el XML-RPC faltan en el servidor.</string>
     <string name="post_format_status">Estado</string>
     <string name="alignment_center">Centrado</string>

--- a/WordPress/src/main/res/values-eu/strings.xml
+++ b/WordPress/src/main/res/values-eu/strings.xml
@@ -149,6 +149,7 @@ Language: eu_ES
     <string name="me_btn_app_settings">App-aren ezarpenak</string>
     <string name="editor_remove_failed_uploads">Ezabatu huts egin duten kargak</string>
     <string name="site_settings_advanced_header">Aurreratua</string>
+    <string name="button_skip">Saltatu</string>
     <string name="post_format_status">Egoera</string>
     <string name="post_format_video">Bideoa</string>
     <string name="alignment_center">Erdira</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -1,18 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-08 10:33:30+0000
+Translation-Revision-Date: 2022-03-24 15:54:07+0000
 Plural-Forms: nplurals=2; plural=n > 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: fr
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Cette combinaison de couleurs peut être difficile à lire pour certaines personnes. Essayez une couleur d’arrière-plan plus claire et/ou une couleur de texte plus foncée.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Cette combinaison de couleurs peut être difficile à lire pour certaines personnes. Essayez une couleur d’arrière-plan plus foncée et/ou une couleur de texte plus claire.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Échec d’insertion du média.\nCliquez pour plus d’informations.</string>
+    <string name="new_site_creation_intents_header_subtitle">Choisir un sujet dans la liste ci-dessous ou saisir le vôtre</string>
+    <string name="new_site_creation_intents_header_title">De quoi parle votre site Web ?</string>
+    <string name="notification_channel_weekly_roundup_title">Résumé hebdomadaire</string>
+    <string name="adding_cat">Ajout d’une catégorie</string>
     <string name="login_select_email_client">Quelle app utilisez-vous pour vos e-mails ?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Un problème est survenu lors de la communication avec le site. Cela a provoqué une erreur HTTP 401.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Le protocole XML-RPC semble être bloqué sur ce site (code erreur 401). Si votre tentative de connexion échoue, tapez sur l’icône d’aide pour afficher la FAQ.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Impossible de lire le site WordPress  à cette adresse web. Tapez sur l’icône d’aide pour afficher la FAQ.</string>
     <string name="login_error_xml_rpc_services_disabled">Les services XML-RPC sont désactivés sur ce site.</string>
-    <string name="my_site_menu_tab_title">Menu</string>
-    <string name="my_site_dashboard_tab_title">Tableau de bord</string>
+    <string name="my_site_menu_tab_title">Menu du site</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Votre recherche contient des caractères non pris en charge dans les domaines WordPress.com. Les caractères sont les seuls autorisés : A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Vérifiez votre connexion Internet et actualisez la page.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Accéder aux statistiques</string>
@@ -701,7 +707,6 @@ Language: fr
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; a aimé votre article</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Menu de bloc déroulant ouvert. Sélectionner un bloc.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Menu de bloc déroulant fermé.</string>
-    <string name="hpp_skip_button">Passer</string>
     <string name="hpp_choose_button">Choisir</string>
     <string name="hpp_subtitle">Sélectionnez votre mise en page préférée pour la page d’accueil. Vous pourrez la personnaliser ou la modifier ultérieurement.</string>
     <string name="hpp_title">Choisir un design</string>
@@ -1209,7 +1214,6 @@ Language: fr
     <string name="gutenberg_native_image_caption_s">Légende de l’image. %s</string>
     <string name="gutenberg_native_hide_keyboard">Masquer le clavier</string>
     <string name="gutenberg_native_help_icon">Icône d’aide</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Échec de l’insertion du média.\nVeuillez appuyer pour accéder aux options.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Appuyer deux fois pour annuler la dernière modification</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Appuyer deux fois pour activer/désactiver le paramètre</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Appuyer deux fois pour sélectionner une image</string>
@@ -2545,6 +2549,7 @@ Language: fr
     <string name="comments_empty_list_filtered_trashed">Aucun commentaire dans la corbeille</string>
     <string name="comments_empty_list_filtered_pending">Aucun commentaire en attente</string>
     <string name="comments_empty_list_filtered_approved">Aucun commentaire approuvé</string>
+    <string name="button_skip">Sauter</string>
     <string name="xmlrpc_missing_method_error">Impossible de se connecter. Le serveur ne dispose pas des méthodes XML-RPC requises.</string>
     <string name="alignment_center">Centré</string>
     <string name="post_format_video">Vidéo</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -1,18 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-08 10:33:30+0000
+Translation-Revision-Date: 2022-03-24 15:54:07+0000
 Plural-Forms: nplurals=2; plural=n > 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: fr
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Cette combinaison de couleurs peut être difficile à lire pour certaines personnes. Essayez une couleur d’arrière-plan plus claire et/ou une couleur de texte plus foncée.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Cette combinaison de couleurs peut être difficile à lire pour certaines personnes. Essayez une couleur d’arrière-plan plus foncée et/ou une couleur de texte plus claire.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Échec d’insertion du média.\nCliquez pour plus d’informations.</string>
+    <string name="new_site_creation_intents_header_subtitle">Choisir un sujet dans la liste ci-dessous ou saisir le vôtre</string>
+    <string name="new_site_creation_intents_header_title">De quoi parle votre site Web ?</string>
+    <string name="notification_channel_weekly_roundup_title">Résumé hebdomadaire</string>
+    <string name="adding_cat">Ajout d’une catégorie</string>
     <string name="login_select_email_client">Quelle app utilisez-vous pour vos e-mails ?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Un problème est survenu lors de la communication avec le site. Cela a provoqué une erreur HTTP 401.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Le protocole XML-RPC semble être bloqué sur ce site (code erreur 401). Si votre tentative de connexion échoue, tapez sur l’icône d’aide pour afficher la FAQ.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Impossible de lire le site WordPress  à cette adresse web. Tapez sur l’icône d’aide pour afficher la FAQ.</string>
     <string name="login_error_xml_rpc_services_disabled">Les services XML-RPC sont désactivés sur ce site.</string>
-    <string name="my_site_menu_tab_title">Menu</string>
-    <string name="my_site_dashboard_tab_title">Tableau de bord</string>
+    <string name="my_site_menu_tab_title">Menu du site</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Votre recherche contient des caractères non pris en charge dans les domaines WordPress.com. Les caractères sont les seuls autorisés : A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Vérifiez votre connexion Internet et actualisez la page.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Accéder aux statistiques</string>
@@ -701,7 +707,6 @@ Language: fr
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; a aimé votre article</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Menu de bloc déroulant ouvert. Sélectionner un bloc.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Menu de bloc déroulant fermé.</string>
-    <string name="hpp_skip_button">Passer</string>
     <string name="hpp_choose_button">Choisir</string>
     <string name="hpp_subtitle">Sélectionnez votre mise en page préférée pour la page d’accueil. Vous pourrez la personnaliser ou la modifier ultérieurement.</string>
     <string name="hpp_title">Choisir un design</string>
@@ -1209,7 +1214,6 @@ Language: fr
     <string name="gutenberg_native_image_caption_s">Légende de l’image. %s</string>
     <string name="gutenberg_native_hide_keyboard">Masquer le clavier</string>
     <string name="gutenberg_native_help_icon">Icône d’aide</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Échec de l’insertion du média.\nVeuillez appuyer pour accéder aux options.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Appuyer deux fois pour annuler la dernière modification</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Appuyer deux fois pour activer/désactiver le paramètre</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Appuyer deux fois pour sélectionner une image</string>
@@ -2545,6 +2549,7 @@ Language: fr
     <string name="comments_empty_list_filtered_trashed">Aucun commentaire dans la corbeille</string>
     <string name="comments_empty_list_filtered_pending">Aucun commentaire en attente</string>
     <string name="comments_empty_list_filtered_approved">Aucun commentaire approuvé</string>
+    <string name="button_skip">Sauter</string>
     <string name="xmlrpc_missing_method_error">Impossible de se connecter. Le serveur ne dispose pas des méthodes XML-RPC requises.</string>
     <string name="alignment_center">Centré</string>
     <string name="post_format_video">Vidéo</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-11 13:00:41+0000
+Translation-Revision-Date: 2022-03-21 14:48:07+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: gl_ES
@@ -11,8 +11,7 @@ Language: gl_ES
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">As chamadas XML-RPC parecen bloqueadas neste sitio (código de erro 401). Se o intento de acceso falla, toca na icona de axuda para ver as FAQ.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Non se puido ler o sitio WordPress nesa URL. Toca na icona de axuda para ver as FAQ.</string>
     <string name="login_error_xml_rpc_services_disabled">Os servizos XML-RPC están desactivados neste sitio.</string>
-    <string name="my_site_menu_tab_title">Menú</string>
-    <string name="my_site_dashboard_tab_title">Escritorio</string>
+    <string name="my_site_menu_tab_title">Menú do sitio</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">A túa busca inclúe caracteres non compatibles nos dominios de WordPress.com. Permítense os seguintes caracteres: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Comproba a túa conexión a Internet e actualiza a páxina.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Ir ás estatísticas</string>
@@ -317,6 +316,7 @@ Language: gl_ES
     <string name="gutenberg_native_preview_post">Previsualizar a entrada</string>
     <string name="gutenberg_native_preview_page">Previsualizar a páxina</string>
     <string name="gutenberg_native_retry">Reintentar</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Un</string>
     <string name="gutenberg_native_no_preview_available">Vista previa non dispoñible</string>
     <string name="gutenberg_native_text_color">Cor do texto</string>
@@ -701,7 +701,6 @@ Language: gl_ES
     <string name="login_prologue_third_subtitle_one">A &lt;b&gt;Madison Ruíz&lt;/b&gt; gustoullea túa entrada</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Abriuse o menú de bloques desprazable. Selecciona un bloque.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Pechouse o menú de bloques desprazable.</string>
-    <string name="hpp_skip_button">Omitir</string>
     <string name="hpp_choose_button">Elixir</string>
     <string name="hpp_subtitle">Elixe o deseño de páxina de inicio que prefiras. Podes personalizalo ou cambialo máis tarde.</string>
     <string name="hpp_title">Elixe un deseño</string>
@@ -1209,7 +1208,6 @@ Language: gl_ES
     <string name="gutenberg_native_image_caption_s">Lenda da imaxe. %s</string>
     <string name="gutenberg_native_hide_keyboard">Ocultar o teclado</string>
     <string name="gutenberg_native_help_icon">Icona de axuda</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Erro ao inserir os medios.\nPor favor, toca para ver as opcións.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Toca dúas veces para desfacer o último cambio</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Toca dúas veces para alternar os axustes</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Toca dúas veces para seleccionar unha imaxe</string>
@@ -2545,6 +2543,7 @@ Language: gl_ES
     <string name="comments_empty_list_filtered_trashed">Non hai comentarios no lixo</string>
     <string name="comments_empty_list_filtered_pending">Non hai comentarios pendentes</string>
     <string name="comments_empty_list_filtered_approved">Non hai comentarios aprobados</string>
+    <string name="button_skip">Omitir</string>
     <string name="xmlrpc_missing_method_error">Non foi posible conectar. Os métodos XML-RPC requiridos non están no servidor.</string>
     <string name="alignment_center">Centro</string>
     <string name="post_format_video">Vídeo</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -11,8 +11,6 @@ Language: he_IL
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">נראה שקריאות XML-RPC חסומות באתר הזה (קוד שגיאה 401). אם הניסיון להתחברות נכשל, יש להקיש על סמל העזרה כדי להציג את השאלות הנפוצות.</string>
     <string name="login_error_xml_rpc_cannot_read_site">לא ניתן לקרוא את אתר WordPress בכתובת URL זו. יש להקיש על סמל העזרה כדי להציג את השאלות הנפוצות.</string>
     <string name="login_error_xml_rpc_services_disabled">שירותי XML-RPC באתר זה מנותקים.</string>
-    <string name="my_site_menu_tab_title">תפריט</string>
-    <string name="my_site_dashboard_tab_title">לוח בקרה</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">החיפוש שלך כולל תווים שלא נתמכים בדומיינים של WordPress.com. התווים הבאים מותרים: A–Z‏, a–z,‏ 0–9.</string>
     <string name="my_site_todays_stat_card_title">הנתונים הסטטיסטיים של היום</string>
     <string name="my_site_error_within_card_subtitle">יש לבדוק את החיבור לאינטרנט ולרענן את העמוד.</string>
@@ -701,7 +699,6 @@ Language: he_IL
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;ישראלה ישראלה&lt;/b&gt; סימנה לייק בפוסט שלך</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">תפריט בלוק לגלילה פתוח. יש לבחור בלוק.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">תפריט בלוק לגלילה סגור.</string>
-    <string name="hpp_skip_button">לדלג</string>
     <string name="hpp_choose_button">לבחור</string>
     <string name="hpp_subtitle">יש לבחור את הפריסה המועדפת עליך לעמוד הבית. אפשר לערוך ולהתאימה אישית מאוחר יותר.</string>
     <string name="hpp_title">לבחור עיצוב</string>
@@ -1208,7 +1205,6 @@ Language: he_IL
     <string name="gutenberg_native_image_caption_s">כיתוב התמונה. %s</string>
     <string name="gutenberg_native_hide_keyboard">הסתרת מקלדת</string>
     <string name="gutenberg_native_help_icon">סמל עזרה</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">שילוב פירטי המדיה נכשל.\nיש להקיש לאפשרויות.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">יש להקיש פעמיים כדי לבטל את השינוי האחרון</string>
     <string name="gutenberg_native_link_text">טקסט לקישור</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">יש להקיש פעמיים כדי לשנות את ההגדרות</string>
@@ -2545,6 +2541,7 @@ Language: he_IL
     <string name="site_settings_advanced_header">אפשרויות מתקדמות</string>
     <string name="comments_empty_list_filtered_pending">אין תגובות שממתינות לאישור</string>
     <string name="comments_empty_list_filtered_approved">אין תגובות מאושרות</string>
+    <string name="button_skip">דילוג</string>
     <string name="xmlrpc_missing_method_error">לא ניתן להתחבר. שיטות XML-RPC נדרשות חסרות בשרת.</string>
     <string name="post_format_video">וידאו</string>
     <string name="alignment_center">מרכז</string>

--- a/WordPress/src/main/res/values-hr/strings.xml
+++ b/WordPress/src/main/res/values-hr/strings.xml
@@ -16,7 +16,6 @@ Language: hr
     <string name="delete_button_alt">Izbrisati</string>
     <string name="scan">Skeniraj</string>
     <string name="reader_discover_empty_title">Dobro došli!</string>
-    <string name="hpp_skip_button">Preskoči</string>
     <string name="hpp_choose_button">Odaberi</string>
     <string name="hpp_title">Odaberite dizajn</string>
     <string name="prepublishing_nudges_add_category_button">Dodaj Kategoriju</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-11 23:44:12+0000
+Translation-Revision-Date: 2022-03-24 11:54:15+0000
 Plural-Forms: nplurals=2; plural=n > 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: id
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Kombinasi warna ini mungkin sulit dibaca. Coba gunakan warna latar belakang yang lebih terang dan/atau warna teks yang lebih gelap.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Kombinasi warna ini mungkin sulit dibaca. Coba gunakan warna latar belakang yang lebih gelap dan/atau warna teks yang lebih terang.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Gagal menyisipkan media.\nKetuk untuk info selengkapnya.</string>
+    <string name="new_site_creation_intents_header_subtitle">Ketikkan topik Anda atau pilih dari daftar di bawah</string>
+    <string name="new_site_creation_intents_header_title">Apa isi situs Anda?</string>
+    <string name="notification_channel_weekly_roundup_title">Ringkasan Mingguan</string>
+    <string name="my_site_dashboard_tab_title">Beranda</string>
+    <string name="adding_cat">Menambahkan kategori</string>
     <string name="login_select_email_client">Aplikasi email apa yang Anda gunakan?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Ada kendala saat berkomunikasi dengan situs. Kode error HTTP 401 dikembalikan.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Panggilan XML-RPC tampaknya diblok di situs ini (kode error 401). Jika upaya login gagal, ketuk ikon bantuan untuk melihat FAQ.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Tidak dapat membaca situs WordPress dalam URL tersebut. Ketuk ikon bantuan untuk melihat FAQ.</string>
     <string name="login_error_xml_rpc_services_disabled">Layanan XML-RPC tidak tersedia di situs ini.</string>
-    <string name="my_site_menu_tab_title">Menu</string>
-    <string name="my_site_dashboard_tab_title">Dasbor</string>
+    <string name="my_site_menu_tab_title">Menu Situs</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Pencarian Anda includes karakter yang tidak didukung di domain WordPress.com. Karakter berikut diperbolehkan: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Periksa koneksi internet Anda dan muat ulang halaman.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Buka statistik</string>
@@ -317,6 +324,7 @@ Language: id
     <string name="gutenberg_native_preview_post">Pratinjau pos</string>
     <string name="gutenberg_native_preview_page">Pratinjau halaman</string>
     <string name="gutenberg_native_retry">Coba lagi</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Satu.</string>
     <string name="gutenberg_native_no_preview_available">Pratinjau tidak tersedia</string>
     <string name="gutenberg_native_text_color">Warna teks</string>
@@ -701,7 +709,6 @@ Language: id
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; menyukai pos Anda</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Menu blok yang dapat digulir terbuka. Pilih blok.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Menu blok yang dapat digulir tertutup.</string>
-    <string name="hpp_skip_button">Lewati</string>
     <string name="hpp_choose_button">Pilih</string>
     <string name="hpp_subtitle">Pilih tata letak halaman beranda favorit Anda. Anda dapat menyunting dan menyesuaikannya nanti.</string>
     <string name="hpp_title">Pilih desain</string>
@@ -1209,7 +1216,6 @@ Language: id
     <string name="gutenberg_native_image_caption_s">Keterangan gambar. %s</string>
     <string name="gutenberg_native_hide_keyboard">Sembunyikan keyboard</string>
     <string name="gutenberg_native_help_icon">Ikon bantuan</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Gagal memasukkan media.\nKetuk untuk melihat pilihan.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Ketuk dua kali untuk mengurungkan perubahan terakhir</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Ketuk dua kali untuk mengaktifkan/menonaktifkan pengaturan</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Ketuk dua kali untuk memilih gambar</string>
@@ -2545,6 +2551,7 @@ Language: id
     <string name="comments_empty_list_filtered_trashed">Tidak ada komentar yang dibuang</string>
     <string name="comments_empty_list_filtered_pending">Tidak komentar tertunda</string>
     <string name="comments_empty_list_filtered_approved">Tidak ada komentar yang disetujui</string>
+    <string name="button_skip">Lewati</string>
     <string name="xmlrpc_missing_method_error">Tidak dapat terhubung. Metode XML-RPC yang diperlukan tidak ditemukan di server.</string>
     <string name="alignment_center">Tengah</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-is/strings.xml
+++ b/WordPress/src/main/res/values-is/strings.xml
@@ -180,6 +180,7 @@ Language: is
     <string name="me_btn_app_settings">Stillingar forrits</string>
     <string name="editor_remove_failed_uploads">Fjarlægja misheppnuð upphöl</string>
     <string name="site_settings_advanced_header">Ítarlegra</string>
+    <string name="button_skip">Sleppa</string>
     <string name="xmlrpc_missing_method_error">Gat ekki tengst. Nauðsynlega XML-RPC virkni vantar á netþjóninn.</string>
     <string name="alignment_center">Miðja</string>
     <string name="post_format_status">Staða</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -1,18 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-11 15:54:08+0000
+Translation-Revision-Date: 2022-03-25 11:54:07+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: it
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Questa combinazione di colori può essere difficile da leggere per le persone. Prova a usare un colore di sfondo più brillante e/o un colore di testo più scuro.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Questa combinazione di colori può essere difficile da leggere per le persone. Prova a usare un colore di sfondo più scuro e/o un colore di testo più brillante.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Impossibile inserire elementi multimediali.\nTocca per ulteriori informazioni.</string>
+    <string name="new_site_creation_intents_header_subtitle">Scegli un argomento dall\'elenco sottostante o digitane uno tuo</string>
+    <string name="new_site_creation_intents_header_title">Qual è l\'argomento del tuo sito web?</string>
+    <string name="notification_channel_weekly_roundup_title">Resoconto settimanale</string>
+    <string name="adding_cat">Aggiunta della categoria</string>
     <string name="login_select_email_client">Quale app per e-mail utilizzi?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Si è verificato un problema durante la comunicazione con il sito. È stato restituito un codice di errore HTTP .</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Le chiamate XML-RPC sembrano bloccate su questo sito (codice di errore 401). Se il tentativo di accesso fallisce, tocca l\'icona della guida per visualizzare le FAQ.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Impossibile leggere il sito WordPress associato a questo URL. Tocca l\'icona della guida per visualizzare le domande frequenti.</string>
     <string name="login_error_xml_rpc_services_disabled">Il servizio XML-RPC è disattivato su questo sito.</string>
-    <string name="my_site_menu_tab_title">Menu</string>
-    <string name="my_site_dashboard_tab_title">Bacheca</string>
+    <string name="my_site_menu_tab_title">Menu del sito</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">La tua ricerca include caratteri non supportati nei domini WordPress.com. Sono consentiti i seguenti caratteri: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Controlla la tua connessione a Internet e ricarica la pagina.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Vai alle statistiche</string>
@@ -701,7 +707,6 @@ Language: it
     <string name="login_prologue_third_subtitle_two">Oggi hai ricevuto &lt;b&gt;50 Mi piace&lt;/b&gt; al tuo sito</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Menu del blocco a scorrimento aperto. Seleziona un blocco.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Menu del blocco a scorrimento chiuso.</string>
-    <string name="hpp_skip_button">Salta</string>
     <string name="hpp_choose_button">Scegli</string>
     <string name="hpp_subtitle">Scegli il layout che preferisci per la tua homepage. Puoi modificarlo e personalizzarlo in seguito.</string>
     <string name="hpp_title">Scegli un design</string>
@@ -1209,7 +1214,6 @@ Language: it
     <string name="gutenberg_native_double_tap_to_undo_last_change">Tocca due volte per annullare l\'ultima modifica</string>
     <string name="gutenberg_native_move_block_down">Sposta il blocco verso il basso</string>
     <string name="gutenberg_native_help_icon">Icona della guida</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Inserimento media non riuscito.\nTocca per ulteriori opzioni.</string>
     <string name="gutenberg_native_link_text">Testo del link</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Tocca due volte per attivare/disattivare l\'impostazione</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Tocca due volte per selezionare un\'immagine</string>
@@ -2545,6 +2549,7 @@ Language: it
     <string name="site_settings_advanced_header">Avanzato</string>
     <string name="comments_empty_list_filtered_pending">Nessun commento in sospeso</string>
     <string name="comments_empty_list_filtered_approved">Nessun commento approvato</string>
+    <string name="button_skip">Salta</string>
     <string name="xmlrpc_missing_method_error">Non è possibile connettersi. Sul server mancano i necessari metodi XML-RPC</string>
     <string name="post_format_status">Stato</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-10 09:54:17+0000
+Translation-Revision-Date: 2022-03-25 10:54:07+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/3.0.0-alpha.2
 Language: ja_JP
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">この色の組み合わせは読みにくい可能性があります。 背景色を明るくするか、文字の色を暗くしてみましょう。</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">この色の組み合わせは読みにくい可能性があります。 背景色を暗くするか、文字の色を明るくしてみましょう。</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">メディアの挿入に失敗しました。\nタップして詳細をご覧ください。</string>
+    <string name="new_site_creation_intents_header_subtitle">以下のリストからテーマを選択するか、自分で入力します</string>
+    <string name="new_site_creation_intents_header_title">どのような内容のサイトですか？</string>
+    <string name="notification_channel_weekly_roundup_title">1週間のまとめ</string>
+    <string name="my_site_dashboard_tab_title">ホーム</string>
+    <string name="adding_cat">カテゴリーを追加しています</string>
     <string name="login_select_email_client">どのメールアプリを使用していますか ?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">サイトとの通信中に問題が発生しました。 HTTP エラーコード401が返されました。</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">このサイトでは XML-RPC コールがブロックされているようです (エラーコード401)。 ログインに失敗する場合は、ヘルプアイコンをタップして FAQ をご確認ください。</string>
     <string name="login_error_xml_rpc_cannot_read_site">ご指定の URL の WordPress サイトを読み込めません。 ヘルプアイコンをタップして FAQ を表示してください。</string>
     <string name="login_error_xml_rpc_services_disabled">このサイトでは XML-RPC サービスが無効になっています。</string>
-    <string name="my_site_menu_tab_title">メニュー</string>
-    <string name="my_site_dashboard_tab_title">ダッシュボード</string>
+    <string name="my_site_menu_tab_title">サイトメニュー</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">検索内容に WordPress.com のドメインではサポートされていない文字が含まれています。 サポートされている文字は A–Z、a–z、0–9です。</string>
     <string name="my_site_error_within_card_subtitle">インターネット接続を確認してページを更新してください。</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">統計情報を表示</string>
@@ -701,7 +708,6 @@ Language: ja_JP
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; さんが投稿に「いいね」しました</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">スクロール可能なブロックメニューが開きました。 ブロックを選択します。</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">スクロール可能なブロックメニューが閉じられました。</string>
-    <string name="hpp_skip_button">スキップ</string>
     <string name="hpp_choose_button">選択</string>
     <string name="hpp_subtitle">お気に入りのホームページのレイアウトを選択します。 後で編集およびカスタマイズできます。</string>
     <string name="hpp_title">デザインを選択</string>
@@ -1209,7 +1215,6 @@ Language: ja_JP
     <string name="gutenberg_native_hide_keyboard">キーボードを非表示</string>
     <string name="gutenberg_native_help_icon">ヘルプアイコン</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">ダブルタップして前回の変更を元に戻す</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">メディアを挿入できませんでした。\nタップするとオプションを表示します。</string>
     <string name="gutenberg_native_link_text">リンクテキスト</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">ダブルタップして設定を切り替え</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">ダブルタップして画像を選択</string>
@@ -2545,6 +2550,7 @@ Language: ja_JP
     <string name="comments_empty_list_filtered_trashed">ゴミ箱内にコメントはありません</string>
     <string name="comments_empty_list_filtered_pending">保留中のコメントはありません</string>
     <string name="comments_empty_list_filtered_approved">承認済みのコメントはありません</string>
+    <string name="button_skip">スキップ</string>
     <string name="xmlrpc_missing_method_error">接続できませんでした。必要な XML-RPC メソッドがサーバーにありません。</string>
     <string name="post_format_status">ステータス</string>
     <string name="post_format_video">動画</string>

--- a/WordPress/src/main/res/values-kmr/strings.xml
+++ b/WordPress/src/main/res/values-kmr/strings.xml
@@ -28,7 +28,6 @@ Language: ku_TR
     <string name="login_prologue_third_subtitle_three">&lt;b&gt;Johan Brandt&lt;/b&gt; bersiv da şandiya te</string>
     <string name="login_prologue_third_subtitle_two">Te îro li ser malpera xwe &lt;b&gt;50 likes&lt;/b&gt; ecibandin sitend</string>
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; şandiya te eciband</string>
-    <string name="hpp_skip_button">Derbas bibe</string>
     <string name="hpp_choose_button">Hilbijêre</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Menuya biloka şemîtonkî vebû. Bilokekê hilbijêre.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Menuya biloka şemîtonkî hate girtin.</string>
@@ -516,7 +515,6 @@ Language: ku_TR
     <string name="gutenberg_native_image_caption_s">Sernivîsa wêneyê. %s</string>
     <string name="gutenberg_native_hide_keyboard">Klavyeyê veşêre</string>
     <string name="gutenberg_native_help_icon">Îkona alîkariyê</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Tevlîkirina medyayê bi ser neket.\nJi bo vebijarkan, bitepîne.</string>
     <string name="gutenberg_native_move_block_down">Blokê bikişîne jêrê</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Ji bo guhertina dawî vegerînî, ducar bitikîne</string>
     <string name="gutenberg_native_double_tap_to_select">Ji bo bijartinê, ducar bitikîne</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-10 17:54:08+0000
+Translation-Revision-Date: 2022-03-24 11:54:15+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/3.0.0-alpha.2
 Language: ko_KR
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">이 색상 조합은 사람들이 읽기 힘들 수 있습니다. 더 밝은 배경 색상 및/또는 더 어두운 텍스트 색상을 사용해 보세요.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">이 색상 조합은 사람들이 읽기 힘들 수 있습니다. 더 어두운 배경 색상 및/또는 더 밝은 텍스트 색상을 사용해 보세요.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">미디어를 삽입하지 못했습니다.\n자세히 알아보려면 누르세요.</string>
+    <string name="new_site_creation_intents_header_subtitle">아래 목록에 있는 주제 선택 또는 원하는 주제 입력</string>
+    <string name="new_site_creation_intents_header_title">웹사이트의 주제가 무엇인가요?</string>
+    <string name="notification_channel_weekly_roundup_title">주간 총정리</string>
+    <string name="my_site_dashboard_tab_title">홈</string>
+    <string name="adding_cat">카테고리 추가하기</string>
     <string name="login_select_email_client">어떤 이메일 앱을 사용하시나요?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">사이트와 통신하는 중 문제가 발생했습니다. HTTP 오류 코드 401이 반환되었습니다.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">XML-RPC 호출이 이 사이트에서 차단된 것 같습니다(오류 코드 401). 로그인 시도가 실패하면 도움말 아이콘을 눌러 FAQ를 확인하세요.</string>
     <string name="login_error_xml_rpc_cannot_read_site">해당 URL에서 워드프레스 사이트를 읽을 수 없습니다. 도움말 아이콘을 눌러 FAQ를 확인하세요.</string>
     <string name="login_error_xml_rpc_services_disabled">XML-RPC 서비스가 이 사이트에서 비활성화되었습니다.</string>
-    <string name="my_site_menu_tab_title">메뉴</string>
-    <string name="my_site_dashboard_tab_title">알림판</string>
+    <string name="my_site_menu_tab_title">사이트 메뉴</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">검색어에 워드프레스닷컴 도메인에 지원되지 않는 문자가 있습니다. 허용되는 문자는 A–Z, a–z, 0–9입니다.</string>
     <string name="my_site_error_within_card_subtitle">인터넷 연결을 확인하고 페이지를 새로 고치세요.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">통계로 이동</string>
@@ -701,7 +708,6 @@ Language: ko_KR
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;메디슨 루이즈&lt;/b&gt;가 글을 좋아합니다</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">스크롤 할 수 있는 블록 메뉴가 열렸습니다. 블록을 선택하세요.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">스크롤 할 수 있는 블록 메뉴를 닫았습니다.</string>
-    <string name="hpp_skip_button">건너뛰기</string>
     <string name="hpp_choose_button">선택하기</string>
     <string name="hpp_subtitle">좋아하는 홈페이지 레이아웃을 고르세요. 사용자 정의하거나 나중에 바꿀 수 있습니다.</string>
     <string name="hpp_title">디자인 선택하기</string>
@@ -1209,7 +1215,6 @@ Language: ko_KR
     <string name="gutenberg_native_image_caption_s">이미지 캡션. %s</string>
     <string name="gutenberg_native_hide_keyboard">키보드 숨기기</string>
     <string name="gutenberg_native_help_icon">도움말 아이콘</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">미디어를 삽입하지 못했습니다.\n옵션을 보려면 누르세요.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">마지막 변경을 취소하려면 두 번 탭하세요.</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">설정을 전환하려면 두 번 탭하세요.</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">이미지를 선택하려면 두 번 탭하세요.</string>
@@ -2545,6 +2550,7 @@ Language: ko_KR
     <string name="comments_empty_list_filtered_trashed">삭제된 댓글 없음</string>
     <string name="comments_empty_list_filtered_pending">대기중인 댓글 없음</string>
     <string name="comments_empty_list_filtered_approved">승인한 댓글 없음</string>
+    <string name="button_skip">넘어가기</string>
     <string name="xmlrpc_missing_method_error">연결할 수 없습니다. 필수 XML-RPC 함수가 서버에 없습니다.</string>
     <string name="alignment_center">가운데</string>
     <string name="post_format_video">비디오</string>

--- a/WordPress/src/main/res/values-ms/strings.xml
+++ b/WordPress/src/main/res/values-ms/strings.xml
@@ -431,6 +431,7 @@ Language: ms
     <string name="start_over">Mula Semula</string>
     <string name="editor_remove_failed_uploads">Buangkan muatnaik yang gagal</string>
     <string name="site_settings_advanced_header">Lanjutan</string>
+    <string name="button_skip">Langkau</string>
     <string name="xmlrpc_missing_method_error">Tidak boleh berhubung. Kaedah XML-RPC yang diperlukan tiada pada pelayan.</string>
     <string name="post_format_status">Status</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-nb/strings.xml
+++ b/WordPress/src/main/res/values-nb/strings.xml
@@ -163,7 +163,6 @@ Language: nb_NO
     <string name="reader_discover_no_posts_title">Ingen nylige innlegg</string>
     <string name="reader_discover_empty_title">Velkommen!</string>
     <string name="scan">Skann</string>
-    <string name="hpp_skip_button">Hopp over</string>
     <string name="hpp_choose_button">Velg</string>
     <string name="hpp_title">Velg en utforming</string>
     <string name="prepublishing_nudges_add_category_button">Legg til kategori</string>
@@ -560,7 +559,6 @@ Language: nb_NO
     <string name="gutenberg_native_image_caption_s">Bildetekst. %s</string>
     <string name="gutenberg_native_hide_keyboard">Skjul tastatur</string>
     <string name="gutenberg_native_help_icon">Hjelpeikon</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Mislyktes i å sette inn media.\nVennligst trykk for alternativer.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Dobbelttrykk for å angre siste endring</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Dobbelttrykk for å veksle innstilling</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Dobbelttrykk for å velge et bilde</string>
@@ -1867,6 +1865,7 @@ Language: nb_NO
     <string name="comments_empty_list_filtered_trashed">Ingen forkastede kommentarer</string>
     <string name="comments_empty_list_filtered_pending">Ingen ventende kommentarer</string>
     <string name="comments_empty_list_filtered_approved">Ingen godkjente kommentarer</string>
+    <string name="button_skip">Hopp over</string>
     <string name="xmlrpc_missing_method_error">Klarte ikke å koble til. De påkrevde XML-RPC-metodene mangler på denne tjeneren.</string>
     <string name="alignment_center">Midten</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -11,8 +11,6 @@ Language: nl
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">XML-RPC aanroepen lijken geblokkeerd op deze site (foutcode 401). Als de poging om in te loggen mislukt, tik je op het hulppictogram om de veelgestelde vragen te bekijken.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Kan de WordPress site niet lezen op die URL. Tik op het hulppictogram om de veelgestelde vragen te bekijken.</string>
     <string name="login_error_xml_rpc_services_disabled">XML-RPC diensten zijn uitgeschakeld op deze site.</string>
-    <string name="my_site_menu_tab_title">Menu</string>
-    <string name="my_site_dashboard_tab_title">Dashboard</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Je zoekopdracht bevat karakters die niet worden ondersteund in WordPress.com domeinen. De volgende tekens zijn toegestaan: A-Z, a-z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Controleer je internetverbinding en vernieuw de pagina.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Ga naar de statistieken</string>
@@ -701,7 +699,6 @@ Language: nl
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; liked je bericht</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Scrolbaar blokmenu geopend. Selecteer een blok.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Scrolbaar blokmenu gesloten.</string>
-    <string name="hpp_skip_button">Overslaan</string>
     <string name="hpp_choose_button">Kies</string>
     <string name="hpp_subtitle">Kies je favoriete homepage lay-out. Je kan deze bewerken of later altijd nog aanpassen.</string>
     <string name="hpp_title">Kies een ontwerp</string>
@@ -1209,7 +1206,6 @@ Language: nl
     <string name="gutenberg_native_image_caption_s">Afbeelding vastleggen. %s</string>
     <string name="gutenberg_native_hide_keyboard">Toetsenbord verbergen</string>
     <string name="gutenberg_native_help_icon">Help-pictogram</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Invoegen van media mislukt.\nTik voor opties.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Twee keer tikken om de laatste wijziging ongedaan te maken</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Twee keer tikken om instelling in/uit te schakelen</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Twee keer tikken om een afbeelding te selecteren</string>
@@ -2545,6 +2541,7 @@ Language: nl
     <string name="comments_empty_list_filtered_trashed">Geen verwijderde reacties</string>
     <string name="comments_empty_list_filtered_pending">Geen reacties in behandeling</string>
     <string name="comments_empty_list_filtered_approved">Geen goedgekeurde reacties</string>
+    <string name="button_skip">Overslaan</string>
     <string name="xmlrpc_missing_method_error">Kon geen verbinding maken. Vereiste XML-RPC-methoden ontbreken op de server.</string>
     <string name="alignment_center">Midden</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -648,7 +648,6 @@ Language: pl
     <string name="login_prologue_third_subtitle_three">&lt;b&gt;Johan Brandt&lt;/b&gt; odpowiedział na twój wpis</string>
     <string name="login_prologue_third_subtitle_two">Twoja witryna otrzymała dziś &lt;b&gt;50 polubień&lt;/b&gt;</string>
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; polubił(a) twój wpis</string>
-    <string name="hpp_skip_button">Pomiń</string>
     <string name="hpp_choose_button">Wybierz</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Otwarto przewijalne menu blokowe. Wybierz blok.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Zamknięto przewijalne menu blokowe. </string>
@@ -1150,7 +1149,6 @@ Language: pl
     <string name="gutenberg_native_move_block_up">Przesuń blok w górę</string>
     <string name="gutenberg_native_move_block_down_from_row_1_s_to_row_2_s">Przesuń blok w dół z wiersza %1$s do wiersza %2$s</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Stuknij dwukrotnie aby cofnąć zmiany</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Nie można było osadzić plików mediów.\nStuknij aby wejść w opcje.</string>
     <string name="gutenberg_native_move_block_down">Przesuń blok w dół</string>
     <string name="gutenberg_native_link_inserted">Wstawiono odnośnik</string>
     <string name="gutenberg_native_hide_keyboard">Ukryj klawiaturę</string>
@@ -2491,6 +2489,7 @@ Language: pl
     <string name="comments_empty_list_filtered_trashed">Brak komentarzy w koszu</string>
     <string name="comments_empty_list_filtered_pending">Brak komentarzy oczekujących na moderację</string>
     <string name="comments_empty_list_filtered_approved">Brak zaakceptowanych komentarzy</string>
+    <string name="button_skip">Pomiń</string>
     <string name="xmlrpc_missing_method_error">Błąd połączenia. Brak wymaganych metod XML-RPC na serwerze.</string>
     <string name="post_format_status">Status</string>
     <string name="post_format_video">Film</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -693,7 +693,6 @@ Language: pt_BR
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; curtiu seu post</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Menu de blocos aberto. Escolha um bloco.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Menu de blocos fechado.</string>
-    <string name="hpp_skip_button">Pular</string>
     <string name="hpp_choose_button">Escolher</string>
     <string name="hpp_subtitle">Escolha seu modelo preferido para a página inicial. Você poderá personalizar ou alterá-lo depois.</string>
     <string name="hpp_title">Escolha um design</string>
@@ -1201,7 +1200,6 @@ Language: pt_BR
     <string name="gutenberg_native_image_caption_s">Legenda da imagem. %s</string>
     <string name="gutenberg_native_hide_keyboard">Esconder teclado</string>
     <string name="gutenberg_native_help_icon">Ícone de ajuda</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Falha ao inserir a mídia.\nToque para ver mais opções.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Toque duas vezes para desfazer a última alteração</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Toque duas vezes para alternar as configurações</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Toque duas vezes para selecionar uma imagem</string>
@@ -2537,6 +2535,7 @@ Language: pt_BR
     <string name="comments_empty_list_filtered_trashed">Nenhum comentário na lixeira</string>
     <string name="comments_empty_list_filtered_pending">Nenhum comentário pendente</string>
     <string name="comments_empty_list_filtered_approved">Nenhum comentário aprovado</string>
+    <string name="button_skip">Pular</string>
     <string name="xmlrpc_missing_method_error">Não foi possível conectar. Alguns métodos XML-RPC necessários estão faltando no servidor.</string>
     <string name="alignment_center">Centro</string>
     <string name="post_format_video">Vídeo</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-07 21:11:54+0000
+Translation-Revision-Date: 2022-03-22 15:31:41+0000
 Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n == 0 || n % 100 >= 2 && n % 100 <= 19) ? 1 : 2);
 Generator: GlotPress/3.0.0-alpha.2
 Language: ro
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Această combinație de culori poate să nu fie lizibilă pentru toți cititorii. Încearcă să folosești o culoare de fundal mai luminoasă și/sau o culoare pentru text mai închisă.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Această combinație de culori poate să nu fie lizibilă pentru toți cititorii. Încearcă să folosești o culoare de fundal mai întunecată și/sau o culoare pentru text mai deschisă.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Inserarea media a eșuat.\nDă tap pentru mai multe informații.</string>
+    <string name="new_site_creation_intents_header_title">Despre ce este site-ul tău web?</string>
+    <string name="new_site_creation_intents_header_subtitle">Alege un subiect din lista de mai jos sau creează tu unul</string>
+    <string name="notification_channel_weekly_roundup_title">Rezumat săptămânal</string>
+    <string name="my_site_dashboard_tab_title">Prima pagină</string>
+    <string name="adding_cat">Se adaugă categorie</string>
     <string name="login_error_xml_rpc_auth_error_communicating">A fost o problemă la comunicarea cu site-ul. A fost returnat codul de eroare HTTP 401.</string>
     <string name="login_select_email_client">Ce aplicație pentru email folosești?</string>
     <string name="login_error_xml_rpc_cannot_read_site">Nu pot să găsesc un site WordPress la acel URL. Atinge iconul pentru ajutor ca să vezi Întrebări frecvente.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Apelările XML-RPC par a fi blocate pe acest site (cod eroare 401). Dacă încercarea de autentificare eșuează, atinge iconul pentru ajutor ca să vezi Întrebări frecvente.</string>
-    <string name="my_site_dashboard_tab_title">Panou control</string>
-    <string name="my_site_menu_tab_title">Meniu</string>
     <string name="login_error_xml_rpc_services_disabled">Serviciile XML-RPC sunt dezactivate pe acest site.</string>
+    <string name="my_site_menu_tab_title">Meniu site</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Căutarea ta include caractere care nu sunt acceptate în domeniile WordPress.com. Sunt permise următoarele caractere: A–Z, a–z, 0–9.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Mergi la statistici</string>
     <string name="my_site_todays_stat_card_title">Statistici pentru azi</string>
@@ -317,6 +324,7 @@ Language: ro
     <string name="gutenberg_native_preview_post">Previzualizează articolul</string>
     <string name="gutenberg_native_preview_page">Previzualizează pagina</string>
     <string name="gutenberg_native_retry">Reîncearcă</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Unu</string>
     <string name="gutenberg_native_no_preview_available">Nu este disponibilă nicio previzualizare</string>
     <string name="gutenberg_native_s_link">Legătură la %s</string>
@@ -701,7 +709,6 @@ Language: ro
     <string name="login_prologue_third_subtitle_two">Azi ai primit &lt;b&gt;50 de aprecieri&lt;/b&gt; pe site</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Meniul de blocuri care poate fi derulat este deschis. Selectează un bloc.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Meniul de blocuri care poate fi derulat este închis.</string>
-    <string name="hpp_skip_button">Sari</string>
     <string name="hpp_choose_button">Alege</string>
     <string name="hpp_subtitle">Alege aranjamentul preferat pentru prima pagină. Îl poți edita sau personaliza mai târziu.</string>
     <string name="hpp_title">Alege un design</string>
@@ -1207,7 +1214,6 @@ Language: ro
     <string name="gutenberg_native_image_caption_s">Text asociat imagine. %s</string>
     <string name="gutenberg_native_hide_keyboard">Ascunde tastatura</string>
     <string name="gutenberg_native_help_icon">Icon pentru ajutor</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Inserarea elementului media a eșuat.\nTe rog atinge pentru opțiuni.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Atinge de două ori pentru a anula ultima modificare</string>
     <string name="gutenberg_native_link_text">Text legătură</string>
     <string name="gutenberg_native_link_inserted">Am inserat legătura</string>
@@ -2545,6 +2551,7 @@ Language: ro
     <string name="site_settings_advanced_header">Avansat</string>
     <string name="comments_empty_list_filtered_pending">Niciun comentariu în așteptare</string>
     <string name="comments_empty_list_filtered_approved">Niciun comentariu aprobat</string>
+    <string name="button_skip">Sari</string>
     <string name="xmlrpc_missing_method_error">Nu ne-am putut conecta. Metodele XML-RPC necesare lipsesc de pe server.</string>
     <string name="post_format_status">Stare</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -1,18 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-10 15:54:08+0000
+Translation-Revision-Date: 2022-03-24 15:54:07+0000
 Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);
 Generator: GlotPress/3.0.0-alpha.2
 Language: ru
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Это сочетание цветов может затруднить чтение. Попробуйте использовать более яркий цвет фона и/или более темный цвет текста.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Это сочетание цветов может затруднить чтение. Попробуйте использовать более темный цвет фона и/или более яркий цвет текста.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Не удалось вставить медиафайл.\nTap for more info.</string>
+    <string name="new_site_creation_intents_header_title">Чему посвящён ваш веб-сайт?</string>
+    <string name="notification_channel_weekly_roundup_title">За неделю</string>
+    <string name="my_site_dashboard_tab_title">Главная</string>
+    <string name="adding_cat">Добавление категории</string>
     <string name="login_select_email_client">Каким приложением электронной почты вы пользуетесь?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Возникла проблема при подключении к сайту. Получен код ошибки HTTP 401.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Вызовы XML-RPC на этом сайте заблокированы (код ошибки 401). Если войти не удалось, нажмите на значок справки, чтобы открыть часто задаваемые вопросы.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Не удалось найти веб-сайт WordPress по этому URL-адресу. Нажмите на значок справки, чтобы открыть часто задаваемые вопросы.</string>
     <string name="login_error_xml_rpc_services_disabled">Сервисы XML-RPC на этом сайте отключены.</string>
-    <string name="my_site_menu_tab_title">Меню</string>
-    <string name="my_site_dashboard_tab_title">Консоль</string>
+    <string name="my_site_menu_tab_title">Меню сайта</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Ваш поиск включает символы, которые не поддерживаются в доменах WordPress.com. Допускаются только буквенно-цифровые символы: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Проверьте подключение к Интернету и обновите страницу.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Перейти к статистике</string>
@@ -317,6 +323,7 @@ Language: ru
     <string name="gutenberg_native_preview_post">Предварительный просмотр записи</string>
     <string name="gutenberg_native_preview_page">Предварительный просмотр страницы</string>
     <string name="gutenberg_native_retry">Повторить</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Один</string>
     <string name="gutenberg_native_no_preview_available">Предварительный просмотр недоступен</string>
     <string name="gutenberg_native_text_color">Цвет текста</string>
@@ -701,7 +708,6 @@ Language: ru
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Юля Петрова&lt;/b&gt; отмечает вашу запись как понравившуюся</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Прокручиваемое меню блоков открыто. Выберите блок.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Прокручиваемое меню блоков закрыто.</string>
-    <string name="hpp_skip_button">Пропустить</string>
     <string name="hpp_choose_button">Выбрать</string>
     <string name="hpp_subtitle">Выберите макет главной страницы. Его можно настроить или изменить позже.</string>
     <string name="hpp_title">Выбрать оформление</string>
@@ -1209,7 +1215,6 @@ Language: ru
     <string name="gutenberg_native_image_caption_s">Подпись к изображению. %s</string>
     <string name="gutenberg_native_hide_keyboard">Скрыть клавиатуру</string>
     <string name="gutenberg_native_help_icon">Значок справки</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Невозможно вставить медиафайл.\nНажмите для выбора вариантов.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Нажмите дважды для отмены последнего действия</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Нажмите дважды для переключения настройки</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Нажмите дважды для выбора изображения</string>
@@ -2545,6 +2550,7 @@ Language: ru
     <string name="comments_empty_list_filtered_trashed">Нет комментариев в корзине</string>
     <string name="comments_empty_list_filtered_pending">Нет комментариев на утверждении</string>
     <string name="comments_empty_list_filtered_approved">Нет одобренных комментариев</string>
+    <string name="button_skip">Пропустить</string>
     <string name="xmlrpc_missing_method_error">Не удалось подключиться. На сервере отсутствуют необходимые методы XML-RPC.</string>
     <string name="alignment_center">По центру</string>
     <string name="post_format_video">Видео</string>

--- a/WordPress/src/main/res/values-sk/strings.xml
+++ b/WordPress/src/main/res/values-sk/strings.xml
@@ -994,6 +994,7 @@ Language: sk
     <string name="comments_empty_list_filtered_trashed">Žiadne komentáre v koši</string>
     <string name="comments_empty_list_filtered_pending">Žiadne čakajúce komentáre</string>
     <string name="comments_empty_list_filtered_approved">Žiadne schválené komentáre</string>
+    <string name="button_skip">Preskočiť</string>
     <string name="xmlrpc_missing_method_error">Nepodarilo sa pripojiť. Vyžadované metódy XML-RPC chýbajú na tomto serveri. </string>
     <string name="post_format_video">Video</string>
     <string name="alignment_center">Na stred</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -1,18 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-08 14:24:22+0000
+Translation-Revision-Date: 2022-03-21 19:18:48+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: sq_AL
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Kjo ndërthurje ngjyrash mund të vështirësojë leximin nga njerëzit. Provoni të përdorni një ngjyrë sfondi më të ndritshme dhe/ose një ngjyrë të errët teksti.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">S’u arrit të futej media.\nPrekeni për më tepër hollësi.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Kjo ndërthurje ngjyrash mund të vështirësojë leximin nga njerëzit. Provoni të përdorni një ngjyrë sfondi më të errët dhe/ose një ngjyrë të ndritshme teksti.</string>
+    <string name="new_site_creation_intents_header_title">Për çfarë është sajti juaj?</string>
+    <string name="notification_channel_weekly_roundup_title">Përmbledhje Javore</string>
+    <string name="my_site_dashboard_tab_title">Kreu</string>
+    <string name="adding_cat">Shtim kategorish</string>
     <string name="login_select_email_client">Cilin aplikacion email përdorni?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Pati një problem komunikimi me sajtin. U kthye një kod gabimi HTTP 401.</string>
     <string name="login_error_xml_rpc_cannot_read_site">S’arrihet të lexohet sajti WordPress tek ajo URL. Prekni ikonën e ndihmës që të shihni PBR.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Duket se në këtë sajt bllokohen thirrjet XML-RPC (kod gabimi 401). Nëse dështon përpjekja për hyrje, prekni ikonën e ndihmës që të shihni PBR.</string>
     <string name="login_error_xml_rpc_services_disabled">Shërbimet XML-RPC janë të çaktivizuara për këtë sajt.</string>
-    <string name="my_site_menu_tab_title">Menu</string>
-    <string name="my_site_dashboard_tab_title">Pult</string>
+    <string name="my_site_menu_tab_title">Menu Sajti</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Kërkimi juaj përmban shenja të pambuluara në përkatësi WordPress.com. Lejohen shenjat vijuese: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Kontrolloni lidhjen tuaj internet dhe rifreskoni faqen.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Shko te statistikat</string>
@@ -312,6 +318,7 @@ Language: sq_AL
     <string name="gutenberg_native_preview_post">Parashiheni postimin</string>
     <string name="gutenberg_native_preview_page">Parashiheni faqen</string>
     <string name="gutenberg_native_retry">Riprovoni</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Një</string>
     <string name="gutenberg_native_no_preview_available">S’ka paraparje gati</string>
     <string name="gutenberg_native_s_link">Lidhje %s</string>
@@ -692,7 +699,6 @@ Language: sq_AL
     <string name="login_prologue_third_subtitle_three">&lt;b&gt;Durim Cerova&lt;/b&gt; iu përgjigj postimit tuaj</string>
     <string name="login_prologue_third_subtitle_two">Sot në sajtin tuaj patët &lt;b&gt;50 pëlqeim&lt;/b&gt;</string>
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Maqo Senko&lt;/b&gt; pëlqeu postimin tuaj</string>
-    <string name="hpp_skip_button">Anashkaloje</string>
     <string name="hpp_choose_button">Zgjidhni</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">U hap me blloqesh. Përzgjidhni një bllok.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Menuja e blloqeve u mbyll.</string>
@@ -1201,7 +1207,6 @@ Language: sq_AL
     <string name="gutenberg_native_image_caption_s">Titull figure. %s</string>
     <string name="gutenberg_native_hide_keyboard">Fshihe tastierën</string>
     <string name="gutenberg_native_help_icon">Ikonë ndihme</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">S’u arrit të futej media.\nJu lutemi, prekeni për mundësi.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Që të zhbëhet ndryshimi i fundit, prekeni dyfish</string>
     <string name="gutenberg_native_link_text">Tekst lidhjeje</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Që shfaqet/fshihet rregullimi, prekeni dyfish</string>
@@ -2538,6 +2543,7 @@ Language: sq_AL
     <string name="comments_empty_list_filtered_trashed">S’ka komente të shpënë në Hedhurina</string>
     <string name="comments_empty_list_filtered_pending">S’ka komente në pritje të shqyrtimit</string>
     <string name="comments_empty_list_filtered_approved">S’ka komente të miratuara</string>
+    <string name="button_skip">Anashkaloje</string>
     <string name="xmlrpc_missing_method_error">S’u lidh dot. Metodat e domosdoshme XML-RPC mungojnë te shërbyesi.</string>
     <string name="post_format_status">Gjendje</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-sr/strings.xml
+++ b/WordPress/src/main/res/values-sr/strings.xml
@@ -132,7 +132,6 @@ Language: sr_RS
     <string name="reader_discover_no_posts_title">Нема недавних чланака</string>
     <string name="scan">Скенирај</string>
     <string name="login_prologue_third_subtitle_three">&lt;b&gt;Јохан Брант&lt;/b&gt; је одговорио на ваш чланак</string>
-    <string name="hpp_skip_button">Прескочи</string>
     <string name="hpp_choose_button">Одабери</string>
     <string name="hpp_title">Одаберите дизајн</string>
     <string name="prepublishing_nudges_add_category_button">Додај категорију</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-07 20:35:07+0000
+Translation-Revision-Date: 2022-03-22 13:09:46+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: sv_SE
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Denna färgkombination kan vara svår för människor att läsa. Försök använda en ljusare bakgrundsfärg och/eller en mörkare textfärg.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Denna färgkombination kan vara svår för människor att läsa. Försök använda en mörkare bakgrundsfärg och/eller en ljusare textfärg.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Misslyckades att infoga media.\nTryck för mer information.</string>
+    <string name="new_site_creation_intents_header_subtitle">Välj ett ämne från listan nedan eller skriv ditt eget</string>
+    <string name="new_site_creation_intents_header_title">Vad handlar din webbplats om?</string>
+    <string name="notification_channel_weekly_roundup_title">Veckosammanfattning</string>
+    <string name="my_site_dashboard_tab_title">Hem</string>
+    <string name="adding_cat">Lägger till kategori</string>
     <string name="login_select_email_client">Vilken e-postapp använder du?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Det uppstod ett problem med att kommunicera med webbplatsen. En HTTP-felkod 401 returnerades.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Anrop med XML-RPC verkar blockerade på denna webbplats (felkod 401). Om försöket att logga in misslyckas tryck på hjälpikonen för att se vanliga frågor.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Kunde inte läsa WordPress-webbplatsen på denna URL. Tryck på hjälpikonen för att se vanliga frågor.</string>
     <string name="login_error_xml_rpc_services_disabled">Tjänsten XML-RPC är inaktiverad på denna webbplats.</string>
-    <string name="my_site_menu_tab_title">Meny</string>
-    <string name="my_site_dashboard_tab_title">Adminpanel</string>
+    <string name="my_site_menu_tab_title">Webbplatsens meny</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Din sökning innehåller tecken som inte stöds i WordPress.com-domäner. Följande tecken är tillåtna: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">Kontrollera din internetanslutning och ladda om sidan.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Gå till statistiken</string>
@@ -317,6 +324,7 @@ Language: sv_SE
     <string name="gutenberg_native_preview_post">Förhandsgranska inlägg</string>
     <string name="gutenberg_native_preview_page">Förhandsgranska sidan</string>
     <string name="gutenberg_native_retry">Försök igen</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Ett</string>
     <string name="gutenberg_native_no_preview_available">Ingen förhandsgranskning tillgänglig</string>
     <string name="gutenberg_native_text_color">Textfärg</string>
@@ -701,7 +709,6 @@ Language: sv_SE
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Anna S&lt;/b&gt; gillade ditt inlägg</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Den rullningsbara blockmenyn har öppnats. Välj ett block.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Den rullningsbara blockmenyn har stängts.</string>
-    <string name="hpp_skip_button">Hoppa över</string>
     <string name="hpp_choose_button">Välj</string>
     <string name="hpp_subtitle">Välj favoritlayout på din startsida Du kan anpassa eller ändra det senare.</string>
     <string name="hpp_title">Välj en design</string>
@@ -1209,7 +1216,6 @@ Language: sv_SE
     <string name="gutenberg_native_image_caption_s">Bildtext. %s</string>
     <string name="gutenberg_native_hide_keyboard">Dölj tangentbordet</string>
     <string name="gutenberg_native_help_icon">Hjälpikon</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Kunde inte lägga in mediafil.\nTryck för att visa alternativ.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Dubbeltryck för att ångra senaste ändring</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Dubbeltryck för att växla inställningens värde</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Dubbeltryck för att välja en bild</string>
@@ -2545,6 +2551,7 @@ Language: sv_SE
     <string name="comments_empty_list_filtered_trashed">Inga kastade kommentarer</string>
     <string name="comments_empty_list_filtered_pending">Inga väntande kommentarer</string>
     <string name="comments_empty_list_filtered_approved">Inga godkända kommentarer</string>
+    <string name="button_skip">Hoppa över</string>
     <string name="xmlrpc_missing_method_error">Kunde inte ansluta. Obligatoriska XML-RPC-metoder saknas på servern.</string>
     <string name="alignment_center">Centrerat</string>
     <string name="post_format_video">Videoklipp</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-11 11:54:08+0000
+Translation-Revision-Date: 2022-03-25 13:54:08+0000
 Plural-Forms: nplurals=2; plural=n > 1;
 Generator: GlotPress/3.0.0-alpha.2
 Language: tr
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Bu renk birleşiminde insanların okuması zor olabilir. Daha parlak bir arka plan ve/veya daha koyu bir metin rengi kullanmayı deneyin.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Bu renk birleşimi insanların okuması zor olabilir. Daha parlak bir arka plan ve/veya daha koyu bir metin rengi kullanmayı deneyin.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Medya eklenemedi.\nDaha fazla bilgi için dokunun.</string>
+    <string name="new_site_creation_intents_header_subtitle">Aşağıdaki listeden bir konu seçin veya kendi konunuzu yazın</string>
+    <string name="new_site_creation_intents_header_title">Web siteniz ne hakkında?</string>
+    <string name="notification_channel_weekly_roundup_title">Haftalık Özet</string>
+    <string name="my_site_dashboard_tab_title">Başlangıç</string>
+    <string name="adding_cat">Kategori ekleniyor</string>
     <string name="login_select_email_client">Hangi e-posta uygulamasını kullanıyorsunuz?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Siteyle iletişimde bir sorun oluştu. Bir HTTP hata kodu 401 döndürüldü.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">Bu sitede XML-RPC çağrıları engellenmiş görünüyor (hata kodu 401). Oturum açma girişimi başarısız olursa, SSS\'yi görüntülemek için yardım simgesine dokunun.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Bu URL\'deki WordPress sitesi okunamıyor. SSS\'yi görüntülemek için yardım simgesine dokunun.</string>
     <string name="login_error_xml_rpc_services_disabled">XML-RPC servisleri bu site için kapalı.</string>
-    <string name="my_site_menu_tab_title">Menü</string>
-    <string name="my_site_dashboard_tab_title">Başlangıç</string>
+    <string name="my_site_menu_tab_title">Site menüsü</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Aramanız, WordPress.com alan adlarında desteklenmeyen karakterler içeriyor. Aşağıdaki karakterlere izin verilir: A–Z, a–z, 0–9.</string>
     <string name="my_site_error_within_card_subtitle">İnternet bağlantınızı kontrol edin ve sayfayı yenileyin.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">İstatistiklere Git</string>
@@ -317,6 +324,7 @@ Language: tr
     <string name="gutenberg_native_preview_post">Yazıyı önizle</string>
     <string name="gutenberg_native_preview_page">Sayfayı önizle</string>
     <string name="gutenberg_native_retry">Tekrar dene</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Bir</string>
     <string name="gutenberg_native_no_preview_available">Önizleme yok</string>
     <string name="gutenberg_native_text_color">Metin rengi</string>
@@ -701,7 +709,6 @@ Language: tr
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; yazınızı beğendi</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Kaydırılabilir blok menüsü açıldı. Bir blok seçin.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Kaydırılabilir blok menüsü kapandı.</string>
-    <string name="hpp_skip_button">Atla</string>
     <string name="hpp_choose_button">Seç</string>
     <string name="hpp_subtitle">En sevdiğiniz ana sayfa düzenini seçin. Daha sonra özelleştirebilir ve değiştirebilirsiniz.</string>
     <string name="hpp_title">Bir tasarım seçin</string>
@@ -1209,7 +1216,6 @@ Language: tr
     <string name="gutenberg_native_image_caption_s">Görsel yazısı. %s</string>
     <string name="gutenberg_native_hide_keyboard">Klavyeyi gizle</string>
     <string name="gutenberg_native_help_icon">Yardım simgesi</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Medya eklenemedi.\nLütfen seçenekler için dokunun.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Son değişikliği geri almak için çift dokunun</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Ayarı değiştirmek için çift dokunun</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Bir görsel seçmek için çift dokunun</string>
@@ -2545,6 +2551,7 @@ Language: tr
     <string name="comments_empty_list_filtered_trashed">Çöpte yorum yok</string>
     <string name="comments_empty_list_filtered_pending">Bekleyen yorum yok</string>
     <string name="comments_empty_list_filtered_approved">Onaylı yorum yok</string>
+    <string name="button_skip">Atla</string>
     <string name="xmlrpc_missing_method_error">Bağlanılamadı. Sunucuda gerekli XML-RPC işlevleri eksik.</string>
     <string name="alignment_center">Ortala</string>
     <string name="post_format_video">Video</string>

--- a/WordPress/src/main/res/values-vi/strings.xml
+++ b/WordPress/src/main/res/values-vi/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-14 02:04:34+0000
+Translation-Revision-Date: 2022-03-24 04:01:15+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/3.0.0-alpha.2
 Language: vi_VN
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">Màu phối này có thể gây khó đọc. Hãy thử sử dụng màu nền sáng hơn hoặc màu văn bản tối hơn.</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">Màu này có thể gây khó đọc cho mọi người. Thử dùng màu nền tối hơn hoặc chữ sáng hơn.</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">Không thể chèn media.\nNhấn để biết thêm thông tin.</string>
+    <string name="new_site_creation_intents_header_subtitle">Chọn một thẻ từ danh sách bên dưới hoặc tự nhập</string>
+    <string name="new_site_creation_intents_header_title">Nội dung blog của bạn là gì?</string>
+    <string name="notification_channel_weekly_roundup_title">Tóm Tắt Tuần</string>
+    <string name="my_site_dashboard_tab_title">Tổng quan</string>
+    <string name="adding_cat">Thêm chuyên mục</string>
     <string name="login_select_email_client">Bạn dùng ứng dụng email nào?</string>
     <string name="login_error_xml_rpc_auth_error_communicating">Xảy ra lỗi khi giao tiếp với blog. Mã lỗi HTTP 401.</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">XML-RPC bị chặn trên blog này (mã lỗi 401). Nếu tiếp tục đăng nhập thất bại, nhấn biểu tượng trợ giúp để xem câu hỏi thường gặp.</string>
     <string name="login_error_xml_rpc_cannot_read_site">Không thể đọc blog WordPress trên URL này. Nhấn biểu tượng trợ giúp để xem câu hỏi thường gặp.</string>
     <string name="login_error_xml_rpc_services_disabled">Dịch vụ XML-RPC bị chặn trên blog này.</string>
     <string name="my_site_menu_tab_title">Menu</string>
-    <string name="my_site_dashboard_tab_title">Tổng quan</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Tên miền WordPress.com không chứa những ký tự này. Chỉ có chữ và số được cho phép.</string>
     <string name="my_site_error_within_card_subtitle">Kiểm tra kết nối mạng và thử lại.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Xem thống kê</string>
@@ -317,6 +324,7 @@ Language: vi_VN
     <string name="gutenberg_native_preview_post">Xem trước bài viết</string>
     <string name="gutenberg_native_preview_page">Xem trước trang</string>
     <string name="gutenberg_native_retry">Thử lại</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">Một</string>
     <string name="gutenberg_native_no_preview_available">Không có bản xem trước</string>
     <string name="gutenberg_native_text_color">Màu chữ</string>
@@ -701,7 +709,6 @@ Language: vi_VN
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; thích bài viết của bạn</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">Đã mở menu khối có thể cuộn. Chọn một khối.</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">Đã đóng menu khối có thể cuộn.</string>
-    <string name="hpp_skip_button">Bỏ qua</string>
     <string name="hpp_choose_button">Chọn</string>
     <string name="hpp_subtitle">Chọn bố cục trang chủ yêu thích. Bạn có thể sửa và tùy biến nó sau này.</string>
     <string name="hpp_title">Chọn một thiết kế</string>
@@ -1121,7 +1128,7 @@ Language: vi_VN
     <string name="reader_filter_empty_tags_list">Bạn có thể theo dõi các bài viết có cùng đề tài bằng cách thêm thẻ</string>
     <string name="reader_filter_empty_sites_list">Đọc bài viết mới nhất từ blog bạn theo dõi</string>
     <string name="reader_filter_main_title">Đang theo dõi</string>
-    <string name="reader_filter_cta">Lọc</string>
+    <string name="reader_filter_cta">Bộ lọc</string>
     <string name="gutenberg_native_video_caption_s">Chú thích video. %s</string>
     <string name="gutenberg_native_edit_video">Sửa video</string>
     <string name="gutenberg_native_edit_media">Sửa media</string>
@@ -1209,7 +1216,6 @@ Language: vi_VN
     <string name="gutenberg_native_image_caption_s">Chú thích ảnh. %s</string>
     <string name="gutenberg_native_hide_keyboard">Ẩn bàn phím</string>
     <string name="gutenberg_native_help_icon">Biểu tượng trợ giúp</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">Chèn media thất bại.\nNhấn để xem tùy chọn.</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">Nhấn hai lần để trở lại thay đổi cuối cùng</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">Nhấn hai lần để chuyển đổi thiết lập</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">Nhấn hai lần để chọn ảnh</string>
@@ -1518,7 +1524,7 @@ Language: vi_VN
     <string name="quick_start_dialog_explore_plans_message_short">Nhấn %1$s Gói dịch vụ %2$s để xem gói hiện tại của bạn và những gói khác.</string>
     <string name="quick_start_dialog_check_stats_message_short">Nhấn %1$s Thống Kê %2$s để xem hiệu suất blog.</string>
     <string name="quick_start_dialog_upload_site_icon_message_short">Nhấn %1$s Biểu Tượng Blog %2$s để tải lên ngay.</string>
-    <string name="quick_start_dialog_publish_post_message">Đăng và chuyển và nháp.</string>
+    <string name="quick_start_dialog_publish_post_message">Tạo nháp và đăng một bài viết.</string>
     <string name="quick_start_dialog_explore_plans_title">Tìm hiểu các gói</string>
     <string name="quick_start_dialog_explore_plans_message">Học về marketing và công cụ SEO trong các gói nâng cấp.</string>
     <string name="quick_start_dialog_enable_sharing_title">Bật chia sẻ bài viết</string>
@@ -2545,6 +2551,7 @@ Language: vi_VN
     <string name="comments_empty_list_filtered_trashed">Thùng rác trống</string>
     <string name="comments_empty_list_filtered_pending">Không có bình luận đang chờ</string>
     <string name="comments_empty_list_filtered_approved">Không có bình luận đã duyệt</string>
+    <string name="button_skip">Bỏ qua</string>
     <string name="xmlrpc_missing_method_error">Không thể kết nối. Máy chủ này không có các phương thức XML-RPC cần thiết.</string>
     <string name="alignment_center">Giữa</string>
     <string name="post_format_video">Video</string>
@@ -2866,9 +2873,9 @@ Language: vi_VN
     <string name="error_refresh_unauthorized_posts">Bạn không có quyền xem hoặc sửa bài viết</string>
     <string name="error_refresh_unauthorized_pages">Bạn không có quyền xem hoặc sửa trang</string>
     <string name="more">Thêm</string>
-    <string name="older_month">1 tháng trước</string>
-    <string name="older_last_week">1 tuần trước</string>
-    <string name="older_two_days">2 ngày trước</string>
+    <string name="older_month">Cũ hơn một tháng</string>
+    <string name="older_last_week">Cũ hơn một tuần</string>
+    <string name="older_two_days">Cũ hơn 2 ngày</string>
     <string name="help_and_support">Trợ giúp</string>
     <string name="mnu_comment_liked">Đã thích</string>
     <string name="comment">Bình luận</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-11 09:54:08+0000
+Translation-Revision-Date: 2022-03-25 09:54:08+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/3.0.0-alpha.2
 Language: zh_CN
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">此颜色搭配可能不便于用户阅读。 不妨尝试使用较浅的背景颜色和/或较深的文本颜色。</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">此颜色搭配可能不便于用户阅读。 不妨尝试使用较深的背景颜色和/或较浅的文本颜色。</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">未能插入媒体。\n点按获取更多信息。</string>
+    <string name="new_site_creation_intents_header_subtitle">请从以下列表中选择主题或输入自己的主题</string>
+    <string name="new_site_creation_intents_header_title">您的网站是关于什么的？</string>
+    <string name="notification_channel_weekly_roundup_title">每周综述</string>
+    <string name="my_site_dashboard_tab_title">首页</string>
+    <string name="adding_cat">添加分类</string>
     <string name="login_select_email_client">您使用哪款电子邮件应用程序？</string>
     <string name="login_error_xml_rpc_auth_error_communicating">与站点通信时出现问题。 返回了 HTTP 错误代码 401。</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">XML-RPC 调用似乎已被该站点屏蔽（错误代码 401）。 如果尝试登录失败，可点击帮助图标查看常见问题解答。</string>
     <string name="login_error_xml_rpc_cannot_read_site">无法通过该 URL 读取 WordPress 站点。 点击帮助图标查看常见问题解答。</string>
     <string name="login_error_xml_rpc_services_disabled">本站点禁用 XML-RPC 服务。</string>
-    <string name="my_site_menu_tab_title">菜单</string>
-    <string name="my_site_dashboard_tab_title">仪表盘</string>
+    <string name="my_site_menu_tab_title">站点菜单</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">您的搜索中包含 WordPress.com 域名不支持的字符。 允许使用以下字符：A–Z、a–z、0–9。</string>
     <string name="my_site_error_within_card_subtitle">请检查您网络连接并刷新页面。</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">转至统计数据</string>
@@ -317,6 +324,7 @@ Language: zh_CN
     <string name="gutenberg_native_preview_post">预览文章</string>
     <string name="gutenberg_native_preview_page">预览页面</string>
     <string name="gutenberg_native_retry">重试</string>
+    <string name="gutenberg_native_gif">GIF</string>
     <string name="gutenberg_native_one">一</string>
     <string name="gutenberg_native_no_preview_available">无可用预览</string>
     <string name="gutenberg_native_text_color">文字颜色</string>
@@ -701,7 +709,6 @@ Language: zh_CN
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; 喜欢了您的文章</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">滚动区块菜单打开。 选择区块。</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">滚动区块菜单关闭。</string>
-    <string name="hpp_skip_button">跳过</string>
     <string name="hpp_choose_button">选择</string>
     <string name="hpp_subtitle">选择您喜欢的主页布局。 您可以稍后对其进行编辑和自定义。</string>
     <string name="hpp_title">选择设计</string>
@@ -1209,7 +1216,6 @@ Language: zh_CN
     <string name="gutenberg_native_image_caption_s">图片说明。%s</string>
     <string name="gutenberg_native_hide_keyboard">隐藏键盘</string>
     <string name="gutenberg_native_help_icon">“帮助”图标</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">无法插入媒体。\n请轻按以查看选项。</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">轻按两下以撤销上次的更改</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">轻按两下以切换设置</string>
     <string name="gutenberg_native_double_tap_to_select_an_image">轻按两下以选择图片</string>
@@ -2545,6 +2551,7 @@ Language: zh_CN
     <string name="comments_empty_list_filtered_trashed">无已移至回收站的评论</string>
     <string name="comments_empty_list_filtered_pending">无待审评论</string>
     <string name="comments_empty_list_filtered_approved">无已批准的评论</string>
+    <string name="button_skip">跳过</string>
     <string name="xmlrpc_missing_method_error">无法连接。服务器上没有所需的 XML-RPC 方法。</string>
     <string name="alignment_center">居中</string>
     <string name="post_format_video">视频</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-10 22:14:08+0000
+Translation-Revision-Date: 2022-03-25 09:54:07+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/3.0.0-alpha.2
 Language: zh_TW
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">此色彩組合可能讓人難以閱讀。 請嘗試更亮的背景顏色和/或較深的文字顏色。</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">此色彩組合可能讓人難以閱讀。 請嘗試更深的背景顏色和/或較亮的文字顏色。</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">無法插入媒體。\n點選以瞭解更多資訊。</string>
+    <string name="new_site_creation_intents_header_subtitle">請從下方清單選擇一個主題，或輸入你自己的主題</string>
+    <string name="new_site_creation_intents_header_title">你的網站主題為何？</string>
+    <string name="notification_channel_weekly_roundup_title">每週綜合整理</string>
+    <string name="my_site_dashboard_tab_title">首頁</string>
+    <string name="adding_cat">新增類別中</string>
     <string name="login_select_email_client">你使用哪個電子郵件應用程式？</string>
     <string name="login_error_xml_rpc_auth_error_communicating">與網站通訊時發生問題。 已傳回 HTTP 錯誤代碼 401。</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">這個網站似乎封鎖了 XML-RPC 呼叫 (錯誤代碼 401)。 如果嘗試登入失敗，請點選說明圖示，查看常見問題集。</string>
     <string name="login_error_xml_rpc_cannot_read_site">無法透過該 URL 讀取 WordPress 網站。 請點選說明圖示，查看常見問題集。</string>
     <string name="login_error_xml_rpc_services_disabled">這個網站尚未開啟 XML-RPC 服務</string>
-    <string name="my_site_menu_tab_title">選單</string>
-    <string name="my_site_dashboard_tab_title">控制台</string>
+    <string name="my_site_menu_tab_title">網站選單</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">你的搜尋包含 WordPress.com 網域不支援的字元。 允許使用以下字元：A–Z、a–z、0–9。</string>
     <string name="my_site_error_within_card_subtitle">請檢查你的網際網路連線並重新整理頁面。</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">前往統計資料</string>
@@ -701,7 +708,6 @@ Language: zh_TW
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; 已對你的文章按讚</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">已開啟可捲動的區塊選單。 請選取一個區塊。</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">已關閉可捲動的區塊選單。</string>
-    <string name="hpp_skip_button">跳過</string>
     <string name="hpp_choose_button">選擇</string>
     <string name="hpp_subtitle">選擇你喜愛的首頁版面配置。 你可於稍後加以編輯及自訂。</string>
     <string name="hpp_title">選擇一款設計</string>
@@ -1208,7 +1214,6 @@ Language: zh_TW
     <string name="gutenberg_native_image_caption_s">圖片說明。%s</string>
     <string name="gutenberg_native_hide_keyboard">隱藏鍵盤</string>
     <string name="gutenberg_native_help_icon">說明圖示</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">無法插入媒體。\n請點選以顯示選項。</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">按兩次即可復原上次變更</string>
     <string name="gutenberg_native_link_text">連結文字</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">按兩下以切換設定</string>
@@ -2545,6 +2550,7 @@ Language: zh_TW
     <string name="site_settings_advanced_header">進階</string>
     <string name="comments_empty_list_filtered_pending">無待審核的迴響</string>
     <string name="comments_empty_list_filtered_approved">沒有已核准的留言</string>
+    <string name="button_skip">略過</string>
     <string name="xmlrpc_missing_method_error">無法連結。伺服器缺少必要的 XML-RPC 方式。</string>
     <string name="post_format_status">狀態</string>
     <string name="post_format_video">影片</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-03-10 22:14:08+0000
+Translation-Revision-Date: 2022-03-25 09:54:07+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/3.0.0-alpha.2
 Language: zh_TW
 -->
 <resources>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a_a31656b3">此色彩組合可能讓人難以閱讀。 請嘗試更亮的背景顏色和/或較深的文字顏色。</string>
+    <string name="gutenberg_native_this_color_combination_may_be_hard_for_people_to_read_try_using_a">此色彩組合可能讓人難以閱讀。 請嘗試更深的背景顏色和/或較亮的文字顏色。</string>
+    <string name="gutenberg_native_failed_to_insert_media_tap_for_more_info">無法插入媒體。\n點選以瞭解更多資訊。</string>
+    <string name="new_site_creation_intents_header_subtitle">請從下方清單選擇一個主題，或輸入你自己的主題</string>
+    <string name="new_site_creation_intents_header_title">你的網站主題為何？</string>
+    <string name="notification_channel_weekly_roundup_title">每週綜合整理</string>
+    <string name="my_site_dashboard_tab_title">首頁</string>
+    <string name="adding_cat">新增類別中</string>
     <string name="login_select_email_client">你使用哪個電子郵件應用程式？</string>
     <string name="login_error_xml_rpc_auth_error_communicating">與網站通訊時發生問題。 已傳回 HTTP 錯誤代碼 401。</string>
     <string name="login_error_xml_rpc_cannot_read_site_auth_required">這個網站似乎封鎖了 XML-RPC 呼叫 (錯誤代碼 401)。 如果嘗試登入失敗，請點選說明圖示，查看常見問題集。</string>
     <string name="login_error_xml_rpc_cannot_read_site">無法透過該 URL 讀取 WordPress 網站。 請點選說明圖示，查看常見問題集。</string>
     <string name="login_error_xml_rpc_services_disabled">這個網站尚未開啟 XML-RPC 服務</string>
-    <string name="my_site_menu_tab_title">選單</string>
-    <string name="my_site_dashboard_tab_title">控制台</string>
+    <string name="my_site_menu_tab_title">網站選單</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">你的搜尋包含 WordPress.com 網域不支援的字元。 允許使用以下字元：A–Z、a–z、0–9。</string>
     <string name="my_site_error_within_card_subtitle">請檢查你的網際網路連線並重新整理頁面。</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">前往統計資料</string>
@@ -701,7 +708,6 @@ Language: zh_TW
     <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; 已對你的文章按讚</string>
     <string name="gutenberg_native_scrollable_block_menu_opened_select_a_block">已開啟可捲動的區塊選單。 請選取一個區塊。</string>
     <string name="gutenberg_native_scrollable_block_menu_closed">已關閉可捲動的區塊選單。</string>
-    <string name="hpp_skip_button">跳過</string>
     <string name="hpp_choose_button">選擇</string>
     <string name="hpp_subtitle">選擇你喜愛的首頁版面配置。 你可於稍後加以編輯及自訂。</string>
     <string name="hpp_title">選擇一款設計</string>
@@ -1208,7 +1214,6 @@ Language: zh_TW
     <string name="gutenberg_native_image_caption_s">圖片說明。%s</string>
     <string name="gutenberg_native_hide_keyboard">隱藏鍵盤</string>
     <string name="gutenberg_native_help_icon">說明圖示</string>
-    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options">無法插入媒體。\n請點選以顯示選項。</string>
     <string name="gutenberg_native_double_tap_to_undo_last_change">按兩次即可復原上次變更</string>
     <string name="gutenberg_native_link_text">連結文字</string>
     <string name="gutenberg_native_double_tap_to_toggle_setting">按兩下以切換設定</string>
@@ -2545,6 +2550,7 @@ Language: zh_TW
     <string name="site_settings_advanced_header">進階</string>
     <string name="comments_empty_list_filtered_pending">無待審核的迴響</string>
     <string name="comments_empty_list_filtered_approved">沒有已核准的留言</string>
+    <string name="button_skip">略過</string>
     <string name="xmlrpc_missing_method_error">無法連結。伺服器缺少必要的 XML-RPC 方式。</string>
     <string name="post_format_status">狀態</string>
     <string name="post_format_video">影片</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
@@ -87,7 +88,9 @@ class StatsViewModelTest : BaseUnitTest() {
         viewModel.onSectionSelected(INSIGHTS)
 
         verify(statsSectionManager).setSelectedSection(INSIGHTS)
-        verify(analyticsTracker).track(STATS_INSIGHTS_ACCESSED)
+        /* First one is default insights section selection which is set when no value is passed to vm for
+           initial section */
+        verify(analyticsTracker, times(2)).track(STATS_INSIGHTS_ACCESSED)
     }
 
     @Test

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -222,28 +222,17 @@ REPOSITORY_NAME = 'WordPress-Android'
   lane :update_wordpress_appstore_strings do |options|
     metadata_folder = File.join(Dir.pwd, '..', 'WordPress', 'metadata')
 
+    # <key in po file> => <path to txt file to read the content from>
     files = {
       release_note: File.join(metadata_folder, 'release_notes.txt'),
       release_note_short: File.join(metadata_folder, 'release_notes_short.txt'),
       play_store_promo: File.join(metadata_folder, 'short_description.txt'),
       play_store_desc: File.join(metadata_folder, 'full_description.txt'),
       play_store_app_title: File.join(metadata_folder, 'title.txt'),
-      play_store_screenshot_1: File.join(metadata_folder, 'screenshot_1.txt'),
-      play_store_screenshot_2: File.join(metadata_folder, 'screenshot_2.txt'),
-      play_store_screenshot_3: File.join(metadata_folder, 'screenshot_3.txt'),
-      play_store_screenshot_4: File.join(metadata_folder, 'screenshot_4.txt'),
-      play_store_screenshot_5: File.join(metadata_folder, 'screenshot_5.txt'),
-      play_store_screenshot_6: File.join(metadata_folder, 'screenshot_6.txt'),
-      play_store_screenshot_7: File.join(metadata_folder, 'screenshot_7.txt'),
-
-      enhanced_app_store_screenshot_1: File.join(metadata_folder, 'enhanced_screenshot_1.html'),
-      enhanced_app_store_screenshot_2: File.join(metadata_folder, 'enhanced_screenshot_2.html'),
-      enhanced_app_store_screenshot_3: File.join(metadata_folder, 'enhanced_screenshot_3.html'),
-      enhanced_app_store_screenshot_4: File.join(metadata_folder, 'enhanced_screenshot_4.html'),
-      enhanced_app_store_screenshot_5: File.join(metadata_folder, 'enhanced_screenshot_5.html'),
-      enhanced_app_store_screenshot_6: File.join(metadata_folder, 'enhanced_screenshot_6.html'),
-      enhanced_app_store_screenshot_7: File.join(metadata_folder, 'enhanced_screenshot_7.html'),
     }
+    files.merge!((1..9).map do |n|
+      [:"play_store_screenshot_#{n}", File.join(metadata_folder, "screenshot_#{n}.txt")]
+    end.to_h)
 
     android_update_metadata_source(
       po_file_path: File.join(metadata_folder, 'PlayStoreStrings.po'),

--- a/fastlane/ScreenshotFastfile
+++ b/fastlane/ScreenshotFastfile
@@ -124,23 +124,10 @@ platform :android do
   #####################################################################################
   desc "Downloads translated promo strings from the translation system"
   lane :download_promo_strings do |options|
-    files = {
-      "play_store_screenshot_1" => {desc: "play_store_screenshot_1.txt"},
-      "play_store_screenshot_2" => {desc: "play_store_screenshot_2.txt"},
-      "play_store_screenshot_3" => {desc: "play_store_screenshot_3.txt"},
-      "play_store_screenshot_4" => {desc: "play_store_screenshot_4.txt"},
-      "play_store_screenshot_5" => {desc: "play_store_screenshot_5.txt"},
-      "play_store_screenshot_6" => {desc: "play_store_screenshot_6.txt"},
-      "play_store_screenshot_7" => {desc: "play_store_screenshot_7.txt"},
-
-      "enhanced_app_store_screenshot_1" => {desc: "play_store_screenshot_1.html"},
-      "enhanced_app_store_screenshot_2" => {desc: "play_store_screenshot_2.html"},
-      "enhanced_app_store_screenshot_3" => {desc: "play_store_screenshot_3.html"},
-      "enhanced_app_store_screenshot_4" => {desc: "play_store_screenshot_4.html"},
-      "enhanced_app_store_screenshot_5" => {desc: "play_store_screenshot_5.html"},
-      "enhanced_app_store_screenshot_6" => {desc: "play_store_screenshot_6.html"},
-      "enhanced_app_store_screenshot_7" => {desc: "play_store_screenshot_7.html"},
-    }
+    # "<key in .po file>" => { desc: "<name of txt file>" }
+    files = (1..9).map do |n|
+      ["play_store_screenshot_#{n}", { desc: "play_store_screenshot_#{n}.txt" }]
+    end.to_h
 
     locales = ALL_LOCALES
       .select { |hsh| hsh[:promo_config] != false }
@@ -150,7 +137,8 @@ platform :android do
       target_files: files,
       locales: locales,
       source_locale: "en-US",
-      download_path: File.join(Dir.pwd, "/playstoreres/metadata"))
+      download_path: File.join(Dir.pwd, "/playstoreres/metadata")
+    )
   end
 
 

--- a/version.properties
+++ b/version.properties
@@ -1,9 +1,9 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=19.5-rc-1
-versionCode=1184
+versionName=19.5-rc-2
+versionCode=1186
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
-alpha.versionName=alpha-349
-alpha.versionCode=1185
+alpha.versionName=alpha-350
+alpha.versionCode=1187


### PR DESCRIPTION
Merging the release branch after doing a new beta.

## Usual stuff:

 * Changes from fix #16169 
 * Changes from fix #16171
 * Latest `strings.xml` from GlotPress
 * Version bump in `version.properties`

## Screenshot copies

Since the new screenshots for WPAndroid just landed in pbArwn-46A-p2, I've decided to also include the new copies from those English screenshots in this PR, in order to have those be imported in GlotPress and start being translated ASAP.

Even if we will only update the English screenshots during release of 19.5 and plan to localize the new screenshots only on the next sprint (once we get time to update the UITests to generate new raw screenshots and the `fastlane/screenshots.json` to update the image compositor instructions accordingly), I figured it would be useful to have the translation for those as early as possible to have everything needed when we start working on them starting next sprint.