### PR TITLE
My Site Dashboard: Initial Screen App Setting

### DIFF
--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -134,6 +134,9 @@
     <string name="pref_key_jetpack_require_two_factor" translatable="false">wp_pref_jetpack_require_two_factor</string>
     <string name="pref_key_jetpack_learn_more" translatable="false">wp_pref_jetpack_learn_more</string>
 
+    <!-- Initial Screen -->
+    <string name="pref_key_initial_screen" translatable="false">wp_pref_initial_screen</string>
+
     <string name="wp_pref_notifications_root" translatable="false">wp_pref_notifications_root</string>
     <string name="wp_pref_notifications_main" translatable="false">wp_pref_notifications_master</string>
     <string name="wp_pref_custom_notification_sound" translatable="false">wp_pref_custom_notification_sound</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4005,4 +4005,22 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_prompts_onboarding_try_it_now">Try it now</string>
     <string name="blogging_prompts_onboarding_remind_me">Remind me</string>
     <string name="blogging_prompts_onboarding_card_prompt">Cast the movie of your life.</string>
+
+    <!-- Initial Screen -->
+    <string name="initial_screen">Initial Screen</string>
+    <string name="initial_screen_home">Home</string>
+    <string name="initial_screen_site_menu">Site Menu</string>
+    <string name="initial_screen_default">Home</string>
+    <string name="initial_screen_entry_value_home" translatable="false">home</string>
+    <string name="initial_screen_entry_value_site_menu" translatable="false">site_menu</string>
+    <string name="initial_screen_entry_value_default" translatable="false">home</string>
+    <string name="initial_screen_entry_value_default_key" translatable="false">@string/initial_screen_entry_value_home</string>
+    <string-array name="initial_screen_entries" translatable="false" tools:ignore="InconsistentArrays">
+        <item>@string/initial_screen_home</item>
+        <item>@string/initial_screen_site_menu</item>
+    </string-array>
+    <string-array name="initial_screen_entry_values" translatable="false" tools:ignore="InconsistentArrays">
+        <item>@string/initial_screen_entry_value_home</item>
+        <item>@string/initial_screen_entry_value_site_menu</item>
+    </string-array>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4006,8 +4006,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Initial Screen -->
     <string name="initial_screen">Initial Screen</string>
-    <string name="initial_screen_home">@string/my_site_dashboard_tab_title</string>
-    <string name="initial_screen_site_menu">@string/my_site_menu_tab_title</string>
+    <string name="initial_screen_home" translatable="false">@string/my_site_dashboard_tab_title</string>
+    <string name="initial_screen_site_menu" translatable="false">@string/my_site_menu_tab_title</string>
     <string name="initial_screen_entry_value_home" translatable="false">home</string>
     <string name="initial_screen_entry_value_site_menu" translatable="false">site_menu</string>
     <string name="initial_screen_entry_value_default_key" translatable="false">@string/initial_screen_entry_value_site_menu</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4010,10 +4010,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="initial_screen">Initial Screen</string>
     <string name="initial_screen_home">Home</string>
     <string name="initial_screen_site_menu">Site Menu</string>
-    <string name="initial_screen_default">Home</string>
     <string name="initial_screen_entry_value_home" translatable="false">home</string>
     <string name="initial_screen_entry_value_site_menu" translatable="false">site_menu</string>
-    <string name="initial_screen_entry_value_default" translatable="false">home</string>
     <string name="initial_screen_entry_value_default_key" translatable="false">@string/initial_screen_entry_value_home</string>
     <string-array name="initial_screen_entries" translatable="false" tools:ignore="InconsistentArrays">
         <item>@string/initial_screen_home</item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4012,7 +4012,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="initial_screen_site_menu">@string/my_site_menu_tab_title</string>
     <string name="initial_screen_entry_value_home" translatable="false">home</string>
     <string name="initial_screen_entry_value_site_menu" translatable="false">site_menu</string>
-    <string name="initial_screen_entry_value_default_key" translatable="false">@string/initial_screen_entry_value_home</string>
+    <string name="initial_screen_entry_value_default_key" translatable="false">@string/initial_screen_entry_value_site_menu</string>
     <string-array name="initial_screen_entries" translatable="false" tools:ignore="InconsistentArrays">
         <item>@string/initial_screen_home</item>
         <item>@string/initial_screen_site_menu</item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4008,8 +4008,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Initial Screen -->
     <string name="initial_screen">Initial Screen</string>
-    <string name="initial_screen_home">Home</string>
-    <string name="initial_screen_site_menu">Site Menu</string>
+    <string name="initial_screen_home">@string/my_site_dashboard_tab_title</string>
+    <string name="initial_screen_site_menu">@string/my_site_menu_tab_title</string>
     <string name="initial_screen_entry_value_home" translatable="false">home</string>
     <string name="initial_screen_entry_value_site_menu" translatable="false">site_menu</string>
     <string name="initial_screen_entry_value_default_key" translatable="false">@string/initial_screen_entry_value_home</string>

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -67,6 +67,15 @@
         android:key="@string/pref_key_device_settings"
         android:title="@string/preference_open_device_settings" />
 
+    <ListPreference
+        android:defaultValue="@string/initial_screen_entry_value_default_key"
+        android:dialogTitle="@string/initial_screen"
+        android:entries="@array/initial_screen_entries"
+        android:entryValues="@array/initial_screen_entry_values"
+        android:key="@string/pref_key_initial_screen"
+        android:summary="%s"
+        android:title="@string/initial_screen" />
+
     <Preference
         android:key="@string/pref_key_whats_new"
         android:title="@string/whats_new_in_version_title" />

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -838,7 +838,8 @@ public final class AnalyticsTracker {
         MY_SITE_TAB_TAPPED,
         MY_SITE_DASHBOARD_SHOWN,
         MY_SITE_SITE_MENU_SHOWN,
-        MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED
+        MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED,
+        APP_SETTINGS_INITIAL_SCREEN_CHANGED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2174,6 +2174,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "my_site_site_menu_shown";
             case MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED:
                 return "my_site_default_tab_experiment_variant_assigned";
+            case APP_SETTINGS_INITIAL_SCREEN_CHANGED:
+                return "app_settings_initial_screen_changed";
         }
         return null;
     }


### PR DESCRIPTION
Parent #15989 

This PR adds the “initial screen” setting to the App Settings view. The setting is only visible when tabs are enabled for My Site Dashboard. This setting will persist until the app is uninstalled/reinstalled - similar to other device app settings.

**Merge Instructions**
- You can review, but not merge this PR yet. I am waiting on some verifications from the iOS team with regards to what the default value should be for the setting. I will review the "do not merge label" after the direction has been clarified.

**To test**
Do a clean install of the app and don't enable the MySiteDashboardTabsFeatureConfig flag. Then:

1. Login or create a new account
2. Navigate to Me → App Settings 
3. Note: You don’t see an "Initial Screen" option 
4. Navigate to Me → App Settings → Debug
5. Enable the MySiteDashboardTabsFeatureConfig flag and restart the App
6. When the app has restarted, Navigate to Me → App Settings 
7. Note: You see an "Initial Screen" option
8. Change the value
9. Make sure that an event is fired on the console, like: `🔵 Tracked: app_settings_initial_screen_changed, Properties: {"default_tab_experiment":"site_menu","selected":"site_menu"}`
10. Close and reopen the app
11. Navigate back to Me → App Settings
12. Note: The option you selected is now the default

## Regression Notes
1. Potential unintended areas of impact
The app setting does not show or hide the initial screen setting

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual test

3. What automated tests I added (or what prevented me from doing so)
There are no unit tests for the AppSettingsFragment.

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
