### PR TITLE
Clickable site header on collapsed state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -4,14 +4,12 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
 import android.view.WindowManager
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.NonNull
 import androidx.appcompat.widget.TooltipCompat
-import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -124,17 +122,11 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     private fun MySiteFragmentBinding.updateCollapsibleToolbar(currentOffset: Int) {
         if (currentOffset == 0) {
             collapsingToolbar.title = siteTitle
-            siteInfo.siteInfoCard.setAllEnabled(false)
+            siteInfo.siteInfoCard.visibility = View.INVISIBLE
         } else {
             collapsingToolbar.title = null
-            siteInfo.siteInfoCard.setAllEnabled(true)
+            siteInfo.siteInfoCard.visibility = View.VISIBLE
         }
-    }
-
-    // This function disables the viewgroup as well as the views in it by recursively calling the function.
-    fun View.setAllEnabled(enabled: Boolean) {
-        isEnabled = enabled
-        if (this is ViewGroup) children.forEach { child -> child.setAllEnabled(enabled) }
     }
 
     private fun MySiteFragmentBinding.fadeSiteInfoHeader(percentage: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -4,12 +4,14 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
 import android.view.WindowManager
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.NonNull
 import androidx.appcompat.widget.TooltipCompat
+import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -102,7 +104,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             val maxOffset = appBarLayout.totalScrollRange
             val currentOffset = maxOffset + verticalOffset
 
-            updateCollapsibleToolbarTitle(currentOffset)
+            updateCollapsibleToolbar(currentOffset)
 
             val percentage = ((currentOffset.toFloat() / maxOffset.toFloat()) * 100).toInt()
             fadeSiteInfoHeader(percentage)
@@ -119,12 +121,20 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         })
     }
 
-    private fun MySiteFragmentBinding.updateCollapsibleToolbarTitle(currentOffset: Int) {
+    private fun MySiteFragmentBinding.updateCollapsibleToolbar(currentOffset: Int) {
         if (currentOffset == 0) {
             collapsingToolbar.title = siteTitle
+            siteInfo.siteInfoCard.setAllEnabled(false)
         } else {
             collapsingToolbar.title = null
+            siteInfo.siteInfoCard.setAllEnabled(true)
         }
+    }
+
+    // This function disables the viewgroup as well as the views in it by recursively calling the function.
+    fun View.setAllEnabled(enabled: Boolean) {
+        isEnabled = enabled
+        if (this is ViewGroup) children.forEach { child -> child.setAllEnabled(enabled) }
     }
 
     private fun MySiteFragmentBinding.fadeSiteInfoHeader(percentage: Int) {


### PR DESCRIPTION
Fixes #16156 

The Site info header was clickable when the toolbar was collapsed even though none of the views was shown. This is fixed in this PR. 

To test:

Test 1
- Go to My Site -> Me -> App Settings 
- Scroll to the bottom 
- Notice that clicking on the toolbar doesn't navigate anywhere 
- Notice that Clicking on the User Icon lead you to the `Me` screen

Test 2
- Go to My Site -> Me -> App Settings -> Test Feature Configuration.
- Turn the MySiteDashboardPhase2FeatureConfig feature flag ON.
- Relaunch the app.
- Scroll to the bottom 
- Notice that clicking on the toolbar doesn't navigate anywhere 
- Notice that Clicking on the User Icon lead you to the `Me` screen

## Review Instructions
Code review from only one reviewer is sufficient.

## Regression Notes
1. Potential unintended areas of impact
- Site header not clickable on expanded state 
- Quick start focus point not clickable 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
None


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
