### PR TITLE
Media Picker: Adds media type in the thumbnail content description

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/PhotoThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/PhotoThumbnailViewHolder.kt
@@ -39,6 +39,9 @@ class PhotoThumbnailViewHolder(
                 item.url,
                 FIT_CENTER
         )
+        imgThumbnail.apply {
+            contentDescription = resources.getString(R.string.photo_picker_image_thumbnail_content_description)
+        }
         mediaThumbnailViewUtils.setupListeners(
                 imgThumbnail,
                 false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/VideoThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/VideoThumbnailViewHolder.kt
@@ -45,6 +45,9 @@ class VideoThumbnailViewHolder(
                 item.url,
                 FIT_CENTER
         )
+        imgThumbnail.apply {
+            contentDescription = resources.getString(R.string.photo_picker_video_thumbnail_content_description)
+        }
         mediaThumbnailViewUtils.setupListeners(
                 imgThumbnail,
                 true,

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2730,6 +2730,7 @@
     <string name="photo_picker_use_audio">Use this audio</string>
     <string name="photo_picker_use_media">Use this media</string>
     <string name="photo_picker_image_thumbnail_content_description">Image Thumbnail</string>
+    <string name="photo_picker_video_thumbnail_content_description">Video Thumbnail</string>
     <string name="photo_picker_media_thumbnail_content_description">Media Thumbnail</string>
     <string name="photo_picker_image_thumbnail_selected">Image selected</string>
     <string name="photo_picker_video_thumbnail_selected">Video selected</string>


### PR DESCRIPTION
This PR continues the work on https://github.com/wordpress-mobile/WordPress-Android/pull/16426 by adding the media type Image/Video on the accessibility announcement of each item.

To test:
1. Enable talkback
2. Open Media
3. Press the ➕ button at the top left and select Choose from device
4. Browse the images and videos
5. Verify that the correct media type is announced

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
