### PR TITLE
Add Gradle Enterprise to Project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,18 +172,6 @@ subprojects {
     }
 }
 
-buildScan {
-    // Always run Gradle scan on CI builds
-    if (System.getenv('CI')) {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
-        tag 'CI'
-        publishAlways()
-        // Otherwise CI might shut down before it's uploaded
-        uploadInBackground = false
-    }
-}
-
 // Onboarding and dev env setup tasks
 tasks.register("checkBundler", Exec) {
     doFirst {

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,9 @@ gradleEnterprise {
     allowUntrustedServer = true // Unless a trusted certificate is already configured in GE.
     buildScan {
         publishAlways()
+        capture {
+            taskInputFiles = true
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ plugins {
 
 gradleEnterprise {
     server = "https://gradle.a8c.com"
+    allowUntrustedServer = true // Unless a trusted certificate is already configured in GE.
 }
 
 rootProject.name = 'WPAndroid'

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,10 @@ plugins {
     id "com.gradle.enterprise" version "3.9"
 }
 
+gradleEnterprise {
+    server = "https://gradle.a8c.com"
+}
+
 rootProject.name = 'WPAndroid'
 
 include ':WordPress'

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,9 @@ plugins {
 gradleEnterprise {
     server = "https://gradle.a8c.com"
     allowUntrustedServer = true // Unless a trusted certificate is already configured in GE.
+    buildScan {
+        publishAlways()
+    }
 }
 
 rootProject.name = 'WPAndroid'

--- a/settings.gradle
+++ b/settings.gradle
@@ -129,15 +129,3 @@ if (localBuilds.exists()) {
         }
     }
 }
-
-// Build cache is only enabled for CI, at least for now
-if (System.getenv().containsKey("CI")) {
-    buildCache {
-        remote(HttpBuildCache) {
-            url = "http://10.0.2.215:5071/cache/"
-            allowUntrustedServer = true
-            allowInsecureProtocol = true
-            push = true
-        }
-    }
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,17 @@ gradleEnterprise {
     }
 }
 
+if (System.getenv().containsKey("CI")) {
+    buildCache {
+        remote(HttpBuildCache) {
+            url = "http://10.0.2.215:5071/cache/"
+            allowUntrustedServer = true
+            allowInsecureProtocol = true
+            push = true
+        }
+    }
+}
+
 rootProject.name = 'WPAndroid'
 
 include ':WordPress'

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,8 @@ plugins {
   id "com.gradle.enterprise" version "3.4.1"
 }
 
+rootProject.name = 'WPAndroid'
+
 include ':WordPress'
 
 include ':libs:image-editor:ImageEditor'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradle.enterprise" version "3.4.1"
+    id "com.gradle.enterprise" version "3.9"
 }
 
 rootProject.name = 'WPAndroid'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "com.gradle.enterprise" version "3.9"
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.6.5'
 }
 
 gradleEnterprise {

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ gradleEnterprise {
         capture {
             taskInputFiles = true
         }
+        uploadInBackground = System.getenv("CI") == null
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ plugins {
 
 gradleEnterprise {
     server = "https://gradle.a8c.com"
-    allowUntrustedServer = true // Unless a trusted certificate is already configured in GE.
+    allowUntrustedServer = false
     buildScan {
         publishAlways()
         capture {


### PR DESCRIPTION
The goal of this PR is to test the `Gradle Enterprise` configuration in order for the GE trial to begin.

To test:

- Verify builds on [gradle.a8c.com](https://gradle.a8c.com/) (ie `Dashboard`, `Build Scan`, etc).
- CI should also publish to GE (ie `Build Scan` urls, etc).
- Additionally, you could also build and test GE locally (ie `Build Scan` urls, etc).

## Regression Notes
1. Potential unintended areas of impact

Build degradation.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` steps above.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
