### PR TITLE
Fix a unit test in QuickStartRepositoryTest

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -65,7 +65,6 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     private val siteLocalId = 1
 
     private val siteMenuTasks = listOf(
-            QuickStartTask.VIEW_SITE,
             QuickStartTask.ENABLE_POST_SHARING,
             QuickStartTask.EXPLORE_PLANS
     )


### PR DESCRIPTION
In #16373, `VIEW_SITE` is removed from site menu tasks. But it was still in the unit test list. It's removed from the `QuickStartRepositoryTest` to fix unit tests.

To test: Run unit tests.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
