### PR TITLE
Fix: Quick Start Prompt not shown on API 25

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -308,7 +308,13 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        binding?.viewPager?.getCurrentFragment()?.onActivityResult(requestCode, resultCode, data)
+        /* Add brief delay before passing result to nested (view pager) tab fragments to give them time to get created.
+           This is a workaround to fix API Level 25 (GitHub #16225) issue where we noticed that nested fragments
+           were created after parent fragment was shown the first time and received activity result. It might not be a
+           real issue as we could only test it on an emulator, we added it to be safe in such cases. */
+        view?.postDelayed({
+            binding?.viewPager?.getCurrentFragment()?.onActivityResult(requestCode, resultCode, data)
+        }, PASS_ACTIVITY_RESULT_TO_TAB_FRAGMENT_DELAY)
     }
 
     private fun ViewPager2.getCurrentFragment() =
@@ -346,6 +352,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     companion object {
+        private const val PASS_ACTIVITY_RESULT_TO_TAB_FRAGMENT_DELAY = 300L
         fun newInstance(): MySiteFragment {
             return MySiteFragment()
         }


### PR DESCRIPTION
Fixes #16225

This PR adds a quick fix for the issue where we noticed that the order of nested child fragments creation/parent fragment result handling is different between different Android versions (as a result QS prompt was not shown after the `Login Epilogue` was dismissed) by adding a small delay before passing the result to nested child fragments.

(Internal Slack Ref: p1648794037279879-slack-C02QANACA)

It might not be a real issue as we could verify the issue only on a lower API level emulator but this workaround takes care of the scenario if it actually happens.

To test:

1. Fresh install the app on an API 25 emulator.
2. Login with a site eligible for Quick Start.
3. Notice that the Quick Start prompt is shown after the login epilogue screen.

To be safe, test it on a higher API level emulator/ device as well.

## Regression Notes
1. Potential unintended areas of impact
Other activity result scenarios like site icon change, stories photo picker should work as intended.

    Note that I also tried passing data from parent to child fragment using a shared parent fragment VM (in [this branch](https://github.com/wordpress-mobile/WordPress-Android/tree/issue/16225-fix-activity-result-issue)) but the site icon change was broken with this approach. 
   
    We might want to find a better way so that we don't have to add even this small delay but considering time constraints and that the delay added is negligible, the workaround serves the purpose. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.