### PR TITLE
[Site design revamp] Remove unused string resource hpp_subtitle

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3341,7 +3341,6 @@
 
     <!-- Home Page Picker -->
     <string name="hpp_title">Choose a theme</string>
-    <string name="hpp_subtitle">Pick your favorite homepage layout. You can edit and customize it later.</string>
     <string name="hpp_choose_button">Choose</string>
     <string name="hpp_choose_and_create_site">Create site</string>
     <string name="hpp_error_title">Layouts not available while offline</string>


### PR DESCRIPTION
Suggestion for #16414

To test:
- CI should be green.

## Regression Notes
1. Potential unintended areas of impact
   Build

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   - Searched through the code excluding `strings.xml` files to be sure the resource is no longer used.
   - Built the app after making this change and smoke-tested the site design picker & page layout picker.
3. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
