### PR TITLE
My Site Dashboard: Add tracking for Today's Stats nudge

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -486,8 +486,8 @@ class MySiteViewModel @Inject constructor(
         MySiteTabType.ALL -> emptyList()
     }
 
-    @Suppress("EmptyFunctionBlock")
     private fun onGetMoreViewsClick() {
+        cardsTracker.trackTodaysStatsCardGetMoreViewsNudgeClicked()
     }
 
     private fun onTodaysStatsCardFooterLinkClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -58,6 +58,7 @@ import org.wordpress.android.ui.mysite.cards.CardsBuilder
 import org.wordpress.android.ui.mysite.cards.DomainRegistrationCardShownTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
+import org.wordpress.android.ui.mysite.cards.dashboard.todaysstats.TodaysStatsCardBuilder.Companion.URL_GET_MORE_VIEWS_AND_TRAFFIC
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
@@ -399,7 +400,7 @@ class MySiteViewModel @Inject constructor(
                                 todaysStatsCard = cardsUpdate?.cards?.firstOrNull { it is TodaysStatsCardModel }
                                         as? TodaysStatsCardModel,
                                 onTodaysStatsCardClick = this::onTodaysStatsCardClick,
-                                onGetMoreViewsClick = this:: onGetMoreViewsClick,
+                                onGetMoreViewsClick = this::onGetMoreViewsClick,
                                 onFooterLinkClick = this::onTodaysStatsCardFooterLinkClick
                         ),
                         postCardBuilderParams = PostCardBuilderParams(
@@ -488,6 +489,9 @@ class MySiteViewModel @Inject constructor(
 
     private fun onGetMoreViewsClick() {
         cardsTracker.trackTodaysStatsCardGetMoreViewsNudgeClicked()
+        _onNavigation.value = Event(
+                SiteNavigationAction.OpenTodaysStatsGetMoreViewsExternalUrl(URL_GET_MORE_VIEWS_AND_TRAFFIC)
+        )
     }
 
     private fun onTodaysStatsCardFooterLinkClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -71,4 +71,5 @@ sealed class SiteNavigationAction {
     data class EditDraftPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
     data class EditScheduledPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
     data class OpenTodaysStats(val site: SiteModel) : SiteNavigationAction()
+    data class OpenTodaysStatsGetMoreViewsExternalUrl(val url: String) : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -21,7 +21,8 @@ class CardsTracker @Inject constructor(
     }
 
     enum class StatsSubtype(val label: String) {
-        TODAYS_STATS("todays_stats")
+        TODAYS_STATS("todays_stats"),
+        TODAYS_STATS_NUDGE("todays_stats_nudge")
     }
 
     enum class PostSubtype(val label: String) {
@@ -29,6 +30,10 @@ class CardsTracker @Inject constructor(
         CREATE_NEXT("create_next"),
         DRAFT("draft"),
         SCHEDULED("scheduled")
+    }
+
+    fun trackTodaysStatsCardGetMoreViewsNudgeClicked() {
+        trackCardItemClicked(Type.STATS.label, StatsSubtype.TODAYS_STATS_NUDGE.label)
     }
 
     fun trackTodaysStatsCardFooterLinkClicked() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
@@ -61,6 +61,7 @@ class TodaysStatsCardViewHolder(
             val startIndex = spannable.getSpanStart(urlSpan)
             val endIndex = spannable.getSpanEnd(urlSpan)
             links.forEach { link ->
+                spannable.removeSpan(urlSpan)
                 spannable.withClickableSpan(startIndex, endIndex) {
                     link.navigationAction.click()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -318,6 +318,8 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             ActivityLauncher.viewCurrentBlogPostsOfType(requireActivity(), action.site, PostListType.SCHEDULED)
         is SiteNavigationAction.OpenTodaysStats ->
             ActivityLauncher.viewBlogStatsForTimeframe(requireActivity(), action.site, StatsTimeframe.DAY)
+        is SiteNavigationAction.OpenTodaysStatsGetMoreViewsExternalUrl ->
+            ActivityLauncher.openUrlExternal(requireActivity(), action.url)
     }
 
     private fun openQuickStartFullScreenDialog(action: SiteNavigationAction.OpenQuickStartFullScreenDialog) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -92,6 +92,7 @@ import org.wordpress.android.ui.mysite.cards.CardsBuilder
 import org.wordpress.android.ui.mysite.cards.DomainRegistrationCardShownTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
+import org.wordpress.android.ui.mysite.cards.dashboard.todaysstats.TodaysStatsCardBuilder.Companion.URL_GET_MORE_VIEWS_AND_TRAFFIC
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
@@ -221,6 +222,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private var dynamicCardMoreClick: ((DynamicCardMenuModel) -> Unit)? = null
     private var onPostCardFooterLinkClick: ((postCardType: PostCardType) -> Unit)? = null
     private var onPostItemClick: ((params: PostItemClickParams) -> Unit)? = null
+    private var onTodaysStatsCardGetMoreViewsClick: (() -> Unit) = {}
     private var onTodaysStatsCardClick: (() -> Unit) = {}
     private var onTodaysStatsCardFooterLinkClick: (() -> Unit) = {}
     private var onDashboardErrorRetryClick: (() -> Unit)? = null
@@ -1252,6 +1254,21 @@ class MySiteViewModelTest : BaseUnitTest() {
                 onTodaysStatsCardFooterLinkClick.invoke()
 
                 assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenTodaysStats(site))
+            }
+
+    @Test
+    fun `given todays stat card, when get more views url is clicked, then external link is opened`() =
+            test {
+                initSelectedSite()
+
+                onTodaysStatsCardGetMoreViewsClick.invoke()
+
+                assertThat(navigationActions)
+                        .containsOnly(
+                                SiteNavigationAction.OpenTodaysStatsGetMoreViewsExternalUrl(
+                                        URL_GET_MORE_VIEWS_AND_TRAFFIC
+                                )
+                        )
             }
 
     /* DASHBOARD POST CARD - FOOTER LINK */
@@ -2311,9 +2328,9 @@ class MySiteViewModelTest : BaseUnitTest() {
             val quickStartCard = initQuickStartCard(it)
             val dashboardCards = initDashboardCards(it)
             val listOfCards = arrayListOf<MySiteCardAndItem>(
-                        quickActionsCard,
-                        domainRegistrationCard,
-                        quickStartCard
+                    quickActionsCard,
+                    domainRegistrationCard,
+                    quickStartCard
             )
 
             if (mySiteDashboardPhase2FeatureConfig.isEnabled())
@@ -2396,7 +2413,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         quickLinkRibbonMediaClickAction = params.onMediaClick
         quickLinkRibbonStatsClickAction = params.onStatsClick
         return QuickLinkRibbon(
-            quickLinkRibbonItems = mock()
+                quickLinkRibbonItems = mock()
         )
     }
 
@@ -2467,6 +2484,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     private fun initTodaysStatsCard(mockInvocation: InvocationOnMock): TodaysStatsCard {
         val params = (mockInvocation.arguments.filterIsInstance<DashboardCardsBuilderParams>()).first()
+        onTodaysStatsCardGetMoreViewsClick = params.todaysStatsCardBuilderParams.onGetMoreViewsClick
         onTodaysStatsCardClick = params.todaysStatsCardBuilderParams.onTodaysStatsCardClick
         onTodaysStatsCardFooterLinkClick = params.todaysStatsCardBuilderParams.onFooterLinkClick
         return TodaysStatsCardWithData(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -28,6 +28,13 @@ class CardsTrackerTest {
     }
 
     @Test
+    fun `when today's stats card get more views link is clicked, then today's stats nudge event is tracked`() {
+        cardsTracker.trackTodaysStatsCardGetMoreViewsNudgeClicked()
+
+        verifyCardItemClickedTracked(Type.STATS, StatsSubtype.TODAYS_STATS_NUDGE.label)
+    }
+
+    @Test
     fun `when today's stats card footer link is clicked, then today's stats card footer click event is tracked`() {
         cardsTracker.trackTodaysStatsCardFooterLinkClicked()
 


### PR DESCRIPTION
Parent #16256

This PR tracks Today's Stats nudge click.

Note: It also removes `URLSpan` and uses the standard `SiteNavigationAction` pattern to open external URL for the nudge. For details, see [commit message](https://github.com/wordpress-mobile/WordPress-Android/commit/65d1ca0807ccf2b577230dabc3819d1722b40de7).

To test:

#### Interacting with the nudge

1. Make sure you have a site with a few views, visitors, or likes and one with zero
2. Open the app
3. Tap home
4. ✅ Check that the nudge appears for a site without views, visitors, and likes
5. Tap on the nudge
6. ✅ Make sure `my_site_dashboard_card_item_tapped` is fired with `sub_type: todays_stats_nudge`
7. ✅ Make sure a webview displaying `https://wordpress.com/support/getting-more-views-and-traffic/` appears

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
