### PR TITLE
[Site Name] Hides keyboard on back navigation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -132,6 +132,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         })
         siteCreationSiteNameViewModel.onBackButtonPressed.observe(this, Observer {
             mainViewModel.onBackPressed()
+            ActivityUtils.hideKeyboard(this)
         })
         siteCreationSiteNameViewModel.onSkipButtonPressed.observe(this, Observer {
             ActivityUtils.hideKeyboard(this)


### PR DESCRIPTION
## Description
Hides keyboard on back navigation from the site name screen.

Internal ref: `p5T066-3a9-p2#comment-12083`

Note: A side effect of the applied solution is that the keyboard will hide even when the site intent name screen is in search mode. This seemed less of an inconvenience compared to the original issue described in the Internal ref above

To test:
<details>
<summary>1. Toggle ON the Site Name feature</summary>

1. From My Site Go to Me → App Settings → Debug settings
2. Scroll to Features in development section and tap on SiteNameFeatureConfig
3. Tap RESTART THE APP button
4. Since this feature is A/B tested go to **Abacus**, find the `wpandroid_site_name_v1` experiment and assign to your test a8c-user the treatment variation

**Alternatively hardcode the feature on by returning `true` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/521e6b3a296339bec026f8ee2648eab326d31129/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt#L19)** 
</details>

2. Start the Site Creation flow
3. Choose an intent for your site from the default or skip
4. Press the back button
5. Verify that the keyboard is hidden

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
