### PR TITLE
App Data Coverage: Add site dialog and create site flow accessed events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -95,6 +95,7 @@ import org.wordpress.android.ui.publicize.PublicizeListActivity;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.sitecreation.SiteCreationActivity;
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
 import org.wordpress.android.ui.stats.StatsConstants;
 import org.wordpress.android.ui.stats.StatsTimeframe;
@@ -1331,26 +1332,29 @@ public class ActivityLauncher {
         context.startActivity(intent);
     }
 
-    public static void newBlogForResult(Activity activity) {
+    public static void newBlogForResult(Activity activity, SiteCreationSource source) {
         Intent intent = new Intent(activity, SiteCreationActivity.class);
+        intent.putExtra(SiteCreationActivity.ARG_CREATE_SITE_SOURCE, source.getLabel());
         activity.startActivityForResult(intent, RequestCodes.CREATE_SITE);
     }
 
-    public static void showMainActivityAndSiteCreationActivity(Activity activity) {
+    public static void showMainActivityAndSiteCreationActivity(Activity activity, SiteCreationSource source) {
         // If we just wanted to have WPMainActivity in the back stack after starting SiteCreationActivity, we could have
         // used a TaskStackBuilder to do so. However, since we want to handle the SiteCreationActivity result in
         // WPMainActivity, we must start it this way.
-        final Intent intent = createMainActivityAndSiteCreationActivityIntent(activity, null);
+        final Intent intent = createMainActivityAndSiteCreationActivityIntent(activity, null, source);
         activity.startActivity(intent);
     }
 
     @NonNull
     public static Intent createMainActivityAndSiteCreationActivityIntent(Context context,
-                                                                         @Nullable NotificationType notificationType) {
+                                                                         @Nullable NotificationType notificationType,
+                                                                         SiteCreationSource source) {
         final Intent intent = new Intent(context, WPMainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
         intent.putExtra(WPMainActivity.ARG_SHOW_SITE_CREATION, true);
+        intent.putExtra(WPMainActivity.ARG_SITE_CREATION_SOURCE, source.getLabel());
         if (notificationType != null) {
             intent.putExtra(ARG_NOTIFICATION_TYPE, notificationType);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.accounts.login.LoginEpilogueListener;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesFragment;
 import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource;
 
 import java.util.ArrayList;
 
@@ -123,7 +124,7 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
     }
 
     private void createNewSite() {
-        ActivityLauncher.newBlogForResult(this);
+        ActivityLauncher.newBlogForResult(this, SiteCreationSource.LOGIN_EPILOGUE);
     }
 
     private void closeWithResultOk() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PostSignupInterstitialActivityBinding
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.viewmodel.accounts.PostSignupInterstitialViewModel
 import org.wordpress.android.viewmodel.accounts.PostSignupInterstitialViewModel.NavigationAction
 import org.wordpress.android.viewmodel.accounts.PostSignupInterstitialViewModel.NavigationAction.DISMISS
@@ -59,7 +60,7 @@ class PostSignupInterstitialActivity : LocaleAwareActivity() {
     }
 
     private fun startSiteCreationFlow() {
-        ActivityLauncher.showMainActivityAndSiteCreationActivity(this)
+        ActivityLauncher.showMainActivityAndSiteCreationActivity(this, SiteCreationSource.SIGNUP_EPILOGUE)
         finish()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenS
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.ShowSignInFlow
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.StartCreateSiteFlow
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.ViewPostInReader
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource.DEEP_LINK
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
@@ -31,7 +32,9 @@ class DeepLinkNavigator
     fun handleNavigationAction(navigateAction: NavigateAction, activity: AppCompatActivity) {
         when (navigateAction) {
             LoginForResult -> ActivityLauncher.loginForDeeplink(activity)
-            StartCreateSiteFlow -> ActivityLauncher.showMainActivityAndSiteCreationActivity(activity)
+            StartCreateSiteFlow -> {
+                ActivityLauncher.showMainActivityAndSiteCreationActivity(activity, DEEP_LINK)
+            }
             ShowSignInFlow -> ActivityLauncher.showSignInForResultWpComOnly(activity)
             OpenEditor -> ActivityLauncher.openEditorInNewStack(activity)
             is OpenEditorForSite -> ActivityLauncher.openEditorForSiteInNewStack(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -110,6 +110,7 @@ import org.wordpress.android.ui.reader.ReaderFragment;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.ui.reader.tracker.ReaderTracker;
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource;
 import org.wordpress.android.ui.stats.StatsTimeframe;
 import org.wordpress.android.ui.stories.intro.StoriesIntroDialogFragment;
 import org.wordpress.android.ui.uploads.UploadActionUseCase;
@@ -179,6 +180,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     public static final String ARG_SHOW_LOGIN_EPILOGUE = "show_login_epilogue";
     public static final String ARG_SHOW_SIGNUP_EPILOGUE = "show_signup_epilogue";
     public static final String ARG_SHOW_SITE_CREATION = "show_site_creation";
+    public static final String ARG_SITE_CREATION_SOURCE = "ARG_SITE_CREATION_SOURCE";
     public static final String ARG_WP_COM_SIGN_UP = "sign_up";
     public static final String ARG_OPEN_PAGE = "open_page";
     public static final String ARG_MY_SITE = "show_my_site";
@@ -396,7 +398,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     getIntent().getStringExtra(SignupEpilogueActivity.EXTRA_SIGNUP_USERNAME), false);
         } else if (getIntent().getBooleanExtra(ARG_SHOW_SITE_CREATION, false) && savedInstanceState == null) {
             canShowAppRatingPrompt = false;
-            ActivityLauncher.newBlogForResult(this);
+            ActivityLauncher.newBlogForResult(this,
+                    SiteCreationSource.fromString(getIntent().getStringExtra(ARG_SITE_CREATION_SOURCE)));
         } else if (getIntent().getBooleanExtra(ARG_WP_COM_SIGN_UP, false) && savedInstanceState == null) {
             canShowAppRatingPrompt = false;
             ActivityLauncher.showSignInForResultWpComOnly(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -288,7 +288,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     private fun handleNavigationAction(action: SiteNavigationAction) = when (action) {
         is SiteNavigationAction.OpenMeScreen -> ActivityLauncher.viewMeActivityForResult(activity)
-        is SiteNavigationAction.AddNewSite -> SitePickerActivity.addSite(activity, action.hasAccessToken)
+        is SiteNavigationAction.AddNewSite -> SitePickerActivity.addSite(activity, action.hasAccessToken, action.source)
         else -> {
             // Pass all other navigationAction on to the child fragment, so they can be handled properly
             binding?.viewPager?.getCurrentFragment()?.handleNavigationAction(action)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -80,6 +80,7 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Dis
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Negative
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Positive
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.BuildConfigWrapper
@@ -984,7 +985,12 @@ class MySiteViewModel @Inject constructor(
     }
 
     fun onAddSitePressed() {
-        _onNavigation.value = Event(SiteNavigationAction.AddNewSite(accountStore.hasAccessToken()))
+        _onNavigation.value = Event(
+                SiteNavigationAction.AddNewSite(
+                        accountStore.hasAccessToken(),
+                        SiteCreationSource.MY_SITE_NO_SITES
+                )
+        )
         analyticsTrackerWrapper.track(Stat.MY_SITE_NO_SITES_VIEW_ACTION_TAPPED)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -5,6 +5,7 @@ import com.wordpress.stories.compose.frame.StorySaveEvents.StorySaveResult
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.util.UriWrapper
 
 sealed class SiteNavigationAction {
@@ -52,7 +53,7 @@ sealed class SiteNavigationAction {
     ) : SiteNavigationAction()
 
     data class OpenDomainRegistration(val site: SiteModel) : SiteNavigationAction()
-    data class AddNewSite(val hasAccessToken: Boolean) : SiteNavigationAction()
+    data class AddNewSite(val hasAccessToken: Boolean, val source: SiteCreationSource) : SiteNavigationAction()
     data class ShowQuickStartDialog(
         @StringRes val title: Int,
         @StringRes val message: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -291,7 +291,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
                 action.site,
                 CTA_DOMAIN_CREDIT_REDEMPTION
         )
-        is SiteNavigationAction.AddNewSite -> SitePickerActivity.addSite(activity, action.hasAccessToken)
+        is SiteNavigationAction.AddNewSite -> SitePickerActivity.addSite(activity, action.hasAccessToken, action.source)
         is SiteNavigationAction.ShowQuickStartDialog -> showQuickStartDialog(
                 action.title,
                 action.message,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.ui.sitecreation.domains.DomainsScreenListener
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment
 import org.wordpress.android.ui.sitecreation.misc.OnHelpClickedListener
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.ui.sitecreation.previews.SiteCreationPreviewFragment
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewScreenListener
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState
@@ -73,7 +74,8 @@ class SiteCreationActivity : LocaleAwareActivity(),
                 .get(SiteCreationIntentsViewModel::class.java)
         siteCreationSiteNameViewModel = ViewModelProvider(this, viewModelFactory)
                 .get(SiteCreationSiteNameViewModel::class.java)
-        mainViewModel.start(savedInstanceState)
+        val siteCreationSource = intent.extras?.getString(ARG_CREATE_SITE_SOURCE)
+        mainViewModel.start(savedInstanceState, SiteCreationSource.fromString(siteCreationSource))
         hppViewModel.loadSavedState(savedInstanceState)
 
         observeVMState()
@@ -230,5 +232,9 @@ class SiteCreationActivity : LocaleAwareActivity(),
 
     override fun onBackPressed() {
         mainViewModel.onBackPressed()
+    }
+
+    companion object {
+        const val ARG_CREATE_SITE_SOURCE = "ARG_CREATE_SITE_SOURCE"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_DESIGNS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -75,10 +76,10 @@ class SiteCreationMainVM @Inject constructor(
     private val _onBackPressedObservable = SingleLiveEvent<Unit>()
     val onBackPressedObservable: LiveData<Unit> = _onBackPressedObservable
 
-    fun start(savedInstanceState: Bundle?) {
+    fun start(savedInstanceState: Bundle?, siteCreationSource: SiteCreationSource) {
         if (isStarted) return
         if (savedInstanceState == null) {
-            tracker.trackSiteCreationAccessed()
+            tracker.trackSiteCreationAccessed(siteCreationSource)
             tracker.trackSiteNameExperimentVariation(siteNameABExperiment.getVariation())
             siteCreationState = SiteCreationState()
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationSource.kt
@@ -24,4 +24,3 @@ enum class SiteCreationSource(val label: String) {
         }
     }
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationSource.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.ui.sitecreation.misc
+
+enum class SiteCreationSource(val label: String) {
+    DEEP_LINK("deep_link"),
+    LOGIN_EPILOGUE("login_epilogue"),
+    MY_SITE("my_site"),
+    MY_SITE_NO_SITES("my_sites_no_sites"),
+    NOTIFICATION("notification"),
+    SIGNUP_EPILOGUE("signup_epilogue"),
+    UNSPECIFIED("unspecified");
+
+    override fun toString() = label
+
+    companion object {
+        @JvmStatic
+        fun fromString(label: String?) = when {
+            DEEP_LINK.label == label -> DEEP_LINK
+            LOGIN_EPILOGUE.label == label -> LOGIN_EPILOGUE
+            MY_SITE.label == label -> MY_SITE
+            MY_SITE_NO_SITES.label == label -> MY_SITE_NO_SITES
+            NOTIFICATION.label == label -> NOTIFICATION
+            SIGNUP_EPILOGUE.label == label -> SIGNUP_EPILOGUE
+            else -> UNSPECIFIED
+        }
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
@@ -29,6 +29,7 @@ enum class SiteCreationErrorType {
 
 private const val DESIGN_ERROR_CONTEXT = "design"
 private const val SITE_CREATION_LOCATION = "site_creation"
+private const val SITE_CREATION_SOURCE = "source"
 
 @Singleton
 @Suppress("TooManyFunctions")
@@ -51,8 +52,11 @@ class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapp
 
     private var designSelectionSkipped: Boolean = false
 
-    fun trackSiteCreationAccessed() {
-        tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_ACCESSED)
+    fun trackSiteCreationAccessed(siteCreationSource: SiteCreationSource) {
+        tracker.track(
+                AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_ACCESSED,
+                mapOf(SITE_CREATION_SOURCE to siteCreationSource.label)
+        )
     }
 
     fun trackSegmentsViewed() {

--- a/WordPress/src/main/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationHandler.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.push.NotificationType.CREATE_SITE
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.workers.notification.local.LocalNotificationHandler
 import javax.inject.Inject
 
@@ -20,7 +21,11 @@ class CreateSiteNotificationHandler @Inject constructor(
     }
 
     override fun buildIntent(context: Context): Intent {
-        return ActivityLauncher.createMainActivityAndSiteCreationActivityIntent(context, CREATE_SITE)
+        return ActivityLauncher.createMainActivityAndSiteCreationActivityIntent(
+                context,
+                CREATE_SITE,
+                SiteCreationSource.NOTIFICATION
+        )
     }
 
     override fun onNotificationShown() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -109,6 +109,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
@@ -629,14 +630,18 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* EMPTY VIEW - ADD SITE */
-
     @Test
-    fun `add new site press is handled correctly`() {
+    fun `given empty site view, when add new site is tapped, then navigated to AddNewSite`() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
 
         viewModel.onAddSitePressed()
 
-        assertThat(navigationActions).containsOnly(SiteNavigationAction.AddNewSite(true))
+        assertThat(navigationActions).containsOnly(
+                SiteNavigationAction.AddNewSite(
+                        true,
+                        SiteCreationSource.MY_SITE_NO_SITES
+                )
+        )
     }
 
     /* ON RESUME */

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -851,7 +851,8 @@ public final class AnalyticsTracker {
         APP_SETTINGS_INITIAL_SCREEN_CHANGED,
         CHANGE_USERNAME_DISPLAYED,
         CHANGE_USERNAME_DISMISSED,
-        CHANGE_USERNAME_SEARCH_PERFORMED
+        CHANGE_USERNAME_SEARCH_PERFORMED,
+        ADD_SITE_ALERT_DISPLAYED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2209,6 +2209,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "change_username_dismissed";
             case CHANGE_USERNAME_SEARCH_PERFORMED:
                 return "change_username_search_performed";
+            case ADD_SITE_ALERT_DISPLAYED:
+                return "add_site_alert_displayed";
         }
         return null;
     }


### PR DESCRIPTION
Parent #16343 

**Description**

Included in this PR:
- Track a new event when the **Add Site Dialog** is shown based on where it was tapped from:
    - `add_site_alert_displayed` with property “source” = “my_site_no_sites|my_site”
- Add `source` property to  `enhanced_site_creation_accessed` event based on where it was tapped from

Yes, it may seem like a long testing instruction list, but it flows very easily.

**To test:**
1. Uninstall existing app
2. Install and launch app
3. Follow the signup flow all the way through (create a password) and stop when you land on the Signup Epilogue (a.k.a. Welcome view)
4. Tap the `Create Wordpress.com Site` button
5. ✅ Verify logs contain: `🔵 Tracked: enhanced_site_creation_accessed, Properties: {"source":"signup_epilogue"}`
6. Cancel out of the Create Site flow
7. Background the app
8. Head over to your _email_ for the user who signed up in step 3
9. Look for **Finish Creating Your Site** email and open it
10. Tap the **Create your site button** in the email
11. The app should launch
12. ✅ Verify logs contain: `🔵 Tracked: enhanced_site_creation_accessed, Properties: {"source":"deep_link"}`
13. Cancel out of create site flow
14. Log out
15. Log in to the app with the same account that you created in step 3
16. You will either see the “welcome/signup epilogue” or “no site view”. If you see the welcome view, then tap Not Right Now and then navigation back to My Site tab. This will bring you back to the no sites view. When you are on the “no site view”, tap the “Add new site button” to launch the Add new site dialog.
17. ✅ Verify logs contain: `🔵 Tracked: add_site_alert_displayed, Properties: {"source":"my_site_no_sites"}`
18. Tap the “**Create WordPress.com**” button
19. ✅ Verify logs contain: `🔵 Tracked: enhanced_site_creation_accessed, Properties: {"source":"my_site_no_sites"}`
20. Cancel out of the create site flow
21. Log out of the app
22. Log in with a user that has sites
23. When shown the login epilogue, do not chose a site, instead tap “**Create a new site**” button
24. ✅ Verify logs contain: `🔵 Tracked: enhanced_site_creation_accessed, Properties: {,"source":"login_epilogue"}`
25. Cancel out of the create site flow
26. Select a site from the Login Epilogue view
27. From within My Site, tap the site selector to launch the Site Picker
28. Tap the “+” menu item
29. ✅ Verify logs contain: `🔵 Tracked: add_site_alert_displayed, Properties: {"source":"my_site"}`
30. Tap the “**Create WordPress.com site**” option
31. ✅ Verify logs contain: `🔵 Tracked: enhanced_site_creation_accessed, Properties: {"source":"my_site"}`


## Regression Notes
1. Potential unintended areas of impact
Unintentional passing of a null param to a non-null fun

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

3. What automated tests I added (or what prevented me from doing so)
Updated tests in MySiteViewModelTest and SiteCreationMainVMTest

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
