### PR TITLE
Update Aztec to 1.5.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.13.0'
-    gutenbergMobileVersion = 'v1.74.0-alpha1'
+    gutenbergMobileVersion = '4735-617f56b3e8aa2f81734ebc2e311297e7a523b153'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.13.0'
-    gutenbergMobileVersion = '4735-eee61bc8b349bbe23c49b7efc9b67db6cf62effd'
+    gutenbergMobileVersion = 'v1.75.0-alpha1'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.13.0'
-    gutenbergMobileVersion = '4735-617f56b3e8aa2f81734ebc2e311297e7a523b153'
+    gutenbergMobileVersion = '4735-eee61bc8b349bbe23c49b7efc9b67db6cf62effd'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.aztecVersion = 'trunk-f3fc2a67ba38feb4adb4a93703587627aa29c762'
+    ext.aztecVersion = '975-e69dca965397a9f2978c8722976bee2f9de597ba'
 }
 
 repositories {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.aztecVersion = '975-e69dca965397a9f2978c8722976bee2f9de597ba'
+    ext.aztecVersion = 'v1.5.7'
 }
 
 repositories {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaToolbarAction.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaToolbarAction.java
@@ -65,6 +65,11 @@ public enum MediaToolbarAction implements IToolbarAction {
         return false;
     }
 
+    @Override
+    public boolean isInlineAction() {
+        return false;
+    }
+
     public interface MediaToolbarButtonClickListener {
         void onMediaToolbarButtonClicked(MediaToolbarAction button);
     }


### PR DESCRIPTION
Updates the Aztec version to 1.5.6.

See the [Gutenberg PR](https://github.com/WordPress/gutenberg/pull/40099) for more info.

## Regression Notes
1. Potential unintended areas of impact
The Aztec and Gutenberg editors are effected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ran Gutenberg's automated tests, performed manual smoke testing of the Gutenberg editor, and did some smoke testing of the Aztec editor.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
