### PR TITLE
[Blogging prompts v1] Adjust feature introduction ems

### DIFF
--- a/WordPress/src/main/res/layout/blogging_prompts_onboarding_dialog_content_view.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_onboarding_dialog_content_view.xml
@@ -17,6 +17,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/content_top">
 
+        <View
+            android:id="@+id/card_cover_view"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <include
             android:id="@+id/prompt_card"
             layout="@layout/my_site_blogging_promp_card"
@@ -27,22 +36,14 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <View
-            android:id="@+id/card_cover_view"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/content_top"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center"
+        android:maxEms="70"
         android:textAppearance="?attr/textAppearanceBody1"
         app:layout_constraintBottom_toTopOf="@+id/prompt_card_container"
         app:layout_constraintEnd_toEndOf="parent"
@@ -53,10 +54,11 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/content_bottom"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_extra_medium_large"
         android:gravity="center"
+        android:maxEms="70"
         android:textAppearance="?attr/textAppearanceBody1"
         app:layout_constraintBottom_toTopOf="@+id/content_note"
         app:layout_constraintEnd_toEndOf="parent"
@@ -78,7 +80,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/content_bottom"
-        tools:text="@string/blogging_prompts_onboarding_content_note" />
-
+        tools:text="@string/blogging_prompts_onboarding_content_note_content" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -270,9 +270,6 @@
     <ID>MaxLineLength:StoryMediaSaveUploadBridge.kt$StoryMediaSaveUploadBridge.&lt;no name provided&gt;$// here we change the ids on the actual StoryFrameItems, and also update the flattened / composed image</ID>
     <ID>MaxLineLength:WPWebViewUsageCategory.kt$WPWebViewUsageCategory$*</ID>
     <ID>MaxLineLength:XPostsCapabilityChecker.kt$XPostsCapabilityChecker$// suggestions, but because the response will almost always be empty, it's not an expensive call.</ID>
-    <ID>MaximumLineLength:org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingViewModel.kt:47</ID>
-    <ID>MaximumLineLength:org.wordpress.android.workers.reminder.PromptReminderNotifier.kt:43</ID>
-    <ID>MaximumLineLength:org.wordpress.android.viewmodel.main.WPMainActivityViewModel.kt:220</ID>
     <ID>MemberNameEqualsClassName:ActivityLogTypeFilterViewModel.kt$ActivityLogTypeFilterViewModel.Action$lateinit var action: (() -&gt; Unit)</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.posts.PostDatePickerDialogFragment.kt:51</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.posts.PostDatePickerDialogFragment.kt:53</ID>


### PR DESCRIPTION
Fixes #16469 

Thank you @ParaskP7 for implementing [this refactor](https://github.com/wordpress-mobile/WordPress-Android/pull/16472/commits/b6959bdc3cd8231a90c2b1813693dad86b38eed2) 👍 

To test:
- Enable the blogging prompts notification feature flag (see `BloggingPromptsNotificationConfig`)
- Open app logged in and with a site selected
- Click on the blogging prompts onboarding notification OR in the "Learn more" button
- Blogging prompts onboarding dialog should be seen with the correct layout

## Regression Notes
1. Potential unintended areas of impact
Blogging prompts onboarding dialog

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
