### PR TITLE
Issue/16309 compact blogging prompt card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
@@ -9,6 +9,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.R
 import org.wordpress.android.R.dimen
+import org.wordpress.android.databinding.MainActionListItemBinding
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.NO_ACTION
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.util.QuickStartUtils
@@ -17,7 +18,7 @@ import org.wordpress.android.util.image.ImageManager
 class ActionListItemViewHolder(
     internal val parent: ViewGroup,
     val imageManager: ImageManager
-) : ViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.main_action_list_item, parent, false)) {
+) : AddContentViewHolder(MainActionListItemBinding::inflate) {
     private val regularTypeface = Typeface.create("sans-serif", Typeface.NORMAL)
     private val mediumTypeface = Typeface.create("sans-serif-medium", Typeface.NORMAL)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
@@ -1,24 +1,25 @@
 package org.wordpress.android.ui.main
 
 import android.graphics.Typeface
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.R
 import org.wordpress.android.R.dimen
 import org.wordpress.android.databinding.MainActionListItemBinding
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.NO_ACTION
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.util.QuickStartUtils
+import org.wordpress.android.util.extensions.viewBinding
 import org.wordpress.android.util.image.ImageManager
 
 class ActionListItemViewHolder(
     internal val parent: ViewGroup,
     val imageManager: ImageManager
-) : AddContentViewHolder(MainActionListItemBinding::inflate) {
+) : AddContentViewHolder<MainActionListItemBinding>(
+        parent.viewBinding(MainActionListItemBinding::inflate)
+) {
     private val regularTypeface = Typeface.create("sans-serif", Typeface.NORMAL)
     private val mediumTypeface = Typeface.create("sans-serif-medium", Typeface.NORMAL)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentAdapter.kt
@@ -44,7 +44,7 @@ class AddContentAdapter(context: Context) : Adapter<AddContentViewHolder<*>>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AddContentViewHolder<*> {
         return when (viewType) {
-            ActionType.ANSWER_BLOGGING_PROMP.ordinal -> CompactBloggingPromptCardViewHolder(parent, uiHelpers)
+            ActionType.ANSWER_BLOGGING_PROMPT.ordinal -> CompactBloggingPromptCardViewHolder(parent, uiHelpers)
             else -> ActionListItemViewHolder(parent, imageManager)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentAdapter.kt
@@ -4,16 +4,15 @@ import android.content.Context
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView.Adapter
-import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
-import org.wordpress.android.ui.main.MainActionListItem.ActionType.ANSWER_BLOGGING_PROMP
+import org.wordpress.android.ui.main.MainActionListItem.AnswerBloggingPromptAction
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
-class AddContentAdapter(context: Context) : Adapter<ActionListItemViewHolder>() {
+class AddContentAdapter(context: Context) : Adapter<AddContentViewHolder<*>>() {
     private var items: List<MainActionListItem> = listOf()
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var uiHelpers: UiHelpers
@@ -35,15 +34,17 @@ class AddContentAdapter(context: Context) : Adapter<ActionListItemViewHolder>() 
 
     override fun getItemCount(): Int = items.size
 
-    override fun onBindViewHolder(holder: ActionListItemViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: AddContentViewHolder<*>, position: Int) {
         val item = items[position]
-        // Currently we have only one ViewHolder type
-        holder.bind(item as CreateAction)
+        when (holder) {
+            is ActionListItemViewHolder -> holder.bind(item as CreateAction)
+            is CompactBloggingPromptCardViewHolder -> holder.bind(item as AnswerBloggingPromptAction)
+        }
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        return when (ActionType.values()[viewType]) {
-            ANSWER_BLOGGING_PROMP -> CompactBloggingPromptCardViewHolder(parent, uiHelpers)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AddContentViewHolder<*> {
+        return when (viewType) {
+            ActionType.ANSWER_BLOGGING_PROMP.ordinal -> CompactBloggingPromptCardViewHolder(parent, uiHelpers)
             else -> ActionListItemViewHolder(parent, imageManager)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentAdapter.kt
@@ -4,14 +4,19 @@ import android.content.Context
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView.Adapter
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.main.MainActionListItem.ActionType
+import org.wordpress.android.ui.main.MainActionListItem.ActionType.ANSWER_BLOGGING_PROMP
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
+import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
 class AddContentAdapter(context: Context) : Adapter<ActionListItemViewHolder>() {
     private var items: List<MainActionListItem> = listOf()
     @Inject lateinit var imageManager: ImageManager
+    @Inject lateinit var uiHelpers: UiHelpers
 
     init {
         (context.applicationContext as WordPress).component().inject(this)
@@ -36,9 +41,11 @@ class AddContentAdapter(context: Context) : Adapter<ActionListItemViewHolder>() 
         holder.bind(item as CreateAction)
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ActionListItemViewHolder {
-        // Currently we have only one ViewHolder type
-        return ActionListItemViewHolder(parent, imageManager)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return when (ActionType.values()[viewType]) {
+            ANSWER_BLOGGING_PROMP -> CompactBloggingPromptCardViewHolder(parent, uiHelpers)
+            else -> ActionListItemViewHolder(parent, imageManager)
+        }
     }
 
     override fun getItemViewType(position: Int): Int {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/AddContentViewHolder.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.main
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
+
+open class AddContentViewHolder<T : ViewBinding>(protected val binding: T) : RecyclerView.ViewHolder(binding.root)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/CompactBloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/CompactBloggingPromptCardViewHolder.kt
@@ -2,37 +2,30 @@ package org.wordpress.android.ui.main
 
 import android.view.ViewGroup
 import org.wordpress.android.databinding.BloggingPrompCardCompactBinding
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.BloggingPromptCard.BloggingPromptCardWithData
+import org.wordpress.android.ui.main.MainActionListItem.AnswerBloggingPromptAction
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.extensions.viewBinding
 
-class CompactBloggingPromptCardViewHolder(   parent: ViewGroup,
+class CompactBloggingPromptCardViewHolder(
+    parent: ViewGroup,
     private val uiHelpers: UiHelpers
 ) : AddContentViewHolder<BloggingPrompCardCompactBinding>(
         parent.viewBinding(BloggingPrompCardCompactBinding::inflate)
 ) {
-    fun bind(card: BloggingPromptCardWithData) = with(binding) {
-        uiHelpers.setTextOrHide(promptContent, card.prompt)
+    fun bind(action: AnswerBloggingPromptAction) = with(binding) {
+        uiHelpers.setTextOrHide(promptContent, action.promptTitle)
 
-        uiHelpers.updateVisibility(answerButton, !card.isAnswered)
-
+        uiHelpers.updateVisibility(answerButton, !action.isAnswered)
 
         answerButton.setOnClickListener {
             uiHelpers.updateVisibility(answerButton, false)
-            uiHelpers.updateVisibility(answeredPromptControls, true)
+            uiHelpers.updateVisibility(answeredButton, true)
         }
         answeredButton.setOnClickListener {
             uiHelpers.updateVisibility(answerButton, true)
-            uiHelpers.updateVisibility(answeredPromptControls, false)
+            uiHelpers.updateVisibility(answeredButton, false)
         }
-        shareButton.setOnClickListener {
-            card.onShareClick.invoke(
-                    uiHelpers.getTextOfUiString(
-                            shareButton.context,
-                            card.prompt
-                    ).toString()
-            )
-        }
-        uiHelpers.updateVisibility(answeredPromptControls, card.isAnswered)
+
+        uiHelpers.updateVisibility(answeredButton, action.isAnswered)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/CompactBloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/CompactBloggingPromptCardViewHolder.kt
@@ -1,0 +1,38 @@
+package org.wordpress.android.ui.main
+
+import android.view.ViewGroup
+import org.wordpress.android.databinding.BloggingPrompCardCompactBinding
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.BloggingPromptCard.BloggingPromptCardWithData
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.viewBinding
+
+class CompactBloggingPromptCardViewHolder(   parent: ViewGroup,
+    private val uiHelpers: UiHelpers
+) : AddContentViewHolder<BloggingPrompCardCompactBinding>(
+        parent.viewBinding(BloggingPrompCardCompactBinding::inflate)
+) {
+    fun bind(card: BloggingPromptCardWithData) = with(binding) {
+        uiHelpers.setTextOrHide(promptContent, card.prompt)
+
+        uiHelpers.updateVisibility(answerButton, !card.isAnswered)
+
+
+        answerButton.setOnClickListener {
+            uiHelpers.updateVisibility(answerButton, false)
+            uiHelpers.updateVisibility(answeredPromptControls, true)
+        }
+        answeredButton.setOnClickListener {
+            uiHelpers.updateVisibility(answerButton, true)
+            uiHelpers.updateVisibility(answeredPromptControls, false)
+        }
+        shareButton.setOnClickListener {
+            card.onShareClick.invoke(
+                    uiHelpers.getTextOfUiString(
+                            shareButton.context,
+                            card.prompt
+                    ).toString()
+            )
+        }
+        uiHelpers.updateVisibility(answeredPromptControls, card.isAnswered)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
@@ -27,6 +27,6 @@ sealed class MainActionListItem {
         override val actionType: ActionType,
         val promptTitle: UiString,
         val isAnswered: Boolean,
-        val onClickAction: ((actionType: ActionType) -> Unit)?,
+        val onClickAction: (() -> Unit)?,
     ) : MainActionListItem()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
@@ -12,7 +12,7 @@ sealed class MainActionListItem {
         CREATE_NEW_PAGE,
         CREATE_NEW_POST,
         CREATE_NEW_STORY,
-        ANSWER_BLOGGING_PROMP
+        ANSWER_BLOGGING_PROMPT
     }
 
     data class CreateAction(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.main
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import org.wordpress.android.ui.utils.UiString
 
 sealed class MainActionListItem {
     abstract val actionType: ActionType
@@ -10,7 +11,8 @@ sealed class MainActionListItem {
         NO_ACTION,
         CREATE_NEW_PAGE,
         CREATE_NEW_POST,
-        CREATE_NEW_STORY
+        CREATE_NEW_STORY,
+        ANSWER_BLOGGING_PROMP
     }
 
     data class CreateAction(
@@ -19,5 +21,12 @@ sealed class MainActionListItem {
         @StringRes val labelRes: Int,
         val onClickAction: ((actionType: ActionType) -> Unit)?,
         val showQuickStartFocusPoint: Boolean = false
+    ) : MainActionListItem()
+
+    data class AnswerBloggingPromptAction(
+        override val actionType: ActionType,
+        val promptTitle: UiString,
+        val isAnswered: Boolean,
+        val onClickAction: ((actionType: ActionType) -> Unit)?,
     ) : MainActionListItem()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
@@ -27,6 +27,6 @@ sealed class MainActionListItem {
         override val actionType: ActionType,
         val promptTitle: UiString,
         val isAnswered: Boolean,
-        val onClickAction: (() -> Unit)?,
+        val onClickAction: (() -> Unit)?
     ) : MainActionListItem()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -487,6 +487,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         mViewModel.getCreateAction().observe(this, createAction -> {
             switch (createAction) {
                 case CREATE_NEW_POST:
+                case ANSWER_BLOGGING_PROMP: // TODO @klymyam open editor with BP content
                     handleNewPostAction(PagePostCreationSourcesDetail.POST_FROM_MY_SITE);
                     break;
                 case CREATE_NEW_PAGE:

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -487,7 +487,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         mViewModel.getCreateAction().observe(this, createAction -> {
             switch (createAction) {
                 case CREATE_NEW_POST:
-                case ANSWER_BLOGGING_PROMP: // TODO @klymyam open editor with BP content
+                case ANSWER_BLOGGING_PROMPT: // TODO @klymyam open editor with BP content
                     handleNewPostAction(PagePostCreationSourcesDetail.POST_FROM_MY_SITE);
                     break;
                 case CREATE_NEW_PAGE:

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -16,16 +16,19 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
+import org.wordpress.android.ui.main.MainActionListItem.ActionType.ANSWER_BLOGGING_PROMP
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_STORY
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.NO_ACTION
+import org.wordpress.android.ui.main.MainActionListItem.AnswerBloggingPromptAction
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.main.MainFabUiState
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.FluxCUtils
@@ -131,7 +134,14 @@ class WPMainActivityViewModel @Inject constructor(
 
     private fun loadMainActions(site: SiteModel?) {
         val actionsList = ArrayList<MainActionListItem>()
-
+        actionsList.add(
+                AnswerBloggingPromptAction(
+                        actionType = ANSWER_BLOGGING_PROMP,
+                        promptTitle = UiStringText("Cast the movie of your life"),
+                        isAnswered = false,
+                        onClickAction = null
+                )
+        )
         actionsList.add(
                 CreateAction(
                         actionType = NO_ACTION,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -16,7 +16,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
-import org.wordpress.android.ui.main.MainActionListItem.ActionType.ANSWER_BLOGGING_PROMP
+import org.wordpress.android.ui.main.MainActionListItem.ActionType.ANSWER_BLOGGING_PROMPT
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_STORY
@@ -140,7 +140,7 @@ class WPMainActivityViewModel @Inject constructor(
         if (bloggingPromptsFeatureConfig.isEnabled()) {
             actionsList.add(
                     AnswerBloggingPromptAction(
-                            actionType = ANSWER_BLOGGING_PROMP,
+                            actionType = ANSWER_BLOGGING_PROMPT,
                             promptTitle = UiStringText("Cast the movie of your life"),
                             isAnswered = false,
                             onClickAction = ::onAnswerPromptActionClicked
@@ -205,7 +205,7 @@ class WPMainActivityViewModel @Inject constructor(
     private fun onAnswerPromptActionClicked() {
         // TODO @klymyam add analytics
         _isBottomSheetShowing.postValue(Event(false))
-        _createAction.postValue(ANSWER_BLOGGING_PROMP)
+        _createAction.postValue(ANSWER_BLOGGING_PROMPT)
     }
 
     private fun disableTooltip(site: SiteModel?) {

--- a/WordPress/src/main/res/layout/blogging_promp_card_compact.xml
+++ b/WordPress/src/main/res/layout/blogging_promp_card_compact.xml
@@ -38,7 +38,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/prompt_content"
             style="@style/MySiteCardItemTitle"

--- a/WordPress/src/main/res/layout/blogging_promp_card_compact.xml
+++ b/WordPress/src/main/res/layout/blogging_promp_card_compact.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/WordPress.CardView.Unelevated"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/my_site_card_row_padding"
+        android:paddingTop="@dimen/my_site_card_row_top_padding"
+        android:paddingEnd="@dimen/my_site_card_row_padding"
+        android:paddingBottom="@dimen/margin_small">
+
+        <ImageView
+            android:id="@+id/title_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_small_medium"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_outline_lightbulb_white_24dp"
+            android:tint="?attr/colorOnSurface"
+            app:layout_constraintEnd_toStartOf="@+id/card_title"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/card_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@string/my_site_blogging_prompt_card_title"
+            android:textAlignment="viewStart"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <LinearLayout
+            android:id="@+id/answered_prompt_controls"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/prompt_content">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/answered_button"
+                style="@style/MySiteCardAnsweredButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/my_site_blogging_prompt_card_answered_prompt"
+                android:textColor="@color/success_emphasis_medium_selector" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/share_button"
+                style="@style/MySiteCardAnsweredButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/my_site_blogging_prompt_card_share" />
+        </LinearLayout>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/prompt_content"
+            style="@style/MySiteCardItemTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_medium"
+            android:textAlignment="center"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/card_title"
+            tools:text="Cast the movie of your life." />
+
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/answer_button"
+            style="@style/MySiteCardAnswerButton"
+            android:padding="0dp"
+            android:layout_marginTop="@dimen/margin_large"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/my_site_blogging_prompt_card_answer_prompt"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/prompt_content" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/layout/blogging_promp_card_compact.xml
+++ b/WordPress/src/main/res/layout/blogging_promp_card_compact.xml
@@ -14,39 +14,45 @@
         android:paddingEnd="@dimen/margin_extra_large"
         android:paddingBottom="@dimen/margin_extra_medium_large">
 
-        <ImageView
-            android:id="@+id/title_icon"
+        <LinearLayout
+            android:id="@+id/card_title_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_small_medium"
-            android:importantForAccessibility="no"
-            android:src="@drawable/ic_outline_lightbulb_white_24dp"
-            android:tint="?attr/colorOnSurface"
-            app:layout_constraintEnd_toStartOf="@+id/card_title"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/card_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:maxLines="1"
-            android:text="@string/my_site_blogging_prompt_card_title"
-            android:textAlignment="viewStart"
-            android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:orientation="horizontal"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/title_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/margin_small_medium"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_outline_lightbulb_white_24dp"
+                android:tint="?attr/colorOnSurface" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/card_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:text="@string/my_site_blogging_prompt_card_title"
+                android:textAlignment="viewStart"
+                android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+        </LinearLayout>
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/prompt_content"
             style="@style/MySiteCardItemTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_medium"
+            android:layout_marginTop="@dimen/margin_large"
             android:textAlignment="center"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/card_title"
+            app:layout_constraintTop_toBottomOf="@+id/card_title_container"
             tools:text="Cast the movie of your life." />
 
         <com.google.android.material.textview.MaterialTextView
@@ -54,7 +60,7 @@
             style="@style/MySiteCardAnswerButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_extra_large"
+            android:layout_marginTop="@dimen/margin_large"
             android:padding="0dp"
             android:text="@string/my_site_blogging_prompt_card_answer_prompt"
             app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/layout/blogging_promp_card_compact.xml
+++ b/WordPress/src/main/res/layout/blogging_promp_card_compact.xml
@@ -72,7 +72,7 @@
             style="@style/MySiteCardAnsweredButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_extra_large"
+            android:layout_marginTop="@dimen/margin_large"
             android:padding="0dp"
             android:text="@string/my_site_blogging_prompt_card_answered_prompt"
             android:textColor="@color/success_emphasis_medium_selector"

--- a/WordPress/src/main/res/layout/blogging_promp_card_compact.xml
+++ b/WordPress/src/main/res/layout/blogging_promp_card_compact.xml
@@ -2,17 +2,17 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/WordPress.CardView.Unelevated"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="0dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingStart="@dimen/my_site_card_row_padding"
-        android:paddingTop="@dimen/my_site_card_row_top_padding"
-        android:paddingEnd="@dimen/my_site_card_row_padding"
-        android:paddingBottom="@dimen/margin_small">
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingTop="@dimen/margin_extra_large"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingBottom="@dimen/margin_extra_medium_large">
 
         <ImageView
             android:id="@+id/title_icon"
@@ -38,31 +38,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <LinearLayout
-            android:id="@+id/answered_prompt_controls"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/prompt_content">
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/answered_button"
-                style="@style/MySiteCardAnsweredButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/my_site_blogging_prompt_card_answered_prompt"
-                android:textColor="@color/success_emphasis_medium_selector" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/share_button"
-                style="@style/MySiteCardAnsweredButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/my_site_blogging_prompt_card_share" />
-        </LinearLayout>
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/prompt_content"
@@ -75,19 +50,31 @@
             app:layout_constraintTop_toBottomOf="@+id/card_title"
             tools:text="Cast the movie of your life." />
 
-
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/answer_button"
             style="@style/MySiteCardAnswerButton"
-            android:padding="0dp"
-            android:layout_marginTop="@dimen/margin_large"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:padding="0dp"
             android:text="@string/my_site_blogging_prompt_card_answer_prompt"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/prompt_content" />
 
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/answered_button"
+            style="@style/MySiteCardAnsweredButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:padding="0dp"
+            android:text="@string/my_site_blogging_prompt_card_answered_prompt"
+            android:textColor="@color/success_emphasis_medium_selector"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/prompt_content" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -30,7 +30,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_S
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.VIEW_SITE
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.test
-import org.wordpress.android.ui.main.MainActionListItem.ActionType.ANSWER_BLOGGING_PROMP
+import org.wordpress.android.ui.main.MainActionListItem.ActionType.ANSWER_BLOGGING_PROMPT
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_STORY
@@ -372,7 +372,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `bottom sheet does not show prompt card when FF is OFF`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
         startViewModelWithDefaultParameters()
-        val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMP }
+        val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMPT }
         assertThat(hasBloggingPromptAction).isFalse()
     }
 
@@ -380,7 +380,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `bottom sheet does show prompt card when FF is ON`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
         startViewModelWithDefaultParameters()
-        val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMP }
+        val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMPT }
         assertThat(hasBloggingPromptAction).isTrue()
     }
 
@@ -389,11 +389,11 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
         startViewModelWithDefaultParameters()
         val action = viewModel.mainActions.value?.firstOrNull {
-            it.actionType == ANSWER_BLOGGING_PROMP
+            it.actionType == ANSWER_BLOGGING_PROMPT
         } as AnswerBloggingPromptAction?
         assertThat(action).isNotNull
         action!!.onClickAction?.invoke()
-        assertThat(viewModel.createAction.value).isEqualTo(ANSWER_BLOGGING_PROMP)
+        assertThat(viewModel.createAction.value).isEqualTo(ANSWER_BLOGGING_PROMPT)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -377,7 +377,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `bottom sheet does  show prompt card when FF is ON`() {
+    fun `bottom sheet does show prompt card when FF is ON`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
         startViewModelWithDefaultParameters()
         val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMP }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -30,10 +30,12 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_S
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.VIEW_SITE
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.test
+import org.wordpress.android.ui.main.MainActionListItem.ActionType.ANSWER_BLOGGING_PROMP
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_STORY
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.NO_ACTION
+import org.wordpress.android.ui.main.MainActionListItem.AnswerBloggingPromptAction
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.main.MainFabUiState
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
@@ -46,6 +48,7 @@ import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel.FocusPointInfo
 
 @RunWith(MockitoJUnitRunner::class)
@@ -66,6 +69,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Mock lateinit var accountStore: AccountStore
     @Mock lateinit var siteStore: SiteStore
     @Mock lateinit var mySiteDefaultTabExperiment: MySiteDefaultTabExperiment
+    @Mock lateinit var bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig
 
     private val featureAnnouncement = FeatureAnnouncement(
             "14.7",
@@ -96,6 +100,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         activeTask = MutableLiveData()
         externalFocusPointEvents = mutableListOf()
         whenever(quickStartRepository.activeTask).thenReturn(activeTask)
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
         viewModel = WPMainActivityViewModel(
                 featureAnnouncementProvider,
                 buildConfigWrapper,
@@ -106,6 +111,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
                 accountStore,
                 siteStore,
                 mySiteDefaultTabExperiment,
+                bloggingPromptsFeatureConfig,
                 NoDelayCoroutineDispatcher()
         )
         viewModel.onFeatureAnnouncementRequested.observeForever(
@@ -360,6 +366,34 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         assertThat(action).isNotNull
         action.onClickAction?.invoke(CREATE_NEW_STORY)
         assertThat(viewModel.createAction.value).isEqualTo(CREATE_NEW_STORY)
+    }
+
+    @Test
+    fun `bottom sheet does not show prompt card when FF is OFF`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
+        startViewModelWithDefaultParameters()
+        val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMP }
+        assertThat(hasBloggingPromptAction).isFalse()
+    }
+
+    @Test
+    fun `bottom sheet does  show prompt card when FF is ON`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        startViewModelWithDefaultParameters()
+        val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMP }
+        assertThat(hasBloggingPromptAction).isTrue()
+    }
+
+    @Test
+    fun `bottom sheet action is answer BP when the BP answer button is clicked`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        startViewModelWithDefaultParameters()
+        val action = viewModel.mainActions.value?.firstOrNull {
+            it.actionType == ANSWER_BLOGGING_PROMP
+        } as AnswerBloggingPromptAction?
+        assertThat(action).isNotNull
+        action!!.onClickAction?.invoke()
+        assertThat(viewModel.createAction.value).isEqualTo(ANSWER_BLOGGING_PROMP)
     }
 
     @Test


### PR DESCRIPTION
Fixes #16309

This PR ads a compact card to the Create Content bottom sheet. The are some placeholder logic for the answer button, but it is not wider to the button yet. Button toggles between Answer and Answered states for test purposes.

[![Image from Gyazo](https://i.gyazo.com/70a18ce6fa8aae4d54e7a64832a98942.png)](https://gyazo.com/70a18ce6fa8aae4d54e7a64832a98942)

To test:
- Enable BP FF and tap on the + icon on My Site screen.
- Confirm that the compact card is visible at the top of the bottom sheet, and that it looks like the design.
- With the BP FF off, confirm that the compact card is not visible in the bottom sheet.

## Regression Notes
1. Potential unintended areas of impact
- Card is visible when FF is off. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Atuomated and manual testing.

3. What automated tests I added (or what prevented me from doing so)
- FF test and card click action test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
