### PR TITLE
MSD - Tabs - Fix spinner keeps showing occasionally

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -542,8 +542,10 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         swipeToRefreshHelper.setEnabled(isEnabled)
     }
 
-    private fun hideRefreshIndicatorIfNeeded() {
-        swipeToRefreshHelper.isRefreshing = viewModel.isRefreshing()
+    private fun MySiteTabFragmentBinding.hideRefreshIndicatorIfNeeded() {
+        swipeRefreshLayout.postDelayed({
+            swipeToRefreshHelper.isRefreshing = viewModel.isRefreshing()
+        }, CHECK_REFRESH_DELAY)
     }
 
     private fun shareMessage(message: String) {
@@ -564,6 +566,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         private const val KEY_NESTED_LISTS_STATES = "key_nested_lists_states"
         private const val TAG_QUICK_START_DIALOG = "TAG_QUICK_START_DIALOG"
         private const val KEY_MY_SITE_TAB_TYPE = "key_my_site_tab_type"
+        private const val CHECK_REFRESH_DELAY = 300L
 
         @JvmStatic
         fun newInstance(mySiteTabType: MySiteTabType) = MySiteTabFragment().apply {


### PR DESCRIPTION
Internal Ref: p5T066-3a9-p2#comment-12120

This PR adds a workaround to fix spinner not going away issue when switching from `Home` to `Menu` to `Home`. 

It appears that occasionally, my site sources get refreshed slightly later than when we check for refresh status at the time `uiModel` is updated (see [logs](https://cloudup.com/im80Vw7Kbj4)). This was more noticeable on self-hosted jetpack sites.

I tried to resolve it by observing my site sources refresh value to update the spinner but the [animation looked weird](https://cloudup.com/igDCXiYjAl5) so dropped the idea. Currently, I'm adding a slight delay before we check for refresh status. This is a temporary workaround till we find an elegant solution.

To test:

1. Launch the app
2. Go to My Site tab
3. Select a self-hosted Jetpack site
4. Toggle between Home and Menu tabs and wait for few secs
5. Notice that spinner goes away

Merging Instructions:

The issue was found in beta testing for 19.7 release. While it happens occasionally, it'd be good if we can target frozen branch `19.7` as it might be annoying for users to keep seeing the spinner. 

/cc @AliSoftware  

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.