### PR TITLE
Site name tracks events continued...

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.experiments.SiteNameABExperiment
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
 import org.wordpress.android.util.wizard.WizardState
@@ -45,7 +46,8 @@ typealias NavigationTarget = WizardNavigationTarget<SiteCreationStep, SiteCreati
 
 class SiteCreationMainVM @Inject constructor(
     private val tracker: SiteCreationTracker,
-    private val wizardManager: WizardManager<SiteCreationStep>
+    private val wizardManager: WizardManager<SiteCreationStep>,
+    private val siteNameABExperiment: SiteNameABExperiment
 ) : ViewModel() {
     private var isStarted = false
     private var siteCreationCompleted = false
@@ -77,6 +79,7 @@ class SiteCreationMainVM @Inject constructor(
         if (isStarted) return
         if (savedInstanceState == null) {
             tracker.trackSiteCreationAccessed()
+            tracker.trackSiteNameExperimentVariation(siteNameABExperiment.getVariation())
             siteCreationState = SiteCreationState()
         } else {
             siteCreationCompleted = savedInstanceState.getBoolean(KEY_SITE_CREATION_COMPLETED, false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.S
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.SEGMENT_ID
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.SEGMENT_NAME
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.SELECTED_FILTERS
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.SITE_NAME
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.TEMPLATE
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.THUMBNAIL_MODE
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.VARIATION
@@ -46,7 +47,8 @@ class SiteCreationTracker @Inject constructor(
         FILTER("filter"),
         SELECTED_FILTERS("selected_filters"),
         VERTICAL_SLUG("vertical_slug"),
-        VARIATION("variation")
+        VARIATION("variation"),
+        SITE_NAME("site_name")
     }
 
     private var designSelectionSkipped: Boolean = false
@@ -289,8 +291,8 @@ class SiteCreationTracker @Inject constructor(
         tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_SITE_NAME_SKIPPED)
     }
 
-    fun trackSiteNameEntered() {
-        tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_SITE_NAME_ENTERED)
+    fun trackSiteNameEntered(siteName: String?) {
+        tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_SITE_NAME_ENTERED, mapOf(SITE_NAME.key to siteName))
     }
 
     fun trackSiteIntentQuestionExperimentVariation() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
@@ -31,6 +31,7 @@ private const val DESIGN_ERROR_CONTEXT = "design"
 private const val SITE_CREATION_LOCATION = "site_creation"
 
 @Singleton
+@Suppress("TooManyFunctions")
 class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapper) : LayoutPickerTracker {
     private enum class PROPERTY(val key: String) {
         TEMPLATE("template"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.sitecreation.misc
 
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.model.experiments.Variation
 import org.wordpress.android.ui.layoutpicker.LayoutPickerTracker
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationErrorType.INTERNET_UNAVAILABLE_ERROR
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationErrorType.UNKNOWN
@@ -18,7 +19,6 @@ import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.T
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.VARIATION
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.VERTICAL_SLUG
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.experiments.SiteNameABExperiment
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -31,10 +31,7 @@ private const val DESIGN_ERROR_CONTEXT = "design"
 private const val SITE_CREATION_LOCATION = "site_creation"
 
 @Singleton
-class SiteCreationTracker @Inject constructor(
-    val tracker: AnalyticsTrackerWrapper,
-    private val siteNameABExperiment: SiteNameABExperiment
-) : LayoutPickerTracker {
+class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapper) : LayoutPickerTracker {
     private enum class PROPERTY(val key: String) {
         TEMPLATE("template"),
         SEGMENT_NAME("segment_name"),
@@ -295,10 +292,10 @@ class SiteCreationTracker @Inject constructor(
         tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_SITE_NAME_ENTERED, mapOf(SITE_NAME.key to siteName))
     }
 
-    fun trackSiteIntentQuestionExperimentVariation() {
+    fun trackSiteNameExperimentVariation(variation: Variation) {
         tracker.track(
-                AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_INTENT_QUESTION_EXPERIMENT,
-                mapOf(VARIATION.key to siteNameABExperiment.getVariation())
+                AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_SITE_NAME_EXPERIMENT,
+                mapOf(VARIATION.key to variation)
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
@@ -38,26 +38,23 @@ class SiteCreationSiteNameViewModel @Inject constructor(
 
     fun start() {
         if (isInitialized) return
-        // TODO: analyticsTracker.trackSiteNameViewed()
-        Log.d("siteNameWip", "Site name viewed")
+        analyticsTracker.trackSiteNameViewed()
         isInitialized = true
     }
 
     fun onSkipPressed() {
-        // TODO: analyticsTracker.trackSiteNameSkipped()
-        Log.d("siteNameWip", "Site name skipped")
+        analyticsTracker.trackSiteNameSkipped()
         _onSkipButtonPressed.call()
     }
 
     fun onBackPressed() {
-        // TODO: analyticsTracker.trackSiteNameCancelled()
-        Log.d("siteNameWip", "Site name cancelled")
+        analyticsTracker.trackSiteNameCanceled()
         _onBackButtonPressed.call()
     }
 
     fun onSiteNameEntered() {
-        // TODO: analyticsTracker.trackSiteNameEntered(siteName?) maybe we don't want to track the names here?
         uiState.value?.siteName.let {
+            analyticsTracker.trackSiteNameEntered(it)
             if (it.isNullOrBlank()) return
             Log.d("siteNameWip", "Site name entered: $it")
             _onSiteNameEntered.value = it

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.sitecreation.sitename
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -56,7 +55,6 @@ class SiteCreationSiteNameViewModel @Inject constructor(
         uiState.value?.siteName.let {
             analyticsTracker.trackSiteNameEntered(it)
             if (it.isNullOrBlank()) return
-            Log.d("siteNameWip", "Site name entered: $it")
             _onSiteNameEntered.value = it
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModelTest.kt
@@ -10,7 +10,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
-import org.wordpress.android.util.LocaleManagerWrapper
 
 @RunWith(MockitoJUnitRunner::class)
 class SiteCreationSiteNameViewModelTest {
@@ -18,7 +17,6 @@ class SiteCreationSiteNameViewModelTest {
     @JvmField val rule = InstantTaskExecutorRule()
 
     @Mock lateinit var analyticsTracker: SiteCreationTracker
-    @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
     @Mock lateinit var dispatcher: CoroutineDispatcher
 
     private lateinit var viewModel: SiteCreationSiteNameViewModel

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModelTest.kt
@@ -1,0 +1,55 @@
+package org.wordpress.android.ui.sitecreation.sitename
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.CoroutineDispatcher
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
+import org.wordpress.android.util.LocaleManagerWrapper
+
+@RunWith(MockitoJUnitRunner::class)
+class SiteCreationSiteNameViewModelTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    @Mock lateinit var analyticsTracker: SiteCreationTracker
+    @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
+    @Mock lateinit var dispatcher: CoroutineDispatcher
+
+    private lateinit var viewModel: SiteCreationSiteNameViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = SiteCreationSiteNameViewModel(analyticsTracker, dispatcher)
+    }
+
+    @Test
+    fun `when the screen starts an analytics event is emitted`() {
+        viewModel.start()
+        verify(analyticsTracker).trackSiteNameViewed()
+    }
+
+    @Test
+    fun `when the skip button is pressed an analytics event is emitted`() {
+        viewModel.onSkipPressed()
+        verify(analyticsTracker).trackSiteNameSkipped()
+    }
+
+    @Test
+    fun `when the back button is pressed an analytics event is emitted`() {
+        viewModel.onBackPressed()
+        verify(analyticsTracker).trackSiteNameCanceled()
+    }
+
+    @Test
+    fun `when the the site name is entered an analytics event is emitted`() {
+        viewModel.onSiteNameChanged("site name")
+        viewModel.onSiteNameEntered()
+        verify(analyticsTracker).trackSiteNameEntered("site name")
+    }
+}


### PR DESCRIPTION
This is a continuation of https://github.com/wordpress-mobile/WordPress-Android/pull/16330. In order to work asynchronously, this is based on that PR and can be merged directly to that PR. cc: @ovitrif 

This PR adds tests for the tracking events, and completes the tracking implementation described in the "parent" PR.

To test:

Follow testing instructions on the base PR.