### PR TITLE
Fixes self-hosted upload failure when the filename is non-latin

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] On self-hosted sites, allow previewing unsaved changes to draft posts [https://github.com/wordpress-mobile/WordPress-Android/pull/16296]
 * [*] Editor: Fix issue that caused previews on atomic sites to sometimes be out-of-date. [https://github.com/wordpress-mobile/WordPress-Android/pull/16332]
+* [*] Fixes self-hosted upload failure when the filename is non-latin [https://github.com/wordpress-mobile/WordPress-Android/pull/16421]
 
 19.7
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = 'trunk-6418ddf1778f19895d20a84727207fb9c7470cd6'
+    fluxCVersion = '2370-539bcb76067b6bf2fc78a9aea76dca936ddc7b80'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '2370-539bcb76067b6bf2fc78a9aea76dca936ddc7b80'
+    fluxCVersion = 'trunk-889b815f5bfeddfc877f1bc6820fa72129b422c7'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #16130

`WordPress-FluxC-Android` PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2370

To test:
1. Rename any images file name with non-English/Latin characters (i.e. 菈妮 or テスト or Αντώνης)
2. Open the WordPress App and select a self-hosted site
3. Open `Media`
4. Press the ➕ button at the top left and select `Choose from device`
5. Select the image from (1)
6. **Verify** that the upload completes successfully 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

7. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
