### PR TITLE
Issue/16150 blogging prompt card menu and additional buttons

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -178,7 +178,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val prompt: UiString,
                         val answeredUsers: List<AnsweredUser>,
                         val numberOfAnswers: Int,
-                        val isAnswered: Boolean
+                        val isAnswered: Boolean,
+                        val onShareClick: (String) -> Unit
                     ) : BloggingPromptCard(dashboardCardType = DashboardCardType.BLOGGING_PROMPT_CARD) {
                         data class AnsweredUser(
                             val avatarUrl: String?

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -79,6 +79,7 @@ sealed class MySiteCardAndItemBuilderParams {
     ) : MySiteCardAndItemBuilderParams()
 
     data class BloggingPromptCardBuilderParams(
-        val bloggingPrompt: BloggingPrompt?
+        val bloggingPrompt: BloggingPrompt?,
+        val onShareClick: (message: String) -> Unit
     ) : MySiteCardAndItemBuilderParams()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -143,6 +143,7 @@ class MySiteViewModel @Inject constructor(
     private val _onMediaUpload = MutableLiveData<Event<MediaModel>>()
     private val _activeTaskPosition = MutableLiveData<Pair<QuickStartTask, Int>>()
     private val _onShowSwipeRefreshLayout = MutableLiveData<Event<Boolean>>()
+    private val _onShare = MutableLiveData<Event<String>>()
     private val _tabsUiState = MutableLiveData<TabsUiState>()
 
     /* Capture and track the site selected event so we can circumvent refreshing sources on resume
@@ -178,6 +179,7 @@ class MySiteViewModel @Inject constructor(
     val onMediaUpload = _onMediaUpload as LiveData<Event<MediaModel>>
     val onUploadedItem = siteIconUploadHandler.onUploadedItem
     val onShowSwipeRefreshLayout = _onShowSwipeRefreshLayout
+    val onShare = _onShare
 
     val state: LiveData<MySiteUiState> =
             selectedSiteRepository.siteSelected.switchMap { siteLocalId ->
@@ -344,14 +346,15 @@ class MySiteViewModel @Inject constructor(
                         ),
                         bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
                                 // TODO @klymyam fetch the actual blogging prompt
-                                if (bloggingPromptsFeatureConfig.isEnabled()) {
+                                bloggingPrompt = if (bloggingPromptsFeatureConfig.isEnabled()) {
                                     @Suppress("MagicNumber")
                                     BloggingPrompt(
                                             "Test Prompt",
                                             19,
                                             ""
                                     )
-                                } else null
+                                } else null,
+                                onShareClick = this::onBloggingPromptShareClick
                         )
                 )
         )
@@ -915,6 +918,10 @@ class MySiteViewModel @Inject constructor(
                 PostCardType.SCHEDULED -> Event(SiteNavigationAction.OpenScheduledPosts(site))
             }
         }
+    }
+
+    private fun onBloggingPromptShareClick(message: String) {
+        onShare.postValue(Event(message))
     }
 
     fun isRefreshing() = mySiteSourceManager.isRefreshing()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
@@ -11,7 +11,8 @@ class BloggingPromptCardBuilder @Inject constructor() {
                 prompt = UiStringText(it.text),
                 answeredUsers = emptyList(),
                 numberOfAnswers = it.numberOfAnswers,
-                isAnswered = false
+                isAnswered = false,
+                onShareClick = params.onShareClick
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts
 
 import android.view.ViewGroup
+import androidx.appcompat.widget.PopupMenu
+import androidx.core.view.MenuCompat
 import org.wordpress.android.R
 import org.wordpress.android.databinding.MySiteBloggingPrompCardBinding
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.BloggingPromptCard.BloggingPromptCardWithData
@@ -22,5 +24,38 @@ class BloggingPromptCardViewHolder(
                 card.numberOfAnswers
         )
         uiHelpers.setTextOrHide(numberOfAnswers, numberOfAnswersLabel)
+        uiHelpers.updateVisibility(answerButton, !card.isAnswered)
+
+        bloggingPromptCardMenu.setOnClickListener {
+            showCardMenu()
+        }
+
+        answerButton.setOnClickListener {
+            uiHelpers.updateVisibility(answerButton, false)
+            uiHelpers.updateVisibility(answeredPromptControls, true)
+        }
+        answeredButton.setOnClickListener {
+            uiHelpers.updateVisibility(answerButton, true)
+            uiHelpers.updateVisibility(answeredPromptControls, false)
+        }
+        shareButton.setOnClickListener {
+            card.onShareClick.invoke(
+                    uiHelpers.getTextOfUiString(
+                            shareButton.context,
+                            card.prompt
+                    ).toString()
+            )
+        }
+        uiHelpers.updateVisibility(answeredPromptControls, card.isAnswered)
+    }
+
+    private fun MySiteBloggingPrompCardBinding.showCardMenu() {
+        val quickStartPopupMenu = PopupMenu(itemView.context, bloggingPromptCardMenu)
+        quickStartPopupMenu.setOnMenuItemClickListener {
+            return@setOnMenuItemClickListener true
+        }
+        quickStartPopupMenu.inflate(R.menu.blogging_prompt_card_menu)
+        MenuCompat.setGroupDividerEnabled(quickStartPopupMenu.menu, true)
+        quickStartPopupMenu.show()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -67,9 +67,9 @@ import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
 import org.wordpress.android.util.extensions.getColorFromAttribute
+import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.viewmodel.observeEvent
 import java.io.File
 import javax.inject.Inject
@@ -233,6 +233,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         })
         viewModel.onUploadedItem.observeEvent(viewLifecycleOwner, { handleUploadedItem(it) })
         viewModel.onShowSwipeRefreshLayout.observeEvent(viewLifecycleOwner, { showSwipeToRefreshLayout(it) })
+        viewModel.onShare.observeEvent(viewLifecycleOwner) { shareMessage(it) }
     }
 
     @Suppress("ComplexMethod", "LongMethod")
@@ -549,6 +550,19 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
 
     private fun hideRefreshIndicatorIfNeeded() {
         swipeToRefreshHelper.isRefreshing = viewModel.isRefreshing()
+    }
+
+    private fun shareMessage(message: String) {
+        val shareIntent = Intent(Intent.ACTION_SEND)
+        shareIntent.type = "text/plain"
+        shareIntent.putExtra(Intent.EXTRA_TEXT, message)
+
+        startActivity(
+                Intent.createChooser(
+                        shareIntent,
+                        resources.getString(R.string.my_site_blogging_prompt_card_share_chooser_title)
+                )
+        )
     }
 
     companion object {

--- a/WordPress/src/main/res/color/success_emphasis_medium_selector.xml
+++ b/WordPress/src/main/res/color/success_emphasis_medium_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="@dimen/material_emphasis_disabled" android:color="?attr/wpColorSuccess" android:state_pressed="true" />
+    <item android:color="?attr/wpColorSuccess" />
+</selector>

--- a/WordPress/src/main/res/layout/my_site_blogging_promp_card.xml
+++ b/WordPress/src/main/res/layout/my_site_blogging_promp_card.xml
@@ -157,7 +157,7 @@
                 style="@style/MySiteCardAnsweredButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/share_action" />
+                android:text="@string/my_site_blogging_prompt_card_share" />
         </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WordPress/src/main/res/layout/my_site_blogging_promp_card.xml
+++ b/WordPress/src/main/res/layout/my_site_blogging_promp_card.xml
@@ -11,7 +11,8 @@
         android:layout_height="wrap_content"
         android:paddingStart="@dimen/my_site_card_row_padding"
         android:paddingTop="@dimen/my_site_card_row_top_padding"
-        android:paddingEnd="@dimen/my_site_card_row_padding">
+        android:paddingEnd="@dimen/my_site_card_row_padding"
+        android:paddingBottom="@dimen/margin_small">
 
         <ImageView
             android:id="@+id/title_icon"
@@ -33,12 +34,12 @@
             android:text="@string/my_site_blogging_prompt_card_title"
             android:textAlignment="viewStart"
             android:textAppearance="?attr/textAppearanceSubtitle1"
-            app:layout_constraintEnd_toStartOf="@+id/my_site_card_toolbar_more"
+            app:layout_constraintEnd_toStartOf="@+id/blogging_prompt_card_menu"
             app:layout_constraintStart_toEndOf="@+id/title_icon"
             app:layout_constraintTop_toTopOf="parent" />
 
         <ImageView
-            android:id="@+id/my_site_card_toolbar_more"
+            android:id="@+id/blogging_prompt_card_menu"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:background="?attr/selectableItemBackgroundBorderless"
@@ -125,18 +126,39 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/answer_button"
-            style="@style/MySiteCardFooterLinkItem"
+            style="@style/MySiteCardAnswerButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_small_medium"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            android:clickable="true"
-            android:focusable="true"
             android:text="@string/my_site_blogging_prompt_card_answer_prompt"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/answered_users_container" />
 
+        <LinearLayout
+            android:id="@+id/answered_prompt_controls"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/answered_users_container">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/answered_button"
+                style="@style/MySiteCardAnsweredButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/my_site_blogging_prompt_card_answered_prompt"
+                android:textColor="@color/success_emphasis_medium_selector" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/share_button"
+                style="@style/MySiteCardAnsweredButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/share_action" />
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/menu/blogging_prompt_card_menu.xml
+++ b/WordPress/src/main/res/menu/blogging_prompt_card_menu.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <group android:id="@+id/prompt_actions">
+        <item
+            android:id="@+id/view_more"
+            android:title="@string/my_site_blogging_prompt_card_menu_view_more" />
+        <item
+            android:id="@+id/skip"
+            android:title="@string/my_site_blogging_prompt_card_menu_skip" />
+    </group>
+    <item
+        android:id="@+id/remove"
+        android:title="@string/my_site_blogging_prompt_card_menu_remove" />
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2250,7 +2250,13 @@
     <!-- My Site - Blogging Prompt Card -->
     <string name="my_site_blogging_prompt_card_title">Prompts</string>
     <string name="my_site_blogging_prompt_card_answer_prompt">Answer prompt</string>
+    <string name="my_site_blogging_prompt_card_answered_prompt">✓ Answered</string>
+    <string name="my_site_blogging_prompt_card_share" translatable="false">@string/share_action</string>
+    <string name="my_site_blogging_prompt_card_share_chooser_title">Share blogging prompt</string>
     <string name="my_site_blogging_prompt_card_number_of_answers">%d answers</string>
+    <string name="my_site_blogging_prompt_card_menu_view_more">View more prompts</string>
+    <string name="my_site_blogging_prompt_card_menu_skip">Skip this prompt</string>
+    <string name="my_site_blogging_prompt_card_menu_remove">Remove from dashboard</string>
 
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -832,6 +832,17 @@
         <item name="tint">?attr/wpColorOnSurfaceMedium</item>
     </style>
 
+    <!--My Site Card - Blogging Prompt-->
+
+    <style name="MySiteCardAnswerButton" parent="@style/MySiteCardFooterLinkItem">
+        <item name="android:layout_marginTop">@dimen/margin_large</item>
+    </style>
+
+    <style name="MySiteCardAnsweredButton" parent="@style/MySiteCardAnswerButton">
+        <item name="android:paddingStart">@dimen/margin_medium</item>
+        <item name="android:paddingEnd">@dimen/margin_medium</item>
+    </style>
+
     <!--People Management Styles-->
     <style name="PersonAvatar">
         <item name="android:layout_width">@dimen/people_avatar_sz</item>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -44,6 +44,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.test
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.BloggingPromptCard.BloggingPromptCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
@@ -164,6 +165,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private lateinit var dynamicCardMenu: MutableList<DynamicCardMenuModel>
     private lateinit var navigationActions: MutableList<SiteNavigationAction>
     private lateinit var showSwipeRefreshLayout: MutableList<Boolean>
+    private lateinit var shareRequests: MutableList<String>
     private val avatarUrl = "https://1.gravatar.com/avatar/1000?s=96&d=identicon"
     private val siteLocalId = 1
     private val siteUrl = "http://site.com"
@@ -207,6 +209,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private var onTodaysStatsCardClick: (() -> Unit) = {}
     private var onTodaysStatsCardFooterLinkClick: (() -> Unit) = {}
     private var onDashboardErrorRetryClick: (() -> Unit)? = null
+    private var onBloggingPromptShareClicked: ((message: String) -> Unit)? = null
     private val quickStartCategory: QuickStartCategory
         get() = QuickStartCategory(
                 taskType = QuickStartTaskType.CUSTOMIZE,
@@ -317,6 +320,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         navigationActions = mutableListOf()
         dynamicCardMenu = mutableListOf()
         showSwipeRefreshLayout = mutableListOf()
+        shareRequests = mutableListOf()
         launch(Dispatchers.Default) {
             viewModel.uiModel.observeForever {
                 uiModels.add(it)
@@ -350,6 +354,11 @@ class MySiteViewModelTest : BaseUnitTest() {
         viewModel.onShowSwipeRefreshLayout.observeForever { event ->
             event?.getContentIfNotHandled()?.let {
                 showSwipeRefreshLayout.add(it)
+            }
+        }
+        viewModel.onShare.observeForever { event ->
+            event?.getContentIfNotHandled()?.let {
+                shareRequests.add(it)
             }
         }
         site = SiteModel()
@@ -1230,6 +1239,17 @@ class MySiteViewModelTest : BaseUnitTest() {
         })
     }
 
+    @Test
+    fun `given blogging prompt card, when share button is clicked, share action is called`() = test {
+        initSelectedSite()
+
+        val expectedShareMessage = "Test prompt"
+
+        requireNotNull(onBloggingPromptShareClicked).invoke(expectedShareMessage)
+
+        assertThat(shareRequests.last()).isEqualTo(expectedShareMessage)
+    }
+
     /* DASHBOARD ERROR SNACKBAR */
 
     @Test
@@ -2027,6 +2047,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                     } else {
                         add(initPostCard(mockInvocation))
                         add(initTodaysStatsCard(mockInvocation))
+                        add(initBloggingPromptCard(mockInvocation))
                     }
                 }
         )
