### PR TITLE
Migrate stats screens to hilt

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -336,6 +336,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
     implementation 'androidx.legacy:legacy-support-core-ui:1.0.0'
     implementation 'androidx.fragment:fragment:1.2.4'
+    implementation "androidx.fragment:fragment-ktx:$fragmentKtx"
 
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -335,8 +335,8 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
     implementation 'androidx.legacy:legacy-support-core-ui:1.0.0'
-    implementation 'androidx.fragment:fragment:1.2.4'
-    implementation "androidx.fragment:fragment-ktx:$fragmentKtx"
+    implementation "androidx.fragment:fragment:$fragmentVersion"
+    implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
 
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -201,7 +201,6 @@ import org.wordpress.android.ui.sitecreation.theme.DesignPreviewFragment;
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerFragment;
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsFragment;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
-import org.wordpress.android.ui.stats.refresh.StatsActivity;
 import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetBlockListProviderFactory;
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetListProvider;
@@ -526,8 +525,6 @@ public interface AppComponent {
     void inject(TodayWidgetListProvider object);
 
     void inject(TodayWidgetBlockListProviderFactory object);
-
-    void inject(StatsActivity object);
 
     void inject(StatsListFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -26,7 +26,6 @@ import org.wordpress.android.ui.reader.ReaderPostWebViewCachingFragment;
 import org.wordpress.android.ui.reader.subfilter.SubfilterPageFragment;
 import org.wordpress.android.ui.sitecreation.SiteCreationStep;
 import org.wordpress.android.ui.sitecreation.SiteCreationStepsProvider;
-import org.wordpress.android.ui.stats.refresh.StatsFragment;
 import org.wordpress.android.ui.stats.refresh.StatsViewAllFragment;
 import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment;
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailFragment;
@@ -64,9 +63,6 @@ public abstract class ApplicationModule {
 
     @ContributesAndroidInjector
     abstract InsightsManagementFragment contributeInsightsManagementFragment();
-
-    @ContributesAndroidInjector
-    abstract StatsFragment contributeStatsFragment();
 
     @ContributesAndroidInjector
     abstract StatsDetailFragment contributeStatsDetailFragment();

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -66,7 +66,6 @@ import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel;
 import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewModel;
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerViewModel;
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel;
-import org.wordpress.android.ui.stats.refresh.StatsViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.DaysListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.MonthsListViewModel;
@@ -213,11 +212,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(DetailListViewModel.class)
     abstract ViewModel detailListViewModel(DetailListViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(StatsViewModel.class)
-    abstract ViewModel statsViewModel(StatsViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -4,7 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.lifecycle.ViewModelProvider
+import androidx.activity.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.StatsListActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
@@ -15,13 +16,12 @@ import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class StatsActivity : LocaleAwareActivity() {
     @Inject lateinit var statsSiteProvider: StatsSiteProvider
-    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
-    private lateinit var viewModel: StatsViewModel
+    private val viewModel: StatsViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (application as WordPress).component().inject(this)
         setContentView(StatsListActivityBinding.inflate(layoutInflater).root)
     }
 
@@ -37,7 +37,6 @@ class StatsActivity : LocaleAwareActivity() {
         intent?.let {
             val siteId = intent.getIntExtra(WordPress.LOCAL_SITE_ID, -1)
             if (siteId > -1) {
-                viewModel = ViewModelProvider(this, viewModelFactory).get(StatsViewModel::class.java)
                 viewModel.start(intent, restart = true)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -14,7 +14,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.google.android.material.tabs.TabLayout.Tab
 import com.google.android.material.tabs.TabLayoutMediator
-import dagger.android.support.DaggerFragment
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -42,7 +41,7 @@ import javax.inject.Inject
 private val statsSections = listOf(INSIGHTS, DAYS, WEEKS, MONTHS, YEARS)
 
 @AndroidEntryPoint
-class StatsFragment : DaggerFragment(R.layout.stats_fragment), ScrollableViewInitializedListener {
+class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializedListener {
     @Inject lateinit var uiHelpers: UiHelpers
     private val viewModel: StatsViewModel by viewModels()
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -7,7 +7,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.MarginPageTransformer
 import com.google.android.material.snackbar.Snackbar
@@ -15,6 +15,7 @@ import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.google.android.material.tabs.TabLayout.Tab
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.android.support.DaggerFragment
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.StatsFragmentBinding
@@ -40,10 +41,10 @@ import javax.inject.Inject
 
 private val statsSections = listOf(INSIGHTS, DAYS, WEEKS, MONTHS, YEARS)
 
+@AndroidEntryPoint
 class StatsFragment : DaggerFragment(R.layout.stats_fragment), ScrollableViewInitializedListener {
-    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var uiHelpers: UiHelpers
-    private lateinit var viewModel: StatsViewModel
+    private val viewModel: StatsViewModel by viewModels()
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
     private lateinit var selectedTabListener: SelectedTabListener
 
@@ -103,8 +104,6 @@ class StatsFragment : DaggerFragment(R.layout.stats_fragment), ScrollableViewIni
         isFirstStart: Boolean,
         savedInstanceState: Bundle?
     ) {
-        viewModel = ViewModelProvider(activity, viewModelFactory).get(StatsViewModel::class.java)
-
         viewModel.onRestoreInstanceState(savedInstanceState)
 
         setupObservers(activity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -56,6 +57,7 @@ import javax.inject.Inject
 import javax.inject.Named
 
 @Suppress("TooManyFunctions", "LongParameterList")
+@HiltViewModel
 class StatsViewModel
 @Inject constructor(
     @Named(LIST_STATS_USE_CASES) private val listUseCases: Map<StatsSection, BaseListUseCase>,

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ ext {
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'
+    fragmentKtx = '1.4.1'
     lifecycleVersion = '2.2.0'
     constraintLayoutVersion = '1.1.3'
     materialVersion = '1.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'
-    fragmentKtx = '1.4.1'
+    fragmentVersion = '1.2.4'
     lifecycleVersion = '2.2.0'
     constraintLayoutVersion = '1.1.3'
     materialVersion = '1.2.1'


### PR DESCRIPTION
This PR removes dagger from `StatsActivity`, `StatsFragment` and `StatsViewModel`. The same changes should be applied to other screens for the migration.

**Steps to migrate:**
1. Add `@AndroidEntryPoint` to the activity or fragment.
2. Remove dagger injection from the activity or fragment, usually this line: `(application as WordPress).component().inject(this)`.
3. Add `@HiltViewModel` to the view model you want to migrate.
5. Remove activities, fragments, and view models from dagger modules.
6. Remove injecting view models via `ViewModelProvider.Factory`, use `by viewModels()`.

To test: 
- Ensure the project is buildable and there isn't any crash on stats screens. 
- Smoke test to check layout and animation problems.

## Regression Notes
1. Potential unintended areas of impact
Fragment KTX dependency may cause some layout or animation problems. 

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested, and see no crash or layout problem.

7. What automated tests I added (or what prevented me from doing so)
None, not added any new feature. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
