### PR TITLE
Fixes: Make FAB be always above snackbar.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/LayoutBehaviors.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/LayoutBehaviors.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.View.MeasureSpec
 import android.view.animation.AccelerateInterpolator
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.coordinatorlayout.widget.CoordinatorLayout.Behavior
 import androidx.core.view.marginBottom
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar.SnackbarLayout
@@ -25,7 +24,7 @@ class WPTooltipViewBehavior : CoordinatorLayout.Behavior<WPTooltipView> {
     }
 
     override fun onDependentViewChanged(parent: CoordinatorLayout, child: WPTooltipView, dependency: View): Boolean {
-        if (child.getPosition() != ABOVE) {
+        if (child.position != ABOVE) {
             // Remove this condition if you want to support different TooltipPosition
             throw IllegalArgumentException("This behavior only supports TooltipPosition.ABOVE")
         }
@@ -51,7 +50,7 @@ class WPTooltipViewBehavior : CoordinatorLayout.Behavior<WPTooltipView> {
  * This class will let FloatingActionButton anchor above SnackBar with transition animation.
  */
 
-class FloatingActionButtonBehavior : Behavior<FloatingActionButton> {
+class FloatingActionButtonBehavior : CoordinatorLayout.Behavior<FloatingActionButton> {
     constructor() : super()
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/LayoutBehaviors.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/LayoutBehaviors.kt
@@ -1,0 +1,93 @@
+package org.wordpress.android.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.view.View.MeasureSpec
+import android.view.animation.AccelerateInterpolator
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.coordinatorlayout.widget.CoordinatorLayout.Behavior
+import androidx.core.view.marginBottom
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.snackbar.Snackbar.SnackbarLayout
+import org.wordpress.android.ui.WPTooltipView.TooltipPosition.ABOVE
+
+/**
+ * This class will let WPTooltipViewBehavior anchor above FloatingActionButton with transition animation.
+ */
+
+class WPTooltipViewBehavior : CoordinatorLayout.Behavior<WPTooltipView> {
+    constructor() : super()
+    constructor(context: Context, attr: AttributeSet) : super(context, attr)
+
+    override fun layoutDependsOn(parent: CoordinatorLayout, child: WPTooltipView, dependency: View): Boolean {
+        return dependency is FloatingActionButton
+    }
+
+    override fun onDependentViewChanged(parent: CoordinatorLayout, child: WPTooltipView, dependency: View): Boolean {
+        if (child.getPosition() != ABOVE) {
+            // Remove this condition if you want to support different TooltipPosition
+            throw IllegalArgumentException("This behavior only supports TooltipPosition.ABOVE")
+        }
+
+        if (dependency.measuredWidth == 0 || child.measuredWidth == 0) {
+            dependency.measure(MeasureSpec.UNSPECIFIED, MeasureSpec.UNSPECIFIED)
+            child.measure(MeasureSpec.UNSPECIFIED, MeasureSpec.UNSPECIFIED)
+        }
+
+        child.x = dependency.x - child.measuredWidth + dependency.measuredWidth
+        child.y = dependency.y - child.measuredHeight
+
+        return true
+    }
+
+    override fun onDependentViewRemoved(parent: CoordinatorLayout, child: WPTooltipView, dependency: View) {
+        super.onDependentViewRemoved(parent, child, dependency)
+        child.visibility = View.GONE
+    }
+}
+
+/**
+ * This class will let FloatingActionButton anchor above SnackBar with transition animation.
+ */
+
+class FloatingActionButtonBehavior : Behavior<FloatingActionButton> {
+    constructor() : super()
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+    override fun layoutDependsOn(parent: CoordinatorLayout, child: FloatingActionButton, dependency: View): Boolean {
+        return dependency is SnackbarLayout
+    }
+
+    override fun onDependentViewChanged(
+        parent: CoordinatorLayout,
+        child: FloatingActionButton,
+        dependency: View
+    ): Boolean {
+        if (dependency.visibility == View.VISIBLE) {
+            moveChildUp(child, dependency.height + dependency.marginBottom)
+            return true
+        }
+        return false
+    }
+
+    override fun onDependentViewRemoved(parent: CoordinatorLayout, child: FloatingActionButton, dependency: View) {
+        moveChildToInitialPosition(child)
+    }
+
+    private fun moveChildUp(child: View, translation: Int) {
+        child.animate()
+                .translationY((-translation).toFloat())
+                .setInterpolator(AccelerateInterpolator())
+                .setDuration(child.resources.getInteger(android.R.integer.config_shortAnimTime).toLong())
+                .start()
+    }
+
+    private fun moveChildToInitialPosition(child: View) {
+        child.animate()
+                .translationY(0f)
+                .setInterpolator(AccelerateInterpolator())
+                .setDuration(child.resources.getInteger(android.R.integer.config_shortAnimTime).toLong())
+                .start()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -33,7 +33,6 @@ class WPTooltipView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr) {
-    private var position = LEFT
     private var messageId = 0
     private var arrowHorizontalOffsetFromEndResId = 0
     private var arrowHorizontalOffsetFromStartResId = 0
@@ -41,6 +40,8 @@ class WPTooltipView @JvmOverloads constructor(
     private var arrowHorizontalOffsetFromStart = -1
     private var animationDuration: Int
     private var tvMessage: TextView
+    var position = LEFT
+        private set
 
     init {
         attrs?.also {
@@ -147,6 +148,4 @@ class WPTooltipView @JvmOverloads constructor(
     fun setMessage(message: CharSequence) {
         tvMessage.text = message
     }
-
-    fun getPosition() = position
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -6,12 +6,9 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
-import android.view.View.MeasureSpec
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import androidx.coordinatorlayout.widget.CoordinatorLayout
-import com.google.android.material.floatingactionbutton.FloatingActionButton
 import org.wordpress.android.R
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.ABOVE
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.BELOW
@@ -152,33 +149,4 @@ class WPTooltipView @JvmOverloads constructor(
     }
 
     fun getPosition() = position
-}
-
-class WPTooltipViewBehavior : CoordinatorLayout.Behavior<WPTooltipView> {
-    constructor()
-    constructor(context: Context, attr: AttributeSet)
-
-    override fun layoutDependsOn(parent: CoordinatorLayout, child: WPTooltipView, dependency: View): Boolean {
-        return dependency is FloatingActionButton
-    }
-
-    override fun onDependentViewChanged(parent: CoordinatorLayout, child: WPTooltipView, dependency: View): Boolean {
-        if (child.getPosition() != ABOVE) {
-            // Remove this condition if you want to support different TooltipPosition
-            throw IllegalArgumentException("This behavior only supports TooltipPosition.ABOVE")
-        }
-
-        dependency.measure(MeasureSpec.UNSPECIFIED, MeasureSpec.UNSPECIFIED)
-        child.measure(MeasureSpec.UNSPECIFIED, MeasureSpec.UNSPECIFIED)
-
-        child.x = dependency.x - child.measuredWidth + dependency.measuredWidth
-        child.y = dependency.y - child.measuredHeight
-
-        return true
-    }
-
-    override fun onDependentViewRemoved(parent: CoordinatorLayout, child: WPTooltipView, dependency: View) {
-        super.onDependentViewRemoved(parent, child, dependency)
-        child.visibility = View.GONE
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -6,16 +6,18 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
+import android.view.View.MeasureSpec
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.LayoutRes
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import org.wordpress.android.R
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.ABOVE
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.BELOW
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.LEFT
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.RIGHT
 import org.wordpress.android.util.RtlUtils
-import java.lang.IllegalArgumentException
 
 /**
  * Partially based on https://stackoverflow.com/a/42756576
@@ -29,7 +31,7 @@ import java.lang.IllegalArgumentException
 
 private const val HIDE_ANIMATION_DURATION = 50L
 
-class WPTooltipView @JvmOverloads constructor (
+class WPTooltipView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
@@ -147,5 +149,36 @@ class WPTooltipView @JvmOverloads constructor (
 
     fun setMessage(message: CharSequence) {
         tvMessage.text = message
+    }
+
+    fun getPosition() = position
+}
+
+class WPTooltipViewBehavior : CoordinatorLayout.Behavior<WPTooltipView> {
+    constructor()
+    constructor(context: Context, attr: AttributeSet)
+
+    override fun layoutDependsOn(parent: CoordinatorLayout, child: WPTooltipView, dependency: View): Boolean {
+        return dependency is FloatingActionButton
+    }
+
+    override fun onDependentViewChanged(parent: CoordinatorLayout, child: WPTooltipView, dependency: View): Boolean {
+        if (child.getPosition() != ABOVE) {
+            // Remove this condition if you want to support different TooltipPosition
+            throw IllegalArgumentException("This behavior only supports TooltipPosition.ABOVE")
+        }
+
+        dependency.measure(MeasureSpec.UNSPECIFIED, MeasureSpec.UNSPECIFIED)
+        child.measure(MeasureSpec.UNSPECIFIED, MeasureSpec.UNSPECIFIED)
+
+        child.x = dependency.x - child.measuredWidth + dependency.measuredWidth
+        child.y = dependency.y - child.measuredHeight
+
+        return true
+    }
+
+    override fun onDependentViewRemoved(parent: CoordinatorLayout, child: WPTooltipView, dependency: View) {
+        super.onDependentViewRemoved(parent, child, dependency)
+        child.visibility = View.GONE
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -15,6 +15,7 @@ import android.widget.Toast
 import androidx.annotation.DrawableRes
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
@@ -35,6 +36,7 @@ import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_POSTS_LIST
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.ScrollableViewInitializedListener
+import org.wordpress.android.ui.WPTooltipViewBehavior
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils.observeBottomSheet
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
@@ -214,6 +216,10 @@ class PostsListActivity : LocaleAwareActivity(),
         }
 
         fabButton.redirectContextClickToLongPressListener()
+
+        fabTooltip.layoutParams = (fabTooltip.layoutParams as CoordinatorLayout.LayoutParams).apply {
+            behavior = WPTooltipViewBehavior()
+        }
 
         fabTooltip.setOnClickListener {
             postListCreateMenuViewModel.onTooltipTapped()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -15,7 +15,6 @@ import android.widget.Toast
 import androidx.annotation.DrawableRes
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
@@ -36,7 +35,6 @@ import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_POSTS_LIST
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.ScrollableViewInitializedListener
-import org.wordpress.android.ui.WPTooltipViewBehavior
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils.observeBottomSheet
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
@@ -216,10 +214,6 @@ class PostsListActivity : LocaleAwareActivity(),
         }
 
         fabButton.redirectContextClickToLongPressListener()
-
-        fabTooltip.layoutParams = (fabTooltip.layoutParams as CoordinatorLayout.LayoutParams).apply {
-            behavior = WPTooltipViewBehavior()
-        }
 
         fabTooltip.setOnClickListener {
             postListCreateMenuViewModel.onTooltipTapped()

--- a/WordPress/src/main/res/layout/post_list_activity.xml
+++ b/WordPress/src/main/res/layout/post_list_activity.xml
@@ -82,8 +82,9 @@
         android:layout_marginEnd="@dimen/fab_margin"
         android:contentDescription="@string/fab_create_desc"
         android:src="@drawable/ic_create_white_24dp"
+        android:layout_gravity="end|bottom"
         app:borderWidth="0dp"
-        android:layout_gravity="end|bottom" />
+        app:layout_behavior="org.wordpress.android.ui.FloatingActionButtonBehavior" />
 
     <org.wordpress.android.ui.WPTooltipView
         android:id="@+id/fab_tooltip"

--- a/WordPress/src/main/res/layout/post_list_activity.xml
+++ b/WordPress/src/main/res/layout/post_list_activity.xml
@@ -74,44 +74,27 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         app:layout_constraintTop_toBottomOf="@id/toolbar" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_button"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="end|bottom">
+        android:layout_marginBottom="@dimen/fab_margin"
+        android:layout_marginEnd="@dimen/fab_margin"
+        android:contentDescription="@string/fab_create_desc"
+        android:src="@drawable/ic_create_white_24dp"
+        app:borderWidth="0dp"
+        android:layout_gravity="end|bottom" />
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/fab_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/fab_margin"
-            android:layout_marginEnd="@dimen/fab_margin"
-            android:contentDescription="@string/fab_create_desc"
-            android:src="@drawable/ic_create_white_24dp"
-            app:borderWidth="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="1.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="1.0" />
-
-        <org.wordpress.android.ui.WPTooltipView
-            android:id="@+id/fab_tooltip"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_above="@+id/fab_button"
-            android:layout_alignParentEnd="true"
-            android:layout_marginEnd="@dimen/margin_medium"
-            android:layout_marginStart="@dimen/margin_medium"
-            android:importantForAccessibility="noHideDescendants"
-            android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@id/fab_button"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="1.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:wpArrowHorizontalOffsetFromEnd="@dimen/main_fab_tooltip_offset_end"
-            app:wpTooltipMessage="@string/create_post_story_fab_tooltip"
-            app:wpTooltipPosition="above"
-            tools:visibility="visible" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    <org.wordpress.android.ui.WPTooltipView
+        android:id="@+id/fab_tooltip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_medium"
+        android:layout_marginStart="@dimen/margin_medium"
+        android:importantForAccessibility="noHideDescendants"
+        android:visibility="gone"
+        app:wpArrowHorizontalOffsetFromEnd="@dimen/main_fab_tooltip_offset_end"
+        app:wpTooltipMessage="@string/create_post_story_fab_tooltip"
+        app:wpTooltipPosition="above"
+        tools:visibility="visible" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/post_list_activity.xml
+++ b/WordPress/src/main/res/layout/post_list_activity.xml
@@ -93,6 +93,7 @@
         android:layout_marginStart="@dimen/margin_medium"
         android:importantForAccessibility="noHideDescendants"
         android:visibility="gone"
+        app:layout_behavior="org.wordpress.android.ui.WPTooltipViewBehavior"
         app:wpArrowHorizontalOffsetFromEnd="@dimen/main_fab_tooltip_offset_end"
         app:wpTooltipMessage="@string/create_post_story_fab_tooltip"
         app:wpTooltipPosition="above"


### PR DESCRIPTION
Fixes #16149 

Removed the nested ConstraintLayout for letting FAB anchor above snackbar in CoordinatorLayout by default.

Moreover, added layout behaviors let views can anchor to the correct position with a transition animation.

To test:
Edit a draft and leave the page like the videos in **Before** and **After**.

## Before

https://user-images.githubusercontent.com/4656348/159555194-04e5b0e7-3d6d-4e67-b93d-2736419b24a5.mp4

## After

https://user-images.githubusercontent.com/3839951/161393458-65c2bb74-5fad-4170-8ea1-89ad69f2e6c8.mp4

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
