### PR TITLE
Issue/expand comment editing tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -639,8 +639,6 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == INTENT_COMMENT_EDITOR && resultCode == Activity.RESULT_OK) {
             reloadComment();
-            AnalyticsUtils.trackCommentActionWithSiteDetails(Stat.COMMENT_EDITED,
-                    mCommentSource.toAnalyticsCommentActionSource(), mSite);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
@@ -56,7 +56,7 @@ class UnifiedCommentsEditViewModel @Inject constructor(
     private val getCommentUseCase: GetCommentUseCase,
     private val notificationActionsWrapper: NotificationsActionsWrapper,
     private val readerCommentTableWrapper: ReaderCommentTableWrapper,
-    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper,
+    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private val _uiState = MutableLiveData<EditCommentUiState>()
     private val _uiActionEvent = MutableLiveData<Event<EditCommentActionEvent>>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.COMMENT_EDITED
 import org.wordpress.android.datasets.wrappers.ReaderCommentTableWrapper
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
@@ -16,6 +17,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.comments.unified.CommentIdentifier.NotificationCommentIdentifier
 import org.wordpress.android.ui.comments.unified.CommentIdentifier.ReaderCommentIdentifier
+import org.wordpress.android.ui.comments.unified.CommentIdentifier.SiteCommentIdentifier
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.EditCommentActionEvent.CANCEL_EDIT_CONFIRM
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.EditCommentActionEvent.CLOSE
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditViewModel.EditCommentActionEvent.DONE
@@ -33,6 +35,8 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.validateEmail
 import org.wordpress.android.util.validateUrl
 import org.wordpress.android.viewmodel.Event
@@ -51,7 +55,8 @@ class UnifiedCommentsEditViewModel @Inject constructor(
     private val localCommentCacheUpdateHandler: LocalCommentCacheUpdateHandler,
     private val getCommentUseCase: GetCommentUseCase,
     private val notificationActionsWrapper: NotificationsActionsWrapper,
-    private val readerCommentTableWrapper: ReaderCommentTableWrapper
+    private val readerCommentTableWrapper: ReaderCommentTableWrapper,
+    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper,
 ) : ScopedViewModel(mainDispatcher) {
     private val _uiState = MutableLiveData<EditCommentUiState>()
     private val _uiActionEvent = MutableLiveData<Event<EditCommentActionEvent>>()
@@ -250,6 +255,11 @@ class UnifiedCommentsEditViewModel @Inject constructor(
         commentEntity?.run {
             val isCommentEntityUpdated = updateCommentEntity(this, editedCommentEssentials)
             if (isCommentEntityUpdated) {
+                analyticsUtilsWrapper.trackCommentActionWithSiteDetails(
+                        COMMENT_EDITED,
+                        commentIdentifier.toCommentActionSource(),
+                        site
+                )
                 when (commentIdentifier) {
                     is NotificationCommentIdentifier -> {
                         updateNotificationEntity()
@@ -378,6 +388,20 @@ class UnifiedCommentsEditViewModel @Inject constructor(
                 this.userNameError,
                 this.userUrlError
         ).any { !it.isNullOrEmpty() }
+    }
+
+    private fun CommentIdentifier.toCommentActionSource(): AnalyticsCommentActionSource {
+        return when (this) {
+            is NotificationCommentIdentifier -> {
+                AnalyticsCommentActionSource.NOTIFICATIONS
+            }
+            is ReaderCommentIdentifier -> {
+                AnalyticsCommentActionSource.READER
+            }
+            is SiteCommentIdentifier -> {
+                AnalyticsCommentActionSource.SITE_COMMENTS
+            }
+        }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewholders/CommentViewHolder.kt
@@ -37,6 +37,7 @@ class CommentViewHolder(
         textCommentDate.text = state.datePublished
         imageManager.loadIntoCircle(imageCommentAvatar, AVATAR, state.avatarUrl)
         authorBadge.visibility = if (state.showAuthorBadge) View.VISIBLE else View.GONE
+        commentActionButtonContainer.visibility = View.GONE
 
         threadedCommentsUtils.setLinksClickable(textCommentText, state.isPrivatePost)
         CommentUtils.displayHtmlComment(

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.util.UriWrapper
+import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource
 import org.wordpress.android.util.analytics.AnalyticsUtils.RecommendAppSource
 import javax.inject.Inject
 
@@ -108,4 +109,10 @@ class AnalyticsUtilsWrapper @Inject constructor(
 
     fun trackRecommendAppFetchFailed(source: RecommendAppSource, error: String) =
             AnalyticsUtils.trackRecommendAppFetchFailed(source, error)
+
+    fun trackCommentActionWithSiteDetails(
+        stat: Stat,
+        actionSource: AnalyticsCommentActionSource,
+        site: SiteModel
+    ) = AnalyticsUtils.trackCommentActionWithSiteDetails(stat, actionSource, site)
 }


### PR DESCRIPTION
This PR adds missing comment editing tracking for Reader comments.

Is also squeezed a quick fix that hides the comment overflow menu from reader post comment snippet:

Before:
[![Image from Gyazo](https://i.gyazo.com/b0acefdb2803118639071b269f352e2d.png)](https://gyazo.com/b0acefdb2803118639071b269f352e2d)

After:
[![Image from Gyazo](https://i.gyazo.com/15635ebc1cdaaa18c41c202f6d633dd1.png)](https://gyazo.com/15635ebc1cdaaa18c41c202f6d633dd1)

To test:
- You can put a breakpoint at the tracker calling point, and confirm that it's called with correct parameters from Site Comments, Reader and Notifications after comment successfully edited.
- Visually confirm that the overflow menu is not visible in reader post comment snippet.

## Regression Notes
1. Potential unintended areas of impact
Nothing I can think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and automated tests.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
