### PR TITLE
[Site name] Complete the site title quickstart task when site name is entered

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -158,7 +158,14 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
                     SitePickerActivity.KEY_SITE_LOCAL_ID,
                     SelectedSiteRepository.UNAVAILABLE
             );
-            setResult(RESULT_OK, new Intent().putExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, newSiteLocalID));
+            boolean isTitleTaskCompleted = data.getBooleanExtra(
+                    SitePickerActivity.KEY_SITE_TITLE_TASK_COMPLETED,
+                    false
+            );
+            setResult(RESULT_OK, new Intent()
+                    .putExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, newSiteLocalID)
+                    .putExtra(SitePickerActivity.KEY_SITE_TITLE_TASK_COMPLETED, isTitleTaskCompleted)
+            );
             finish();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -78,6 +78,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         SearchView.OnQueryTextListener {
     public static final String KEY_SITE_LOCAL_ID = "local_id";
     public static final String KEY_SITE_CREATED_BUT_NOT_FETCHED = "key_site_created_but_not_fetched";
+    public static final String KEY_SITE_TITLE_TASK_COMPLETED = "key_site_title_task_completed";
 
     public static final String KEY_SITE_PICKER_MODE = "key_site_picker_mode";
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -460,29 +460,23 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             RequestCodes.CREATE_SITE -> {
                 viewModel.onCreateSiteResult()
                 viewModel.performFirstStepAfterSiteCreation(
-                        data.getIntExtra(
-                                SitePickerActivity.KEY_SITE_LOCAL_ID,
-                                SelectedSiteRepository.UNAVAILABLE
-                        )
+                        data.getIntExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, SelectedSiteRepository.UNAVAILABLE),
+                        data.getBooleanExtra(SitePickerActivity.KEY_SITE_TITLE_TASK_COMPLETED, false)
                 )
             }
             RequestCodes.SITE_PICKER -> {
                 if (data.getIntExtra(WPMainActivity.ARG_CREATE_SITE, 0) == RequestCodes.CREATE_SITE) {
                     viewModel.onCreateSiteResult()
                     viewModel.performFirstStepAfterSiteCreation(
-                            data.getIntExtra(
-                                    SitePickerActivity.KEY_SITE_LOCAL_ID,
-                                    SelectedSiteRepository.UNAVAILABLE
-                            )
+                            data.getIntExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, SelectedSiteRepository.UNAVAILABLE),
+                            data.getBooleanExtra(SitePickerActivity.KEY_SITE_TITLE_TASK_COMPLETED, false)
                     )
                 }
             }
             RequestCodes.EDIT_LANDING_PAGE -> {
                 viewModel.checkAndStartQuickStart(
-                        data.getIntExtra(
-                                SitePickerActivity.KEY_SITE_LOCAL_ID,
-                                SelectedSiteRepository.UNAVAILABLE
-                        )
+                        data.getIntExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, SelectedSiteRepository.UNAVAILABLE),
+                        data.getBooleanExtra(SitePickerActivity.KEY_SITE_TITLE_TASK_COMPLETED, false)
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -91,18 +91,20 @@ class SiteCreationActivity : LocaleAwareActivity(),
         mainViewModel.wizardFinishedObservable.observe(this, Observer { createSiteState ->
             createSiteState?.let {
                 val intent = Intent()
-                val (siteCreated, localSiteId) = when (createSiteState) {
+                val (siteCreated, localSiteId, titleTaskComplete) = when (createSiteState) {
                     // site creation flow was canceled
-                    is SiteNotCreated -> Pair(false, null)
+                    is SiteNotCreated -> Triple(false, null, false)
                     is SiteNotInLocalDb -> {
                         // Site was created, but we haven't been able to fetch it, let `SitePickerActivity` handle
                         // this with a Snackbar message.
                         intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
-                        Pair(true, null)
+                        Triple(true, null, createSiteState.isSiteTitleTaskComplete)
                     }
-                    is SiteCreationCompleted -> Pair(true, createSiteState.localSiteId)
+                    is SiteCreationCompleted -> Triple(true, createSiteState.localSiteId,
+                            createSiteState.isSiteTitleTaskComplete)
                 }
                 intent.putExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, localSiteId)
+                intent.putExtra(SitePickerActivity.KEY_SITE_TITLE_TASK_COMPLETED, titleTaskComplete)
                 setResult(if (siteCreated) Activity.RESULT_OK else Activity.RESULT_CANCELED, intent)
                 finish()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -225,7 +225,7 @@ class SitePreviewViewModel @Inject constructor(
             SUCCESS -> {
                 val remoteSiteId = (event.payload as Pair<*, *>).first as Long
                 urlWithoutScheme = urlUtils.removeScheme(event.payload.second as String).trimEnd('/')
-                createSiteState = SiteNotInLocalDb(remoteSiteId)
+                createSiteState = SiteNotInLocalDb(remoteSiteId, !siteTitle.isNullOrBlank())
                 startPreLoadingWebView()
                 fetchNewlyCreatedSiteModel(remoteSiteId)
                 _onSiteCreationCompleted.asyncCall()
@@ -252,9 +252,9 @@ class SitePreviewViewModel @Inject constructor(
                 val siteBySiteId = requireNotNull(siteStore.getSiteBySiteId(remoteSiteId)) {
                     "Site successfully fetched but has not been found in the local db."
                 }
-                CreateSiteState.SiteCreationCompleted(siteBySiteId.id)
+                CreateSiteState.SiteCreationCompleted(siteBySiteId.id, !siteTitle.isNullOrBlank())
             } else {
-                SiteNotInLocalDb(remoteSiteId)
+                SiteNotInLocalDb(remoteSiteId, !siteTitle.isNullOrBlank())
             }
         }
     }
@@ -434,12 +434,12 @@ class SitePreviewViewModel @Inject constructor(
          * before the request is finished.
          */
         @Parcelize
-        data class SiteNotInLocalDb(val remoteSiteId: Long) : CreateSiteState()
+        data class SiteNotInLocalDb(val remoteSiteId: Long, val isSiteTitleTaskComplete: Boolean) : CreateSiteState()
 
         /**
          * The site has been successfully created and stored into local db.
          */
         @Parcelize
-        data class SiteCreationCompleted(val localSiteId: Int) : CreateSiteState()
+        data class SiteCreationCompleted(val localSiteId: Int, val isSiteTitleTaskComplete: Boolean) : CreateSiteState()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CREATE_SITE
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartPayload
 import org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartVariant.NEXT_STEPS
@@ -109,8 +110,11 @@ class QuickStartUtilsWrapper
                 !QuickStartUtils.isQuickStartAvailableForTheSite(site)
     }
 
-    fun startQuickStart(siteLocalId: Int) {
+    fun startQuickStart(siteLocalId: Int, isSiteTitleTaskCompleted: Boolean) {
         quickStartStore.setDoneTask(siteLocalId.toLong(), CREATE_SITE, true)
+        if (isSiteTitleTaskCompleted) {
+            quickStartStore.setDoneTask(siteLocalId.toLong(), UPDATE_SITE_TITLE, true)
+        }
         analyticsTrackerWrapper.track(QUICK_START_STARTED)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1105,9 +1105,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given QS dynamic cards cards feature is on, when check and start QS is triggered, then QS starts`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(true)
 
-        viewModel.checkAndStartQuickStart(siteLocalId)
+        viewModel.checkAndStartQuickStart(siteLocalId, false)
 
-        verify(quickStartUtilsWrapper).startQuickStart(siteLocalId)
+        verify(quickStartUtilsWrapper).startQuickStart(siteLocalId, false)
         verify(mySiteSourceManager).refreshQuickStart()
     }
 
@@ -1116,7 +1116,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
 
-        viewModel.checkAndStartQuickStart(siteLocalId)
+        viewModel.checkAndStartQuickStart(siteLocalId, false)
 
         assertThat(navigationActions).isEmpty()
     }
@@ -1127,7 +1127,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(false)
 
-        viewModel.checkAndStartQuickStart(siteLocalId)
+        viewModel.checkAndStartQuickStart(siteLocalId, false)
 
         assertThat(navigationActions).isEmpty()
     }
@@ -1138,7 +1138,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(true)
 
-        viewModel.checkAndStartQuickStart(siteLocalId)
+        viewModel.checkAndStartQuickStart(siteLocalId, false)
 
         assertThat(navigationActions).containsExactly(
                 SiteNavigationAction.ShowQuickStartDialog(
@@ -1163,7 +1163,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         viewModel.startQuickStart()
 
-        verify(quickStartUtilsWrapper).startQuickStart(site.id)
+        verify(quickStartUtilsWrapper).startQuickStart(site.id, false)
         verify(mySiteSourceManager).refreshQuickStart()
     }
 
@@ -1824,7 +1824,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given the land on the editor feature is enabled, then the home page editor is shown`() = test {
         whenever(landOnTheEditorFeatureConfig.isEnabled()).thenReturn(true)
 
-        viewModel.performFirstStepAfterSiteCreation(siteLocalId)
+        viewModel.performFirstStepAfterSiteCreation(siteLocalId, false)
 
         verify(analyticsTrackerWrapper).track(Stat.LANDING_EDITOR_SHOWN)
         assertThat(navigationActions).containsExactly(SiteNavigationAction.OpenHomepage(site, localHomepageId))
@@ -1834,7 +1834,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given the land on the editor feature is not enabled, then the home page editor is not shown`() = test {
         whenever(landOnTheEditorFeatureConfig.isEnabled()).thenReturn(false)
 
-        viewModel.performFirstStepAfterSiteCreation(siteLocalId)
+        viewModel.performFirstStepAfterSiteCreation(siteLocalId, false)
 
         assertThat(navigationActions).isEmpty()
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -88,7 +88,7 @@ class SiteCreationMainVMTest {
 
     @Test
     fun wizardFinishedInvokedOnSitePreviewCompleted() {
-        val state = SiteCreationCompleted(LOCAL_SITE_ID)
+        val state = SiteCreationCompleted(LOCAL_SITE_ID, false)
         viewModel.onSitePreviewScreenFinished(state)
 
         val captor = ArgumentCaptor.forClass(CreateSiteState::class.java)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -256,14 +256,14 @@ class SitePreviewViewModelTest {
     fun `CreateSiteState is SiteCreationCompleted on fetchFromRemote success`() = testWithSuccessResponse {
         initViewModel()
         viewModel.onSiteCreationServiceStateUpdated(createServiceSuccessState())
-        assertThat(getCreateSiteState()).isEqualTo(SiteCreationCompleted(LOCAL_SITE_ID))
+        assertThat(getCreateSiteState()).isEqualTo(SiteCreationCompleted(LOCAL_SITE_ID, false))
     }
 
     @Test
     fun `CreateSiteState is NotInLocalDb on fetchFromRemote failure`() = testWithErrorResponse {
         initViewModel()
         viewModel.onSiteCreationServiceStateUpdated(createServiceSuccessState())
-        assertThat(getCreateSiteState()).isEqualTo(SiteNotInLocalDb(REMOTE_SITE_ID))
+        assertThat(getCreateSiteState()).isEqualTo(SiteNotInLocalDb(REMOTE_SITE_ID, false))
     }
 
     @Test
@@ -302,7 +302,7 @@ class SitePreviewViewModelTest {
     @Test
     fun `start pre-loading WebView when restoring from SiteNotInLocalDb state`() = testWithSuccessResponse {
         whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
-                .thenReturn(SiteNotInLocalDb(REMOTE_SITE_ID))
+                .thenReturn(SiteNotInLocalDb(REMOTE_SITE_ID, false))
         initViewModel(bundle)
 
         assertThat(viewModel.uiState.value).isInstanceOf(SitePreviewFullscreenProgressUiState::class.java)
@@ -311,7 +311,7 @@ class SitePreviewViewModelTest {
     @Test
     fun `fetch newly created SiteModel when restoring from SiteNotInLocalDb state`() = testWithSuccessResponse {
         whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
-                .thenReturn(SiteNotInLocalDb(REMOTE_SITE_ID))
+                .thenReturn(SiteNotInLocalDb(REMOTE_SITE_ID, false))
         initViewModel(bundle)
 
         verify(fetchWpComUseCase).fetchSiteWithRetry(REMOTE_SITE_ID)
@@ -320,7 +320,7 @@ class SitePreviewViewModelTest {
     @Test
     fun `start pre-loading WebView when restoring from SiteCreationCompleted state`() {
         whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
-                .thenReturn(SiteCreationCompleted(LOCAL_SITE_ID))
+                .thenReturn(SiteCreationCompleted(LOCAL_SITE_ID, false))
         initViewModel(bundle)
 
         assertThat(viewModel.preloadPreview.value).isEqualTo(URL)


### PR DESCRIPTION
Fixes #16265

This completes the "Check your site title" quickstart task when the user already set their site name during site creation.

### Testing steps:

#### Test with a site name

Precondition: The site name feature must be turned on, and with an account that has the experiment enabled.

<details>
<summary>Alternatively, this patch can be applied be substituted for convenience</summary>

```patch
diff --git a/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt b/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt
index 38a9b4c2f1..e41da7f4fb 100644
--- a/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt
@@ -16,6 +16,7 @@ class SiteNameFeatureConfig
         BuildConfig.SITE_NAME
 ) {
     override fun isEnabled(): Boolean {
+        return true
         return super.isEnabled() && siteNameABExperiment.getVariation() != Control
     }
 }
```
</details>

1. Start the create a site flow
2. Enter any intent (or skip)
3. Enter a site name
4. Choose any design (or skip)
5. Complete the site creation and tap OK after the preview screen
6. When the quickstart dialog appears, tap "Show me around"

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/8507675/163350850-5e8ed17a-4d74-4623-a388-a14ff04c33aa.png" width="360">
</details>


Expect that the quickstart task for setting the site title is already complete (i.e. the "Customize your site" subtitle should say "2 of 6", with the title task in the completed section after tapping).

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/8507675/163351252-c4d7ce2b-d62b-414f-991d-fc0248ad738e.png" width="360">
</details>


#### Test when skipping a site name

1. Start the create a site flow
2. Enter any intent (or skip)
3. _Skip_ the site name
4. Choose any design (or skip)
5. Complete the site creation and tap OK after the preview screen
6. When the quickstart dialog appears, tap "Show me around"


Expect that the quickstart task for setting the site title is not complete (i.e. the "Customize your site" subtitle should say "1 of 6", with the title task in the uncompleted section after tapping).
<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/8507675/163352022-86777cc2-b236-4a90-a414-90ff7b1de411.png" width="360">
</details>

### Flows to test

Test the above steps in the following flows:

* Logged in user
* With the login epilogue (tapping Create Site button after a fresh login)
* With the signup interstitial (tapping Create Site button after an account creation)
  * For convenience, an account can be used by entering an email with "+" followed by some random numbers or text
  * Note that this flow may require the convenience patch applied, since these new accounts will not have the experiment enabled.


## Regression Notes
1. Potential unintended areas of impact
Site creation completion and quickstart

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

8. What automated tests I added (or what prevented me from doing so)
Introducing the necessary harness for integration testing between the relevant components was out of scope for this task.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
