### PR TITLE
[Site Name] Removes the username parameter from the site creation call

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
@@ -4,7 +4,6 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload
 import org.wordpress.android.fluxc.store.SiteStore.OnNewSiteCreated
@@ -23,8 +22,7 @@ import kotlin.coroutines.suspendCoroutine
 class CreateSiteUseCase @Inject constructor(
     private val dispatcher: Dispatcher,
     @Suppress("unused") private val siteStore: SiteStore,
-    private val urlUtilsWrapper: UrlUtilsWrapper,
-    private val accountStore: AccountStore
+    private val urlUtilsWrapper: UrlUtilsWrapper
 ) {
     private var continuation: Continuation<OnNewSiteCreated>? = null
 
@@ -54,7 +52,6 @@ class CreateSiteUseCase @Inject constructor(
         }
         return suspendCoroutine { cont ->
             val newSitePayload = NewSitePayload(
-                    accountStore.account.userName,
                     domain,
                     siteData.title,
                     languageWordPressId,

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
@@ -15,8 +15,6 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.annotations.action.Action
-import org.wordpress.android.fluxc.model.AccountModel
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload
 import org.wordpress.android.fluxc.store.SiteStore.OnNewSiteCreated
@@ -33,7 +31,6 @@ private val DUMMY_SITE_DATA: SiteCreationServiceData = SiteCreationServiceData(
         "domain",
         SITE_TITLE
 )
-private const val USERNAME = "username"
 private const val LANGUAGE_ID = "lang_id"
 private const val TIMEZONE_ID = "timezone_id"
 
@@ -45,16 +42,12 @@ class CreateSiteUseCaseTest {
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var store: SiteStore
     @Mock private lateinit var urlUtilsWrapper: UrlUtilsWrapper
-    @Mock private lateinit var accountStore: AccountStore
-    @Mock lateinit var accountModel: AccountModel
     private lateinit var useCase: CreateSiteUseCase
     private lateinit var event: OnNewSiteCreated
 
     @Before
     fun setUp() {
-        whenever(accountStore.account).thenReturn(accountModel)
-        whenever(accountModel.userName).thenReturn(USERNAME)
-        useCase = CreateSiteUseCase(dispatcher, store, urlUtilsWrapper, accountStore)
+        useCase = CreateSiteUseCase(dispatcher, store, urlUtilsWrapper)
         event = OnNewSiteCreated(newSiteRemoteId = 123)
     }
 
@@ -80,7 +73,6 @@ class CreateSiteUseCaseTest {
         assertThat(payload.siteName).isEqualTo(DUMMY_SITE_DATA.domain)
         assertThat(payload.segmentId).isEqualTo(DUMMY_SITE_DATA.segmentId)
         assertThat(payload.siteTitle).isEqualTo(SITE_TITLE)
-        assertThat(payload.username).isEqualTo(USERNAME)
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     androidxWorkVersion = "2.7.0"
 
     daggerVersion = '2.41'
-    fluxCVersion = '2363-cd79ffabce89ceba5437795aec0592020ec4a000'
+    fluxCVersion = 'trunk-d49cf4e9d716af757b1c7044a0f786d3015d491e'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     androidxWorkVersion = "2.7.0"
 
     daggerVersion = '2.41'
-    fluxCVersion = 'trunk-2af6fd589b99606ffc0ef216e7c58a63a2944903'
+    fluxCVersion = '2363-cd79ffabce89ceba5437795aec0592020ec4a000'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2363

# Description 
This PR removes the username parameter from the site creation call (introduced with https://github.com/wordpress-mobile/WordPress-Android/pull/16278)

# To test
Validate that the tests on https://github.com/wordpress-mobile/WordPress-Android/pull/16278 pass

### Site name with invalid characters
<details>
<summary>Toggle the Site Name feature</summary>

Since this feature is A/B tested go to **Abacus**, find the `wpandroid_site_name_v1` experiment and assign to your test a8c-user the treatment variation

**Alternatively hardcode the feature on by returning `true` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/521e6b3a296339bec026f8ee2648eab326d31129/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt#L19)** 
</details>

### Site name skipped
1. Toggle the Site Name feature
2. Start the Site Creation flow
3. Choose an intent for your site
4. Verify that the Site Name screen is shown
5. Press the Skip button
6. Select a design or skip
7. Verify that the Domain screen is NOT shown
8. Verify that the site is created with a `*.wordpress.com` domain starting with your `site` ( e.g. site131331.wordpress.com)

#### Invalid site name
1. Toggle the Site Name feature
2. Start the Site Creation flow
3. Choose an intent for your site
4. Verify that the Site Name screen is shown
5. Enter an invalid site name (e.g. `...$` or `Αντώνης`) and press continue
6. Select a design or skip
7. Verify that the site is created with a `*.wordpress.com` domain starting with your `site` ( e.g. site131331.wordpress.com)

### Site name entered
1. Toggle the Site Name feature 
2. Start the Site Creation flow
3. Choose an intent for your site
4. Verify that the Site Name screen is shown
5. Entered your desired site name and press continue (e.g. My Site Name is Awesome)
6. Select a design or skip
7. Verify that the Domain screen is NOT shown
8. Verify that the site is created with a `*.wordpress.com` domain starting with name provided in 5 ( e.g. mysitenameisawesome) and possibly followed by a random number if the domain is used ( e.g. mysitenameisawesome13235)

### Current/Control flow
1. Toggle the **Site Name** feature **OFF** 
2. Start the Site Creation flow
3. Verify that the Site Name screen is NOT shown
4. Select a design or skip
5. Verify that the Domain screen is shown
6. Search and select a domain and press continue
7. Verify that the site is created with the desired domain

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Modified existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
