### PR TITLE
My Site Dashboard: Adjust QS focus points for Stats and Pages

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -72,10 +72,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
             val onPagesClick: ListItemInteraction,
             val onPostsClick: ListItemInteraction,
             val onMediaClick: ListItemInteraction,
-            val showPages: Boolean = true,
-            val showStatsFocusPoint: Boolean = false,
-            val showPagesFocusPoint: Boolean = false
-        ) : Card(QUICK_ACTIONS_CARD, activeQuickStartItem = showStatsFocusPoint || showPagesFocusPoint)
+            val showPages: Boolean = true
+        ) : Card(QUICK_ACTIONS_CARD)
 
         data class QuickLinkRibbon(
             val quickLinkRibbonItems: List<QuickLinkRibbonItem>,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -76,15 +76,12 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         ) : Card(QUICK_ACTIONS_CARD)
 
         data class QuickLinkRibbon(
-            val quickLinkRibbonItems: List<QuickLinkRibbonItem>,
-            val showPagesFocusPoint: Boolean = false,
-            val showStatsFocusPoint: Boolean = false
-        ) : Card(QUICK_LINK_RIBBON, activeQuickStartItem = showPagesFocusPoint || showStatsFocusPoint) {
+            val quickLinkRibbonItems: List<QuickLinkRibbonItem>
+        ) : Card(QUICK_LINK_RIBBON) {
             data class QuickLinkRibbonItem(
                 @StringRes val label: Int,
                 @DrawableRes val icon: Int,
-                val onClick: ListItemInteraction,
-                val showFocusPoint: Boolean = false
+                val onClick: ListItemInteraction
             )
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -38,9 +38,7 @@ sealed class MySiteCardAndItemBuilderParams {
         val onPagesClick: () -> Unit,
         val onPostsClick: () -> Unit,
         val onMediaClick: () -> Unit,
-        val onStatsClick: () -> Unit,
-        val activeTask: QuickStartTask?,
-        val enableFocusPoints: Boolean = false
+        val onStatsClick: () -> Unit
     ) : MySiteCardAndItemBuilderParams()
 
     data class DomainRegistrationCardBuilderParams(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -27,12 +27,10 @@ sealed class MySiteCardAndItemBuilderParams {
 
     data class QuickActionsCardBuilderParams(
         val siteModel: SiteModel,
-        val activeTask: QuickStartTask?,
         val onQuickActionStatsClick: () -> Unit,
         val onQuickActionPagesClick: () -> Unit,
         val onQuickActionPostsClick: () -> Unit,
-        val onQuickActionMediaClick: () -> Unit,
-        val enableFocusPoints: Boolean = false
+        val onQuickActionMediaClick: () -> Unit
     ) : MySiteCardAndItemBuilderParams()
 
     data class QuickLinkRibbonBuilderParams(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -633,6 +633,7 @@ class MySiteViewModel @Inject constructor(
                 }
                 ListItemAction.POSTS -> SiteNavigationAction.OpenPosts(selectedSite)
                 ListItemAction.PAGES -> {
+                    quickStartRepository.requestNextStepOfTask(QuickStartTask.EDIT_HOMEPAGE)
                     quickStartRepository.completeTask(QuickStartTask.REVIEW_PAGES)
                     SiteNavigationAction.OpenPages(selectedSite)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -397,12 +397,10 @@ class MySiteViewModel @Inject constructor(
         val cardsResult = cardsBuilder.build(
                 QuickActionsCardBuilderParams(
                         siteModel = site,
-                        activeTask = activeTask,
                         onQuickActionStatsClick = this::quickActionStatsClick,
                         onQuickActionPagesClick = this::quickActionPagesClick,
                         onQuickActionPostsClick = this::quickActionPostsClick,
-                        onQuickActionMediaClick = this::quickActionMediaClick,
-                        enableFocusPoints = enableQuickActionCardFocusPoints()
+                        onQuickActionMediaClick = this::quickActionMediaClick
                 ),
                 DomainRegistrationCardBuilderParams(
                         isDomainCreditAvailable = isDomainCreditAvailable,
@@ -504,10 +502,6 @@ class MySiteViewModel @Inject constructor(
                         listOf()
                 )
         )
-    }
-
-    private fun enableQuickActionCardFocusPoints(): Boolean {
-        return defaultABExperimentTab != MySiteTabType.DASHBOARD
     }
 
     private fun enableQuickLinkRibbonFocusPoints(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -455,9 +455,7 @@ class MySiteViewModel @Inject constructor(
                         onPagesClick = this::onQuickLinkRibbonPagesClick,
                         onPostsClick = this::onQuickLinkRibbonPostsClick,
                         onMediaClick = this::onQuickLinkRibbonMediaClick,
-                        onStatsClick = this::onQuickLinkRibbonStatsClick,
-                        activeTask = activeTask,
-                        enableFocusPoints = enableQuickLinkRibbonFocusPoints()
+                        onStatsClick = this::onQuickLinkRibbonStatsClick
                 )
         )
         val dynamicCards = dynamicCardsBuilder.build(
@@ -502,10 +500,6 @@ class MySiteViewModel @Inject constructor(
                         listOf()
                 )
         )
-    }
-
-    private fun enableQuickLinkRibbonFocusPoints(): Boolean {
-        return defaultABExperimentTab == MySiteTabType.DASHBOARD
     }
 
     private fun getCardTypeExclusionFiltersForTab(tabType: MySiteTabType) = when (tabType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsCardBuilder.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.mysite.cards.quickactions
 
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.utils.ListItemInteraction
@@ -15,9 +14,6 @@ class QuickActionsCardBuilder @Inject constructor() {
             onPagesClick = ListItemInteraction.create(params.onQuickActionPagesClick),
             onPostsClick = ListItemInteraction.create(params.onQuickActionPostsClick),
             onMediaClick = ListItemInteraction.create(params.onQuickActionMediaClick),
-            showPages = params.siteModel.isSelfHostedAdmin || params.siteModel.hasCapabilityEditPages,
-            showStatsFocusPoint = params.activeTask == QuickStartTask.CHECK_STATS && params.enableFocusPoints,
-            showPagesFocusPoint = (params.activeTask == QuickStartTask.EDIT_HOMEPAGE ||
-                    params.activeTask == QuickStartTask.REVIEW_PAGES) && params.enableFocusPoints
+            showPages = params.siteModel.isSelfHostedAdmin || params.siteModel.hasCapabilityEditPages
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsViewHolder.kt
@@ -34,8 +34,5 @@ class QuickActionsViewHolder(
         val pagesVisibility = if (card.showPages) View.VISIBLE else View.GONE
         quickActionPagesButton.visibility = pagesVisibility
         quickActionPagesLabel.visibility = pagesVisibility
-
-        quickStartStatsFocusPoint.setVisibleOrGone(card.showStatsFocusPoint)
-        quickStartPagesFocusPoint.setVisibleOrGone(card.showPagesFocusPoint)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinkribbons/QuickLinkRibbonBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinkribbons/QuickLinkRibbonBuilder.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.mysite.cards.quicklinkribbons
 
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinkRibbon
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinkRibbon.QuickLinkRibbonItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickLinkRibbonBuilderParams
@@ -10,9 +9,7 @@ import javax.inject.Inject
 
 class QuickLinkRibbonBuilder @Inject constructor() {
     fun build(params: QuickLinkRibbonBuilderParams) = QuickLinkRibbon(
-        quickLinkRibbonItems = getQuickLinkRibbonItems(params),
-        showPagesFocusPoint = shouldShowPagesFocusPoint(params),
-        showStatsFocusPoint = shouldShowStatsFocusPoint(params)
+        quickLinkRibbonItems = getQuickLinkRibbonItems(params)
     )
 
     private fun getQuickLinkRibbonItems(params: QuickLinkRibbonBuilderParams): MutableList<QuickLinkRibbonItem> {
@@ -21,8 +18,7 @@ class QuickLinkRibbonBuilder @Inject constructor() {
             val pages = QuickLinkRibbonItem(
                 label = R.string.pages,
                 icon = R.drawable.ic_pages_white_24dp,
-                onClick = ListItemInteraction.create(params.onPagesClick),
-                showFocusPoint = shouldShowPagesFocusPoint(params)
+                onClick = ListItemInteraction.create(params.onPagesClick)
             )
             items.add(pages)
         }
@@ -46,20 +42,10 @@ class QuickLinkRibbonBuilder @Inject constructor() {
                 QuickLinkRibbonItem(
                     label = R.string.stats,
                     icon = R.drawable.ic_stats_alt_white_24dp,
-                    onClick = ListItemInteraction.create(params.onStatsClick),
-                    showFocusPoint = shouldShowStatsFocusPoint(params)
+                    onClick = ListItemInteraction.create(params.onStatsClick)
                 )
             )
         }
         return items
-    }
-
-    private fun shouldShowPagesFocusPoint(params: QuickLinkRibbonBuilderParams): Boolean {
-        return params.enableFocusPoints && (params.activeTask == QuickStartTask.EDIT_HOMEPAGE ||
-                params.activeTask == QuickStartTask.REVIEW_PAGES)
-    }
-
-    private fun shouldShowStatsFocusPoint(params: QuickLinkRibbonBuilderParams): Boolean {
-        return params.enableFocusPoints && params.activeTask == QuickStartTask.CHECK_STATS
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinkribbons/QuickLinkRibbonItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinkribbons/QuickLinkRibbonItemViewHolder.kt
@@ -14,6 +14,5 @@ class QuickLinkRibbonItemViewHolder(
         quickLinkItem.setText(item.label)
         quickLinkItem.setIconResource(item.icon)
         quickLinkItem.setOnClickListener { item.onClick.click() }
-        quickStartFocusPoint.setVisibleOrGone(item.showFocusPoint)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinkribbons/QuickLinkRibbonViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinkribbons/QuickLinkRibbonViewHolder.kt
@@ -31,12 +31,6 @@ class QuickLinkRibbonViewHolder(
     fun bind(quickLinkRibbon: QuickLinkRibbon) = with(binding) {
         setOnTouchItemListener()
         (quickLinkRibbonItemList.adapter as QuickLinkRibbonItemAdapter).update(quickLinkRibbon.quickLinkRibbonItems)
-        if (quickLinkRibbon.showStatsFocusPoint) {
-            quickLinkRibbonItemList.smoothScrollToPosition(quickLinkRibbon.quickLinkRibbonItems.size)
-        }
-        if (quickLinkRibbon.showPagesFocusPoint) {
-            quickLinkRibbonItemList.smoothScrollToPosition(0)
-        }
     }
 
     @SuppressLint("ClickableViewAccessibility")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -292,7 +292,10 @@ class QuickStartRepository
     private fun QuickStartTask.showInSiteMenu() = when (this) {
         QuickStartTask.VIEW_SITE,
         QuickStartTask.ENABLE_POST_SHARING,
-        QuickStartTask.EXPLORE_PLANS -> true
+        QuickStartTask.EXPLORE_PLANS,
+        QuickStartTask.CHECK_STATS,
+        QuickStartTask.REVIEW_PAGES,
+        QuickStartTask.EDIT_HOMEPAGE -> true
         else -> false
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -28,6 +28,7 @@ class SiteItemsBuilder @Inject constructor(
         null
     }
 
+    @Suppress("LongMethod")
     fun build(params: SiteItemsBuilderParams): List<MySiteCardAndItem> {
         val showViewSiteFocusPoint = params.activeTask == QuickStartTask.VIEW_SITE
         val showEnablePostSharingFocusPoint = params.activeTask == QuickStartTask.ENABLE_POST_SHARING

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -1,9 +1,7 @@
 package org.wordpress.android.ui.mysite.items
 
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_POST_SHARING
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EXPLORE_PLANS
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.VIEW_SITE
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.InfoItem
@@ -31,9 +29,12 @@ class SiteItemsBuilder @Inject constructor(
     }
 
     fun build(params: SiteItemsBuilderParams): List<MySiteCardAndItem> {
-        val showViewSiteFocusPoint = params.activeTask == VIEW_SITE
-        val showEnablePostSharingFocusPoint = params.activeTask == ENABLE_POST_SHARING
-        val showExplorePlansFocusPoint = params.activeTask == EXPLORE_PLANS
+        val showViewSiteFocusPoint = params.activeTask == QuickStartTask.VIEW_SITE
+        val showEnablePostSharingFocusPoint = params.activeTask == QuickStartTask.ENABLE_POST_SHARING
+        val showExplorePlansFocusPoint = params.activeTask == QuickStartTask.EXPLORE_PLANS
+        val showStatsFocusPoint = params.activeTask == QuickStartTask.CHECK_STATS
+        val showPagesFocusPoint = params.activeTask == QuickStartTask.EDIT_HOMEPAGE ||
+                params.activeTask == QuickStartTask.REVIEW_PAGES
 
         return listOfNotNull(
                 siteListItemBuilder.buildPlanItemIfAvailable(params.site, showExplorePlansFocusPoint, params.onClick),
@@ -41,7 +42,8 @@ class SiteItemsBuilder @Inject constructor(
                 ListItem(
                         R.drawable.ic_stats_alt_white_24dp,
                         UiStringRes(R.string.stats),
-                        onClick = ListItemInteraction.create(ListItemAction.STATS, params.onClick)
+                        onClick = ListItemInteraction.create(ListItemAction.STATS, params.onClick),
+                        showFocusPoint = showStatsFocusPoint
                 ),
                 siteListItemBuilder.buildActivityLogItemIfAvailable(params.site, params.onClick),
                 siteListItemBuilder.buildBackupItemIfAvailable(params.onClick, params.backupAvailable),
@@ -58,7 +60,7 @@ class SiteItemsBuilder @Inject constructor(
                         UiStringRes(R.string.media),
                         onClick = ListItemInteraction.create(ListItemAction.MEDIA, params.onClick)
                 ),
-                siteListItemBuilder.buildPagesItemIfAvailable(params.site, params.onClick),
+                siteListItemBuilder.buildPagesItemIfAvailable(params.site, params.onClick, showPagesFocusPoint),
                 ListItem(
                         R.drawable.ic_comment_white_24dp,
                         UiStringRes(R.string.my_site_btn_comments),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -108,12 +108,17 @@ class SiteListItemBuilder @Inject constructor(
         } else null
     }
 
-    fun buildPagesItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
+    fun buildPagesItemIfAvailable(
+        site: SiteModel,
+        onClick: (ListItemAction) -> Unit,
+        showFocusPoint: Boolean = false
+    ): ListItem? {
         return if (site.isSelfHostedAdmin || site.hasCapabilityEditPages) {
             ListItem(
                     R.drawable.ic_pages_white_24dp,
                     UiStringRes(R.string.my_site_btn_site_pages),
-                    onClick = ListItemInteraction.create(PAGES, onClick)
+                    onClick = ListItemInteraction.create(PAGES, onClick),
+                    showFocusPoint = showFocusPoint
             )
         } else null
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -111,7 +111,7 @@ class SiteListItemBuilder @Inject constructor(
     fun buildPagesItemIfAvailable(
         site: SiteModel,
         onClick: (ListItemAction) -> Unit,
-        showFocusPoint: Boolean = false
+        showFocusPoint: Boolean
     ): ListItem? {
         return if (site.isSelfHostedAdmin || site.hasCapabilityEditPages) {
             ListItem(

--- a/WordPress/src/main/res/layout/quick_actions_card.xml
+++ b/WordPress/src/main/res/layout/quick_actions_card.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/quick_actions_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -33,21 +32,6 @@
         app:layout_constraintEnd_toEndOf="@+id/quick_action_stats_button"
         app:layout_constraintStart_toStartOf="@+id/quick_action_stats_button"
         app:layout_constraintTop_toBottomOf="@+id/quick_action_stats_button" />
-
-    <org.wordpress.android.widgets.QuickStartFocusPoint
-        android:id="@+id/quick_start_stats_focus_point"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:contentDescription="@string/quick_start_focus_point_description"
-        android:elevation="@dimen/quick_start_focus_point_elevation"
-        app:layout_constraintBottom_toBottomOf="@+id/quick_action_stats_button"
-        app:layout_constraintEnd_toEndOf="@+id/quick_action_stats_button"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="@+id/quick_action_stats_button"
-        app:layout_constraintTop_toTopOf="@+id/quick_action_stats_button"
-        app:layout_constraintVertical_bias="0.0"
-        app:size="small"
-        tools:ignore="RtlSymmetry" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/quick_action_posts_button"
@@ -112,20 +96,5 @@
         app:layout_constraintEnd_toEndOf="@+id/quick_action_pages_button"
         app:layout_constraintStart_toStartOf="@+id/quick_action_pages_button"
         app:layout_constraintTop_toBottomOf="@+id/quick_action_pages_button" />
-
-    <org.wordpress.android.widgets.QuickStartFocusPoint
-        android:id="@+id/quick_start_pages_focus_point"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:contentDescription="@string/quick_start_focus_point_description"
-        android:elevation="@dimen/quick_start_focus_point_elevation"
-        app:layout_constraintBottom_toBottomOf="@+id/quick_action_pages_button"
-        app:layout_constraintEnd_toEndOf="@+id/quick_action_pages_button"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="@+id/quick_action_pages_button"
-        app:layout_constraintTop_toTopOf="@+id/quick_action_pages_button"
-        app:layout_constraintVertical_bias="0.0"
-        app:size="small"
-        tools:ignore="RtlSymmetry" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/quick_link_ribbon_item.xml
+++ b/WordPress/src/main/res/layout/quick_link_ribbon_item.xml
@@ -16,15 +16,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <org.wordpress.android.widgets.QuickStartFocusPoint
-        android:id="@+id/quick_start_focus_point"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:contentDescription="@string/quick_start_focus_point_description"
-        android:elevation="@dimen/quick_start_focus_point_elevation"
-        app:layout_constraintStart_toStartOf="@+id/quick_link_item"
-        app:layout_constraintTop_toTopOf="@+id/quick_link_item"
-        app:layout_constraintVertical_bias="0.0"
-        app:size="small" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2513,9 +2513,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 onPagesClick = ListItemInteraction.create { params.onQuickActionPagesClick.invoke() },
                 onPostsClick = ListItemInteraction.create { params.onQuickActionPostsClick.invoke() },
                 onMediaClick = ListItemInteraction.create { params.onQuickActionMediaClick.invoke() },
-                showPages = site.isSelfHostedAdmin || site.hasCapabilityEditPages,
-                showPagesFocusPoint = false,
-                showStatsFocusPoint = false
+                showPages = site.isSelfHostedAdmin || site.hasCapabilityEditPages
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2436,7 +2436,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private fun setUpCardsBuilder() {
         doAnswer {
             val quickActionsCard = initQuickActionsCard(it)
-            val quickLinkRibbons = initQuickLinkRibbons(it)
+            val quickLinkRibbon = initQuickLinkRibbon(it)
             val domainRegistrationCard = initDomainRegistrationCard(it)
             val quickStartCard = initQuickStartCard(it)
             val dashboardCards = initDashboardCards(it)
@@ -2449,7 +2449,7 @@ class MySiteViewModelTest : BaseUnitTest() {
             if (mySiteDashboardPhase2FeatureConfig.isEnabled())
                 listOfCards.add(dashboardCards)
             if (mySiteDashboardTabsFeatureConfig.isEnabled())
-                listOfCards.add(quickLinkRibbons)
+                listOfCards.add(quickLinkRibbon)
             listOfCards
         }.whenever(cardsBuilder).build(
                 quickActionsCardBuilderParams = any(),
@@ -2517,17 +2517,13 @@ class MySiteViewModelTest : BaseUnitTest() {
         )
     }
 
-    private fun initQuickLinkRibbons(mockInvocation: InvocationOnMock): QuickLinkRibbon {
+    private fun initQuickLinkRibbon(mockInvocation: InvocationOnMock): QuickLinkRibbon {
         val params = (mockInvocation.arguments.filterIsInstance<QuickLinkRibbonBuilderParams>()).first()
         quickLinkRibbonPagesClickAction = params.onPagesClick
         quickLinkRibbonPostsClickAction = params.onPostsClick
         quickLinkRibbonMediaClickAction = params.onMediaClick
         quickLinkRibbonStatsClickAction = params.onStatsClick
-        return QuickLinkRibbon(
-            quickLinkRibbonItems = mock(),
-            showStatsFocusPoint = false,
-            showPagesFocusPoint = false
-        )
+        return QuickLinkRibbon(quickLinkRibbonItems = mock())
     }
 
     private fun initDomainRegistrationCard(mockInvocation: InvocationOnMock) = DomainRegistrationCard(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
@@ -141,19 +140,19 @@ class CardsBuilderTest {
         assertThat(cards.findDashboardCards()).isNotNull
     }
 
-    /*  QUICK LINK RIBBONS */
+    /*  QUICK LINK RIBBON */
     @Test
     fun `given mySiteDashboardTabsFeatureConfig disabled, when cards are built, then quick link ribbon not built`() {
         val cards = buildCards(isMySiteDashboardPhase2FeatureConfigEnabled = false)
 
-        assertThat(cards.findQuickLinkRibbons()).isNull()
+        assertThat(cards.findQuickLinkRibbon()).isNull()
     }
 
     @Test
     fun `given mySiteDashboardTabsFeatureConfig enabled, when cards are built, then quick link ribbons built`() {
         val cards = buildCards(isMySiteTabsBuildConfigEnabled = true)
 
-        assertThat(cards.findQuickLinkRibbons()).isNotNull
+        assertThat(cards.findQuickLinkRibbon()).isNotNull
     }
 
     private fun List<MySiteCardAndItem>.findQuickActionsCard() =
@@ -166,11 +165,10 @@ class CardsBuilderTest {
     private fun List<MySiteCardAndItem>.findDomainRegistrationCard() =
             this.find { it is DomainRegistrationCard } as DomainRegistrationCard?
 
-    private fun List<MySiteCardAndItem>.findQuickLinkRibbons() =
+    private fun List<MySiteCardAndItem>.findQuickLinkRibbon() =
         this.find { it is QuickLinkRibbon } as QuickLinkRibbon?
 
     private fun buildCards(
-        activeTask: QuickStartTask? = null,
         isDomainCreditAvailable: Boolean = false,
         isQuickStartInProgress: Boolean = false,
         isQuickStartDynamicCardEnabled: Boolean = false,
@@ -208,8 +206,7 @@ class CardsBuilderTest {
                         onPagesClick = mock(),
                         onPostsClick = mock(),
                         onMediaClick = mock(),
-                        onStatsClick = mock(),
-                        activeTask = activeTask
+                        onStatsClick = mock()
                 )
         )
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -9,7 +9,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.invocation.InvocationOnMock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
@@ -184,7 +183,6 @@ class CardsBuilderTest {
         return cardsBuilder.build(
                 quickActionsCardBuilderParams = QuickActionsCardBuilderParams(
                         siteModel = site,
-                        activeTask = activeTask,
                         onQuickActionMediaClick = mock(),
                         onQuickActionPagesClick = mock(),
                         onQuickActionPostsClick = mock(),
@@ -218,7 +216,7 @@ class CardsBuilderTest {
 
     private fun setUpQuickActionsBuilder() {
         doAnswer {
-            initQuickActionsCard(it)
+            initQuickActionsCard()
         }.whenever(quickActionsCardBuilder).build(any())
     }
 
@@ -253,20 +251,14 @@ class CardsBuilderTest {
         )
     }
 
-    private fun initQuickActionsCard(mockInvocation: InvocationOnMock): QuickActionsCard {
-        val params = (mockInvocation.arguments.filterIsInstance<QuickActionsCardBuilderParams>()).first()
-        return QuickActionsCard(
-                title = UiStringText(""),
-                onStatsClick = mock(),
-                onPagesClick = mock(),
-                onPostsClick = mock(),
-                onMediaClick = mock(),
-                showPages = false,
-                showStatsFocusPoint = params.activeTask == QuickStartTask.CHECK_STATS,
-                showPagesFocusPoint = params.activeTask == QuickStartTask.EDIT_HOMEPAGE ||
-                        params.activeTask == QuickStartTask.REVIEW_PAGES
-        )
-    }
+    private fun initQuickActionsCard() = QuickActionsCard(
+            title = UiStringText(""),
+            onStatsClick = mock(),
+            onPagesClick = mock(),
+            onPostsClick = mock(),
+            onMediaClick = mock(),
+            showPages = false
+    )
 
     private fun initQuickStartCard() = QuickStartCard(
             title = UiStringText(""),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickactions/QuickActionsCardBuilderTest.kt
@@ -9,7 +9,6 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -49,58 +48,22 @@ class QuickActionsCardBuilderTest : BaseUnitTest() {
         assertThat(quickActionsCard.onMediaClick).isNotNull
     }
 
-    /* FOCUS POINT*/
-    @Test
-    fun `given stats active task, when card is built, then stats focus point should be true`() {
-        val quickActionsCard = buildQuickActionsCard(showStatsFocusPoint = true)
-
-        assertThat(quickActionsCard.showStatsFocusPoint).isEqualTo(true)
-    }
-
-    @Test
-    fun `given pages active task, when card is built, then pages focus point should be true`() {
-        val quickActionsCard = buildQuickActionsCard(showPagesFocusPoint = true)
-
-        assertThat(quickActionsCard.showPagesFocusPoint).isEqualTo(true)
-    }
-
-    @Test
-    fun `given enable focus point is false, when card is built, then active focus point should false`() {
-        val quickActionsCard = buildQuickActionsCard(showPagesFocusPoint = true, enableFocusPoints = false)
-
-        assertThat(quickActionsCard.showPagesFocusPoint).isEqualTo(false)
-        assertThat(quickActionsCard.activeQuickStartItem).isEqualTo(false)
-    }
-
     private fun buildQuickActionsCard(
-        showPages: Boolean = true,
-        showStatsFocusPoint: Boolean = false,
-        showPagesFocusPoint: Boolean = false,
-        enableFocusPoints: Boolean = true
+        showPages: Boolean = true
     ): QuickActionsCard {
         setShowPages(showPages)
         return builder.build(
             QuickActionsCardBuilderParams(
                 siteModel,
-                setActiveTask(showStatsFocusPoint, showPagesFocusPoint),
                 onStatsClick,
                 onPagesClick,
                 onPostsClick,
-                onMediaClick,
-                enableFocusPoints = enableFocusPoints
+                onMediaClick
             )
         )
     }
 
     private fun setShowPages(showPages: Boolean) {
         whenever(siteModel.isSelfHostedAdmin).thenReturn(showPages)
-    }
-
-    private fun setActiveTask(showStats: Boolean, showPages: Boolean): QuickStartTask? {
-        return when {
-            showStats -> QuickStartTask.CHECK_STATS
-            showPages -> QuickStartTask.EDIT_HOMEPAGE
-            else -> null
-        }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quicklinkribbons/QuickLinkRibbonBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quicklinkribbons/QuickLinkRibbonBuilderTest.kt
@@ -9,7 +9,6 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinkRibbon
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickLinkRibbonBuilderParams
 import org.wordpress.android.ui.utils.ListItemInteraction
@@ -50,37 +49,8 @@ class QuickLinkRibbonBuilderTest : BaseUnitTest() {
         assertThat(quickLinkRibbon.quickLinkRibbonItems[3].onClick).isEqualTo(ListItemInteraction.create(onStatsClick))
     }
 
-    /* FOCUS POINT*/
-    @Test
-    fun `given stats active task, when card is built, then stats focus point should be true`() {
-        val quickLinkRibbon = buildQuickLinkRibbon(showStatsFocusPoint = true)
-
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[3].showFocusPoint).isEqualTo(true)
-        assertThat(quickLinkRibbon.showStatsFocusPoint).isEqualTo(true)
-    }
-
-    @Test
-    fun `given pages active task, when card is built, then pages focus point should be true`() {
-        val quickLinkRibbon = buildQuickLinkRibbon(showPagesFocusPoint = true)
-
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[0].showFocusPoint).isEqualTo(true)
-        assertThat(quickLinkRibbon.showPagesFocusPoint).isEqualTo(true)
-    }
-
-    @Test
-    fun `given enable focus point is false, when card is built, then active focus point should false`() {
-        val quickLinkRibbon = buildQuickLinkRibbon(showPagesFocusPoint = true, enableFocusPoints = false)
-
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[0].showFocusPoint).isEqualTo(false)
-        assertThat(quickLinkRibbon.showPagesFocusPoint).isEqualTo(false)
-        assertThat(quickLinkRibbon.activeQuickStartItem).isEqualTo(false)
-    }
-
     private fun buildQuickLinkRibbon(
-        showPages: Boolean = true,
-        showPagesFocusPoint: Boolean = false,
-        showStatsFocusPoint: Boolean = false,
-        enableFocusPoints: Boolean = true
+        showPages: Boolean = true
     ): QuickLinkRibbon {
         setShowPages(showPages)
         return builder.build(
@@ -89,22 +59,12 @@ class QuickLinkRibbonBuilderTest : BaseUnitTest() {
                         onPagesClick,
                         onPostsClick,
                         onMediaClick,
-                        onStatsClick,
-                        setActiveTask(showPagesFocusPoint, showStatsFocusPoint),
-                        enableFocusPoints = enableFocusPoints
+                        onStatsClick
                 )
         )
     }
 
     private fun setShowPages(showPages: Boolean) {
         whenever(siteModel.isSelfHostedAdmin).thenReturn(showPages)
-    }
-
-    private fun setActiveTask(showPages: Boolean, showStats: Boolean): QuickStartStore.QuickStartTask? {
-        return when {
-            showPages -> QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
-            showStats -> QuickStartStore.QuickStartTask.CHECK_STATS
-            else -> null
-        }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -67,7 +67,10 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     private val siteMenuTasks = listOf(
             QuickStartTask.VIEW_SITE,
             QuickStartTask.ENABLE_POST_SHARING,
-            QuickStartTask.EXPLORE_PLANS
+            QuickStartTask.EXPLORE_PLANS,
+            QuickStartTask.CHECK_STATS,
+            QuickStartTask.REVIEW_PAGES,
+            QuickStartTask.EDIT_HOMEPAGE
     )
 
     private val nonSiteMenuTasks = QuickStartTask.values().subtract(siteMenuTasks)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
@@ -283,7 +283,7 @@ class SiteItemsBuilderTest {
                     siteListItemBuilder.buildPagesItemIfAvailable(
                             siteModel,
                             SITE_ITEM_ACTION,
-                            showPagesFocusPoint,
+                            showPagesFocusPoint
                     )
             ).thenReturn(
                     PAGES_ITEM.copy(showFocusPoint = showPagesFocusPoint)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
@@ -8,6 +8,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EXPLORE_PLANS
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.InfoItemBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteItemsBuilderParams
@@ -107,6 +109,8 @@ class SiteItemsBuilderTest {
         )
     }
 
+    /* QUICK START - FOCUS POINT */
+
     @Test
     fun `passes parameter to show focus point to plan item`() {
         val showPlansFocusPoint = true
@@ -121,6 +125,37 @@ class SiteItemsBuilderTest {
         )
 
         assertThat(buildSiteItems.first()).isEqualTo(PLAN_ITEM.copy(showFocusPoint = showPlansFocusPoint))
+    }
+
+    @Test
+    fun `passes parameter to show focus point to pages item`() {
+        val showPagesFocusPoint = true
+        setupHeaders(addPagesItem = true, showPagesFocusPoint = showPagesFocusPoint)
+
+        val buildSiteItems = siteItemsBuilder.build(
+                SiteItemsBuilderParams(
+                        site = siteModel,
+                        onClick = SITE_ITEM_ACTION,
+                        activeTask = EDIT_HOMEPAGE
+                )
+        )
+
+        assertThat(buildSiteItems).contains(PAGES_ITEM.copy(showFocusPoint = showPagesFocusPoint))
+    }
+
+    @Test
+    fun `passes parameter to show focus point to stats item`() {
+        setupHeaders()
+
+        val buildSiteItems = siteItemsBuilder.build(
+                SiteItemsBuilderParams(
+                        site = siteModel,
+                        onClick = SITE_ITEM_ACTION,
+                        activeTask = CHECK_STATS
+                )
+        )
+
+        assertThat(buildSiteItems).contains(STATS_ITEM.copy(showFocusPoint = true))
     }
 
     /* INFO ITEM */
@@ -194,7 +229,8 @@ class SiteItemsBuilderTest {
         addThemesItem: Boolean = false,
         addBackupItem: Boolean = false,
         addScanItem: Boolean = false,
-        showPlansFocusPoint: Boolean = false
+        showPlansFocusPoint: Boolean = false,
+        showPagesFocusPoint: Boolean = false
     ) {
         if (addJetpackHeader) {
             whenever(siteCategoryItemBuilder.buildJetpackCategoryIfAvailable(siteModel)).thenReturn(
@@ -243,8 +279,14 @@ class SiteItemsBuilderTest {
             )
         }
         if (addPagesItem) {
-            whenever(siteListItemBuilder.buildPagesItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
-                    PAGES_ITEM
+            whenever(
+                    siteListItemBuilder.buildPagesItemIfAvailable(
+                            siteModel,
+                            SITE_ITEM_ACTION,
+                            showPagesFocusPoint,
+                    )
+            ).thenReturn(
+                    PAGES_ITEM.copy(showFocusPoint = showPagesFocusPoint)
             )
         }
         if (addAdminItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
@@ -294,7 +294,7 @@ class SiteListItemBuilderTest {
     fun `pages item not built when not self-hosted admin and cannot edit pages`() {
         setupPagesItem(isSelfHostedAdmin = false, canEditPages = false)
 
-        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, SITE_ITEM_ACTION)
+        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, SITE_ITEM_ACTION, showFocusPoint = false)
 
         assertThat(item).isNull()
     }
@@ -302,19 +302,21 @@ class SiteListItemBuilderTest {
     @Test
     fun `pages item built when self-hosted admin`() {
         setupPagesItem(isSelfHostedAdmin = true)
+        val showFocusPoint = true
 
-        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, SITE_ITEM_ACTION)
+        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, SITE_ITEM_ACTION, showFocusPoint)
 
-        assertThat(item).isEqualTo(PAGES_ITEM)
+        assertThat(item).isEqualTo(PAGES_ITEM.copy(showFocusPoint = showFocusPoint))
     }
 
     @Test
     fun `pages item built when can edit pages`() {
         setupPagesItem(canEditPages = true)
+        val showFocusPoint = true
 
-        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, SITE_ITEM_ACTION)
+        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, SITE_ITEM_ACTION, showFocusPoint)
 
-        assertThat(item).isEqualTo(PAGES_ITEM)
+        assertThat(item).isEqualTo(PAGES_ITEM.copy(showFocusPoint = showFocusPoint))
     }
 
     private fun setupPagesItem(isSelfHostedAdmin: Boolean = false, canEditPages: Boolean = false) {


### PR DESCRIPTION
Parent #16301

This PR removes focus points for `Stats` and `Pages` from `Quick Links Card`, `Quick Links Ribbon`, and displays them on rows (similar to iOS).
Internal Ref: p1649763254844489/1649694944.738209-slack-C0290FLA0RM

/cc @tiagomar 

To test:

#### Test: QS Task: Edit your homepage

Prerequisite: Initial Tab: Home

1. Launch the app.
2. Select `Customize your site` in the `Next Steps` card.
3. Select `Edit your homepage`.
4. ❌ Notice that QS focus point is not shown on `Quick Links` -> `Pages`.
5. ✅ Notice that "Tap Menu to Continue" snackbar is shown with focus point on `Menu` tab.
6. Click `Menu` tab.
7. ✅ Notice that 
    - `Select pages to see your list` snackbar is shown
    - QS focus point is shown on `Pages` site item 
9. Click `Pages` list item.
10. ✅ Notice that QS focus point and snackbar is shown on the `Homepage` list item on `Pages` screen.

Repeat above steps for `Initial Tab: Menu` test skipping steps 5, 6 and confirm that focus points are displayed correctly on Stats and Pages list items.

#### Test: QS Task: Review site pages

Prerequisite: Initial Tab: Home

1. Launch the app.
2. Select `Customize your site` in the `Next Steps` card.
3. Select `Review site pages`.
4. ❌  Notice that QS focus point is not shown on `Quick Links` -> `Pages`.
5. ✅ Notice that "Tap Menu to Continue" snackbar is shown with focus point on `Menu` tab.
6. Click `Menu` tab.
7. ✅ Notice that 
    - `Select pages to see your list` snackbar is shown
    - QS focus point is shown on `Pages` site item 
9. Click `Pages` list item.
10. ✅ Notice that `Pages` screen is opened.

Repeat above steps for `Initial Tab: Menu` test skipping steps 5, 6 and confirm that focus points are displayed correctly on Stats and Pages list items.

#### Test: QS Task: Check your stats

Prerequisite: Initial Tab: Home

1. Launch the app.
2. Select `Grow your audience` in the `Next Steps` card.
3. Select `Check your stats.
4. ❌ Notice that QS focus point is not shown on `Quick Links` -> `Stats`.
5. ✅ Notice that "Tap Menu to Continue" snackbar is shown with focus point on `Menu` tab.
6. Click `Menu` tab.
7. ✅ Notice that 
    - `Tap Stats to see how your stats are performing.` snackbar is shown.
    - QS focus point is shown on `Stats` list item. 
9. Click `Stats` list item.
10. ✅ Notice that `Stats` screen is opened.

Repeat above steps for `Initial Tab: Menu` test skipping steps 5, 6 and confirm that focus points are displayed correctly on Stats and Pages list items.

#### Test: Without Tabs

- Disable the tabs feature from Debug Settings and restart the app.
- Repeat the above tests and confirm that focus points are displayed correctly on Stats and Pages list items. Note that `Site Menu Step` (step 5, 6 in tests) will not be shown when tabs are disabled.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.