### PR TITLE
Fixes Connected tests : Removes deleted site from displaying #16063

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -412,7 +412,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (BuildConfig.IS_JETPACK_APP) {
             ActivityLauncher.showSignInForResultJetpackOnly(activity);
         } else {
-            ActivityLauncher.showSignInForResultWpComOnly(activity);
+            ActivityLauncher.showSignInForResult(activity);
         }
     }
 


### PR DESCRIPTION
This PR fixes the issue which caused connected tests to fail after merging PR #16063 .

## Test (Tests from the PR #16063)

#### Test 1
1. when there are **more than two sites**, delete a site.
2. Then it should delete the site
3. And Then navigate to the `Choose site` screen.

#### Test 2
1. when there are **two sites**, delete a site.
2. Then it should delete the site
3. And Then navigate to the `My Site` screen with the remaining site being selected automatically.

#### Test 3
1. when there is **one site**, delete a site.
2. Then it should delete the site
3. And Then it should show `Create a new site`.

#### Test 4
1. when the user is neither signed in to a WordPress.com account nor if he has a .org site.
2. And deletes the site
4. And Then navigate to the `Signin` screen.

### Failed Connected tests 
Ensure that the [failed connected tests](https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670/matrices/8646961231756570801/details?stepId=bs.30483818accf22db&testCaseId=30&tabId=errors) pass

## Regression Notes
1. Potential unintended areas of impact
Sign in page is not being shown properly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests and Automated tests

3. What automated tests I added (or what prevented me from doing so)
None 

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
