### PR TITLE
Display site name screen in site creation flow

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -119,6 +119,7 @@ android {
         buildConfigField "boolean", "COMMENTS_SNIPPET", "false"
         buildConfigField "boolean", "READER_COMMENTS_MODERATION", "false"
         buildConfigField "boolean", "SITE_INTENT_QUESTION", "true"
+        buildConfigField "boolean", "SITE_NAME", "false"
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
         buildConfigField "boolean", "MY_SITE_DEFAULT_TAB_EXPERIMENT", "false"

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -205,6 +205,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationActivity;
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment;
 import org.wordpress.android.ui.sitecreation.previews.SiteCreationPreviewFragment;
 import org.wordpress.android.ui.sitecreation.services.SiteCreationService;
+import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameFragment;
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerFragment;
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsFragment;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
@@ -586,6 +587,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(HomePagePickerFragment object);
 
     void inject(SiteCreationIntentsFragment object);
+
+    void inject(SiteCreationSiteNameFragment object);
 
     void inject(SubfilterBottomSheetFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ExperimentModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ExperimentModule.kt
@@ -1,8 +1,11 @@
 package org.wordpress.android.modules
 
+import dagger.Binds
 import dagger.Module
+import dagger.multibindings.IntoSet
 import dagger.multibindings.Multibinds
 import org.wordpress.android.util.experiments.Experiment
+import org.wordpress.android.util.experiments.SiteNameABExperiment
 
 @Module
 interface ExperimentModule {
@@ -10,4 +13,6 @@ interface ExperimentModule {
 
     // Copy and paste the line below to add a new experiment.
     // @Binds @IntoSet fun exampleExperiment(experiment: ExampleExperiment): Experiment
+
+    @Binds @IntoSet fun siteNameABExperiment(experiment: SiteNameABExperiment): Experiment
 }

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -63,6 +63,7 @@ import org.wordpress.android.ui.reader.viewmodels.SubfilterPageViewModel;
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM;
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel;
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel;
+import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewModel;
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerViewModel;
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel;
 import org.wordpress.android.ui.stats.refresh.StatsViewModel;
@@ -254,6 +255,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(SiteCreationIntentsViewModel.class)
     abstract ViewModel siteCreationIntentsViewModel(SiteCreationIntentsViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(SiteCreationSiteNameViewModel.class)
+    abstract ViewModel siteCreationSiteNameViewModel(SiteCreationSiteNameViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -20,7 +20,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.INTENTS
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_DESIGNS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.ui.sitecreation.domains.DomainsScreenListener
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment
@@ -151,7 +151,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         val screenTitle = getScreenTitle(target.wizardStep)
         val fragment = when (target.wizardStep) {
             INTENTS -> SiteCreationIntentsFragment()
-            SEGMENTS -> HomePagePickerFragment()
+            SITE_DESIGNS -> HomePagePickerFragment()
             DOMAINS -> SiteCreationDomainsFragment.newInstance(
                     screenTitle
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -60,6 +60,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
     private lateinit var hppViewModel: HomePagePickerViewModel
     private lateinit var siteCreationIntentsViewModel: SiteCreationIntentsViewModel
     private lateinit var siteCreationSiteNameViewModel: SiteCreationSiteNameViewModel
+    @Inject lateinit var siteCreationStepsProvider: SiteCreationStepsProvider
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -143,7 +144,9 @@ class SiteCreationActivity : LocaleAwareActivity(),
 
     override fun onIntentSelected(intent: String) {
         mainViewModel.onSiteIntentSelected(intent)
-        ActivityUtils.hideKeyboard(this)
+        if (!siteCreationStepsProvider.isSiteNameEnabled) {
+            ActivityUtils.hideKeyboard(this)
+        }
     }
 
     override fun onSiteNameEntered(siteName: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -130,6 +130,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
             mainViewModel.onBackPressed()
         })
         siteCreationSiteNameViewModel.onSkipButtonPressed.observe(this, Observer {
+            ActivityUtils.hideKeyboard(this)
             mainViewModel.onSiteNameSkipped()
         })
         hppViewModel.onBackButtonPressed.observe(this, Observer {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.INTENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_DESIGNS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_NAME
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.ui.sitecreation.domains.DomainsScreenListener
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment
@@ -31,6 +32,9 @@ import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.Creat
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState.SiteCreationCompleted
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState.SiteNotCreated
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState.SiteNotInLocalDb
+import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameFragment
+import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewModel
+import org.wordpress.android.ui.sitecreation.sitename.SiteNameScreenListener
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerFragment
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerViewModel
 import org.wordpress.android.ui.sitecreation.verticals.IntentsScreenListener
@@ -44,6 +48,7 @@ import javax.inject.Inject
 @Suppress("TooManyFunctions")
 class SiteCreationActivity : LocaleAwareActivity(),
         IntentsScreenListener,
+        SiteNameScreenListener,
         DomainsScreenListener,
         SitePreviewScreenListener,
         OnHelpClickedListener,
@@ -54,6 +59,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
     private lateinit var mainViewModel: SiteCreationMainVM
     private lateinit var hppViewModel: HomePagePickerViewModel
     private lateinit var siteCreationIntentsViewModel: SiteCreationIntentsViewModel
+    private lateinit var siteCreationSiteNameViewModel: SiteCreationSiteNameViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -63,6 +69,8 @@ class SiteCreationActivity : LocaleAwareActivity(),
         hppViewModel = ViewModelProvider(this, viewModelFactory).get(HomePagePickerViewModel::class.java)
         siteCreationIntentsViewModel = ViewModelProvider(this, viewModelFactory)
                 .get(SiteCreationIntentsViewModel::class.java)
+        siteCreationSiteNameViewModel = ViewModelProvider(this, viewModelFactory)
+                .get(SiteCreationSiteNameViewModel::class.java)
         mainViewModel.start(savedInstanceState)
         hppViewModel.loadSavedState(savedInstanceState)
 
@@ -118,6 +126,12 @@ class SiteCreationActivity : LocaleAwareActivity(),
         siteCreationIntentsViewModel.onSkipButtonPressed.observe(this, Observer {
             mainViewModel.onSiteIntentSkipped()
         })
+        siteCreationSiteNameViewModel.onBackButtonPressed.observe(this, Observer {
+            mainViewModel.onBackPressed()
+        })
+        siteCreationSiteNameViewModel.onSkipButtonPressed.observe(this, Observer {
+            mainViewModel.onSiteNameSkipped()
+        })
         hppViewModel.onBackButtonPressed.observe(this, Observer {
             mainViewModel.onBackPressed()
         })
@@ -128,6 +142,11 @@ class SiteCreationActivity : LocaleAwareActivity(),
 
     override fun onIntentSelected(intent: String) {
         mainViewModel.onSiteIntentSelected(intent)
+        ActivityUtils.hideKeyboard(this)
+    }
+
+    override fun onSiteNameEntered(siteName: String) {
+        mainViewModel.onSiteNameEntered(siteName)
         ActivityUtils.hideKeyboard(this)
     }
 
@@ -151,6 +170,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         val screenTitle = getScreenTitle(target.wizardStep)
         val fragment = when (target.wizardStep) {
             INTENTS -> SiteCreationIntentsFragment()
+            SITE_NAME -> SiteCreationSiteNameFragment()
             SITE_DESIGNS -> HomePagePickerFragment()
             DOMAINS -> SiteCreationDomainsFragment.newInstance(
                     screenTitle

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -103,10 +103,12 @@ class SiteCreationMainVM @Inject constructor(
     }
 
     fun onSiteIntentSkipped() {
+        siteCreationState = siteCreationState.copy(siteIntent = null)
         wizardManager.showNextStep()
     }
 
     fun onSiteNameSkipped() {
+        siteCreationState = siteCreationState.copy(siteName = null)
         wizardManager.showNextStep()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_DESIGNS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState
@@ -131,7 +131,7 @@ class SiteCreationMainVM @Inject constructor(
 
     private fun clearOldSiteCreationState(wizardStep: SiteCreationStep) {
         when (wizardStep) {
-            SEGMENTS -> { }
+            SITE_DESIGNS -> { }
             DOMAINS -> siteCreationState.domain?.let {
                 siteCreationState = siteCreationState.copy(domain = null)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -35,6 +35,7 @@ const val KEY_SITE_CREATION_STATE = "key_site_creation_state"
 @SuppressLint("ParcelCreator")
 data class SiteCreationState(
     val siteIntent: String? = null,
+    val siteName: String? = null,
     val segmentId: Long? = null,
     val siteDesign: String? = null,
     val domain: String? = null
@@ -102,6 +103,15 @@ class SiteCreationMainVM @Inject constructor(
     }
 
     fun onSiteIntentSkipped() {
+        wizardManager.showNextStep()
+    }
+
+    fun onSiteNameSkipped() {
+        wizardManager.showNextStep()
+    }
+
+    fun onSiteNameEntered(siteName: String) {
+        siteCreationState = siteCreationState.copy(siteName = siteName)
         wizardManager.showNextStep()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -1,24 +1,41 @@
 package org.wordpress.android.ui.sitecreation
 
+import org.wordpress.android.fluxc.model.experiments.Variation.Control
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.INTENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_DESIGNS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_NAME
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.util.config.SiteIntentQuestionFeatureConfig
+import org.wordpress.android.util.config.SiteNameFeatureConfig
+import org.wordpress.android.util.experiments.SiteNameABExperiment
 import org.wordpress.android.util.wizard.WizardStep
 import javax.inject.Inject
 import javax.inject.Singleton
 
 enum class SiteCreationStep : WizardStep {
-    SITE_DESIGNS, DOMAINS, SITE_PREVIEW, INTENTS;
+    SITE_DESIGNS, DOMAINS, SITE_PREVIEW, INTENTS, SITE_NAME;
 }
 
 @Singleton
 class SiteCreationStepsProvider @Inject constructor(
-    private val siteIntentQuestionFeatureConfig: SiteIntentQuestionFeatureConfig
+    private val siteIntentQuestionFeatureConfig: SiteIntentQuestionFeatureConfig,
+    private val siteNameFeatureConfig: SiteNameFeatureConfig,
+    private val siteNameABExperiment: SiteNameABExperiment,
 ) {
     fun getSteps(): List<SiteCreationStep> {
         if (siteIntentQuestionFeatureConfig.isEnabled()) {
+            // if (siteNameFeatureConfig.isEnabled() && siteNameABExperiment.getVariation() != Control) {
+            // For convenience while testing, hardcode to true:
+            if (true) {
+                return listOf(
+                        INTENTS,
+                        SITE_NAME,
+                        SITE_DESIGNS,
+                        SITE_PREVIEW
+                )
+            }
+
             return listOf(
                     INTENTS,
                     SITE_DESIGNS,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -23,14 +23,12 @@ class SiteCreationStepsProvider @Inject constructor(
     private val siteNameFeatureConfig: SiteNameFeatureConfig,
     private val siteNameABExperiment: SiteNameABExperiment
 ) {
-    fun getSteps(): List<SiteCreationStep> {
-        val isSiteNameEnabled = siteNameFeatureConfig.isEnabled() && siteNameABExperiment.getVariation() != Control
-        val isIntentsEnabled = siteIntentQuestionFeatureConfig.isEnabled()
+    val isSiteNameEnabled get() = siteNameFeatureConfig.isEnabled() && siteNameABExperiment.getVariation() != Control
+    val isIntentsEnabled get() = siteIntentQuestionFeatureConfig.isEnabled()
 
-        return when {
-            isSiteNameEnabled -> listOf(INTENTS, SITE_NAME, SITE_DESIGNS, SITE_PREVIEW)
-            isIntentsEnabled -> listOf(INTENTS, SITE_DESIGNS, DOMAINS, SITE_PREVIEW)
-            else -> listOf(SITE_DESIGNS, DOMAINS, SITE_PREVIEW)
-        }
+    fun getSteps(): List<SiteCreationStep> = when {
+        isSiteNameEnabled -> listOf(INTENTS, SITE_NAME, SITE_DESIGNS, SITE_PREVIEW)
+        isIntentsEnabled -> listOf(INTENTS, SITE_DESIGNS, DOMAINS, SITE_PREVIEW)
+        else -> listOf(SITE_DESIGNS, DOMAINS, SITE_PREVIEW)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -29,7 +29,7 @@ class SiteCreationStepsProvider @Inject constructor(
 
         return when {
             isSiteNameEnabled -> listOf(INTENTS, SITE_NAME, SITE_DESIGNS, SITE_PREVIEW)
-            isIntentsEnabled-> listOf(INTENTS, SITE_DESIGNS, DOMAINS, SITE_PREVIEW)
+            isIntentsEnabled -> listOf(INTENTS, SITE_DESIGNS, DOMAINS, SITE_PREVIEW)
             else -> listOf(SITE_DESIGNS, DOMAINS, SITE_PREVIEW)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -21,7 +21,7 @@ enum class SiteCreationStep : WizardStep {
 class SiteCreationStepsProvider @Inject constructor(
     private val siteIntentQuestionFeatureConfig: SiteIntentQuestionFeatureConfig,
     private val siteNameFeatureConfig: SiteNameFeatureConfig,
-    private val siteNameABExperiment: SiteNameABExperiment,
+    private val siteNameABExperiment: SiteNameABExperiment
 ) {
     fun getSteps(): List<SiteCreationStep> {
         if (siteIntentQuestionFeatureConfig.isEnabled()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -24,28 +24,13 @@ class SiteCreationStepsProvider @Inject constructor(
     private val siteNameABExperiment: SiteNameABExperiment
 ) {
     fun getSteps(): List<SiteCreationStep> {
-        if (siteIntentQuestionFeatureConfig.isEnabled()) {
-             if (siteNameFeatureConfig.isEnabled() && siteNameABExperiment.getVariation() != Control) {
-                return listOf(
-                        INTENTS,
-                        SITE_NAME,
-                        SITE_DESIGNS,
-                        SITE_PREVIEW
-                )
-            }
+        val isSiteNameEnabled = siteNameFeatureConfig.isEnabled() && siteNameABExperiment.getVariation() != Control
+        val isIntentsEnabled = siteIntentQuestionFeatureConfig.isEnabled()
 
-            return listOf(
-                    INTENTS,
-                    SITE_DESIGNS,
-                    DOMAINS,
-                    SITE_PREVIEW
-            )
+        return when {
+            isSiteNameEnabled -> listOf(INTENTS, SITE_NAME, SITE_DESIGNS, SITE_PREVIEW)
+            isIntentsEnabled-> listOf(INTENTS, SITE_DESIGNS, DOMAINS, SITE_PREVIEW)
+            else -> listOf(SITE_DESIGNS, DOMAINS, SITE_PREVIEW)
         }
-
-        return listOf(
-                SITE_DESIGNS,
-                DOMAINS,
-                SITE_PREVIEW
-        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -25,9 +25,7 @@ class SiteCreationStepsProvider @Inject constructor(
 ) {
     fun getSteps(): List<SiteCreationStep> {
         if (siteIntentQuestionFeatureConfig.isEnabled()) {
-            // if (siteNameFeatureConfig.isEnabled() && siteNameABExperiment.getVariation() != Control) {
-            // For convenience while testing, hardcode to true:
-            if (true) {
+             if (siteNameFeatureConfig.isEnabled() && siteNameABExperiment.getVariation() != Control) {
                 return listOf(
                         INTENTS,
                         SITE_NAME,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.sitecreation
 
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.INTENTS
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_DESIGNS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.util.config.SiteIntentQuestionFeatureConfig
 import org.wordpress.android.util.wizard.WizardStep
@@ -10,7 +10,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 enum class SiteCreationStep : WizardStep {
-    SEGMENTS, DOMAINS, SITE_PREVIEW, INTENTS;
+    SITE_DESIGNS, DOMAINS, SITE_PREVIEW, INTENTS;
 }
 
 @Singleton
@@ -21,14 +21,14 @@ class SiteCreationStepsProvider @Inject constructor(
         if (siteIntentQuestionFeatureConfig.isEnabled()) {
             return listOf(
                     INTENTS,
-                    SEGMENTS,
+                    SITE_DESIGNS,
                     DOMAINS,
                     SITE_PREVIEW
             )
         }
 
         return listOf(
-                SEGMENTS,
+                SITE_DESIGNS,
                 DOMAINS,
                 SITE_PREVIEW
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
@@ -7,11 +7,14 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
+import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SiteCreationSiteNameFragmentBinding
+import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewModel.SiteNameUiState
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtilsWrapper
 import javax.inject.Inject
@@ -61,6 +64,7 @@ class SiteCreationSiteNameFragment : Fragment() {
     }
 
     private fun SiteCreationSiteNameFragmentBinding.setupViewModel() {
+        viewModel.uiState.observe(viewLifecycleOwner) { updateUiState(it) }
         viewModel.onSiteNameEntered.observe(viewLifecycleOwner, (requireActivity() as
                 SiteNameScreenListener)::onSiteNameEntered)
         viewModel.start()
@@ -69,19 +73,25 @@ class SiteCreationSiteNameFragment : Fragment() {
     private fun SiteCreationSiteNameFragmentBinding.setupActionListeners() {
         siteCreationSiteNameTitlebar.skipButton.setOnClickListener { viewModel.onSkipPressed() }
         siteCreationSiteNameTitlebar.backButton.setOnClickListener { viewModel.onBackPressed() }
-        // TODO: disable continue button when input is empty
         continueButton.setOnClickListener {
-            viewModel.onSiteNameEntered(input.text.toString())
+            viewModel.onSiteNameEntered()
+        }
+        input.doOnTextChanged { text, _, _, _ ->
+            viewModel.onSiteNameChanged(text?.toString() ?: "")
         }
         input.setOnEditorActionListener { _, actionId, _ ->
             when (actionId) {
                 EditorInfo.IME_ACTION_DONE -> {
-                    viewModel.onSiteNameEntered(input.text.toString())
+                    viewModel.onSiteNameEntered()
                     return@setOnEditorActionListener true
                 }
                 else -> return@setOnEditorActionListener false
             }
         }
+    }
+
+    private fun SiteCreationSiteNameFragmentBinding.updateUiState(uiState: SiteNameUiState) {
+        continueButtonContainer.isVisible = uiState.isContinueButtonEnabled
     }
 
     override fun onDestroyView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
@@ -1,0 +1,97 @@
+package org.wordpress.android.ui.sitecreation.sitename
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import androidx.core.view.isInvisible
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.SiteCreationSiteNameFragmentBinding
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.DisplayUtilsWrapper
+import javax.inject.Inject
+
+/**
+ * Implements the Site Name UI
+ */
+@Suppress("TooManyFunctions")
+class SiteCreationSiteNameFragment : Fragment() {
+    @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject internal lateinit var uiHelper: UiHelpers
+    @Inject internal lateinit var displayUtils: DisplayUtilsWrapper
+
+    private lateinit var viewModel: SiteCreationSiteNameViewModel
+    private var binding: SiteCreationSiteNameFragmentBinding? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.site_creation_site_name_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
+                .get(SiteCreationSiteNameViewModel::class.java)
+
+        val binding = SiteCreationSiteNameFragmentBinding.bind(view)
+        this.binding = binding
+        with(binding) {
+            setupUi()
+            setupViewModel()
+            setupActionListeners()
+        }
+    }
+
+    private fun SiteCreationSiteNameFragmentBinding.setupUi() {
+        siteCreationSiteNameTitlebar.appBarTitle.isInvisible = !isPhoneLandscape()
+    }
+
+    private fun SiteCreationSiteNameFragmentBinding.setupViewModel() {
+        viewModel.onSiteNameEntered.observe(viewLifecycleOwner, (requireActivity() as
+                SiteNameScreenListener)::onSiteNameEntered)
+        viewModel.start()
+    }
+
+    private fun SiteCreationSiteNameFragmentBinding.setupActionListeners() {
+        siteCreationSiteNameTitlebar.skipButton.setOnClickListener { viewModel.onSkipPressed() }
+        siteCreationSiteNameTitlebar.backButton.setOnClickListener { viewModel.onBackPressed() }
+        // TODO: disable continue button when input is empty
+        continueButton.setOnClickListener {
+            viewModel.onSiteNameEntered(input.text.toString())
+        }
+        input.setOnEditorActionListener { _, actionId, _ ->
+            when (actionId) {
+                EditorInfo.IME_ACTION_DONE -> {
+                    viewModel.onSiteNameEntered(input.text.toString())
+                    return@setOnEditorActionListener true
+                }
+                else -> return@setOnEditorActionListener false
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+
+    private fun isPhoneLandscape() = displayUtils.isLandscapeBySize() && !displayUtils.isTablet()
+
+    companion object {
+        const val TAG = "site_creation_site_name_fragment_tag"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SiteCreationSiteNameFragmentBinding
 import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewModel.SiteNameUiState
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.DisplayUtilsWrapper
 import javax.inject.Inject
 
@@ -61,6 +62,9 @@ class SiteCreationSiteNameFragment : Fragment() {
 
     private fun SiteCreationSiteNameFragmentBinding.setupUi() {
         siteCreationSiteNameTitlebar.appBarTitle.isInvisible = !isPhoneLandscape()
+        viewModel.uiState.value?.siteName.let { input.setText(it) }
+        input.requestFocus()
+        ActivityUtils.showKeyboard(input)
     }
 
     private fun SiteCreationSiteNameFragmentBinding.setupViewModel() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.ui.sitecreation.sitename
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
+import org.wordpress.android.viewmodel.SingleLiveEvent
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.coroutines.CoroutineContext
+
+class SiteCreationSiteNameViewModel @Inject constructor(
+    private val analyticsTracker: SiteCreationTracker,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+) : ViewModel(), CoroutineScope {
+    private val job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = bgDispatcher + job
+
+    private var isInitialized = false
+
+    private val _onSkipButtonPressed = SingleLiveEvent<Unit>()
+    val onSkipButtonPressed: LiveData<Unit> = _onSkipButtonPressed
+
+    private val _onBackButtonPressed = SingleLiveEvent<Unit>()
+    val onBackButtonPressed: LiveData<Unit> = _onBackButtonPressed
+
+    private val _onSiteNameEntered = SingleLiveEvent<String>()
+    val onSiteNameEntered: LiveData<String> = _onSiteNameEntered
+
+    fun start() {
+        if (isInitialized) return
+        // TODO: analyticsTracker.trackSiteNameViewed()
+        Log.d("siteNameWip", "Site name viewed")
+        isInitialized = true
+    }
+
+    fun onSkipPressed() {
+        // TODO: analyticsTracker.trackSiteNameSkipped()
+        Log.d("siteNameWip", "Site name skipped")
+        _onSkipButtonPressed.call()
+    }
+
+    fun onBackPressed() {
+        // TODO: analyticsTracker.trackSiteNameCancelled()
+        Log.d("siteNameWip", "Site name cancelled")
+        _onBackButtonPressed.call()
+    }
+
+    fun onSiteNameEntered(siteName: String) {
+        // TODO: analyticsTracker.trackSiteNameEntered(siteName?) maybe we don't want to track the names here?
+        Log.d("siteNameWip", "Site name entered: $siteName")
+        _onSiteNameEntered.value = siteName
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.sitecreation.sitename
 
 import android.util.Log
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -32,6 +33,9 @@ class SiteCreationSiteNameViewModel @Inject constructor(
     private val _onSiteNameEntered = SingleLiveEvent<String>()
     val onSiteNameEntered: LiveData<String> = _onSiteNameEntered
 
+    private val _uiState: MutableLiveData<SiteNameUiState> = MutableLiveData()
+    val uiState: LiveData<SiteNameUiState> = _uiState
+
     fun start() {
         if (isInitialized) return
         // TODO: analyticsTracker.trackSiteNameViewed()
@@ -51,9 +55,20 @@ class SiteCreationSiteNameViewModel @Inject constructor(
         _onBackButtonPressed.call()
     }
 
-    fun onSiteNameEntered(siteName: String) {
+    fun onSiteNameEntered() {
         // TODO: analyticsTracker.trackSiteNameEntered(siteName?) maybe we don't want to track the names here?
-        Log.d("siteNameWip", "Site name entered: $siteName")
-        _onSiteNameEntered.value = siteName
+        uiState.value?.siteName.let {
+            if (it.isNullOrBlank()) return
+            Log.d("siteNameWip", "Site name entered: $it")
+            _onSiteNameEntered.value = it
+        }
+    }
+
+    fun onSiteNameChanged(siteName: String) {
+        _uiState.value = SiteNameUiState(siteName)
+    }
+
+    data class SiteNameUiState(val siteName: String) {
+        val isContinueButtonEnabled get() = siteName.isNotBlank()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteNameScreenListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteNameScreenListener.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.ui.sitecreation.sitename
+
+interface SiteNameScreenListener {
+    fun onSiteNameEntered(siteName: String)
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration of the Site Name step in the Site Creation flow
+ */
+@FeatureInDevelopment
+class SiteNameFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.SITE_NAME
+)

--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/SiteNameABExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/SiteNameABExperiment.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.util.experiments
+
+import javax.inject.Inject
+
+class SiteNameABExperiment
+@Inject constructor(exPlat: ExPlat) : Experiment(name = "wpandroid_site_name_experiment", exPlat)

--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/SiteNameABExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/SiteNameABExperiment.kt
@@ -3,4 +3,4 @@ package org.wordpress.android.util.experiments
 import javax.inject.Inject
 
 class SiteNameABExperiment
-@Inject constructor(exPlat: ExPlat) : Experiment(name = "wpandroid_site_name_experiment", exPlat)
+@Inject constructor(exPlat: ExPlat) : Experiment(name = "wpandroid_site_name_v1", exPlat)

--- a/WordPress/src/main/res/layout/site_creation_site_name_fragment.xml
+++ b/WordPress/src/main/res/layout/site_creation_site_name_fragment.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/layoutPickerBackground"
+    android:animateLayoutChanges="true"
+    android:fitsSystemWindows="false"
+    android:focusableInTouchMode="true">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/layoutPickerBackground"
+        android:fitsSystemWindows="false">
+
+        <com.google.android.material.appbar.CollapsingToolbarLayout
+            android:id="@+id/collapsing_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="false"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+            <include
+                android:id="@+id/site_creation_site_name_header"
+                layout="@layout/site_creation_site_name_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom"
+                android:layout_marginTop="@dimen/toolbar_height" />
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/layoutPickerBackground"
+                android:elevation="0dp"
+                app:layout_collapseMode="pin">
+
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/toolbar_height"
+                    android:layout_marginTop="@dimen/margin_extra_small"
+                    android:orientation="vertical">
+
+                    <include
+                        android:id="@+id/site_creation_site_name_titlebar"
+                        layout="@layout/site_creation_intents_titlebar"
+                        android:layout_width="match_parent"
+                        android:layout_gravity="center_vertical"
+                        android:layout_height="wrap_content" />
+
+                </FrameLayout>
+
+            </com.google.android.material.appbar.MaterialToolbar>
+
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/input_container"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/margin_extra_large"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/continue_button_container"
+            app:hintEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_rectangle_stroke_placeholder_radius_4dp"
+                android:hint="@string/new_site_creation_site_name_input_hint"
+                android:imeOptions="actionDone|flagNoFullscreen"
+                android:importantForAutofill="noExcludeDescendants"
+                android:inputType="text"
+                android:singleLine="true"
+                android:textAlignment="viewStart"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                tools:targetApi="o" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </com.google.android.material.appbar.AppBarLayout>
+
+
+        <FrameLayout
+            android:id="@+id/continue_button_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:background="?attr/layoutPickerBackground"
+            android:gravity="center"
+            android:paddingVertical="@dimen/picker_bottom_button_vertical_margin"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/input_container"
+            app:layout_constraintVertical_bias="1">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/continue_button"
+                style="@style/Widget.ModalLayoutPicker.Button.Primary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/mlp_bottom_button_horizontal_margin"
+                android:text="@string/continue_label" />
+        </FrameLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/site_creation_site_name_fragment.xml
+++ b/WordPress/src/main/res/layout/site_creation_site_name_fragment.xml
@@ -89,6 +89,8 @@
             android:id="@+id/continue_button_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:visibility="invisible"
+            tools:visibility="visible"
             android:layout_gravity="bottom"
             android:background="?attr/layoutPickerBackground"
             android:gravity="center"

--- a/WordPress/src/main/res/layout/site_creation_site_name_header.xml
+++ b/WordPress/src/main/res/layout/site_creation_site_name_header.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/SiteCreationHeaderLinearLayoutStyle"
+    android:paddingHorizontal="@dimen/site_creation_segments_content_padding_horizontal"
+    tools:ignore="InconsistentLayout">
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/title"
+        style="@style/ModalLayoutPickerTitle"
+        android:lineSpacingExtra="-4sp"
+        android:letterSpacing="0.01"
+        android:paddingBottom="@dimen/margin_large"
+        app:fixWidowWords="true"
+        android:text="@string/new_site_creation_site_name_header_title" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/subtitle"
+        style="@style/ModalLayoutPickerSubtitle"
+        android:paddingBottom="@dimen/margin_extra_medium_large"
+        android:lineSpacingExtra="5sp"
+        android:letterSpacing="0.01"
+        app:fixWidowWords="true"
+        android:text="@string/new_site_creation_site_name_header_subtitle" />
+</LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2930,16 +2930,16 @@
     <string name="content_description_person_building_website">Person building website</string>
 
     <!-- Android O notification channels, these show in the Android app settings -->
-    
-    
-    
-    
+
+
+
+
     <string name="notification_channel_weekly_roundup_title">Weekly Roundup</string>
 
     <string name="notification_channel_normal_id" translatable="false">wpandroid_notification_normal_channel_id</string>
-    
+
     <string name="notification_channel_transient_id" translatable="false">wpandroid_notification_transient_channel_id</string>
-    
+
     <string name="notification_channel_weekly_roundup_id" translatable="false">wpandroid_notification_weekly_roundup_channel_id</string>
 
     <!-- Required by the login library - overwrites the placeholder value with a real channel -->
@@ -3208,6 +3208,9 @@
     <string name="new_site_creation_intents_header_title">What’s your website about?</string>
     <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type your own</string>
     <string name="new_site_creation_intents_input_hint">Eg. Fashion, Poetry, Politics</string>
+    <string name="new_site_creation_site_name_header_title">Give your website a name</string>
+    <string name="new_site_creation_site_name_header_subtitle">A good name is short and memorable.\nYou can change it later</string>
+    <string name="new_site_creation_site_name_input_hint">Fashion Designerly</string>
     <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>
     <string name="new_site_creation_unavailable_domain">This domain is unavailable</string>

--- a/WordPress/src/test/java/org/wordpress/android/util/wizard/WizardManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/wizard/WizardManagerTest.kt
@@ -13,10 +13,10 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.ui.sitecreation.SiteCreationStep
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.SEGMENTS
+import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_DESIGNS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 
-private val STEPS = listOf(SEGMENTS, DOMAINS, SITE_PREVIEW)
+private val STEPS = listOf(SITE_DESIGNS, DOMAINS, SITE_PREVIEW)
 private val LAST_STEP_INDEX = STEPS.size - 1
 
 @RunWith(MockitoJUnitRunner::class)


### PR DESCRIPTION
Fixes #16245, #16246, #16248

### Description

This PR adds the site name screen (behind a feature flag and ExPlat experiment).



**Note**:

* This currently resolves the feature flag and ExPlat tasks as well. If it helps to review in smaller pieces, I've broken the commits (https://github.com/wordpress-mobile/WordPress-Android/pull/16259/commits/48f9ce85959cfe4c9e5065d2678815f4fa693483, https://github.com/wordpress-mobile/WordPress-Android/pull/16259/commits/89e857aaa2b8de17e1a5e838c62d5b0f3be54d8e) up so they can be merged in separate PRs if needed.
* This commit (https://github.com/wordpress-mobile/WordPress-Android/pull/16259/commits/a793e89a79c92e381358a4c9ac1aef167d0b78a6) can be reverted to hard-code the flag to `true` for convenience while testing.
  * Also, the behavior remains conditioned behind the site intent question flag
* The experiment name is: `"wpandroid_site_name_experiment"`, we can change this if necessary

**Not yet implemented**:
* <s>The continue button is enabled when the input is empty</s>
  * This should be disabled (or hidden?) when the input is empty
  * I have hidden the continue button, but we can change to a disabled state (and style) if needed
* Tracks events are not implemented (will be addressed in a future PR)
  * I left a question about whether we'd want to be tracking site names entered, or just the event itself
  * In places were tracking would occur, I placed `Log` statements instead to aid in manual testing

### Testing

#### Feature flag & ExPlat

Note: It may be helpful to manually hard-code a value for `true` for the ExPlat flag if testing before that is established server-side.

* Toggle the feature flag: Me -> App settings -> Debug settings -> Toggle flag (`SiteNameFeatureConfig`)
* Navigate through the site creation flow: My Sites -> `+` -> Create WordPress.com site -> Choose an intent
* Expect the site name screen to appear after the intent screen
* Toggle the feature off
* Expect the site designs screen to appear after the intent screen

#### Site Screen UI

Note: for these tests, the stubs for tracking can be tested by filtering Logcat for `siteNameWip`

##### Continuing

1. Perform the steps above to navigate to the site name screen
  * The logs should show that the site name screen has been viewed
  * The input should be focused and soft keyboard opened (if a physical keyboard is not present)
  * The Continue button should not be visible
2. Type in a site name
  * The Continue button should become visible
3. Tap Continue
  * The logs should show that the site name was entered
  * The site design screen should be shown

##### Skipping

1. Perform the steps above to navigate to the site name screen
  * The logs should show that the site name screen has been viewed
  * The input should be focused and soft keyboard opened (if a physical keyboard is not present)
  * The Continue button should not be visible
2. Tap Skip
  * The logs should show that the site name was skipped
  * The site design screen should be shown

##### Backtracking

1. Perform the steps above to navigate to the site name screen
  * The logs should show that the site name screen has been viewed
  * The input should be focused and soft keyboard opened (if a physical keyboard is not present)
  * The Continue button should not be visible
2. Type in a site name
  * The Continue button should become visible
3. Tap the back button
  *  The site intent screen should be shown
4. Choose another intent (could be the same one, it doesn't matter)
  * The site name screen should be shown with the previously entered site name (i.e. backtracking should not delete previously entered form data)

### Screenshots

| Empty Input | Filled Input |
|-|-|
|![site-name-screen-empty](https://user-images.githubusercontent.com/8507675/161929278-b1aec40c-15ab-415b-aa04-bfa287471594.png)|![site-name-screen-filled](https://user-images.githubusercontent.com/8507675/161929296-b6ade85f-400f-422e-b5e5-89402fe54fc5.png)|



## Regression Notes
1. Potential unintended areas of impact
This could affect the site creation flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Existing automated tests for the site creation flow provide good coverage

3. What automated tests I added (or what prevented me from doing so)
More coverage for these changes to the flow will come in later PRs (this is currently behind a feature flag)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
