### PR TITLE
App Data Coverage: add more tracking for page list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -453,6 +453,7 @@ class PagesViewModel
     }
 
     private fun cancelPendingAutoUpload(pageId: LocalId) {
+        trackMenuSelectionEvent(CANCEL_AUTO_UPLOAD)
         val page = postStore.getPostByLocalPostId(pageId.value)
         val msgRes = UploadUtils.cancelPendingAutoUpload(page, dispatcher)
         _showSnackbarMessage.postValue(SnackbarMessageHolder(UiStringRes(msgRes)))
@@ -468,6 +469,8 @@ class PagesViewModel
 
     private fun setHomepage(homepageId: Long) {
         performIfNetworkAvailable {
+            trackMenuSelectionEvent(SET_AS_HOMEPAGE)
+
             if (site.showOnFront == PAGE.value) {
                 launch {
                     val result = siteOptionsStore.updatePageOnFront(
@@ -497,6 +500,8 @@ class PagesViewModel
 
     private fun setPostsPage(remoteId: Long) {
         performIfNetworkAvailable {
+            trackMenuSelectionEvent(SET_AS_POSTS_PAGE)
+
             if (site.showOnFront == PAGE.value) {
                 launch {
                     val result = siteOptionsStore.updatePageForPosts(
@@ -593,17 +598,22 @@ class PagesViewModel
     private fun trackMenuSelectionEvent(action: Action) {
         val menu = when (action) {
             VIEW_PAGE -> "view"
+            CANCEL_AUTO_UPLOAD -> "cancel_auto_upload"
             SET_PARENT -> "set_parent"
-            MOVE_TO_DRAFT -> "move_to_draft"
-            MOVE_TO_TRASH -> "move_to_bin"
+            SET_AS_HOMEPAGE -> "set_homepage"
+            SET_AS_POSTS_PAGE -> "set_posts_page"
             COPY -> "copy"
-            else -> return
+            PUBLISH_NOW -> "publish_now"
+            MOVE_TO_DRAFT -> "move_to_draft"
+            DELETE_PERMANENTLY -> "delete_permanently"
+            MOVE_TO_TRASH -> "move_to_bin"
         }
         val properties = mutableMapOf("option_name" to menu as Any)
         AnalyticsUtils.trackWithSiteDetails(PAGES_OPTIONS_PRESSED, site, properties)
     }
 
     private fun publishPageNow(remoteId: Long) {
+        trackMenuSelectionEvent(PUBLISH_NOW)
         _publishAction.value = pageMap[remoteId]
         launch(uiDispatcher) {
             delay(SCROLL_DELAY)
@@ -718,6 +728,7 @@ class PagesViewModel
     }
 
     private fun deletePage(page: PageModel) {
+        trackMenuSelectionEvent(DELETE_PERMANENTLY)
         val action = PageAction(page.remoteId, DELETE) {
             pageMap = pageMap.filter { it.key != page.remoteId }
 


### PR DESCRIPTION
Parent #16343 

This PR adds tracking events for the remainder of the menu item actions on the Pages List.

**To test:**
- Launch the app
- Navigate to Pages -> Published tab
- Tap on the "more" menu icon on the non-home page page item within the Published Tab
- Tap on Set as Homepage
- ✅  Verify the logs contains: 🔵 Tracked: site_pages_options_pressed, Properties: {"option_name":"set_homepage","blog_id":186945892,"is_jetpack":false,"site_type":"blog"}
- Tap on the "more" menu icon of the same page
- Tap on Set as Posts Page
- ✅  Verify the logs contains:  🔵 Tracked: site_pages_options_pressed, Properties: {"option_name":"set_posts_page","blog_id":186945892,"is_jetpack":false,"site_type":"blog"}
- Navigate to the Trashed tab
- If you don't have a trashed post, create a new post or move a published post to trash
- Tap the "more" menu icon on a trashed page 
- Tap Delete Permanently
- ✅  Verify the logs contains: Tracked: site_pages_options_pressed, Properties: {"option_name":"delete_permanently","blog_id":186945892,"is_jetpack":false,"site_type":"blog","default_tab_experiment":"site_menu"}
- Navigate to Drafts Tab
- If you have no pages in draft tabs, copy an existing page to create another and choose save instead of Publish Now
- Tap on the "more" menu icon on the drafts page
- Tap "Publish Now"
- ✅  Verify the logs contains: 🔵 Tracked: site_pages_tabs_pressed, Properties: {"tab_name":"published","blog_id":186945892,"is_jetpack":false,"site_type":"blog"}
- 

## Regression Notes
1. Potential unintended areas of impact
Only added track events

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
