### PR TITLE
My Site Dashboard: Tabs - Allow tabs + Show dashboard cards in Jetpack app

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -178,7 +178,7 @@ android {
             buildConfigField "boolean", "ENABLE_QUICK_ACTION", "true"
             buildConfigField "boolean", "ENABLE_FOLLOWED_SITES_SETTINGS", "true"
             buildConfigField "boolean", "ENABLE_WHATS_NEW_FEATURE", "true"
-            buildConfigField "boolean", "ENABLE_MY_SITE_DASHBOARD_TABS", "false"
+            buildConfigField "boolean", "ENABLE_MY_SITE_DASHBOARD_TABS", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.Dyn
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction.Pin
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction.Unpin
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsSource
-import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
 import javax.inject.Inject
@@ -31,7 +30,6 @@ class MySiteSourceManager @Inject constructor(
     cardsSource: CardsSource,
     siteIconProgressSource: SiteIconProgressSource,
     private val mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig,
-    private val buildConfigWrapper: BuildConfigWrapper,
     private val selectedSiteRepository: SelectedSiteRepository
 ) {
     private val mySiteSources: List<MySiteSource<*>> = listOf(
@@ -47,7 +45,6 @@ class MySiteSourceManager @Inject constructor(
 
     private val showDashboardCards: Boolean
         get() = mySiteDashboardPhase2FeatureConfig.isEnabled() &&
-                !buildConfigWrapper.isJetpackApp &&
                 selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi == true
 
     private val allSupportedMySiteSources: List<MySiteSource<*>>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrati
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardSource
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel.DynamicCardMenuInteraction
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsSource
-import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
 
@@ -47,7 +46,6 @@ class MySiteSourceManagerTest : BaseUnitTest() {
     @Mock lateinit var siteIconProgressSource: SiteIconProgressSource
     @Mock lateinit var selectedSiteSource: SelectedSiteSource
     @Mock lateinit var mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig
-    @Mock lateinit var builderConfigWrapper: BuildConfigWrapper
     @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
     @Mock lateinit var siteModel: SiteModel
     private lateinit var mySiteSourceManager: MySiteSourceManager
@@ -77,7 +75,6 @@ class MySiteSourceManagerTest : BaseUnitTest() {
                 cardsSource,
                 siteIconProgressSource,
                 mySiteDashboardPhase2FeatureConfig,
-                builderConfigWrapper,
                 selectedSiteRepository
         )
 
@@ -138,26 +135,13 @@ class MySiteSourceManagerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given with site local id and wordpress app, when build, then all sources are built`() {
+    fun `given with site local id, when build, then all sources are built`() {
         val coroutineScope = testScope()
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
-        whenever(builderConfigWrapper.isJetpackApp).thenReturn(false)
 
         mySiteSourceManager.build(coroutineScope, SITE_LOCAL_ID)
 
         allRefreshedMySiteSources.forEach { verify(it).build(coroutineScope, SITE_LOCAL_ID) }
-    }
-
-    @Test
-    fun `given with site local id and jetpack app, when build, then all sources except cards source are built`() {
-        val coroutineScope = testScope()
-        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
-        whenever(builderConfigWrapper.isJetpackApp).thenReturn(true)
-
-        mySiteSourceManager.build(coroutineScope, SITE_LOCAL_ID)
-
-        allRefreshedMySiteSourcesExceptCardsSource.forEach { verify(it).build(coroutineScope, SITE_LOCAL_ID) }
-        verify(cardsSource, times(0)).build(coroutineScope, SITE_LOCAL_ID)
     }
 
     @Test


### PR DESCRIPTION
Parent #16253

This PR allows tabs (e1748eedd2a3b06a8311837d4ff015ff47c86168) and displays dashboard cards (7546dc05a9a724d593efb40a201b3feb9ef39f02, d867c727819d3ebc6a535d20e055cc0fa3b806e0) in the Jetpack app.

**Review Instructions**

Review from only one reviewer is sufficient.

##### PS: I did a undo/ redo of commit 7546dc05a9a724d593efb40a201b3feb9ef39f02; during redo changes were not committed to `MySiteSourceManager` so had to push another commit: d867c727819d3ebc6a535d20e055cc0fa3b806e0.

**To Test**

#### Test.1 - Without tabs

1. Launch the Jetpack app.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
3. Turn off the `MySiteDashboardTabsFeatureConfig` flag under the Features in development section.
4. Restart the app.
6. Note that tabs are not displayed.
7. Select a site that allows showing dashboard cards (`isUsingWpComRestApi`).
8. Note that
    - `Post` dashboard card is displayed.
    (One or more of: `Create your first post`/ `Work on a draft post/` `Upcoming scheduled posts`/ `Create your next post` cards based on existing logic)
    - `Today's Stats` dashboard card is displayed.
     (Note that the card is shown based on an active A/B experiment. If the card is not displayed, enable `Me`->`App Settings`->`Debug settings` ->`my_site_dashbaord_todays_stats_card`)

#### Test.2 - With tabs

1. Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
2. Turn off the `MySiteDashboardTabsFeatureConfig` flag under the Features in the development section.
3. Restart the app.
4. Notice that tabs are displayed.
5. Select a site that allows showing dashboard cards (`isUsingWpComRestApi`).
6. Note that `Post` and `Today's Stats` dashboard cards are displayed on the `Dashboard`/ `Home` tab.

/cc @tiagomar 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.