### PR TITLE
Beta Fix: Unable to select WordPress app when sharing images or videos

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -602,7 +602,7 @@
             android:excludeFromRecents="true"
             android:launchMode="singleTask"
             android:theme="@style/NoDisplay"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <action android:name="android.intent.action.SEND_MULTIPLE" />


### PR DESCRIPTION
Fixes #16182

This PR fixes WordPress icon not getting listed among the "Share via" app list by reverting `exported=false` done as part of [`Android 12` changes](https://github.com/wordpress-mobile/WordPress-Android/pull/16076).

**To test**

- Open an image or video and tap the share icon.
- Notice that WordPress icon is present among the "Share via" app list.

**Merging Notes**

Targets `release/19.5` in code-freeze.
/cc @AliSoftware 

## Regression Notes
1. Potential unintended areas of impact 
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually (see `To test` section).

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
