### PR TITLE
Quick Start for Existing Users V2 - Changes to Existing Tasks - Reader (Part i)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -280,7 +280,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         val customView = tab.customView ?: createTabCustomView(tab)
         with(customView) {
             val title = findViewById<TextView>(R.id.tab_label)
-            val quickStartFocusPoint = findViewById<QuickStartFocusPoint>(R.id.my_site_tab_quick_start_focus_point)
+            val quickStartFocusPoint = findViewById<QuickStartFocusPoint>(R.id.tab_quick_start_focus_point)
             title.text = uiHelpers.getTextOfUiString(requireContext(), tabUiState.label)
             quickStartFocusPoint?.setVisible(tabUiState.showQuickStartFocusPoint)
         }
@@ -319,7 +319,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     private fun MySiteFragmentBinding.createTabCustomView(tab: TabLayout.Tab): View {
         val customView = LayoutInflater.from(context)
-                .inflate(R.layout.my_site_tab_custom_view, tabLayout, false)
+                .inflate(R.layout.tab_custom_view, tabLayout, false)
         tab.customView = customView
         return customView
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskDetails.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskDetails.java
@@ -41,7 +41,7 @@ public enum QuickStartTaskDetails {
             QuickStartTask.FOLLOW_SITE,
             R.string.quick_start_list_follow_site_title,
             R.string.quick_start_list_follow_site_subtitle,
-            R.drawable.ic_reader_follow_white_24dp
+            R.drawable.ic_reader_white_24dp
     ),
     UPLOAD_SITE_ICON(
             QuickStartTask.UPLOAD_SITE_ICON,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -409,7 +409,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
             mHasUpdatedPosts = savedInstanceState.getBoolean(ReaderConstants.KEY_ALREADY_UPDATED);
             mFirstLoad = savedInstanceState.getBoolean(ReaderConstants.KEY_FIRST_LOAD);
             mSearchTabsPos = savedInstanceState.getInt(ReaderConstants.KEY_ACTIVE_SEARCH_TAB, NO_POSITION);
-            mViewModel.setQuickStartEvent(savedInstanceState.getParcelable(QuickStartEvent.KEY));
         }
     }
 
@@ -953,7 +952,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
         }
         outState.putSerializable(ReaderConstants.ARG_POST_LIST_TYPE, getPostListType());
         outState.putBoolean(ReaderConstants.ARG_IS_TOP_LEVEL, mIsTopLevel);
-        outState.putParcelable(QuickStartEvent.KEY, mViewModel.getQuickStartEvent());
 
         if (isSearchTabsShowing()) {
             int tabPosition = getSearchTabsPosition();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -908,8 +908,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
     private void showQuickStartSnackbar() {
         Spannable title = mQuickStartUtilsWrapper.stylizeQuickStartPrompt(
                 requireContext(),
-                R.string.quick_start_dialog_follow_sites_message_short_search,
-                R.drawable.ic_search_white_24dp
+                R.string.quick_start_dialog_follow_sites_message_short_settings,
+                R.drawable.ic_cog_white_24dp
         );
         mSnackbarSequencer.enqueue(
                 new SnackbarItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -56,7 +56,6 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AddOrDeleteSubscriptionPayload;
 import org.wordpress.android.fluxc.store.AccountStore.AddOrDeleteSubscriptionPayload.SubscriptionAction;
 import org.wordpress.android.fluxc.store.AccountStore.OnSubscriptionUpdated;
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
 import org.wordpress.android.fluxc.store.ReaderStore;
 import org.wordpress.android.fluxc.store.ReaderStore.OnReaderSitesSearched;
 import org.wordpress.android.fluxc.store.ReaderStore.ReaderSearchSitesPayload;
@@ -210,7 +209,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
     private final HistoryStack mTagPreviewHistory = new HistoryStack("tag_preview_history");
 
     private AlertDialog mBookmarksSavedLocallyDialog;
-    private QuickStartEvent mQuickStartEvent;
 
     private ReaderPostListViewModel mViewModel;
     // This VM is initialized only on the Following tab
@@ -411,7 +409,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
             mHasUpdatedPosts = savedInstanceState.getBoolean(ReaderConstants.KEY_ALREADY_UPDATED);
             mFirstLoad = savedInstanceState.getBoolean(ReaderConstants.KEY_FIRST_LOAD);
             mSearchTabsPos = savedInstanceState.getInt(ReaderConstants.KEY_ACTIVE_SEARCH_TAB, NO_POSITION);
-            mQuickStartEvent = savedInstanceState.getParcelable(QuickStartEvent.KEY);
+            mViewModel.setQuickStartEvent(savedInstanceState.getParcelable(QuickStartEvent.KEY));
         }
     }
 
@@ -466,6 +464,27 @@ public class ReaderPostListFragment extends ViewPagerFragment
         mViewModel.getSnackbarEvents().observe(getViewLifecycleOwner(), event ->
                 event.applyIfNotHandled(holder -> {
                     showSnackbar(holder);
+                    return Unit.INSTANCE;
+                })
+        );
+
+        mViewModel.getQuickStartPromptEvent().observe(getViewLifecycleOwner(), event ->
+                event.applyIfNotHandled(prompt -> {
+                    Spannable message = mQuickStartUtilsWrapper.stylizeQuickStartPrompt(
+                            requireContext(),
+                            prompt.getShortMessagePrompt(),
+                            prompt.getIconId()
+                    );
+                    showSnackbar(
+                            new SnackbarMessageHolder(
+                                    new UiStringText(message),
+                                    null,
+                                    () -> null,
+                                    (dismissEvent) -> null,
+                                    Snackbar.LENGTH_LONG,
+                                    true
+                            )
+                    );
                     return Unit.INSTANCE;
                 })
         );
@@ -898,27 +917,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
             return;
         }
 
