### PR TITLE
Quick Start for Existing Users V2-Changes to existing task-Preview Site 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -56,7 +56,10 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         val onIconClick: ListItemInteraction,
         val onUrlClick: ListItemInteraction,
         val onSwitchSiteClick: ListItemInteraction
-    ) : MySiteCardAndItem(SITE_INFO_CARD, activeQuickStartItem = showTitleFocusPoint || showIconFocusPoint || showSubtitleFocusPoint) {
+    ) : MySiteCardAndItem(
+            SITE_INFO_CARD,
+            activeQuickStartItem = showTitleFocusPoint || showIconFocusPoint || showSubtitleFocusPoint
+    ) {
         sealed class IconState {
             object Progress : IconState()
             data class Visible(val url: String? = null) : IconState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -50,12 +50,13 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         val url: String,
         val iconState: IconState,
         val showTitleFocusPoint: Boolean,
+        val showSubtitleFocusPoint: Boolean,
         val showIconFocusPoint: Boolean,
         val onTitleClick: ListItemInteraction? = null,
         val onIconClick: ListItemInteraction,
         val onUrlClick: ListItemInteraction,
         val onSwitchSiteClick: ListItemInteraction
-    ) : MySiteCardAndItem(SITE_INFO_CARD, activeQuickStartItem = showTitleFocusPoint || showIconFocusPoint) {
+    ) : MySiteCardAndItem(SITE_INFO_CARD, activeQuickStartItem = showTitleFocusPoint || showIconFocusPoint || showSubtitleFocusPoint) {
         sealed class IconState {
             object Progress : IconState()
             data class Visible(val url: String? = null) : IconState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -223,6 +223,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         }
         siteInfoContainer.title.text = siteInfoHeader.title
         quickStartTitleFocusPoint.setVisibleOrGone(siteInfoHeader.showTitleFocusPoint)
+        quickStartSubTitleFocusPoint.setVisibleOrGone(siteInfoHeader.showSubtitleFocusPoint)
         siteInfoContainer.subtitle.text = siteInfoHeader.url
         siteInfoContainer.subtitle.setOnClickListener { siteInfoHeader.onUrlClick.click() }
         switchSite.setOnClickListener { siteInfoHeader.onSwitchSiteClick.click() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -593,8 +593,7 @@ class MySiteViewModel @Inject constructor(
     }
 
     private fun isValidQuickStartFocusPosition(quickStartTask: QuickStartTask, position: Int): Boolean {
-        return if (position == LIST_INDEX_NO_ACTIVE_QUICK_START_ITEM && isSiteHeaderQuickStartTask(quickStartTask))
-            return true
+        return if (position == LIST_INDEX_NO_ACTIVE_QUICK_START_ITEM && isSiteHeaderQuickStartTask(quickStartTask)) true
         else position >= 0
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -483,7 +483,11 @@ class MySiteViewModel @Inject constructor(
                         cardsResult.filterNot {
                             getCardTypeExclusionFiltersForTab(MySiteTabType.SITE_MENU).contains(it.type)
                         },
-                        if (shouldIncludeDynamicCards(MySiteTabType.SITE_MENU)) { dynamicCards } else { listOf() },
+                        if (shouldIncludeDynamicCards(MySiteTabType.SITE_MENU)) {
+                            dynamicCards
+                        } else {
+                            listOf()
+                        },
                         siteItems
                 ),
                 MySiteTabType.DASHBOARD to orderForDisplay(
@@ -491,7 +495,11 @@ class MySiteViewModel @Inject constructor(
                         cardsResult.filterNot {
                             getCardTypeExclusionFiltersForTab(MySiteTabType.DASHBOARD).contains(it.type)
                         },
-                        if (shouldIncludeDynamicCards(MySiteTabType.DASHBOARD)) { dynamicCards } else { listOf() },
+                        if (shouldIncludeDynamicCards(MySiteTabType.DASHBOARD)) {
+                            dynamicCards
+                        } else {
+                            listOf()
+                        },
                         listOf()
                 )
         )
@@ -593,8 +601,11 @@ class MySiteViewModel @Inject constructor(
     }
 
     private fun isValidQuickStartFocusPosition(quickStartTask: QuickStartTask, position: Int): Boolean {
-        return if (position == LIST_INDEX_NO_ACTIVE_QUICK_START_ITEM && isSiteHeaderQuickStartTask(quickStartTask)) true
-        else position >= 0
+        return if (position == LIST_INDEX_NO_ACTIVE_QUICK_START_ITEM && isSiteHeaderQuickStartTask(quickStartTask)) {
+            true
+        } else {
+            position >= 0
+        }
     }
 
     private fun isSiteHeaderQuickStartTask(quickStartTask: QuickStartTask): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -483,11 +483,7 @@ class MySiteViewModel @Inject constructor(
                         cardsResult.filterNot {
                             getCardTypeExclusionFiltersForTab(MySiteTabType.SITE_MENU).contains(it.type)
                         },
-                        if (shouldIncludeDynamicCards(MySiteTabType.SITE_MENU)) {
-                            dynamicCards
-                        } else {
-                            listOf()
-                        },
+                        if (shouldIncludeDynamicCards(MySiteTabType.SITE_MENU)) dynamicCards else listOf(),
                         siteItems
                 ),
                 MySiteTabType.DASHBOARD to orderForDisplay(
@@ -495,11 +491,7 @@ class MySiteViewModel @Inject constructor(
                         cardsResult.filterNot {
                             getCardTypeExclusionFiltersForTab(MySiteTabType.DASHBOARD).contains(it.type)
                         },
-                        if (shouldIncludeDynamicCards(MySiteTabType.DASHBOARD)) {
-                            dynamicCards
-                        } else {
-                            listOf()
-                        },
+                        if (shouldIncludeDynamicCards(MySiteTabType.DASHBOARD)) dynamicCards else listOf(),
                         listOf()
                 )
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -658,7 +658,6 @@ class MySiteViewModel @Inject constructor(
                 ListItemAction.MEDIA -> SiteNavigationAction.OpenMedia(selectedSite)
                 ListItemAction.COMMENTS -> SiteNavigationAction.OpenUnifiedComments(selectedSite)
                 ListItemAction.VIEW_SITE -> {
-                    quickStartRepository.completeTask(QuickStartTask.VIEW_SITE)
                     SiteNavigationAction.OpenSite(selectedSite)
                 }
                 ListItemAction.JETPACK_SETTINGS -> SiteNavigationAction.OpenJetpackSettings(selectedSite)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -369,7 +369,6 @@ class MySiteViewModel @Inject constructor(
     }
 
     private fun QuickStartTask.showInSiteMenu() = when (this) {
-        QuickStartTask.VIEW_SITE,
         QuickStartTask.ENABLE_POST_SHARING,
         QuickStartTask.EXPLORE_PLANS -> true
         else -> false
@@ -742,6 +741,7 @@ class MySiteViewModel @Inject constructor(
 
     private fun urlClick() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
+        quickStartRepository.completeTask(QuickStartTask.VIEW_SITE)
         _onNavigation.value = Event(SiteNavigationAction.OpenSite(selectedSite))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -22,9 +22,6 @@ import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.TodaysStatsCardModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.VIEW_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.models.bloggingprompts.BloggingPrompt
 import org.wordpress.android.models.bloggingprompts.BloggingPromptRespondent
@@ -603,7 +600,9 @@ class MySiteViewModel @Inject constructor(
 
     private fun isSiteHeaderQuickStartTask(quickStartTask: QuickStartTask): Boolean {
         return when (quickStartTask) {
-            UPDATE_SITE_TITLE, UPLOAD_SITE_ICON, VIEW_SITE -> true
+            QuickStartTask.UPDATE_SITE_TITLE,
+            QuickStartTask.UPLOAD_SITE_ICON,
+            QuickStartTask.VIEW_SITE -> true
             else -> false
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.VIEW_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.models.bloggingprompts.BloggingPrompt
 import org.wordpress.android.models.bloggingprompts.BloggingPromptRespondent
@@ -587,7 +588,7 @@ class MySiteViewModel @Inject constructor(
         quickStartTask: QuickStartTask,
         position: Int
     ) {
-        if (_activeTaskPosition.value?.first != quickStartTask && isSiteHeaderQuickStartTask(
+        if (_activeTaskPosition.value?.first != quickStartTask && isValidQuickStartFocusPosition(
                         quickStartTask,
                         position
                 )) {
@@ -595,10 +596,17 @@ class MySiteViewModel @Inject constructor(
         }
     }
 
-    private fun isSiteHeaderQuickStartTask(quickStartTask: QuickStartTask, position: Int): Boolean {
-        return if (position == LIST_INDEX_NO_ACTIVE_QUICK_START_ITEM &&
-                (quickStartTask == UPDATE_SITE_TITLE || quickStartTask == UPLOAD_SITE_ICON)) true
+    private fun isValidQuickStartFocusPosition(quickStartTask: QuickStartTask, position: Int): Boolean {
+        return if (position == LIST_INDEX_NO_ACTIVE_QUICK_START_ITEM && isSiteHeaderQuickStartTask(quickStartTask))
+            return true
         else position >= 0
+    }
+
+    private fun isSiteHeaderQuickStartTask(quickStartTask: QuickStartTask): Boolean {
+        return when (quickStartTask) {
+            UPDATE_SITE_TITLE, UPLOAD_SITE_ICON, VIEW_SITE -> true
+            else -> false
+        }
     }
 
     fun onTabChanged(position: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -152,6 +152,13 @@ class QuickStartRepository
                 )
                 _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(shortQuickStartMessage.asHtml()))))
             }
+            task == QuickStartTask.VIEW_SITE -> {
+                val shortQuickStartMessage = resourceProvider.getString(
+                        R.string.quick_start_dialog_view_site_message_short,
+                        SiteUtils.getHomeURLOrHostName(selectedSiteRepository.getSelectedSite())
+                )
+                _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(shortQuickStartMessage.asHtml()))))
+            }
             else -> {
                 QuickStartMySitePrompts.getPromptDetailsForTask(task)?.let { activeTutorialPrompt ->
                     _onQuickStartMySitePrompts.postValue(Event(activeTutorialPrompt))

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -154,7 +154,7 @@ class QuickStartRepository
             }
             task == QuickStartTask.VIEW_SITE -> {
                 val shortQuickStartMessage = resourceProvider.getString(
-                        R.string.quick_start_dialog_view_site_message_short,
+                        R.string.quick_start_dialog_view_your_site_message_short,
                         SiteUtils.getHomeURLOrHostName(selectedSiteRepository.getSelectedSite())
                 )
                 _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(shortQuickStartMessage.asHtml()))))

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -291,7 +291,6 @@ class QuickStartRepository
             quickStartTaskOrigin == MySiteTabType.DASHBOARD && task.showInSiteMenu()
 
     private fun QuickStartTask.showInSiteMenu() = when (this) {
-        QuickStartTask.VIEW_SITE,
         QuickStartTask.ENABLE_POST_SHARING,
         QuickStartTask.EXPLORE_PLANS,
         QuickStartTask.CHECK_STATS,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardBuilder.kt
@@ -33,6 +33,7 @@ class SiteInfoHeaderCardBuilder
                 homeUrl,
                 siteIcon,
                 params.activeTask == QuickStartTask.UPDATE_SITE_TITLE,
+                params.activeTask == QuickStartTask.VIEW_SITE,
                 params.activeTask == QuickStartTask.UPLOAD_SITE_ICON,
                 buildTitleClick(params.site, params.titleClick),
                 ListItemInteraction.create(params.iconClick),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -30,7 +30,6 @@ class SiteItemsBuilder @Inject constructor(
 
     @Suppress("LongMethod")
     fun build(params: SiteItemsBuilderParams): List<MySiteCardAndItem> {
-        val showViewSiteFocusPoint = params.activeTask == QuickStartTask.VIEW_SITE
         val showEnablePostSharingFocusPoint = params.activeTask == QuickStartTask.ENABLE_POST_SHARING
         val showExplorePlansFocusPoint = params.activeTask == QuickStartTask.EXPLORE_PLANS
         val showStatsFocusPoint = params.activeTask == QuickStartTask.CHECK_STATS
@@ -85,7 +84,6 @@ class SiteItemsBuilder @Inject constructor(
                         UiStringRes(R.string.my_site_btn_view_site),
                         secondaryIcon = R.drawable.ic_external_white_24dp,
                         onClick = ListItemInteraction.create(ListItemAction.VIEW_SITE, params.onClick),
-                        showFocusPoint = showViewSiteFocusPoint
                 ),
                 siteListItemBuilder.buildAdminItemIfAvailable(params.site, params.onClick)
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -83,7 +83,7 @@ class SiteItemsBuilder @Inject constructor(
                         R.drawable.ic_globe_white_24dp,
                         UiStringRes(R.string.my_site_btn_view_site),
                         secondaryIcon = R.drawable.ic_external_white_24dp,
-                        onClick = ListItemInteraction.create(ListItemAction.VIEW_SITE, params.onClick),
+                        onClick = ListItemInteraction.create(ListItemAction.VIEW_SITE, params.onClick)
                 ),
                 siteListItemBuilder.buildAdminItemIfAvailable(params.site, params.onClick)
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartMySitePrompts.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartMySitePrompts.kt
@@ -24,9 +24,9 @@ enum class QuickStartMySitePrompts constructor(
     VIEW_SITE_TUTORIAL(
             QuickStartTask.VIEW_SITE,
             -1,
-            -1,
+            R.id.my_site_subtitle_label,
             R.string.quick_start_dialog_view_site_message_short,
-            R.drawable.ic_globe_white_24dp
+            QuickStartUtils.ICON_NOT_SET
     ),
     SHARE_SITE_TUTORIAL(
             QuickStartTask.ENABLE_POST_SHARING,

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartMySitePrompts.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartMySitePrompts.kt
@@ -25,7 +25,7 @@ enum class QuickStartMySitePrompts constructor(
             QuickStartTask.VIEW_SITE,
             -1,
             R.id.my_site_subtitle_label,
-            R.string.quick_start_dialog_view_site_message_short,
+            R.string.quick_start_dialog_view_your_site_message_short,
             QuickStartUtils.ICON_NOT_SET
     ),
     SHARE_SITE_TUTORIAL(

--- a/WordPress/src/main/res/layout/my_site_info_header_card.xml
+++ b/WordPress/src/main/res/layout/my_site_info_header_card.xml
@@ -102,8 +102,10 @@
         android:layout_gravity="center_vertical|center"
         android:contentDescription="@string/quick_start_focus_point_description"
         android:elevation="@dimen/quick_start_focus_point_elevation"
-        app:layout_constraintEnd_toEndOf="@id/site_info_container"
         app:layout_constraintBottom_toBottomOf="@id/site_info_container"
+        app:layout_constraintEnd_toEndOf="@id/site_info_container"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@+id/blavatar_container"
         tools:ignore="RtlSymmetry" />
 
     <ImageButton

--- a/WordPress/src/main/res/layout/my_site_info_header_card.xml
+++ b/WordPress/src/main/res/layout/my_site_info_header_card.xml
@@ -94,6 +94,18 @@
         app:layout_constraintTop_toTopOf="@id/site_info_container"
         tools:ignore="RtlSymmetry" />
 
+
+    <org.wordpress.android.widgets.QuickStartFocusPoint
+        android:id="@+id/quick_start_sub_title_focus_point"
+        android:layout_width="@dimen/quick_start_focus_point_size"
+        android:layout_height="@dimen/quick_start_focus_point_size"
+        android:layout_gravity="center_vertical|center"
+        android:contentDescription="@string/quick_start_focus_point_description"
+        android:elevation="@dimen/quick_start_focus_point_elevation"
+        app:layout_constraintEnd_toEndOf="@id/site_info_container"
+        app:layout_constraintBottom_toBottomOf="@id/site_info_container"
+        tools:ignore="RtlSymmetry" />
+
     <ImageButton
         android:id="@+id/switch_site"
         android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/my_site_info_header_card.xml
+++ b/WordPress/src/main/res/layout/my_site_info_header_card.xml
@@ -91,7 +91,9 @@
         android:contentDescription="@string/quick_start_focus_point_description"
         android:elevation="@dimen/quick_start_focus_point_elevation"
         app:layout_constraintEnd_toEndOf="@id/site_info_container"
-        app:layout_constraintTop_toTopOf="@id/site_info_container"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@+id/blavatar_container"
+        app:layout_constraintTop_toTopOf="parent"
         tools:ignore="RtlSymmetry" />
 
 

--- a/WordPress/src/main/res/layout/my_site_info_header_card.xml
+++ b/WordPress/src/main/res/layout/my_site_info_header_card.xml
@@ -99,15 +99,16 @@
 
     <org.wordpress.android.widgets.QuickStartFocusPoint
         android:id="@+id/quick_start_sub_title_focus_point"
-        android:layout_width="@dimen/quick_start_focus_point_size"
-        android:layout_height="@dimen/quick_start_focus_point_size"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_gravity="center_vertical|center"
         android:contentDescription="@string/quick_start_focus_point_description"
         android:elevation="@dimen/quick_start_focus_point_elevation"
-        app:layout_constraintBottom_toBottomOf="@id/site_info_container"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@id/site_info_container"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="@+id/site_info_container"
+        app:size="small"
         tools:ignore="RtlSymmetry" />
 
     <ImageButton

--- a/WordPress/src/main/res/layout/my_site_info_header_card.xml
+++ b/WordPress/src/main/res/layout/my_site_info_header_card.xml
@@ -92,7 +92,7 @@
         android:elevation="@dimen/quick_start_focus_point_elevation"
         app:layout_constraintEnd_toEndOf="@id/site_info_container"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toEndOf="@+id/blavatar_container"
+        app:layout_constraintStart_toStartOf="@+id/site_info_container"
         app:layout_constraintTop_toTopOf="parent"
         tools:ignore="RtlSymmetry" />
 
@@ -107,7 +107,7 @@
         app:layout_constraintBottom_toBottomOf="@id/site_info_container"
         app:layout_constraintEnd_toEndOf="@id/site_info_container"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toEndOf="@+id/blavatar_container"
+        app:layout_constraintStart_toStartOf="@+id/site_info_container"
         tools:ignore="RtlSymmetry" />
 
     <ImageButton

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3054,7 +3054,7 @@
     <string name="quick_start_dialog_upload_icon_message">Your visitors will see your icon in their browser. Add a custom icon for a polished, pro look.</string>
     <string name="quick_start_dialog_upload_icon_title">Choose a unique site icon</string>
     <string name="quick_start_dialog_view_site_message">Preview your site to see what your visitors will see.</string>
-    <string name="quick_start_dialog_view_site_message_short" tools:ignore="UnusedResources">Tap &lt;b&gt;%1$s&lt;/b&gt; to view your site</string>
+    <string name="quick_start_dialog_view_your_site_message_short" tools:ignore="UnusedResources">Tap &lt;b&gt;%1$s&lt;/b&gt; to view your site</string>
     <string name="quick_start_dialog_view_site_title">View your site</string>
     <string name="quick_start_dialog_update_site_title_message_short">Tap &lt;b&gt;%1$s&lt;/b&gt; to set a new title</string>
     <string name="quick_start_dialog_edit_homepage_title">Edit your homepage</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3053,8 +3053,8 @@
     <string name="quick_start_dialog_explore_plans_message_short" tools:ignore="UnusedResources">Tap %1$s Plan %2$s to see your current plan and other available plans</string>
     <string name="quick_start_dialog_upload_icon_message">Your visitors will see your icon in their browser. Add a custom icon for a polished, pro look.</string>
     <string name="quick_start_dialog_upload_icon_title">Choose a unique site icon</string>
-    <string name="quick_start_dialog_view_site_message">Enjoy your finished product!</string>
-    <string name="quick_start_dialog_view_site_message_short" tools:ignore="UnusedResources">Tap %1$s View Site %2$s to preview your site</string>
+    <string name="quick_start_dialog_view_site_message">Preview your site to see what your visitors will see.</string>
+    <string name="quick_start_dialog_view_site_message_short" tools:ignore="UnusedResources">Tap &lt;b&gt;%1$s&lt;/b&gt; to view your site</string>
     <string name="quick_start_dialog_view_site_title">View your site</string>
     <string name="quick_start_dialog_update_site_title_message_short">Tap &lt;b&gt;%1$s&lt;/b&gt; to set a new title</string>
     <string name="quick_start_dialog_edit_homepage_title">Edit your homepage</string>
@@ -3083,7 +3083,7 @@
     <string name="quick_start_list_upload_icon_subtitle">Shown in your visitor\'s browser tab and other places online.</string>
     <string name="quick_start_list_upload_icon_title" translatable="false">@string/quick_start_dialog_upload_icon_title</string>
     <string name="quick_start_list_view_site_subtitle" translatable="false">@string/quick_start_dialog_view_site_message</string>
-    <string name="quick_start_list_view_site_title">Visit your site</string>
+    <string name="quick_start_list_view_site_title">View your site</string>
     <string name="quick_start_list_edit_homepage_subtitle" translatable="false">@string/quick_start_dialog_edit_homepage_message</string>
     <string name="quick_start_list_edit_homepage_title" translatable="false">@string/quick_start_dialog_edit_homepage_title</string>
     <string name="quick_start_list_review_pages_subtitle">Check your pages and make changes, or add or remove pages.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteCardAndItemTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteCardAndItemTest.kt
@@ -33,6 +33,13 @@ class MySiteCardAndItemTest {
     }
 
     @Test
+    fun `given site info block is active when focus point on subtitle`() {
+        val siteInfoCard = initSiteInfoCard(showSubtitleFocusPoint = true)
+
+        assertThat(siteInfoCard.activeQuickStartItem).isTrue()
+    }
+
+    @Test
     fun `site info block is not active when focus point not added`() {
         val siteInfoCard = initSiteInfoCard()
 
@@ -41,6 +48,7 @@ class MySiteCardAndItemTest {
 
     private fun initSiteInfoCard(
         showTitleFocusPoint: Boolean = false,
+        showSubtitleFocusPoint: Boolean = false,
         showIconFocusPoint: Boolean = false
     ): SiteInfoHeaderCard {
         return SiteInfoHeaderCard(
@@ -48,6 +56,7 @@ class MySiteCardAndItemTest {
                 url = "url",
                 iconState = Visible(null),
                 showTitleFocusPoint = showTitleFocusPoint,
+                showSubtitleFocusPoint = showSubtitleFocusPoint,
                 showIconFocusPoint = showIconFocusPoint,
                 onTitleClick = null,
                 onIconClick = interaction,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteCardAndItemTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteCardAndItemTest.kt
@@ -33,7 +33,7 @@ class MySiteCardAndItemTest {
     }
 
     @Test
-    fun `given site info block is active when focus point on subtitle`() {
+    fun `when focus point on subtitle, then site info block is active`() {
         val siteInfoCard = initSiteInfoCard(showSubtitleFocusPoint = true)
 
         assertThat(siteInfoCard.activeQuickStartItem).isTrue()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -848,7 +848,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `site info card url click opens site and and completes View Site task`() = test {
+    fun `site info card url click opens site and completes View Site task`() = test {
         invokeSiteInfoCardAction(SiteInfoHeaderCardAction.URL_CLICK)
 
         verify(quickStartRepository).completeTask(QuickStartTask.VIEW_SITE)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -848,7 +848,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `site info card url click opens site and requests next step of View Site task`() = test {
+    fun `site info card url click opens site and and completes View Site task`() = test {
         invokeSiteInfoCardAction(SiteInfoHeaderCardAction.URL_CLICK)
 
         verify(quickStartRepository).completeTask(QuickStartTask.VIEW_SITE)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -848,9 +848,10 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `site info card url click opens site`() = test {
+    fun `site info card url click opens site and requests next step of View Site task`() = test {
         invokeSiteInfoCardAction(SiteInfoHeaderCardAction.URL_CLICK)
 
+        verify(quickStartRepository).completeTask(QuickStartTask.VIEW_SITE)
         assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenSite(site))
     }
 
@@ -2530,6 +2531,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 url = siteUrl,
                 iconState = IconState.Visible(siteIcon),
                 showTitleFocusPoint = false,
+                showSubtitleFocusPoint = false,
                 showIconFocusPoint = false,
                 onTitleClick = ListItemInteraction.create { params.titleClick.invoke() },
                 onIconClick = ListItemInteraction.create { params.iconClick.invoke() },

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardBuilderTest.kt
@@ -58,7 +58,6 @@ class SiteInfoHeaderCardBuilderTest {
         assertThat(buildSiteInfoCard.showIconFocusPoint).isFalse()
     }
 
-
     @Test
     fun `given View Site active task, when card built, then showSubtitleFocusPoint is true`() {
         val buildSiteInfoCard = buildSiteInfoCard(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardBuilderTest.kt
@@ -58,8 +58,28 @@ class SiteInfoHeaderCardBuilderTest {
         assertThat(buildSiteInfoCard.showIconFocusPoint).isFalse()
     }
 
+
+    @Test
+    fun `given View Site active task, when card built, then showSubtitleFocusPoint is true`() {
+        val buildSiteInfoCard = buildSiteInfoCard(
+                showViewSiteFocusPoint = true
+        )
+
+        assertThat(buildSiteInfoCard.showSubtitleFocusPoint).isTrue
+    }
+
+    @Test
+    fun `given View Site not active task, when card built, then showSubtitleFocusPoint is false`() {
+        val buildSiteInfoCard = buildSiteInfoCard(
+                showViewSiteFocusPoint = false
+        )
+
+        assertThat(buildSiteInfoCard.showSubtitleFocusPoint).isFalse
+    }
+
     private fun buildSiteInfoCard(
         showUpdateSiteTitleFocusPoint: Boolean = false,
+        showViewSiteFocusPoint: Boolean = false,
         showUploadSiteIconFocusPoint: Boolean = false
     ) = siteInfoHeaderCardBuilder.buildSiteInfoCard(
             SiteInfoCardBuilderParams(
@@ -69,16 +89,22 @@ class SiteInfoHeaderCardBuilderTest {
                     iconClick = {},
                     urlClick = {},
                     switchSiteClick = {},
-                    setActiveTask(showUpdateSiteTitleFocusPoint, showUploadSiteIconFocusPoint)
+                    setActiveTask(
+                            showUpdateSiteTitleFocusPoint,
+                            showViewSiteFocusPoint,
+                            showUploadSiteIconFocusPoint
+                    )
             )
     )
 
     private fun setActiveTask(
         showUpdateSiteTitleFocusPoint: Boolean,
+        showViewSiteFocusPoint: Boolean,
         showUploadSiteIconFocusPoint: Boolean
     ): QuickStartTask? {
         return when {
             showUpdateSiteTitleFocusPoint -> QuickStartTask.UPDATE_SITE_TITLE
+            showViewSiteFocusPoint -> QuickStartTask.VIEW_SITE
             showUploadSiteIconFocusPoint -> QuickStartTask.UPLOAD_SITE_ICON
             else -> null
         }


### PR DESCRIPTION
Parent #16349 

This PR has the following changes 
-  Updates title, subtitle of `View your Site` task 
-  Update Notice for `View your Site` task 
- Changes Focus Point to Site URL rather than `View Site` list item.
- Additional Updates Site Title Focus Point to the Start of the Site Title. (Before it was at the end of the Site title which didn't look proper for a short Site Title. So have updated the position to the top left corner of the Site Title)

| Site URL QS Focus point | Site Title Focus Point | 
|---|---|
| ![SiteURL_QS](https://user-images.githubusercontent.com/17463767/165050853-e6c0c526-3749-41fc-9c3a-889fa6a7c5b1.png)  | ![SiteTitleQS](https://user-images.githubusercontent.com/17463767/165057165-1a55abe4-db8e-4eda-a201-a2acd6c7d37b.png)  | 


/cc @jostnes

To test:
- Launch the app with a site having a quick start in progress.
- Go to My Site tab.
- Select **Customize your site** from Next Steps card on My Site screen. The card will be present on the Initial Screen tab set in the Settings.
- Notice that title, subtitle of the `View your site` task are changed to `Visit your site`,`Preview your site to see what your visitors will see.`
- Click `View your site` row.
- Notice that snackbar text is changed to Select `Tap *Site Url* to view your site`.
- Notice that Focus point is shown on Site URL in the Site header 
- To test Notice with Go Button info, restart QS flow by clearing cache/ relogin. Run all QS tasks sequentially till you reach the **`Visit your site: Preview your site to see what your visitors will see`**. notice.


## Regression Notes
1. Potential unintended areas of impact
View your site title task not shown properly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests and Unit tests 

3. What automated tests I added (or what prevented me from doing so)
Unit tests 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

