### PR TITLE
App Data Coverage: add more tracking to the Change Username flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
@@ -46,6 +46,7 @@ public class FullScreenDialogFragment extends DialogFragment {
     private FullScreenDialogController mController;
     private OnConfirmListener mOnConfirmListener;
     private OnDismissListener mOnDismissListener;
+    private OnShownListener mOnShownListener;
     private String mAction;
     private MenuItem mActionItem;
     private String mSubtitle;
@@ -91,12 +92,17 @@ public class FullScreenDialogFragment extends DialogFragment {
         void onDismiss();
     }
 
+    public interface OnShownListener {
+        void onShown();
+    }
+
     protected static FullScreenDialogFragment newInstance(Builder builder) {
         FullScreenDialogFragment dialog = new FullScreenDialogFragment();
         dialog.setArguments(setArguments(builder));
         dialog.setContent(Fragment.instantiate(builder.mContext, builder.mClass.getName(), builder.mArguments));
         dialog.setOnConfirmListener(builder.mOnConfirmListener);
         dialog.setOnDismissListener(builder.mOnDismissListener);
+        dialog.setOnShownListener(builder.mOnShownListener);
         dialog.setHideActivityBar(builder.mHideActivityBar);
         dialog.setLiftOnScroll(builder.mIsLiftOnScroll);
         return dialog;
@@ -217,6 +223,7 @@ public class FullScreenDialogFragment extends DialogFragment {
     @Override
     public int show(FragmentTransaction transaction, String tag) {
         initBuilderArguments();
+        shown();
         transaction.setCustomAnimations(R.anim.full_screen_dialog_fragment_slide_up, 0, 0,
                 R.anim.full_screen_dialog_fragment_slide_down);
         return transaction.add(android.R.id.content, this, tag).addToBackStack(null).commit();
@@ -228,6 +235,12 @@ public class FullScreenDialogFragment extends DialogFragment {
         }
 
         dismiss();
+    }
+
+    protected void shown() {
+        if (mOnShownListener != null) {
+            mOnShownListener.onShown();
+        }
     }
 
     /**
@@ -384,6 +397,16 @@ public class FullScreenDialogFragment extends DialogFragment {
     }
 
     /**
+     * Set callback to call when dialog is shown due to shown requested.
+     *
+     * @param listener {@link OnShownListener} interface to call on shown executed
+     */
+    public void setOnShownListener(@Nullable OnShownListener listener) {
+        this.mOnShownListener = listener;
+    }
+
+
+    /**
      * Set {@link FullScreenDialogFragment} subtitle text.
      *
      * @param text {@link String} to set as subtitle text
@@ -447,6 +470,7 @@ public class FullScreenDialogFragment extends DialogFragment {
         Context mContext;
         OnConfirmListener mOnConfirmListener;
         OnDismissListener mOnDismissListener;
+        OnShownListener mOnShownListener;
         String mAction = "";
         String mSubtitle = "";
         String mTitle = "";
@@ -603,6 +627,17 @@ public class FullScreenDialogFragment extends DialogFragment {
          */
         public Builder setOnDismissListener(@Nullable OnDismissListener listener) {
             this.mOnDismissListener = listener;
+            return this;
+        }
+
+        /**
+         * Set callback to call when dialog is shown.
+         *
+         * @param listener {@link OnShownListener} interface to call on shown
+         * @return {@link Builder} object to allow for chaining of calls to set methods
+         */
+        public Builder setOnShownListener(@Nullable OnShownListener listener) {
+            this.mOnShownListener = listener;
             return this;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
@@ -42,8 +42,10 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -71,6 +73,7 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
     private boolean mIsShowingDismissDialog;
     private boolean mShouldWatchText; // Flag handling text watcher to avoid network call on device rotation.
     private int mUsernameSelectedIndex;
+    private int mSearchCount = 0;
 
     public static final String EXTRA_DISPLAY_NAME = "EXTRA_DISPLAY_NAME";
     public static final String EXTRA_USERNAME = "EXTRA_USERNAME";
@@ -80,7 +83,10 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
     public static final String KEY_USERNAME_SELECTED_INDEX = "KEY_USERNAME_SELECTED_INDEX";
     public static final String KEY_USERNAME_SUGGESTIONS = "KEY_USERNAME_SUGGESTIONS";
     public static final String RESULT_USERNAME = "RESULT_USERNAME";
+    public static final String KEY_SEARCH_COUNT = "KEY_SEARCH_COUNT";
     public static final int GET_SUGGESTIONS_INTERVAL_MS = 1000;
+    public static final String SOURCE = "source";
+    public static final String SEARCH_COUNT = "search_count";
 
     @Inject protected Dispatcher mDispatcher;
 
@@ -108,6 +114,12 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
      * @return formatted header template
      */
     abstract Spanned getHeaderText(String username, String display);
+
+    /**
+     * Fragments that extend this class are required to provide the tracking event source
+     * @return String
+     */
+    abstract String getTrackEventSource();
 
     public static Bundle newBundle(String displayName, String username) {
         Bundle bundle = new Bundle();
@@ -149,6 +161,7 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
             mShouldWatchText = savedInstanceState.getBoolean(KEY_SHOULD_WATCH_TEXT);
             mUsernameSelected = savedInstanceState.getString(KEY_USERNAME_SELECTED);
             mUsernameSelectedIndex = savedInstanceState.getInt(KEY_USERNAME_SELECTED_INDEX);
+            mSearchCount = savedInstanceState.getInt(KEY_SEARCH_COUNT);
             ArrayList<String> suggestions = savedInstanceState.getStringArrayList(KEY_USERNAME_SUGGESTIONS);
             if (suggestions != null) {
                 setUsernameSuggestions(suggestions);
@@ -166,6 +179,7 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
             mUsernameSelectedIndex = 0;
             mUsernameSuggestionInput = getUsernameQueryFromDisplayName();
             getUsernameSuggestions(mUsernameSuggestionInput);
+            mSearchCount = 0;
         }
 
         mHeaderView = getView().findViewById(R.id.header);
@@ -199,6 +213,8 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
 
         mGetSuggestionsHandler = new Handler();
         mGetSuggestionsRunnable = () -> {
+            mSearchCount++;
+            trackSearch();
             mUsernameSuggestionInput = mUsernameView.getText().toString();
             getUsernameSuggestions(mUsernameSuggestionInput);
         };
@@ -260,6 +276,7 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
         if (mUsernamesAdapter != null) {
             outState.putStringArrayList(KEY_USERNAME_SUGGESTIONS, new ArrayList<>(mUsernamesAdapter.mItems));
         }
+        outState.putInt(KEY_SEARCH_COUNT, mSearchCount);
     }
 
     @Override
@@ -342,6 +359,12 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
         mProgressBar.setVisibility(showProgress ? View.VISIBLE : View.GONE);
     }
 
+    private void trackSearch() {
+        Map<String, String> props = new HashMap<>();
+        props.put(SOURCE, getTrackEventSource());
+        props.put(SEARCH_COUNT, String.valueOf(mSearchCount));
+        AnalyticsTracker.track(Stat.CHANGE_USERNAME_SEARCH_PERFORMED, props);
+    }
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onUsernameSuggestionsFetched(OnUsernameSuggestionsFetched event) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SettingsUsernameChangerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SettingsUsernameChangerFragment.kt
@@ -46,6 +46,8 @@ class SettingsUsernameChangerFragment : BaseUsernameChangerFullScreenDialogFragm
             ), HtmlCompat.FROM_HTML_MODE_LEGACY
     )
 
+    override fun getTrackEventSource() = SOURCE
+
     override fun setController(controller: FullScreenDialogController) {
         super.setController(controller)
         dialogController = controller
@@ -185,5 +187,9 @@ class SettingsUsernameChangerFragment : BaseUsernameChangerFullScreenDialogFragm
                 Snackbar.LENGTH_LONG
         )
                 .show()
+    }
+
+    companion object {
+        const val SOURCE = "account_settings"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -56,6 +56,7 @@ import org.wordpress.android.networking.GravatarApi;
 import org.wordpress.android.ui.FullScreenDialogFragment;
 import org.wordpress.android.ui.FullScreenDialogFragment.OnConfirmListener;
 import org.wordpress.android.ui.FullScreenDialogFragment.OnDismissListener;
+import org.wordpress.android.ui.FullScreenDialogFragment.OnShownListener;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker;
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Click;
@@ -87,6 +88,7 @@ import java.net.URISyntaxException;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -94,7 +96,7 @@ import static org.wordpress.android.analytics.AnalyticsTracker.Stat.SIGNUP_EMAIL
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.SIGNUP_EMAIL_EPILOGUE_GRAVATAR_SHOT_NEW;
 
 public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogueListener>
-        implements OnConfirmListener, OnDismissListener {
+        implements OnConfirmListener, OnDismissListener, OnShownListener {
     private EditText mEditTextDisplayName;
     private EditText mEditTextUsername;
     private FullScreenDialogFragment mDialog;
@@ -133,6 +135,9 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     private static final String KEY_IS_UPDATING_PASSWORD = "KEY_IS_UPDATING_PASSWORD";
     private static final String KEY_HAS_UPDATED_PASSWORD = "KEY_HAS_UPDATED_PASSWORD";
     private static final String KEY_HAS_MADE_UPDATES = "KEY_HAS_MADE_UPDATES";
+
+    private static final String SOURCE = "source";
+    private static final String SOURCE_SIGNUP_EPILOGUE = "signup_epilogue";
 
     public static final String TAG = "signup_epilogue_fragment_tag";
 
@@ -451,6 +456,13 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     }
 
     @Override
+    public void onShown() {
+        Map<String, String> props = new HashMap<>();
+        props.put(SOURCE, SOURCE_SIGNUP_EPILOGUE);
+        AnalyticsTracker.track(AnalyticsTracker.Stat.CHANGE_USERNAME_DISPLAYED, props);
+    }
+
+    @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putString(KEY_PHOTO_URL, mPhotoUrl);
@@ -582,6 +594,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                 .setToolbarTheme(R.style.ThemeOverlay_LoginFlow_Toolbar)
                 .setOnConfirmListener(this)
                 .setOnDismissListener(this)
+                .setOnShownListener(this)
                 .setContent(UsernameChangerFullScreenDialogFragment.class, bundle)
                 .build();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
@@ -452,6 +453,9 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
 
     @Override
     public void onDismiss() {
+        Map<String, String> props = new HashMap<>();
+        props.put(SOURCE, SOURCE_SIGNUP_EPILOGUE);
+        AnalyticsTracker.track(Stat.CHANGE_USERNAME_DISMISSED, props);
         mDialog = null;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragment.kt
@@ -25,8 +25,14 @@ class UsernameChangerFullScreenDialogFragment : BaseUsernameChangerFullScreenDia
             )
     )
 
+    override fun getTrackEventSource() = SOURCE
+
     override fun onUsernameConfirmed(controller: FullScreenDialogController, usernameSelected: String) {
         val result = Bundle().apply { putString(RESULT_USERNAME, usernameSelected) }
         controller.confirm(result)
+    }
+
+    companion object {
+        const val SOURCE = "signup_epilogue"
     }
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -848,7 +848,8 @@ public final class AnalyticsTracker {
         MY_SITE_DASHBOARD_SHOWN,
         MY_SITE_SITE_MENU_SHOWN,
         MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED,
-        APP_SETTINGS_INITIAL_SCREEN_CHANGED
+        APP_SETTINGS_INITIAL_SCREEN_CHANGED,
+        CHANGE_USERNAME_DISPLAYED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -849,7 +849,9 @@ public final class AnalyticsTracker {
         MY_SITE_SITE_MENU_SHOWN,
         MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED,
         APP_SETTINGS_INITIAL_SCREEN_CHANGED,
-        CHANGE_USERNAME_DISPLAYED
+        CHANGE_USERNAME_DISPLAYED,
+        CHANGE_USERNAME_DISMISSED,
+        CHANGE_USERNAME_SEARCH_PERFORMED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2203,6 +2203,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "my_site_default_tab_experiment_variant_assigned";
             case APP_SETTINGS_INITIAL_SCREEN_CHANGED:
                 return "app_settings_initial_screen_changed";
+            case CHANGE_USERNAME_DISPLAYED:
+                return "change_username_displayed";
         }
         return null;
     }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2205,6 +2205,10 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "app_settings_initial_screen_changed";
             case CHANGE_USERNAME_DISPLAYED:
                 return "change_username_displayed";
+            case CHANGE_USERNAME_DISMISSED:
+                return "change_username_dismissed";
+            case CHANGE_USERNAME_SEARCH_PERFORMED:
+                return "change_username_search_performed";
         }
         return null;
     }


