### PR TITLE
[Site Name] Adjusts design picker buttons for treatment variation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -206,6 +206,7 @@ import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment
 import org.wordpress.android.ui.sitecreation.previews.SiteCreationPreviewFragment;
 import org.wordpress.android.ui.sitecreation.services.SiteCreationService;
 import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameFragment;
+import org.wordpress.android.ui.sitecreation.theme.DesignPreviewFragment;
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerFragment;
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsFragment;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
@@ -703,6 +704,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(CategoryDetailFragment object);
 
     void inject(LayoutPreviewFragment object);
+
+    void inject(DesignPreviewFragment object);
 
     void inject(QuickStartPromptDialogFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/DesignPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/DesignPreviewFragment.kt
@@ -1,21 +1,36 @@
 package org.wordpress.android.ui.sitecreation.theme
 
+import android.content.Context
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
+import org.wordpress.android.WordPress
 import org.wordpress.android.ui.layoutpicker.LayoutPreviewFragment
+import org.wordpress.android.util.config.SiteNameFeatureConfig
+import javax.inject.Inject
 
 /**
  * Implements the Home Page Picker Design Preview UI
  */
 class DesignPreviewFragment : LayoutPreviewFragment() {
+    @Inject lateinit var siteNameFeatureConfig: SiteNameFeatureConfig
+
     companion object {
         const val DESIGN_PREVIEW_TAG = "DESIGN_PREVIEW_TAG"
 
         fun newInstance() = DesignPreviewFragment()
     }
 
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
+    }
+
     override fun getViewModel() =
             ViewModelProvider(requireActivity(), viewModelFactory).get(HomePagePickerViewModel::class.java)
 
-    override fun getChooseButtonText() = R.string.hpp_choose_button
+    override fun getChooseButtonText() = if (siteNameFeatureConfig.isEnabled()) {
+        R.string.hpp_choose_and_create_site
+    } else {
+        R.string.hpp_choose_button
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -96,7 +96,6 @@ class HomePagePickerFragment : Fragment() {
         modalLayoutPickerHeaderSection.modalLayoutPickerSubtitleRow?.description?.setText(R.string.hpp_subtitle)
         if (siteNameFeatureConfig.isEnabled()) {
             homePagePickerBottomToolbar.chooseButton.setText(R.string.hpp_choose_and_create_site)
-            homePagePickerTitlebar.skipButton.setText(R.string.hpp_skip_and_create_site)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.config.SiteNameFeatureConfig
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.viewmodel.observeEvent
@@ -39,6 +40,7 @@ class HomePagePickerFragment : Fragment() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var displayUtils: DisplayUtilsWrapper
     @Inject internal lateinit var uiHelper: UiHelpers
+    @Inject lateinit var siteNameFeatureConfig: SiteNameFeatureConfig
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: HomePagePickerViewModel
     private lateinit var previewModeSelectorPopup: PreviewModeSelectorPopup
@@ -92,6 +94,10 @@ class HomePagePickerFragment : Fragment() {
         homePagePickerTitlebar.title.isInvisible = !displayUtils.isPhoneLandscape()
         modalLayoutPickerHeaderSection.modalLayoutPickerTitleRow?.header?.setText(R.string.hpp_title)
         modalLayoutPickerHeaderSection.modalLayoutPickerSubtitleRow?.description?.setText(R.string.hpp_subtitle)
+        if (siteNameFeatureConfig.isEnabled()) {
+            homePagePickerBottomToolbar.chooseButton.setText(R.string.hpp_choose_and_create_site)
+            homePagePickerTitlebar.skipButton.setText(R.string.hpp_skip_and_create_site)
+        }
     }
 
     private fun HomePagePickerFragmentBinding.setupViewModel() {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3339,6 +3339,8 @@
     <string name="hpp_title">Choose a design</string>
     <string name="hpp_subtitle">Pick your favorite homepage layout. You can edit and customize it later.</string>
     <string name="hpp_choose_button">Choose</string>
+    <string name="hpp_choose_and_create_site">Create site</string>
+    <string name="hpp_skip_and_create_site">Skip and create</string>
     <string name="hpp_error_title">Layouts not available while offline</string>
     <string name="hpp_error_subtitle">Tap retry when you\'re back online.</string>
     <string name="hpp_retry_error">Please Check your internet connection and retry.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3340,7 +3340,6 @@
     <string name="hpp_subtitle">Pick your favorite homepage layout. You can edit and customize it later.</string>
     <string name="hpp_choose_button">Choose</string>
     <string name="hpp_choose_and_create_site">Create site</string>
-    <string name="hpp_skip_and_create_site">Skip and create</string>
     <string name="hpp_error_title">Layouts not available while offline</string>
     <string name="hpp_error_subtitle">Tap retry when you\'re back online.</string>
     <string name="hpp_retry_error">Please Check your internet connection and retry.</string>


### PR DESCRIPTION
## Description
This PR adjusts the design picker `Choose` and `Skip` buttons to communicate to the user that their action will create the site.

|Design Chooser(Control)|Design Chooser(Treatment)|
|---|---|
|![Screenshot_20220419_115412](https://user-images.githubusercontent.com/304044/163967354-fdc6cf71-a6a9-428c-b266-104a25c1ea37.png)|![Screenshot_20220426_080559](https://user-images.githubusercontent.com/304044/165225623-5b2da829-9af5-4c8d-8b48-bea7654c259d.png)|

|Design Preview(Control)|Design Preview(Treatment)|
|---|---|
|![Screenshot_20220419_115424](https://user-images.githubusercontent.com/304044/163967483-fc18b16a-5c64-44d1-865b-da62a8d29b0a.png)|![Screenshot_20220419_114941](https://user-images.githubusercontent.com/304044/163967539-433f993e-2971-4e48-b9ae-18de1f11089c.png)|

## To test
### Treatment variation
<details>
<summary>1. Toggle ON the Site Name feature</summary>

1. From My Site Go to Me → App Settings → Debug settings
2. Scroll to Features in development section and tap on SiteNameFeatureConfig
3. Tap RESTART THE APP button
4. Since this feature is A/B tested go to **Abacus**, find the `wpandroid_site_name_v1` experiment and assign to your test a8c-user the treatment variation

**Alternatively hardcode the feature on by returning `true` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/521e6b3a296339bec026f8ee2648eab326d31129/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt#L19)** 
</details>

2. Start the Site Creation flow
3. Choose an intent for your site or skip
4. Enter a site name or skip
5. Select a design
6. Verify that the `skip` and `choose` button are changed to `skip and create` and `create site` respectively
7. Preview a design and verify that the `choose` button is changed to `create site`

### Control variation
1. Toggle OFF the Site Name feature
2. On steps 6 and 7 above verify that the buttons are not changed

## Regression Notes
1. Potential unintended areas of impact
N/A

3. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

4. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
