### PR TITLE
[Tooling] Improve comment for the RELEASE-NOTES.txt format

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,14 @@
-*** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+// PLEASE FOLLOW THIS FORMAT:
+// 
+// * [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+// 
+// The priority indicator usually ranges from `*` (small impact/importance) to `***` (high importance), and will help pick the most important items when wordsmithing the final, editorialized release notes from the items listed here.
+// 
+// INTERNAL CHANGES:
+//
+// If your change is not user-facing (and thus should not be included in the final public-facing release notes) but still needs to be included in the Call for Testing
+// so that it is still beta-tested during that sprint (e.g. for features behind feature flags), use `[internal]` in place or after the priority indicator.
+//
 
 19.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,13 +1,13 @@
-// PLEASE FOLLOW THIS FORMAT:
+// ## Please follow the below format. See pdcxQM-Km-p2 for more details.
 // 
-// * [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+// ```
+// * [<priority indicator, more stars = higher priority>] <optional app area>: <description> [<PR URL>]
+// ```
 // 
-// The priority indicator usually ranges from `*` (small impact/importance) to `***` (high importance), and will help pick the most important items when wordsmithing the final, editorialized release notes from the items listed here.
-// 
-// INTERNAL CHANGES:
-//
-// If your change is not user-facing (and thus should not be included in the final public-facing release notes) but still needs to be included in the Call for Testing
-// so that it is still beta-tested during that sprint (e.g. for features behind feature flags), use `[internal]` in place or after the priority indicator.
+// - The priority indicator usually ranges from `*` (small impact/importance) to `***` (high importance), and will help pick the most important items when wordsmithing the final, editorialized release notes from the items listed here.
+// - The app area prefix before the description is optional, but can help categorize features. Examples include: `Block Editor:`, `Reader:`, etc.
+// - If your change is not user-facing (and thus should not be included in the final public-facing release notes) but still needs to be included in the Call for Testing,
+//   so that it is still beta-tested during that sprint (e.g. for features behind feature flags), use `[internal]` in place or after the priority indicator.
 //
 
 19.8


### PR DESCRIPTION
This is a draft PR / example change to go alongside @thehenrybyrd's recent P2 post pdcxQM-Km-p2 to provide more hints on the format we expect for release notes.

### To Test

We want to ensure that those new comments still work with our tooling which extracts release notes from this file, and the one which adds a new section on top of that file for the next version after a code freeze:

* Cut a new test branch from this one
* Run `bundle exec fastlane run extract_release_notes_for_version version:19.7 release_notes_file_path:RELEASE-NOTES.txt`
* Verify that this ends up extracting and printing just the items about 19.7, and not include the comments we added at the top of that file (nor lines from other sections)
* Run `bundle exec fastlane android_update_release_notes new_version:99.9`
* Verify that this ends up adding a new entry in the `RELEASE-NOTES.txt` file that properly ends up after the header comment lines (`// …`) but before the first `19.7` section.
  * Note that the action will also commit and try to push that change, and if you didn't have a tracking upstream branch associated with your local test branch, the `git push` will likely fail, that's no big deal as long as you can confirm that the change to the file was made locally.
* Delete your test git branch.

### Notes

 - This PR is just an example as a starting point. @thehenrybyrd feel free to push new commits to adjust the instruction comments with a better wording or more information.
 - I've only done that change in WPAndroid but we might want to provide similar instructions in the WPiOS's `RELEASE-NOTES.txt` file as well.