### PR TITLE
[Tooling] Ignore `values-night/colors_aztec.xml` linter errors properly this time

### DIFF
--- a/WordPress/src/main/res/values-night/colors_aztec.xml
+++ b/WordPress/src/main/res/values-night/colors_aztec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--Overloaded Aztec colors. Remove after Aztec is phased out.-->
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingDefaultResource">
-    <color name="format_bar_background">#282828</color>  <!-- 4dp elevated surface -->
-    <color name="format_bar_divider">?android:attr/listDivider</color>
+    <color name="format_bar_background" tools:ignore="UnusedResources">#282828</color>  <!-- 4dp elevated surface -->
+    <color name="format_bar_divider" tools:ignore="UnusedResources">?android:attr/listDivider</color>
     <color name="text">@color/material_on_surface_emphasis_high_type</color>
     <color name="title_color">@color/text</color>
     <color name="hint_text">@color/material_on_surface_emphasis_medium</color>

--- a/config/lint.xml
+++ b/config/lint.xml
@@ -81,7 +81,7 @@
         <ignore path="**/WordPressEditor/**" />
         <ignore path="**/.gradle/caches/**" />
         <ignore path="**/generated/**" />
-        <ignore regexp=".*\/values\-([a-z]|[A-Z]|\-){2,6}\/.*\.xml$"/>
+        <ignore regexp=".*\/values\-([a-z]|[A-Z]|\-){2,6}\/strings\.xml$"/>
     </issue>
 
     <issue id="Typos" severity="error">


### PR DESCRIPTION
This addresses the rightful feedback from @oguzkocer in https://github.com/wordpress-mobile/WordPress-Android/pull/16285#discussion_r846318394 and re-solves the linter errors on `aztec-colors.xml` in a more individual way, more in line we what I discussed with @ParaskP7 in Zoom and Slack.

That way, when we get time to investigate those linter errors in more details later, we already have the problematic ones to look at first being isolated and pre-identified; and annotating those individually will also prevent future colors or other resources added later to be missed as being unused.