### PR TITLE
[ExPlat] Only make assignment requests for authenticated users

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.fluxc.model.experiments.Assignments
 import org.wordpress.android.fluxc.model.experiments.Variation
 import org.wordpress.android.fluxc.model.experiments.Variation.Control
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.ExperimentStore
 import org.wordpress.android.fluxc.store.ExperimentStore.Platform
 import org.wordpress.android.fluxc.utils.AppLogWrapper
@@ -25,6 +26,7 @@ class ExPlat
     private val experiments: Lazy<Set<Experiment>>,
     private val experimentStore: ExperimentStore,
     private val appLog: AppLogWrapper,
+    private val accountStore: AccountStore,
     @Named(APPLICATION_SCOPE) private val coroutineScope: CoroutineScope
 ) {
     private val platform = Platform.WORDPRESS_ANDROID
@@ -70,7 +72,7 @@ class ExPlat
     }
 
     private fun refresh(refreshStrategy: RefreshStrategy) {
-        if (experimentNames.isNotEmpty()) {
+        if (experimentNames.isNotEmpty() && accountStore.hasAccessToken()) {
             getAssignments(refreshStrategy)
         }
     }


### PR DESCRIPTION
Fixes a bug allowing ExPlat assignment requests from unauthenticated users (internal ref: `pbArwn-4lF-p2`)

To test:
Verify that no ExPlat assignment requests are made for unauthenticated users

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added two new test cases

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
