### PR TITLE
[Tooling] Add WordPressEditor lib to the list of `strings.xml` files to merge during code-freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -756,7 +756,8 @@ REPOSITORY_NAME = 'WordPress-Android'
   MAIN_STRINGS_PATH = './WordPress/src/main/res/values/strings.xml'.freeze
   FROZEN_STRINGS_DIR_PATH = './fastlane/resources/values/'.freeze
   LOCAL_LIBRARIES_STRINGS_PATHS = [
-    { library: "Image Editor", strings_path: "./libs/image-editor/ImageEditor/src/main/res/values/strings.xml", exclusions: [] }
+    { library: "Image Editor", strings_path: "./libs/image-editor/ImageEditor/src/main/res/values/strings.xml", exclusions: [] },
+    { library: "WordPress Editor", strings_path: "./libs/editor/WordPressEditor/src/main/res/values/strings.xml", exclusions: [] }
   ].freeze
   REMOTE_LIBRARIES_STRINGS_PATHS = [
     {


### PR DESCRIPTION
As noted in p5T066-34Q-p2#comment-11836 we seem to have missed merging the `strings.xml` file for the `WordPressEditor` lib into the main file imported by GlotPress (`fastlane/resources/values/strings.xml`) during code-freeze.

This PR simply adds the reference to the `strings.xml` file of the `WordPressEditor` lib (which lives locally in the `./libs` directory of this repo) alongside the reference to the other strings we merge from other libs.