### PR TITLE
Enable domains purchase on Jetpack Mobile app 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -78,7 +78,6 @@ class SiteItemsBuilder @Inject constructor(
                         params.onClick,
                         showEnablePostSharingFocusPoint
                 ),
-                siteListItemBuilder.buildDomainsItemIfAvailable(params.site, params.onClick),
                 siteListItemBuilder.buildSiteSettingsItemIfAvailable(params.site, params.onClick),
                 CategoryHeaderItem(UiStringRes(R.string.my_site_header_external)),
                 ListItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -77,6 +77,7 @@ class SiteItemsBuilder @Inject constructor(
                         params.onClick,
                         showEnablePostSharingFocusPoint
                 ),
+                siteListItemBuilder.buildDomainsItemIfAvailable(params.site, params.onClick),
                 siteListItemBuilder.buildSiteSettingsItemIfAvailable(params.site, params.onClick),
                 CategoryHeaderItem(UiStringRes(R.string.my_site_header_external)),
                 ListItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -50,7 +50,6 @@ class SiteItemsBuilder @Inject constructor(
                 siteListItemBuilder.buildBackupItemIfAvailable(params.onClick, params.backupAvailable),
                 siteListItemBuilder.buildScanItemIfAvailable(params.onClick, params.scanAvailable),
                 siteListItemBuilder.buildJetpackItemIfAvailable(params.site, params.onClick),
-                siteListItemBuilder.buildDomainsItemForJetpackIfAvailable(params.site, params.onClick),
                 CategoryHeaderItem(UiStringRes(R.string.my_site_header_publish)),
                 ListItem(
                         R.drawable.ic_posts_white_24dp,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -50,6 +50,7 @@ class SiteItemsBuilder @Inject constructor(
                 siteListItemBuilder.buildBackupItemIfAvailable(params.onClick, params.backupAvailable),
                 siteListItemBuilder.buildScanItemIfAvailable(params.onClick, params.scanAvailable),
                 siteListItemBuilder.buildJetpackItemIfAvailable(params.site, params.onClick),
+                siteListItemBuilder.buildDomainsItemForJetpackIfAvailable(params.site, params.onClick),
                 CategoryHeaderItem(UiStringRes(R.string.my_site_header_publish)),
                 ListItem(
                         R.drawable.ic_posts_white_24dp,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -74,30 +74,17 @@ class SiteListItemBuilder @Inject constructor(
     }
 
     fun buildJetpackItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
-        return if (isJetpackSettingsVisible(site)) {
+        val jetpackSettingsVisible = site.isJetpackConnected && // jetpack is installed and connected
+                !site.isWPComAtomic &&
+                siteUtilsWrapper.isAccessedViaWPComRest(site) && // is using .com login
+                site.hasCapabilityManageOptions // has permissions to manage the site
+        return if (jetpackSettingsVisible) {
             ListItem(
                     R.drawable.ic_cog_white_24dp,
                     UiStringRes(R.string.my_site_btn_jetpack_settings),
                     onClick = ListItemInteraction.create(JETPACK_SETTINGS, onClick)
             )
         } else null
-    }
-
-    fun buildDomainsItemForJetpackIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
-        return if (siteDomainsFeatureConfig.isEnabled() && isJetpackSettingsVisible(site)) {
-            ListItem(
-                    R.drawable.ic_domains_white_24dp,
-                    UiStringRes(R.string.my_site_btn_domains),
-                    onClick = ListItemInteraction.create(DOMAINS, onClick)
-            )
-        } else null
-    }
-
-    private fun isJetpackSettingsVisible(site: SiteModel): Boolean {
-        return site.isJetpackConnected && // jetpack is installed and connected
-                !site.isWPComAtomic &&
-                siteUtilsWrapper.isAccessedViaWPComRest(site) && // is using .com login
-                site.hasCapabilityManageOptions // has permissions to manage the site
     }
 
     @Suppress("ComplexCondition")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -169,6 +169,22 @@ class SiteListItemBuilder @Inject constructor(
         } else null
     }
 
+    fun buildDomainsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
+        return if (hasManageOptionsCapability(site) || isNotAccessedViaWPComRest(site)) {
+            ListItem(
+                    R.drawable.ic_domains_white_24dp,
+                    UiStringRes(R.string.my_site_btn_domains),
+                    onClick = ListItemInteraction.create(DOMAINS, onClick)
+            )
+        } else null
+    }
+
+    private fun hasManageOptionsCapability(site: SiteModel) =
+            siteDomainsFeatureConfig.isEnabled() && site.hasCapabilityManageOptions
+
+    private fun isNotAccessedViaWPComRest(site: SiteModel) =
+            siteDomainsFeatureConfig.isEnabled() && !siteUtilsWrapper.isAccessedViaWPComRest(site)
+
     fun buildSiteSettingsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (site.hasCapabilityManageOptions || !siteUtilsWrapper.isAccessedViaWPComRest(site)) {
             ListItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -182,22 +182,6 @@ class SiteListItemBuilder @Inject constructor(
         } else null
     }
 
-    fun buildDomainsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
-        return if (hasManageOptionsCapability(site) || isNotAccessedViaWPComRest(site)) {
-            ListItem(
-                    R.drawable.ic_domains_white_24dp,
-                    UiStringRes(R.string.my_site_btn_domains),
-                    onClick = ListItemInteraction.create(DOMAINS, onClick)
-            )
-        } else null
-    }
-
-    private fun hasManageOptionsCapability(site: SiteModel) =
-            siteDomainsFeatureConfig.isEnabled() && site.hasCapabilityManageOptions
-
-    private fun isNotAccessedViaWPComRest(site: SiteModel) =
-            siteDomainsFeatureConfig.isEnabled() && !siteUtilsWrapper.isAccessedViaWPComRest(site)
-
     fun buildSiteSettingsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (site.hasCapabilityManageOptions || !siteUtilsWrapper.isAccessedViaWPComRest(site)) {
             ListItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.themes.ThemeBrowserUtils
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.config.SiteDomainsFeatureConfig
@@ -37,6 +38,7 @@ class SiteListItemBuilder @Inject constructor(
     private val accountStore: AccountStore,
     private val pluginUtilsWrapper: PluginUtilsWrapper,
     private val siteUtilsWrapper: SiteUtilsWrapper,
+    private val buildConfigWrapper: BuildConfigWrapper,
     private val themeBrowserUtils: ThemeBrowserUtils,
     private val siteDomainsFeatureConfig: SiteDomainsFeatureConfig
 ) {
@@ -170,7 +172,11 @@ class SiteListItemBuilder @Inject constructor(
     }
 
     fun buildDomainsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
-        return if (hasManageOptionsCapability(site) || isNotAccessedViaWPComRest(site)) {
+        return if (
+                buildConfigWrapper.isJetpackApp &&
+                siteDomainsFeatureConfig.isEnabled() &&
+                site.hasCapabilityManageOptions
+        ) {
             ListItem(
                     R.drawable.ic_domains_white_24dp,
                     UiStringRes(R.string.my_site_btn_domains),
@@ -178,12 +184,6 @@ class SiteListItemBuilder @Inject constructor(
             )
         } else null
     }
-
-    private fun hasManageOptionsCapability(site: SiteModel) =
-            siteDomainsFeatureConfig.isEnabled() && site.hasCapabilityManageOptions
-
-    private fun isNotAccessedViaWPComRest(site: SiteModel) =
-            siteDomainsFeatureConfig.isEnabled() && !siteUtilsWrapper.isAccessedViaWPComRest(site)
 
     fun buildSiteSettingsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (site.hasCapabilityManageOptions || !siteUtilsWrapper.isAccessedViaWPComRest(site)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -74,17 +74,30 @@ class SiteListItemBuilder @Inject constructor(
     }
 
     fun buildJetpackItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
-        val jetpackSettingsVisible = site.isJetpackConnected && // jetpack is installed and connected
-                !site.isWPComAtomic &&
-                siteUtilsWrapper.isAccessedViaWPComRest(site) && // is using .com login
-                site.hasCapabilityManageOptions // has permissions to manage the site
-        return if (jetpackSettingsVisible) {
+        return if (isJetpackSettingsVisible(site)) {
             ListItem(
                     R.drawable.ic_cog_white_24dp,
                     UiStringRes(R.string.my_site_btn_jetpack_settings),
                     onClick = ListItemInteraction.create(JETPACK_SETTINGS, onClick)
             )
         } else null
+    }
+
+    fun buildDomainsItemForJetpackIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
+        return if (siteDomainsFeatureConfig.isEnabled() && isJetpackSettingsVisible(site)) {
+            ListItem(
+                    R.drawable.ic_domains_white_24dp,
+                    UiStringRes(R.string.my_site_btn_domains),
+                    onClick = ListItemInteraction.create(DOMAINS, onClick)
+            )
+        } else null
+    }
+
+    private fun isJetpackSettingsVisible(site: SiteModel): Boolean {
+        return site.isJetpackConnected && // jetpack is installed and connected
+                !site.isWPComAtomic &&
+                siteUtilsWrapper.isAccessedViaWPComRest(site) && // is using .com login
+                site.hasCapabilityManageOptions // has permissions to manage the site
     }
 
     @Suppress("ComplexCondition")

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.ListItem
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
+import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.DOMAINS
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -109,3 +110,9 @@ val VIEW_SITE_ITEM = ListItem(
         secondaryIcon = R.drawable.ic_external_white_24dp,
         onClick = ListItemInteraction.create(ListItemAction.VIEW_SITE, SITE_ITEM_ACTION)
 )
+val DOMAINS_ITEM = ListItem(
+        R.drawable.ic_domains_white_24dp,
+        UiStringRes(R.string.my_site_btn_domains),
+        onClick = ListItemInteraction.create(DOMAINS, SITE_ITEM_ACTION)
+)
+

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
@@ -115,4 +115,3 @@ val DOMAINS_ITEM = ListItem(
         UiStringRes(R.string.my_site_btn_domains),
         onClick = ListItemInteraction.create(DOMAINS, SITE_ITEM_ACTION)
 )
-

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteItemsB
 import org.wordpress.android.ui.mysite.items.categoryheader.SiteCategoryItemBuilder
 import org.wordpress.android.ui.mysite.items.listitem.SiteListItemBuilder
 import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
+import org.wordpress.android.util.config.SiteDomainsFeatureConfig
 
 @RunWith(MockitoJUnitRunner::class)
 class SiteItemsBuilderTest {
@@ -70,6 +71,7 @@ class SiteItemsBuilderTest {
                 addPeopleItem = true,
                 addPluginItem = true,
                 addShareItem = true,
+                addSiteDomainsItem = true,
                 addSiteSettingsItem = true,
                 addThemesItem = true,
                 addBackupItem = true,
@@ -91,6 +93,7 @@ class SiteItemsBuilderTest {
                 BACKUP_ITEM,
                 SCAN_ITEM,
                 JETPACK_ITEM,
+                DOMAINS_ITEM,
                 PUBLISH_HEADER,
                 POSTS_ITEM,
                 MEDIA_ITEM,
@@ -225,6 +228,7 @@ class SiteItemsBuilderTest {
         addPeopleItem: Boolean = false,
         addPluginItem: Boolean = false,
         addShareItem: Boolean = false,
+        addSiteDomainsItem: Boolean = false,
         addSiteSettingsItem: Boolean = false,
         addThemesItem: Boolean = false,
         addBackupItem: Boolean = false,
@@ -317,6 +321,11 @@ class SiteItemsBuilderTest {
         if (addThemesItem) {
             whenever(siteListItemBuilder.buildThemesItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
                     THEMES_ITEM
+            )
+        }
+        if (addSiteDomainsItem) {
+            whenever(siteListItemBuilder.buildDomainsItemForJetpackIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                    DOMAINS_ITEM
             )
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
@@ -15,15 +15,15 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.InfoItemBu
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteItemsBuilderParams
 import org.wordpress.android.ui.mysite.items.categoryheader.SiteCategoryItemBuilder
 import org.wordpress.android.ui.mysite.items.listitem.SiteListItemBuilder
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.config.MySiteDashboardPhase2FeatureConfig
-import org.wordpress.android.util.config.SiteDomainsFeatureConfig
 
 @RunWith(MockitoJUnitRunner::class)
 class SiteItemsBuilderTest {
     @Mock lateinit var siteCategoryItemBuilder: SiteCategoryItemBuilder
     @Mock lateinit var siteListItemBuilder: SiteListItemBuilder
     @Mock lateinit var mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig
-    @Mock lateinit var siteDomainsFeatureConfig: SiteDomainsFeatureConfig
+    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var siteModel: SiteModel
     private lateinit var siteItemsBuilder: SiteItemsBuilder
 
@@ -94,7 +94,6 @@ class SiteItemsBuilderTest {
                 BACKUP_ITEM,
                 SCAN_ITEM,
                 JETPACK_ITEM,
-                DOMAINS_ITEM,
                 PUBLISH_HEADER,
                 POSTS_ITEM,
                 MEDIA_ITEM,
@@ -106,6 +105,7 @@ class SiteItemsBuilderTest {
                 PEOPLE_ITEM,
                 PLUGINS_ITEM,
                 SHARING_ITEM,
+                DOMAINS_ITEM,
                 SITE_SETTINGS_ITEM,
                 EXTERNAL_HEADER,
                 VIEW_SITE_ITEM,
@@ -218,7 +218,7 @@ class SiteItemsBuilderTest {
 
     @Test
     fun `given site domains flag is not enabled, when build site domains is invoked, then site domains is built`() {
-        whenever(siteListItemBuilder.buildDomainsItemForJetpackIfAvailable(siteModel, SITE_ITEM_ACTION))
+        whenever(siteListItemBuilder.buildDomainsItemIfAvailable(siteModel, SITE_ITEM_ACTION))
                 .thenReturn(null)
 
         val siteDomainsItems = siteItemsBuilder.build(
@@ -233,7 +233,7 @@ class SiteItemsBuilderTest {
 
     @Test
     fun `given site domains flag is enabled, when build site domains is invoked, then site domains is built`() {
-        whenever(siteListItemBuilder.buildDomainsItemForJetpackIfAvailable(siteModel, SITE_ITEM_ACTION))
+        whenever(siteListItemBuilder.buildDomainsItemIfAvailable(siteModel, SITE_ITEM_ACTION))
                 .thenReturn(DOMAINS_ITEM)
 
         val siteDomainsItems = siteItemsBuilder.build(
@@ -355,7 +355,7 @@ class SiteItemsBuilderTest {
             )
         }
         if (addSiteDomainsItem) {
-            whenever(siteListItemBuilder.buildDomainsItemForJetpackIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+            whenever(siteListItemBuilder.buildDomainsItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
                     DOMAINS_ITEM
             )
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
@@ -23,6 +23,7 @@ class SiteItemsBuilderTest {
     @Mock lateinit var siteCategoryItemBuilder: SiteCategoryItemBuilder
     @Mock lateinit var siteListItemBuilder: SiteListItemBuilder
     @Mock lateinit var mySiteDashboardPhase2FeatureConfig: MySiteDashboardPhase2FeatureConfig
+    @Mock lateinit var siteDomainsFeatureConfig: SiteDomainsFeatureConfig
     @Mock lateinit var siteModel: SiteModel
     private lateinit var siteItemsBuilder: SiteItemsBuilder
 
@@ -213,6 +214,36 @@ class SiteItemsBuilderTest {
         )
 
         assertThat(infoItem).isNull()
+    }
+
+    @Test
+    fun `given site domains flag is not enabled, when build site domains is invoked, then site domains is built`() {
+        whenever(siteListItemBuilder.buildDomainsItemForJetpackIfAvailable(siteModel, SITE_ITEM_ACTION))
+                .thenReturn(null)
+
+        val siteDomainsItems = siteItemsBuilder.build(
+                SiteItemsBuilderParams(
+                        site = siteModel,
+                        onClick = SITE_ITEM_ACTION
+                )
+        )
+
+        assertThat(siteDomainsItems).doesNotContain(DOMAINS_ITEM)
+    }
+
+    @Test
+    fun `given site domains flag is enabled, when build site domains is invoked, then site domains is built`() {
+        whenever(siteListItemBuilder.buildDomainsItemForJetpackIfAvailable(siteModel, SITE_ITEM_ACTION))
+                .thenReturn(DOMAINS_ITEM)
+
+        val siteDomainsItems = siteItemsBuilder.build(
+                SiteItemsBuilderParams(
+                        site = siteModel,
+                        onClick = SITE_ITEM_ACTION
+                )
+        )
+
+        assertThat(siteDomainsItems).contains(DOMAINS_ITEM)
     }
 
     @Suppress("ComplexMethod", "LongMethod", "LongParameterList")

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.mysite.items.SITE_ITEM_ACTION
 import org.wordpress.android.ui.mysite.items.SITE_SETTINGS_ITEM
 import org.wordpress.android.ui.plugins.PluginUtilsWrapper
 import org.wordpress.android.ui.themes.ThemeBrowserUtils
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.config.SiteDomainsFeatureConfig
 
@@ -33,6 +34,7 @@ class SiteListItemBuilderTest {
     @Mock lateinit var accountStore: AccountStore
     @Mock lateinit var pluginUtilsWrapper: PluginUtilsWrapper
     @Mock lateinit var siteUtilsWrapper: SiteUtilsWrapper
+    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var themeBrowserUtils: ThemeBrowserUtils
     @Mock lateinit var siteModel: SiteModel
     @Mock lateinit var siteDomainsFeatureConfig: SiteDomainsFeatureConfig
@@ -44,6 +46,7 @@ class SiteListItemBuilderTest {
                 accountStore,
                 pluginUtilsWrapper,
                 siteUtilsWrapper,
+                buildConfigWrapper,
                 themeBrowserUtils,
                 siteDomainsFeatureConfig
         )


### PR DESCRIPTION
Enable domains purchase on Jetpack Mobile app only

Fixes #16381 

| Feature Config | Domains | 
|---|---|
| ![Screenshot_20220422_131651](https://user-images.githubusercontent.com/990349/164589493-40fa7626-c210-4719-a7bb-a2a781e2e148.png)|![Screenshot_20220422_125553](https://user-images.githubusercontent.com/990349/164588866-b4f022dd-7c4f-43e4-8d22-99ce5a829782.png)|


To test:

Setup
- Make sure you're using Jetpack app
- Go to App Settings -> Debug settings -> Enable SiteDomainsFeatureConfig and restart app 

Test 1

- Launch Jetpack app
- Find Domains menu under Configuration (under My Site or the new SITE MENU tab)
- Tap on Domains, it should take to Domains dashboard

Test 2

- Launch WordPress app
- Go to App Settings -> Debug settings -> Enable SiteDomainsFeatureConfig and restart app 
- Make sure Domains menu doesn't show up under Configuration (under My Site or the new SITE MENU tab)

Test 3 - Main Scenario

1. Open the Jetpack app.
1. On the Main screen, tap the "Domains" item under the "Configuration" section.
1. On the Domains Dashboard screen, tap the "Add a domain" or "Search for a domain" button.
1. Complete the domain registration flow.
1. On the Success screen, tap "Done".
1. On the Dashboard screen, notice the domain list is updated with the newly registered domain

Other scenarios to try out, that have been tested as part of feature development on WordPress app
1. Free plan with custom domains
3. Free plan with no custom domains
4. Paid plan with custom domains and credits
5. Paid plan with custom domains and no credits
6. Paid plan with no custom domains and credits
7. Paid plan with no custom domains and no credits

NOTE:  There are a few flows based on credits and other site settings.  Mainly make sure the purchase flow happens with the credits or payment

## Regression Notes
1. Potential unintended areas of impact
None, it is behind a feature config

8. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested both WordPress and Jetpack apps

9. What automated tests I added (or what prevented me from doing so)
Existing unit tests

Before merging

- [ ] Confirm merge for launch
- [ ] Update Feature Config for Remote field
- [ ] Update release notes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
