### PR TITLE
My Site Dashboard - Tabs - Enable Feature

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardTabsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteDashboardTabsFeatureConfig.kt
@@ -1,16 +1,25 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig.Companion.MY_SITE_DASHBOARD_TABS
 import javax.inject.Inject
 
 /**
  * Configuration of the 'My Site Dashboard - Tabs' that will display tabs on the 'My Site' screen.
  */
-@FeatureInDevelopment
+@Feature(
+        remoteField = MY_SITE_DASHBOARD_TABS,
+        defaultValue = true
+)
 class MySiteDashboardTabsFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
         appConfig,
-        BuildConfig.MY_SITE_DASHBOARD_TABS
-)
+        BuildConfig.MY_SITE_DASHBOARD_TABS,
+        MY_SITE_DASHBOARD_TABS
+) {
+    companion object {
+        const val MY_SITE_DASHBOARD_TABS = "my_site_dashboard_tabs"
+    }
+}


### PR DESCRIPTION
Closes #16008

This PR enables the remote flag for the `My Site Dashboard - Tabs` feature.

To test:

1. Clear app data.
2. Open the app.
3. Make sure you don't manually activate the feature flag.
4. Go to `My Site` and notice that two tabs exist: `Home` and `Site Menu`.

Merging Notes: 

I've triggered optional connected tests on this PR. Wait for them to pass. 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
