### PR TITLE
My Site Dashboard: Display small nudge on Today's Stats when there's no views 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/Constants.java
+++ b/WordPress/src/main/java/org/wordpress/android/Constants.java
@@ -8,4 +8,5 @@ public class Constants {
     public static final String URL_TIMEZONE_ENDPOINT = "https://public-api.wordpress.com/wpcom/v2/timezones";
     public static final String URL_JETPACK_SETTINGS = "https://wordpress.com/settings/jetpack";
     public static final String URL_MANAGE_DOMAINS = "https://wordpress.com/domains/manage";
+    public static final String URL_GET_MORE_VIEWS_AND_TRAFFIC = "https://wordpress.com/support/getting-more-views-and-traffic";
 }

--- a/WordPress/src/main/java/org/wordpress/android/Constants.java
+++ b/WordPress/src/main/java/org/wordpress/android/Constants.java
@@ -8,5 +8,4 @@ public class Constants {
     public static final String URL_TIMEZONE_ENDPOINT = "https://public-api.wordpress.com/wpcom/v2/timezones";
     public static final String URL_JETPACK_SETTINGS = "https://wordpress.com/settings/jetpack";
     public static final String URL_MANAGE_DOMAINS = "https://wordpress.com/domains/manage";
-    public static final String URL_GET_MORE_VIEWS_AND_TRAFFIC = "https://wordpress.com/support/getting-more-views-and-traffic";
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -119,6 +119,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val visitors: UiString,
                         val likes: UiString,
                         val onCardClick: () -> Unit,
+                        val message: Text? = null,
                         val footerLink: FooterLink
                     ) : TodaysStatsCard(dashboardCardType = DashboardCardType.TODAYS_STATS_CARD)
 
@@ -126,6 +127,16 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val label: UiString,
                         val onClick: () -> Unit
                     )
+
+                    data class Text(
+                        val text: UiString,
+                        val links: List<Clickable>? = null,
+                    ) {
+                        data class Clickable(
+                            val link: String,
+                            val navigationAction: ListItemInteraction
+                        )
+                    }
                 }
 
                 sealed class PostCard(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -132,10 +132,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val text: UiString,
                         val links: List<Clickable>? = null
                     ) {
-                        data class Clickable(
-                            val link: String,
-                            val navigationAction: ListItemInteraction
-                        )
+                        data class Clickable(val navigationAction: ListItemInteraction)
                     }
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -130,7 +130,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
 
                     data class Text(
                         val text: UiString,
-                        val links: List<Clickable>? = null,
+                        val links: List<Clickable>? = null
                     ) {
                         data class Clickable(
                             val link: String,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -119,7 +119,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val visitors: UiString,
                         val likes: UiString,
                         val onCardClick: () -> Unit,
-                        val message: Text? = null,
+                        val message: TextWithLinks? = null,
                         val footerLink: FooterLink
                     ) : TodaysStatsCard(dashboardCardType = DashboardCardType.TODAYS_STATS_CARD)
 
@@ -128,7 +128,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val onClick: () -> Unit
                     )
 
