### PR TITLE
My Site Dashboard: Tabs - Track default tab experiment variant assigned

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mysite.tabs
 
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
@@ -41,6 +42,7 @@ class MySiteDefaultTabExperiment @Inject constructor(
 
     private fun setExperimentVariant(variant: MySiteTabExperimentVariant) {
         appPrefsWrapper.setMySiteDefaultTabExperimentVariant(variant.label)
+        analyticsTrackerWrapper.track(Stat.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED)
     }
 
     private fun getVariantMapForTracking() =

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
 import org.wordpress.android.ui.mysite.tabs.MySiteTabExperimentVariant
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -110,5 +111,29 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
         mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
 
         verify(analyticsTrackerWrapper, never()).setInjectExperimentProperties(any())
+    }
+
+    @Test
+    fun `given experiment is running, when variant is not assigned, then assignment is tracked`() {
+        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(appPrefsWrapper.getMySiteDefaultTabExperimentVariant())
+                .thenReturn(MySiteTabExperimentVariant.NONEXISTENT.label)
+
+        mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
+
+        verify(analyticsTrackerWrapper, atLeastOnce()).track(Stat.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED)
+    }
+
+    @Test
+    fun `given experiment is running, when variant is assigned, then assignment is not tracked`() {
+        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(appPrefsWrapper.getMySiteDefaultTabExperimentVariant())
+                .thenReturn(MySiteTabExperimentVariant.DASHBOARD.label)
+
+        mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
+
+        verify(analyticsTrackerWrapper, never()).track(Stat.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED)
     }
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -834,6 +834,7 @@ public final class AnalyticsTracker {
         MY_SITE_MENU_ITEM_TAPPED,
         MY_SITE_DASHBOARD_CARD_SHOWN,
         MY_SITE_DASHBOARD_CARD_ITEM_TAPPED,
+        MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2164,6 +2164,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "my_site_dashboard_card_shown";
             case MY_SITE_DASHBOARD_CARD_ITEM_TAPPED:
                 return "my_site_dashboard_card_item_tapped";
+            case MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED:
+                return "my_site_default_tab_experiment_variant_assigned";
         }
         return null;
     }


### PR DESCRIPTION
Parent #15989 

This PR tracks `MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED` when the value is set. This is needed because the "signed_in" event is called from `LoginAnalyticsTracker` and we shouldn't be injecting logic for setting the experiment variant in a tracker. Thus we set the variant in `LoginEpilogue`, but the signed_in events have already been tracked at this point. This event will give us a starting point for funnels following a sign up or login. 

**To test:**
Test A: Login
- Launch the app
- If not enabled, please enable MySiteDashboardTabsFeatureConfig, then restart the app and logout
- Login
- Verify the logs contain: (the default can be dashboard or site_menu)
 🔵 Tracked: my_site_default_tab_experiment_variant_assigned, Properties: {"default_tab_experiment":"dashboard"}

Test B: Signup
- Launch the app
- If not enabled, please enable MySiteDashboardTabsFeatureConfig, then restart the app and logout
- Signup with a new account
- Verify the logs contain: (the default can be dashboard or site_menu)
 🔵 Tracked: my_site_default_tab_experiment_variant_assigned, Properties: {"default_tab_experiment":"dashboard"}

## Regression Notes
1. Potential unintended areas of impact
The event is not tracked

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing & unit testing

3. What automated tests I added (or what prevented me from doing so)
Added two new tests to MySiteDefaultTabExperimentTest

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

FYI: @leandroalonso 