-        mQuickStartEvent = event;
+        mViewModel.onQuickStartEventReceived(event);
         EventBus.getDefault().removeStickyEvent(event);
-
-        if (mQuickStartEvent.getTask() == QuickStartTask.FOLLOW_SITE
-            && isAdded() && getActivity() instanceof WPMainActivity) {
-            showQuickStartSnackbar();
-            if (getSelectedSite() != null) mQuickStartRepository.completeTask(QuickStartTask.FOLLOW_SITE);
-        }
-    }
-
-    private void showQuickStartSnackbar() {
-        Spannable title = mQuickStartUtilsWrapper.stylizeQuickStartPrompt(
-                requireContext(),
-                R.string.quick_start_dialog_follow_sites_message_short_settings,
-                R.drawable.ic_cog_white_24dp
-        );
-        mSnackbarSequencer.enqueue(
-                new SnackbarItem(
-                        new SnackbarItem.Info(getSnackbarParent(), new UiStringText(title), Snackbar.LENGTH_LONG)
-                )
-        );
     }
 
     @Override
@@ -953,7 +953,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         }
         outState.putSerializable(ReaderConstants.ARG_POST_LIST_TYPE, getPostListType());
         outState.putBoolean(ReaderConstants.ARG_IS_TOP_LEVEL, mIsTopLevel);