### PR DESCRIPTION
Parent #16343 

Description
This PR adds 3 new tracking events to the change username flow:
- When the view is displayed
- When the view is dismissed
- When a user performs a search; including the number of searches perfomred

Since this username change feature is available within the signup flow + within the account settings, a "source" property will be captured with the above. Values = "signup_epilogue" and "account_settings"

**To test:**
**Prereqs**
- Launch the app 
- Navigate to Me -> App Settings -> Privacy Settings
- Turn on Collect Information
- Logout

**Test tracking events are in the logs**
- Start the create the signup flow by entering a new email
- View your email
- Launch the app by tapping the "Sign up to WordPress.com" in the signup email
- You should now be in the `Signup Epilogue` view
- Tap the username to launch the Change Username full screen dialog
- ✅  Verify the logs contain: 🔵 Tracked: change_username_displayed, Properties: {"source":"signup_epilogue"}
- Enter some text in the search view
- ✅  Verify the logs contain: 🔵 Tracked: change_username_search_performed, Properties: {"source":"signup_epilogue"}
- Tap the X button
- ✅  Verify the logs contain: 🔵 Tracked: change_username_dismissed, Properties: {"source":"signup_epilogue"}
- Finish creating the account
- Tap on Me -> Account Settings to launch the Change Username full screen dialog
- ✅  Verify the logs contain: 🔵 Tracked: change_username_displayed, Properties: {"source":"account_settings"}
- Enter some text in the search view
- ✅  Verify the logs contain: 🔵 Tracked: change_username_search_performed, Properties: {"source":"account_settings"}
- Tap the X button
- ✅  Verify the logs contain: 🔵 Tracked: change_username_dismissed, Properties: {"source":"account_settings


## Regression Notes
1. Potential unintended areas of impact
The events are not tracked

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
