### PR TITLE
Integrate gutenberg-mobile release 1.73.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.13.0'
-    gutenbergMobileVersion = '4753-940355651ad733e4fd57582e25273a55ab399b76'
+    gutenbergMobileVersion = '4753-1b4db3e90d14d2e58380d5c5c51bb2121f608610'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.13.0'
-    gutenbergMobileVersion = 'v1.74.0-alpha1'
+    gutenbergMobileVersion = '4753-940355651ad733e4fd57582e25273a55ab399b76'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.73.2 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4753

**Note**: This release includes one change that is behind a feature flag so there are no release note changes.

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.