### PR TITLE
Enable larger video uploads for Jetpack customers with standalone VideoPress subs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -454,8 +454,8 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         final String mimeType = getContentResolver().getType(videoUri);
         final boolean isVideo = mMediaUtilsWrapper.isVideoMimeType(mimeType);
 
-        if (isVideo && mSite.getHasFreePlan() && !mSite.isActiveModuleEnabled("videopress")) {
-            if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, videoUri)) {
+        if (isVideo && mSite.getHasFreePlan()) {
+            if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, mSite, videoUri)) {
                 fetchMediaAndDoNext(videoUri, requestCode, mimeType);
             } else {
                 ToastUtils.showToast(this, R.string.error_media_video_duration_exceeds_limit, LONG);
@@ -478,8 +478,8 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     private void checkRecordedVideoDurationBeforeUploadAndTrack() {
         Uri uri = MediaUtils.getLastRecordedVideoUri(this);
 
-        if (mSite.getHasFreePlan() && !mSite.isActiveModuleEnabled("videopress")) {
-            if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, uri)) {
+        if (mSite.getHasFreePlan()) {
+            if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, mSite, uri)) {
                 queueFileForUpload(uri, getContentResolver().getType(uri));
             } else {
                 ToastUtils.showToast(this, R.string.error_media_video_duration_exceeds_limit, LONG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -454,7 +454,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         final String mimeType = getContentResolver().getType(videoUri);
         final boolean isVideo = mMediaUtilsWrapper.isVideoMimeType(mimeType);
 
-        if (isVideo && !mSite.isVideoPressSupported()) {
+        if (isVideo && (mSite.getHasFreePlan() || !mSite.isVideoPressSupported())) {
             if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, videoUri)) {
                 fetchMediaAndDoNext(videoUri, requestCode, mimeType);
             } else {
@@ -478,7 +478,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     private void checkRecordedVideoDurationBeforeUploadAndTrack() {
         Uri uri = MediaUtils.getLastRecordedVideoUri(this);
 
-        if (!mSite.isVideoPressSupported()) {
+        if (mSite.getHasFreePlan() || !mSite.isVideoPressSupported()) {
             if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, uri)) {
                 queueFileForUpload(uri, getContentResolver().getType(uri));
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -454,7 +454,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         final String mimeType = getContentResolver().getType(videoUri);
         final boolean isVideo = mMediaUtilsWrapper.isVideoMimeType(mimeType);
 
-        if (isVideo && (mSite.getHasFreePlan() || !mSite.isVideoPressSupported())) {
+        if (isVideo && (mSite.getHasFreePlan() && !mSite.isVideoPressSupported())) {
             if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, videoUri)) {
                 fetchMediaAndDoNext(videoUri, requestCode, mimeType);
             } else {
@@ -478,7 +478,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     private void checkRecordedVideoDurationBeforeUploadAndTrack() {
         Uri uri = MediaUtils.getLastRecordedVideoUri(this);
 
-        if (mSite.getHasFreePlan() || !mSite.isVideoPressSupported()) {
+        if (mSite.getHasFreePlan() && !mSite.isVideoPressSupported()) {
             if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, uri)) {
                 queueFileForUpload(uri, getContentResolver().getType(uri));
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -452,14 +452,9 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
 
     private void getMediaFromDeviceAndTrack(Uri videoUri, int requestCode) {
         final String mimeType = getContentResolver().getType(videoUri);
-        final boolean isVideo = mMediaUtilsWrapper.isVideoMimeType(mimeType);
 
-        if (isVideo && mSite.getHasFreePlan()) {
-            if (!mMediaUtilsWrapper.isProhibitedVideoDuration(this, mSite, videoUri)) {
-                fetchMediaAndDoNext(videoUri, requestCode, mimeType);
-            } else {
-                ToastUtils.showToast(this, R.string.error_media_video_duration_exceeds_limit, LONG);
-            }
+        if (mMediaUtilsWrapper.isProhibitedVideoDuration(this, mSite, videoUri)) {
+            ToastUtils.showToast(this, R.string.error_media_video_duration_exceeds_limit, LONG);
         } else {
             fetchMediaAndDoNext(videoUri, requestCode, mimeType);
         }
@@ -478,12 +473,8 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     private void checkRecordedVideoDurationBeforeUploadAndTrack() {
         Uri uri = MediaUtils.getLastRecordedVideoUri(this);
 
-        if (mSite.getHasFreePlan()) {
-            if (!mMediaUtilsWrapper.isProhibitedVideoDuration(this, mSite, uri)) {
-                queueFileForUpload(uri, getContentResolver().getType(uri));
-            } else {
-                ToastUtils.showToast(this, R.string.error_media_video_duration_exceeds_limit, LONG);
-            }
+        if (mMediaUtilsWrapper.isProhibitedVideoDuration(this, mSite, uri)) {
+            ToastUtils.showToast(this, R.string.error_media_video_duration_exceeds_limit, LONG);
         } else {
             queueFileForUpload(uri, getContentResolver().getType(uri));
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -455,7 +455,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         final boolean isVideo = mMediaUtilsWrapper.isVideoMimeType(mimeType);
 
         if (isVideo && mSite.getHasFreePlan()) {
-            if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, mSite, videoUri)) {
+            if (!mMediaUtilsWrapper.isProhibitedVideoDuration(this, mSite, videoUri)) {
                 fetchMediaAndDoNext(videoUri, requestCode, mimeType);
             } else {
                 ToastUtils.showToast(this, R.string.error_media_video_duration_exceeds_limit, LONG);
@@ -479,7 +479,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         Uri uri = MediaUtils.getLastRecordedVideoUri(this);
 
         if (mSite.getHasFreePlan()) {
-            if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, mSite, uri)) {
+            if (!mMediaUtilsWrapper.isProhibitedVideoDuration(this, mSite, uri)) {
                 queueFileForUpload(uri, getContentResolver().getType(uri));
             } else {
                 ToastUtils.showToast(this, R.string.error_media_video_duration_exceeds_limit, LONG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -454,7 +454,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         final String mimeType = getContentResolver().getType(videoUri);
         final boolean isVideo = mMediaUtilsWrapper.isVideoMimeType(mimeType);
 
-        if (isVideo && mSite.getHasFreePlan()) {
+        if (isVideo && !mSite.isVideoPressSupported()) {
             if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, videoUri)) {
                 fetchMediaAndDoNext(videoUri, requestCode, mimeType);
             } else {
@@ -478,7 +478,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     private void checkRecordedVideoDurationBeforeUploadAndTrack() {
         Uri uri = MediaUtils.getLastRecordedVideoUri(this);
 
-        if (mSite.getHasFreePlan()) {
+        if (!mSite.isVideoPressSupported()) {
             if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, uri)) {
                 queueFileForUpload(uri, getContentResolver().getType(uri));
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -454,7 +454,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         final String mimeType = getContentResolver().getType(videoUri);
         final boolean isVideo = mMediaUtilsWrapper.isVideoMimeType(mimeType);
 
-        if (isVideo && (mSite.getHasFreePlan() && !mSite.isVideoPressSupported())) {
+        if (isVideo && (mSite.getHasFreePlan() && !mSite.isActiveModuleEnabled("videopress"))) {
             if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, videoUri)) {
                 fetchMediaAndDoNext(videoUri, requestCode, mimeType);
             } else {
@@ -478,7 +478,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     private void checkRecordedVideoDurationBeforeUploadAndTrack() {
         Uri uri = MediaUtils.getLastRecordedVideoUri(this);
 
-        if (mSite.getHasFreePlan() && !mSite.isVideoPressSupported()) {
+        if (mSite.getHasFreePlan() && !mSite.isActiveModuleEnabled("videopress")) {
             if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, uri)) {
                 queueFileForUpload(uri, getContentResolver().getType(uri));
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -454,7 +454,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         final String mimeType = getContentResolver().getType(videoUri);
         final boolean isVideo = mMediaUtilsWrapper.isVideoMimeType(mimeType);
 
-        if (isVideo && (mSite.getHasFreePlan() && !mSite.isActiveModuleEnabled("videopress"))) {
+        if (isVideo && mSite.getHasFreePlan() && !mSite.isActiveModuleEnabled("videopress")) {
             if (mMediaUtilsWrapper.isAllowedVideoDurationForFreeSites(this, videoUri)) {
                 fetchMediaAndDoNext(videoUri, requestCode, mimeType);
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -57,9 +57,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
     ): Boolean {
         val allowedUris = uriList.filter {
             // filter out long video files on free sites
-            if (site.hasFreePlan &&
-                    mediaUtilsWrapper.isVideoFile(it) &&
-                    mediaUtilsWrapper.isProhibitedVideoDuration(context, site, it)) {
+            if (mediaUtilsWrapper.isProhibitedVideoDuration(context, site, it)) {
                 // put out a notice to the user that the particular video file was rejected
                 editorMediaListener.showVideoDurationLimitWarning(it.path.toString())
                 return@filter false

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -57,7 +57,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
     ): Boolean {
         val allowedUris = uriList.filter {
             // filter out long video files on free sites
-            if ((site.hasFreePlan && !site.isVideoPressSupported) &&
+            if ((site.hasFreePlan && !site.isActiveModuleEnabled("videopress")) &&
                     mediaUtilsWrapper.isVideoFile(it) &&
                     !mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, it)) {
                 // put out a notice to the user that the particular video file was rejected

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -57,10 +57,9 @@ class AddLocalMediaToPostUseCase @Inject constructor(
     ): Boolean {
         val allowedUris = uriList.filter {
             // filter out long video files on free sites
-            val hasNoVideoPressSubscription = site.hasFreePlan && !site.isActiveModuleEnabled("videopress")
-            if (hasNoVideoPressSubscription &&
+            if (site.hasFreePlan &&
                     mediaUtilsWrapper.isVideoFile(it) &&
-                    !mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, it)) {
+                    !mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, site, it)) {
                 // put out a notice to the user that the particular video file was rejected
                 editorMediaListener.showVideoDurationLimitWarning(it.path.toString())
                 return@filter false

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -57,7 +57,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
     ): Boolean {
         val allowedUris = uriList.filter {
             // filter out long video files on free sites
-            if (!site.isVideoPressSupported &&
+            if ((site.hasFreePlan || !site.isVideoPressSupported) &&
                     mediaUtilsWrapper.isVideoFile(it) &&
                     !mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, it)) {
                 // put out a notice to the user that the particular video file was rejected

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -57,7 +57,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
     ): Boolean {
         val allowedUris = uriList.filter {
             // filter out long video files on free sites
-            if (site.hasFreePlan &&
+            if (!site.isVideoPressSupported &&
                     mediaUtilsWrapper.isVideoFile(it) &&
                     !mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, it)) {
                 // put out a notice to the user that the particular video file was rejected

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -57,7 +57,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
     ): Boolean {
         val allowedUris = uriList.filter {
             // filter out long video files on free sites
-            val hasNoVideoPressSubscription = site.hasFreePlan && !site.isActiveModuleEnabled("videopress");
+            val hasNoVideoPressSubscription = site.hasFreePlan && !site.isActiveModuleEnabled("videopress")
             if (hasNoVideoPressSubscription &&
                     mediaUtilsWrapper.isVideoFile(it) &&
                     !mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, it)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -57,7 +57,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
     ): Boolean {
         val allowedUris = uriList.filter {
             // filter out long video files on free sites
-            if ((site.hasFreePlan || !site.isVideoPressSupported) &&
+            if ((site.hasFreePlan && !site.isVideoPressSupported) &&
                     mediaUtilsWrapper.isVideoFile(it) &&
                     !mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, it)) {
                 // put out a notice to the user that the particular video file was rejected

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -57,7 +57,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
     ): Boolean {
         val allowedUris = uriList.filter {
             // filter out long video files on free sites
-            if ((site.hasFreePlan && !site.isActiveModuleEnabled("videopress")) &&
+            if (site.hasFreePlan && !site.isActiveModuleEnabled("videopress") &&
                     mediaUtilsWrapper.isVideoFile(it) &&
                     !mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, it)) {
                 // put out a notice to the user that the particular video file was rejected

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -57,7 +57,8 @@ class AddLocalMediaToPostUseCase @Inject constructor(
     ): Boolean {
         val allowedUris = uriList.filter {
             // filter out long video files on free sites
-            if (site.hasFreePlan && !site.isActiveModuleEnabled("videopress") &&
+            val hasNoVideoPressSubscription = site.hasFreePlan && !site.isActiveModuleEnabled("videopress");
+            if (hasNoVideoPressSubscription &&
                     mediaUtilsWrapper.isVideoFile(it) &&
                     !mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, it)) {
                 // put out a notice to the user that the particular video file was rejected

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -59,7 +59,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
             // filter out long video files on free sites
             if (site.hasFreePlan &&
                     mediaUtilsWrapper.isVideoFile(it) &&
-                    !mediaUtilsWrapper.isAllowedVideoDurationForFreeSites(context, site, it)) {
+                    mediaUtilsWrapper.isProhibitedVideoDuration(context, site, it)) {
                 // put out a notice to the user that the particular video file was rejected
                 editorMediaListener.showVideoDurationLimitWarning(it.path.toString())
                 return@filter false

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -66,8 +66,8 @@ class MediaUtilsWrapper @Inject constructor(private val appContext: Context) {
     fun isVideoFile(mediaUri: Uri): Boolean =
         isVideo(mediaUri) || isVideoMimeType(getMimeType(mediaUri))
 
-    fun isAllowedVideoDurationForFreeSites(context: Context, site: SiteModel, uri: Uri): Boolean {
-        if (site.isActiveModuleEnabled("videopress")) return true
+    fun isProhibitedVideoDuration(context: Context, site: SiteModel, uri: Uri): Boolean {
+        if (site.isActiveModuleEnabled("videopress")) return false
 
         val retriever = MediaMetadataRetriever()
 
@@ -81,7 +81,7 @@ class MediaUtilsWrapper @Inject constructor(private val appContext: Context) {
         retriever.release()
 
         val allowedVideoDurationForFreeSites = TimeUnit.MILLISECONDS.convert(DURATION_5_MIN, TimeUnit.MINUTES)
-        return videoDuration <= allowedVideoDurationForFreeSites
+        return allowedVideoDurationForFreeSites < videoDuration
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -66,7 +66,9 @@ class MediaUtilsWrapper @Inject constructor(private val appContext: Context) {
     fun isVideoFile(mediaUri: Uri): Boolean =
         isVideo(mediaUri) || isVideoMimeType(getMimeType(mediaUri))
 
-    fun isAllowedVideoDurationForFreeSites(context: Context, uri: Uri): Boolean {
+    fun isAllowedVideoDurationForFreeSites(context: Context, site: SiteModel, uri: Uri): Boolean {
+        if (site.isActiveModuleEnabled("videopress")) return true
+
         val retriever = MediaMetadataRetriever()
 
         try {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/16077

This PR addresses an issue where Jetpack-connected users with standalone VideoPress subscriptions were blocked from uploading videos via the app. 

The reason for the block was that, as per https://github.com/wordpress-mobile/WordPress-Android/pull/15719, users with free plans were recently prevented from uploading videos longer than five minutes in length via the app. If a Jetpack user has a standalone subscription, they're technically counted as being on a "free plan", even though they're paying for VideoPress.

## Testing

Pre-requisites: 

* A Jetpack-connected site with a standalone VideoPress subscription.
* A video that is longer than five minutes in length uploaded to your Android device.

To test:

* Navigate to the post editor for your Jetpack-connected site.
* Add a new video block and select the "choose from device" option.
* Select the larger video (it should be longer than five minutes for our purposes) and wait for it to upload.
* Verify that the video uploads with no error.

## Code changes

`isActiveModuleEnabled("videopress")` has been added alongside existing checks for `hasFreePlan`. This new check will always return `false` for WordPress.com sites and only return `true` in cases where a Jetpack site has the VideoPress module enabled, which can only be the case if there is an active VideoPress subscription. 

Note, the `IsVideoPressSupported` check was not used as it always returns as `false` if there is no paid plan, even if there is a standalone VideoPress subscription. The `isActiveModuleEnabled("videopress")` check was the only method I could find to fix our specific use case, where we need to determine if a site has a standalone VideoPress subscription.

## Regression Notes
1. Potential unintended areas of impact

This PR shouldn't impact or block the way other users are able to upload videos. Those with free WordPress.com plans should still _not_ be able to upload videos while those with a self-hosted site should be able to.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I went through the manual testing steps on the following site types:

* Simple WordPress.com site with a free plan.
* Simple WordPress.com site with a paid plan.
* Atomic WordPress.com site.
* Jetpack-connected site with a VideoPress subscription.
* Jetpack-connected site without a VideoPress subscription.
* Self-hosted site.

3. What automated tests I added (or what prevented me from doing so)

No automated tests were added as this is a small change that I didn't feel warranted such tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
