### PR TITLE
Fixes Media Picker video selection Accessibility issue

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] On self-hosted sites, allow previewing unsaved changes to draft posts [https://github.com/wordpress-mobile/WordPress-Android/pull/16296]
 * [*] Editor: Fix issue that caused previews on atomic sites to sometimes be out-of-date. [https://github.com/wordpress-mobile/WordPress-Android/pull/16332]
+* [*] Fixes Media Picker video selection Accessibility issue [https://github.com/wordpress-mobile/WordPress-Android/pull/16426]
 
 19.7
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -596,7 +596,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
     }
 
-    private void setItemSelectedByPosition(GridViewHolder holder, int position, boolean selected) {
+    private void setItemSelectedByPosition(GridViewHolder holder, int position, boolean isVideo, boolean selected) {
         if (!isValidPosition(position)) {
             return;
         }
@@ -638,7 +638,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             mCallback.onAdapterSelectionCountChanged(mSelectedItems.size());
         }
 
-        PhotoPickerUtils.announceSelectedImageForAccessibility(holder.mImageView, selected);
+        PhotoPickerUtils.announceSelectedImageForAccessibility(holder.mImageView, isVideo, selected);
     }
 
     private void toggleItemSelected(GridViewHolder holder, int position) {
@@ -646,12 +646,17 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             return;
         }
         boolean isSelected = isItemSelectedByPosition(position);
-        setItemSelectedByPosition(holder, position, !isSelected);
+        boolean isVideo = isItemIsVideoByPosition(position);
+        setItemSelectedByPosition(holder, position, isVideo, !isSelected);
     }
 
     private boolean isItemSelectedByPosition(int position) {
         int localMediaId = mMediaList.get(position).getId();
         return mSelectedItems.contains(localMediaId);
+    }
+
+    private boolean isItemIsVideoByPosition(int position) {
+        return mMediaList.get(position).isVideo();
     }
 
     public void setSelectedItems(ArrayList<Integer> selectedItems) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -638,7 +638,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             mCallback.onAdapterSelectionCountChanged(mSelectedItems.size());
         }
 
