### PR TITLE
[Site Name] Display the site intent in the header title if available

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -175,7 +175,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         val screenTitle = getScreenTitle(target.wizardStep)
         val fragment = when (target.wizardStep) {
             INTENTS -> SiteCreationIntentsFragment()
-            SITE_NAME -> SiteCreationSiteNameFragment()
+            SITE_NAME -> SiteCreationSiteNameFragment.newInstance(target.wizardState.siteIntent)
             SITE_DESIGNS -> HomePagePickerFragment()
             DOMAINS -> SiteCreationDomainsFragment.newInstance(
                     screenTitle

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SiteCreationSiteNameFragmentBinding
 import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewModel.SiteNameUiState
+import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.DisplayUtilsWrapper
@@ -27,6 +28,7 @@ class SiteCreationSiteNameFragment : Fragment() {
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject internal lateinit var uiHelper: UiHelpers
     @Inject internal lateinit var displayUtils: DisplayUtilsWrapper
+    @Inject internal lateinit var htmlMessageUtils: HtmlMessageUtils
 
     private lateinit var viewModel: SiteCreationSiteNameViewModel
     private var binding: SiteCreationSiteNameFragmentBinding? = null
@@ -59,8 +61,14 @@ class SiteCreationSiteNameFragment : Fragment() {
         }
     }
 
+    val siteIntent: String?
+        get() = arguments?.getString(ARG_SITE_INTENT)
+
     private fun SiteCreationSiteNameFragmentBinding.setupUi() {
-        siteCreationSiteNameHeader.title?.setText(R.string.new_site_creation_site_name_header_title)
+        siteCreationSiteNameHeader.title?.text = htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                R.string.new_site_creation_site_name_header_title,
+                siteIntent?.let { "<span style='color:#0675C4;'>$it</span>" }.orEmpty()
+        )
         siteCreationSiteNameHeader.subtitle?.setText(R.string.new_site_creation_site_name_header_subtitle)
         siteCreationSiteNameTitlebar.appBarTitle.setText(R.string.new_site_creation_site_name_title)
         siteCreationSiteNameTitlebar.appBarTitle.isInvisible = !displayUtils.isPhoneLandscape()
@@ -108,6 +116,18 @@ class SiteCreationSiteNameFragment : Fragment() {
     }
 
     companion object {
+        private const val ARG_SITE_INTENT = "arg_site_intent"
+
+        fun newInstance(siteIntent: String?): SiteCreationSiteNameFragment {
+            val bundle = Bundle().apply {
+                putString(ARG_SITE_INTENT, siteIntent)
+            }
+
+            return SiteCreationSiteNameFragment().apply {
+                arguments = bundle
+            }
+        }
+
         const val TAG = "site_creation_site_name_fragment_tag"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
@@ -11,6 +11,8 @@ import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
+import org.wordpress.android.R.color
+import org.wordpress.android.R.string
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SiteCreationSiteNameFragmentBinding
 import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewModel.SiteNameUiState
@@ -18,6 +20,7 @@ import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.DisplayUtilsWrapper
+import org.wordpress.android.util.HtmlUtils
 import javax.inject.Inject
 
 /**
@@ -61,14 +64,20 @@ class SiteCreationSiteNameFragment : Fragment() {
         }
     }
 
-    val siteIntent: String?
+    private val siteIntent: String?
         get() = arguments?.getString(ARG_SITE_INTENT)
 
+    private val headerTitleWithIntentColoredBlueIfSpecified: CharSequence
+        get() {
+            val blueColorHexCode = HtmlUtils.colorResToHtmlColor(requireContext(), color.blue)
+            return htmlMessageUtils.getHtmlMessageFromStringFormatResId(
+                    string.new_site_creation_site_name_header_title,
+                    siteIntent?.let { "<span style='color:$blueColorHexCode;'>$it</span>" }.orEmpty()
+            )
+        }
+
     private fun SiteCreationSiteNameFragmentBinding.setupUi() {
-        siteCreationSiteNameHeader.title?.text = htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                R.string.new_site_creation_site_name_header_title,
-                siteIntent?.let { "<span style='color:#0675C4;'>$it</span>" }.orEmpty()
-        )
+        siteCreationSiteNameHeader.title?.text = headerTitleWithIntentColoredBlueIfSpecified
         siteCreationSiteNameHeader.subtitle?.setText(R.string.new_site_creation_site_name_header_subtitle)
         siteCreationSiteNameTitlebar.appBarTitle.setText(R.string.new_site_creation_site_name_title)
         siteCreationSiteNameTitlebar.appBarTitle.isInvisible = !displayUtils.isPhoneLandscape()

--- a/WordPress/src/main/res/layout/site_creation_header_v2.xml
+++ b/WordPress/src/main/res/layout/site_creation_header_v2.xml
@@ -13,6 +13,7 @@
         android:letterSpacing="0.01"
         android:paddingBottom="@dimen/margin_large"
         app:fixWidowWords="true"
+        app:autoSizeTextType="uniform"
         tools:text="@string/new_site_creation_intents_header_title" />
 
     <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3217,7 +3217,7 @@
     <string name="new_site_creation_site_name_title">Site name</string>
     <!-- translators: Give your Photography website a name -->
     <string name="new_site_creation_site_name_header_title">Give your %s website a name</string>
-    <string name="new_site_creation_site_name_header_subtitle">A good name is short and memorable.\nYou can change it later</string>
+    <string name="new_site_creation_site_name_header_subtitle">A good name is short and memorable.\nYou can change it later.</string>
     <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>
     <string name="new_site_creation_unavailable_domain">This domain is unavailable</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3215,7 +3215,8 @@
     <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type your own.</string>
     <string name="new_site_creation_intents_input_hint">E.g. Fashion, Poetry, Politics</string>
     <string name="new_site_creation_site_name_title">Site name</string>
-    <string name="new_site_creation_site_name_header_title">Give your website a name</string>
+    <!-- translators: Give your Photography website a name -->
+    <string name="new_site_creation_site_name_header_title">Give your %s website a name</string>
     <string name="new_site_creation_site_name_header_subtitle">A good name is short and memorable.\nYou can change it later</string>
     <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
     <string name="new_site_creation_empty_domain_list_message_invalid_query">Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.</string>


### PR DESCRIPTION
Fixes #16316 & #16298

Displays the site intent in the title of the Site Name screen header visible _only_ in portrait orientation, colored in blue:

<img width="314" src="https://user-images.githubusercontent.com/4588074/163407630-9529eb84-8f96-4169-862a-d9f45d097377.png">

<details>
<summary>Video Preview</summary>

https://user-images.githubusercontent.com/4588074/163412211-e345925c-956e-415c-abc3-38b916554d74.mov
</details>

## To test:
<details>
<summary>1. Toggle the Site Name feature <b>on</b></summary>

1. From My Site Go to Me → App Settings → Debug settings
2. Scroll to Features in development section and tap on SiteNameFeatureConfig
3. Tap RESTART THE APP button
4. Since this feature is A/B tested go to **Abacus**, find the `wpandroid_site_name_v1` experiment and assign to your test a8c-user the treatment variation

**Alternatively hardcode the feature on by returning `true` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/521e6b3a296339bec026f8ee2648eab326d31129/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt#L19)** 
</details>

2. Start the Site Creation flow
3. Choose an intent for your site
4. `Verify` that the Site Name screen is shown
   - Header title includes the chosen site intent, colored in blue (see preview above / [#16316](https://github.com/wordpress-mobile/WordPress-Android/issues/16316) description)
5. Navigate back
6. Tap `SKIP`
7. `Verify` that the Site Name screen is shown
   - Header title is: `Give your website a name`
   - Header subtitle ends with a period (see [#16298](https://github.com/wordpress-mobile/WordPress-Android/issues/16298) description)

## Regression Notes
1. Potential unintended areas of impact
   N/a - The changes are just ui tweaks specific to the new Site Name screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

3. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
