### PR TITLE
Fixes: Scrolling and focusing Quick Start position

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -170,7 +170,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             if (quickStartScrollPosition == -1) {
                 appbarMain.setExpanded(true, true)
                 quickStartScrollPosition = 0
-            } else if (quickStartScrollPosition > 2) {
+            } else {
                 appbarMain.setExpanded(false, true)
             }
             binding?.viewPager?.getCurrentFragment()?.handleScrollTo(quickStartScrollPosition)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -170,6 +170,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             if (quickStartScrollPosition == -1) {
                 appbarMain.setExpanded(true, true)
                 quickStartScrollPosition = 0
+            } else if (quickStartScrollPosition > 2) {
+                appbarMain.setExpanded(false, true)
             }
             binding?.viewPager?.getCurrentFragment()?.handleScrollTo(quickStartScrollPosition)
         }


### PR DESCRIPTION
Fixes #16224
This PR fixes the issue where the Quickstart focus point which would only be seen if scrolled to the bottom was not shown properly if the site info header was expanded.


https://user-images.githubusercontent.com/17463767/161259048-27be13e3-cc14-493a-9839-85e7f82ef409.mp4


To test:
- Launch the app with a site having a QuickStart in progress
- Keeping the Site header expanded, select a quick start that has a QuickStart focus point that needs to be scrolled down (Visit your site, Social Sharing)
- Notice that the Site info header gets collapsed and the Quickstart focus point is scrolled to the top to be visible properly 


## Regression Notes
1. Potential unintended areas of impact
Quick start focus point on the Site header is not visible when collapsed 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested Manually 

3. What automated tests I added (or what prevented me from doing so)
None 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
