### PR TITLE
Refactor Account Settings Screen - Implement LifeCycleOwner for PreferenceFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
@@ -1,0 +1,60 @@
+package org.wordpress.android.ui.prefs
+
+import android.os.Bundle
+import android.preference.PreferenceFragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.Event.ON_CREATE
+import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
+import androidx.lifecycle.Lifecycle.Event.ON_PAUSE
+import androidx.lifecycle.Lifecycle.Event.ON_START
+import androidx.lifecycle.Lifecycle.Event.ON_STOP
+import androidx.lifecycle.LifecycleCoroutineScope
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.coroutineScope
+
+/**
+ * LifecycleOwner is a single method interface that denotes that the class has a Lifecycle.
+ * android.preference.PreferenceFragment doesn't implement android.app.Fragment.LifecycleOwner interface.
+ * Fragments and Activities in Support Library 26.1.0 and later already implement the LifecycleOwner interface.
+ * Until we migrate to androidx Preference Library, we can use this class instead of deprecated PreferenceFragment,
+ * which supports the use of lifecycleCoroutineScope for observing Live data or Flows.
+ * https://developer.android.com/topic/libraries/architecture/lifecycle#implementing-lco
+ */
+@SuppressWarnings("deprecation")
+open class PreferenceFragmentLifeCycleOwner : PreferenceFragment(), LifecycleOwner {
+    private lateinit var lifecycleRegistry: LifecycleRegistry
+
+    val lifecycleScope: LifecycleCoroutineScope
+        get() = lifecycle.coroutineScope
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        lifecycleRegistry = LifecycleRegistry(this)
+        lifecycleRegistry.handleLifecycleEvent(ON_CREATE)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        lifecycleRegistry.handleLifecycleEvent(ON_START)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        lifecycleRegistry.handleLifecycleEvent(ON_PAUSE)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        lifecycleRegistry.handleLifecycleEvent(ON_STOP)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        lifecycleRegistry.handleLifecycleEvent(ON_DESTROY)
+    }
+
+    override fun getLifecycle(): Lifecycle {
+        return lifecycleRegistry
+    }
+}


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-Android/issues/12372

### **Description**
The Third PR for the task of refactoring the `AccountSettingsFragment` to MVVM following the reactive approach using Flow. This PR implements the `LifeCycleOwner` for `PreferenceFragment`.

### Why
Since android.preference.PreferenceFragment doesn't have support to observe Flows and LiveData. Implementing reactive approach seems impossible.

### Possible Solutions
1. App has to be migrated to Androidx Preference Library. 
2. Implement LifeCycleOwner interface to support observing Flows and LiveData.

### Reason for choosing Approach 2 - Implement LifeCycleOwner interface
Approach-1 (migrating to Androidx preference library) requires code changes in all Preference related classes. This can be done as a separate task.
So I have created a separate class, which implements LifeCycleOwner interface to support observing Flows and LiveData.

Note: This is just a temporary solution. Once the app is migrated to Androidx Preference Library, this class can be deleted.

## Regression Notes
No Potential impact on screens as the implementation is not consumed by AccountSetingsFragment.

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