-                    data class Text(
+                    data class TextWithLinks(
                         val text: UiString,
                         val links: List<Clickable>? = null
                     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -56,6 +56,7 @@ sealed class MySiteCardAndItemBuilderParams {
     data class TodaysStatsCardBuilderParams(
         val todaysStatsCard: TodaysStatsCardModel?,
         val onTodaysStatsCardClick: () -> Unit,
+        val onGetMoreViewsClick: () -> Unit,
         val onFooterLinkClick: () -> Unit
     ) : MySiteCardAndItemBuilderParams()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -398,6 +398,7 @@ class MySiteViewModel @Inject constructor(
                                 todaysStatsCard = cardsUpdate?.cards?.firstOrNull { it is TodaysStatsCardModel }
                                         as? TodaysStatsCardModel,
                                 onTodaysStatsCardClick = this::onTodaysStatsCardClick,
+                                onGetMoreViewsClick = this:: onGetMoreViewsClick,
                                 onFooterLinkClick = this::onTodaysStatsCardFooterLinkClick
                         ),
                         postCardBuilderParams = PostCardBuilderParams(
@@ -473,6 +474,9 @@ class MySiteViewModel @Inject constructor(
             add(Type.DOMAIN_REGISTRATION_CARD)
         }
         MySiteTabType.ALL -> emptyList()
+    }
+
+    private fun onGetMoreViewsClick() {
     }
 
     private fun onTodaysStatsCardFooterLinkClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -476,6 +476,7 @@ class MySiteViewModel @Inject constructor(
         MySiteTabType.ALL -> emptyList()
     }
 
+    @Suppress("EmptyFunctionBlock")
     private fun onGetMoreViewsClick() {
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilder.kt
@@ -7,8 +7,8 @@ import org.wordpress.android.fluxc.store.dashboard.CardsStore.TodaysStatsCardErr
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.FooterLink
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.Text
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.Text.Clickable
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TextWithLinks
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TextWithLinks.Clickable
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TodaysStatsCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.TodaysStatsCardBuilderParams
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
@@ -49,7 +49,7 @@ class TodaysStatsCardBuilder @Inject constructor(
                     likes = statToUiString(model.likes),
                     onCardClick = params.onTodaysStatsCardClick,
                     message = model.takeIf { it.isEmptyStats() }?.let {
-                        Text(
+                        TextWithLinks(
                                 text = UiStringText(
                                         htmlMessageUtils.getHtmlMessageFromStringFormatResId(
                                                 R.string.my_site_todays_stats_get_more_views_message,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilder.kt
@@ -57,13 +57,7 @@ class TodaysStatsCardBuilder @Inject constructor(
                                                 Constants.URL_GET_MORE_VIEWS_AND_TRAFFIC
                                         )
                                 ),
-                                links = listOf(
-                                        Clickable(
-                                                link = Constants.URL_GET_MORE_VIEWS_AND_TRAFFIC,
-                                                navigationAction = ListItemInteraction
-                                                        .create(params.onGetMoreViewsClick)
-                                        )
-                                )
+                                links = listOf(Clickable(ListItemInteraction.create(params.onGetMoreViewsClick)))
                         )
                     },
                     footerLink = FooterLink(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilder.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.todaysstats
 
-import org.wordpress.android.Constants
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.dashboard.CardModel.TodaysStatsCardModel
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.TodaysStatsCardError
@@ -54,7 +53,7 @@ class TodaysStatsCardBuilder @Inject constructor(
                                 text = UiStringText(
                                         htmlMessageUtils.getHtmlMessageFromStringFormatResId(
                                                 R.string.my_site_todays_stats_get_more_views_message,
-                                                Constants.URL_GET_MORE_VIEWS_AND_TRAFFIC
+                                                URL_GET_MORE_VIEWS_AND_TRAFFIC
                                         )
                                 ),
                                 links = listOf(Clickable(ListItemInteraction.create(params.onGetMoreViewsClick)))
@@ -71,4 +70,8 @@ class TodaysStatsCardBuilder @Inject constructor(
     private fun statToUiString(stat: Int) = UiStringText(statsUtils.toFormattedString(stat))
 
     private fun TodaysStatsCardModel.isEmptyStats() = views == 0 && visitors == 0 && likes == 0
+
+    companion object {
+        const val URL_GET_MORE_VIEWS_AND_TRAFFIC = "https://wordpress.com/support/getting-more-views-and-traffic"
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.todaysstats
 
+import org.wordpress.android.Constants
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.dashboard.CardModel.TodaysStatsCardModel
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.TodaysStatsCardError
@@ -7,9 +8,13 @@ import org.wordpress.android.fluxc.store.dashboard.CardsStore.TodaysStatsCardErr
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.FooterLink
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.Text
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.Text.Clickable
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TodaysStatsCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.TodaysStatsCardBuilderParams
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
+import org.wordpress.android.ui.utils.HtmlMessageUtils
+import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
@@ -17,7 +22,8 @@ import javax.inject.Inject
 
 class TodaysStatsCardBuilder @Inject constructor(
     private val statsUtils: StatsUtils,
-    private val appLogWrapper: AppLogWrapper
+    private val appLogWrapper: AppLogWrapper,
+    private val htmlMessageUtils: HtmlMessageUtils
 ) {
     fun build(params: TodaysStatsCardBuilderParams) = params.todaysStatsCard?.let {
         val error = it.error
@@ -43,6 +49,23 @@ class TodaysStatsCardBuilder @Inject constructor(
                     visitors = statToUiString(model.visitors),
                     likes = statToUiString(model.likes),
                     onCardClick = params.onTodaysStatsCardClick,
+                    message = model.takeIf { it.isEmptyStats() }?.let {
+                        Text(
+                                text = UiStringText(
+                                        htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                                                R.string.my_site_todays_stats_get_more_views_message,
+                                                Constants.URL_GET_MORE_VIEWS_AND_TRAFFIC
+                                        )
+                                ),
+                                links = listOf(
+                                        Clickable(
+                                                link = Constants.URL_GET_MORE_VIEWS_AND_TRAFFIC,
+                                                navigationAction = ListItemInteraction
+                                                        .create(params.onGetMoreViewsClick)
+                                        )
+                                )
+                        )
+                    },
                     footerLink = FooterLink(
                             label = UiStringRes(R.string.my_site_todays_stats_card_footer_link_go_to_stats),
                             onClick = params.onFooterLinkClick
@@ -52,4 +75,6 @@ class TodaysStatsCardBuilder @Inject constructor(
     private fun shouldShowError(error: TodaysStatsCardError) = error.type == TodaysStatsCardErrorType.GENERIC_ERROR
 
     private fun statToUiString(stat: Int) = UiStringText(statsUtils.toFormattedString(stat))
+
+    private fun TodaysStatsCardModel.isEmptyStats() = views == 0 && visitors == 0 && likes == 0
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
@@ -17,7 +17,7 @@ import androidx.core.content.ContextCompat
 import org.wordpress.android.R
 import org.wordpress.android.R.drawable
 import org.wordpress.android.databinding.MySiteTodaysStatsCardBinding
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.Text.Clickable
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TextWithLinks.Clickable
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TodaysStatsCardWithData
 import org.wordpress.android.ui.mysite.cards.dashboard.CardViewHolder
 import org.wordpress.android.ui.utils.UiHelpers

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
@@ -1,10 +1,27 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.todaysstats
 
+import android.content.Context
+import android.graphics.Typeface
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.SpannableStringBuilder
+import android.text.TextPaint
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
+import android.text.style.ImageSpan
+import android.text.style.URLSpan
+import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import org.wordpress.android.R
+import org.wordpress.android.R.drawable
 import org.wordpress.android.databinding.MySiteTodaysStatsCardBinding
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.Text.Clickable
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TodaysStatsCardWithData
 import org.wordpress.android.ui.mysite.cards.dashboard.CardViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.getColorFromAttribute
 import org.wordpress.android.util.extensions.viewBinding
 
 class TodaysStatsCardViewHolder(
@@ -13,10 +30,22 @@ class TodaysStatsCardViewHolder(
 ) : CardViewHolder<MySiteTodaysStatsCardBinding>(
         parent.viewBinding(MySiteTodaysStatsCardBinding::inflate)
 ) {
+    private val linkColor = itemView.context.getColorFromAttribute(R.attr.colorPrimary)
+
+    init {
+        with(binding.getMoreViewsMessage) {
+            linksClickable = true
+            isClickable = true
+            movementMethod = LinkMovementMethod.getInstance()
+        }
+    }
+
     fun bind(card: TodaysStatsCardWithData) = with(binding) {
         uiHelpers.setTextOrHide(viewsCount, card.views)
         uiHelpers.setTextOrHide(visitorsCount, card.visitors)
         uiHelpers.setTextOrHide(likesCount, card.likes)
+        uiHelpers.setTextOrHide(getMoreViewsMessage, card.message?.text)
+        card.message?.links?.let { getMoreViewsMessage.updateLink(it) }
         uiHelpers.setTextOrHide(footerLink.linkLabel, card.footerLink.label)
         footerLink.linkLabel.setOnClickListener {
             card.footerLink.onClick.invoke()
@@ -24,5 +53,61 @@ class TodaysStatsCardViewHolder(
         mySiteTodaysStatCard.setOnClickListener {
             card.onCardClick.invoke()
         }
+    }
+
+    fun TextView.updateLink(links: List<Clickable>) {
+        val spannableBuilder = SpannableStringBuilder()
+        spannableBuilder.append(SpannableString(text))
+        spannableBuilder.insert(text.length - 1, SpannableString(" "))
+        for (urlSpan in spannableBuilder.getSpans(0, spannableBuilder.length, URLSpan::class.java)) {
+            val startIndex = spannableBuilder.getSpanStart(urlSpan)
+            val endIndex = spannableBuilder.getSpanEnd(urlSpan)
+            links.forEach { link ->
+                spannableBuilder.withClickableSpan(startIndex, endIndex) {
+                    link.navigationAction.click()
+                }
+            }
+            spannableBuilder.withExternalLinkImageSpan(endIndex)
+        }
+        text = spannableBuilder
+    }
+
+    private fun SpannableStringBuilder.withClickableSpan(
+        startIndex: Int,
+        endIndex: Int,
+        onClickListener: (Context) -> Unit
+    ) {
+        val clickableSpan = object : ClickableSpan() {
+            override fun onClick(widget: View) {
+                widget.context?.let { onClickListener.invoke(it) }
+            }
+
+            override fun updateDrawState(ds: TextPaint) {
+                ds.color = linkColor
+                ds.typeface = Typeface.create(
+                        Typeface.DEFAULT_BOLD,
+                        Typeface.NORMAL
+                )
+                ds.isUnderlineText = false
+            }
+        }
+        setSpan(
+                clickableSpan,
+                startIndex,
+                endIndex,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+    }
+
+    private fun SpannableStringBuilder.withExternalLinkImageSpan(endIndex: Int) {
+        val drawable = ContextCompat.getDrawable(itemView.context, drawable.ic_external_white_24dp) ?: return
+        drawable.setTint(linkColor)
+        drawable.setBounds(5, 0, drawable.intrinsicWidth / 2, drawable.intrinsicHeight / 2)
+        setSpan(
+                ImageSpan(drawable, ImageSpan.ALIGN_BASELINE),
+                endIndex,
+                endIndex + 1,
+                Spannable.SPAN_INCLUSIVE_EXCLUSIVE
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
@@ -4,11 +4,11 @@ import android.content.Context
 import android.graphics.Typeface
 import android.text.Spannable
 import android.text.SpannableString
-import android.text.SpannableStringBuilder
 import android.text.TextPaint
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
 import android.text.style.ImageSpan
+import android.text.style.StyleSpan
 import android.text.style.URLSpan
 import android.view.View
 import android.view.ViewGroup
@@ -56,23 +56,22 @@ class TodaysStatsCardViewHolder(
     }
 
     fun TextView.updateLink(links: List<Clickable>) {
-        val spannableBuilder = SpannableStringBuilder()
-        spannableBuilder.append(SpannableString(text))
-        spannableBuilder.insert(text.length - 1, SpannableString(" "))
-        for (urlSpan in spannableBuilder.getSpans(0, spannableBuilder.length, URLSpan::class.java)) {
-            val startIndex = spannableBuilder.getSpanStart(urlSpan)
-            val endIndex = spannableBuilder.getSpanEnd(urlSpan)
+        val spannable = SpannableString(text)
+        for (urlSpan in spannable.getSpans(0, spannable.length, URLSpan::class.java)) {
+            val startIndex = spannable.getSpanStart(urlSpan)
+            val endIndex = spannable.getSpanEnd(urlSpan)
             links.forEach { link ->
-                spannableBuilder.withClickableSpan(startIndex, endIndex) {
+                spannable.withClickableSpan(startIndex, endIndex) {
                     link.navigationAction.click()
                 }
             }
-            spannableBuilder.withExternalLinkImageSpan(endIndex)
+            spannable.withExternalLinkImageSpan(endIndex)
+            spannable.withBoldSpan(startIndex, endIndex)
         }
-        text = spannableBuilder
+        text = spannable
     }
 
-    private fun SpannableStringBuilder.withClickableSpan(
+    private fun SpannableString.withClickableSpan(
         startIndex: Int,
         endIndex: Int,
         onClickListener: (Context) -> Unit
@@ -99,15 +98,36 @@ class TodaysStatsCardViewHolder(
         )
     }
 
-    private fun SpannableStringBuilder.withExternalLinkImageSpan(endIndex: Int) {
+    private fun SpannableString.withExternalLinkImageSpan(endIndex: Int) {
         val drawable = ContextCompat.getDrawable(itemView.context, drawable.ic_external_white_24dp) ?: return
         drawable.setTint(linkColor)
-        drawable.setBounds(5, 0, drawable.intrinsicWidth / 2, drawable.intrinsicHeight / 2)
+        drawable.setBounds(
+                EXTERNAL_LINK_DRAWABLE_BOUND_LEFT,
+                0,
+                drawable.intrinsicWidth / 2,
+                drawable.intrinsicHeight / 2
+        )
         setSpan(
                 ImageSpan(drawable, ImageSpan.ALIGN_BASELINE),
                 endIndex,
                 endIndex + 1,
                 Spannable.SPAN_INCLUSIVE_EXCLUSIVE
         )
+    }
+
+    private fun SpannableString.withBoldSpan(
+        startIndex: Int,
+        endIndex: Int
+    ) {
+        setSpan(
+                StyleSpan(Typeface.BOLD),
+                startIndex,
+                endIndex,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+    }
+
+    companion object {
+        private const val EXTERNAL_LINK_DRAWABLE_BOUND_LEFT = 5
     }
 }

--- a/WordPress/src/main/res/layout/my_site_todays_stats_card.xml
+++ b/WordPress/src/main/res/layout/my_site_todays_stats_card.xml
@@ -117,6 +117,17 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/get_more_views_message"
+            style="@style/MySiteTodaysStatsCardMessage"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toTopOf="@+id/footer_link"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/views_layout"
+            tools:text="@string/my_site_todays_stats_get_more_views_message" />
+
         <include
             android:id="@+id/footer_link"
             layout="@layout/my_site_card_footer_link"
@@ -124,7 +135,7 @@
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/views_layout" />
+            app:layout_constraintTop_toBottomOf="@+id/get_more_views_message" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2227,6 +2227,7 @@
     <string name="my_site_todays_stat_card_likes" translatable="false">@string/stats_likes</string>
     <string name="my_site_todays_stat_card_views" translatable="false">@string/stats_views</string>
     <string name="my_site_todays_stat_card_visitors" translatable="false">@string/stats_visitors</string>
+    <string name="my_site_todays_stats_get_more_views_message">If you want to try get more views and traffic check out our &lt;a href="%1$s"&gt;top tips&lt;/a&gt;.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Go to stats</string>
 
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -821,6 +821,18 @@
         <item name="android:ellipsize">end</item>
     </style>
 
+    <style name="MySiteTodaysStatsCardMessage">
+        <item name="android:textAlignment">textStart</item>
+        <item name="android:textSize">@dimen/text_sz_medium</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:alpha">@dimen/material_emphasis_high_type</item>
+        <item name="android:lineSpacingMultiplier">1.2</item>
+        <item name="android:paddingBottom">@dimen/margin_medium</item>
+        <item name="android:paddingEnd">@dimen/margin_extra_large</item>
+        <item name="android:paddingStart">@dimen/margin_extra_large</item>
+        <item name="android:paddingTop">@dimen/margin_extra_large</item>
+    </style>
+
     <!--My Site Card - Post Item-->
     <style name="MySitePostItemTitle" parent="MySiteCardItemTitle"/>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -174,7 +174,7 @@ class CardsBuilderTest {
                 ),
                 dashboardCardsBuilderParams = DashboardCardsBuilderParams(
                         onErrorRetryClick = mock(),
-                        todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock()),
+                        todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                         postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                         bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(mock(), mock())
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -143,7 +143,7 @@ class CardsBuilderTest : BaseUnitTest() {
                 dashboardCardsBuilderParams = DashboardCardsBuilderParams(
                         showErrorCard = showErrorCard,
                         onErrorRetryClick = { },
-                        todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock()),
+                        todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                         postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                         bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(mock(), mock())
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilderTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TodaysStatsCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.TodaysStatsCardBuilderParams
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
+import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 
@@ -34,6 +35,7 @@ private const val TODAYS_STATS_LIKES_FORMATTED_STRING = "100"
 class TodaysStatsCardBuilderTest : BaseUnitTest() {
     @Mock private lateinit var statsUtils: StatsUtils
     @Mock private lateinit var appLogWrapper: AppLogWrapper
+    @Mock private lateinit var htmlMessageUtils: HtmlMessageUtils
 
     private lateinit var builder: TodaysStatsCardBuilder
     private val todaysStatsCardModel = TodaysStatsCardModel(
@@ -45,7 +47,7 @@ class TodaysStatsCardBuilderTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        builder = TodaysStatsCardBuilder(statsUtils, appLogWrapper)
+        builder = TodaysStatsCardBuilder(statsUtils, appLogWrapper, htmlMessageUtils)
         setUpMocks()
     }
 
@@ -123,9 +125,15 @@ class TodaysStatsCardBuilderTest : BaseUnitTest() {
     }
 
     private fun buildTodaysStatsCard(todaysStatsCardModel: TodaysStatsCardModel?) = builder.build(
-            TodaysStatsCardBuilderParams(todaysStatsCardModel, onTodaysStatsCardClick, onTodaysStatsCardFooterLinkClick)
+            TodaysStatsCardBuilderParams(
+                    todaysStatsCardModel,
+                    onTodaysStatsCardClick,
+                    onGetMoreViewsClick,
+                    onTodaysStatsCardFooterLinkClick
+            )
     )
 
+    private val onGetMoreViewsClick: () -> Unit = { }
     private val onTodaysStatsCardFooterLinkClick: () -> Unit = { }
     private val onTodaysStatsCardClick: () -> Unit = { }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardBuilderTest.kt
@@ -8,7 +8,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.Constants
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.dashboard.CardModel.TodaysStatsCardModel
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.TodaysStatsCardError
@@ -18,6 +17,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TodaysStatsCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.TodaysStatsCardBuilderParams
+import org.wordpress.android.ui.mysite.cards.dashboard.todaysstats.TodaysStatsCardBuilder.Companion.URL_GET_MORE_VIEWS_AND_TRAFFIC
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -34,7 +34,7 @@ private const val TODAYS_STATS_LIKES_FORMATTED_STRING = "100"
 
 private const val GET_MORE_VIEWS_MSG_WITH_CLICKABLE_LINK =
         "If you want to try get more views and traffic check out our " +
-                "<a href=\"${Constants.URL_GET_MORE_VIEWS_AND_TRAFFIC}\">top tips</a>."
+                "<a href=\"${URL_GET_MORE_VIEWS_AND_TRAFFIC}\">top tips</a>."
 
 @RunWith(MockitoJUnitRunner::class)
 class TodaysStatsCardBuilderTest : BaseUnitTest() {
@@ -159,7 +159,7 @@ class TodaysStatsCardBuilderTest : BaseUnitTest() {
         whenever(
                 htmlMessageUtils.getHtmlMessageFromStringFormatResId(
                         R.string.my_site_todays_stats_get_more_views_message,
-                        Constants.URL_GET_MORE_VIEWS_AND_TRAFFIC
+                        URL_GET_MORE_VIEWS_AND_TRAFFIC
                 )
         ).thenReturn(GET_MORE_VIEWS_MSG_WITH_CLICKABLE_LINK)
         return builder.build(


### PR DESCRIPTION
Parent #16256

This PR displays a small nudge on `Today's Stats` dashboard card when  a user has 0 views, 0 visitors, and 0 likes.

Dark Mode | Light Mode
-----------|----------
<img width="383" alt="Screenshot 2022-04-06 at 7 22 03 PM" src="https://user-images.githubusercontent.com/1405144/161990611-f8a826e9-5322-407e-ae3d-14ae9b804fdb.png"> | <img width="383" alt="Screenshot 2022-04-06 at 7 22 19 PM" src="https://user-images.githubusercontent.com/1405144/161990635-be0ef8ae-82e2-4373-91eb-1ca652a7fe8d.png">

To test:

#### Interacting with the nudge

1. Make sure you have a site with a few views, visitors, or likes and one with zero
2. Open the app
3. Tap home
4. ✅ Check that the nudge appears for a site without views, visitors, and likes
5. Tap on the nudge
6. ✅ Make sure a webview displaying `https://wordpress.com/support/getting-more-views-and-traffic/` appears

#### Switching sites

1. Switch to a site with views, visitors and/or likes
2. ✅ Make sure the nudge is not displayed
3. Switch back to a site without any views, visitors and likes
4. ✅ Make sure the nudge is displayed

Notes: Tracking to be added as a separate sub-task.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