-        outState.putParcelable(QuickStartEvent.KEY, mQuickStartEvent);
+        outState.putParcelable(QuickStartEvent.KEY, mViewModel.getQuickStartEvent());
 
         if (isSearchTabsShowing()) {
             int tabPosition = getSearchTabsPosition();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -125,6 +125,8 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.QuickStartUtilsWrapper;
 import org.wordpress.android.util.SnackbarItem;
+import org.wordpress.android.util.SnackbarItem.Action;
+import org.wordpress.android.util.SnackbarItem.Info;
 import org.wordpress.android.util.SnackbarSequencer;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -505,18 +507,19 @@ public class ReaderPostListFragment extends ViewPagerFragment
     }
 
     private void showSnackbar(SnackbarMessageHolder holder) {
-        Snackbar snackbar = WPSnackbar.make(
-                getSnackbarParent(),
-                mUiHelpers.getTextOfUiString(requireContext(), holder.getMessage()),
-                Snackbar.LENGTH_LONG
+        if (!isAdded() || getView() == null) return;
+        mSnackbarSequencer.enqueue(
+                new SnackbarItem(
+                        new Info(
+                                getSnackbarParent(),
+                                holder.getMessage(),
+                                holder.getDuration(),
+                                holder.isImportant()
+                        ),
+                        holder.getButtonTitle() != null
+                                ? new Action(holder.getButtonTitle(), view -> holder.getButtonAction().invoke()) : null
+                )
         );
-        if (holder.getButtonTitle() != null) {
-            snackbar.setAction(
-                    mUiHelpers.getTextOfUiString(requireContext(), holder.getButtonTitle()),
-                    v -> holder.getButtonAction().invoke()
-            );
-        }
-        snackbar.show();
     }
 
     private void addWebViewCachingFragment(Long blogId, Long postId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -57,7 +57,6 @@ class ReaderPostListViewModel @Inject constructor(
     private var isStarted = false
 
     private var readerViewModel: ReaderViewModel? = null
-    var quickStartEvent: QuickStartEvent? = null
 
     /**
      * Post which is about to be reblogged after the user selects a target site.
@@ -320,7 +319,6 @@ class ReaderPostListViewModel @Inject constructor(
     /* QUICK START */
 
     fun onQuickStartEventReceived(event: QuickStartEvent) {
-        quickStartEvent = event
         if (event.task == QuickStartTask.FOLLOW_SITE) startQuickStartFollowSiteTaskSettingsStep()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -1,16 +1,23 @@
 package org.wordpress.android.ui.reader.viewmodels
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.datasets.ReaderPostTable
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
@@ -42,12 +49,15 @@ class ReaderPostListViewModel @Inject constructor(
     private val reblogUseCase: ReblogUseCase,
     private val readerTracker: ReaderTracker,
     private val seenStatusToggleUseCase: ReaderSeenStatusToggleUseCase,
+    private val quickStartRepository: QuickStartRepository,
+    private val selectedSiteRepository: SelectedSiteRepository,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {
     private var isStarted = false
 
     private var readerViewModel: ReaderViewModel? = null
+    var quickStartEvent: QuickStartEvent? = null
 
     /**
      * Post which is about to be reblogged after the user selects a target site.
@@ -59,6 +69,9 @@ class ReaderPostListViewModel @Inject constructor(
 
     private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
     val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
+    private val _quickStartPromptEvent = MutableLiveData<Event<QuickStartReaderPrompt>>()
+    val quickStartPromptEvent = _quickStartPromptEvent as LiveData<Event<QuickStartReaderPrompt>>
 
     private val _preloadPostEvents = MediatorLiveData<Event<PreLoadPostContent>>()
     val preloadPostEvents = _preloadPostEvents
@@ -302,5 +315,33 @@ class ReaderPostListViewModel @Inject constructor(
         if (isFilterable) {
             readerTracker.stop(ReaderTrackerType.SUBFILTERED_LIST)
         }
+    }
+
+    /* QUICK START */
+
+    fun onQuickStartEventReceived(event: QuickStartEvent) {
+        quickStartEvent = event
+        if (event.task == QuickStartTask.FOLLOW_SITE) startQuickStartFollowSiteTaskSettingsStep()
+    }
+
+    private fun startQuickStartFollowSiteTaskSettingsStep() {
+        _quickStartPromptEvent.postValue(Event(QuickStartReaderPrompt.FollowSiteSettingsStepPrompt))
+        selectedSiteRepository.getSelectedSite()?.let { completeQuickStartFollowSiteTask() }
+    }
+
+    private fun completeQuickStartFollowSiteTask() {
+        quickStartRepository.completeTask(QuickStartTask.FOLLOW_SITE)
+    }
+
+    sealed class QuickStartReaderPrompt(
+        val task: QuickStartTask,
+        @StringRes val shortMessagePrompt: Int,
+        @DrawableRes val iconId: Int
+    ) {
+        object FollowSiteSettingsStepPrompt : QuickStartReaderPrompt(
+                QuickStartTask.FOLLOW_SITE,
+                R.string.quick_start_dialog_follow_sites_message_short_settings,
+                R.drawable.ic_cog_white_24dp
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
@@ -24,6 +23,9 @@ import org.wordpress.android.ui.reader.tracker.ReaderTrackerType.MAIN_READER
 import org.wordpress.android.ui.reader.usecases.LoadReaderTabsUseCase
 import org.wordpress.android.ui.reader.utils.DateProvider
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState.ContentUiState
+import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState.ContentUiState.TabUiState
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.distinct
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -83,7 +85,7 @@ class ReaderViewModel @Inject constructor(
             val tagList = loadReaderTabsUseCase.loadTabs()
             if (tagList.isNotEmpty()) {
                 _uiState.value = ContentUiState(
-                        tagList.map { it.label },
+                        tagList.map { TabUiState(label = UiStringText(it.label)) },
                         tagList,
                         searchIconVisible = isSearchSupported(),
                         settingsIconVisible = isSettingsSupported()
@@ -135,7 +137,7 @@ class ReaderViewModel @Inject constructor(
         val tabLayoutVisible: Boolean = false
     ) {
         data class ContentUiState(
-            val tabTitles: List<String>,
+            val tabUiStates: List<TabUiState>,
             val readerTagList: ReaderTagList,
             override val searchIconVisible: Boolean,
             override val settingsIconVisible: Boolean
@@ -144,7 +146,12 @@ class ReaderViewModel @Inject constructor(
                 settingsIconVisible = settingsIconVisible,
                 appBarExpanded = true,
                 tabLayoutVisible = true
-        )
+        ) {
+            data class TabUiState(
+                val label: UiString,
+                val showQuickStartFocusPoint: Boolean = false
+            )
+        }
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/res/layout/tab_custom_view.xml
+++ b/WordPress/src/main/res/layout/tab_custom_view.xml
@@ -18,7 +18,7 @@
         tools:text="@string/my_site_menu_tab_title"/>
 
     <org.wordpress.android.widgets.QuickStartFocusPoint
-        android:id="@+id/my_site_tab_quick_start_focus_point"
+        android:id="@+id/tab_quick_start_focus_point"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:contentDescription="@string/quick_start_focus_point_description"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3038,8 +3038,8 @@
     <string name="quick_start_dialog_explore_plans_message">Learn about the marketing and SEO tools in our paid plans.</string>
     <string name="quick_start_dialog_explore_plans_title">Explore plans</string>
     <string name="quick_start_dialog_follow_sites_message">Find sites that inspire you, and follow them to get updates when they post.</string>
-    <string name="quick_start_dialog_follow_sites_message_short_reader" tools:ignore="UnusedResources">Tap %1$s Reader %2$s to continue</string>
-    <string name="quick_start_dialog_follow_sites_message_short_search">Tap %1$s Search %2$s to look for sites with similar topics</string>
+    <string name="quick_start_dialog_follow_sites_message_short_reader" tools:ignore="UnusedResources">Select %1$s Reader %2$s to find other sites.</string>
+    <string name="quick_start_dialog_follow_sites_message_short_settings">Select %1$s Settings %2$s to add topics you like.</string>
     <string name="quick_start_dialog_follow_sites_title">Connect with other sites</string>
     <string name="quick_start_dialog_publish_post_message">Draft and publish a post.</string>
     <string name="quick_start_dialog_publish_post_message_short" tools:ignore="UnusedResources">Tap %1$s Create Post %2$s to create a new post</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3040,7 +3040,7 @@
     <string name="quick_start_dialog_follow_sites_message">Find sites that inspire you, and follow them to get updates when they post.</string>
     <string name="quick_start_dialog_follow_sites_message_short_reader" tools:ignore="UnusedResources">Tap %1$s Reader %2$s to continue</string>
     <string name="quick_start_dialog_follow_sites_message_short_search">Tap %1$s Search %2$s to look for sites with similar topics</string>
-    <string name="quick_start_dialog_follow_sites_title">Follow other sites</string>
+    <string name="quick_start_dialog_follow_sites_title">Connect with other sites</string>
     <string name="quick_start_dialog_publish_post_message">Draft and publish a post.</string>
     <string name="quick_start_dialog_publish_post_message_short" tools:ignore="UnusedResources">Tap %1$s Create Post %2$s to create a new post</string>
     <string name="quick_start_dialog_publish_post_title">Publish a post</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3037,7 +3037,7 @@
     <string name="quick_start_dialog_enable_sharing_title" tools:ignore="UnusedResources">Enable post sharing</string>
     <string name="quick_start_dialog_explore_plans_message">Learn about the marketing and SEO tools in our paid plans.</string>
     <string name="quick_start_dialog_explore_plans_title">Explore plans</string>
-    <string name="quick_start_dialog_follow_sites_message">Find sites that inspire you, and follow them to get updates when they post.</string>
+    <string name="quick_start_dialog_follow_sites_message" translatable="false">@string/quick_start_list_follow_site_subtitle</string>
     <string name="quick_start_dialog_follow_sites_message_short_reader" tools:ignore="UnusedResources">Select %1$s Reader %2$s to find other sites.</string>
     <string name="quick_start_dialog_follow_sites_message_short_settings">Select %1$s Settings %2$s to add topics you like.</string>
     <string name="quick_start_dialog_follow_sites_title">Connect with other sites</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -52,12 +52,7 @@ class ReaderViewModelTest {
     @Mock lateinit var getFollowedTagsUseCase: GetFollowedTagsUseCase
 
     private val emptyReaderTagList = ReaderTagList()
-    private val nonEmptyReaderTagList = ReaderTagList().apply {
-        this.add(mock())
-        this.add(mock())
-        this.add(mock())
-        this.add(mock())
-    }
+    private val nonEmptyReaderTagList = createNonMockedNonEmptyReaderTagList()
 
     @Before
     fun setup() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -1,7 +1,12 @@
 package org.wordpress.android.viewmodel.reader
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -9,13 +14,17 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
+import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionsHandler
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.usecases.ReaderSeenStatusToggleUseCase
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel.QuickStartReaderPrompt
+import org.wordpress.android.viewmodel.Event
 
 @InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -47,7 +56,53 @@ class ReaderPostListViewModelTest {
         )
     }
 
+    /* QUICK START */
+
     @Test
-    fun foo() {
+    fun `when quick start follow site task event received, then follow site setting step prompt shown`() {
+        val observers = initObservers()
+
+        viewModel.onQuickStartEventReceived(QuickStartEvent(QuickStartTask.FOLLOW_SITE))
+
+        val quickStartReaderPrompt = observers.quickStartReaderPrompts.last().peekContent()
+        assertThat(quickStartReaderPrompt).isEqualTo(QuickStartReaderPrompt.FollowSiteSettingsStepPrompt)
     }
+
+    @Test
+    fun `when quick start non follow site event received, then follow site setting step prompt not shown`() {
+        val observers = initObservers()
+
+        viewModel.onQuickStartEventReceived(QuickStartEvent(QuickStartTask.CHECK_STATS))
+
+        assertThat(observers.quickStartReaderPrompts).isEmpty()
+    }
+
+    @Test
+    fun `given site present, when quick start follow site event received, then follow site task is completed`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mock())
+
+        viewModel.onQuickStartEventReceived(QuickStartEvent(QuickStartTask.FOLLOW_SITE))
+
+        verify(quickStartRepository).completeTask(QuickStartTask.FOLLOW_SITE)
+    }
+
+    @Test
+    fun `given site present, when quick start non follow site event received, then follow site task not completed`() {
+        viewModel.onQuickStartEventReceived(QuickStartEvent(QuickStartTask.CHECK_STATS))
+
+        verify(quickStartRepository, times(0)).completeTask(QuickStartTask.FOLLOW_SITE)
+    }
+
+    private fun initObservers(): Observers {
+        val quickStartReaderPrompts = mutableListOf<Event<QuickStartReaderPrompt>>()
+        viewModel.quickStartPromptEvent.observeForever {
+            quickStartReaderPrompts.add(it)
+        }
+
+        return Observers(quickStartReaderPrompts)
+    }
+
+    private data class Observers(
+        val quickStartReaderPrompts: List<Event<QuickStartReaderPrompt>>
+    )
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -59,7 +59,7 @@ class ReaderPostListViewModelTest {
     /* QUICK START */
 
     @Test
-    fun `when quick start follow site task event received, then follow site setting step prompt shown`() {
+    fun `when quick start event received is follow site, then follow site setting step prompt shown`() {
         val observers = initObservers()
 
         viewModel.onQuickStartEventReceived(QuickStartEvent(QuickStartTask.FOLLOW_SITE))
@@ -69,7 +69,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `when quick start non follow site event received, then follow site setting step prompt not shown`() {
+    fun `when quick start event received is not follow site, then follow site setting step prompt not shown`() {
         val observers = initObservers()
 
         viewModel.onQuickStartEventReceived(QuickStartEvent(QuickStartTask.CHECK_STATS))
@@ -78,7 +78,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `given site present, when quick start follow site event received, then follow site task is completed`() {
+    fun `given site present, when quick start event received is follow site, then follow site task is completed`() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mock())
 
         viewModel.onQuickStartEventReceived(QuickStartEvent(QuickStartTask.FOLLOW_SITE))
@@ -87,7 +87,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `given site present, when quick start non follow site event received, then follow site task not completed`() {
+    fun `given site present, when quick start event received not follow site, then follow site task not completed`() {
         viewModel.onQuickStartEventReceived(QuickStartEvent(QuickStartTask.CHECK_STATS))
 
         verify(quickStartRepository, times(0)).completeTask(QuickStartTask.FOLLOW_SITE)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -9,6 +9,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionsHandler
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
@@ -26,6 +28,8 @@ class ReaderPostListViewModelTest {
     @Mock private lateinit var readerTracker: ReaderTracker
     @Mock private lateinit var readerPostCardActionsHandler: ReaderPostCardActionsHandler
     @Mock private lateinit var readerSeenStatusToggleUseCase: ReaderSeenStatusToggleUseCase
+    @Mock private lateinit var quickStartRepository: QuickStartRepository
+    @Mock private lateinit var selectedSiteRepository: SelectedSiteRepository
 
     private lateinit var viewModel: ReaderPostListViewModel
 
@@ -36,6 +40,8 @@ class ReaderPostListViewModelTest {
                 reblogUseCase,
                 readerTracker,
                 readerSeenStatusToggleUseCase,
+                quickStartRepository,
+                selectedSiteRepository,
                 TEST_DISPATCHER,
                 TEST_DISPATCHER
         )


### PR DESCRIPTION
Parent #16349

This PR

- Updates `FOLLOW_SITE` QS task (shown on `Reader` tab) icon, title in `Grow your audience` full screen dialog, `Notice With Go Button` info and `Notice` info as follows:

Task | Notice with Go Button | Notice Step One | Notice Step Two
---|---|----|---
<img width="550" alt="Screenshot 2022-04-20 at 4 40 50 PM" src="https://user-images.githubusercontent.com/1405144/164218373-c77f4ee0-6021-4397-9044-8d0d5105e407.png">|<img width="550" alt="Screenshot 2022-04-20 at 4 41 19 PM" src="https://user-images.githubusercontent.com/1405144/164218410-4cdb8a65-b5e6-4fe9-8827-35add2a9e07a.png"> | <img width="550" alt="Screenshot 2022-04-20 at 4 35 37 PM" src="https://user-images.githubusercontent.com/1405144/164217732-e9174e85-bf28-45dd-81e1-a7decc357229.png"> | <img width="550" alt="Screenshot 2022-04-20 at 4 36 04 PM" src="https://user-images.githubusercontent.com/1405144/164217766-5c3f30a8-e976-48b0-84f7-bb56430acc48.png">


It also makes the following changes as a preparatory step to show an intermediate (conditional) discover step in the next PR:
- Adds custom view for the tabs so that QS focus point can be shown on the tab. 
- Replaces the use of `WPSnackbar` with snackbar sequencer so that all snackbars on the screen are shown using the sequencer.
- Moves `FOLLOW_SITE` QS task logic from fragment to the VM and adds tests for this existing piece of code.

/cc @jostnes 

To test:

1. Launch the app with a site having a quick start in progress.
2. Go to `My Site` tab.
3. Select `Grow your audience` from `Next Steps` card on `My Site` screen. The card will be present on the `Initial Screen` tab set in the `Settings`. 
4. Notice that icon, title are changed to `ic_reader_white_24dp`, `Connect with other sites`.
5. Click `Connect with other sites` row.
6. Notice that snackbar text is changed to `Select <ic_reader_white_24dp icon> Reader to find other sites.`
7. Tap on the Reader tab.
8. Notice that 
    - Snackbar text is changed to `Select  <ic_cog_white_24dp icon> Settings to add topics you like.`.
    - Focus point is not shown on `Setting` menu (it was not shown for `Search` menu item also). We will add it in a future PR.

To test `Notice with Go Button` info, restart QS flow by clearing cache/ relogin. Run all QS tasks sequentially till you reach the `Connect with other sites: Discover and follow sites that inspire you.` notice.

## Regression Notes
1. Potential unintended areas of impact
a. Reader tabs selection (since we added custom views for tabs). cbd183cbddfeda5c26372edf41b9352adb5861b7
b. Snack bar display (since we replaced the use of `WPSnackbar` with snackbar sequencer). 08f5b86b94754b27a899061e5f6d94709e4e14cc
c. Existing Reader task flow (since we moved logic from fragment to vm). a80a0b110380c9e5a841b0f3a59c37fbe8130a92

2. What I did to test those areas of impact (or what existing automated tests I relied on)
a. Tested manually by toggling Reader tabs. 
b. Tested by hardcoding below line in `ReaderPostListViewModel` > `init()` function and checking that snackbar is shown coreclty using the snackbar sequencer instead of `WPSnackbar`. 
`_snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.reader_reblog_error))))`
c. Tested manually, see `To Test` section. Also added unit tests.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for the Reader task logic which is now moved vm.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
