### PR TITLE
Quick Start for Existing Users V2 - Add Feature Flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -126,6 +126,7 @@ android {
         buildConfigField "boolean", "MY_SITE_DEFAULT_TAB_EXPERIMENT", "false"
         buildConfigField "boolean", "MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD", "false"
         buildConfigField "boolean", "STATS_REVAMP_V2", "false"
+        buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/QuickStartExistingUsersV2FeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/QuickStartExistingUsersV2FeatureConfig.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration of the 'Quick Start for Existing Users V2' that will introduce a new set of
+ * Quick Start steps that are relevant to existing users.
+ */
+@FeatureInDevelopment
+class QuickStartExistingUsersV2FeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.QUICK_START_EXISTING_USERS_V2
+)


### PR DESCRIPTION
Closes #16348

This PR adds the feature flags for `My Site Dashboard - Tabs.

1. Launch the app.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
3. Notice that `QuickStartExistingUsersV2FeatureConfig` exists under `Features in development` section.

<img width=320 src="https://user-images.githubusercontent.com/1405144/163802849-14d6c703-9759-40ec-9879-75ced2c9d2d3.png"/>


## Regression Notes
1. Potential unintended areas of impact 🟢 


2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 


3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