@@ -2077,6 +2098,18 @@ class MySiteViewModelTest : BaseUnitTest() {
                         label = UiStringRes(0),
                         onClick = onPostCardFooterLinkClick as ((postCardType: PostCardType) -> Unit)
                 )
+        )
+    }
+
+    private fun initBloggingPromptCard(mockInvocation: InvocationOnMock): BloggingPromptCardWithData {
+        val params = (mockInvocation.arguments.filterIsInstance<DashboardCardsBuilderParams>()).first()
+        onBloggingPromptShareClicked = params.bloggingPromptCardBuilderParams.onShareClick
+        return BloggingPromptCardWithData(
+                prompt = UiStringText("Test prompt"),
+                answeredUsers = emptyList(),
+                numberOfAnswers = 5,
+                isAnswered = false,
+                onShareClick = onBloggingPromptShareClicked as ((message: String) -> Unit)
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -209,7 +209,7 @@ class CardsBuilderTest {
                         onErrorRetryClick = mock(),
                         todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock()),
                         postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
-                        bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(mock())
+                        bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(mock(), mock())
                 )
         )
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -145,7 +145,7 @@ class CardsBuilderTest : BaseUnitTest() {
                         onErrorRetryClick = { },
                         todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock()),
                         postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
-                        bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(mock())
+                        bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(mock(), mock())
                 )
         )
     }


