### PR TITLE
[Tooling] Identify the source library when merging strings and add tools:ignore="UnusedResources" when appropriate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,10 +116,10 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (4.0.0)
+    fastlane-plugin-wpmreleasetoolkit (4.1.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
-      buildkit (~> 1.4)
+      buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
@@ -131,7 +131,7 @@ GEM
       rake (>= 12.3, < 14.0)
       rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
-    git (1.10.2)
+    git (1.11.0)
       rchardet (~> 1.8)
     google-apis-androidpublisher_v3 (0.16.0)
       google-apis-core (>= 0.4, < 2.a)
@@ -211,7 +211,7 @@ GEM
     public_suffix (4.0.6)
     racc (1.6.0)
     rake (13.0.6)
-    rake-compiler (1.1.9)
+    rake-compiler (1.2.0)
       rake
     rchardet (1.8.0)
     representable (3.1.1)
@@ -271,7 +271,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 4.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 4.1)
   nokogiri
   rmagick (~> 4.1)
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-# gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', branch: 'trunk'
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 4.0'
+# gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', branch: ''
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 4.1'

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -279,34 +279,38 @@ platform :android do
   MAIN_STRINGS_PATH = './WordPress/src/main/res/values/strings.xml'.freeze
   FROZEN_STRINGS_DIR_PATH = './fastlane/resources/values/'.freeze
   LOCAL_LIBRARIES_STRINGS_PATHS = [
-    { library: "Image Editor", strings_path: "./libs/image-editor/ImageEditor/src/main/res/values/strings.xml", exclusions: [] },
-    { library: "WordPress Editor", strings_path: "./libs/editor/WordPressEditor/src/main/res/values/strings.xml", exclusions: [] }
+    { library: "Image Editor", strings_path: "./libs/image-editor/ImageEditor/src/main/res/values/strings.xml", source_id: 'module:image-editor' },
+    { library: "WordPress Editor", strings_path: "./libs/editor/WordPressEditor/src/main/res/values/strings.xml", source_id: 'module:editor' }
   ].freeze
   REMOTE_LIBRARIES_STRINGS_PATHS = [
     {
       name: 'Gutenberg Native',
       import_key: 'gutenbergMobileVersion',
       repository: 'wordpress-mobile/gutenberg-mobile',
-      strings_file_path: 'bundle/android/strings.xml'
+      strings_file_path: 'bundle/android/strings.xml',
+      source_id: 'gutenberg'
     },
     {
       name: 'Login Library',
       import_key: 'wordPressLoginVersion',
       repository: 'wordpress-mobile/WordPress-Login-Flow-Android',
       strings_file_path: 'WordPressLoginFlow/src/main/res/values/strings.xml',
-      exclusions: ['default_web_client_id']
+      exclusions: ['default_web_client_id'],
+      source_id: 'login'
     },
     {
       name: "Stories Library",
       import_key: "storiesVersion",
       repository: "Automattic/stories-android",
-      strings_file_path: "stories/src/main/res/values/strings.xml"
+      strings_file_path: "stories/src/main/res/values/strings.xml",
+      source_id: 'stories'
     },
     {
       name: "About Library",
       import_key: "aboutAutomatticVersion",
       repository: "Automattic/about-automattic-android",
-      strings_file_path: "library/src/main/res/values/strings.xml"
+      strings_file_path: "library/src/main/res/values/strings.xml",
+      source_id: 'about'
     },
   ].freeze
 
@@ -347,7 +351,8 @@ platform :android do
         lib_to_merge = [{
           library: lib[:name],
           strings_path: download_path,
-          exclusions: lib[:exclusions]
+          exclusions: lib[:exclusions],
+          source_id: lib[:source_id]
         }]
         an_localize_libs(app_strings_path: MAIN_STRINGS_PATH, libs_strings_path: lib_to_merge)
         File.delete(download_path) if File.exist?(download_path)

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -287,33 +287,26 @@ platform :android do
       name: 'Gutenberg Native',
       import_key: 'gutenbergMobileVersion',
       repository: 'wordpress-mobile/gutenberg-mobile',
-      strings_file_path: 'bundle/android/strings.xml',
-      github_release_prefix: '',
-      exclusions: []
+      strings_file_path: 'bundle/android/strings.xml'
     },
     {
       name: 'Login Library',
       import_key: 'wordPressLoginVersion',
       repository: 'wordpress-mobile/WordPress-Login-Flow-Android',
       strings_file_path: 'WordPressLoginFlow/src/main/res/values/strings.xml',
-      github_release_prefix: '',
       exclusions: ['default_web_client_id']
     },
     {
       name: "Stories Library",
       import_key: "storiesVersion",
       repository: "Automattic/stories-android",
-      strings_file_path: "stories/src/main/res/values/strings.xml",
-      github_release_prefix: "",
-      exclusions: []
+      strings_file_path: "stories/src/main/res/values/strings.xml"
     },
     {
       name: "About Library",
       import_key: "aboutAutomatticVersion",
       repository: "Automattic/about-automattic-android",
-      strings_file_path: "library/src/main/res/values/strings.xml",
-      github_release_prefix: "",
-      exclusions: []
+      strings_file_path: "library/src/main/res/values/strings.xml"
     },
   ].freeze
 
@@ -339,8 +332,7 @@ platform :android do
         library_name: lib[:name],
         import_key: lib[:import_key],
         repository: lib[:repository],
