### PR TITLE
Jetpack Scan: add VaultPress message and option to open the dashboard 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/Constants.java
+++ b/WordPress/src/main/java/org/wordpress/android/Constants.java
@@ -8,5 +8,5 @@ public class Constants {
     public static final String URL_TIMEZONE_ENDPOINT = "https://public-api.wordpress.com/wpcom/v2/timezones";
     public static final String URL_JETPACK_SETTINGS = "https://wordpress.com/settings/jetpack";
     public static final String URL_MANAGE_DOMAINS = "https://wordpress.com/domains/manage";
-    public static final String URL_VISIT_DASHBOARD = "https://dashboard.vaultpress.com/";
+    public static final String URL_VISIT_VAULTPRESS_DASHBOARD = "https://dashboard.vaultpress.com/";
 }

--- a/WordPress/src/main/java/org/wordpress/android/Constants.java
+++ b/WordPress/src/main/java/org/wordpress/android/Constants.java
@@ -8,4 +8,5 @@ public class Constants {
     public static final String URL_TIMEZONE_ENDPOINT = "https://public-api.wordpress.com/wpcom/v2/timezones";
     public static final String URL_JETPACK_SETTINGS = "https://wordpress.com/settings/jetpack";
     public static final String URL_MANAGE_DOMAINS = "https://wordpress.com/domains/manage";
+    public static final String URL_VISIT_DASHBOARD = "https://dashboard.vaultpress.com/";
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -92,7 +92,8 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
                         is ErrorUiState.NoConnection,
                         is ErrorUiState.GenericRequestFailed,
                         is ErrorUiState.ScanRequestFailed,
-                        is ErrorUiState.MultisiteNotSupported -> updateErrorLayout(uiState as ErrorUiState)
+                        is ErrorUiState.MultisiteNotSupported,
+                        is ErrorUiState.VaultPressActiveOnSite -> updateErrorLayout(uiState as ErrorUiState)
                     }
                 }
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -18,7 +18,7 @@ import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreats
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowContactSupport
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowJetpackSettings
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
-import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.VisitDashboard
+import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.VisitVaultPressDashboard
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ContentUiState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ErrorUiState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.FullScreenLoadingUiState
@@ -118,7 +118,7 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
 
                 is ShowJetpackSettings -> ActivityLauncher.openUrlExternal(context, events.url)
 
