### PR TITLE
[Site Name] Corrects the API parameters in the site creation call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     androidxWorkVersion = "2.7.0"
 
     daggerVersion = '2.41'
-    fluxCVersion = 'trunk-8ecbb160edcbb7a042da234f732d2e15b06314ac'
+    fluxCVersion = '2360-06fcd5c6d47b4f50d01bf26ce30f3dcfac8a1785'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     androidxWorkVersion = "2.7.0"
 
     daggerVersion = '2.41'
-    fluxCVersion = '2360-31c0551370259c194818c2400b26770dc8f55d7e'
+    fluxCVersion = 'trunk-2af6fd589b99606ffc0ef216e7c58a63a2944903'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     androidxWorkVersion = "2.7.0"
 
     daggerVersion = '2.41'
-    fluxCVersion = '2360-06fcd5c6d47b4f50d01bf26ce30f3dcfac8a1785'
+    fluxCVersion = '2360-31c0551370259c194818c2400b26770dc8f55d7e'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2360

# Description 
This PR reverts the validation introduced with https://github.com/wordpress-mobile/WordPress-Android/pull/16308 and corrects the api call to pass the `site_creation_flow` parameter inside the options dictionary

# To test
Validate that the tests on https://github.com/wordpress-mobile/WordPress-Android/pull/16278 pass

### Site name with invalid characters
<details>
<summary>1. Toggle the Site Name feature</summary>

1. From My Site Go to Me → App Settings → Debug settings
2. Scroll to Features in development section and tap on SiteNameFeatureConfig
3. Tap RESTART THE APP button
4. Since this feature is A/B tested go to **Abacus**, find the `wpandroid_site_name_v1` experiment and assign to your test a8c-user the treatment variation

**Alternatively hardcode the feature on by returning `true` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/521e6b3a296339bec026f8ee2648eab326d31129/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt#L19)** 
</details>

2. Start the Site Creation flow
3. Choose an intent for your site
4. Verify that the Site Name screen is shown
5. Enter an invalid site name (e.g. `...$` or `Αντώνης`) and press continue
6. Select a design or skip
7. Verify that the site is created with a `*.wordpress.com` domain starting with your `site` ( e.g. site131331.wordpress.com)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added a unit test on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2356

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
