### PR TITLE
My Site Dashboard: Feature Announcement 

### DIFF
--- a/WordPress/src/main/res/layout/feature_announcement_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/feature_announcement_dialog_fragment.xml
@@ -34,7 +34,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/feature_announcement_dialog_label">
 
                 <com.google.android.material.textview.MaterialTextView


### PR DESCRIPTION
Closes #16181

This PR adjusts the feature announcement dialog layout to have content closer to the title. 
(See p1648808258327999/1648805906.470849-slack-C0290FLA0RM)

WordPress (tested in dark mode) | Jetpack (tested in light mode)
--------|---------
<img width=320 src="https://user-images.githubusercontent.com/1405144/161257779-5af7fcc4-68c3-4cfd-8d46-8b417d187eb1.png"/> | <img width=320 src="https://user-images.githubusercontent.com/1405144/161262387-bfe396f1-823a-44ed-9a76-950c9a08f724.png"/>



**To test:**

**Setup**
- Mobile feature announcement **_224_** is set up for 19.7, it is in a disabled state. You can momentarily enable it as the target versionName is not the next release but the one after it. Make sure you disable it afterward.
- Checkout this branch
- The test instructions assume you don't have WP or JP versions on your test device.

**WordPress Test - wasabi variant**
- Bump up the app version to match the version in your test announcement (For **_224_**, use versionName to 19.7)
- Gradle sync, build a WordPress wasabi variant and run 
- Login to the app
- Increase the VersionCode
- Re-sync gradle then re-run the app
- You should see the feature announcement pop up

**Jetpack Test - wasabi variant**
- Bump up the app version to match the version in your test announcement (For **_224_**, use versionName to 19.7)
- Gradle sync, build a Jetpack wasabi variant and run 
- Login to the app
- Increase the VersionCode
- Re-sync gradle and re-run the app
- You should see the feature announcement pop up

**Merging Instructions**

- Targets 19.7 but can be merged to 19.6.

## Regression Notes
1. Potential unintended areas of impact
N/A (only minor layout fix, no changes to the logic)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.