### PR DESCRIPTION
#16150 part 2 of 3

This PR adds "Answered" and "Share" buttons to the bottom of the blogging prompt card, and an overflow menu.

For testing purposes clicking on Answer buttons shows "answered" state buttons. Clicking on "Answered" shows the "Answer" button again. Share button is wired to share action with the content of the prompt as a message (I'm not sure at this point how it will work in the future, but for now the prompt message is just passed back from VH). Rest of the buttons do not do anything at the moment.

Some parts of the layout are still WIP, but I'm starting to clean it up.

[![Image from Gyazo](https://i.gyazo.com/185e480350154196338c8253e1ef96da.png)](https://gyazo.com/185e480350154196338c8253e1ef96da)

[![Image from Gyazo](https://i.gyazo.com/ff14e06e7ca1c9560d7d942c575e884a.png)](https://gyazo.com/ff14e06e7ca1c9560d7d942c575e884a)

To test:
- Using wasabi version build variant, navigate to App Settings -> Debug settings and enable `blogging_prompts_remote_field` option.
- Confirm that clicking on "Answer" button of BP card shows "Answered" and "Share" buttons like the are displayed in Figma.
- Confirm that tapping on Share buttons shows an intent picker with the content of a prompt as a message.
- Confirm that tapping on overflow menu shows a menu that looks like the one in Figma.


## Regression Notes
1. Potential unintended areas of impact
- Changes are contained to the card, so should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Automated and manual tests.

3. What automated tests I added (or what prevented me from doing so)
Testing that clicking on Share button calls appropriate method.

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
