### PR TITLE
[Site Intent Question] Adds release note

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 19.6
 -----
 * [*] My Site: Fixes an issue where a deleted site is displayed until the app restarts [https://github.com/wordpress-mobile/WordPress-Android/pull/16063]
+* [*] [internal] Site creation: Adds a new screen asking the user the intent of the site [https://github.com/wordpress-mobile/WordPress-Android/pull/16243]
 
 19.5
 -----


### PR DESCRIPTION
Adds release note for the Site Intent Question screen

To test:
See Test Plan at `pdcxQM-IX-p2`

Note:
You can install a version that bypasses the A/B test and has the feature on by default at https://github.com/wordpress-mobile/WordPress-Android/pull/16257


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
