### PR TITLE
[Site Name] Turn the feature flag ON by default

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 19.7
 -----
+* [*] [internal] Site creation: Adds a new screen asking the user the name of the site []
 * [***] My Site: your My Site screen now has two tabs, "Site Menu" and "Home". Under "Home", you'll find contextual cards with some highlights of whats going on with your site. Check your drafts or scheduled posts, your today's stats or go directly to another section of the app. [https://github.com/wordpress-mobile/WordPress-Android/issues/15989]
 * [*] Site creation: Adds a new screen asking the user the intent of the site [https://github.com/wordpress-mobile/WordPress-Android/pull/16306]
 * [*] Notifications: Fixed notification detail crash for comments with File block [https://github.com/wordpress-mobile/WordPress-Android/pull/16314]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 19.7
 -----
-* [*] [internal] Site creation: Adds a new screen asking the user the name of the site []
+* [*] [internal] Site creation: Adds a new screen asking the user the name of the site [https://github.com/wordpress-mobile/WordPress-Android/pull/16259]
 * [***] My Site: your My Site screen now has two tabs, "Site Menu" and "Home". Under "Home", you'll find contextual cards with some highlights of whats going on with your site. Check your drafts or scheduled posts, your today's stats or go directly to another section of the app. [https://github.com/wordpress-mobile/WordPress-Android/issues/15989]
 * [*] Site creation: Adds a new screen asking the user the intent of the site [https://github.com/wordpress-mobile/WordPress-Android/pull/16306]
 * [*] Notifications: Fixed notification detail crash for comments with File block [https://github.com/wordpress-mobile/WordPress-Android/pull/16314]

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -119,7 +119,7 @@ android {
         buildConfigField "boolean", "COMMENTS_SNIPPET", "false"
         buildConfigField "boolean", "READER_COMMENTS_MODERATION", "false"
         buildConfigField "boolean", "SITE_INTENT_QUESTION", "true"
-        buildConfigField "boolean", "SITE_NAME", "false"
+        buildConfigField "boolean", "SITE_NAME", "true"
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS_NOTIFICATION", "false"


### PR DESCRIPTION
Fixes #16318

This PR enables the Site Name feature flag by default.

To test:

#### Verify that the feature is turned on by default



* Start with a fresh install (or clear all app data on the device)
* Log in with a user account
* Set that user account to be assigned the treatment variation in Abacus
  * Or alternatively, it may be convenient to manually hard-code a value for `true` for the ExPlat flag
* Navigate through the site creation flow: My Sites -> `+` -> Create WordPress.com site -> Choose an intent
* Expect the site name screen to appear after the intent screen

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