-        file_path: lib[:strings_file_path],
-        github_release_prefix: lib[:github_release_prefix]
+        file_path: lib[:strings_file_path]
       )
 
       if download_path.nil?

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -279,6 +279,8 @@ platform :android do
   MAIN_STRINGS_PATH = './WordPress/src/main/res/values/strings.xml'.freeze
   FROZEN_STRINGS_DIR_PATH = './fastlane/resources/values/'.freeze
   LOCAL_LIBRARIES_STRINGS_PATHS = [
+    # Note: for those we don't set `add_ignore_attr` to true because we currently use `checkDependencies true` in `WordPress/build.gradle`
+    # Which will correctly detect strings from the app's `strings.xml` being used by one of the module.
     { library: "Image Editor", strings_path: "./libs/image-editor/ImageEditor/src/main/res/values/strings.xml", source_id: 'module:image-editor' },
     { library: "WordPress Editor", strings_path: "./libs/editor/WordPressEditor/src/main/res/values/strings.xml", source_id: 'module:editor' }
   ].freeze
@@ -352,7 +354,8 @@ platform :android do
           library: lib[:name],
           strings_path: download_path,
           exclusions: lib[:exclusions],
-          source_id: lib[:source_id]
+          source_id: lib[:source_id],
+          add_ignore_attr: true # The linter is not be able to detect if a merged string is actually used by a binary dependency
         }]
         an_localize_libs(app_strings_path: MAIN_STRINGS_PATH, libs_strings_path: lib_to_merge)
         File.delete(download_path) if File.exist?(download_path)


### PR DESCRIPTION
🚧  We need to land this [PR in release-toolkit about `tools:ignore`](https://github.com/wordpress-mobile/release-toolkit/pull/354) first, then update the reference in the `Pluginfile`, before merging this PR (hence the current "Not Ready for Merge" label)

## Why?

### Identify where the strings are merged from

This PR uses the new feature currently being introduced in https://github.com/wordpress-mobile/release-toolkit/pull/351 in order to identify which libs each merged string came from.

This will be useful:
 - For developers and platform engineers, to understand where the source of truth of each string resides
 - To better follow the source of each string, and potentially help us do some spring cleaning of unused strings in the future

This work started after internal discussion paaHJt-3fg-p2 about how strings from libs are merged into the apps' strings to be sent to translation.

### Add `tools:ignore="UnusedResources"` to merged strings from binary dependencies

When merging strings from binary dependencies, the linter is not capable of detecting that the strings that will get merged in the app's `strings.xml` are actually used in the binary dependencies and that the app will just override their value at runtime. Thus, we need to add `tools:ignore="UnusedResources"` to all the strings merged from binary dependencies to avoid extra linter warnings.

This uses the new feature of the `release-toolkit` implemented in https://github.com/wordpress-mobile/release-toolkit/pull/354

Note that for strings merged from local modules, we don't want to add `tools:ignore="UnusedResources"` for those, because [we have the `checkDependencies true` option enabled on our lint config of the WordPress project](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/build.gradle#L265), so the linter WILL be able to detect when a string merged into the app's `strings.xml` is in fact used by the code from the module.

Note that this doesn't always necessarily means that any string merged from a module but for which the linter would warn us about it being an unused resource… would be a true positive and genuinely unused string: such string could still be a string value that we decided to override in the module… from a transitive dependency that the module itself depends on, for example. But still, for those we do want the linter to emit the warnings, so that we can decide manually if it's genuinely unused and we should remove the string from the module's `strings.xml` (and the app's), or if it's a false positive and we should add `tools:ignore="UnusedResources"` manually to it, case by case.

## To Test

 - Run `bundle exec fastlane localize_libs`
 - Verify that the `strings.xml` file was not changed after the run (I've already run it on commit 65f00b3e6d70a2da67c4e470a9d8b78a26a7925f)
 - Manually change some entries in the `WordPress/src/main/res/values/strings.xml` file:
   - Remove some random entries which come from a library
   - Change the text of a random entry which come from a library
   - Change the `a8c-src-lib` attribute of some entries to a different dummy value
   - Remove the `a8c-src-lib` attribute of some entries
   - Remove a `tools:ignore="UnusedResources"` from a string which was merged from one of the binary dependencies (e.g. a string that came from the login lib)
   - Change a `tools:ignore="UnusedResources"` which came from a binary lib to `tools:ignore="X"`
   - Change a `tools:ignore="UnusedResources"` which came from a binary lib to `tools:ignore="X,UnusedResources,Y"`
 - Run `bundle exec fastlane localize_libs` again
 - Notice how all your changes got reverted back.
   - The entries you removed (or for which you removed attributes) should be added back, except at the end of the XML
   - The entries that you changed should be updated in-place to restore the previous values — the one from the lib
   - The entries for which you changed `UnusedResources` to `X` should now be `X,UnusedResources`, and the one with `X,UnsedResources,Y` should still have the same attribute
 - Run `./gradlew mergeWordPressVanillaReleaseResources` and verify that there is no error nor warning about the `values/strings.xml` file
   - Side note that you will still have many "Multiple substitutions specified in non-positional format" warnings on `values-{locale}/strings.xml` files, but those are unrelated and can be ignored (they will disappear once [the fixes on the originals](https://github.com/wordpress-mobile/WordPress-Android/pull/16177) finally get fixed by polyglots in GlotPress' translations too)