### PR TITLE
[Site Intent Question] String corrections and input sanitisation 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -126,7 +126,8 @@ class SiteCreationIntentsViewModel @Inject constructor(
         }
     }
 
-    fun onSearchTextChanged(query: String) {
+    fun onSearchTextChanged(userInput: String) {
+        val query = userInput.trim()
         val searchResults = searchResultsProvider.search(fullItemsList.items, query).toMutableList().apply {
             val isAnExactMatch = query.isNotEmpty() && !(size == 1 && this[0].verticalText.equals(query, true))
             if (isAnExactMatch) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3206,8 +3206,8 @@
     <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>
     <string name="new_site_creation_intents_title">Site topic</string>
     <string name="new_site_creation_intents_header_title">What’s your website about?</string>
-    <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type your own</string>
-    <string name="new_site_creation_intents_input_hint">Eg. Fashion, Poetry, Politics</string>
+    <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type your own.</string>
+    <string name="new_site_creation_intents_input_hint">E.g. Fashion, Poetry, Politics</string>
     <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>
     <string name="new_site_creation_unavailable_domain">This domain is unavailable</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
@@ -134,7 +134,7 @@ class SiteCreationIntentsViewModelTest {
     @Test
     fun `when the user types white spaces the custom vertical is not visible`() {
         val valueOfSearchInput = "   \n "
-        whenever(resources.getStringArray(any())).thenReturn(arrayOf("Test1" , "Test2", "Test3"))
+        whenever(resources.getStringArray(any())).thenReturn(arrayOf("Test1", "Test2", "Test3"))
         viewModel.initializeFromResources(resources)
         viewModel.onSearchTextChanged(valueOfSearchInput)
         assertThat(viewModel.uiState.value?.content?.items?.size).isEqualTo(3)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
@@ -109,7 +109,18 @@ class SiteCreationIntentsViewModelTest {
     }
 
     @Test
-    fun `when there are matching search results but not exact the custom vertical is not visible`() {
+    fun `when the user types white spaces at the beginning or the end of the input those are ignored`() {
+        val valueOfSearchInput = " \n  test1    \n"
+        val matchingItem = "Test1"
+        whenever(resources.getStringArray(any())).thenReturn(arrayOf(matchingItem, "Test2", "Test3"))
+        viewModel.initializeFromResources(resources)
+        viewModel.onSearchTextChanged(valueOfSearchInput)
+        assertThat(viewModel.uiState.value?.content?.items?.size).isEqualTo(1)
+        assertThat(viewModel.uiState.value?.content?.items?.firstOrNull()?.verticalText).isEqualTo("Test1")
+    }
+
+    @Test
+    fun `when there are matching search results but not exact the custom vertical is visible`() {
         val valueOfSearchInput = "test"
         val matchingItem = "Test1"
         whenever(resources.getStringArray(any())).thenReturn(arrayOf(matchingItem, "Test2", "Test3"))
@@ -118,6 +129,15 @@ class SiteCreationIntentsViewModelTest {
         assertThat(viewModel.uiState.value?.content?.items?.size).isEqualTo(4)
         assertThat(viewModel.uiState.value?.content?.items?.getOrNull(0)?.verticalText)
                 .isEqualTo(valueOfSearchInput)
+    }
+
+    @Test
+    fun `when the user types white spaces the custom vertical is not visible`() {
+        val valueOfSearchInput = "   \n "
+        whenever(resources.getStringArray(any())).thenReturn(arrayOf("Test1" , "Test2", "Test3"))
+        viewModel.initializeFromResources(resources)
+        viewModel.onSearchTextChanged(valueOfSearchInput)
+        assertThat(viewModel.uiState.value?.content?.items?.size).isEqualTo(3)
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR:
* [Trims the user input to avoid empty custom verticals](https://github.com/wordpress-mobile/WordPress-Android/commit/d2659c6c79a2012cfc708245d482546e5775ce60) and erroneous search results
* Changes `Eg.` to `E.g.` and adds a period at the end of the site intent subtitle

To test:

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added a couple new unit tests with 8c78c8a50c3a8677203ec18c6085aac7195adcc1

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
