### PR TITLE
Hide plan information from My Site tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -32,7 +32,6 @@ class SiteItemsBuilder @Inject constructor(
     fun build(params: SiteItemsBuilderParams): List<MySiteCardAndItem> {
         val showViewSiteFocusPoint = params.activeTask == QuickStartTask.VIEW_SITE
         val showEnablePostSharingFocusPoint = params.activeTask == QuickStartTask.ENABLE_POST_SHARING
-        val showExplorePlansFocusPoint = params.activeTask == QuickStartTask.EXPLORE_PLANS
         val showStatsFocusPoint = params.activeTask == QuickStartTask.CHECK_STATS
         val showPagesFocusPoint = params.activeTask == QuickStartTask.EDIT_HOMEPAGE ||
                 params.activeTask == QuickStartTask.REVIEW_PAGES

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -38,7 +38,6 @@ class SiteItemsBuilder @Inject constructor(
                 params.activeTask == QuickStartTask.REVIEW_PAGES
 
         return listOfNotNull(
-                siteListItemBuilder.buildPlanItemIfAvailable(params.site, showExplorePlansFocusPoint, params.onClick),
                 siteCategoryItemBuilder.buildJetpackCategoryIfAvailable(params.site),
                 ListItem(
                         R.drawable.ic_stats_alt_white_24dp,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.mysite.items
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -64,7 +65,7 @@ class SiteItemsBuilderTest {
                 addLookAndFeelHeader = true,
                 addConfigurationHeader = true,
                 addActivityLogItem = true,
-                addPlanItem = true,
+                addPlanItem = false,
                 addPagesItem = true,
                 addAdminItem = true,
                 addPeopleItem = true,
@@ -84,7 +85,6 @@ class SiteItemsBuilderTest {
         )
 
         assertThat(buildSiteItems).containsExactly(
-                PLAN_ITEM,
                 JETPACK_HEADER,
                 STATS_ITEM,
                 ACTIVITY_ITEM,
@@ -111,6 +111,7 @@ class SiteItemsBuilderTest {
 
     /* QUICK START - FOCUS POINT */
 
+    @Ignore("Ignored after a decision was made to hide the Plans screen.")
     @Test
     fun `passes parameter to show focus point to plan item`() {
         val showPlansFocusPoint = true

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.junit.Ignore;
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
@@ -152,6 +153,7 @@ class SiteListItemBuilderTest {
         assertThat(item).isNull()
     }
 
+    @Ignore("Ignored after a decision was made to hide the Plans screen.")
     @Test
     fun `plan item built when plan not empty, site can manage options, is not WP for teams and is WPcom`() {
         setupPlanItem(
@@ -168,6 +170,7 @@ class SiteListItemBuilderTest {
         assertThat(item).isEqualTo(PLAN_ITEM.copy(showFocusPoint = showFocusPoint))
     }
 
+    @Ignore("Ignored after a decision was made to hide the Plans screen.")
     @Test
     fun `plan item built when plan not empty, site can manage options, is not WP for teams and is AT`() {
         setupPlanItem(
@@ -183,6 +186,7 @@ class SiteListItemBuilderTest {
         assertThat(item).isEqualTo(PLAN_ITEM)
     }
 
+    @Ignore("Ignored after a decision was made to hide the Plans screen.")
     @Test
     fun `plan item not built when plan name is empty`() {
         setupPlanItem(planShortName = "")
@@ -192,6 +196,7 @@ class SiteListItemBuilderTest {
         assertThat(item).isNull()
     }
 
+    @Ignore("Ignored after a decision was made to hide the Plans screen.")
     @Test
     fun `plan item not built when site cannot manage options`() {
         setupPlanItem(canManageOptions = false)
@@ -201,6 +206,7 @@ class SiteListItemBuilderTest {
         assertThat(item).isNull()
     }
 
+    @Ignore("Ignored after a decision was made to hide the Plans screen.")
     @Test
     fun `plan item not built when site is WP for teams`() {
         setupPlanItem(isWpForTeams = true)
@@ -210,6 +216,7 @@ class SiteListItemBuilderTest {
         assertThat(item).isNull()
     }
 
+    @Ignore("Ignored after a decision was made to hide the Plans screen.")
     @Test
     fun `plan item not built when site is neither WP com nor AT`() {
         setupPlanItem(isWPCom = false, isAutomatedTransfer = false)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
@@ -4,7 +4,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.junit.Ignore;
+import org.junit.Ignore
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/16471

Since the new Free and Pro plans were introduced, the plans shown in the app are outdated. Given that WPiOS doesn't show plans, a decision was made (internal reference: p1651589219305459/1651587009.445519-slack-C011BKNU1V5) to remove plans from WPAndroid as well.

### To test
1. Log into the WordPress for Android app
2. Under the My Site tab, switch to the Menu section
3. Verify that the "Plan" list item is no longer visible
4. Repeat steps 1 to 3 for the Jetpack for Android app

## Regression Notes
1. Potential unintended areas of impact

The Menu section within the My Site tab on both WordPress Mobile and Jetpack Mobile could be affected by this change.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I manually checked the My Site screen using different site types (Simple and Atomic) while logged into a WP.com site. I then checked a Jetpack site and a self-hosted site. Finally, I repeated the WP.com and Jetpack tested via the Jetpack for Android build available on this PR.

I'm not familiar with WPAndroid tests so I'm not sure what automated tests I could rely on.

3. What automated tests I added (or what prevented me from doing so)

Instead of disabling tests as I have done, I could leave them enabled but change the test expectations to be "verify that there is no plans list item. I have little experience with tests on Android so in the interest of making the hotfix as soon as I could, I've simply ignored the tests. Is this a good approach? I welcome any suggestions.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.