### PR TITLE
Remove jitpack repository from root level repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://jitpack.io" }
         maven {
             url "https://a8c-libs.s3.amazonaws.com/android/jcenter-mirror"
             content {

--- a/libs/image-editor/ImageEditor/build.gradle
+++ b/libs/image-editor/ImageEditor/build.gradle
@@ -44,6 +44,10 @@ android {
     }
 }
 
+repositories {
+    maven { url "https://www.jitpack.io" }
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     // Kotlin


### PR DESCRIPTION
Some dependencies are trying to be resolved from Jitpack even though they are being hosted in repositories such as our S3 Maven. Having repositories section in both root level and particular modules makes it difficult to properly order them.

We need to re-work our repositories sections for the most efficient results, which I'll take a look as soon as I can. Until then, this simple removal of Jitpack repository from the root level should address the intermittent failures (and loss of time) for some dependencies, such as Tracks which used to be fetched from Jitpack.

**To test:**
* CI checks should be enough

## Regression Notes
1. Potential unintended areas of impact
There is a potential dependency resolution failure for some tasks, but it should show up in CI and would be very easy to address.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
