### PR TITLE
Hotfix - Jetpack App: Pass magic link scheme to signup flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -562,8 +562,10 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Override
     public void showSignupMagicLink(String email) {
         boolean isEmailClientAvailable = WPActivityUtils.isEmailClientAvailable(this);
+        AuthEmailPayloadScheme scheme = mViewModel.getMagicLinkScheme();
         SignupMagicLinkFragment signupMagicLinkFragment = SignupMagicLinkFragment.newInstance(email, mIsJetpackConnect,
-                mJetpackConnectSource != null ? mJetpackConnectSource.toString() : null, isEmailClientAvailable);
+                mJetpackConnectSource != null ? mJetpackConnectSource.toString() : null, isEmailClientAvailable,
+                scheme);
         slideInFragment(signupMagicLinkFragment, true, SignupMagicLinkFragment.TAG);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
-    wordPressLoginVersion = '0.13.0'
+    wordPressLoginVersion = '0.14.0'
     gutenbergMobileVersion = 'v1.74.1'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'


### PR DESCRIPTION
This PR cherry picks commit from `trunk` branch from already tested [pass magic link scheme to signup flow](https://github.com/wordpress-mobile/WordPress-Android/pull/16449) PR as a hotfix to `19.7` release (Internal Ref: p1651494646147879/1651257368.040849-slack-C0180B5PRJ4).

Login lib latest tag is updated to `0.14.0` as discussed in internal thread p1651497865147889-slack-CC7L49W13

To test:
1. Install `Jetpack` app.
2. Notice that `Log in or signup with WordPress.com` is shown on the `Login Prologue` screen.
3. Signup using a new email.
4. Notice that signup succeeds.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.