-        PhotoPickerUtils.announceSelectedImageForAccessibility(holder.mImageView, isVideo, selected);
+        PhotoPickerUtils.announceSelectedMediaForAccessibility(holder.mImageView, isVideo, selected);
     }
 
     private void toggleItemSelected(GridViewHolder holder, int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaThumbnailViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaThumbnailViewUtils.kt
@@ -18,8 +18,10 @@ import org.wordpress.android.util.extensions.redirectContextClickToLongPressList
 import java.util.Locale
 
 class MediaThumbnailViewUtils(val imageManager: ImageManager) {
+    @Suppress("LongParameterList")
     fun setupListeners(
         imgThumbnail: ImageView,
+        isVideo: Boolean,
         isSelected: Boolean,
         toggleAction: ToggleAction,
         clickAction: ClickAction,
@@ -30,6 +32,7 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
             toggleAction.toggle()
             PhotoPickerUtils.announceSelectedImageForAccessibility(
                     imgThumbnail,
+                    isVideo,
                     !isSelected
             )
         }
@@ -64,6 +67,7 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
             toggleAction.toggle()
             PhotoPickerUtils.announceSelectedImageForAccessibility(
                     imgThumbnail,
+                    false,
                     !isSelected
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaThumbnailViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaThumbnailViewUtils.kt
@@ -30,7 +30,7 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
         addImageSelectedToAccessibilityFocusedEvent(imgThumbnail, isSelected)
         imgThumbnail.setOnClickListener {
             toggleAction.toggle()
-            PhotoPickerUtils.announceSelectedImageForAccessibility(
+            PhotoPickerUtils.announceSelectedMediaForAccessibility(
                     imgThumbnail,
                     isVideo,
                     !isSelected
@@ -65,7 +65,7 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
         addImageSelectedToAccessibilityFocusedEvent(imgThumbnail, isSelected)
         container.setOnClickListener {
             toggleAction.toggle()
-            PhotoPickerUtils.announceSelectedImageForAccessibility(
+            PhotoPickerUtils.announceSelectedMediaForAccessibility(
                     imgThumbnail,
                     false,
                     !isSelected

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaThumbnailViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaThumbnailViewUtils.kt
@@ -30,7 +30,7 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
             toggleAction.toggle()
             PhotoPickerUtils.announceSelectedImageForAccessibility(
                     imgThumbnail,
-                    isSelected
+                    !isSelected
             )
         }
         imgThumbnail.setOnLongClickListener {
@@ -64,7 +64,7 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
             toggleAction.toggle()
             PhotoPickerUtils.announceSelectedImageForAccessibility(
                     imgThumbnail,
-                    isSelected
+                    !isSelected
             )
         }
         container.setOnLongClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/PhotoThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/PhotoThumbnailViewHolder.kt
@@ -40,7 +40,9 @@ class PhotoThumbnailViewHolder(
                 FIT_CENTER
         )
         mediaThumbnailViewUtils.setupListeners(
-                imgThumbnail, item.isSelected,
+                imgThumbnail,
+                false,
+                item.isSelected,
                 item.toggleAction,
                 item.clickAction,
                 animateSelection

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/VideoThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/VideoThumbnailViewHolder.kt
@@ -46,7 +46,9 @@ class VideoThumbnailViewHolder(
                 FIT_CENTER
         )
         mediaThumbnailViewUtils.setupListeners(
-                imgThumbnail, item.isSelected,
+                imgThumbnail,
+                true,
+                item.isSelected,
                 item.toggleAction,
                 item.clickAction,
                 animateSelection

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoThumbnailViewHolder.kt
@@ -45,7 +45,9 @@ class PhotoThumbnailViewHolder(
                 FIT_CENTER
         )
         thumbnailViewUtils.setupListeners(
-                imgThumbnail, item.isSelected,
+                imgThumbnail,
+                false,
+                item.isSelected,
                 item.toggleAction,
                 item.clickAction,
                 animateSelection

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/ThumbnailViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/ThumbnailViewUtils.kt
@@ -20,8 +20,10 @@ import java.util.Locale
 @Deprecated("This class is being refactored, if you implement any change, please also update " +
         "{@link org.wordpress.android.ui.mediapicker.ThumbnailViewUtils}")
 class ThumbnailViewUtils(val imageManager: ImageManager) {
+    @Suppress("LongParameterList")
     fun setupListeners(
         imgThumbnail: ImageView,
+        isVideo: Boolean,
         isSelected: Boolean,
         toggleAction: ToggleAction,
         clickAction: ClickAction,
@@ -32,6 +34,7 @@ class ThumbnailViewUtils(val imageManager: ImageManager) {
             toggleAction.toggle()
             PhotoPickerUtils.announceSelectedImageForAccessibility(
                     imgThumbnail,
+                    isVideo,
                     !isSelected
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/ThumbnailViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/ThumbnailViewUtils.kt
@@ -32,7 +32,7 @@ class ThumbnailViewUtils(val imageManager: ImageManager) {
             toggleAction.toggle()
             PhotoPickerUtils.announceSelectedImageForAccessibility(
                     imgThumbnail,
-                    isSelected
+                    !isSelected
             )
         }
         imgThumbnail.setOnLongClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/ThumbnailViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/ThumbnailViewUtils.kt
@@ -32,7 +32,7 @@ class ThumbnailViewUtils(val imageManager: ImageManager) {
         addImageSelectedToAccessibilityFocusedEvent(imgThumbnail, isSelected)
         imgThumbnail.setOnClickListener {
             toggleAction.toggle()
-            PhotoPickerUtils.announceSelectedImageForAccessibility(
+            PhotoPickerUtils.announceSelectedMediaForAccessibility(
                     imgThumbnail,
                     isVideo,
                     !isSelected

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/VideoThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/VideoThumbnailViewHolder.kt
@@ -52,7 +52,9 @@ class VideoThumbnailViewHolder(
                 FIT_CENTER
         )
         thumbnailViewUtils.setupListeners(
-                imgThumbnail, item.isSelected,
+                imgThumbnail,
+                true,
+                item.isSelected,
                 item.toggleAction,
                 item.clickAction,
                 animateSelection

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -719,7 +719,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
             boolean isSelected = isItemSelected(position);
             setItemSelected(holder, position, !isSelected);
             notifySelectionCountChanged();
-            PhotoPickerUtils.announceSelectedImageForAccessibility(holder.mImageView, !isSelected);
+            PhotoPickerUtils.announceSelectedImageForAccessibility(holder.mImageView, false, !isSelected);
         }
 
         @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -719,7 +719,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
             boolean isSelected = isItemSelected(position);
             setItemSelected(holder, position, !isSelected);
             notifySelectionCountChanged();
-            PhotoPickerUtils.announceSelectedImageForAccessibility(holder.mImageView, false, !isSelected);
+            PhotoPickerUtils.announceSelectedMediaForAccessibility(holder.mImageView, false, !isSelected);
         }
 
         @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/util/PhotoPickerUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/PhotoPickerUtils.java
@@ -8,7 +8,7 @@ import androidx.annotation.StringRes;
 import org.wordpress.android.R;
 
 public class PhotoPickerUtils {
-    public static void announceSelectedImageForAccessibility(@NonNull ImageView imageThumbnail,
+    public static void announceSelectedMediaForAccessibility(@NonNull ImageView imageThumbnail,
                                                              boolean isVideo,
                                                              boolean itemSelected) {
         @StringRes int accessibilityAnnouncement;

--- a/WordPress/src/main/java/org/wordpress/android/util/PhotoPickerUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/PhotoPickerUtils.java
@@ -3,18 +3,24 @@ package org.wordpress.android.util;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 
 import org.wordpress.android.R;
 
 public class PhotoPickerUtils {
-    public static void announceSelectedImageForAccessibility(@NonNull ImageView imageThumbnail, boolean itemSelected) {
-        if (itemSelected) {
-            imageThumbnail.announceForAccessibility(
-                    imageThumbnail.getContext()
-                                  .getString(R.string.photo_picker_image_thumbnail_selected));
+    public static void announceSelectedImageForAccessibility(@NonNull ImageView imageThumbnail,
+                                                             boolean isVideo,
+                                                             boolean itemSelected) {
+        @StringRes int accessibilityAnnouncement;
+        if (itemSelected && isVideo) {
+            accessibilityAnnouncement = R.string.photo_picker_video_thumbnail_selected;
+        } else if (itemSelected) {
+            accessibilityAnnouncement = R.string.photo_picker_image_thumbnail_selected;
+        } else if (isVideo) {
+            accessibilityAnnouncement = R.string.photo_picker_video_thumbnail_unselected;
         } else {
-            imageThumbnail.announceForAccessibility(
-                    imageThumbnail.getContext().getString(R.string.photo_picker_image_thumbnail_unselected));
+            accessibilityAnnouncement = R.string.photo_picker_image_thumbnail_unselected;
         }
+        imageThumbnail.announceForAccessibility(imageThumbnail.getContext().getString(accessibilityAnnouncement));
     }
 }

--- a/WordPress/src/main/res/layout/media_picker_thumbnail_item.xml
+++ b/WordPress/src/main/res/layout/media_picker_thumbnail_item.xml
@@ -13,7 +13,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="@drawable/photo_picker_item_background"
-        android:contentDescription="@string/photo_picker_image_thumbnail_content_description"
+        android:contentDescription="@string/photo_picker_media_thumbnail_content_description"
         android:scaleType="centerCrop"
         app:layout_constraintDimensionRatio="@string/media_grid_item_ratio"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2730,8 +2730,10 @@
     <string name="photo_picker_image_thumbnail_content_description">Image Thumbnail</string>
     <string name="photo_picker_media_thumbnail_content_description">Media Thumbnail</string>
     <string name="photo_picker_image_thumbnail_selected">Image selected</string>
+    <string name="photo_picker_video_thumbnail_selected">Video selected</string>
     <string name="photo_picker_image_selected">,Selected</string>
     <string name="photo_picker_image_thumbnail_unselected">Image unselected</string>
+    <string name="photo_picker_video_thumbnail_unselected">Video unselected</string>
     <string name="stock_media_picker_search_hint">Search free photo library</string>
     <string name="stock_media_picker_list_content_description">Photo library</string>
     <string name="stock_media_picker_initial_empty_text">Search to find free photos to add to your Media Library</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2728,6 +2728,7 @@
     <string name="photo_picker_use_audio">Use this audio</string>
     <string name="photo_picker_use_media">Use this media</string>
     <string name="photo_picker_image_thumbnail_content_description">Image Thumbnail</string>
+    <string name="photo_picker_media_thumbnail_content_description">Media Thumbnail</string>
     <string name="photo_picker_image_thumbnail_selected">Image selected</string>
     <string name="photo_picker_image_selected">,Selected</string>
     <string name="photo_picker_image_thumbnail_unselected">Image unselected</string>


### PR DESCRIPTION
Fixes #11077

# Description
This PR:
* [Announces the correct media type on selection](https://github.com/wordpress-mobile/WordPress-Android/pull/16426/commits/e04617da4ea802b37a8db4aa573613486a9d5131)
* [Fixes the default announcement while browsing media to avoid confusion by always announcing `image`](https://github.com/wordpress-mobile/WordPress-Android/pull/16426/commits/1bcef3a7a36851addcc711f8170794764034dbc7)

# To test:
1. Enable talkback
2. Open `Media`
3. Press the ➕ button at the top left and select `Choose from device`
4. Select a video or an image
5. **Verify** that the correct media type is announced

## Regression Notes
1. Potential unintended areas of impact
N/A

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

7. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
