### PR TITLE
Fix "Multiple substitutions specified in non-positional format" errors

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -366,7 +366,7 @@
     <!-- post version sync conflict dialog -->
     <string name="dialog_confirm_load_remote_post_title">Resolve sync conflict</string>
     <string name="dialog_confirm_load_remote_post_body">This post has two versions that are in conflict. Select the version you would like to discard.\n\n</string>
-    <string name="dialog_confirm_load_remote_post_body_2">Local\nSaved on %s\n\nWeb\nSaved on %s\n</string>
+    <string name="dialog_confirm_load_remote_post_body_2">Local\nSaved on %1$s\n\nWeb\nSaved on %2$s\n</string>
     <string name="dialog_confirm_load_remote_post_discard_local">Discard Local</string>
     <string name="dialog_confirm_load_remote_post_discard_web">Discard Web</string>
     <string name="toast_conflict_updating_post">Updating post</string>
@@ -378,7 +378,7 @@
     <string name="dialog_confirm_autosave_title">Which version would you like to edit?</string>
     <string name="dialog_confirm_autosave_body_first_part">You recently made changes to this post but didn\'t save them. Choose a version to load:\n\n</string>
     <string name="dialog_confirm_autosave_body_first_part_for_page">You recently made changes to this page but didn\'t save them. Choose a version to load:\n\n</string>
-    <string name="dialog_confirm_autosave_body_second_part">From this app\nSaved on %s\n\nFrom another device\nSaved on %s\n</string>
+    <string name="dialog_confirm_autosave_body_second_part">From this app\nSaved on %1$s\n\nFrom another device\nSaved on %2$s\n</string>
     <string name="dialog_confirm_autosave_restore_button">The version from another device</string>
     <string name="dialog_confirm_autosave_dont_restore_button">The version from this app</string>
 
@@ -427,7 +427,7 @@
     <string name="comment_delete_talkback">Comment deleted</string>
     <string name="comment_spam_talkback">Comment marked as spam</string>
     <string name="comment_unspam_talkback">Comment marked as not spam</string>
-    <string name="comment_title">%s on %s</string>
+    <string name="comment_title">%1$s on %2$s</string>
     <string name="comment_read_source_post">Read the source post</string>
     <string name="comment_toast_err_share_intent">Unable to share</string>
     <string name="comment_share_link_via">Share via</string>
@@ -1096,7 +1096,7 @@
     <string name="activity_log_activity_type_empty_title">No activities available</string>
     <string name="activity_log_activity_type_empty_subtitle">No activities recorded in the selected date range.</string>
     <string name="activity_log_activity_type_filter_no_item_selected_content_description">Activity Type filter</string>
-    <string name="activity_log_activity_type_filter_single_item_selected_content_description">%s (showing %s items)</string>
+    <string name="activity_log_activity_type_filter_single_item_selected_content_description">%1$s (showing %2$s items)</string>
     <string name="activity_log_activity_type_filter_multiple_items_selected_content_description">Activity Type filter (%s types selected)</string>
     <string name="activity_log_multisite_message">Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores. For more information %1$s.</string>
     <string name="activity_log_visit_our_documentation_page">visit our documentation page</string>
@@ -1146,7 +1146,7 @@
     <string name="scan_scanning_is_initial_description">Welcome to Jetpack Scan, we are taking a first look at your site now and the results will be with you soon.</string>
     <string name="scan_provisioning_description">Welcome to Jetpack Scan! We\'re scoping out your site, setting up to do a full scan. We\'ll let you know if we spot any issues that might impact a scan, then your first full scan will start.</string>
     <string name="scan_idle_manual_scan_description">To review your site again run a manual scan, or wait for Jetpack to scan your site later today.</string>
-    <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and did not find any risks. %s</string>
+    <string name="scan_idle_last_scan_description">The last Jetpack scan ran %1$s and did not find any risks. %2$s</string>
     <!-- translators: %3$s: "here to help" clickable text linking to help screen inside the app. -->
     <string name="scan_idle_threats_description_plural">The scan found %1$s potential threats with %2$s. Please review them below and take action or tap the fix all button. We are %3$s if you need us.</string>
     <!-- translators: %2$s: "here to help" clickable text linking to help screen inside the app. -->
