### PR TITLE
Adjust site verticals animations and styles

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -92,7 +92,6 @@ class SiteCreationIntentsFragment : Fragment() {
 
     private fun SiteCreationIntentsFragmentBinding.updateContinueButtonVisibility(shouldBeVisible: Boolean) {
         continueButtonContainer.isVisible = shouldBeVisible
-        continueButtonShadow.isVisible = shouldBeVisible
     }
 
     private fun SiteCreationIntentsFragmentBinding.animateHeaderVisibility(shouldBeVisible: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -77,7 +77,6 @@ class SiteCreationIntentsFragment : Fragment() {
         (recyclerView.adapter as SiteCreationIntentsAdapter).update(uiState.content.items)
         updateTitleVisibility(uiState.isAppBarTitleVisible)
         if (!uiState.isHeaderVisible) input.requestFocus()
-        // More instantaneous alternative:
         siteCreationIntentsHeader.root.isVisible = uiState.isHeaderVisible
         updateContinueButtonVisibility(uiState.isContinueButtonVisible)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
@@ -79,8 +78,7 @@ class SiteCreationIntentsFragment : Fragment() {
         updateTitleVisibility(uiState.isAppBarTitleVisible)
         if (!uiState.isHeaderVisible) input.requestFocus()
         // More instantaneous alternative:
-//        siteCreationIntentsHeader.root.isVisible = uiState.isHeaderVisible
-        animateHeaderVisibility(uiState.isHeaderVisible)
+        siteCreationIntentsHeader.root.isVisible = uiState.isHeaderVisible
         updateContinueButtonVisibility(uiState.isContinueButtonVisible)
     }
 
@@ -95,22 +93,6 @@ class SiteCreationIntentsFragment : Fragment() {
 
     private fun SiteCreationIntentsFragmentBinding.updateContinueButtonVisibility(shouldBeVisible: Boolean) {
         continueButtonContainer.isVisible = shouldBeVisible
-    }
-
-    private fun SiteCreationIntentsFragmentBinding.animateHeaderVisibility(shouldBeVisible: Boolean) {
-        val headerLayout = siteCreationIntentsHeader.root
-        val toggleVisibility = Runnable { headerLayout.isVisible = shouldBeVisible }
-
-        when {
-            !shouldBeVisible && headerLayout.isVisible -> {
-                headerLayout.animate().alpha(0f).withEndAction(toggleVisibility)
-            }
-            shouldBeVisible && headerLayout.isGone -> {
-                // I don't think we ever encounter this transition in the current code
-                headerLayout.isVisible = shouldBeVisible
-                headerLayout.animate().alpha(1f)
-            }
-        }
     }
 
     private fun SiteCreationIntentsFragmentBinding.setupViewModel() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -70,6 +70,7 @@ class SiteCreationIntentsFragment : Fragment() {
 
     private fun SiteCreationIntentsFragmentBinding.setupUi() {
         siteCreationIntentsTitlebar.appBarTitle.isInvisible = !isPhoneLandscape()
+        recyclerView.itemAnimator = null
         recyclerView.adapter = SiteCreationIntentsAdapter()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -77,6 +77,8 @@ class SiteCreationIntentsFragment : Fragment() {
         (recyclerView.adapter as SiteCreationIntentsAdapter).update(uiState.content.items)
         updateTitleVisibility(uiState.isAppBarTitleVisible)
         if (!uiState.isHeaderVisible) input.requestFocus()
+        // More instantaneous alternative:
+//        siteCreationIntentsHeader.root.isVisible = uiState.isHeaderVisible
         animateHeaderVisibility(uiState.isHeaderVisible)
         updateContinueButtonVisibility(uiState.isContinueButtonVisible)
     }
@@ -100,10 +102,12 @@ class SiteCreationIntentsFragment : Fragment() {
 
         when {
             !shouldBeVisible && headerLayout.isVisible -> {
-                headerLayout.animate().translationY(-headerLayout.height.toFloat()).withEndAction(toggleVisibility)
+                headerLayout.animate().alpha(0f).withEndAction(toggleVisibility)
             }
             shouldBeVisible && headerLayout.isGone -> {
-                headerLayout.animate().translationY(0f).withEndAction(toggleVisibility)
+                // I don't think we ever encounter this transition in the current code
+                headerLayout.isVisible = shouldBeVisible
+                headerLayout.animate().alpha(1f)
             }
         }
     }

--- a/WordPress/src/main/res/layout/site_creation_intents_fragment.xml
+++ b/WordPress/src/main/res/layout/site_creation_intents_fragment.xml
@@ -104,13 +104,6 @@
             app:layout_constraintTop_toBottomOf="@id/input_container"
             tools:listitem="@layout/site_creation_intents_item" />
 
-        <View
-            android:id="@+id/continue_button_shadow"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/siq_bottom_shadow_height"
-            android:background="@drawable/modal_layout_picker_bottom_shadow"
-            app:layout_constraintBottom_toTopOf="@id/continue_button_container" />
-
         <FrameLayout
             android:id="@+id/continue_button_container"
             android:layout_width="match_parent"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -652,7 +652,6 @@
     <!-- Site Intent Question -->
     <dimen name="siq_title_padding_start">@dimen/margin_extra_extra_large</dimen>
     <dimen name="siq_header_scroll_snap_threshold">-96dp</dimen>
-    <dimen name="siq_bottom_shadow_height">@dimen/margin_medium</dimen>
 
     <!-- Login Prologue -->
     <dimen name="login_prologue_content_area">320dp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3207,7 +3207,7 @@
     <string name="new_site_creation_intents_title">Site topic</string>
     <string name="new_site_creation_intents_header_title">What’s your website about?</string>
     <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type your own</string>
-    <string name="new_site_creation_intents_input_hint">Eg. Lifestyle, Poetry, Politics</string>
+    <string name="new_site_creation_intents_input_hint">Eg. Fashion, Poetry, Politics</string>
     <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>
     <string name="new_site_creation_unavailable_domain">This domain is unavailable</string>


### PR DESCRIPTION
Fixes #16209

### Description

This PR makes some minor style and animations to address the linked issue, as well as some issues described [here](https://github.com/wordpress-mobile/WordPress-Android/pull/16198#issuecomment-1083863537).

To test:

1. Navigate to the site intent screen (with the feature flag turned on)
2. Check that the input hint reads "E.g. Fashion, Poetry, Politics"
3. Tap the input box
4. Check that the header animation is a fade animation
   * If this proves to still be too janky, I've left [some code](https://github.com/wordpress-mobile/WordPress-Android/pull/16218/files#diff-f052313359db4ebc693a154aa6be96f3dedb5f00ae11dbed7884229c771cafeeR82) to make the transition more instantaneous
5. Type some letters (i.e. 'a', 'r', 't')
6. Check that the item animator is instantaneous (not the default item animator)
7. Type enough letters to make the Continue button visible
8. Check that the input button no longer has a shadow

## Regression Notes
1. Potential unintended areas of impact
N/A

9. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

10. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
