### PR TITLE
[Site name] Complete the site title quickstart task when the site is fetched after site creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -19,6 +19,7 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.store.QuickStartStore
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
@@ -252,7 +253,8 @@ class SitePreviewViewModel @Inject constructor(
                 val siteBySiteId = requireNotNull(siteStore.getSiteBySiteId(remoteSiteId)) {
                     "Site successfully fetched but has not been found in the local db."
                 }
-                CreateSiteState.SiteCreationCompleted(siteBySiteId.id)
+                quickStartStore.setDoneTask(siteBySiteId.id.toLong(), UPDATE_SITE_TITLE, !siteTitle.isNullOrBlank())
+                SiteCreationCompleted(siteBySiteId.id)
             } else {
                 SiteNotInLocalDb(remoteSiteId)
             }


### PR DESCRIPTION
Fixes #16265

This completes the "Check your site title" quickstart task when the user already set their site name during site creation.
This is an alternative simplified approach that may fail when the site fails to be fetched after site creation.

To test:
Perform the testing steps on https://github.com/wordpress-mobile/WordPress-Android/pull/16325

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
