### PR TITLE
Stats Revamp V2: Add Feature Config

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -123,6 +123,7 @@ android {
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
         buildConfigField "boolean", "MY_SITE_DEFAULT_TAB_EXPERIMENT", "false"
         buildConfigField "boolean", "MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD", "false"
+        buildConfigField "boolean", "STATS_REVAMP_V2", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/StatsRevampV2FeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/StatsRevampV2FeatureConfig.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+// TODO: Uncomment the lines 8 and 14 when remote field is configured and remove line 9 and this to-do
+// @Feature(StatsRevampV2FeatureConfig.STATS_REVAMP_V2_REMOTE_FIELD, false)
+@FeatureInDevelopment
+class StatsRevampV2FeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.STATS_REVAMP_V2
+//        STATS_REVAMP_V2_REMOTE_FIELD
+) {
+    companion object {
+        const val STATS_REVAMP_V2_REMOTE_FIELD = "stats_revamp_v2_remote_field"
+    }
+}


### PR DESCRIPTION
Add local development feature flag for Stats Revamp v2 feature

Fixes #16192 

<img width=320 src="https://user-images.githubusercontent.com/990349/160523948-e3f71879-d33d-41ee-8440-5c93df499ed4.png" />

To test:

1. Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
2. Select Debug Settings
3. Find StatsRevampV2FeatureConfig under Features in development as shown in the image above


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
