### PR TITLE
[Site Design Revamp]  Remove category filter pills

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -5,17 +5,15 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.ViewCompat
+import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.HomePagePickerFragmentBinding
-import org.wordpress.android.ui.layoutpicker.CategoriesAdapter
 import org.wordpress.android.ui.layoutpicker.LayoutCategoryAdapter
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState
 import org.wordpress.android.ui.layoutpicker.LayoutPickerViewModel.DesignPreviewAction.Dismiss
@@ -25,9 +23,8 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.config.SiteNameFeatureConfig
-import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.extensions.setVisible
-import org.wordpress.android.viewmodel.observeEvent
+import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
 /**
@@ -61,17 +58,8 @@ class HomePagePickerFragment : Fragment() {
         viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(HomePagePickerViewModel::class.java)
 
         with(HomePagePickerFragmentBinding.bind(view)) {
-            categoriesRecyclerView.apply {
-                layoutManager = LinearLayoutManager(
-                        context,
-                        RecyclerView.HORIZONTAL,
-                        false
-                )
-                setRecycledViewPool(RecyclerView.RecycledViewPool())
-                adapter = CategoriesAdapter()
-                ViewCompat.setNestedScrollingEnabled(this, false)
-            }
-
+            modalLayoutPickerCategoriesSkeleton.root.isGone = true
+            categoriesRecyclerView.isGone = true
             layoutsRecyclerView.apply {
                 layoutManager = LinearLayoutManager(requireActivity())
                 adapter = LayoutCategoryAdapter(viewModel.nestedScrollStates)
@@ -99,7 +87,6 @@ class HomePagePickerFragment : Fragment() {
                 is LayoutPickerUiState.Loading -> { // Nothing more to do here
                 }
                 is LayoutPickerUiState.Content -> {
-                    (categoriesRecyclerView.adapter as CategoriesAdapter).setData(uiState.categories)
                     (layoutsRecyclerView.adapter as? LayoutCategoryAdapter)?.update(uiState.layoutCategories)
                 }
                 is LayoutPickerUiState.Error -> {
@@ -122,10 +109,6 @@ class HomePagePickerFragment : Fragment() {
             }
         }
 
-        viewModel.onCategorySelectionChanged.observeEvent(viewLifecycleOwner) {
-            layoutsRecyclerView.smoothScrollToPosition(0)
-        }
-
         viewModel.start(displayUtils.isTablet())
     }
 
@@ -138,8 +121,6 @@ class HomePagePickerFragment : Fragment() {
     }
 
     private fun HomePagePickerFragmentBinding.setContentVisibility(skeleton: Boolean, error: Boolean) {
-        modalLayoutPickerCategoriesSkeleton.categoriesSkeleton.setVisible(skeleton)
-        categoriesRecyclerView.setVisible(!skeleton && !error)
         modalLayoutPickerLayoutsSkeleton.layoutsSkeleton.setVisible(skeleton)
         layoutsRecyclerView.setVisible(!skeleton && !error)
         errorView.setVisible(error)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -74,7 +74,10 @@ class HomePagePickerFragment : Fragment() {
     private fun HomePagePickerFragmentBinding.setupUi() {
         homePagePickerTitlebar.title.isInvisible = !displayUtils.isPhoneLandscape()
         with(modalLayoutPickerHeaderSection) {
-            modalLayoutPickerTitleRow?.header?.setText(R.string.hpp_title)
+            modalLayoutPickerTitleRow?.header?.apply {
+                textAlignment = View.TEXT_ALIGNMENT_TEXT_START
+                setText(R.string.hpp_title)
+            }
             modalLayoutPickerSubtitleRow?.root?.visibility = View.GONE
         }
     }

--- a/WordPress/src/main/res/layout/home_page_picker_titlebar.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_titlebar.xml
@@ -18,6 +18,7 @@
         style="@style/ModalLayoutPickerHeader"
         android:layout_width="0dp"
         android:layout_weight="1"
+        android:textAlignment="textStart"
         android:paddingStart="@dimen/hpp_title_padding_start"
         android:paddingEnd="0dp"
         android:text="@string/hpp_title" />

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -646,7 +646,7 @@
     <dimen name="mlp_layout_skeleton_line_width">100dp</dimen>
 
     <!-- Home Page Picker -->
-    <dimen name="hpp_title_padding_start">@dimen/margin_extra_extra_medium_large</dimen>
+    <dimen name="hpp_title_padding_start">@dimen/margin_none</dimen>
 
     <!-- Site Intent Question -->
     <dimen name="siq_title_padding_start">@dimen/margin_extra_extra_large</dimen>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1515,6 +1515,8 @@
         <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:paddingTop">@dimen/mlp_titles_top_margin</item>
         <item name="android:paddingBottom">@dimen/margin_small_medium</item>
+        <item name="android:paddingStart">@dimen/margin_extra_large</item>
+        <item name="android:paddingEnd">@dimen/margin_extra_large</item>
         <item name="android:maxLines">3</item>
         <item name="fontFamily">serif</item>
     </style>


### PR DESCRIPTION
Fixes point **D** on #16392.

Removes the category filter pills on the Site ~design~ theme screen & sets the text alignment of the large "Choose a theme" title to the left.

### To test:

#### Theme (Site Design) Picker

1. Start the site creation flow
2. Choose an Intent (or skip)
3. Choose a site name (or skip)
4. Expect to be at the site design screen

Expectations:
* The horizontal scrolling category filter pills are gone.
* The text of the large title is aligned at the left (right for RTL languages).

#### Page Picker

1. Navigate to the pages list
2. Tap the FAB to create a new page
3. Expect to be at the page layout picker

Expectations:
* The horizontal scrolling category filter pills are not changed.
* The text of the large title is still aligned at the center of the screen.


## Regression Notes
1. Potential unintended areas of impact
   Modal layout picker (for page creation).

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing to ensure there's no regression on that screen.

3. What automated tests I added (or what prevented me from doing so)
   Existing view models unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
