### PR TITLE
Display stats insights tab when clicking on Today's stats card 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -487,7 +487,7 @@ class MySiteViewModel @Inject constructor(
 
     private fun navigateToTodaysStats() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
-        _onNavigation.value = Event(SiteNavigationAction.OpenTodaysStats(selectedSite))
+        _onNavigation.value = Event(SiteNavigationAction.OpenStatsInsights(selectedSite))
     }
 
     private fun buildNoSiteState(): NoSites {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -70,5 +70,5 @@ sealed class SiteNavigationAction {
     data class OpenEditorToCreateNewPost(val site: SiteModel) : SiteNavigationAction()
     data class EditDraftPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
     data class EditScheduledPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
-    data class OpenTodaysStats(val site: SiteModel) : SiteNavigationAction()
+    data class OpenStatsInsights(val site: SiteModel) : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -316,8 +316,8 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             ActivityLauncher.viewCurrentBlogPostsOfType(requireActivity(), action.site, PostListType.DRAFTS)
         is SiteNavigationAction.EditScheduledPost ->
             ActivityLauncher.viewCurrentBlogPostsOfType(requireActivity(), action.site, PostListType.SCHEDULED)
-        is SiteNavigationAction.OpenTodaysStats ->
-            ActivityLauncher.viewBlogStatsForTimeframe(requireActivity(), action.site, StatsTimeframe.DAY)
+        is SiteNavigationAction.OpenStatsInsights ->
+            ActivityLauncher.viewBlogStatsForTimeframe(requireActivity(), action.site, StatsTimeframe.INSIGHTS)
     }
 
     private fun openQuickStartFullScreenDialog(action: SiteNavigationAction.OpenQuickStartFullScreenDialog) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1243,7 +1243,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
                 onTodaysStatsCardClick.invoke()
 
-                assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenTodaysStats(site))
+                assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenStatsInsights(site))
             }
 
     @Test
@@ -1253,7 +1253,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
                 onTodaysStatsCardFooterLinkClick.invoke()
 
-                assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenTodaysStats(site))
+                assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenStatsInsights(site))
             }
 
     /* DASHBOARD POST CARD - FOOTER LINK */


### PR DESCRIPTION
Fixes #16300 

Description
Updated the Today's Stats dashboard card to open the Stats Insights tab instead of the Stats Days tab 

Ref: p1649694944738209-slack-C0290FLA0RM

To test:
- Go to My Site and select the Home tab
- Click on Today's Stats dashboard card
- The Stats Insights tab should be displayed


https://user-images.githubusercontent.com/17463767/162965622-346d0b78-284b-46f2-a022-0ead563fc4e4.mp4




## Regression Notes
1. Potential unintended areas of impact
The stats page not being shown properly on clicking Today's stats card 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests and Unit tests 

3. What automated tests I added (or what prevented me from doing so)
Unit tests 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
