### PR TITLE
Crash fix on Clicking at Top tips link on Translations 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
@@ -7,15 +7,12 @@ import android.text.SpannableString
 import android.text.TextPaint
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
-import android.text.style.ImageSpan
 import android.text.style.StyleSpan
 import android.text.style.URLSpan
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.core.content.ContextCompat
 import org.wordpress.android.R
-import org.wordpress.android.R.drawable
 import org.wordpress.android.databinding.MySiteTodaysStatsCardBinding
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TextWithLinks.Clickable
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TodaysStatsCardWithData
@@ -66,7 +63,6 @@ class TodaysStatsCardViewHolder(
                     link.navigationAction.click()
                 }
             }
-            spannable.withExternalLinkImageSpan(endIndex)
             spannable.withBoldSpan(startIndex, endIndex)
         }
         text = spannable
@@ -96,23 +92,6 @@ class TodaysStatsCardViewHolder(
                 startIndex,
                 endIndex,
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-        )
-    }
-
-    private fun SpannableString.withExternalLinkImageSpan(endIndex: Int) {
-        val drawable = ContextCompat.getDrawable(itemView.context, drawable.ic_external_white_24dp) ?: return
-        drawable.setTint(linkColor)
-        drawable.setBounds(
-                EXTERNAL_LINK_DRAWABLE_BOUND_LEFT,
-                0,
-                drawable.intrinsicWidth / 2,
-                drawable.intrinsicHeight / 2
-        )
-        setSpan(
-                ImageSpan(drawable, ImageSpan.ALIGN_BASELINE),
-                endIndex,
-                endIndex + 1,
-                Spannable.SPAN_INCLUSIVE_EXCLUSIVE
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsCardViewHolder.kt
@@ -106,8 +106,4 @@ class TodaysStatsCardViewHolder(
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
         )
     }
-
-    companion object {
-        private const val EXTERNAL_LINK_DRAWABLE_BOUND_LEFT = 5
-    }
 }


### PR DESCRIPTION
Fixes # 
In the case of a Site with Empty Stats(0 views, 0 Visitors, 0 likes), a button (**top tips**) with a link is shown to provide users tips to increase the views. On some devices with languages other than english, while rendering the Screen this screen was crashing. 

The cause of the crash was due to a drawable that was added to the button (**top tips**) , the drawable was added to the end of the text. The logic of adding the drawable to the end assumed the '.' at the end of the text. In some translations, the '.' was not present which caused crash. 

This PR, Removes the logic of adding the drawable in the text with span after checking the text length.

To test:
- Open the app with a Site having empty stats
- Check the app in the following languages 
- English, French, Korean, Japanese, Chinese 
- Make sure that clicking on **Top tips**(respective translation) doesn't crash

## Regression Notes
1. Potential unintended areas of impact
Top tips not working properly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
