### PR TITLE
My Site Dashboard: Tabs - Remove Domain Registration Card from Home tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -406,6 +406,7 @@ class MySiteViewModel @Inject constructor(
         }
         MySiteTabType.DASHBOARD -> mutableListOf<Type>().apply {
             if (quickStartRepository.quickStartOrigin == QuickStartOrigin.SITE_MENU) add(Type.QUICK_START_CARD)
+            add(Type.DOMAIN_REGISTRATION_CARD)
         }
         MySiteTabType.ALL -> emptyList()
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1809,6 +1809,28 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(items.filterIsInstance(QuickStartCard::class.java)).isNotEmpty
     }
 
+    @Test
+    fun `given selected site with domain credit, when dashboard cards and items, then domain reg card does not exist`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        initSelectedSite()
+        isDomainCreditAvailable.value = DomainCreditAvailable(true)
+
+        val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
+
+        assertThat(items.filterIsInstance(DomainRegistrationCard::class.java)).isEmpty()
+    }
+
+    @Test
+    fun `given selected site with domain credit, when site menu cards and items, then domain reg card exists`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        initSelectedSite()
+        isDomainCreditAvailable.value = DomainCreditAvailable(true)
+
+        val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
+
+        assertThat(items.filterIsInstance(DomainRegistrationCard::class.java)).isNotEmpty
+    }
+
     private fun findQuickActionsCard() = getLastItems().find { it is QuickActionsCard } as QuickActionsCard?
 
     private fun findQuickStartDynamicCard() = getLastItems().find { it is DynamicCard } as DynamicCard?

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1810,7 +1810,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given selected site with domain credit, when dashboard cards and items, then domain reg card does not exist`() {
+    fun `given selected site with domain credit, when dashboard cards + items, then domain reg card does not exist`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
         initSelectedSite()
         isDomainCreditAvailable.value = DomainCreditAvailable(true)


### PR DESCRIPTION
Fixes #16178 

This PR removes the domain registration card from the home/dashboard tab. It will only display on the "site emnu" tab.

<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/160250255-330480ca-99e8-4a81-b8f1-7694fdb9329e.png">

**To test:**
- Launch app
- Login with an account that has a site with domain credit
- Select site with domain credit from the login epilogue view
- Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
- Enable `MySiteDefaultTabsFeatureConfig` & restart app
- Navigate back to My Site
- Note the domain card is only shown on the Site Menu tab

## Regression Notes
1. Potential unintended areas of impact
Domain registration card continues to show on both tabs

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + unit testing

3. What automated tests I added (or what prevented me from doing so)
Added two new tests in MySiteViewModelTest

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
