### PR TITLE
Integrate gutenberg-mobile release 1.73.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = 'trunk-39557b2153d1b0c0e7e3fd3a4fa32e6099bf50a2'
     wordPressLoginVersion = 'trunk-d4f9830a9e2d2cbf7e1edec2886af687363b0980'
-    gutenbergMobileVersion = 'v1.73.0-alpha4'
+    gutenbergMobileVersion = '4719-40ffec68ac3dc6ec936312e2cccf2a13b81a519a'
     storiesVersion = 'trunk-0b727f84440048e39d5e4835e2a84c67d043d225'
     aboutAutomatticVersion = 'trunk-99c45a25f4493f1ff19f1b88f718438dc7b3297a'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = 'trunk-39557b2153d1b0c0e7e3fd3a4fa32e6099bf50a2'
     wordPressLoginVersion = 'trunk-d4f9830a9e2d2cbf7e1edec2886af687363b0980'
-    gutenbergMobileVersion = '4719-40ffec68ac3dc6ec936312e2cccf2a13b81a519a'
+    gutenbergMobileVersion = 'v1.73.0'
     storiesVersion = 'trunk-0b727f84440048e39d5e4835e2a84c67d043d225'
     aboutAutomatticVersion = 'trunk-99c45a25f4493f1ff19f1b88f718438dc7b3297a'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.73.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4719

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

**Note**: This release does not include any user-facing changes, hence no updates for the release notes.