### PR TITLE
Changes: The tab title to Menu from Site Menu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -71,7 +71,6 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsTracker
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
-import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource
@@ -187,7 +186,7 @@ class MySiteViewModel @Inject constructor(
 
     private val defaultABExperimentTab: MySiteTabType
         get() = if (isMySiteTabsEnabled) {
-            if (appPrefsWrapper.getMySiteInitialScreen() == MySiteDefaultTabExperiment.VARIANT_MENU) {
+            if (appPrefsWrapper.getMySiteInitialScreen() == MySiteTabType.SITE_MENU.label) {
                 MySiteTabType.SITE_MENU
             } else {
                 MySiteTabType.DASHBOARD

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -71,6 +71,7 @@ import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardsBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsTracker
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
+import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource
@@ -186,7 +187,7 @@ class MySiteViewModel @Inject constructor(
 
     private val defaultABExperimentTab: MySiteTabType
         get() = if (isMySiteTabsEnabled) {
-            if (appPrefsWrapper.getMySiteInitialScreen() == MySiteTabType.SITE_MENU.label) {
+            if (appPrefsWrapper.getMySiteInitialScreen() == MySiteDefaultTabExperiment.VARIANT_MENU) {
                 MySiteTabType.SITE_MENU
             } else {
                 MySiteTabType.DASHBOARD

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1132,7 +1132,7 @@ class MySiteViewModel @Inject constructor(
         if (event.currentTab == MySiteTabType.ALL) {
             analyticsTrackerWrapper.track(event.stat, event.properties ?: emptyMap())
         } else {
-            val props: MutableMap<String, Any> = mutableMapOf(event.key to event.currentTab.label)
+            val props: MutableMap<String, Any> = mutableMapOf(event.key to event.currentTab.trackingLabel)
             if (!event.properties.isNullOrEmpty()) {
                 props.putAll(event.properties)
             }
@@ -1170,10 +1170,16 @@ class MySiteViewModel @Inject constructor(
 
     private fun trackTabChanged(isSiteMenu: Boolean) {
         if (isSiteMenu) {
-            analyticsTrackerWrapper.track(Stat.MY_SITE_TAB_TAPPED, mapOf(MY_SITE_TAB to MySiteTabType.SITE_MENU.label))
+            analyticsTrackerWrapper.track(
+                    Stat.MY_SITE_TAB_TAPPED,
+                    mapOf(MY_SITE_TAB to MySiteTabType.SITE_MENU.trackingLabel)
+            )
             analyticsTrackerWrapper.track(Stat.MY_SITE_SITE_MENU_SHOWN)
         } else {
-            analyticsTrackerWrapper.track(Stat.MY_SITE_TAB_TAPPED, mapOf(MY_SITE_TAB to MySiteTabType.DASHBOARD.label))
+            analyticsTrackerWrapper.track(
+                    Stat.MY_SITE_TAB_TAPPED,
+                    mapOf(MY_SITE_TAB to MySiteTabType.DASHBOARD.trackingLabel)
+            )
             analyticsTrackerWrapper.track(Stat.MY_SITE_DASHBOARD_SHOWN)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -22,7 +22,7 @@ class MySiteDefaultTabExperiment @Inject constructor(
                 setVariantAssigned()
                 when (mySiteDefaultTabExperimentVariationDashboardFeatureConfig.isDashboardVariant()) {
                     true -> setExperimentVariant(VARIANT_HOME)
-                    false -> setExperimentVariant(VARIANT_SITE_MENU)
+                    false -> setExperimentVariant(VARIANT_MENU)
                 }
                 analyticsTrackerWrapper.setInjectExperimentProperties(getVariantMapForTracking())
                 analyticsTrackerWrapper.track(Stat.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED)
@@ -70,6 +70,7 @@ class MySiteDefaultTabExperiment @Inject constructor(
         private const val VARIANT_DASHBOARD = "dashboard"
         private const val VARIANT_SITE_MENU = "site_menu"
         private const val VARIANT_HOME = "home"
+        private const val VARIANT_MENU = "menu"
         private const val NONEXISTENT = "nonexistent"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -70,7 +70,7 @@ class MySiteDefaultTabExperiment @Inject constructor(
         private const val VARIANT_DASHBOARD = "dashboard"
         private const val VARIANT_SITE_MENU = "site_menu"
         private const val VARIANT_HOME = "home"
-        private const val VARIANT_MENU = "menu"
+        const val VARIANT_MENU = "menu"
         private const val NONEXISTENT = "nonexistent"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -21,8 +21,8 @@ class MySiteDefaultTabExperiment @Inject constructor(
             if (!isVariantAssigned()) {
                 setVariantAssigned()
                 when (mySiteDefaultTabExperimentVariationDashboardFeatureConfig.isDashboardVariant()) {
-                    true -> setExperimentVariant(VARIANT_DASHBOARD)
-                    false -> setExperimentVariant(VARIANT_SITE_MENU)
+                    true -> setExperimentVariant(MySiteTabType.DASHBOARD.trackingLabel)
+                    false -> setExperimentVariant(MySiteTabType.SITE_MENU.trackingLabel)
                 }
                 analyticsTrackerWrapper.setInjectExperimentProperties(getVariantMapForTracking())
                 analyticsTrackerWrapper.track(Stat.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED)
@@ -59,16 +59,14 @@ class MySiteDefaultTabExperiment @Inject constructor(
     private fun getVariantTrackingLabel(): String {
         if (!isVariantAssigned()) return NONEXISTENT
         return if (appPrefsWrapper.getMySiteInitialScreen() == VARIANT_HOME) {
-            VARIANT_DASHBOARD
+            MySiteTabType.DASHBOARD.trackingLabel
         } else {
-            VARIANT_SITE_MENU
+            MySiteTabType.SITE_MENU.trackingLabel
         }
     }
 
     companion object {
         private const val DEFAULT_TAB_EXPERIMENT = "default_tab_experiment"
-        private const val VARIANT_DASHBOARD = "dashboard"
-        private const val VARIANT_SITE_MENU = "site_menu"
         const val VARIANT_HOME = "home"
         const val VARIANT_MENU = "menu"
         private const val NONEXISTENT = "nonexistent"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -21,8 +21,8 @@ class MySiteDefaultTabExperiment @Inject constructor(
             if (!isVariantAssigned()) {
                 setVariantAssigned()
                 when (mySiteDefaultTabExperimentVariationDashboardFeatureConfig.isDashboardVariant()) {
-                    true -> setExperimentVariant(VARIANT_HOME)
-                    false -> setExperimentVariant(VARIANT_MENU)
+                    true -> setExperimentVariant(VARIANT_DASHBOARD)
+                    false -> setExperimentVariant(VARIANT_SITE_MENU)
                 }
                 analyticsTrackerWrapper.setInjectExperimentProperties(getVariantMapForTracking())
                 analyticsTrackerWrapper.track(Stat.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED)
@@ -69,7 +69,7 @@ class MySiteDefaultTabExperiment @Inject constructor(
         private const val DEFAULT_TAB_EXPERIMENT = "default_tab_experiment"
         private const val VARIANT_DASHBOARD = "dashboard"
         private const val VARIANT_SITE_MENU = "site_menu"
-        private const val VARIANT_HOME = "home"
+        const val VARIANT_HOME = "home"
         const val VARIANT_MENU = "menu"
         private const val NONEXISTENT = "nonexistent"
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -58,7 +58,7 @@ class MySiteDefaultTabExperiment @Inject constructor(
 
     private fun getVariantTrackingLabel(): String {
         if (!isVariantAssigned()) return NONEXISTENT
-        return if (appPrefsWrapper.getMySiteInitialScreen() == VARIANT_HOME) {
+        return if (appPrefsWrapper.getMySiteInitialScreen() == MySiteTabType.DASHBOARD.label) {
             MySiteTabType.DASHBOARD.trackingLabel
         } else {
             MySiteTabType.SITE_MENU.trackingLabel
@@ -67,8 +67,6 @@ class MySiteDefaultTabExperiment @Inject constructor(
 
     companion object {
         private const val DEFAULT_TAB_EXPERIMENT = "default_tab_experiment"
-        const val VARIANT_HOME = "home"
-        const val VARIANT_MENU = "menu"
         private const val NONEXISTENT = "nonexistent"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -133,8 +133,8 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
     private fun initTabType() {
         mySiteTabType = if (viewModel.isMySiteTabsEnabled) {
             MySiteTabType.fromString(
-                    this.arguments?.getString(KEY_MY_SITE_TAB_TYPE, MySiteTabType.SITE_MENU.label)
-                            ?: MySiteTabType.SITE_MENU.label
+                    this.arguments?.getString(KEY_MY_SITE_TAB_TYPE, MySiteTabType.SITE_MENU.trackingLabel)
+                            ?: MySiteTabType.SITE_MENU.trackingLabel
             )
         } else {
             MySiteTabType.ALL
@@ -574,7 +574,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         @JvmStatic
         fun newInstance(mySiteTabType: MySiteTabType) = MySiteTabFragment().apply {
             arguments = Bundle().apply {
-                putString(KEY_MY_SITE_TAB_TYPE, mySiteTabType.label)
+                putString(KEY_MY_SITE_TAB_TYPE, mySiteTabType.trackingLabel)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -133,8 +133,8 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
     private fun initTabType() {
         mySiteTabType = if (viewModel.isMySiteTabsEnabled) {
             MySiteTabType.fromString(
-                    this.arguments?.getString(KEY_MY_SITE_TAB_TYPE, MySiteTabType.SITE_MENU.trackingLabel)
-                            ?: MySiteTabType.SITE_MENU.trackingLabel
+                    this.arguments?.getString(KEY_MY_SITE_TAB_TYPE, MySiteTabType.SITE_MENU.label)
+                            ?: MySiteTabType.SITE_MENU.label
             )
         } else {
             MySiteTabType.ALL
@@ -574,7 +574,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         @JvmStatic
         fun newInstance(mySiteTabType: MySiteTabType) = MySiteTabFragment().apply {
             arguments = Bundle().apply {
-                putString(KEY_MY_SITE_TAB_TYPE, mySiteTabType.trackingLabel)
+                putString(KEY_MY_SITE_TAB_TYPE, mySiteTabType.label)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabType.kt
@@ -3,19 +3,19 @@ package org.wordpress.android.ui.mysite.tabs
 import androidx.annotation.StringRes
 import org.wordpress.android.R
 
-enum class MySiteTabType(val label: String, @StringRes val stringResId: Int) {
+enum class MySiteTabType(val trackingLabel: String, @StringRes val stringResId: Int) {
     ALL("all", R.string.my_site_all_tab_title),
     DASHBOARD("dashboard", R.string.my_site_dashboard_tab_title),
     SITE_MENU("site_menu", R.string.my_site_menu_tab_title);
 
-    override fun toString() = label
+    override fun toString() = trackingLabel
 
     companion object {
         @JvmStatic
         fun fromString(label: String) = when {
-            ALL.label == label -> ALL
-            DASHBOARD.label == label -> DASHBOARD
-            SITE_MENU.label == label -> SITE_MENU
+            ALL.trackingLabel == label -> ALL
+            DASHBOARD.trackingLabel == label -> DASHBOARD
+            SITE_MENU.trackingLabel == label -> SITE_MENU
             else -> SITE_MENU
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabType.kt
@@ -3,19 +3,19 @@ package org.wordpress.android.ui.mysite.tabs
 import androidx.annotation.StringRes
 import org.wordpress.android.R
 
-enum class MySiteTabType(val trackingLabel: String, @StringRes val stringResId: Int) {
-    ALL("all", R.string.my_site_all_tab_title),
-    DASHBOARD("dashboard", R.string.my_site_dashboard_tab_title),
-    SITE_MENU("site_menu", R.string.my_site_menu_tab_title);
+enum class MySiteTabType(val label: String, @StringRes val stringResId: Int, val trackingLabel: String) {
+    ALL("all", R.string.my_site_all_tab_title, "nonexistent"),
+    DASHBOARD("home", R.string.my_site_dashboard_tab_title, "dashboard"),
+    SITE_MENU("menu", R.string.my_site_menu_tab_title, "site_menu");
 
-    override fun toString() = trackingLabel
+    override fun toString() = label
 
     companion object {
         @JvmStatic
         fun fromString(label: String) = when {
-            ALL.trackingLabel == label -> ALL
-            DASHBOARD.trackingLabel == label -> DASHBOARD
-            SITE_MENU.trackingLabel == label -> SITE_MENU
+            ALL.label == label -> ALL
+            DASHBOARD.label == label -> DASHBOARD
+            SITE_MENU.label == label -> SITE_MENU
             else -> SITE_MENU
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -1365,7 +1365,7 @@ public class AppPrefs {
         // AppSettings are undeletable across logouts and keys are all lower case.
         // This method will be removed when the experiment has completed and thus
         // the settings will be maintained only from the AppSettings view{
-        String initialScreen = variant.equals(MySiteTabType.SITE_MENU.getLabel())
+        String initialScreen = variant.equals(MySiteTabType.SITE_MENU.getTrackingLabel())
                 ? MySiteDefaultTabExperiment.VARIANT_MENU : MySiteDefaultTabExperiment.VARIANT_HOME;
         setString(UndeletablePrefKey.wp_pref_initial_screen, initialScreen);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -21,7 +21,7 @@ import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
-import org.wordpress.android.ui.mysite.tabs.MySiteTabType;
+import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment;
 import org.wordpress.android.ui.posts.AuthorFilterSelection;
 import org.wordpress.android.ui.posts.PostListViewLayoutType;
 import org.wordpress.android.ui.reader.tracker.ReaderTab;
@@ -1370,6 +1370,6 @@ public class AppPrefs {
     public static String getMySiteInitialScreen() {
         return getString(
                 UndeletablePrefKey.wp_pref_initial_screen,
-                MySiteTabType.SITE_MENU.getLabel());
+                MySiteDefaultTabExperiment.VARIANT_MENU);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -22,6 +22,7 @@ import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment;
+import org.wordpress.android.ui.mysite.tabs.MySiteTabType;
 import org.wordpress.android.ui.posts.AuthorFilterSelection;
 import org.wordpress.android.ui.posts.PostListViewLayoutType;
 import org.wordpress.android.ui.reader.tracker.ReaderTab;
@@ -1363,8 +1364,10 @@ public class AppPrefs {
         // This supports the MySiteDefaultTab AB Experiment.
         // AppSettings are undeletable across logouts and keys are all lower case.
         // This method will be removed when the experiment has completed and thus
-        // the settings will be maintained only from the AppSettings view
-        setString(UndeletablePrefKey.wp_pref_initial_screen, variant);
+        // the settings will be maintained only from the AppSettings view{
+        String initialScreen = variant.equals(MySiteTabType.SITE_MENU.getLabel())
+                ? MySiteDefaultTabExperiment.VARIANT_MENU : MySiteDefaultTabExperiment.VARIANT_HOME;
+        setString(UndeletablePrefKey.wp_pref_initial_screen, initialScreen);
     }
 
     public static String getMySiteInitialScreen() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -21,7 +21,6 @@ import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
-import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment;
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType;
 import org.wordpress.android.ui.posts.AuthorFilterSelection;
 import org.wordpress.android.ui.posts.PostListViewLayoutType;
@@ -1366,13 +1365,14 @@ public class AppPrefs {
         // This method will be removed when the experiment has completed and thus
         // the settings will be maintained only from the AppSettings view{
         String initialScreen = variant.equals(MySiteTabType.SITE_MENU.getTrackingLabel())
-                ? MySiteDefaultTabExperiment.VARIANT_MENU : MySiteDefaultTabExperiment.VARIANT_HOME;
+                ? MySiteTabType.SITE_MENU.getLabel() : MySiteTabType.DASHBOARD.getLabel();
         setString(UndeletablePrefKey.wp_pref_initial_screen, initialScreen);
     }
 
     public static String getMySiteInitialScreen() {
         return getString(
                 UndeletablePrefKey.wp_pref_initial_screen,
-                MySiteDefaultTabExperiment.VARIANT_MENU);
+                MySiteTabType.SITE_MENU.getLabel()
+        );
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -429,7 +429,7 @@ public class AppSettingsFragment extends PreferenceFragment
             // restart activity to make sure changes are applied to PreferenceScreen
             getActivity().recreate();
         } else if (preference == mInitialScreenPreference) {
-            String trackValue = newValue.equals(MySiteDefaultTabExperiment.VARIANT_MENU)
+            String trackValue = newValue.equals(MySiteTabType.SITE_MENU.getLabel())
                     ? MySiteTabType.SITE_MENU.getTrackingLabel()
                     : MySiteTabType.DASHBOARD.getTrackingLabel();
             Map<String, Object> properties = new HashMap<>();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -430,8 +430,8 @@ public class AppSettingsFragment extends PreferenceFragment
             getActivity().recreate();
         } else if (preference == mInitialScreenPreference) {
             String trackValue = newValue.equals(MySiteDefaultTabExperiment.VARIANT_MENU)
-                    ? MySiteTabType.SITE_MENU.getLabel()
-                    : MySiteTabType.DASHBOARD.getLabel();
+                    ? MySiteTabType.SITE_MENU.getTrackingLabel()
+                    : MySiteTabType.DASHBOARD.getTrackingLabel();
             Map<String, Object> properties = new HashMap<>();
             properties.put("selected", trackValue);
             AnalyticsTracker.track(Stat.APP_SETTINGS_INITIAL_SCREEN_CHANGED, properties);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -429,8 +429,8 @@ public class AppSettingsFragment extends PreferenceFragment
             // restart activity to make sure changes are applied to PreferenceScreen
             getActivity().recreate();
         } else if (preference == mInitialScreenPreference) {
-            String trackValue = (((String) newValue).equals(MySiteTabType.SITE_MENU.getLabel()))
-                    ? (String) newValue
+            String trackValue = newValue.equals(MySiteDefaultTabExperiment.VARIANT_MENU)
+                    ? MySiteTabType.SITE_MENU.getLabel()
                     : MySiteTabType.DASHBOARD.getLabel();
             Map<String, Object> properties = new HashMap<>();
             properties.put("selected", trackValue);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -435,7 +435,7 @@ public class AppSettingsFragment extends PreferenceFragment
             Map<String, Object> properties = new HashMap<>();
             properties.put("selected", trackValue);
             AnalyticsTracker.track(Stat.APP_SETTINGS_INITIAL_SCREEN_CHANGED, properties);
-            mMySiteDefaultTabExperiment.changeExperimentVariantAssignmentIfNeeded((String) newValue);
+            mMySiteDefaultTabExperiment.changeExperimentVariantAssignmentIfNeeded(trackValue);
         }
         return true;
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2219,7 +2219,7 @@
 
     <!-- My Site - Dashboard -->
     <string name="my_site_dashboard_tab_title">Home</string>
-    <string name="my_site_menu_tab_title">Site Menu</string>
+    <string name="my_site_menu_tab_title">Menu</string>
     <string name="my_site_all_tab_title">All</string>
     <string name="my_site_dashboard_update_error">Couldn\'t update dashboard.</string>
     <string name="my_site_dashboard_stale_message">The dashboard is not updated. Please check your connection and then pull to refresh.</string>
@@ -4068,16 +4068,16 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <!-- Initial Screen -->
     <string name="initial_screen">Initial Screen</string>
     <string name="initial_screen_home" translatable="false">@string/my_site_dashboard_tab_title</string>
-    <string name="initial_screen_site_menu" translatable="false">@string/my_site_menu_tab_title</string>
+    <string name="initial_screen_menu" translatable="false">@string/my_site_menu_tab_title</string>
     <string name="initial_screen_entry_value_home" translatable="false">home</string>
-    <string name="initial_screen_entry_value_site_menu" translatable="false">site_menu</string>
-    <string name="initial_screen_entry_value_default_key" translatable="false">@string/initial_screen_entry_value_site_menu</string>
+    <string name="initial_screen_entry_value_menu" translatable="false">menu</string>
+    <string name="initial_screen_entry_value_default_key" translatable="false">@string/initial_screen_entry_value_menu</string>
     <string-array name="initial_screen_entries" translatable="false" tools:ignore="InconsistentArrays">
         <item>@string/initial_screen_home</item>
-        <item>@string/initial_screen_site_menu</item>
+        <item>@string/initial_screen_menu</item>
     </string-array>
     <string-array name="initial_screen_entry_values" translatable="false" tools:ignore="InconsistentArrays">
         <item>@string/initial_screen_entry_value_home</item>
-        <item>@string/initial_screen_entry_value_site_menu</item>
+        <item>@string/initial_screen_entry_value_menu</item>
     </string-array>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
@@ -88,7 +88,7 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
         verify(
                 appPrefsWrapper,
                 atLeastOnce()
-        ).setInitialScreenFromMySiteDefaultTabExperimentVariant(MySiteTabType.SITE_MENU.label)
+        ).setInitialScreenFromMySiteDefaultTabExperimentVariant(MySiteTabType.SITE_MENU.trackingLabel)
     }
 
     @Test
@@ -152,12 +152,12 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
         whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
         whenever(appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()).thenReturn(false)
 
-        mySiteDefaultTabExperiment.changeExperimentVariantAssignmentIfNeeded(MySiteTabType.SITE_MENU.label)
+        mySiteDefaultTabExperiment.changeExperimentVariantAssignmentIfNeeded(MySiteTabType.SITE_MENU.trackingLabel)
 
         verify(
                 appPrefsWrapper,
                 never()
-        ).setInitialScreenFromMySiteDefaultTabExperimentVariant(MySiteTabType.SITE_MENU.label)
+        ).setInitialScreenFromMySiteDefaultTabExperimentVariant(MySiteTabType.SITE_MENU.trackingLabel)
     }
 
     @Test
@@ -166,11 +166,11 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
         whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
         whenever(appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()).thenReturn(true)
 
-        mySiteDefaultTabExperiment.changeExperimentVariantAssignmentIfNeeded(MySiteTabType.SITE_MENU.label)
+        mySiteDefaultTabExperiment.changeExperimentVariantAssignmentIfNeeded(MySiteTabType.SITE_MENU.trackingLabel)
 
         verify(
                 appPrefsWrapper,
                 atLeastOnce()
-        ).setInitialScreenFromMySiteDefaultTabExperimentVariant(MySiteTabType.SITE_MENU.label)
+        ).setInitialScreenFromMySiteDefaultTabExperimentVariant(MySiteTabType.SITE_MENU.trackingLabel)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
@@ -88,7 +88,7 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
         verify(
                 appPrefsWrapper,
                 atLeastOnce()
-        ).setInitialScreenFromMySiteDefaultTabExperimentVariant(MySiteTabType.SITE_MENU.label)
+        ).setInitialScreenFromMySiteDefaultTabExperimentVariant(MySiteDefaultTabExperiment.VARIANT_MENU)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
@@ -88,7 +88,7 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
         verify(
                 appPrefsWrapper,
                 atLeastOnce()
-        ).setInitialScreenFromMySiteDefaultTabExperimentVariant(MySiteDefaultTabExperiment.VARIANT_MENU)
+        ).setInitialScreenFromMySiteDefaultTabExperimentVariant(MySiteTabType.SITE_MENU.label)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -186,8 +186,6 @@ class MySiteViewModelTest : BaseUnitTest() {
     private val emailAddress = "test@email.com"
     private val postId = 100
     private val localHomepageId = 1
-    private val home = "home"
-    private val menu = "menu"
     private lateinit var site: SiteModel
     private lateinit var siteInfoHeader: SiteInfoHeaderCard
     private lateinit var homepage: PageModel
@@ -485,12 +483,12 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given tabs enabled + initial screen is home, when site is selected, then default tab is dashboard`() {
-        whenever(appPrefsWrapper.getMySiteInitialScreen()).thenReturn(home)
+        whenever(appPrefsWrapper.getMySiteInitialScreen()).thenReturn(MySiteTabType.DASHBOARD.label)
 
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = home
+                initialScreen = MySiteTabType.DASHBOARD.label
         )
 
         assertThat(tabNavigation)
@@ -499,11 +497,11 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given tabs enabled + initial screen is site_menu, when site is selected, then default tab is site menu`() {
-        whenever(appPrefsWrapper.getMySiteInitialScreen()).thenReturn(menu)
+        whenever(appPrefsWrapper.getMySiteInitialScreen()).thenReturn(MySiteTabType.SITE_MENU.label)
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = menu
+                initialScreen = MySiteTabType.SITE_MENU.label
         )
 
         assertThat(tabNavigation)
@@ -517,7 +515,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = menu
+                initialScreen = MySiteTabType.SITE_MENU.label
         )
 
         viewModel.onCreateSiteResult()
@@ -1923,7 +1921,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = home
+                initialScreen = MySiteTabType.DASHBOARD.label
         )
 
         val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
@@ -1939,7 +1937,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = menu
+                initialScreen = MySiteTabType.SITE_MENU.label
         )
 
         val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
@@ -1977,7 +1975,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = home
+                initialScreen = MySiteTabType.DASHBOARD.label
         )
 
         val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
@@ -1993,7 +1991,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = menu
+                initialScreen = MySiteTabType.SITE_MENU.label
         )
 
         val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
@@ -2066,7 +2064,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = menu,
+                initialScreen = MySiteTabType.SITE_MENU.label,
                 isQuickStartDynamicCardEnabled = true
         )
 
@@ -2083,7 +2081,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = home,
+                initialScreen = MySiteTabType.DASHBOARD.label,
                 isQuickStartDynamicCardEnabled = true
         )
 
@@ -2100,7 +2098,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = menu,
+                initialScreen = MySiteTabType.SITE_MENU.label,
                 isQuickStartDynamicCardEnabled = true
         )
 
@@ -2117,7 +2115,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = home,
+                initialScreen = MySiteTabType.DASHBOARD.label,
                 isQuickStartDynamicCardEnabled = true
         )
 
@@ -2414,7 +2412,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         isQuickStartDynamicCardEnabled: Boolean = false,
         isQuickStartInProgress: Boolean = false,
         showStaleMessage: Boolean = false,
-        initialScreen: String = menu
+        initialScreen: String = MySiteTabType.SITE_MENU.label
     ) {
         setUpDynamicCardsBuilder(isQuickStartDynamicCardEnabled)
         whenever(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -189,6 +189,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private val postId = 100
     private val localHomepageId = 1
     private val home = "home"
+    private val menu = "menu"
     private lateinit var site: SiteModel
     private lateinit var siteInfoHeader: SiteInfoHeaderCard
     private lateinit var homepage: PageModel
@@ -500,11 +501,11 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given tabs enabled + initial screen is site_menu, when site is selected, then default tab is site menu`() {
-        whenever(appPrefsWrapper.getMySiteInitialScreen()).thenReturn(SITE_MENU.label)
+        whenever(appPrefsWrapper.getMySiteInitialScreen()).thenReturn(menu)
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = SITE_MENU.label
+                initialScreen = menu
         )
 
         assertThat(tabNavigation)
@@ -518,7 +519,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = SITE_MENU.label
+                initialScreen = menu
         )
 
         viewModel.onCreateSiteResult()
@@ -1940,7 +1941,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = SITE_MENU.label
+                initialScreen = menu
         )
 
         val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
@@ -1994,7 +1995,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = MySiteTabType.SITE_MENU.label
+                initialScreen = menu
         )
 
         val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
@@ -2067,7 +2068,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = SITE_MENU.label,
+                initialScreen = menu,
                 isQuickStartDynamicCardEnabled = true
         )
 
@@ -2101,7 +2102,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,
-                initialScreen = SITE_MENU.label,
+                initialScreen = menu,
                 isQuickStartDynamicCardEnabled = true
         )
 
@@ -2415,7 +2416,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         isQuickStartDynamicCardEnabled: Boolean = false,
         isQuickStartInProgress: Boolean = false,
         showStaleMessage: Boolean = false,
-        initialScreen: String = SITE_MENU.label
+        initialScreen: String = menu
     ) {
         setUpDynamicCardsBuilder(isQuickStartDynamicCardEnabled)
         whenever(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2031,7 +2031,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         verify(analyticsTrackerWrapper, atLeastOnce()).track(
                 Stat.MY_SITE_TAB_TAPPED,
-                mapOf(MySiteViewModel.MY_SITE_TAB to MySiteTabType.SITE_MENU.label)
+                mapOf(MySiteViewModel.MY_SITE_TAB to MySiteTabType.SITE_MENU.trackingLabel)
         )
         verify(analyticsTrackerWrapper, atLeastOnce()).track(Stat.MY_SITE_SITE_MENU_SHOWN)
     }
@@ -2044,7 +2044,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         verify(analyticsTrackerWrapper, atLeastOnce()).track(
                 Stat.MY_SITE_TAB_TAPPED,
-                mapOf(MySiteViewModel.MY_SITE_TAB to MySiteTabType.DASHBOARD.label)
+                mapOf(MySiteViewModel.MY_SITE_TAB to MySiteTabType.DASHBOARD.trackingLabel)
         )
         verify(analyticsTrackerWrapper, atLeastOnce()).track(Stat.MY_SITE_DASHBOARD_SHOWN)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -105,8 +105,6 @@ import org.wordpress.android.ui.mysite.items.SiteItemsBuilder
 import org.wordpress.android.ui.mysite.items.SiteItemsTracker
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType
-import org.wordpress.android.ui.mysite.tabs.MySiteTabType.DASHBOARD
-import org.wordpress.android.ui.mysite.tabs.MySiteTabType.SITE_MENU
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -496,7 +494,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         )
 
         assertThat(tabNavigation)
-                .containsOnly(TabNavigation(viewModel.orderedTabTypes.indexOf(DASHBOARD), false))
+                .containsOnly(TabNavigation(viewModel.orderedTabTypes.indexOf(MySiteTabType.DASHBOARD), false))
     }
 
     @Test
@@ -509,7 +507,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         )
 
         assertThat(tabNavigation)
-                .containsOnly(TabNavigation(viewModel.orderedTabTypes.indexOf(SITE_MENU), false))
+                .containsOnly(TabNavigation(viewModel.orderedTabTypes.indexOf(MySiteTabType.SITE_MENU), false))
     }
 
     /* CREATE SITE - DEFAULT TAB */
@@ -528,7 +526,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         /* First time default tab is set when My Site screen is shown and site is selected.
            When site is created then again it sets the default tab. */
         assertThat(tabNavigation.last())
-                .isEqualTo(TabNavigation(viewModel.orderedTabTypes.indexOf(SITE_MENU), false))
+                .isEqualTo(TabNavigation(viewModel.orderedTabTypes.indexOf(MySiteTabType.SITE_MENU), false))
     }
 
     /* AVATAR */


### PR DESCRIPTION
Fixes #16305 

This PR changes the title of the tab from `Site menu` to `Menu` as per [this reference](pbArwn-4jn). 

![Screenshot_20220412_192436](https://user-images.githubusercontent.com/17463767/162980405-53cfd562-bbe4-4538-a0de-154078bf957f.png)


To test:

Test 1 
- Go to My Site 
- Notice that the title of the tabs are `Home` and `Menu` 

Test 2
- Go to My Site -> App Settings -> Initial Screen 
- Notice the selections are `Home` and `Menu`

Test 3 
- Go to My Site screen with a Site having Quick Start in Progress 
- Set Initial screen as Home 
- Start any quick start(Visit Site, Explore Plans or Post Sharing) which has focus point in `Menu` tab
- Notice that the snackbar prompt says to click at the `Menu` tab

## Regression Notes
1. Potential unintended areas of impact
Tab title is not shown properly in 
- Initial screen settings 
- Quick start snack bar prompt 


2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
none 

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
