### PR TITLE
[Site Name] Keep vertical input focused on back and reset the Site Intent screen on skip

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -132,6 +132,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         })
         siteCreationSiteNameViewModel.onBackButtonPressed.observe(this, Observer {
             mainViewModel.onBackPressed()
+            ActivityUtils.hideKeyboard(this)
         })
         siteCreationSiteNameViewModel.onSkipButtonPressed.observe(this, Observer {
             ActivityUtils.hideKeyboard(this)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -132,7 +132,6 @@ class SiteCreationActivity : LocaleAwareActivity(),
         })
         siteCreationSiteNameViewModel.onBackButtonPressed.observe(this, Observer {
             mainViewModel.onBackPressed()
-            ActivityUtils.hideKeyboard(this)
         })
         siteCreationSiteNameViewModel.onSkipButtonPressed.observe(this, Observer {
             ActivityUtils.hideKeyboard(this)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -83,7 +83,7 @@ class SiteCreationIntentsFragment : Fragment() {
         (recyclerView.adapter as SiteCreationIntentsAdapter).update(uiState.content.items)
         updateTitleVisibility(uiState.isAppBarTitleVisible)
 
-        uiState.inputValue
+        uiState.retainedInputValue
                 ?.let {
                     it.also {
                         input.requestFocus()
@@ -121,7 +121,7 @@ class SiteCreationIntentsFragment : Fragment() {
         viewModel.uiState.observe(viewLifecycleOwner) { updateUiState(it) }
         viewModel.onIntentSelected.observe(viewLifecycleOwner) {
             input.isFocusable = false
-            input.setTextUnobserved(viewModel.uiState.value?.searchQuery ?: it)
+            input.setTextUnobserved(viewModel.uiState.value?.takeSearchQueryIfItExists() ?: it)
             (requireActivity() as IntentsScreenListener).onIntentSelected(it)
         }
         viewModel.initializeFromResources(resources)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -121,7 +121,7 @@ class SiteCreationIntentsFragment : Fragment() {
         viewModel.uiState.observe(viewLifecycleOwner) { updateUiState(it) }
         viewModel.onIntentSelected.observe(viewLifecycleOwner) {
             input.isFocusable = false
-            input.setTextUnobserved(it)
+            input.setTextUnobserved(viewModel.uiState.value?.searchQuery ?: it)
             (requireActivity() as IntentsScreenListener).onIntentSelected(it)
         }
         viewModel.initializeFromResources(resources)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -101,9 +101,11 @@ class SiteCreationIntentsFragment : Fragment() {
     }
 
     private fun TextInputEditText.setTextUnobserved(text: CharSequence) {
-        removeTextChangedListener(inputWatcher)
-        setText(text)
-        addTextChangedListener(inputWatcher)
+        inputWatcher?.let {
+            removeTextChangedListener(it)
+            setText(text)
+            addTextChangedListener(it)
+        }
     }
 
     private fun SiteCreationIntentsFragmentBinding.updateTitleVisibility(shouldAppBarTitleBeVisible: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -83,7 +83,7 @@ class SiteCreationIntentsFragment : Fragment() {
         (recyclerView.adapter as SiteCreationIntentsAdapter).update(uiState.content.items)
         updateTitleVisibility(uiState.isAppBarTitleVisible)
 
-        uiState.vertical
+        uiState.inputValue
                 ?.let {
                     it.also {
                         input.requestFocus()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -85,8 +85,10 @@ class SiteCreationIntentsFragment : Fragment() {
 
         uiState.vertical
                 ?.let {
-                    input.requestFocus()
-                    ActivityUtils.showKeyboard(input)
+                    it.also {
+                        input.requestFocus()
+                        ActivityUtils.showKeyboard(input)
+                    }
                 }
                 ?: run {
                     if (!uiState.searchQuery.isNullOrBlank()) return@run

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -89,6 +89,7 @@ class SiteCreationIntentsFragment : Fragment() {
                     ActivityUtils.showKeyboard(input)
                 }
                 ?: run {
+                    if (!uiState.searchQuery.isNullOrBlank()) return@run
                     input.setTextUnobserved("")
                     ActivityUtils.hideKeyboard(requireActivity())
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -66,7 +66,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
             analyticsTracker.trackSiteIntentQuestionCustomVerticalSelected(state.searchQuery.orEmpty())
             _onIntentSelected.value = state.searchQuery
             updateUiState(
-                    state.copy(vertical = state.searchQuery)
+                    state.copy(inputValue = state.searchQuery)
             )
         }
     }
@@ -106,7 +106,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
         _onIntentSelected.value = vertical
         uiState.value?.let {
             updateUiState(
-                    it.copy(vertical = it.searchQuery ?: vertical)
+                    it.copy(inputValue = it.searchQuery ?: vertical)
             )
         }
     }
@@ -163,7 +163,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
         val isAppBarTitleVisible: Boolean = false,
         val isHeaderVisible: Boolean = true,
         val searchQuery: String? = null,
-        val vertical: String? = null,
+        val inputValue: String? = null,
         val content: Content
     ) {
         sealed class Content(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -66,7 +66,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
             analyticsTracker.trackSiteIntentQuestionCustomVerticalSelected(state.searchQuery.orEmpty())
             _onIntentSelected.value = state.searchQuery
             updateUiState(
-                    state.copy(inputValue = state.searchQuery)
+                    state.copy(retainedInputValue = state.searchQuery)
             )
         }
     }
@@ -106,7 +106,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
         _onIntentSelected.value = vertical
         uiState.value?.let {
             updateUiState(
-                    it.copy(inputValue = it.searchQuery ?: vertical)
+                    it.copy(retainedInputValue = it.takeSearchQueryIfItExists() ?: vertical)
             )
         }
     }
@@ -163,7 +163,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
         val isAppBarTitleVisible: Boolean = false,
         val isHeaderVisible: Boolean = true,
         val searchQuery: String? = null,
-        val inputValue: String? = null,
+        val retainedInputValue: String? = null,
         val content: Content
     ) {
         sealed class Content(
@@ -183,6 +183,8 @@ class SiteCreationIntentsViewModel @Inject constructor(
 
             object Empty : Content(emptyList())
         }
+
+        fun takeSearchQueryIfItExists() = searchQuery.takeIf { !it.isNullOrBlank() }
 
         companion object {
             fun resetToContent(content: Content) = IntentsUiState(content = content)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -104,8 +104,10 @@ class SiteCreationIntentsViewModel @Inject constructor(
     fun intentSelected(slug: String, vertical: String) {
         analyticsTracker.trackSiteIntentQuestionVerticalSelected(slug)
         _onIntentSelected.value = vertical
-        uiState.value?.let { updateUiState(
-                it.copy(vertical = vertical))
+        uiState.value?.let {
+            updateUiState(
+                    it.copy(vertical = vertical)
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -106,7 +106,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
         _onIntentSelected.value = vertical
         uiState.value?.let {
             updateUiState(
-                    it.copy(vertical = vertical)
+                    it.copy(vertical = it.searchQuery ?: vertical)
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -18,6 +18,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
+@Suppress("TooManyFunctions")
 class SiteCreationIntentsViewModel @Inject constructor(
     private val analyticsTracker: SiteCreationTracker,
     private val searchResultsProvider: VerticalsSearchResultsProvider,

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
@@ -87,7 +87,7 @@ class SiteCreationIntentsViewModelTest {
 
         viewModel.intentSelected(slug, vertical)
 
-        assertThat(viewModel.uiState.value?.vertical).isEqualTo(vertical)
+        assertThat(viewModel.uiState.value?.inputValue).isEqualTo(vertical)
     }
 
     @Test
@@ -100,7 +100,7 @@ class SiteCreationIntentsViewModelTest {
         viewModel.onSearchTextChanged(searchQuery)
         viewModel.intentSelected(slug, vertical)
 
-        assertThat(viewModel.uiState.value?.vertical).isEqualTo(searchQuery)
+        assertThat(viewModel.uiState.value?.inputValue).isEqualTo(searchQuery)
     }
 
     @Test
@@ -143,7 +143,7 @@ class SiteCreationIntentsViewModelTest {
 
         viewModel.onCustomVerticalSelected()
 
-        assertThat(viewModel.uiState.value?.vertical).isEqualTo(viewModel.uiState.value?.searchQuery)
+        assertThat(viewModel.uiState.value?.inputValue).isEqualTo(viewModel.uiState.value?.searchQuery)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
@@ -91,6 +91,19 @@ class SiteCreationIntentsViewModelTest {
     }
 
     @Test
+    fun `when an item is tapped after searching the search query is persisted`() {
+        val slug = "parenting1"
+        val vertical = "parenting"
+        val searchQuery = "renting"
+        viewModel.initializeFromResources(resources)
+
+        viewModel.onSearchTextChanged(searchQuery)
+        viewModel.intentSelected(slug, vertical)
+
+        assertThat(viewModel.uiState.value?.vertical).isEqualTo(searchQuery)
+    }
+
+    @Test
     fun `when the user scroll beyond a threshold the title becomes visible`() {
         viewModel.initializeFromResources(resources)
         viewModel.onAppBarOffsetChanged(9, 10)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
@@ -87,7 +87,7 @@ class SiteCreationIntentsViewModelTest {
 
         viewModel.intentSelected(slug, vertical)
 
-        assertThat(viewModel.uiState.value?.inputValue).isEqualTo(vertical)
+        assertThat(viewModel.uiState.value?.retainedInputValue).isEqualTo(vertical)
     }
 
     @Test
@@ -100,7 +100,7 @@ class SiteCreationIntentsViewModelTest {
         viewModel.onSearchTextChanged(searchQuery)
         viewModel.intentSelected(slug, vertical)
 
-        assertThat(viewModel.uiState.value?.inputValue).isEqualTo(searchQuery)
+        assertThat(viewModel.uiState.value?.retainedInputValue).isEqualTo(searchQuery)
     }
 
     @Test
@@ -143,7 +143,7 @@ class SiteCreationIntentsViewModelTest {
 
         viewModel.onCustomVerticalSelected()
 
-        assertThat(viewModel.uiState.value?.inputValue).isEqualTo(viewModel.uiState.value?.searchQuery)
+        assertThat(viewModel.uiState.value?.retainedInputValue).isEqualTo(viewModel.uiState.value?.searchQuery)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
@@ -48,7 +48,10 @@ class SiteCreationIntentsViewModelTest {
 
     @Test
     fun `when the skip button is pressed an analytics event is emitted`() {
+        viewModel.initializeFromResources(resources)
+
         viewModel.onSkipPressed()
+
         verify(analyticsTracker).trackSiteIntentQuestionSkipped()
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModelTest.kt
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
+import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentsUiState
 import org.wordpress.android.util.LocaleManagerWrapper
 import java.util.Locale
 
@@ -52,6 +53,16 @@ class SiteCreationIntentsViewModelTest {
     }
 
     @Test
+    fun `when the skip button is pressed the ui state is reset to its initial value`() {
+        viewModel.initializeFromResources(resources)
+
+        viewModel.onSkipPressed()
+
+        val expectedState = IntentsUiState(content = viewModel.uiState.value!!.content)
+        assertThat(viewModel.uiState.value).isEqualTo(expectedState)
+    }
+
+    @Test
     fun `when the back button is pressed an analytics event is emitted`() {
         viewModel.onBackPressed()
         verify(analyticsTracker).trackSiteIntentQuestionCanceled()
@@ -63,6 +74,17 @@ class SiteCreationIntentsViewModelTest {
         viewModel.initializeFromResources(resources)
         viewModel.intentSelected(slug, slug)
         verify(analyticsTracker).trackSiteIntentQuestionVerticalSelected(slug)
+    }
+
+    @Test
+    fun `when an item is tapped the vertical is persisted`() {
+        val slug = "test1"
+        val vertical = "test vertical"
+        viewModel.initializeFromResources(resources)
+
+        viewModel.intentSelected(slug, vertical)
+
+        assertThat(viewModel.uiState.value?.vertical).isEqualTo(vertical)
     }
 
     @Test
@@ -95,6 +117,17 @@ class SiteCreationIntentsViewModelTest {
         viewModel.onSearchTextChanged(valueOfSearchInput)
         viewModel.onCustomVerticalSelected()
         verify(analyticsTracker).trackSiteIntentQuestionCustomVerticalSelected(eq(valueOfSearchInput))
+    }
+
+    @Test
+    fun `when the custom vertical is tapped its value is persisted`() {
+        val valueOfSearchInput = "test vertical"
+        viewModel.initializeFromResources(resources)
+        viewModel.onSearchTextChanged(valueOfSearchInput)
+
+        viewModel.onCustomVerticalSelected()
+
+        assertThat(viewModel.uiState.value?.vertical).isEqualTo(viewModel.uiState.value?.searchQuery)
     }
 
     @Test


### PR DESCRIPTION
Alternative solution to: #16378

Internal ref: `p5T066-3a9-p2#comment-12083`

Proposes a different approach for handling the input focus on the `Site Intent screen` and hiding/showing the keyboard when navigating back from the `Site Name screen`.

<details open>
<summary>Preview</summary>

<img width="314" src="https://user-images.githubusercontent.com/4588074/164539776-5832030c-136a-4ecb-a4e5-292827de6b7e.gif">
</details>

<details>
<summary>1. Toggle ON the Site Name feature</summary>

1. From My Site Go to Me → App Settings → Debug settings
2. Scroll to Features in development section and tap on SiteNameFeatureConfig
3. Tap RESTART THE APP button
4. Since this feature is A/B tested go to **Abacus**, find the `wpandroid_site_name_v1` experiment and assign to your test a8c-user the treatment variation

**Alternatively hardcode the feature on by returning `true` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/521e6b3a296339bec026f8ee2648eab326d31129/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt#L19)** 
</details>

2. Start the Site Creation flow
3. Choose an intent for your site from the default or proceed with a custom one
4. Tap the `←` back button
5. `Verify` that **the keyboard is shown and the input is focused**.
   Typing on the keyboard should work as expected = change the value of the input and trigger the search.
7. Tap `Skip`
4. Tap the `←` back button
5. `Verify` that **the keyboard is hidden and the screen UI is reset** to its initial state
   (equal to how it looks when starting the Site Creation Flow)
7. Keep doing exploratory testing by repeating steps `3 - 5` to check that it works as expected in all cases.

## Regression Notes
1. Potential unintended areas of impact
   N/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

3. What automated tests I added (or what prevented me from doing so)
  - I added unit tests in `SiteCreationIntentsViewModelTest` to cover the updated logic.
  - 


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
