### PR TITLE
Change reported file format for detekt violations

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -548,7 +548,7 @@ tasks.register("violationCommentsToGitHub", ViolationCommentsToGitHubTask) {
 **Reporter**: {{violation.reporter}}{{#violation.rule}}\n
 **Rule**: {{violation.rule}}{{/violation.rule}}
 **Severity**: {{violation.severity}}
-**File**: {{violation.file}} L{{violation.startLine}}{{#violation.source}}
+**File**: {{violation.file}}:{{violation.startLine}}{{#violation.source}}
 **Source**: {{violation.source}}{{/violation.source}}
 {{violation.message}}
 """


### PR DESCRIPTION
This PR addresses a platform request for changing the reported file format from `ProductPricingFragment.kt L237` to `ProductPricingFragment.kt:237` so it can be pasted directly to IDE.

**To test:**
We haven't ported the violation Github comments to Buildkite yet, so this change will not have an immediate effect. However, I think the PR is straightforward enough that we can merge it without testing it.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
