### PR TITLE
My Site Dashboard: Hide tabs for self hosted sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -53,9 +53,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     private var binding: MySiteFragmentBinding? = null
     private var siteTitle: String? = null
-    private var tabLayoutMediator: TabLayoutMediator? = null
-    private val isTabMediatorAttached: Boolean
-        get() = tabLayoutMediator?.isAttached == true
 
     private val viewPagerCallback = object : ViewPager2.OnPageChangeCallback() {
         override fun onPageSelected(position: Int) {
@@ -146,8 +143,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     private fun MySiteFragmentBinding.setupViewPager() {
-        val adapter = MySiteTabsAdapter(this@MySiteFragment, viewModel.orderedTabTypes)
-        viewPager.adapter = adapter
         viewPager.registerOnPageChangeCallback(viewPagerCallback)
     }
 
@@ -266,13 +261,15 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         header.visibility = if (visibility) View.VISIBLE else View.INVISIBLE
     }
 
-    private fun MySiteFragmentBinding.attachTabLayoutMediator(state: TabsUiState) {
-        tabLayoutMediator = TabLayoutMediator(tabLayout, viewPager, MySiteTabConfigurationStrategy(state.tabUiStates))
-        tabLayoutMediator?.attach()
+    private fun MySiteFragmentBinding.updateViewPagerAdapterAndMediatorIfNeeded(state: TabsUiState) {
+        if (viewPager.adapter == null || state.shouldUpdateViewPager) {
+            viewPager.adapter = MySiteTabsAdapter(this@MySiteFragment, state.tabUiStates)
+            TabLayoutMediator(tabLayout, viewPager, MySiteTabConfigurationStrategy(state.tabUiStates)).attach()
+        }
     }
 
     private fun MySiteFragmentBinding.updateTabs(state: TabsUiState) {
-        if (!isTabMediatorAttached) attachTabLayoutMediator(state)
+        updateViewPagerAdapterAndMediatorIfNeeded(state)
         state.tabUiStates.forEachIndexed { index, tabUiState ->
             val tab = tabLayout.getTabAt(index) as TabLayout.Tab
             updateTab(tab, tabUiState)
@@ -347,8 +344,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
-        tabLayoutMediator?.detach()
-        tabLayoutMediator = null
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -177,7 +177,7 @@ class MySiteViewModel @Inject constructor(
     val isMySiteTabsEnabled: Boolean
         get() = mySiteDashboardTabsFeatureConfig.isEnabled() &&
                 buildConfigWrapper.isMySiteTabsEnabled &&
-                selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi == true
+                selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi ?: true
 
     val orderedTabTypes: List<MySiteTabType>
         get() = if (isMySiteTabsEnabled) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1220,7 +1220,8 @@ class MySiteViewModel @Inject constructor(
 
     data class TabsUiState(
         val showTabs: Boolean = false,
-        val tabUiStates: List<TabUiState>
+        val tabUiStates: List<TabUiState>,
+        val shouldUpdateViewPager: Boolean = false
     ) {
         data class TabUiState(
             val label: UiString,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -175,7 +175,9 @@ class MySiteViewModel @Inject constructor(
     private var isSiteSelected = false
 
     val isMySiteTabsEnabled: Boolean
-        get() = mySiteDashboardTabsFeatureConfig.isEnabled() && buildConfigWrapper.isMySiteTabsEnabled
+        get() = mySiteDashboardTabsFeatureConfig.isEnabled() &&
+                buildConfigWrapper.isMySiteTabsEnabled &&
+                selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi == true
 
     val orderedTabTypes: List<MySiteTabType>
         get() = if (isMySiteTabsEnabled) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
-import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import javax.inject.Inject
 
@@ -28,7 +27,6 @@ class CardsBuilder @Inject constructor(
     private val quickLinkRibbonBuilder: QuickLinkRibbonBuilder,
     private val dashboardCardsBuilder: CardsBuilder,
     private val mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig,
-    private val mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig,
     private val mySiteDefaultTabExperiment: MySiteDefaultTabExperiment
 ) {
     fun build(
@@ -40,7 +38,7 @@ class CardsBuilder @Inject constructor(
         isMySiteTabsEnabled: Boolean
     ): List<MySiteCardAndItem> {
         val cards = mutableListOf<MySiteCardAndItem>()
-        if (mySiteDashboardTabsFeatureConfig.isEnabled()) {
+        if (isMySiteTabsEnabled) {
             cards.add(quickLinkRibbonBuilder.build(quickLinkRibbonsBuilderParams))
         }
         if (shouldShowQuickActionsCard(isMySiteTabsEnabled)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -84,7 +84,7 @@ class QuickStartRepository
     private var _isQuickStartNoticeShown: Boolean = false
     private val isMySiteTabsEnabled = mySiteDashboardTabsFeatureConfig.isEnabled() &&
             buildConfigWrapper.isMySiteTabsEnabled &&
-            selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi == true
+            selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi ?: true
     val onSnackbar = _onSnackbar as LiveData<Event<SnackbarMessageHolder>>
     val onQuickStartMySitePrompts = _onQuickStartMySitePrompts as LiveData<Event<QuickStartMySitePrompts>>
     val onQuickStartSiteMenuStep = _onQuickStartSiteMenuStep as LiveData<QuickStartSiteMenuStep?>

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -82,8 +82,9 @@ class QuickStartRepository
     private val _onQuickStartMySitePrompts = MutableLiveData<Event<QuickStartMySitePrompts>>()
     private val _onQuickStartSiteMenuStep = MutableLiveData<QuickStartSiteMenuStep?>()
     private var _isQuickStartNoticeShown: Boolean = false
-    private val isMySiteTabsEnabled =
-            mySiteDashboardTabsFeatureConfig.isEnabled() && buildConfigWrapper.isMySiteTabsEnabled
+    private val isMySiteTabsEnabled = mySiteDashboardTabsFeatureConfig.isEnabled() &&
+            buildConfigWrapper.isMySiteTabsEnabled &&
+            selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi == true
     val onSnackbar = _onSnackbar as LiveData<Event<SnackbarMessageHolder>>
     val onQuickStartMySitePrompts = _onQuickStartMySitePrompts as LiveData<Event<QuickStartMySitePrompts>>
     val onQuickStartSiteMenuStep = _onQuickStartSiteMenuStep as LiveData<QuickStartSiteMenuStep?>

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabsAdapter.kt
@@ -2,12 +2,13 @@ package org.wordpress.android.ui.mysite.tabs
 
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import org.wordpress.android.ui.mysite.MySiteViewModel.TabsUiState.TabUiState
 
 class MySiteTabsAdapter(
     parent: Fragment,
-    private val orderedTabTypes: List<MySiteTabType>
+    private val tabUiStates: List<TabUiState>
 ) : FragmentStateAdapter(parent) {
-    override fun getItemCount(): Int = orderedTabTypes.size
+    override fun getItemCount(): Int = tabUiStates.size
 
-    override fun createFragment(position: Int) = MySiteTabFragment.newInstance(orderedTabTypes[position])
+    override fun createFragment(position: Int) = MySiteTabFragment.newInstance(tabUiStates[position].tabType)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -884,7 +884,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.setIsJetpackInstalled(false)
         site.setIsJetpackConnected(false)
 
-        initSelectedSite()
+        initSelectedSite(isSiteUsingWpComRestApi = false)
 
         requireNotNull(quickActionsStatsClickAction).invoke()
 
@@ -912,7 +912,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.setIsJetpackInstalled(false)
         site.setIsJetpackConnected(false)
 
-        initSelectedSite()
+        initSelectedSite(isSiteUsingWpComRestApi = false)
 
         requireNotNull(quickActionsStatsClickAction).invoke()
 
@@ -1610,8 +1610,9 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(accountStore.hasAccessToken()).thenReturn(false)
         site.setIsJetpackConnected(false)
         site.setIsWPCom(false)
+        site.origin = SiteModel.ORIGIN_XMLRPC
 
-        invokeItemClickAction(ListItemAction.STATS)
+        invokeItemClickAction(ListItemAction.STATS, isSiteUsingWpComRestApi = false)
 
         assertThat(navigationActions).containsExactly(SiteNavigationAction.ConnectJetpackForStats(site))
     }
@@ -2301,7 +2302,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         site.setIsJetpackInstalled(false)
         site.setIsJetpackConnected(false)
 
-        initSelectedSite(isMySiteDashboardTabsFeatureFlagEnabled = true)
+        initSelectedSite(isMySiteDashboardTabsFeatureFlagEnabled = true, isSiteUsingWpComRestApi = false)
 
         requireNotNull(quickLinkRibbonStatsClickAction).invoke()
 
@@ -2394,7 +2395,10 @@ class MySiteViewModelTest : BaseUnitTest() {
         }
     }
 
-    private fun invokeItemClickAction(action: ListItemAction) {
+    private fun invokeItemClickAction(
+        action: ListItemAction,
+        isSiteUsingWpComRestApi: Boolean = true
+    ) {
         var clickAction: ((ListItemAction) -> Unit)? = null
         doAnswer {
             val params = (it.arguments.filterIsInstance<SiteItemsBuilderParams>()).first()
@@ -2402,7 +2406,7 @@ class MySiteViewModelTest : BaseUnitTest() {
             listOf<MySiteCardAndItem>()
         }.whenever(siteItemsBuilder).build(any<SiteItemsBuilderParams>())
 
-        initSelectedSite()
+        initSelectedSite(isSiteUsingWpComRestApi = isSiteUsingWpComRestApi)
 
         assertThat(clickAction).isNotNull
         clickAction!!.invoke(action)
@@ -2414,7 +2418,8 @@ class MySiteViewModelTest : BaseUnitTest() {
         isQuickStartDynamicCardEnabled: Boolean = false,
         isQuickStartInProgress: Boolean = false,
         showStaleMessage: Boolean = false,
-        initialScreen: String = MySiteTabType.SITE_MENU.label
+        initialScreen: String = MySiteTabType.SITE_MENU.label,
+        isSiteUsingWpComRestApi: Boolean = true
     ) {
         setUpDynamicCardsBuilder(isQuickStartDynamicCardEnabled)
         whenever(
@@ -2426,6 +2431,11 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsFeatureFlagEnabled)
         whenever(buildConfigWrapper.isMySiteTabsEnabled).thenReturn(isMySiteTabsBuildConfigEnabled)
         whenever(appPrefsWrapper.getMySiteInitialScreen()).thenReturn(initialScreen)
+        if (isSiteUsingWpComRestApi) {
+            site.setIsWPCom(true)
+            site.setIsJetpackConnected(true)
+            site.origin = SiteModel.ORIGIN_WPCOM_REST
+        }
         onSiteSelected.value = siteLocalId
         onSiteChange.value = site
         selectedSite.value = SelectedSite(site)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -448,7 +448,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given site using wpcom rest api, when site is selected, then tabs are not visible`() {
+    fun `given site using wpcom rest api, when site is selected, then tabs are visible`() {
         initSelectedSite(
                 isMySiteDashboardTabsFeatureFlagEnabled = true,
                 isMySiteTabsBuildConfigEnabled = true,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -435,6 +435,30 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given site not using wpcom rest api, when site is selected, then tabs are not visible`() {
+        site.setIsJetpackConnected(false)
+
+        initSelectedSite(
+                isMySiteDashboardTabsFeatureFlagEnabled = true,
+                isMySiteTabsBuildConfigEnabled = true,
+                isSiteUsingWpComRestApi = false
+        )
+
+        assertThat((uiModels.last().state as SiteSelected).tabsUiState.showTabs).isFalse
+    }
+
+    @Test
+    fun `given site using wpcom rest api, when site is selected, then tabs are not visible`() {
+        initSelectedSite(
+                isMySiteDashboardTabsFeatureFlagEnabled = true,
+                isMySiteTabsBuildConfigEnabled = true,
+                isSiteUsingWpComRestApi = true
+        )
+
+        assertThat((uiModels.last().state as SiteSelected).tabsUiState.showTabs).isTrue()
+    }
+
+    @Test
     fun `given my site tabs build, when site is selected, then site header is visible`() {
         initSelectedSite()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -36,7 +36,6 @@ import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
-import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsBuilder as DashboardCardsBuilder
 
@@ -50,7 +49,6 @@ class CardsBuilderTest {
     @Mock lateinit var quickLinkRibbonBuilder: QuickLinkRibbonBuilder
     @Mock lateinit var site: SiteModel
     @Mock lateinit var mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig
-    @Mock lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
     @Mock lateinit var mySiteDefaultTabExperiment: MySiteDefaultTabExperiment
 
     private lateinit var cardsBuilder: CardsBuilder
@@ -210,7 +208,6 @@ class CardsBuilderTest {
         whenever(buildConfigWrapper.isQuickActionEnabled).thenReturn(isQuickActionEnabled)
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(isQuickStartDynamicCardEnabled)
         whenever(mySiteDashboardPhase2FeatureConfig.isEnabled()).thenReturn(isMySiteDashboardPhase2FeatureConfigEnabled)
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteTabsEnabled)
         whenever(mySiteDefaultTabExperiment.isExperimentRunning()).thenReturn(isDefaultTabExperimentRunning)
         whenever(mySiteDefaultTabExperiment.isVariantAssigned()).thenReturn(isDefaultTabVariantAssigned)
         return cardsBuilder.build(
@@ -280,7 +277,6 @@ class CardsBuilderTest {
                 quickLinkRibbonBuilder,
                 dashboardCardsBuilder,
                 mySiteDashboardPhase2FeatureConfig,
-                mySiteDashboardTabsFeatureConfig,
                 mySiteDefaultTabExperiment
         )
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -169,14 +169,14 @@ class CardsBuilderTest {
 
     /*  QUICK LINK RIBBON */
     @Test
-    fun `given mySiteDashboardTabsFeatureConfig disabled, when cards are built, then quick link ribbon not built`() {
-        val cards = buildCards(isMySiteDashboardPhase2FeatureConfigEnabled = false)
+    fun `given tabs disabled, when cards are built, then quick link ribbon not built`() {
+        val cards = buildCards(isMySiteTabsEnabled = false)
 
         assertThat(cards.findQuickLinkRibbon()).isNull()
     }
 
     @Test
-    fun `given mySiteDashboardTabsFeatureConfig enabled, when cards are built, then quick link ribbons built`() {
+    fun `given tabs enabled, when cards are built, then quick link ribbons built`() {
         val cards = buildCards(isMySiteTabsEnabled = true)
 
         assertThat(cards.findQuickLinkRibbon()).isNotNull


### PR DESCRIPTION
Closes #16341

This PR 
- Hides tabs for self-hosted sites (matching [check in iOS](https://github.com/wordpress-mobile/WordPress-iOS/blob/a97d9d8e17e6de453b12439777befe95bc2d7fec/WordPress/Classes/ViewRelated/Blog/My%20Site/MySiteViewController.swift#L265)). 
- Uses updated tabs enabled state from `MySiteViewModel` to display quick links ribbon.

To test:

Test1. No tabs after login using (jetpack disconnected) self-hosted site 
1. Launch the app.
2. Login with a (jetpack disconnected) self-hosted site (you can use jurassic ninja site).
3. ✅ Notice that tabs are not shown.
4. ✅ Notice that quick links ribbon is not shown.

Test2. No tabs on switching to Jetpack site in a userless ("site-connection") state

1. Get a Jetpack site in a userless ("site-connection") state. Instructions below.
2. In the WP app, head to My Site > Stats if you're not there already, and tap "Log in".
3. Go through the login flow and check that the site is shown on the My Site tab.
3. ❌ Notice that tabs are not shown for the site.
4. Switch to a site using wpcom rest API.
5. ✅ Notice that tabs are shown for this site.
6. Switch back to Jetpack site in a userless ("site-connection") state.
7. ❌  Notice that tabs are not shown for this site.

Getting to a userless state (taken from https://github.com/wordpress-mobile/WordPress-iOS/issues/16489)

1. Create a self-hosted site.
2. Uninstall Jetpack (via wp-admin) and reinstall, but don't connect your WordPress.com account.
3. In the WP app, add this self-hosted site (Switch Sites > + > Self-hosted)
8. Head into Stats and note the Install Jetpack notice. Go through the flow until you see "Jetpack Installed" and the "Set up" button
9. Tap "Set up", which brings up the "Set up Jetpack" screen. Press the < button and then "cancel" to back out at this point.
10. Double-check that your site is userless at Pc9OEs-v-p2. Under Blog Details, you'll find "Primary User: This site does not have an owner. The email of the user who connected Jetpack is...."

https://user-images.githubusercontent.com/1405144/163720851-275a5b5a-71ac-4527-8995-71d0feacedf7.mp4

## Regression Notes
1. Potential unintended areas of impact
Switching to Jetpack site in a userless ("site-connection") state should not show the tabs.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Relied on unit tests added in c9e8a2a.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for showing tabs based on whether the selected site is using `wpcom` rest API.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.