### PR TITLE
My Site Dashboard: Tabs - Refactor default tab to use initial screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -183,10 +183,10 @@ class MySiteViewModel @Inject constructor(
 
     private val defaultABExperimentTab: MySiteTabType
         get() = if (isMySiteTabsEnabled) {
-            if (appPrefsWrapper.getMySiteDefaultTabExperimentVariant() == MySiteTabType.DASHBOARD.label) {
-                MySiteTabType.DASHBOARD
-            } else {
+            if (appPrefsWrapper.getMySiteInitialScreen() == MySiteTabType.SITE_MENU.label) {
                 MySiteTabType.SITE_MENU
+            } else {
+                MySiteTabType.DASHBOARD
             }
         } else {
             MySiteTabType.ALL

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -37,7 +37,7 @@ class MySiteDefaultTabExperiment @Inject constructor(
     }
 
     fun changeExperimentVariantAssignmentIfNeeded(toVariant: String) {
-        if (isExperimentRunning()) {
+        if (isExperimentRunning() && isVariantAssigned()) {
             setExperimentVariant(toVariant)
             analyticsTrackerWrapper.setInjectExperimentProperties(getVariantMapForTracking())
             analyticsTrackerWrapper.track(Stat.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -19,9 +19,10 @@ class MySiteDefaultTabExperiment @Inject constructor(
     fun checkAndSetVariantIfNeeded() {
         if (isExperimentRunning()) {
             if (!isVariantAssigned()) {
+                setVariantAssigned()
                 when (mySiteDefaultTabExperimentVariationDashboardFeatureConfig.isDashboardVariant()) {
-                    true -> setExperimentVariant(MySiteTabExperimentVariant.DASHBOARD)
-                    false -> setExperimentVariant(MySiteTabExperimentVariant.SITE_MENU)
+                    true -> setExperimentVariant(VARIANT_HOME)
+                    false -> setExperimentVariant(VARIANT_SITE_MENU)
                 }
                 analyticsTrackerWrapper.setInjectExperimentProperties(getVariantMapForTracking())
                 analyticsTrackerWrapper.track(Stat.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED)
@@ -40,15 +41,20 @@ class MySiteDefaultTabExperiment @Inject constructor(
 
     private fun isVariantAssigned() = appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()
 
-    private fun setExperimentVariant(variant: MySiteTabExperimentVariant) {
-        appPrefsWrapper.setMySiteDefaultTabExperimentVariant(variant.label)
-    }
+    private fun setVariantAssigned() = appPrefsWrapper.setMySiteDefaultTabExperimentVariantAssigned()
+
+    private fun setExperimentVariant(variant: String) =
+            appPrefsWrapper.setInitialScreenFromMySiteDefaultTabExperimentVariant(variant)
 
     private fun getVariantMapForTracking() =
             mapOf(DEFAULT_TAB_EXPERIMENT to appPrefsWrapper.getMySiteDefaultTabExperimentVariant())
 
     companion object {
         private const val DEFAULT_TAB_EXPERIMENT = "default_tab_experiment"
+        private const val VARIANT_DASHBOARD = "dashboard"
+        private const val VARIANT_SITE_MENU = "site_menu"
+        private const val VARIANT_HOME = "home"
+        private const val NONEXISTENT = "nonexistent"
     }
 }
 enum class MySiteTabExperimentVariant(val label: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -18,7 +18,7 @@ class MySiteDefaultTabExperiment @Inject constructor(
 ) {
     fun checkAndSetVariantIfNeeded() {
         if (isExperimentRunning()) {
-            if (isVariantNotAssigned()) {
+            if (!isVariantAssigned()) {
                 when (mySiteDefaultTabExperimentVariationDashboardFeatureConfig.isDashboardVariant()) {
                     true -> setExperimentVariant(MySiteTabExperimentVariant.DASHBOARD)
                     false -> setExperimentVariant(MySiteTabExperimentVariant.SITE_MENU)
@@ -38,8 +38,7 @@ class MySiteDefaultTabExperiment @Inject constructor(
     private fun isExperimentRunning() =
             mySiteDashboardTabsFeatureConfig.isEnabled() && mySiteDefaultTabExperimentFeatureConfig.isEnabled()
 
-    private fun isVariantNotAssigned() =
-            appPrefsWrapper.getMySiteDefaultTabExperimentVariant() == MySiteTabExperimentVariant.NONEXISTENT.label
+    private fun isVariantAssigned() = appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()
 
     private fun setExperimentVariant(variant: MySiteTabExperimentVariant) {
         appPrefsWrapper.setMySiteDefaultTabExperimentVariant(variant.label)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -73,24 +73,3 @@ class MySiteDefaultTabExperiment @Inject constructor(
         private const val NONEXISTENT = "nonexistent"
     }
 }
-enum class MySiteTabExperimentVariant(val label: String) {
-    NONEXISTENT(MySiteTabExperimentVariant.VARIANT_NONEXISTENT),
-    DASHBOARD(MySiteTabExperimentVariant.VARIANT_DASHBOARD),
-    SITE_MENU(MySiteTabExperimentVariant.VARIANT_SITE_MENU);
-
-    override fun toString() = label
-
-    companion object {
-        private const val VARIANT_NONEXISTENT = "nonexistent"
-        private const val VARIANT_DASHBOARD = "dashboard"
-        private const val VARIANT_SITE_MENU = "site_menu"
-
-        @JvmStatic
-        fun fromString(label: String) = when {
-            NONEXISTENT.label == label -> NONEXISTENT
-            DASHBOARD.label == label -> DASHBOARD
-            SITE_MENU.label == label -> SITE_MENU
-            else -> NONEXISTENT
-        }
-    }
-}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -46,8 +46,16 @@ class MySiteDefaultTabExperiment @Inject constructor(
     private fun setExperimentVariant(variant: String) =
             appPrefsWrapper.setInitialScreenFromMySiteDefaultTabExperimentVariant(variant)
 
-    private fun getVariantMapForTracking() =
-            mapOf(DEFAULT_TAB_EXPERIMENT to appPrefsWrapper.getMySiteDefaultTabExperimentVariant())
+    private fun getVariantMapForTracking() = mapOf(DEFAULT_TAB_EXPERIMENT to getVariantTrackingLabel())
+
+    private fun getVariantTrackingLabel(): String {
+        if (!isVariantAssigned()) return NONEXISTENT
+        return if (appPrefsWrapper.getMySiteInitialScreen() == VARIANT_HOME) {
+            VARIANT_DASHBOARD
+        } else {
+            VARIANT_SITE_MENU
+        }
+    }
 
     companion object {
         private const val DEFAULT_TAB_EXPERIMENT = "default_tab_experiment"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -36,6 +36,14 @@ class MySiteDefaultTabExperiment @Inject constructor(
         }
     }
 
+    fun changeExperimentVariantAssignmentIfNeeded(toVariant: String) {
+        if (isExperimentRunning()) {
+            setExperimentVariant(toVariant)
+            analyticsTrackerWrapper.setInjectExperimentProperties(getVariantMapForTracking())
+            analyticsTrackerWrapper.track(Stat.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED)
+        }
+    }
+
     private fun isExperimentRunning() =
             mySiteDashboardTabsFeatureConfig.isEnabled() && mySiteDefaultTabExperimentFeatureConfig.isEnabled()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -269,6 +269,9 @@ public class AppPrefs {
 
         // Tracks which block types are considered "new" via impression counts
         GUTENBERG_BLOCK_TYPE_IMPRESSIONS,
+
+        // Used to identify the App Settings for initial screen that is updated when the variant is assigned
+        wp_pref_initial_screen,
     }
 
     private static SharedPreferences prefs() {
@@ -1364,5 +1367,17 @@ public class AppPrefs {
                 DeletablePrefKey.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED,
                 false
         );
+    }
+
+    public static void setMySiteDefaultTabExperimentVariantAssigned() {
+        setBoolean(DeletablePrefKey.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED, true);
+    }
+
+    public static void setInitialScreenFromMySiteDefaultTabExperimentVariant(String variant) {
+        // This supports the MySiteDefaultTab AB Experiment.
+        // AppSettings are undeletable across logouts and keys are all lower case.
+        // This method will be removed when the experiment has completed and thus
+        // the settings will be maintained only from the AppSettings view
+        setString(UndeletablePrefKey.wp_pref_initial_screen, variant);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -171,7 +171,10 @@ public class AppPrefs {
         SHOULD_SHOW_WEEKLY_ROUNDUP_NOTIFICATION,
 
         // Used to store the variant for the my site default tab experiment
-        MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT
+        MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT,
+
+        // Used to indicate if the variant has been assigned for the My Site Tab experiment
+        MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED
     }
 
     /**
@@ -1353,6 +1356,13 @@ public class AppPrefs {
         return getString(
                 DeletablePrefKey.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT,
                 MySiteTabExperimentVariant.NONEXISTENT.getLabel()
+        );
+    }
+
+    public static boolean isMySiteDefaultTabExperimentVariantAssigned() {
+        return getBoolean(
+                DeletablePrefKey.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED,
+                false
         );
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -1352,17 +1352,6 @@ public class AppPrefs {
         return capabilities;
     }
 
-    public static void setMySiteDefaultTabExperimentVariant(String variant) {
-        setString(DeletablePrefKey.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT, variant);
-    }
-
-    public static String getMySiteDefaultTabExperimentVariant() {
-        return getString(
-                DeletablePrefKey.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT,
-                MySiteTabExperimentVariant.NONEXISTENT.getLabel()
-        );
-    }
-
     public static boolean isMySiteDefaultTabExperimentVariantAssigned() {
         return getBoolean(
                 DeletablePrefKey.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -21,7 +21,6 @@ import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
-import org.wordpress.android.ui.mysite.tabs.MySiteTabExperimentVariant;
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType;
 import org.wordpress.android.ui.posts.AuthorFilterSelection;
 import org.wordpress.android.ui.posts.PostListViewLayoutType;
@@ -170,9 +169,6 @@ public class AppPrefs {
         BLOGGING_REMINDERS_SHOWN,
         SHOULD_SCHEDULE_CREATE_SITE_NOTIFICATION,
         SHOULD_SHOW_WEEKLY_ROUNDUP_NOTIFICATION,
-
-        // Used to store the variant for the my site default tab experiment
-        MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT,
 
         // Used to indicate if the variant has been assigned for the My Site Tab experiment
         MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -22,6 +22,7 @@ import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.mysite.tabs.MySiteTabExperimentVariant;
+import org.wordpress.android.ui.mysite.tabs.MySiteTabType;
 import org.wordpress.android.ui.posts.AuthorFilterSelection;
 import org.wordpress.android.ui.posts.PostListViewLayoutType;
 import org.wordpress.android.ui.reader.tracker.ReaderTab;
@@ -1379,5 +1380,11 @@ public class AppPrefs {
         // This method will be removed when the experiment has completed and thus
         // the settings will be maintained only from the AppSettings view
         setString(UndeletablePrefKey.wp_pref_initial_screen, variant);
+    }
+
+    public static String getMySiteInitialScreen() {
+        return getString(
+                UndeletablePrefKey.wp_pref_initial_screen,
+                MySiteTabType.SITE_MENU.getLabel());
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -214,7 +214,7 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun setMySiteDefaultTabExperimentVariant(variant: String) = AppPrefs.setMySiteDefaultTabExperimentVariant(variant)
 
-    fun getMySiteDefaultTabExperimentVariant() = AppPrefs.getMySiteDefaultTabExperimentVariant()
+    fun getMySiteDefaultTabExperimentVariant(): String = AppPrefs.getMySiteDefaultTabExperimentVariant()
 
     fun isMySiteDefaultTabExperimentVariantAssigned() = AppPrefs.isMySiteDefaultTabExperimentVariantAssigned()
 
@@ -222,6 +222,8 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun setInitialScreenFromMySiteDefaultTabExperimentVariant(variant: String) =
             AppPrefs.setInitialScreenFromMySiteDefaultTabExperimentVariant(variant)
+
+    fun getMySiteInitialScreen(): String = AppPrefs.getMySiteInitialScreen()
 
     companion object {
         private const val LIGHT_MODE_ID = 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -216,6 +216,8 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun getMySiteDefaultTabExperimentVariant() = AppPrefs.getMySiteDefaultTabExperimentVariant()
 
+    fun isMySiteDefaultTabExperimentVariantAssigned() = AppPrefs.isMySiteDefaultTabExperimentVariantAssigned()
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -218,6 +218,11 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun isMySiteDefaultTabExperimentVariantAssigned() = AppPrefs.isMySiteDefaultTabExperimentVariantAssigned()
 
+    fun setMySiteDefaultTabExperimentVariantAssigned() = AppPrefs.setMySiteDefaultTabExperimentVariantAssigned()
+
+    fun setInitialScreenFromMySiteDefaultTabExperimentVariant(variant: String) =
+            AppPrefs.setInitialScreenFromMySiteDefaultTabExperimentVariant(variant)
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -212,10 +212,6 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun setLastSkippedQuickStartTask(task: QuickStartTask) = AppPrefs.setLastSkippedQuickStartTask(task)
 
-    fun setMySiteDefaultTabExperimentVariant(variant: String) = AppPrefs.setMySiteDefaultTabExperimentVariant(variant)
-
-    fun getMySiteDefaultTabExperimentVariant(): String = AppPrefs.getMySiteDefaultTabExperimentVariant()
-
     fun isMySiteDefaultTabExperimentVariantAssigned() = AppPrefs.isMySiteDefaultTabExperimentVariantAssigned()
 
     fun setMySiteDefaultTabExperimentVariantAssigned() = AppPrefs.setMySiteDefaultTabExperimentVariantAssigned()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -44,6 +44,8 @@ import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewAppId;
 import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewFetchPayload;
 import org.wordpress.android.ui.about.UnifiedAboutActivity;
 import org.wordpress.android.ui.debug.DebugSettingsActivity;
+import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment;
+import org.wordpress.android.ui.mysite.tabs.MySiteTabType;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementDialogFragment;
@@ -96,6 +98,7 @@ public class AppSettingsFragment extends PreferenceFragment
     @Inject BuildConfigWrapper mBuildConfigWrapper;
     @Inject UnifiedAboutFeatureConfig mUnifiedAboutFeatureConfig;
     @Inject MySiteDashboardTabsFeatureConfig mMySiteDashboardTabsFeatureConfig;
+    @Inject MySiteDefaultTabExperiment mMySiteDefaultTabExperiment;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -426,9 +429,13 @@ public class AppSettingsFragment extends PreferenceFragment
             // restart activity to make sure changes are applied to PreferenceScreen
             getActivity().recreate();
         } else if (preference == mInitialScreenPreference) {
+            String trackValue = (((String) newValue).equals(MySiteTabType.SITE_MENU.getLabel()))
+                    ? (String) newValue
+                    : MySiteTabType.DASHBOARD.getLabel();
             Map<String, Object> properties = new HashMap<>();
-            properties.put("selected", (String) newValue);
+            properties.put("selected", trackValue);
             AnalyticsTracker.track(Stat.APP_SETTINGS_INITIAL_SCREEN_CHANGED, properties);
+            mMySiteDefaultTabExperiment.changeExperimentVariantAssignmentIfNeeded((String) newValue);
         }
         return true;
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -101,7 +101,6 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsTracker
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
-import org.wordpress.android.ui.mysite.tabs.MySiteTabExperimentVariant
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType.DASHBOARD
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType.SITE_MENU
@@ -186,6 +185,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private val emailAddress = "test@email.com"
     private val postId = 100
     private val localHomepageId = 1
+    private val home = "home"
     private lateinit var site: SiteModel
     private lateinit var siteInfoHeader: SiteInfoHeaderCard
     private lateinit var homepage: PageModel
@@ -476,11 +476,13 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given tabs enabled + dashboard default tab variant, when site is selected, then default tab is dashboard`() {
+    fun `given tabs enabled + initial screen is home, when site is selected, then default tab is dashboard`() {
+        whenever(appPrefsWrapper.getMySiteInitialScreen()).thenReturn(home)
+
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                defaultTabExperimentVariant = MySiteTabExperimentVariant.DASHBOARD
+                initialScreen = home
         )
 
         assertThat(tabNavigation)
@@ -488,23 +490,12 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given tabs enabled + site menu default tab variant, when site is selected, then default tab is site menu`() {
+    fun `given tabs enabled + initial screen is site_menu, when site is selected, then default tab is site menu`() {
+        whenever(appPrefsWrapper.getMySiteInitialScreen()).thenReturn(SITE_MENU.label)
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                defaultTabExperimentVariant = MySiteTabExperimentVariant.SITE_MENU
-        )
-
-        assertThat(tabNavigation)
-                .containsOnly(TabNavigation(viewModel.orderedTabTypes.indexOf(SITE_MENU), false))
-    }
-
-    @Test
-    fun `given tabs enabled + nonexistent default tab variant, when site is selected, then default tab is site menu`() {
-        initSelectedSite(
-                isMySiteDashboardTabsFeatureFlagEnabled = true,
-                isMySiteTabsBuildConfigEnabled = true,
-                defaultTabExperimentVariant = MySiteTabExperimentVariant.NONEXISTENT
+                initialScreen = SITE_MENU.label
         )
 
         assertThat(tabNavigation)
@@ -518,7 +509,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                defaultTabExperimentVariant = MySiteTabExperimentVariant.SITE_MENU
+                initialScreen = SITE_MENU.label
         )
 
         viewModel.onCreateSiteResult()
@@ -1894,13 +1885,14 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given tabs enabled + dashboard default tab variant, when dashboard cards items, then qs card exists`() {
+    fun `given tabs enabled + dashboard variant, when dashboard cards items, then qs card exists`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
         setUpSiteItemBuilder()
+
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                defaultTabExperimentVariant = MySiteTabExperimentVariant.DASHBOARD
+                initialScreen = home
         )
 
         val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
@@ -1912,10 +1904,11 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given tabs enabled + site menu default tab variant, when dashboard cards items, then qs card not exists`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
         setUpSiteItemBuilder()
+
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                defaultTabExperimentVariant = MySiteTabExperimentVariant.SITE_MENU
+                initialScreen = SITE_MENU.label
         )
 
         val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
@@ -1949,10 +1942,11 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given tabs enabled + dashboard default tab variant, when site menu cards + items, then qs card not exists`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
         setUpSiteItemBuilder()
+
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                defaultTabExperimentVariant = MySiteTabExperimentVariant.DASHBOARD
+                initialScreen = home
         )
 
         val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
@@ -1964,10 +1958,11 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given tabs enabled + site menu default tab variant, when site menu cards and items, then qs card exists`() {
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
         setUpSiteItemBuilder()
+
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                defaultTabExperimentVariant = MySiteTabExperimentVariant.SITE_MENU
+                initialScreen = MySiteTabType.SITE_MENU.label
         )
 
         val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
@@ -2190,7 +2185,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         isQuickStartDynamicCardEnabled: Boolean = false,
         isQuickStartInProgress: Boolean = false,
         showStaleMessage: Boolean = false,
-        defaultTabExperimentVariant: MySiteTabExperimentVariant = MySiteTabExperimentVariant.NONEXISTENT
+        initialScreen: String = SITE_MENU.label
     ) {
         setUpDynamicCardsBuilder(isQuickStartDynamicCardEnabled)
         whenever(
@@ -2201,7 +2196,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         )
         whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsFeatureFlagEnabled)
         whenever(buildConfigWrapper.isMySiteTabsEnabled).thenReturn(isMySiteTabsBuildConfigEnabled)
-        whenever(appPrefsWrapper.getMySiteDefaultTabExperimentVariant()).thenReturn(defaultTabExperimentVariant.label)
+        whenever(appPrefsWrapper.getMySiteInitialScreen()).thenReturn(initialScreen)
         onSiteSelected.value = siteLocalId
         onSiteChange.value = site
         selectedSite.value = SelectedSite(site)


### PR DESCRIPTION
Parent #15989 

This [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16252) changes include:

- Adjusts the default tab selection logic in `MySiteViewModel` to use the “initial screen” app setting
- Stores that the experiment variant was assigned (not the variant itself) in a new shared pref `MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED`. This pref is deletable all will be removed on signout.
- Overwrites the initial screen (`wp_pref_initial_screen` ) app setting with the variant assigned by the experiment 
- When a user navigates to Me → App Settings and manually changes their initial screen, if the default tab experiment is running and this user has already been assigned a variant, then we will track this action as an experiment variant assignment change and update the setting accordingly 
- The experiment assignment rules remains unchanged: only when a user complete the login or signup flow (and, of course, the experiment and tabs have been enabled)
- Managed the “home” to “dashboard” conversion for the tracking property
- Removed the `MY_SITE_DEAFULT_TAB_EXPERIMENT_VARIANT` enum
- Removed the `MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT` shared pref key

FYI: This PR added the `wp_pref_initial_screen` App Setting for managing the “initial screen” for the My Site View. This setting, like all other App settings, is undeletable and will persist across log outs.

**Notes**
The “initial screen” app setting is NOT set until an experiment variant has been assigned OR the user navigates to Me → App Setting view. The default value for initial screen remain as: **site_menu**


##Tests
**Prerequisites**
- Do a fresh install of the App
- Log in
- Navigate to `My Site` -> `Me` -> `App Settings` -> `Privacy settings`.
- Enable collection logs
- Navigate to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
- Enable `MySiteDashboardTabsFeatureConfig`
- Restart the app

**Test A: Validate no experiment assignment**
- Navigate to My Site
- ✅ Verify the selected tab is “Site Menu”
- ✅ Verify that "default_tab_experiment":"nonexistent" is being collected in tracked events

**Test B: Initial Screen change is respected on app reopen**
- Navigate to `My Site` -> `Me` -> `App Settings` -> `App settings`.
- Tap `Initial Screen` and select `Home`
- ✅ Verify the change is tracked
    🔵 Tracked: app_settings_initial_screen_changed, Properties: {"default_tab_experiment":"nonexistent","selected":"dashboard"}
- Close the App (not background)
- Reopen the app
- ✅ Verify the selected tab is the Home tab
- Log out of the app

**Test C: Variant assigned upon login is reflected in the selected tab of My Site view**
- Complete Test B
- Log in
- ✅ Verify the experiment has been assigned/tracked
    🔵 Tracked: my_site_default_tab_experiment_variant_assigned, Properties: {"default_tab_experiment":"site_menu"} *variant may be site_menu|dashboard
- ✅ Verify the selected tab matches the variant just assigned

**Test D: Variant assigned upon login or signup is reflected in “initial screen” pref** 
- Complete Test C
- Navigate to `My Site` -> `Me` -> `App Settings` -> `App settings`.
- ✅ Verify  `Initial Screen` value reflects the variant assigned. *Home = dashboard

**Test E: Initial screen change is reflected as a experiment variant assigned**
- Complete Test D
- Navigate to `My Site` -> `Me` -> `App Settings` -> `App settings`.
- Tap “initial screen”
- Select the option not selected
- ✅ Verify the change is tracked
    🔵 Tracked: app_settings_initial_screen_changed, Properties: {"default_tab_experiment":"nonexistent","selected":”site_menu|dashboard"}
- ✅ Verify the experiment has been assigned/tracked
    🔵 Tracked: my_site_default_tab_experiment_variant_assigned, Properties: {"default_tab_experiment":"site_menu|dashboard"}  

Extra credit:  If you are testing on an emulator and want to check the preferences values as you move along, then follow these instructions
    - Open Device File Explorer
    - Navigate to data -> data -> org.wordpress.android.prealpha -> shared_prefs
    - Double click on `org.wordpress.android.prealpha_preferences.xml` to open the file

## Regression Notes
1. Potential unintended areas of impact
The tab selected in My Site view does not reflect initial screen 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

3. What automated tests I added (or what prevented me from doing so)
Updated tests in `MySiteViewModelTest` and `MySiteDefaultTabExperimentTest`
PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
