### PR TITLE
MSD - Auto select initial tab without restarting the app

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -290,8 +290,13 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         is SiteNavigationAction.OpenMeScreen -> ActivityLauncher.viewMeActivityForResult(activity)
         is SiteNavigationAction.AddNewSite -> SitePickerActivity.addSite(activity, action.hasAccessToken)
         else -> {
-            // Pass all other navigationAction on to the child fragment, so they can be handled properly
-            binding?.viewPager?.getCurrentFragment()?.handleNavigationAction(action)
+            /* Pass all other navigationAction on to the child fragment, so they can be handled properly.
+               Added brief delay before passing action to nested (view pager) tab fragments to give them time to get
+               created. */
+            view?.postDelayed({
+                binding?.viewPager?.getCurrentFragment()?.handleNavigationAction(action)
+            }, PASS_TO_TAB_FRAGMENT_DELAY)
+            Unit
         }
     }
 
@@ -311,7 +316,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
            real issue as we could only test it on an emulator, we added it to be safe in such cases. */
         view?.postDelayed({
             binding?.viewPager?.getCurrentFragment()?.onActivityResult(requestCode, resultCode, data)
-        }, PASS_ACTIVITY_RESULT_TO_TAB_FRAGMENT_DELAY)
+        }, PASS_TO_TAB_FRAGMENT_DELAY)
     }
 
     private fun ViewPager2.getCurrentFragment() =
@@ -347,7 +352,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     companion object {
-        private const val PASS_ACTIVITY_RESULT_TO_TAB_FRAGMENT_DELAY = 300L
+        private const val PASS_TO_TAB_FRAGMENT_DELAY = 300L
         fun newInstance(): MySiteFragment {
             return MySiteFragment()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1145,13 +1145,12 @@ class MySiteViewModel @Inject constructor(
 
     private fun selectDefaultTabIfNeeded() {
         if (!isMySiteTabsEnabled) return
-        // This logic checks if the current tab is the same as the tab
+        // This logic checks if the current default tab is the same as the tab
         // set as initial screen, if yes then return
         if (isDefaultABExperimentTabSet) {
             _selectTab.value?.let { tab ->
-                val currentTab = tab.peekContent().position
-                if (currentTab == orderedTabTypes.indexOf(defaultABExperimentTab))
-                    return
+                val currentDefaultTab = tab.peekContent().position
+                if (currentDefaultTab == orderedTabTypes.indexOf(defaultABExperimentTab)) return
             }
         }
         val index = orderedTabTypes.indexOf(defaultABExperimentTab)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1143,6 +1143,7 @@ class MySiteViewModel @Inject constructor(
         }
     }
 
+    @Suppress("NestedBlockDepth")
     private fun selectDefaultTabIfNeeded() {
         if (!isMySiteTabsEnabled) return
         val index = orderedTabTypes.indexOf(defaultABExperimentTab)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1145,16 +1145,16 @@ class MySiteViewModel @Inject constructor(
 
     private fun selectDefaultTabIfNeeded() {
         if (!isMySiteTabsEnabled) return
-        // This logic checks if the current default tab is the same as the tab
-        // set as initial screen, if yes then return
-        if (isDefaultABExperimentTabSet) {
-            _selectTab.value?.let { tab ->
-                val currentDefaultTab = tab.peekContent().position
-                if (currentDefaultTab == orderedTabTypes.indexOf(defaultABExperimentTab)) return
-            }
-        }
         val index = orderedTabTypes.indexOf(defaultABExperimentTab)
         if (index != -1) {
+            if (isDefaultABExperimentTabSet) {
+                // This logic checks if the current default tab is the same as the tab
+                // set as initial screen, if yes then return
+                _selectTab.value?.let { tab ->
+                    val currentDefaultTab = tab.peekContent().position
+                    if (currentDefaultTab == index) return
+                }
+            }
             _selectTab.postValue(Event(TabNavigation(index, smoothAnimation = false)))
             isDefaultABExperimentTabSet = true
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1144,7 +1144,16 @@ class MySiteViewModel @Inject constructor(
     }
 
     private fun selectDefaultTabIfNeeded() {
-        if (!isMySiteTabsEnabled || isDefaultABExperimentTabSet) return
+        if (!isMySiteTabsEnabled) return
+        // This logic checks if the current tab is the same as the tab
+        // set as initial screen, if yes then return
+        if (isDefaultABExperimentTabSet) {
+            _selectTab.value?.let { tab ->
+                val currentTab = tab.peekContent().position
+                if (currentTab == orderedTabTypes.indexOf(defaultABExperimentTab))
+                    return
+            }
+        }
         val index = orderedTabTypes.indexOf(defaultABExperimentTab)
         if (index != -1) {
             _selectTab.postValue(Event(TabNavigation(index, smoothAnimation = false)))


### PR DESCRIPTION
This PR 
- Cherry picks commits (4859e29c9f871ff0f4812db44a73c4238f9e1fe4...5deee15a7be29519360aae09e681e0c0442ebd3c) from `trunk` that auto-select the default tab without restarting the app on changing `Initial Screen`  from `App Settings` and fix "auto-scroll" to quick start focus point on `Menu` tab for `Stats` and `Pages` items: https://github.com/wordpress-mobile/WordPress-Android/pull/16361#issuecomment-1104744839.
- Adds a precautionary delay before passing navigation actions to nested (view pager) tab fragments to give them time to get created as sometimes it was noticed that `Quick Start Prompt Dialog` was not shown in UI connected test on multiple logins (p1651048630539109/1651048455.086839-slack-C011BKNU1V5).

To test:

#### Test.1
Cherry picked commits (4859e29c9f871ff0f4812db44a73c4238f9e1fe4...5deee15a7be29519360aae09e681e0c0442ebd3c) were tested before merging to `trunk`. Still you can test that changing initial screen from app settings and returning to my site screen auto selects corresponding tab.

#### Test.2
Logout and login multiple times and notice that quick start flow is started every time.


Targets release/19.7
/cc @AliSoftware 

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.