### PR TITLE
My Site Dashboard: Tabs - Add release notes 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 19.7
 -----
-
+* [***] My Site: your My Site screen now has two tabs, "Site Menu" and "Home". Under "Home", you'll find contextual cards with some highlights of whats going on with your site. Check your drafts or scheduled posts, your today's stats or go directly to another section of the app. [https://github.com/wordpress-mobile/WordPress-Android/issues/15989]
 
 19.6
 -----


### PR DESCRIPTION
Parent #15989 

This PR adds release notes for the My Site Dashboard tabs feature

cc: @AliSoftware   I'm not sure if the length is too long; but if it is, we can cut it down to `My Site: your My Site screen now has two tabs, "Site Menu" and "Home".` LMK. Thanks


To test:
There is nothing to test for this PR.


## Regression Notes
1. Potential unintended areas of impact N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A
3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
