### PR TITLE
Add missing parameter to InsightsLatestPostModel in unit tests

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapperTest.kt
@@ -54,7 +54,18 @@ class LatestPostSummaryMapperTest {
     @Test
     fun `builds message with no engagement and link`() {
         val viewCount = 0
-        val model = InsightsLatestPostModel(siteId, postTitle, postURL, date, postId, viewCount, 0, 0, listOf())
+        val model = InsightsLatestPostModel(
+                siteId,
+                postTitle,
+                postURL,
+                date,
+                postId,
+                viewCount,
+                0,
+                0,
+                listOf(),
+                ""
+        )
 
         val sinceTimeLabel = "10 mins"
         whenever(statsSinceLabelFormatter.getSinceLabelLowerCase(date)).thenReturn(sinceTimeLabel)
@@ -86,7 +97,18 @@ class LatestPostSummaryMapperTest {
     @Test
     fun `builds message with engagement`() {
         val viewCount = 10
-        val model = InsightsLatestPostModel(siteId, postTitle, postURL, date, postId, viewCount, 0, 0, listOf())
+        val model = InsightsLatestPostModel(
+                siteId,
+                postTitle,
+                postURL,
+                date,
+                postId,
+                viewCount,
+                0,
+                0,
+                listOf(),
+                ""
+        )
 
         val sinceTimeLabel = "10 mins"
         whenever(statsSinceLabelFormatter.getSinceLabelLowerCase(date)).thenReturn(sinceTimeLabel)
@@ -145,7 +167,18 @@ class LatestPostSummaryMapperTest {
         val postTitleWithHtml = "<b>Title</b> with <font color=\"red\">HTML</color>"
 
         val viewCount = 0
-        val model = InsightsLatestPostModel(siteId, postTitleWithHtml, postURL, date, postId, viewCount, 0, 0, listOf())
+        val model = InsightsLatestPostModel(
+                siteId,
+                postTitleWithHtml,
+                postURL,
+                date,
+                postId,
+                viewCount,
+                0,
+                0,
+                listOf(),
+                ""
+        )
 
         val sinceTimeLabel = "10 mins"
         whenever(statsSinceLabelFormatter.getSinceLabelLowerCase(date)).thenReturn(sinceTimeLabel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryMapperTest.kt
@@ -12,8 +12,8 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.stats.InsightsLatestPostModel
-import org.wordpress.android.ui.stats.refresh.utils.StatsSinceLabelFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
+import org.wordpress.android.ui.stats.refresh.utils.StatsSinceLabelFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Date
@@ -30,6 +30,7 @@ class LatestPostSummaryMapperTest {
     private val siteId = 1L
     private val postId = 10L
     private val postURL = "url"
+    private val featuredImageURL = ""
     @Before
     fun setUp() {
         mapper = LatestPostSummaryMapper(
@@ -64,7 +65,7 @@ class LatestPostSummaryMapperTest {
                 0,
                 0,
                 listOf(),
-                ""
+                featuredImageURL
         )
 
         val sinceTimeLabel = "10 mins"
@@ -107,7 +108,7 @@ class LatestPostSummaryMapperTest {
                 0,
                 0,
                 listOf(),
-                ""
+                featuredImageURL
         )
 
         val sinceTimeLabel = "10 mins"
@@ -177,7 +178,7 @@ class LatestPostSummaryMapperTest {
                 0,
                 0,
                 listOf(),
-                ""
+                featuredImageURL
         )
 
         val sinceTimeLabel = "10 mins"

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/LatestPostSummaryUseCaseTest.kt
@@ -216,7 +216,8 @@ class LatestPostSummaryUseCaseTest : BaseUnitTest() {
                 viewsCount,
                 0,
                 0,
-                dayViews
+                dayViews,
+                ""
         )
     }
 }


### PR DESCRIPTION
Fixes failing `LatestPostSummaryMapperTest` and `LatestPostSummaryUseCaseTest`. 
`featuredImageUrl` param is added to `InsightsLatestPostModel` in a [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2373). This model is being created in unit tests. I've added missing `featuredImageUrl`.

To test: Run unit tests, and validate they are passing.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