-                is VisitDashboard -> ActivityLauncher.openUrlExternal(context, events.url)
+                is VisitVaultPressDashboard -> ActivityLauncher.openUrlExternal(context, events.url)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreats
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowContactSupport
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowJetpackSettings
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
+import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.VisitDashboard
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ContentUiState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ErrorUiState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.FullScreenLoadingUiState
@@ -101,24 +102,25 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         viewModel.snackbarEvents.observeEvent(viewLifecycleOwner, { it.showSnackbar() })
 
         viewModel.navigationEvents.observeEvent(
-                viewLifecycleOwner,
-                { events ->
-                    when (events) {
-                        is OpenFixThreatsConfirmationDialog -> showFixThreatsConfirmationDialog(events)
+                viewLifecycleOwner
+        ) { events ->
+            when (events) {
+                is OpenFixThreatsConfirmationDialog -> showFixThreatsConfirmationDialog(events)
 
-                        is ShowThreatDetails -> ActivityLauncher.viewThreatDetails(
-                                this@ScanFragment,
-                                events.siteModel,
-                                events.threatId
-                        )
+                is ShowThreatDetails -> ActivityLauncher.viewThreatDetails(
+                        this@ScanFragment,
+                        events.siteModel,
+                        events.threatId
+                )
 
-                        is ShowContactSupport ->
-                            ActivityLauncher.viewHelpAndSupport(requireContext(), SCAN_SCREEN_HELP, events.site, null)
+                is ShowContactSupport ->
+                    ActivityLauncher.viewHelpAndSupport(requireContext(), SCAN_SCREEN_HELP, events.site, null)
 
-                        is ShowJetpackSettings -> ActivityLauncher.openUrlExternal(context, events.url)
-                    }
-                }
-        )
+                is ShowJetpackSettings -> ActivityLauncher.openUrlExternal(context, events.url)
+
+                is VisitDashboard -> ActivityLauncher.openUrlExternal(context, events.url)
+            }
+        }
     }
 
     private fun ScanFragmentBinding.updateContentLayout(state: ContentUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanNavigationEvents.kt
@@ -19,5 +19,7 @@ sealed class ScanNavigationEvents {
 
     data class ShowContactSupport(val site: SiteModel) : ScanNavigationEvents()
 
+    data class VisitDashboard(val url: String) : ScanNavigationEvents()
+
     data class ShowJetpackSettings(val url: String) : ScanNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanNavigationEvents.kt
@@ -19,7 +19,7 @@ sealed class ScanNavigationEvents {
 
     data class ShowContactSupport(val site: SiteModel) : ScanNavigationEvents()
 
-    data class VisitDashboard(val url: String) : ScanNavigationEvents()
+    data class VisitVaultPressDashboard(val url: String) : ScanNavigationEvents()
 
     data class ShowJetpackSettings(val url: String) : ScanNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreats
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowContactSupport
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowJetpackSettings
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
-import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.VisitDashboard
+import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.VisitVaultPressDashboard
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ContentUiState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ErrorUiState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.FullScreenLoadingUiState
@@ -136,7 +136,7 @@ class ScanViewModel @Inject constructor(
                             updateUiState(ErrorUiState.MultisiteNotSupported)
 
                         is FetchScanState.Failure.VaultPressActiveOnSite ->
-                            updateUiState(ErrorUiState.VaultPressActiveOnSite(::onVisitDashboardClicked))
+                            updateUiState(ErrorUiState.VaultPressActiveOnSite(::onVisitVaultPressDashboardClicked))
 
                         is FetchScanState.Failure.RemoteRequestFailure -> {
                             scanTracker.trackOnError(ErrorAction.FETCH_SCAN_STATE, ErrorCause.REMOTE)
@@ -275,8 +275,8 @@ class ScanViewModel @Inject constructor(
         launch { fetchScanState(isRetry = true) }
     }
 
-    private fun onVisitDashboardClicked() {
-        updateNavigationEvent(VisitDashboard(Constants.URL_VISIT_DASHBOARD))
+    private fun onVisitVaultPressDashboardClicked() {
+        updateNavigationEvent(VisitVaultPressDashboard(Constants.URL_VISIT_VAULTPRESS_DASHBOARD))
     }
 
     private fun onContactSupportClicked() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreats
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowContactSupport
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowJetpackSettings
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
+import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.VisitDashboard
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ContentUiState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ErrorUiState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.FullScreenLoadingUiState
@@ -275,7 +276,7 @@ class ScanViewModel @Inject constructor(
     }
 
     private fun onVisitDashboardClicked() {
-        // to-do @ajesh
+        updateNavigationEvent(VisitDashboard(Constants.URL_VISIT_DASHBOARD))
     }
 
     private fun onContactSupportClicked() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -134,6 +134,9 @@ class ScanViewModel @Inject constructor(
                         is FetchScanState.Failure.MultisiteNotSupported ->
                             updateUiState(ErrorUiState.MultisiteNotSupported)
 
+                        is FetchScanState.Failure.VaultPressActiveOnSite ->
+                            updateUiState(ErrorUiState.VaultPressActiveOnSite(::onVisitDashboardClicked))
+
                         is FetchScanState.Failure.RemoteRequestFailure -> {
                             scanTracker.trackOnError(ErrorAction.FETCH_SCAN_STATE, ErrorCause.REMOTE)
                             scanStateModel?.takeIf { !isInvokedFromInit }
@@ -271,6 +274,10 @@ class ScanViewModel @Inject constructor(
         launch { fetchScanState(isRetry = true) }
     }
 
+    private fun onVisitDashboardClicked() {
+        // to-do @ajesh
+    }
+
     private fun onContactSupportClicked() {
         updateNavigationEvent(ShowContactSupport(site))
     }
@@ -390,6 +397,14 @@ class ScanViewModel @Inject constructor(
                 @ColorRes override val imageColorResId = R.color.gray
                 override val title = UiStringRes(R.string.scan_multisite_not_supported_title)
                 override val subtitle = UiStringRes(R.string.scan_multisite_not_supported_subtitle)
+            }
+
+            data class VaultPressActiveOnSite(override val action: () -> Unit) : ErrorUiState() {
+                @DrawableRes override val image = R.drawable.ic_shield_warning_white
+                @ColorRes override val imageColorResId = R.color.error_60
+                override val title = UiStringRes(R.string.scan_vault_press_active_on_site_title)
+                override val subtitle = UiStringRes(R.string.scan_vault_press_active_on_site_subtitle)
+                override val buttonText = UiStringRes(R.string.scan_vault_press_active_on_site_button_text)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
 import org.wordpress.android.fluxc.store.ScanStore
@@ -63,6 +62,10 @@ class FetchScanStateUseCase @Inject constructor(
                 emit(Failure.MultisiteNotSupported)
                 return@flow
             }
+            if (scanStateModel.reason == ScanStateModel.Reason.VP_ACTIVE_ON_SITE) {
+                emit(Failure.VaultPressActiveOnSite)
+                return@flow
+            }
             emit(Success(scanStateModel))
 
             if (scanStateModel.state != ScanStateModel.State.SCANNING) {
@@ -93,6 +96,7 @@ class FetchScanStateUseCase @Inject constructor(
             object NetworkUnavailable : Failure()
             object RemoteRequestFailure : Failure()
             object MultisiteNotSupported : Failure()
+            object VaultPressActiveOnSite : Failure()
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
 import org.wordpress.android.fluxc.store.ScanStore

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1130,6 +1130,9 @@
     <string name="scan_start_request_failed_subtitle">Jetpack Scan couldn\'t complete a scan of your site. Please check to see if your site is down – if it\'s not, try again. If it is, or if Jetpack Scan is still having problems, contact our support team.</string>
     <string name="scan_multisite_not_supported_title">WordPress multisites are not supported</string>
     <string name="scan_multisite_not_supported_subtitle">We\'re sorry, Jetpack Scan is not compatible with multisite WordPress installations at this time.</string>
+    <string name="scan_vault_press_active_on_site_title">Your site has VaultPress</string>
+    <string name="scan_vault_press_active_on_site_subtitle">Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below.</string>
+    <string name="scan_vault_press_active_on_site_button_text">Visit Dashboard</string>
 
     <string name="scan_state_icon">Scan state icon</string>
     <string name="scan_now">Scan now</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -33,7 +33,7 @@ import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreats
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowContactSupport
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowJetpackSettings
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
-import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.VisitDashboard
+import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.VisitVaultPressDashboard
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ContentUiState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ErrorUiState
@@ -285,7 +285,7 @@ class ScanViewModelTest : BaseUnitTest() {
             }
 
     @Test
-    fun `given vault press active error state, when visit dashboard is clicked, then visit dashboard url is shown`() =
+    fun `given vault press active error state, when button is clicked, then vault press dashboard url is shown`() =
             test {
                 whenever(scanStore.getScanStateForSite(site)).thenReturn(null)
                 whenever(fetchScanStateUseCase.fetchScanState(site)).thenReturn(flowOf(Failure.VaultPressActiveOnSite))
@@ -296,7 +296,7 @@ class ScanViewModelTest : BaseUnitTest() {
                 assertThat(
                         observers.navigation.last()
                                 .peekContent()
-                ).isEqualTo(VisitDashboard(Constants.URL_VISIT_DASHBOARD))
+                ).isEqualTo(VisitVaultPressDashboard(Constants.URL_VISIT_VAULTPRESS_DASHBOARD))
             }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -293,7 +293,10 @@ class ScanViewModelTest : BaseUnitTest() {
 
                 (observers.uiStates.last() as ErrorUiState).action?.invoke()
 
-                assertThat(observers.navigation.last().peekContent()).isEqualTo(VisitDashboard(Constants.URL_VISIT_DASHBOARD))
+                assertThat(
+                        observers.navigation.last()
+                                .peekContent()
+                ).isEqualTo(VisitDashboard(Constants.URL_VISIT_DASHBOARD))
             }
 
     @Test
@@ -322,9 +325,8 @@ class ScanViewModelTest : BaseUnitTest() {
                 }
             }
 
-
     @Test
-    fun `given vault press active on site, when scan state is fetched, then app reaches VaultPressActiveOnSite state`() =
+    fun `given vault press active on site, when scan state is fetched, then app is in VaultPressActiveOnSite state`() =
             test {
                 val observers = initObservers()
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '1.40.0'
+    fluxCVersion = '2368-9f07ad2d5ca92fe6e8ccca71c647da329fad8779'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '2368-9f07ad2d5ca92fe6e8ccca71c647da329fad8779'
+    fluxCVersion = 'trunk-6418ddf1778f19895d20a84727207fb9c7470cd6'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #14168
Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2368

This PR shows a specific error in case a user has VaultPress and tries to access Scan:

| Light Mode |  On Dark Mode  | 
|---|---|
|![error_screen](https://user-images.githubusercontent.com/17463767/165276128-f18e68d7-9353-474f-b8f5-c40a7a1b88aa.png)| ![darkmode](https://user-images.githubusercontent.com/17463767/165276299-4618d43e-1357-4732-99f3-132986858e98.png)| 

cc: @osullivanchris 
Error image color hex - #b32d2e 

To test
- Open a site that has Backup but with VaultPress enabled
- Open Menu -> Scan
- Notice that you see the screen above
- Tap "Visit Dashboard"
- Notice that on Clicking the url **https://dashboard.vaultpress.com/** should open


Merge Instructions
- [x] Make sure that https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2368 is merged
- [x] FluxC hash is updated

## Regression Notes
1. Potential unintended areas of impact
Errors other than the Vaultpress Active not being shown properly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and Unit tests 

3. What automated tests I added (or what prevented me from doing so)
Unit tests

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
