### PR TITLE
My Site Dashboard: Tabs - Show Dynamic Cards on either tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -458,7 +458,7 @@ class MySiteViewModel @Inject constructor(
                         cardsResult.filterNot {
                             getCardTypeExclusionFiltersForTab(MySiteTabType.SITE_MENU).contains(it.type)
                         },
-                        dynamicCards,
+                        if (shouldIncludeDynamicCards(MySiteTabType.SITE_MENU)) { dynamicCards } else { listOf() },
                         siteItems
                 ),
                 MySiteTabType.DASHBOARD to orderForDisplay(
@@ -466,7 +466,7 @@ class MySiteViewModel @Inject constructor(
                         cardsResult.filterNot {
                             getCardTypeExclusionFiltersForTab(MySiteTabType.DASHBOARD).contains(it.type)
                         },
-                        listOf(),
+                        if (shouldIncludeDynamicCards(MySiteTabType.DASHBOARD)) { dynamicCards } else { listOf() },
                         listOf()
                 )
         )
@@ -475,15 +475,25 @@ class MySiteViewModel @Inject constructor(
     private fun getCardTypeExclusionFiltersForTab(tabType: MySiteTabType) = when (tabType) {
         MySiteTabType.SITE_MENU -> mutableListOf<Type>().apply {
             add(Type.DASHBOARD_CARDS)
-            if (defaultABExperimentTab == MySiteTabType.DASHBOARD) add(Type.QUICK_START_CARD)
+            if (defaultABExperimentTab == MySiteTabType.DASHBOARD) {
+                add(Type.QUICK_START_CARD)
+            }
             add(Type.QUICK_LINK_RIBBON)
         }
         MySiteTabType.DASHBOARD -> mutableListOf<Type>().apply {
-            if (defaultABExperimentTab == MySiteTabType.SITE_MENU) add(Type.QUICK_START_CARD)
+            if (defaultABExperimentTab == MySiteTabType.SITE_MENU) {
+                add(Type.QUICK_START_CARD)
+            }
             add(Type.DOMAIN_REGISTRATION_CARD)
             add(Type.QUICK_ACTIONS_CARD)
         }
         MySiteTabType.ALL -> emptyList()
+    }
+
+    private fun shouldIncludeDynamicCards(tabType: MySiteTabType) = when (tabType) {
+        MySiteTabType.SITE_MENU -> defaultABExperimentTab != MySiteTabType.DASHBOARD
+        MySiteTabType.DASHBOARD -> defaultABExperimentTab != MySiteTabType.SITE_MENU
+        MySiteTabType.ALL -> true
     }
 
     @Suppress("EmptyFunctionBlock")

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2042,6 +2042,40 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(siteInfoHeaderCard).isTrue
     }
 
+    @Test
+    fun `given tabs enabled + site menu initial screen, when site menu cards + items, then dynamic card exists`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        setUpSiteItemBuilder()
+
+        initSelectedSite(
+                isMySiteDashboardTabsFeatureFlagEnabled = true,
+                isMySiteTabsBuildConfigEnabled = true,
+                initialScreen = SITE_MENU.label,
+                isQuickStartDynamicCardEnabled = true
+        )
+
+        val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
+
+        assertThat(items.filterIsInstance(DynamicCard::class.java)).isNotEmpty
+    }
+
+    @Test
+    fun `given tabs enabled + dashboard initial screen, when dashboard cards + items, then dynamic card exists`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        setUpSiteItemBuilder()
+
+        initSelectedSite(
+                isMySiteDashboardTabsFeatureFlagEnabled = true,
+                isMySiteTabsBuildConfigEnabled = true,
+                initialScreen = home,
+                isQuickStartDynamicCardEnabled = true
+        )
+
+        val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
+
+        assertThat(items.filterIsInstance(DynamicCard::class.java)).isNotEmpty
+    }
+
     /* TRACK WITH TAB SOURCE */
     @Test
     fun `given tabs are enabled, when pull to refresh invoked, then track with tab source is requested`() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2093,6 +2093,40 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(items.filterIsInstance(DynamicCard::class.java)).isNotEmpty
     }
 
+    @Test
+    fun `given tabs enabled + site menu initial screen, when dashboard cards + items, then dynamic card not exists`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        setUpSiteItemBuilder()
+
+        initSelectedSite(
+                isMySiteDashboardTabsFeatureFlagEnabled = true,
+                isMySiteTabsBuildConfigEnabled = true,
+                initialScreen = SITE_MENU.label,
+                isQuickStartDynamicCardEnabled = true
+        )
+
+        val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
+
+        assertThat(items.filterIsInstance(DynamicCard::class.java)).isEmpty()
+    }
+
+    @Test
+    fun `given tabs enabled + dashboard initial screen, when site menu cards + items, then dynamic card not exists`() {
+        whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(true)
+        setUpSiteItemBuilder()
+
+        initSelectedSite(
+                isMySiteDashboardTabsFeatureFlagEnabled = true,
+                isMySiteTabsBuildConfigEnabled = true,
+                initialScreen = home,
+                isQuickStartDynamicCardEnabled = true
+        )
+
+        val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
+
+        assertThat(items.filterIsInstance(DynamicCard::class.java)).isEmpty()
+    }
+
     /* TRACK WITH TAB SOURCE */
     @Test
     fun `given tabs are enabled, when pull to refresh invoked, then track with tab source is requested`() {


### PR DESCRIPTION
Parent #15989 

This PR adds the Dynamic Quick Start Cards to either tab depending on the initial screen (app setting) value.

Note: Only 1 approval is needed. Thanks

**To test:**
- Launch the app 
- Login in
- After site selection, select "Show me around" when prompted
- Navigate to Me -> App Settings 
- Note down which tab is the "initial screen" 
- Navigate to Me -> App Settings -> Debug Settings
- Enable `QuickStartDynamicCardsFeatureConfig` and restart the app
- Navigate to My Site
- ✅  Verify that Dynamic cards shows up "initial screen" tab
- Navigate back to Me -> App Settings 
- Set "initial screen" to the opposite tab
- Navigate back to My Site
- ✅  Verify that Dynamic cards shows up "initial screen" tab

## Regression Notes
1. Potential unintended areas of impact
Dynamic card doesn't show

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

3. What automated tests I added (or what prevented me from doing so)
Add new tests to `MySiteViewModelTest`

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
