### PR TITLE
My Site Dashboard: Tabs - Track experiment property with all events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -84,6 +84,7 @@ import org.wordpress.android.support.ZendeskHelper;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.debug.cookies.DebugCookieManager;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
+import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
@@ -189,6 +190,7 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
     @Inject DebugCookieManager mDebugCookieManager;
     @Inject @Named(APPLICATION_SCOPE) CoroutineScope mAppScope;
     @Inject SelectedSiteRepository mSelectedSiteRepository;
+    @Inject MySiteDefaultTabExperiment mMySiteDefaultTabExperiment;
 
     // For development and production `AnalyticsTrackerNosara`, for testing a mocked `Tracker` will be injected.
     @Inject Tracker mTracker;
@@ -373,6 +375,8 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
         mExPlat.forceRefresh();
 
         mDebugCookieManager.sync();
+
+        initAnalyticsExperimentPropertiesIfNeeded();
     }
 
     protected void initWorkManager() {
@@ -877,6 +881,11 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
 
     public StoryNotificationTrackerProvider getStoryNotificationTrackerProvider() {
         return mStoryNotificationTrackerProvider;
+    }
+
+    /* If default tab experiment is running, pass along to tracker */
+    private void initAnalyticsExperimentPropertiesIfNeeded() {
+        mMySiteDefaultTabExperiment.checkAndSetTrackingPropertiesIfNeeded();
     }
 
     @Override public AndroidInjector<Object> androidInjector() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.mysite.tabs
 
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.MySiteDefaultTabExperimentFeatureConfig
 import org.wordpress.android.util.config.MySiteDefaultTabExperimentVariationDashboardFeatureConfig
@@ -11,7 +12,8 @@ class MySiteDefaultTabExperiment @Inject constructor(
     private val mySiteDefaultTabExperimentVariationDashboardFeatureConfig:
     MySiteDefaultTabExperimentVariationDashboardFeatureConfig,
     private val mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig,
-    private val appPrefsWrapper: AppPrefsWrapper
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
     fun checkAndSetVariantIfNeeded() {
         if (isExperimentRunning()) {
@@ -20,7 +22,14 @@ class MySiteDefaultTabExperiment @Inject constructor(
                     true -> setExperimentVariant(MySiteTabExperimentVariant.DASHBOARD)
                     false -> setExperimentVariant(MySiteTabExperimentVariant.SITE_MENU)
                 }
+                analyticsTrackerWrapper.setInjectExperimentProperties(getVariantMapForTracking())
             }
+        }
+    }
+
+    fun checkAndSetTrackingPropertiesIfNeeded() {
+        if (isExperimentRunning()) {
+            analyticsTrackerWrapper.setInjectExperimentProperties(getVariantMapForTracking())
         }
     }
 
@@ -32,6 +41,13 @@ class MySiteDefaultTabExperiment @Inject constructor(
 
     private fun setExperimentVariant(variant: MySiteTabExperimentVariant) {
         appPrefsWrapper.setMySiteDefaultTabExperimentVariant(variant.label)
+    }
+
+    private fun getVariantMapForTracking() =
+            mapOf(DEFAULT_TAB_EXPERIMENT to appPrefsWrapper.getMySiteDefaultTabExperimentVariant())
+
+    companion object {
+        private const val DEFAULT_TAB_EXPERIMENT = "default_tab_experiment"
     }
 }
 enum class MySiteTabExperimentVariant(val label: String) {

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.util.analytics
 
 import dagger.Reusable
+import org.wordpress.android.analytics.AnalyticsInjectExperimentProperties
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
@@ -56,6 +57,10 @@ class AnalyticsTrackerWrapper
      */
     fun track(stat: Stat, errorContext: String, errorType: String, errorDescription: String) {
         AnalyticsTracker.track(stat, errorContext, errorType, errorDescription)
+    }
+
+    fun setInjectExperimentProperties(properties: Map<String, Any>) {
+        AnalyticsTracker.setInjectExperimentProperties(AnalyticsInjectExperimentProperties.newInstance(properties))
     }
 
     private fun FeatureConfig.toParams() = mapOf(name() to isEnabled())

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsInjectExperimentProperties.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsInjectExperimentProperties.java
@@ -1,0 +1,39 @@
+package org.wordpress.android.analytics;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AnalyticsInjectExperimentProperties {
+   private Map<String, ?> mProperties;
+
+   private AnalyticsInjectExperimentProperties(Map<String, ?> properties) {
+      mProperties = (properties == null) ? Collections.emptyMap() : properties;
+   }
+
+   public Map<String, ?> getProperties() {
+      return mProperties;
+   }
+
+   public void updateProperties(Map<String, ?> properties) {
+      mProperties = properties;
+   }
+
+   public Map<String, ?> injectProperties(Map<String, ?> properties) {
+      Map<String, Object> props = new HashMap<>();
+      if (properties != null && properties.size() != 0) {
+         props.putAll(properties);
+      }
+      getProperties().forEach(props::put);
+
+      return props;
+   }
+
+   public static AnalyticsInjectExperimentProperties emptyInstance() {
+      return new AnalyticsInjectExperimentProperties(Collections.emptyMap());
+   }
+
+   public static AnalyticsInjectExperimentProperties newInstance(Map<String, ?> properties) {
+      return new AnalyticsInjectExperimentProperties(properties);
+   }
+}

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -5,12 +5,14 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public final class AnalyticsTracker {
     private static boolean mHasUserOptedOut;
+    private static AnalyticsInjectExperimentProperties mInjectExperimentProperties;
 
     public static final String READER_DETAIL_TYPE_KEY = "post_detail_type";
     public static final String READER_DETAIL_TYPE_NORMAL = "normal";
@@ -863,6 +865,12 @@ public final class AnalyticsTracker {
         if (mHasUserOptedOut) {
             return;
         }
+
+        if (shouldInjectExperimentProperties()) {
+            trackWithExperimentProperties(stat, Collections.emptyMap());
+            return;
+        }
+
         for (Tracker tracker : TRACKERS) {
             tracker.track(stat);
         }
@@ -872,8 +880,26 @@ public final class AnalyticsTracker {
         if (mHasUserOptedOut) {
             return;
         }
+
+        if (shouldInjectExperimentProperties()) {
+            trackWithExperimentProperties(stat, properties);
+            return;
+        }
+
         for (Tracker tracker : TRACKERS) {
             tracker.track(stat, properties);
+        }
+    }
+
+    private static void trackWithExperimentProperties(Stat stat, Map<String, ?> properties) {
+        Map<String, ?> props = mInjectExperimentProperties.injectProperties(properties);
+
+        for (Tracker tracker : TRACKERS) {
+            if (props.isEmpty()) {
+                tracker.track(stat);
+            } else {
+                tracker.track(stat, props);
+            }
         }
     }
 
@@ -920,5 +946,16 @@ public final class AnalyticsTracker {
         for (Tracker tracker : TRACKERS) {
             tracker.refreshMetadata(metadata);
         }
+    }
+
+    public static void setInjectExperimentProperties(AnalyticsInjectExperimentProperties injectExperimentProperties) {
+        mInjectExperimentProperties = (injectExperimentProperties != null)
+                ? injectExperimentProperties
+                : AnalyticsInjectExperimentProperties.emptyInstance();
+    }
+
+    private static boolean shouldInjectExperimentProperties() {
+        return mInjectExperimentProperties != null
+               && !mInjectExperimentProperties.getProperties().isEmpty();
     }
 }


### PR DESCRIPTION
Parent #16007 

This PR adds support for tracking My Site Default Tab Experiment properties with every event tracked (when the experiment is running)
The following property is tacked on to every event 
  `default_tab_experiment` values =`dashboard|site_menu|nonexistent`

I tried to keep this as generic as possible and not pollute the "tracker" with references to "MySIteDashboard". 

**Merge Instructions**
- Ensure that ~~PR #16175 and #16176 have been merged~~ 
- ~~-  Remove the Not Ready for Merge label~~ 
- Merge as normal

**To test:**
- Launch the app and Login
- If not enabled, please enable `MySiteDashboardTabsFeatureConfig`, then restart the app and logout
- Login
- Navigate to My Site
- View the logs and note that you see property "default_tab_experiment" being tracked on all events
- Navigate to Me -> App Settings -> Debug Settings 
- Disable `my_site_default_tab_experiment` and restart the app
- View the logs and note that you don't see property  "default_tab_experiment" being tracked


## Regression Notes
1. Potential unintended areas of impact
Events are not tracked

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

3. What automated tests I added (or what prevented me from doing so)
Add unit tests to `MySiteDefaultTabExperimentTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
