### PR TITLE
issue/16402-my-site-dashboard-show-next-steps-card-at-the-top

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -28,7 +28,7 @@ import org.wordpress.android.util.image.ImageManager
 class MySiteAdapter(
     val imageManager: ImageManager,
     val uiHelpers: UiHelpers
-) : ListAdapter<MySiteCardAndItem,MySiteCardAndItemViewHolder<*>>(MySiteAdapterDiffCallback) {
+) : ListAdapter<MySiteCardAndItem, MySiteCardAndItemViewHolder<*>>(MySiteAdapterDiffCallback) {
     private val quickStartViewPool = RecycledViewPool()
     private var nestedScrollStates = Bundle()
 
@@ -57,7 +57,7 @@ class MySiteAdapter(
             is QuickActionsViewHolder -> holder.bind(getItem(position) as QuickActionsCard)
             is QuickLinkRibbonViewHolder -> holder.bind(getItem(position) as QuickLinkRibbon)
             is DomainRegistrationViewHolder -> holder.bind(getItem(position) as DomainRegistrationCard)
-            is QuickStartCardViewHolder  -> holder.bind(getItem(position) as QuickStartCard)
+            is QuickStartCardViewHolder -> holder.bind(getItem(position) as QuickStartCard)
             is QuickStartDynamicCardViewHolder -> holder.bind(getItem(position) as QuickStartDynamicCard)
             is MySiteInfoItemViewHolder -> holder.bind(getItem(position) as InfoItem)
             is MySiteCategoryItemViewHolder -> holder.bind(getItem(position) as CategoryHeaderItem)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -2,8 +2,7 @@ package org.wordpress.android.ui.mysite
 
 import android.os.Bundle
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.RecyclerView.Adapter
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView.RecycledViewPool
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
@@ -29,18 +28,9 @@ import org.wordpress.android.util.image.ImageManager
 class MySiteAdapter(
     val imageManager: ImageManager,
     val uiHelpers: UiHelpers
-) : Adapter<MySiteCardAndItemViewHolder<*>>() {
-    private var items = listOf<MySiteCardAndItem>()
+) : ListAdapter<MySiteCardAndItem,MySiteCardAndItemViewHolder<*>>(MySiteAdapterDiffCallback) {
     private val quickStartViewPool = RecycledViewPool()
     private var nestedScrollStates = Bundle()
-
-    fun loadData(result: List<MySiteCardAndItem>) {
-        val diffResult = DiffUtil.calculateDiff(
-                MySiteAdapterDiffCallback(items, result)
-        )
-        items = result
-        diffResult.dispatchUpdatesTo(this)
-    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MySiteCardAndItemViewHolder<*> {
         return when (viewType) {
@@ -64,15 +54,15 @@ class MySiteAdapter(
 
     override fun onBindViewHolder(holder: MySiteCardAndItemViewHolder<*>, position: Int) {
         when (holder) {
-            is QuickActionsViewHolder -> holder.bind(items[position] as QuickActionsCard)
-            is QuickLinkRibbonViewHolder -> holder.bind(items[position] as QuickLinkRibbon)
-            is DomainRegistrationViewHolder -> holder.bind(items[position] as DomainRegistrationCard)
-            is QuickStartCardViewHolder -> holder.bind(items[position] as QuickStartCard)
-            is QuickStartDynamicCardViewHolder -> holder.bind(items[position] as QuickStartDynamicCard)
-            is MySiteInfoItemViewHolder -> holder.bind(items[position] as InfoItem)
-            is MySiteCategoryItemViewHolder -> holder.bind(items[position] as CategoryHeaderItem)
-            is MySiteListItemViewHolder -> holder.bind(items[position] as ListItem)
-            is CardsViewHolder -> holder.bind(items[position] as DashboardCards)
+            is QuickActionsViewHolder -> holder.bind(getItem(position) as QuickActionsCard)
+            is QuickLinkRibbonViewHolder -> holder.bind(getItem(position) as QuickLinkRibbon)
+            is DomainRegistrationViewHolder -> holder.bind(getItem(position) as DomainRegistrationCard)
+            is QuickStartCardViewHolder  -> holder.bind(getItem(position) as QuickStartCard)
+            is QuickStartDynamicCardViewHolder -> holder.bind(getItem(position) as QuickStartDynamicCard)
+            is MySiteInfoItemViewHolder -> holder.bind(getItem(position) as InfoItem)
+            is MySiteCategoryItemViewHolder -> holder.bind(getItem(position) as CategoryHeaderItem)
+            is MySiteListItemViewHolder -> holder.bind(getItem(position) as ListItem)
+            is CardsViewHolder -> holder.bind(getItem(position) as DashboardCards)
         }
     }
 
@@ -83,9 +73,7 @@ class MySiteAdapter(
         }
     }
 
-    override fun getItemViewType(position: Int) = items[position].type.ordinal
-
-    override fun getItemCount(): Int = items.size
+    override fun getItemViewType(position: Int) = getItem(position).type.ordinal
 
     fun onRestoreInstanceState(savedInstanceState: Bundle) {
         nestedScrollStates = savedInstanceState
@@ -93,5 +81,9 @@ class MySiteAdapter(
 
     fun onSaveInstanceState(): Bundle {
         return nestedScrollStates
+    }
+
+    override fun getItemCount(): Int {
+        return currentList.size
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -12,7 +12,8 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.InfoItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.ListItem
 
-object MySiteAdapterDiffCallback: DiffUtil.ItemCallback<MySiteCardAndItem>() {
+@Suppress("ComplexMethod")
+object MySiteAdapterDiffCallback : DiffUtil.ItemCallback<MySiteCardAndItem>() {
     override fun areItemsTheSame(oldItem: MySiteCardAndItem, updatedItem: MySiteCardAndItem): Boolean {
         return oldItem.type == updatedItem.type && when {
             oldItem is QuickActionsCard && updatedItem is QuickActionsCard -> true

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -12,18 +12,8 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.InfoItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.ListItem
 
-class MySiteAdapterDiffCallback(
-    private val oldCardAndItems: List<MySiteCardAndItem>,
-    private val updatedCardAndItems: List<MySiteCardAndItem>
-) : DiffUtil.Callback() {
-    override fun getOldListSize(): Int = oldCardAndItems.size
-
-    override fun getNewListSize(): Int = updatedCardAndItems.size
-
-    @Suppress("ComplexMethod")
-    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        val oldItem = oldCardAndItems[oldItemPosition]
-        val updatedItem = updatedCardAndItems[newItemPosition]
+object MySiteAdapterDiffCallback: DiffUtil.ItemCallback<MySiteCardAndItem>() {
+    override fun areItemsTheSame(oldItem: MySiteCardAndItem, updatedItem: MySiteCardAndItem): Boolean {
         return oldItem.type == updatedItem.type && when {
             oldItem is QuickActionsCard && updatedItem is QuickActionsCard -> true
             oldItem is QuickLinkRibbon && updatedItem is QuickLinkRibbon -> true
@@ -38,6 +28,7 @@ class MySiteAdapterDiffCallback(
         }
     }
 
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-            oldCardAndItems[oldItemPosition] == updatedCardAndItems[newItemPosition]
+    override fun areContentsTheSame(oldItem: MySiteCardAndItem, newItem: MySiteCardAndItem): Boolean {
+        return oldItem == newItem
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -11,6 +11,7 @@ import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity
@@ -157,6 +158,13 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         )
 
         val adapter = MySiteAdapter(imageManager, uiHelpers)
+
+        adapter.registerAdapterDataObserver(object : AdapterDataObserver() {
+            override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+                super.onItemRangeInserted(positionStart, itemCount)
+                recyclerView.smoothScrollToPosition(0)
+            }
+        })
 
         savedInstanceState?.getBundle(KEY_NESTED_LISTS_STATES)?.let {
             adapter.onRestoreInstanceState(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -517,7 +517,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             MySiteTabType.DASHBOARD -> state.dashboardCardsAndItems
             else -> state.cardAndItems
         }
-        (recyclerView.adapter as? MySiteAdapter)?.loadData(cardAndItems)
+        (recyclerView.adapter as? MySiteAdapter)?.submitList(cardAndItems)
     }
 
     private fun MySiteTabFragmentBinding.loadEmptyView() {


### PR DESCRIPTION
Internal Ref p5T066-3a9#comment-12108

Fixes #16402 

This fixes the bug where after Logging in, the page wasn't scrolled to the top to show the Quick Start Card. 

Upon Investigation, It looks like if there are new items at the top, then the screen is not auto scrolled to the top to show the new items. This PR fixes the issue by autoscrolling to the Top when there are new items inserted. 

https://user-images.githubusercontent.com/17463767/165702711-22fd030a-fbee-4aa4-b8f7-54ac2a9c2262.mp4

To test:

**Test 1**

- Fresh install the app.
- Login to app.
- Tap an existing site from Login Epilogue screen.
- Tap "Show me around" in the onboarding users dialog.
- Notice that the app scroll up to see the "next steps" card.

**Test 2**
- Open app with a site which has QS completed
- Make sure that the `App Settings -> Initial screen` is `Menu`
- Switch to a Site having Quick Start in Progress.
- Notice that the app scrolls up to see the "next steps" card.

### Merging Instructions:

The issue was found in beta testing for 19.7 release. It'd be good if we can target frozen branch 19.7.

/cc @AliSoftware

## Regression Notes
1. Potential unintended areas of impact
Autoscrolling issues on Quick Start tasks 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
