### PR TITLE
Jetpack App: Pass magic link scheme to signup flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,7 +12,7 @@
 * [*] Block Editor: Latest Posts block: Add featured image settings [https://github.com/WordPress/gutenberg/pull/39257]
 * [*] Block Editor: Prevent incorrect notices displaying when switching between HTML-Visual mode quickly [https://github.com/WordPress/gutenberg/pull/40415]
 * [*] Block Editor: Embed block: Fix inline preview cut-off when editing URL [https://github.com/WordPress/gutenberg/pull/35326]
-
+* [*] Jetpack App: Fixes signup magic link URL [https://github.com/wordpress-mobile/WordPress-Android/pull/16449]
 19.7
 -----
 * [*] [internal] Site creation: Adds a new screen asking the user the name of the site [https://github.com/wordpress-mobile/WordPress-Android/pull/16259]

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -562,8 +562,10 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Override
     public void showSignupMagicLink(String email) {
         boolean isEmailClientAvailable = WPActivityUtils.isEmailClientAvailable(this);
+        AuthEmailPayloadScheme scheme = mViewModel.getMagicLinkScheme();
         SignupMagicLinkFragment signupMagicLinkFragment = SignupMagicLinkFragment.newInstance(email, mIsJetpackConnect,
-                mJetpackConnectSource != null ? mJetpackConnectSource.toString() : null, isEmailClientAvailable);
+                mJetpackConnectSource != null ? mJetpackConnectSource.toString() : null, isEmailClientAvailable,
+                scheme);
         slideInFragment(signupMagicLinkFragment, true, SignupMagicLinkFragment.TAG);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
-    wordPressLoginVersion = '0.13.0'
+    wordPressLoginVersion = '85-fb505a1357c934e0803832aad87619652c03bed2'
     gutenbergMobileVersion = 'v1.75.0'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
-    wordPressLoginVersion = '85-fb505a1357c934e0803832aad87619652c03bed2'
+    wordPressLoginVersion = 'trunk-3f0e3fc881b14836043d17c8654b52d57e4c1c12'
     gutenbergMobileVersion = 'v1.75.0'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'


### PR DESCRIPTION
This PR passes the magic link scheme (that are different for `Jetpack` and `WordPress` app) to the sign-up flow via login lib.

Internal Ref: p1651257368040849-slack-C0180B5PRJ4
Corresponding Login Lib PR: https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/85

To test:
1. Install `Jetpack` app.
2. Notice that `Log in or signup with WordPress.com` is shown on the `Login Prologue` screen.
3. Signup using a new email.
4. Notice that signup succeeds.

Review/ Merge Instructions
- Review corresponding login lib PR
- Make sure login lib PR is merged to `trunk` (I can take care of merging and updating the version).
- Update login lib version in the build.gradle
- Remove `Not Ready for Merge` label
- Merge the PR

P.S. This PR currently targets `19.8` before code freeze on Monday.  Any hotfix will be taken up separately.

## Regression Notes
1. Potential unintended areas of impact
Passes only the scheme parameter to the login lib's `SignupMagicLinkFragment`. It should be sufficient to test the magic link sign-up flow.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually. 

4. What automated tests I added (or what prevented me from doing so)
The existing code has no tests for the flow. Add minimal changes to fix the flow at this time. Refactoring the code to support tests is currently out of the scope of this PR. Created https://github.com/wordpress-mobile/WordPress-Android/issues/16452 to take it up separately.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.