### PR TITLE
My Site Dashboard - Hide the Quick Actions under Site menu for users to default tab variant

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -456,7 +456,8 @@ class MySiteViewModel @Inject constructor(
                         onPostsClick = this::onQuickLinkRibbonPostsClick,
                         onMediaClick = this::onQuickLinkRibbonMediaClick,
                         onStatsClick = this::onQuickLinkRibbonStatsClick
-                )
+                ),
+                isMySiteTabsEnabled
         )
         val dynamicCards = dynamicCardsBuilder.build(
                 quickStartCategories,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.ui.mysite.cards.dashboard.CardsBuilder
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
 import org.wordpress.android.ui.mysite.cards.quicklinkribbons.QuickLinkRibbonBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
+import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
@@ -27,20 +28,22 @@ class CardsBuilder @Inject constructor(
     private val quickLinkRibbonBuilder: QuickLinkRibbonBuilder,
     private val dashboardCardsBuilder: CardsBuilder,
     private val mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig,
-    private val mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
+    private val mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig,
+    private val mySiteDefaultTabExperiment: MySiteDefaultTabExperiment
 ) {
     fun build(
         quickActionsCardBuilderParams: QuickActionsCardBuilderParams,
         domainRegistrationCardBuilderParams: DomainRegistrationCardBuilderParams,
         quickStartCardBuilderParams: QuickStartCardBuilderParams,
         dashboardCardsBuilderParams: DashboardCardsBuilderParams,
-        quickLinkRibbonsBuilderParams: QuickLinkRibbonBuilderParams
+        quickLinkRibbonsBuilderParams: QuickLinkRibbonBuilderParams,
+        isMySiteTabsEnabled: Boolean
     ): List<MySiteCardAndItem> {
         val cards = mutableListOf<MySiteCardAndItem>()
         if (mySiteDashboardTabsFeatureConfig.isEnabled()) {
             cards.add(quickLinkRibbonBuilder.build(quickLinkRibbonsBuilderParams))
         }
-        if (buildConfigWrapper.isQuickActionEnabled) {
+        if (shouldShowQuickActionsCard(isMySiteTabsEnabled)) {
             cards.add(quickActionsCardBuilder.build(quickActionsCardBuilderParams))
         }
         if (domainRegistrationCardBuilderParams.isDomainCreditAvailable) {
@@ -55,6 +58,13 @@ class CardsBuilder @Inject constructor(
             cards.add(dashboardCardsBuilder.build(dashboardCardsBuilderParams))
         }
         return cards
+    }
+
+    private fun shouldShowQuickActionsCard(isMySiteTabsEnabled: Boolean): Boolean {
+        val isDefaultTabVariantAssignedInExperiment =
+                mySiteDefaultTabExperiment.isExperimentRunning() && mySiteDefaultTabExperiment.isVariantAssigned()
+        return buildConfigWrapper.isQuickActionEnabled &&
+                (!isMySiteTabsEnabled || !isDefaultTabVariantAssignedInExperiment)
     }
 
     private fun trackAndBuildDomainRegistrationCard(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -44,10 +44,10 @@ class MySiteDefaultTabExperiment @Inject constructor(
         }
     }
 
-    private fun isExperimentRunning() =
+    fun isExperimentRunning() =
             mySiteDashboardTabsFeatureConfig.isEnabled() && mySiteDefaultTabExperimentFeatureConfig.isEnabled()
 
-    private fun isVariantAssigned() = appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()
+    fun isVariantAssigned() = appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()
 
     private fun setVariantAssigned() = appPrefsWrapper.setMySiteDefaultTabExperimentVariantAssigned()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1379,6 +1379,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 argWhere {
                     it.bloggingPromptCardBuilderParams.bloggingPrompt != null
                 },
+                any(),
                 any()
         )
     }
@@ -1394,6 +1395,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 argWhere {
                     it.bloggingPromptCardBuilderParams.bloggingPrompt == null
                 },
+                any(),
                 any()
         )
     }
@@ -2456,7 +2458,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 domainRegistrationCardBuilderParams = any(),
                 quickStartCardBuilderParams = any(),
                 dashboardCardsBuilderParams = any(),
