### PR TITLE
Removes vertical_id from analytics tracking on Android

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.S
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.SELECTED_FILTERS
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.TEMPLATE
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.THUMBNAIL_MODE
-import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.VERTICAL_ID
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.VERTICAL_SLUG
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Locale
@@ -44,7 +43,6 @@ class SiteCreationTracker @Inject constructor(
         LOCATION("location"),
         FILTER("filter"),
         SELECTED_FILTERS("selected_filters"),
-        VERTICAL_ID("vertical_id"),
         VERTICAL_SLUG("vertical_slug")
     }
 
@@ -267,10 +265,10 @@ class SiteCreationTracker @Inject constructor(
         )
     }
 
-    fun trackSiteIntentQuestionVerticalSelected(verticalId: String, verticalSlug: String) {
+    fun trackSiteIntentQuestionVerticalSelected(verticalSlug: String) {
         tracker.track(
                 AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_INTENT_QUESTION_VERTICAL_SELECTED,
-                mapOf(VERTICAL_ID.key to verticalId, VERTICAL_SLUG.key to verticalSlug)
+                mapOf(VERTICAL_SLUG.key to verticalSlug)
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -88,7 +88,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
     }
 
     private fun intentSelected(slug: String, vertical: String) {
-        analyticsTracker.trackSiteIntentQuestionVerticalSelected(vertical, slug)
+        analyticsTracker.trackSiteIntentQuestionVerticalSelected(slug)
         _onIntentSelected.value = vertical
     }
 


### PR DESCRIPTION
Fixes #16173

To test:
1. Start the site creation flow
2. Verify the the [site intent screen](https://github.com/wordpress-mobile/WordPress-Android/pull/16103) is shown
3. Tap on [a default vertical](https://github.com/wordpress-mobile/WordPress-Android/issues/16052)
4. **Verify** that the `enhanced_site_creation_intent_question_vertical_selected` event is emitted with the correct `vertical_slug`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
