### PR TITLE
Stats revamp v2 views and visitors details

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -68,6 +68,7 @@ import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewMo
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerViewModel;
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.DaysListViewModel;
+import org.wordpress.android.ui.stats.refresh.lists.InsightsDetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.MonthsListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.WeeksListViewModel;
@@ -208,6 +209,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(StatsDetailViewModel.class)
     abstract ViewModel statsDetailViewModel(StatsDetailViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(InsightsDetailListViewModel.class)
+    abstract ViewModel insightsDetailListViewModel(InsightsDetailListViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -103,6 +103,7 @@ import org.wordpress.android.ui.stats.StatsTimeframe;
 import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.ui.stats.refresh.StatsActivity;
 import org.wordpress.android.ui.stats.refresh.StatsViewAllActivity;
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection;
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity;
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate;
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementActivity;
@@ -1490,6 +1491,13 @@ public class ActivityLauncher {
         StatsDetailActivity.Companion
                 .start(context, site, post.getRemotePostId(), StatsConstants.ITEM_TYPE_POST, post.getTitle(),
                         post.getLink());
+    }
+
+    public static void viewInsightsDetail(Context context, SiteModel site) {
+        if (site == null) {
+            return;
+        }
+        StatsDetailActivity.startForInsightsDetail(context, site);
     }
 
     public static void viewMediaPickerForResult(Activity activity,

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -103,7 +103,6 @@ import org.wordpress.android.ui.stats.StatsTimeframe;
 import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.ui.stats.refresh.StatsActivity;
 import org.wordpress.android.ui.stats.refresh.StatsViewAllActivity;
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection;
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity;
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate;
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementActivity;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/NavigationTarget.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/NavigationTarget.kt
@@ -42,4 +42,9 @@ sealed class NavigationTarget {
         val postUrl: String,
         val postType: String = StatsConstants.ITEM_TYPE_ATTACHMENT
     ) : NavigationTarget()
+
+    data class ViewViewsAndVisitorsDetail(
+        val statsGranularity: StatsGranularity,
+        val selectedDate: Date?
+    ) : NavigationTarget()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DAYS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHT_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
@@ -188,8 +189,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
             WEEKS -> 2
             MONTHS -> 3
             YEARS -> 4
-            DETAIL -> null
-            ANNUAL_STATS -> null
+            DETAIL, INSIGHT_DETAIL, ANNUAL_STATS -> null
         }
         position?.let {
             if (statsPager.currentItem != position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -398,7 +398,7 @@ class StatsModule {
         countryViewsUseCaseFactory: CountryViewsUseCaseFactory
     ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> {
         return listOf(
-                viewsAndVisitorsUseCaseFactory.build(BLOCK),
+                viewsAndVisitorsUseCaseFactory.build(VIEW_ALL),
                 referrersUseCaseFactory.build(DAYS, BLOCK),
                 countryViewsUseCaseFactory.build(DAYS, BLOCK)
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -14,6 +14,8 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.store.StatsStore
+import org.wordpress.android.fluxc.store.StatsStore.InsightType.VIEWS_AND_VISITORS
+import org.wordpress.android.fluxc.store.StatsStore.TimeStatsType
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
@@ -67,6 +69,8 @@ const val BLOCK_INSIGHTS_USE_CASES = "BlockInsightsUseCases"
 const val VIEW_ALL_INSIGHTS_USE_CASES = "ViewAllInsightsUseCases"
 const val GRANULAR_USE_CASE_FACTORIES = "GranularUseCaseFactories"
 const val BLOCK_DETAIL_USE_CASE = "BlockDetailUseCase"
+const val VIEWS_AND_VISITORS_USE_CASE = "ViewsAndVisitorsUseCase"
+const val BLOCK_VIEWS_AND_VISITORS_USE_CASES = "BlockViewsAndVisitorsUseCases"
 // These are injected only internally
 private const val BLOCK_DETAIL_USE_CASES = "BlockDetailUseCases"
 
@@ -377,6 +381,52 @@ class StatsModule {
                 useCases,
                 { statsStore.getPostDetailTypes() },
                 uiModelMapper::mapDetailStats
+        )
+    }
+
+    /**
+     * Provides a singleton usecase that represents Views And Visitors Details screen.
+     * Update this method when you want to add more blocks to this detail screen.
+     * @param useCases build the use cases for the YEARS granularity
+     */
+    @Provides
+    @Singleton
+    @Named(BLOCK_VIEWS_AND_VISITORS_USE_CASES)
+    fun provideViewsAndVisitorsDetailUseCases(
+        viewsAndVisitorsUseCaseFactory: ViewsAndVisitorsUseCaseFactory,
+        referrersUseCaseFactory: ReferrersUseCaseFactory,
+        countryViewsUseCaseFactory: CountryViewsUseCaseFactory
+    ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> {
+        return listOf(
+                viewsAndVisitorsUseCaseFactory.build(BLOCK),
+                referrersUseCaseFactory.build(DAYS, BLOCK),
+                countryViewsUseCaseFactory.build(DAYS, BLOCK)
+        )
+    }
+
+    /**
+     * Provides a singleton usecase that represents the Year stats screen.
+     * @param useCases build the use cases for the YEARS granularity
+     */
+    @Provides
+    @Singleton
+    @Named(VIEWS_AND_VISITORS_USE_CASE)
+    fun provideViewsAndVisitorsDetailUseCase(
+        @Named(BG_THREAD) bgDispatcher: CoroutineDispatcher,
+        @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+        statsSiteProvider: StatsSiteProvider,
+        @Named(BLOCK_VIEWS_AND_VISITORS_USE_CASES) useCases: List<@JvmSuppressWildcards BaseStatsUseCase<*, *>>,
+        uiModelMapper: UiModelMapper
+    ): BaseListUseCase {
+        return BaseListUseCase(
+                bgDispatcher,
+                mainDispatcher,
+                statsSiteProvider,
+                useCases,
+                {
+                    listOf(VIEWS_AND_VISITORS, TimeStatsType.REFERRERS, TimeStatsType.COUNTRIES)
+                },
+                uiModelMapper::mapViewsVisitorsDetailStats
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -166,6 +166,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
     private fun StatsListFragmentBinding.initializeViewModels(activity: FragmentActivity) {
         val viewModelClass = when (statsSection) {
             StatsSection.DETAIL -> DetailListViewModel::class.java
+            StatsSection.INSIGHT_DETAIL -> InsightsDetailListViewModel::class.java
             StatsSection.ANNUAL_STATS,
             StatsSection.INSIGHTS -> InsightsListViewModel::class.java
             StatsSection.DAYS -> DaysListViewModel::class.java

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -17,7 +17,9 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.StatsListFragmentBinding
 import org.wordpress.android.ui.ViewPagerFragment
+import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHT_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel.Empty
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel.Error
@@ -188,7 +190,11 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         })
 
         viewModel.dateSelectorData.observe(viewLifecycleOwner, { dateSelectorUiModel ->
-            drawDateSelector(dateSelectorUiModel)
+            if (statsSection == INSIGHT_DETAIL) {
+                drawDateSelector(DateSelectorUiModel(false))
+            } else {
+                drawDateSelector(dateSelectorUiModel)
+            }
         })
 
         viewModel.navigationTarget.observeEvent(viewLifecycleOwner, { target ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -18,10 +18,12 @@ import org.wordpress.android.ui.stats.refresh.MONTH_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.NavigationTarget
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewInsightsManagement
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
+import org.wordpress.android.ui.stats.refresh.VIEWS_AND_VISITORS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.WEEK_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.YEAR_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DAYS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHT_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
@@ -59,6 +61,7 @@ abstract class StatsListViewModel(
         MONTHS(R.string.stats_timeframe_months),
         YEARS(R.string.stats_timeframe_years),
         DETAIL(R.string.stats),
+        INSIGHT_DETAIL(R.string.stats),
         ANNUAL_STATS(R.string.stats_insights_annual_site_stats);
     }
 
@@ -210,3 +213,10 @@ class DaysListViewModel @Inject constructor(
     analyticsTracker: AnalyticsTrackerWrapper,
     dateSelectorFactory: StatsDateSelector.Factory
 ) : StatsListViewModel(mainDispatcher, statsUseCase, analyticsTracker, dateSelectorFactory.build(DAYS))
+
+class InsightsDetailListViewModel @Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(VIEWS_AND_VISITORS_USE_CASE) statsUseCase: BaseListUseCase,
+    analyticsTracker: AnalyticsTrackerWrapper,
+    dateSelectorFactory: StatsDateSelector.Factory
+) : StatsListViewModel(mainDispatcher, statsUseCase, analyticsTracker, dateSelectorFactory.build(INSIGHT_DETAIL))

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
@@ -82,6 +82,13 @@ class UiModelMapper
         return mapStatsWithOverview(PostDetailType.POST_OVERVIEW, useCaseModels, showError)
     }
 
+    fun mapViewsVisitorsDetailStats(
+        useCaseModels: List<UseCaseModel>,
+        showError: (Int) -> Unit
+    ): UiModel {
+        return mapStatsWithOverview(TimeStatsType.OVERVIEW, useCaseModels, showError)
+    }
+
     private fun mapStatsWithOverview(
         overViewType: StatsType,
         useCaseModels: List<UseCaseModel>,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
@@ -32,6 +32,7 @@ class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
             with(nonNullActivity as AppCompatActivity) {
                 setSupportActionBar(toolbar)
                 supportActionBar?.let {
+                    it.title = getString(R.string.stats_insights_views_and_visitors)
                     it.setHomeButtonEnabled(true)
                     it.setDisplayHomeAsUpEnabled(true)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
@@ -1,0 +1,63 @@
+package org.wordpress.android.ui.stats.refresh.lists.detail
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.StatsDetailFragmentBinding
+import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.helpers.SwipeToRefreshHelper
+
+@AndroidEntryPoint
+class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
+    private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
+
+    private val viewModel: InsightsDetailViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val nonNullActivity = requireActivity()
+        with(StatsDetailFragmentBinding.bind(view)) {
+            with(nonNullActivity as AppCompatActivity) {
+                setSupportActionBar(toolbar)
+                supportActionBar?.let {
+                    it.setHomeButtonEnabled(true)
+                    it.setDisplayHomeAsUpEnabled(true)
+                }
+            }
+            initializeViewModels(nonNullActivity)
+            initializeViews()
+        }
+    }
+
+    private fun StatsDetailFragmentBinding.initializeViews() {
+        swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
+            viewModel.onPullToRefresh()
+        }
+    }
+
+    private fun initializeViewModels(activity: FragmentActivity) {
+        val siteId = activity.intent?.getIntExtra(WordPress.LOCAL_SITE_ID, 0) ?: 0
+        viewModel.init(siteId)
+        setupObservers(viewModel)
+    }
+
+    private fun setupObservers(viewModel: InsightsDetailViewModel) {
+        viewModel.isRefreshing.observe(viewLifecycleOwner) {
+            it?.let { isRefreshing ->
+                swipeToRefreshHelper.isRefreshing = isRefreshing
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
@@ -1,0 +1,64 @@
+package org.wordpress.android.ui.stats.refresh.lists.detail
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.R
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.stats.refresh.VIEWS_AND_VISITORS_USE_CASE
+import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
+import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.mergeNotNull
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+@HiltViewModel
+class InsightsDetailViewModel
+@Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(VIEWS_AND_VISITORS_USE_CASE) private val detailUseCase: BaseListUseCase,
+    private val statsSiteProvider: StatsSiteProvider,
+    private val networkUtilsWrapper: NetworkUtilsWrapper
+) : ScopedViewModel(mainDispatcher) {
+    private val _isRefreshing = MutableLiveData<Boolean>()
+    val isRefreshing: LiveData<Boolean> = _isRefreshing
+
+    private val _showSnackbarMessage = mergeNotNull(
+            detailUseCase.snackbarMessage,
+            distinct = true,
+            singleEvent = true
+    )
+    val showSnackbarMessage: LiveData<SnackbarMessageHolder> = _showSnackbarMessage
+
+    fun init(localSiteId: Int) {
+        statsSiteProvider.start(localSiteId)
+    }
+
+    fun refresh() {
+        launch {
+            detailUseCase.refreshData(true)
+            _isRefreshing.value = false
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        detailUseCase.onCleared()
+    }
+
+    fun onPullToRefresh() {
+        _showSnackbarMessage.value = null
+        statsSiteProvider.clear()
+        if (networkUtilsWrapper.isNetworkAvailable()) {
+            refresh()
+        } else {
+            _isRefreshing.value = false
+            _showSnackbarMessage.value = SnackbarMessageHolder(UiStringRes(R.string.no_network_title))
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
@@ -4,6 +4,10 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
+import androidx.fragment.app.add
+import androidx.fragment.app.commit
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.databinding.StatsDetailActivityBinding
@@ -18,11 +22,24 @@ const val POST_TYPE = "POST_TYPE"
 const val POST_TITLE = "POST_TITLE"
 const val POST_URL = "POST_URL"
 
+@AndroidEntryPoint
 class StatsDetailActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val binding = StatsDetailActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        val listType = intent.extras?.get(StatsListFragment.LIST_TYPE)
+
+        if (savedInstanceState == null) {
+            supportFragmentManager.commit {
+                setReorderingAllowed(true)
+                when (listType) {
+                    StatsSection.DETAIL -> add<StatsDetailFragment>(R.id.fragment_container)
+                    StatsSection.INSIGHT_DETAIL -> add<InsightsDetailFragment>(R.id.fragment_container)
+                }
+            }
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -56,6 +73,19 @@ class StatsDetailActivity : LocaleAwareActivity() {
                     site.siteId
             )
             context.startActivity(statsPostViewIntent)
+        }
+
+        @JvmStatic
+        fun startForInsightsDetail(
+            context: Context,
+            site: SiteModel
+        ) {
+            val intent = Intent(context, StatsDetailActivity::class.java).apply {
+                putExtra(WordPress.LOCAL_SITE_ID, site.id)
+                putExtra(StatsListFragment.LIST_TYPE, StatsSection.INSIGHT_DETAIL)
+            }
+            // TODO: Add tracking here
+            context.startActivity(intent)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewViewsAndVisitorsDetail
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem
@@ -52,7 +53,8 @@ class ViewsAndVisitorsUseCase
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val statsWidgetUpdaters: StatsWidgetUpdaters,
     private val localeManagerWrapper: LocaleManagerWrapper,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val useCaseMode: UseCaseMode
 ) : BaseStatsUseCase<VisitsAndViewsModel, UiState>(
         VIEWS_AND_VISITORS,
         mainDispatcher,
@@ -209,7 +211,7 @@ class ViewsAndVisitorsUseCase
 
     private fun buildTitle() = TitleWithMore(
             string.stats_insights_views_and_visitors,
-            navigationAction = ListItemInteraction.create(this::onViewMoreClick)
+            navigationAction = if (useCaseMode == BLOCK) ListItemInteraction.create(this::onViewMoreClick) else null
     )
 
     private fun onViewMoreClick() {
@@ -277,7 +279,8 @@ class ViewsAndVisitorsUseCase
                         analyticsTracker,
                         statsWidgetUpdaters,
                         localeManagerWrapper,
-                        resourceProvider
+                        resourceProvider,
+                        useCaseMode
                 )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.store.StatsStore.InsightType.VIEWS_AND_VISITO
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTagsAndCategoriesStats
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewViewsAndVisitorsDetail
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
@@ -214,7 +214,12 @@ class ViewsAndVisitorsUseCase
 
     private fun onViewMoreClick() {
         analyticsTracker.track(AnalyticsTracker.Stat.STATS_VIEWS_AND_VISITORS_VIEW_MORE_TAPPED)
-        navigateTo(ViewTagsAndCategoriesStats) // TODO: Connect this to proper second level navigation later
+        navigateTo(
+                ViewViewsAndVisitorsDetail(
+                        statsGranularity,
+                        selectedDateProvider.getSelectedDate(statsGranularity)
+                )
+        ) // TODO: Connect this to proper second level navigation later
     }
 
     private fun onBarSelected(period: String?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
@@ -221,7 +221,7 @@ class ViewsAndVisitorsUseCase
                         statsGranularity,
                         selectedDateProvider.getSelectedDate(statsGranularity)
                 )
-        ) // TODO: Connect this to proper second level navigation later
+        )
     }
 
     private fun onBarSelected(period: String?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
@@ -44,6 +44,7 @@ class SelectedSectionManager
 fun StatsSection.toStatsGranularity(): StatsGranularity? {
     return when (this) {
         ANNUAL_STATS, DETAIL, INSIGHTS -> null
+        StatsSection.INSIGHT_DETAIL,
         StatsSection.DAYS -> DAYS
         StatsSection.WEEKS -> WEEKS
         StatsSection.MONTHS -> MONTHS

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsAnalyticsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsAnalyticsUtils.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.InsightType
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHT_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.WidgetType
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.WidgetType.ALL_TIME_VIEWS
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.WidgetType.TODAY_VIEWS
@@ -42,7 +43,7 @@ fun AnalyticsTrackerWrapper.trackWithSection(stat: Stat, section: StatsSection) 
         StatsSection.WEEKS -> WEEKS_PROPERTY
         StatsSection.MONTHS -> MONTHS_PROPERTY
         StatsSection.YEARS -> YEARS_PROPERTY
-        StatsSection.INSIGHTS -> INSIGHTS_PROPERTY
+        StatsSection.INSIGHTS, INSIGHT_DETAIL -> INSIGHTS_PROPERTY
         StatsSection.DETAIL -> DETAIL_PROPERTY
         StatsSection.ANNUAL_STATS -> ANNUAL_STATS_PROPERTY
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -74,6 +74,7 @@ constructor(
         return when (statsSection) {
             StatsSection.DETAIL,
             StatsSection.INSIGHTS,
+            StatsSection.INSIGHT_DETAIL,
             StatsSection.DAYS -> DAYS
             StatsSection.WEEKS -> WEEKS
             StatsSection.MONTHS -> MONTHS

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -47,6 +47,7 @@ import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTag
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTagsAndCategoriesStats
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewUrl
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewVideoPlays
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewViewsAndVisitorsDetail
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.util.ToastUtils
@@ -222,6 +223,9 @@ class StatsNavigator @Inject constructor(
                         target.postUrl,
                         readerTracker
                 )
+            }
+            is ViewViewsAndVisitorsDetail -> {
+                ActivityLauncher.viewInsightsDetail(activity, siteProvider.siteModel)
             }
         }
     }

--- a/WordPress/src/main/res/layout/stats_detail_activity.xml
+++ b/WordPress/src/main/res/layout/stats_detail_activity.xml
@@ -7,7 +7,6 @@
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
-        android:name="org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCaseTest.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.test
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.ERROR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
@@ -59,6 +60,7 @@ class ViewsAndVisitorsUseCaseTest : BaseUnitTest() {
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
     @Mock lateinit var statsWidgetUpdaters: StatsWidgetUpdaters
     @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
+    @Mock lateinit var useCaseMode: UseCaseMode
     private lateinit var useCase: ViewsAndVisitorsUseCase
     private val site = SiteModel()
     private val siteId = 1L
@@ -83,7 +85,8 @@ class ViewsAndVisitorsUseCaseTest : BaseUnitTest() {
                 analyticsTrackerWrapper,
                 statsWidgetUpdaters,
                 localeManagerWrapper,
-                resourceProvider
+                resourceProvider,
+                useCaseMode
         )
         site.siteId = siteId
         whenever(statsSiteProvider.siteModel).thenReturn(site)


### PR DESCRIPTION
This PR implements Views and Visitors detail screen with Views and Visitors, Referrer and Countries cards

Fixes #16463 

| Detail | Detail | 
|---|---|
|![Screenshot_20220509_162831](https://user-images.githubusercontent.com/990349/167353015-d5fcc7d3-5ff5-4fe0-8d68-86bd91252ead.png) |![Screenshot_20220509_163853](https://user-images.githubusercontent.com/990349/167353870-4b66bace-5a4d-47ca-bbf8-92d04bc69be5.png)|


To test:

Setup:

- Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
- Select Debug Settings
- Find StatsRevampV2FeatureConfig under Features in development enable it and restart app

Test 1:

- Launch app
- Go to stats either using quick links or menu
- Ensure that it opens in Insights tab otherwise switch to Insights tab
- Notice a new **Views & Visitors** card is shown in Insights tab with Line Chart as in the images above (scroll down if necessary)
- Tap on VIEW_MORE on the top right hand corner on the card
- Ensure it opens the detail screen as shown above (scroll down if necessary) with Views and Visitors, Referrer and Countries cards

Know issue:
- Referrer card doesn't yet show the new donut chart at the top.  It is a separate task
- Date selector is hidden as per discussions.  Will add in a separate PR if required

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
