### PR TITLE
My Site Dashboard: Tabs Add feature flags for default tab experiment

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -121,6 +121,8 @@ android {
         buildConfigField "boolean", "SITE_INTENT_QUESTION", "false"
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
+        buildConfigField "boolean", "MY_SITE_DEFAULT_TAB_EXPERIMENT", "false"
+        buildConfigField "boolean", "MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDefaultTabExperimentFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDefaultTabExperimentFeatureConfig.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.MySiteDefaultTabExperimentFeatureConfig.Companion.MY_SITE_DEFAULT_TAB_EXPERIMENT
+import javax.inject.Inject
+
+/**
+ * Configuration of the 'My Site - Default Tab Experiment' - will guard the experiment
+ */
+@Feature(
+        remoteField = MY_SITE_DEFAULT_TAB_EXPERIMENT,
+        defaultValue = false
+)
+class MySiteDefaultTabExperimentFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.MY_SITE_DEFAULT_TAB_EXPERIMENT,
+        MY_SITE_DEFAULT_TAB_EXPERIMENT
+) {
+    companion object {
+        const val MY_SITE_DEFAULT_TAB_EXPERIMENT = "my_site_default_tab_experiment"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDefaultTabExperimentVariationDashboardFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDefaultTabExperimentVariationDashboardFeatureConfig.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.MySiteDefaultTabExperimentVariationDashboardFeatureConfig.Companion.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD
+import javax.inject.Inject
+
+/**
+ * Configuration of the 'My Site - Default tab Experiment' -
+ * Identifies if this is variant Dashboard with a isEnabled=true, and indicates site_menu isEnabled=false
+ */
+@Feature(
+        remoteField = MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD,
+        defaultValue = false
+)
+class MySiteDefaultTabExperimentVariationDashboardFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD,
+        MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD
+) {
+    companion object {
+        const val MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD = "my_site_default_tab_experiment_variant_dashboard"
+    }
+}


### PR DESCRIPTION
Parent #16007 

This PR adds support for the My Site Default Tab experiment by adding the following feature flags:
MySiteDefaultTabExperimentVariationDashboardFeatureConfig
MySiteDefaultTabExperimentFeatureConfig

<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/160181818-dcadc847-6b5e-4866-8433-c5dd14f315b6.png">

To test:
1. Launch the app.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
3. Notice that `MySiteDefaultTabExperimentVariationDashboardFeatureConfig` and `MySiteDefaultTabExperimentFeatureConfig` exist under `remote features` section.

## Regression Notes
1. Potential unintended areas of impact 🟢
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢
3. What automated tests I added (or what prevented me from doing so) 🟢

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