-                quickLinkRibbonsBuilderParams = any()
+                quickLinkRibbonsBuilderParams = any(),
+                isMySiteTabsEnabled = any()
         )
 
         doAnswer {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilde
 import org.wordpress.android.ui.mysite.cards.quicklinkribbons.QuickLinkRibbonBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
+import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.BuildConfigWrapper
@@ -50,6 +51,7 @@ class CardsBuilderTest {
     @Mock lateinit var site: SiteModel
     @Mock lateinit var mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig
     @Mock lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
+    @Mock lateinit var mySiteDefaultTabExperiment: MySiteDefaultTabExperiment
 
     private lateinit var cardsBuilder: CardsBuilder
     private val quickStartCategory: QuickStartCategory
@@ -86,17 +88,44 @@ class CardsBuilderTest {
     /* QUICK ACTIONS CARD */
 
     @Test
-    fun `when quick action enabled, then quick action card is built`() {
-        whenever(buildConfigWrapper.isQuickActionEnabled).thenReturn(true)
-        val cards = buildCards()
+    fun `given quick action enabled + tabs disabled, when cards built, then quick actions card is built`() {
+        val cards = buildCards(isQuickActionEnabled = true, isMySiteTabsEnabled = false)
 
         assertThat(cards.findQuickActionsCard()).isNotNull
     }
 
     @Test
-    fun `when quick action disabled, then quick action card is not built`() {
-        whenever(buildConfigWrapper.isQuickActionEnabled).thenReturn(false)
-        val cards = buildCards()
+    fun `given quick action disabled, when cards built, then quick actions card is not built`() {
+        val cards = buildCards(isQuickActionEnabled = false)
+
+        assertThat(cards.findQuickActionsCard()).isNull()
+    }
+
+    @Test
+    fun `given tabs enabled + experiment not running, when cards built, then quick actions card is built`() {
+        val cards = buildCards(isMySiteTabsEnabled = true, isDefaultTabExperimentRunning = false)
+
+        assertThat(cards.findQuickActionsCard()).isNotNull
+    }
+
+    @Test
+    fun `given tabs enabled + experiment running + variant not assigned, when cards built, then quick actions built`() {
+        val cards = buildCards(
+                isMySiteTabsEnabled = true,
+                isDefaultTabExperimentRunning = true,
+                isDefaultTabVariantAssigned = false
+        )
+
+        assertThat(cards.findQuickActionsCard()).isNotNull
+    }
+
+    @Test
+    fun `given tabs enabled + experiment running + variant assigned, when cards built, then quick actions not built`() {
+        val cards = buildCards(
+                isMySiteTabsEnabled = true,
+                isDefaultTabExperimentRunning = true,
+                isDefaultTabVariantAssigned = true
+        )
 
         assertThat(cards.findQuickActionsCard()).isNull()
     }
@@ -150,7 +179,7 @@ class CardsBuilderTest {
 
     @Test
     fun `given mySiteDashboardTabsFeatureConfig enabled, when cards are built, then quick link ribbons built`() {
-        val cards = buildCards(isMySiteTabsBuildConfigEnabled = true)
+        val cards = buildCards(isMySiteTabsEnabled = true)
 
         assertThat(cards.findQuickLinkRibbon()).isNotNull
     }
@@ -169,15 +198,21 @@ class CardsBuilderTest {
         this.find { it is QuickLinkRibbon } as QuickLinkRibbon?
 
     private fun buildCards(
+        isQuickActionEnabled: Boolean = true,
         isDomainCreditAvailable: Boolean = false,
         isQuickStartInProgress: Boolean = false,
         isQuickStartDynamicCardEnabled: Boolean = false,
         isMySiteDashboardPhase2FeatureConfigEnabled: Boolean = false,
-        isMySiteTabsBuildConfigEnabled: Boolean = false
+        isMySiteTabsEnabled: Boolean = false,
+        isDefaultTabExperimentRunning: Boolean = false,
+        isDefaultTabVariantAssigned: Boolean = false
     ): List<MySiteCardAndItem> {
+        whenever(buildConfigWrapper.isQuickActionEnabled).thenReturn(isQuickActionEnabled)
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(isQuickStartDynamicCardEnabled)
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(isMySiteDashboardPhase2FeatureConfigEnabled)
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteTabsBuildConfigEnabled)
+        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteTabsEnabled)
+        whenever(mySiteDefaultTabExperiment.isExperimentRunning()).thenReturn(isDefaultTabExperimentRunning)
+        whenever(mySiteDefaultTabExperiment.isVariantAssigned()).thenReturn(isDefaultTabVariantAssigned)
         return cardsBuilder.build(
                 quickActionsCardBuilderParams = QuickActionsCardBuilderParams(
                         siteModel = site,
@@ -207,7 +242,8 @@ class CardsBuilderTest {
                         onPostsClick = mock(),
                         onMediaClick = mock(),
                         onStatsClick = mock()
-                )
+                ),
+                isMySiteTabsEnabled
         )
     }
 
@@ -244,7 +280,8 @@ class CardsBuilderTest {
                 quickLinkRibbonBuilder,
                 dashboardCardsBuilder,
                 mySiteDashboardPhase2FeatureConfig,
-                mySiteDashboardTabsFeatureConfig
+                mySiteDashboardTabsFeatureConfig,
+                mySiteDefaultTabExperiment
         )
     }
 


### PR DESCRIPTION
Closes #16301

This PR hides the Quick Actions under Site Menu for users that are assigned to Site menu or Dashboard AB Experiment variant.

/cc @tiagomar 

Corresponding iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/18344

To test:

#### Test: Tabs feature disabled

Prerequisite: Disable tabs feature from Debug settings and restart the app.

1. Launch the app.
2. ✅ Notice that Quick Actions card is shown on `My Site` tab.

#### Tests: Tabs feature enabled

Prerequisite: Enable tabs feature from Debug settings and restart the app.

##### Test1: Experiment not running

1. Set `MySiteDefaultTabExperiment.isExperimentRunning` to false
2. Install the app 
3. Go to Menu tab
4. ✅ Notice that Quick Actions card is shown

##### Test2: Experiment running, variant not assigned

1. Set `MySiteDefaultTabExperiment.isExperimentRunning` to true
2. Set `MySiteDefaultTabExperiment.isVariantAssigned` to false
3. Install the app 
4. Go to Menu tab
5. ✅ Notice that Quick Actions card is shown

##### Test3: Experiment running, variant assigned

1. Set `MySiteDefaultTabExperiment.isExperimentRunning` to true
2. Set `MySiteDefaultTabExperiment.isVariantAssigned` to true
3. Install the app 
4. Go to Menu tab
5. ❌ Notice that Quick Actions card is not shown


https://user-images.githubusercontent.com/1405144/163569587-c8bcd923-a351-4ec8-8621-5b51a531386f.mp4


Revert all local code changes.

## Regression Notes
1. Potential unintended areas of impact
Quick Actions card is shown to users that are assigned to Site menu or Dashboard variant.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually + added unit tests.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for displaying Quick Actions card based on new conditions.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
