### PR TITLE
My Site Dashboard: Tabs - Assign default tab variant and save to app prefs

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -121,6 +121,8 @@ android {
         buildConfigField "boolean", "SITE_INTENT_QUESTION", "false"
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
+        buildConfigField "boolean", "MY_SITE_DEFAULT_TAB_EXPERIMENT", "false"
+        buildConfigField "boolean", "MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.viewmodel.Event
@@ -13,7 +14,8 @@ import javax.inject.Inject
 class LoginEpilogueViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val buildConfigWrapper: BuildConfigWrapper,
-    private val siteStore: SiteStore
+    private val siteStore: SiteStore,
+    private val mySiteDefaultTabExperiment: MySiteDefaultTabExperiment
 ) : ViewModel() {
     private val _navigationEvents = MediatorLiveData<Event<LoginNavigationEvents>>()
     val navigationEvents: LiveData<Event<LoginNavigationEvents>> = _navigationEvents
@@ -28,6 +30,10 @@ class LoginEpilogueViewModel @Inject constructor(
 
     fun onContinue() {
         if (!siteStore.hasSite()) handleNoSitesFound() else handleSitesFound()
+    }
+
+    fun checkAndSetVariantForMySiteDefaultTabExperiment() {
+        mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
     }
 
     private fun handleNoSitesFound() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -172,8 +172,8 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-
         if (savedInstanceState == null) {
+            mParentViewModel.checkAndSetVariantForMySiteDefaultTabExperiment();
             AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_EPILOGUE_VIEWED);
             mUnifiedLoginTracker.track(Step.SUCCESS);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1263,6 +1263,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     // We'll handle it in onAccountChanged so we know we have
                     // updated account info.
                     AppPrefs.setShouldTrackMagicLinkSignup(true);
+                    mViewModel.checkAndSetVariantForMySiteDefaultTabExperiment();
                     mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
                     if (mJetpackConnectSource != null) {
                         ActivityLauncher.continueJetpackConnect(this, mJetpackConnectSource, getSelectedSite());

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -33,13 +33,6 @@ class MySiteDefaultTabExperiment @Inject constructor(
     private fun setExperimentVariant(variant: MySiteTabExperimentVariant) {
         appPrefsWrapper.setMySiteDefaultTabExperimentVariant(variant.label)
     }
-
-    fun getExperimentVariantForTracking() =
-            mapOf(DEFAULT_TAB_EXPERIMENT to appPrefsWrapper.getMySiteDefaultTabExperimentVariant())
-
-    companion object {
-        private const val DEFAULT_TAB_EXPERIMENT = "default_tab_experiment"
-    }
 }
 enum class MySiteTabExperimentVariant(val label: String) {
     NONEXISTENT(MySiteTabExperimentVariant.VARIANT_NONEXISTENT),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -1,0 +1,64 @@
+package org.wordpress.android.ui.mysite.tabs
+
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
+import org.wordpress.android.util.config.MySiteDefaultTabExperimentFeatureConfig
+import org.wordpress.android.util.config.MySiteDefaultTabExperimentVariationDashboardFeatureConfig
+import javax.inject.Inject
+
+class MySiteDefaultTabExperiment @Inject constructor(
+    private val mySiteDefaultTabExperimentFeatureConfig: MySiteDefaultTabExperimentFeatureConfig,
+    private val mySiteDefaultTabExperimentVariationDashboardFeatureConfig:
+    MySiteDefaultTabExperimentVariationDashboardFeatureConfig,
+    private val mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig,
+    private val appPrefsWrapper: AppPrefsWrapper
+) {
+    fun checkAndSetVariantIfNeeded() {
+        if (isExperimentRunning()) {
+            if (isVariantNotAssigned()) {
+                when (mySiteDefaultTabExperimentVariationDashboardFeatureConfig.isDashboardVariant()) {
+                    true -> setExperimentVariant(MySiteTabExperimentVariant.DASHBOARD)
+                    false -> setExperimentVariant(MySiteTabExperimentVariant.SITE_MENU)
+                }
+            }
+        }
+    }
+
+    private fun isExperimentRunning() =
+            mySiteDashboardTabsFeatureConfig.isEnabled() && mySiteDefaultTabExperimentFeatureConfig.isEnabled()
+
+    private fun isVariantNotAssigned() =
+            appPrefsWrapper.getMySiteDefaultTabExperimentVariant() == MySiteTabExperimentVariant.NONEXISTENT.label
+
+    private fun setExperimentVariant(variant: MySiteTabExperimentVariant) {
+        appPrefsWrapper.setMySiteDefaultTabExperimentVariant(variant.label)
+    }
+
+    fun getExperimentVariantForTracking() =
+            mapOf(DEFAULT_TAB_EXPERIMENT to appPrefsWrapper.getMySiteDefaultTabExperimentVariant())
+
+    companion object {
+        private const val DEFAULT_TAB_EXPERIMENT = "default_tab_experiment"
+    }
+}
+enum class MySiteTabExperimentVariant(val label: String) {
+    NONEXISTENT(MySiteTabExperimentVariant.VARIANT_NONEXISTENT),
+    DASHBOARD(MySiteTabExperimentVariant.VARIANT_DASHBOARD),
+    SITE_MENU(MySiteTabExperimentVariant.VARIANT_SITE_MENU);
+
+    override fun toString() = label
+
+    companion object {
+        private const val VARIANT_NONEXISTENT = "nonexistent"
+        private const val VARIANT_DASHBOARD = "dashboard"
+        private const val VARIANT_SITE_MENU = "site_menu"
+
+        @JvmStatic
+        fun fromString(label: String) = when {
+            NONEXISTENT.label == label -> NONEXISTENT
+            DASHBOARD.label == label -> DASHBOARD
+            SITE_MENU.label == label -> SITE_MENU
+            else -> NONEXISTENT
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -167,7 +167,10 @@ public class AppPrefs {
         PINNED_DYNAMIC_CARD,
         BLOGGING_REMINDERS_SHOWN,
         SHOULD_SCHEDULE_CREATE_SITE_NOTIFICATION,
-        SHOULD_SHOW_WEEKLY_ROUNDUP_NOTIFICATION
+        SHOULD_SHOW_WEEKLY_ROUNDUP_NOTIFICATION,
+
+        // Used to store the variant for the my site default tab experiment
+        MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT
     }
 
     /**
@@ -1339,5 +1342,16 @@ public class AppPrefs {
             capabilities.add(JetpackCapability.Companion.fromString(item));
         }
         return capabilities;
+    }
+
+    public static void setMySiteDefaultTabExperimentVariant(String variant) {
+        setString(DeletablePrefKey.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT, variant);
+    }
+
+    public static String getMySiteDefaultTabExperimentVariant() {
+        return getString(
+                DeletablePrefKey.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT,
+                "nonexistent"
+        );
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -21,6 +21,7 @@ import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
+import org.wordpress.android.ui.mysite.tabs.MySiteTabExperimentVariant;
 import org.wordpress.android.ui.posts.AuthorFilterSelection;
 import org.wordpress.android.ui.posts.PostListViewLayoutType;
 import org.wordpress.android.ui.reader.tracker.ReaderTab;
@@ -1351,7 +1352,7 @@ public class AppPrefs {
     public static String getMySiteDefaultTabExperimentVariant() {
         return getString(
                 DeletablePrefKey.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT,
-                "nonexistent"
+                MySiteTabExperimentVariant.NONEXISTENT.getLabel()
         );
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -212,6 +212,10 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun setLastSkippedQuickStartTask(task: QuickStartTask) = AppPrefs.setLastSkippedQuickStartTask(task)
 
+    fun setMySiteDefaultTabExperimentVariant(variant: String) = AppPrefs.setMySiteDefaultTabExperimentVariant(variant)
+
+    fun getMySiteDefaultTabExperimentVariant() = AppPrefs.getMySiteDefaultTabExperimentVariant()
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDefaultTabExperimentFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDefaultTabExperimentFeatureConfig.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.MySiteDefaultTabExperimentFeatureConfig.Companion.MY_SITE_DEFAULT_TAB_EXPERIMENT
+import javax.inject.Inject
+
+/**
+ * Configuration of the 'My Site - Default Tab Experiment' - will guard the experiment
+ */
+@Feature(
+        remoteField = MY_SITE_DEFAULT_TAB_EXPERIMENT,
+        defaultValue = false
+)
+class MySiteDefaultTabExperimentFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.MY_SITE_DEFAULT_TAB_EXPERIMENT,
+        MY_SITE_DEFAULT_TAB_EXPERIMENT
+) {
+    companion object {
+        const val MY_SITE_DEFAULT_TAB_EXPERIMENT = "my_site_default_tab_experiment"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDefaultTabExperimentVariationDashboardFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDefaultTabExperimentVariationDashboardFeatureConfig.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.MySiteDefaultTabExperimentVariationDashboardFeatureConfig.Companion.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD
+import javax.inject.Inject
+
+/**
+ * Configuration of the 'My Site - Default tab Experiment' -
+ * Identifies if this is variant Dashboard with a isEnabled=true, and indicates site_menu isEnabled=false
+ */
+@Feature(
+        remoteField = MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD,
+        defaultValue = false
+)
+class MySiteDefaultTabExperimentVariationDashboardFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD,
+        MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD
+) {
+    companion object {
+        const val MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD = "my_site_default_tab_experiment_variant_dashboard"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDefaultTabExperimentVariationDashboardFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDefaultTabExperimentVariationDashboardFeatureConfig.kt
@@ -20,6 +20,8 @@ class MySiteDefaultTabExperimentVariationDashboardFeatureConfig @Inject construc
         BuildConfig.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD,
         MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD
 ) {
+    fun isDashboardVariant(): Boolean = isEnabled()
+
     companion object {
         const val MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD = "my_site_default_tab_experiment_variant_dashboard"
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.main.MainActionListItem.ActionType.NO_ACTION
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.main.MainFabUiState
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
+import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider
 import org.wordpress.android.util.BuildConfigWrapper
@@ -45,6 +46,7 @@ class WPMainActivityViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val quickStartRepository: QuickStartRepository,
+    private val mySiteDefaultTabExperiment: MySiteDefaultTabExperiment,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {
     private var isStarted = false
@@ -221,6 +223,10 @@ class WPMainActivityViewModel @Inject constructor(
         appPrefsWrapper.setMainPageIndex(mySitePosition)
         delay(SWITCH_TO_MY_SITE_DELAY)
         _switchToMySite.value = Event(Unit)
+    }
+
+    fun checkAndSetVariantForMySiteDefaultTabExperiment() {
+        mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
     }
 
     fun onResume(site: SiteModel?, isOnMySitePageWithValidSite: Boolean) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.accounts
 
+import com.nhaarman.mockitokotlin2.atLeastOnce
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -8,6 +10,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.BuildConfigWrapper
 
@@ -17,10 +20,11 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
     @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var siteStore: SiteStore
+    @Mock lateinit var mySiteDefaultTabExperiment: MySiteDefaultTabExperiment
 
     @Before
     fun setUp() {
-        viewModel = LoginEpilogueViewModel(appPrefsWrapper, buildConfigWrapper, siteStore)
+        viewModel = LoginEpilogueViewModel(appPrefsWrapper, buildConfigWrapper, siteStore, mySiteDefaultTabExperiment)
     }
 
     @Test
@@ -254,6 +258,13 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
         viewModel.onContinue()
 
         assertThat(navigationEvents.last()).isInstanceOf(LoginNavigationEvents.ShowNoJetpackSites::class.java)
+    }
+
+    @Test
+    fun `given my site default tab experiment, when requested, then check and set for variant is executed `() {
+        viewModel.checkAndSetVariantForMySiteDefaultTabExperiment()
+
+        verify(mySiteDefaultTabExperiment, atLeastOnce()).checkAndSetVariantIfNeeded()
     }
 
     private data class Observers(val navigationEvents: List<LoginNavigationEvents>)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
@@ -1,0 +1,86 @@
+package org.wordpress.android.ui.mysite
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.atLeastOnce
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
+import org.wordpress.android.ui.mysite.tabs.MySiteTabExperimentVariant
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
+import org.wordpress.android.util.config.MySiteDefaultTabExperimentFeatureConfig
+import org.wordpress.android.util.config.MySiteDefaultTabExperimentVariationDashboardFeatureConfig
+
+@RunWith(MockitoJUnitRunner::class)
+class MySiteDefaultTabExperimentTest  : BaseUnitTest() {
+    @Mock lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
+    @Mock lateinit var mySiteDefaultTabExperimentFeatureConfig: MySiteDefaultTabExperimentFeatureConfig
+    @Mock lateinit var mySiteDefaultTabExperimentVariationDashboardFeatureConfig:
+            MySiteDefaultTabExperimentVariationDashboardFeatureConfig
+    @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
+
+    private lateinit var mySiteDefaultTabExperiment: MySiteDefaultTabExperiment
+
+    @Before
+    fun setUp() {
+        init()
+    }
+
+    fun init() {
+        mySiteDefaultTabExperiment = MySiteDefaultTabExperiment(
+                mySiteDefaultTabExperimentFeatureConfig,
+                mySiteDefaultTabExperimentVariationDashboardFeatureConfig,
+                mySiteDashboardTabsFeatureConfig,
+                appPrefsWrapper
+        )
+    }
+
+    @Test
+    fun `given my site tabs feature flag is enabled, when check and set variant, then app prefs is not set`() {
+        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(false)
+
+        mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
+
+        verify(appPrefsWrapper, never()).setMySiteDefaultTabExperimentVariant(any())
+    }
+
+    @Test
+    fun `given default tab experiment flag is not enabled, when check and set variant, then app prefs is not set`() {
+        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(false)
+
+        mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
+
+        verify(appPrefsWrapper, never()).setMySiteDefaultTabExperimentVariant(any())
+    }
+
+    @Test
+    fun `given experiment is running, when variant is not assigned, then app prefs is set`() {
+        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(appPrefsWrapper.getMySiteDefaultTabExperimentVariant())
+                .thenReturn(MySiteTabExperimentVariant.NONEXISTENT.label)
+        mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
+
+        verify(appPrefsWrapper, atLeastOnce()).setMySiteDefaultTabExperimentVariant(any())
+    }
+
+    @Test
+    fun `given experiment is running, when variant is already set, then app prefs is not reset`() {
+        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(appPrefsWrapper.getMySiteDefaultTabExperimentVariant())
+                .thenReturn(MySiteTabExperimentVariant.DASHBOARD.label)
+
+        mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
+
+        verify(appPrefsWrapper, never()).setMySiteDefaultTabExperimentVariant(any())
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
@@ -19,7 +19,7 @@ import org.wordpress.android.util.config.MySiteDefaultTabExperimentFeatureConfig
 import org.wordpress.android.util.config.MySiteDefaultTabExperimentVariationDashboardFeatureConfig
 
 @RunWith(MockitoJUnitRunner::class)
-class MySiteDefaultTabExperimentTest  : BaseUnitTest() {
+class MySiteDefaultTabExperimentTest : BaseUnitTest() {
     @Mock lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
     @Mock lateinit var mySiteDefaultTabExperimentFeatureConfig: MySiteDefaultTabExperimentFeatureConfig
     @Mock lateinit var mySiteDefaultTabExperimentVariationDashboardFeatureConfig:

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -267,7 +267,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         startViewModelWithDefaultParameters()
         viewModel.onTooltipTapped(initSite(hasFullAccessToContent = true))
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
-        assertThat(fabUiState?.isFabTooltipVisible).isFalse()
+        assertThat(fabUiState?.isFabTooltipVisible).isFalse
     }
 
     @Test
@@ -276,7 +276,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(true)
         viewModel.onFabClicked(initSite(hasFullAccessToContent = false))
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
-        assertThat(fabUiState?.isFabTooltipVisible).isFalse()
+        assertThat(fabUiState?.isFabTooltipVisible).isFalse
     }
 
     @Test
@@ -285,7 +285,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(true)
         viewModel.onFabClicked(initSite(hasFullAccessToContent = true))
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
-        assertThat(fabUiState?.isFabTooltipVisible).isFalse()
+        assertThat(fabUiState?.isFabTooltipVisible).isFalse
     }
 
     @Test
@@ -293,7 +293,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         startViewModelWithDefaultParameters()
         viewModel.onFabLongPressed(initSite(hasFullAccessToContent = true))
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
-        assertThat(fabUiState?.isFabTooltipVisible).isFalse()
+        assertThat(fabUiState?.isFabTooltipVisible).isFalse
     }
 
     @Test
@@ -302,7 +302,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         activeTask.value = PUBLISH_POST
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
 
-        assertThat(fabUiState?.isFocusPointVisible).isTrue()
+        assertThat(fabUiState?.isFocusPointVisible).isTrue
     }
 
     @Test
@@ -311,7 +311,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         activeTask.value = UPDATE_SITE_TITLE
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
 
-        assertThat(fabUiState?.isFocusPointVisible).isFalse()
+        assertThat(fabUiState?.isFocusPointVisible).isFalse
     }
 
     @Test
@@ -320,7 +320,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         activeTask.value = null
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
 
-        assertThat(fabUiState?.isFocusPointVisible).isFalse()
+        assertThat(fabUiState?.isFocusPointVisible).isFalse
     }
 
     @Test
@@ -354,7 +354,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `bottom sheet does not show quick start focus point by default`() {
         startViewModelWithDefaultParameters()
         viewModel.onFabClicked(site = initSite(hasFullAccessToContent = true))
-        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isTrue()
+        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isTrue
         assertThat(viewModel.mainActions.value?.any { it is CreateAction && it.showQuickStartFocusPoint }).isEqualTo(
                 false
         )
@@ -365,7 +365,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         startViewModelWithDefaultParameters()
         activeTask.value = PUBLISH_POST
         viewModel.onFabClicked(site = initSite(hasFullAccessToContent = true))
-        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isTrue()
+        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isTrue
         assertThat(viewModel.mainActions.value?.any { it is CreateAction && it.showQuickStartFocusPoint }).isEqualTo(
                 true
         )
@@ -398,7 +398,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         startViewModelWithDefaultParameters()
         activeTask.value = PUBLISH_POST
         viewModel.onFabClicked(site = initSite(hasFullAccessToContent = true))
-        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isTrue()
+        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isTrue
         assertThat(viewModel.mainActions.value?.any { it is CreateAction && it.showQuickStartFocusPoint }).isEqualTo(
                 true
         )
@@ -426,7 +426,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         viewModel.onFabClicked(site = initSite(hasFullAccessToContent = true))
         assertThat(viewModel.createAction.value).isNull()
         assertThat(viewModel.mainActions.value?.size).isEqualTo(4) // 3 options plus NO_ACTION, first in list
-        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isTrue()
+        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isTrue
     }
 
     @Test
@@ -435,7 +435,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         viewModel.onFabClicked(site = initSite(hasFullAccessToContent = false))
         assertThat(viewModel.createAction.value).isNull()
         assertThat(viewModel.mainActions.value?.size).isEqualTo(3) // 2 options plus NO_ACTION, first in list
-        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isTrue()
+        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isTrue
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.atLeastOnce
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
@@ -32,6 +33,7 @@ import org.wordpress.android.ui.main.MainActionListItem.ActionType.NO_ACTION
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.main.MainFabUiState
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
+import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncement
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementItem
@@ -54,6 +56,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
     @Mock lateinit var quickStartRepository: QuickStartRepository
+    @Mock lateinit var mySiteDefaultTabExperiment: MySiteDefaultTabExperiment
 
     private val featureAnnouncement = FeatureAnnouncement(
             "14.7",
@@ -90,6 +93,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
                 appPrefsWrapper,
                 analyticsTrackerWrapper,
                 quickStartRepository,
+                mySiteDefaultTabExperiment,
                 NoDelayCoroutineDispatcher()
         )
         viewModel.onFeatureAnnouncementRequested.observeForever(
@@ -653,6 +657,15 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         )
 
         assertThat(viewModel.mainActions.value!!.map { it.actionType }).isEqualTo(expectedOrder)
+    }
+
+    @Test
+    fun `given my site default tab experiment, when requested, then check and set for variant is executed `() {
+        startViewModelWithDefaultParameters()
+
+        viewModel.checkAndSetVariantForMySiteDefaultTabExperiment()
+
+        verify(mySiteDefaultTabExperiment, atLeastOnce()).checkAndSetVariantIfNeeded()
     }
 
     private fun startViewModelWithDefaultParameters(


### PR DESCRIPTION
Parent #16007

This PR focuses on:
- Retrieval of the My Site Default Tab experiment variant from the remote config field
- Setting the variant to App Prefs

The `MySiteDefaultTabExperiment` class manages the experiment, assignment and retrieval. 
The variant gets assigned to users who Login or Signup. `WPMainActivityViewModel` and `LoginEpilogueViewModel` makes the call out to `MySiteDefaultTabExperiment` for sign up and login scenarios respectively.

In subsequent PRs, the variant assigned will be retrieved from appPrefs for tracking purposes and for determining which tab to set as the default tab in the My Site view.

**Merge Instructions**
~~1. Ensure that PR #16175  has been merged~~
~~2. Remove "Not ready for merge" label~~
3. Merge as normal

**To test:**
**Pre-req:** 
 There are no "in-app" visual checks for this PR, so please download the branch, build locally and install to emulator.  
Note: Please don't manually override the values for `MySiteDefaultTabExperimentVariationDashboardFeatureConfig` and `MySiteDefaultTabExperimentFeatureConfig` 

**Test A - Login email/psw**
- Launch the app
- Verify AppPrefs does not contain `MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT`:
  - Open Device File Explorer
  - Navigate to data -> data -> org.wordpress.android.prealpha -> shared_prefs
  - Double click on `org.wordpress.android.prealpha_preferences.xml` to open the file
- Navigate to`My Site` -> `Me` -> `App Settings` -> `Debug settings`.
- Enable `MySiteDashboardTabsFeatureConfig`
- Restart the app
- Logout
- Login using email/psw combination
- Verify AppPrefs contains `MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT` (The variant value will either be dashboard or site_menu - it's set by Firebase)
- Logout


**Test B - Login using Google**
- If you have not logged out, do so before starting
- Verify AppPrefs does not contain `MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT` (see instructions in test A)
- If not enabled, please enable `MySiteDashboardTabsFeatureConfig`, then restart the app and logout
- Login using Google
- Verify AppPrefs contains `MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT` 
- Logout

**Test C - Login using magic link**
- If you have not logged out, do so before starting
- Verify AppPrefs does not contain `MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT` (see instructions in test A)
- If not enabled, please enable `MySiteDashboardTabsFeatureConfig`, then restart the app and logout
- Login using email
- On password entry view, tap the "Get a login link by email"
- Open email, find the email, and follow the directions to login
- Verify AppPrefs contains `MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT` 
- Logout

**Test D - Sign up**
- If you have not logged out, do so before starting
- Verify AppPrefs does not contain `MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT` (see instructions in test A)
- If not enabled, please enable `MySiteDashboardTabsFeatureConfig`, then restart the app and logout
- Follow instructions to sign up
- You should be shown the My Site no sites view
- Verify AppPrefs contains `MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT` 
- Logout


## Regression Notes
1. Potential unintended areas of impact
A default tab variant is not assigned to a user who signed up or logged in

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit testing

3. What automated tests I added (or what prevented me from doing so)
`MySIteDefaultTabExperimentTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
