### PR TITLE
Integrate gutenberg-mobile release 1.73.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.13.0'
-    gutenbergMobileVersion = 'v1.73.0'
+    gutenbergMobileVersion = '4739-65c77b7f13e6c0a51b483790e628c0d3bff881f1'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.13.0'
-    gutenbergMobileVersion = '4739-78737e4074d29859d85a7a132505adb7b92e099a'
+    gutenbergMobileVersion = 'v1.73.1'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.13.0'
-    gutenbergMobileVersion = '4739-65c77b7f13e6c0a51b483790e628c0d3bff881f1'
+    gutenbergMobileVersion = '4739-78737e4074d29859d85a7a132505adb7b92e099a'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.73.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4739

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.