### PR TITLE
[Site Intent Question] Enables searching through verticals on the Site Intent Question screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.ui.sitecreation.verticals.IntentsScreenListener
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsFragment
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.wizard.WizardNavigationTarget
 import javax.inject.Inject
 
@@ -127,6 +128,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
 
     override fun onIntentSelected(intent: String) {
         mainViewModel.onSiteIntentSelected(intent)
+        ActivityUtils.hideKeyboard(this)
     }
 
     override fun onDomainSelected(domain: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentViewHolder.kt
@@ -3,43 +3,32 @@ package org.wordpress.android.ui.sitecreation.verticals
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.annotation.LayoutRes
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentListItemUiState
-import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentListItemUiState.DefaultIntentItemUiState
-import org.wordpress.android.ui.utils.UiHelpers
 
-sealed class SiteCreationIntentViewHolder(internal val parent: ViewGroup, @LayoutRes layout: Int) :
+class SiteCreationIntentViewHolder(internal val parent: ViewGroup) :
         RecyclerView.ViewHolder(
                 LayoutInflater.from(parent.context).inflate(
-                        layout,
+                        R.layout.site_creation_intents_item,
                         parent,
                         false
                 )
         ) {
-    abstract fun onBind(uiState: IntentListItemUiState)
+    private val container = itemView.findViewById<ViewGroup>(R.id.container)
+    private val verticalText = itemView.findViewById<TextView>(R.id.vertical_text)
+    private val emoji = itemView.findViewById<TextView>(R.id.vertical_emoji)
+    private var onIntentSelected: (() -> Unit)? = null
 
-    class DefaultIntentItemViewHolder(
-        parentView: ViewGroup,
-        private val uiHelpers: UiHelpers
-    ) : SiteCreationIntentViewHolder(parentView, R.layout.site_creation_intents_item) {
-        private val container = itemView.findViewById<ViewGroup>(R.id.container)
-        private val verticalText = itemView.findViewById<TextView>(R.id.vertical_text)
-        private val emoji = itemView.findViewById<TextView>(R.id.vertical_emoji)
-        private var onIntentSelected: (() -> Unit)? = null
-
-        init {
-            container.setOnClickListener {
-                onIntentSelected?.invoke()
-            }
+    init {
+        container.setOnClickListener {
+            onIntentSelected?.invoke()
         }
+    }
 
-        override fun onBind(uiState: IntentListItemUiState) {
-            uiState as DefaultIntentItemUiState
-            onIntentSelected = requireNotNull(uiState.onItemTapped) { "OnItemTapped is required." }
-            verticalText.text = uiState.verticalText
-            emoji.text = uiState.emoji
-        }
+    fun onBind(uiState: IntentListItemUiState) {
+        onIntentSelected = requireNotNull(uiState.onItemTapped) { "OnItemTapped is required." }
+        verticalText.text = uiState.verticalText
+        emoji.text = uiState.emoji
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsAdapter.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.sitecreation.verticals
 
 import android.view.ViewGroup
 import androidx.annotation.MainThread
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentViewHolder.DefaultIntentItemViewHolder
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentListItemUiState
@@ -29,14 +30,41 @@ class SiteCreationIntentsAdapter(private val uiHelpers: UiHelpers) : Adapter<Sit
 
     @MainThread
     fun update(newItems: List<IntentListItemUiState>) {
+        val diffResult = DiffUtil.calculateDiff(IntentsDiffUtils(items.toList(), newItems))
         items.clear()
         items.addAll(newItems)
+        diffResult.dispatchUpdatesTo(this)
     }
 
     override fun getItemViewType(position: Int): Int {
         // this will have more types later
         return when (items[position]) {
             is DefaultIntentItemUiState -> defaultSuggestionItemViewType
+        }
+    }
+
+    private class IntentsDiffUtils(
+        val oldItems: List<IntentListItemUiState>,
+        val newItems: List<IntentListItemUiState>
+    ) : DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = oldItems[oldItemPosition]
+            val newItem = newItems[newItemPosition]
+            if (oldItem::class != newItem::class) {
+                return false
+            }
+            return when (oldItem) {
+                is DefaultIntentItemUiState ->
+                    oldItem.verticalSlug == (newItem as DefaultIntentItemUiState).verticalSlug
+            }
+        }
+
+        override fun getOldListSize(): Int = oldItems.size
+
+        override fun getNewListSize(): Int = newItems.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldItems[oldItemPosition] == newItems[newItemPosition]
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsAdapter.kt
@@ -4,22 +4,16 @@ import android.view.ViewGroup
 import androidx.annotation.MainThread
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView.Adapter
-import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentViewHolder.DefaultIntentItemViewHolder
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentListItemUiState
-import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentListItemUiState.DefaultIntentItemUiState
-import org.wordpress.android.ui.utils.UiHelpers
 
-class SiteCreationIntentsAdapter(private val uiHelpers: UiHelpers) : Adapter<SiteCreationIntentViewHolder>() {
+class SiteCreationIntentsAdapter : Adapter<SiteCreationIntentViewHolder>() {
     private val items = mutableListOf<IntentListItemUiState>()
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
     ): SiteCreationIntentViewHolder {
-        return when (viewType) {
-            defaultSuggestionItemViewType -> DefaultIntentItemViewHolder(parent, uiHelpers)
-            else -> throw NotImplementedError("Unknown ViewType")
-        }
+        return SiteCreationIntentViewHolder(parent)
     }
 
     override fun getItemCount(): Int = items.size
@@ -36,13 +30,6 @@ class SiteCreationIntentsAdapter(private val uiHelpers: UiHelpers) : Adapter<Sit
         diffResult.dispatchUpdatesTo(this)
     }
 
-    override fun getItemViewType(position: Int): Int {
-        // this will have more types later
-        return when (items[position]) {
-            is DefaultIntentItemUiState -> defaultSuggestionItemViewType
-        }
-    }
-
     private class IntentsDiffUtils(
         val oldItems: List<IntentListItemUiState>,
         val newItems: List<IntentListItemUiState>
@@ -53,10 +40,7 @@ class SiteCreationIntentsAdapter(private val uiHelpers: UiHelpers) : Adapter<Sit
             if (oldItem::class != newItem::class) {
                 return false
             }
-            return when (oldItem) {
-                is DefaultIntentItemUiState ->
-                    oldItem.verticalSlug == (newItem as DefaultIntentItemUiState).verticalSlug
-            }
+            return oldItem.verticalSlug == newItem.verticalSlug
         }
 
         override fun getOldListSize(): Int = oldItems.size
@@ -66,9 +50,5 @@ class SiteCreationIntentsAdapter(private val uiHelpers: UiHelpers) : Adapter<Sit
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
             return oldItems[oldItemPosition] == newItems[newItemPosition]
         }
-    }
-
-    companion object {
-        private const val defaultSuggestionItemViewType: Int = 1
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -122,8 +122,8 @@ class SiteCreationIntentsFragment : Fragment() {
         siteCreationIntentsTitlebar.backButton.setOnClickListener { viewModel.onBackPressed() }
         continueButton.setOnClickListener { viewModel.onContinuePressed() }
         setScrollListener()
-        input.setOnFocusChangeListener { _, willFocus ->
-            if (willFocus) {
+        input.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) {
                 viewModel.onSearchInputFocused()
                 recyclerView.smoothScrollToPosition(0)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -70,7 +70,7 @@ class SiteCreationIntentsFragment : Fragment() {
 
     private fun SiteCreationIntentsFragmentBinding.setupUi() {
         siteCreationIntentsTitlebar.appBarTitle.isInvisible = !isPhoneLandscape()
-        recyclerView.adapter = SiteCreationIntentsAdapter(uiHelper)
+        recyclerView.adapter = SiteCreationIntentsAdapter()
     }
 
     private fun SiteCreationIntentsFragmentBinding.updateUiState(uiState: IntentsUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -122,7 +122,12 @@ class SiteCreationIntentsFragment : Fragment() {
         siteCreationIntentsTitlebar.backButton.setOnClickListener { viewModel.onBackPressed() }
         continueButton.setOnClickListener { viewModel.onContinuePressed() }
         setScrollListener()
-        input.setOnFocusChangeListener { _, willFocus -> if (willFocus) viewModel.onSearchInputFocused() }
+        input.setOnFocusChangeListener { _, willFocus ->
+            if (willFocus) {
+                viewModel.onSearchInputFocused()
+                recyclerView.smoothScrollToPosition(0)
+            }
+        }
     }
 
     private fun SiteCreationIntentsFragmentBinding.addSearchTextChangedListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -134,7 +134,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
         uiState.value?.let { state ->
             updateUiState(
                     state.copy(
-                            isContinueButtonVisible = query.isNotEmpty(),
+                            isContinueButtonVisible = query.isNotEmpty() && searchResults.isEmpty(),
                             searchQuery = query,
                             content = IntentsUiState.Content.SearchResults(searchResults)
                     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import org.wordpress.android.R
 import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentListItemUiState.DefaultIntentItemUiState
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentsUiState.Content.DefaultItems
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentsUiState.Content.FullItemsList
@@ -82,7 +81,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
         val newItems = slugsArray.mapIndexed { index, slug ->
             val vertical = verticalArray[index]
             val emoji = emojiArray[index]
-            val item = DefaultIntentItemUiState(slug, vertical, emoji)
+            val item = IntentListItemUiState(slug, vertical, emoji)
             item.onItemTapped = { intentSelected(slug, vertical) }
             return@mapIndexed item
         }
@@ -168,13 +167,11 @@ class SiteCreationIntentsViewModel @Inject constructor(
         }
     }
 
-    sealed class IntentListItemUiState {
+    data class IntentListItemUiState(
+        val verticalSlug: String,
+        val verticalText: String,
+        val emoji: String
+    ) {
         var onItemTapped: (() -> Unit)? = null
-
-        data class DefaultIntentItemUiState(
-            val verticalSlug: String,
-            val verticalText: String,
-            val emoji: String
-        ) : IntentListItemUiState()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -93,7 +93,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
         isInitialized = true
     }
 
-    private fun intentSelected(slug: String, vertical: String) {
+    fun intentSelected(slug: String, vertical: String) {
         analyticsTracker.trackSiteIntentQuestionVerticalSelected(slug)
         _onIntentSelected.value = vertical
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/VerticalsSearchResultsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/VerticalsSearchResultsProvider.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.sitecreation.verticals
+
+import dagger.Reusable
+import org.apache.commons.text.similarity.FuzzyScore
+import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentListItemUiState
+import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentListItemUiState.DefaultIntentItemUiState
+import org.wordpress.android.util.LocaleManagerWrapper
+import javax.inject.Inject
+
+@Reusable
+class VerticalsSearchResultsProvider @Inject constructor(localeManagerWrapper: LocaleManagerWrapper) {
+    private val locale = localeManagerWrapper.getLocale()
+    private val fuzzyScore = FuzzyScore(locale)
+
+    fun search(items: List<IntentListItemUiState>, query: String) = if (query.isEmpty()) items else items.filter {
+        val text = (it as DefaultIntentItemUiState).verticalText.lowercase(locale)
+        val query = query.lowercase(locale)
+        fuzzyScore.fuzzyScore(query, text) > fuzzyScoreThreshold
+    }
+
+    companion object {
+        private const val fuzzyScoreThreshold = 6
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/VerticalsSearchResultsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/VerticalsSearchResultsProvider.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.sitecreation.verticals
 
 import dagger.Reusable
-import org.apache.commons.text.similarity.FuzzyScore
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentListItemUiState
 import org.wordpress.android.util.LocaleManagerWrapper
 import javax.inject.Inject
@@ -9,15 +8,10 @@ import javax.inject.Inject
 @Reusable
 class VerticalsSearchResultsProvider @Inject constructor(localeManagerWrapper: LocaleManagerWrapper) {
     private val locale = localeManagerWrapper.getLocale()
-    private val fuzzyScore = FuzzyScore(locale)
 
     fun search(items: List<IntentListItemUiState>, query: String) = if (query.isEmpty()) items else items.filter {
         val text = it.verticalText.lowercase(locale)
         val query = query.lowercase(locale)
-        fuzzyScore.fuzzyScore(query, text) > fuzzyScoreThreshold
-    }
-
-    companion object {
-        private const val fuzzyScoreThreshold = 6
+        text.contains(query)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/VerticalsSearchResultsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/VerticalsSearchResultsProvider.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.sitecreation.verticals
 import dagger.Reusable
 import org.apache.commons.text.similarity.FuzzyScore
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentListItemUiState
-import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentListItemUiState.DefaultIntentItemUiState
 import org.wordpress.android.util.LocaleManagerWrapper
 import javax.inject.Inject
 
@@ -13,7 +12,7 @@ class VerticalsSearchResultsProvider @Inject constructor(localeManagerWrapper: L
     private val fuzzyScore = FuzzyScore(locale)
 
     fun search(items: List<IntentListItemUiState>, query: String) = if (query.isEmpty()) items else items.filter {
-        val text = (it as DefaultIntentItemUiState).verticalText.lowercase(locale)
+        val text = it.verticalText.lowercase(locale)
         val query = query.lowercase(locale)
         fuzzyScore.fuzzyScore(query, text) > fuzzyScoreThreshold
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
@@ -22,6 +22,7 @@ class SiteCreationIntentsViewModelTest {
     @JvmField val rule = InstantTaskExecutorRule()
 
     @Mock lateinit var analyticsTracker: SiteCreationTracker
+    @Mock lateinit var searchResultsProvider: VerticalsSearchResultsProvider
     @Mock lateinit var dispatcher: CoroutineDispatcher
     @Mock private lateinit var resources: Resources
 
@@ -29,7 +30,7 @@ class SiteCreationIntentsViewModelTest {
 
     @Before
     fun setUp() {
-        viewModel = SiteCreationIntentsViewModel(analyticsTracker, dispatcher)
+        viewModel = SiteCreationIntentsViewModel(analyticsTracker, searchResultsProvider, dispatcher)
         whenever(resources.getStringArray(any())).thenReturn(emptyArray())
     }
 


### PR DESCRIPTION
Fixes #16053

## Description
This PR [adds intents search functionality](https://github.com/wordpress-mobile/WordPress-Android/pull/16198/commits/970aaac84eb977d7a695741b0b5cb323917f00cb) on the Site Intent Question screen. Also it:
* [Hides continue button when there are search results](https://github.com/wordpress-mobile/WordPress-Android/pull/16198/commits/d6688d6642a75ec6637d8390e318f439ece75a0d)
* [Simplifies the implementation to use only one list item type](https://github.com/wordpress-mobile/WordPress-Android/pull/16198/commits/1261d569bfd6079a4736a2b61aecafb1d8ad3295) since in the latest design the list items are the same in the initial defaults screen and the search screen

_Note: though initially a [fuzzy search was implemented](https://github.com/wordpress-mobile/WordPress-Android/pull/16198/commits/970aaac84eb977d7a695741b0b5cb323917f00cb), it [was replaced with simple substring matching](https://github.com/wordpress-mobile/WordPress-Android/pull/16198/commits/aae908fe7a6f964e83f6f9964a5aa4e7f7677695) since this seemed to work better with the current data set_ 

Known issues:
* [there is a UI animation glitch when transitioning from the defaults screen to the search screen](https://github.com/wordpress-mobile/WordPress-Android/issues/16209)

## To test:
[Turn on the feature flag](https://github.com/wordpress-mobile/WordPress-Android/pull/16026) (Me -> App Settings -> Debug settings -> SiteIntentQuestionFeatureConfig)

### The full intents list is initially presented on the screen
1. Start the site creation flow
2. Tap on the search field
3. **Verify** that the full intents list is initially presented
4. **Verify** that the *Continue* button is not shown

### The search results are filtered
1. Start the site creation flow
2. Tap on the search field
3. Type an intent that exists in the list (e.g. Art)
5. **Verify** that the results list is filtered
6. **Verify** that the *Continue* button is not shown

### No results available
1. Start the site creation flow
2. Tap on the search field
3. Type an intent that does not exist in the list (e.g. abc)
5. **Verify** that an empty white screen is below the search field
6. **Verify** that the *Continue* button shown

https://user-images.githubusercontent.com/304044/160638249-6a1ed0a9-de2f-4b35-bb81-eea3443f1a23.mp4

## Regression Notes
1. Potential unintended areas of impact
N/A

8. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

9. What automated tests I added (or what prevented me from doing so)
Added unit tests in `SiteCreationIntentsViewModelTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