@@ -1180,8 +1180,8 @@
     <string name="threat_item_header_infected_core_file">%s: infected core file</string>
     <string name="threat_item_header_database_threat">Database %s threats</string>
     <string name="threat_item_header_file_malicious_code_pattern">%s: malicious code pattern</string>
-    <string name="threat_item_header_vulnerable_plugin">Vulnerable Plugin: %s (version %s)</string>
-    <string name="threat_item_header_vulnerable_theme">Vulnerable Theme: %s (version %s)</string>
+    <string name="threat_item_header_vulnerable_plugin">Vulnerable Plugin: %1$s (version %2$s)</string>
+    <string name="threat_item_header_vulnerable_theme">Vulnerable Theme: %1$s (version %2$s)</string>
 
     <!-- threat item sub header -->
     <string name="threat_item_sub_header_misc_vulnerability">Miscellaneous vulnerability</string>
@@ -1648,7 +1648,7 @@
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" will be published in 1 hour</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" will be published in 10 minutes</string>
     <string name="calendar_scheduled_post_title">WordPress Scheduled Post: \"%s\"</string>
-    <string name="calendar_scheduled_post_description">\"%s\" scheduled for publishing on \"%s\" in your WordPress app \n %s</string>
+    <string name="calendar_scheduled_post_description">\"%1$s\" scheduled for publishing on \"%2$s\" in your WordPress app \n %3$s</string>
 
     <!-- Post Status -->
     <string name="post_status_publish_post">Publish</string>
@@ -2662,7 +2662,7 @@
     <string name="edit">Edit</string>
     <string name="tap_to_try_again">Tap to try again!</string>
     <string name="add_media_progress">Adding media</string>
-    <string name="suggestion_invalid">%s is not a valid %s</string>
+    <string name="suggestion_invalid">%1$s is not a valid %2$s</string>
     <string name="suggestion_selection_needed">Please type to filter the list of suggestions.</string>
     <string name="suggestion_none">No %s suggestions available.</string>
     <string name="suggestion_problem">There was a problem loading suggestions.</string>


### PR DESCRIPTION
## Context

This fixes the many warnings we've been having for a while during `:WordPress:mergeWordpressVanillaReleaseResources` about strings having multiple `%s` substitutions in a single string but not using the positional format (`%1$s`/`%2$s`/…) to differentiate each:
```
…/WordPress/src/main/res/values/strings.xml: Multiple substitutions specified in non-positional format of string resource string/{somekey}. Did you mean to add the formatted="false" attribute?
```

We actually have many warnings about this during the build because despite only 9 original strings having that issue in our `values/strings.xml`, those copies were also translated by polyglots… without the positional parameter either, of course, so that led to probably about… 50 times more warnings in the output, for each 9 issues in each `values-{lang}/strings.xml` files.

### Timeline and fix propagation to translations

As a reminder:
 - The originals that this PR fixes will be sent to GlotPress during the next Code Freeze (for 19.6, on Apr 4).
 - The new originals should then be translated by polyglots — this time using the proper positional placeholders in their translations too, seeing them in the new originals
 - Finally, once we'll pull those translations back before 19.6 release, all the warnings about those (including in the translations) will finally be fixed and should not be seen in build logs again.

This is why this PR only fixes the originals (in `values/strings.xml`) and does not try to fix the translations (which will be overwritten by the next GlotPress download anyway)

## To test:
 - Run `./gradlew :WordPress:mergeWordpressVanillaReleaseResources` and validate that there are no warnings about "Multiple substitutions …" in the `values/strings.xml` file anymore.
 - Smoke-Test the app in English, especially the screens using those strings, to validate they still display the proper text.

## Regression Notes

1. Potential unintended areas of impact
   - Crash when displaying those strings to the user, in case I got those positional placeholders wrong in the strings?
2. What I did to test those areas of impact (or what existing automated tests I relied on)
   - I validated that `./gradlew :WordPress:mergeWordpressVanillaReleaseResources` did not generate any warning for the `values/strings.xml` file after the fix
   - I did NOT test the app with the new strings. Someone should probably smoke-test those changes just to be on the safe side, I guess.
3. What automated tests I added (or what prevented me from doing so)
   - _None_

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
    - (Those are internal changes only, and should not have any user-facing impact, so are not worth an entry in the release notes file)
