### PR TITLE
My Site Dashboard: Today's Stats - Update nudge text

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2229,7 +2229,7 @@
     <string name="my_site_todays_stat_card_likes" translatable="false">@string/stats_likes</string>
     <string name="my_site_todays_stat_card_views" translatable="false">@string/stats_views</string>
     <string name="my_site_todays_stat_card_visitors" translatable="false">@string/stats_visitors</string>
-    <string name="my_site_todays_stats_get_more_views_message">If you want to try get more views and traffic check out our &lt;a href="%1$s"&gt;top tips&lt;/a&gt;.</string>
+    <string name="my_site_todays_stats_get_more_views_message">Interested in building your audience? Check out our &lt;a href="%1$s"&gt;top tips&lt;/a&gt;.</string>
     <string name="my_site_todays_stats_card_footer_link_go_to_stats">Go to stats</string>
 
 


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-Android/pull/16268#issuecomment-1097775380

<img width=400 src="https://user-images.githubusercontent.com/1405144/163147637-7f6a4c5b-f74d-4556-82ca-caff0e5e9c1c.png"/>

To test:
- Launch the app
- Go to `My Site` - `Home` tab
- Notice that `Today's Stats` card has updated nudge text specified [in the comment](https://github.com/wordpress-mobile/WordPress-Android/pull/16268#issuecomment-1097775380). The text 'top tips' still hyperlinks to https://wordpress.com/support/getting-more-views-and-traffic/. 

Note: `Today's Stats` card is still in A/B experiment. If you don't see the card, enable it from Me -> App Settings -> Debug settings -> `my_site_dashboard_todays_stats_card`.

#### Review Instructions

Only one approval is sufficient.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
