### PR TITLE
[Site Design Revamp] Main View - Hide layouts row separators

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutCategoryAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutCategoryAdapter.kt
@@ -11,7 +11,8 @@ import androidx.recyclerview.widget.RecyclerView.Adapter
 class LayoutCategoryAdapter(
     private var nestedScrollStates: Bundle,
     private val thumbDimensionProvider: ThumbDimensionProvider,
-    private val recommendedDimensionProvider: ThumbDimensionProvider? = null
+    private val recommendedDimensionProvider: ThumbDimensionProvider? = null,
+    private val showRowDividers: Boolean = true
 ) : Adapter<LayoutsItemViewHolder>() {
     private var items: List<LayoutCategoryUiState> = listOf()
 
@@ -42,7 +43,8 @@ class LayoutCategoryAdapter(
                     parent = parent,
                     nestedScrollStates = nestedScrollStates,
                     thumbDimensionProvider = thumbDimensionProvider,
-                    recommendedDimensionProvider = recommendedDimensionProvider
+                    recommendedDimensionProvider = recommendedDimensionProvider,
+                    showRowDividers = showRowDividers
             )
 
     fun onRestoreInstanceState(savedInstanceState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutsItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutsItemViewHolder.kt
@@ -3,8 +3,10 @@ package org.wordpress.android.ui.layoutpicker
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -18,6 +20,7 @@ import org.wordpress.android.util.extensions.setVisible
 class LayoutsItemViewHolder(
     parent: ViewGroup,
     private val prefetchItemCount: Int = 4,
+    private val showRowDividers: Boolean,
     private var nestedScrollStates: Bundle,
     private val thumbDimensionProvider: ThumbDimensionProvider,
     private val recommendedDimensionProvider: ThumbDimensionProvider?
@@ -35,6 +38,7 @@ class LayoutsItemViewHolder(
         itemView.updateLayoutParams {
             height = if (isRecommended) recommendedDimensionProvider!!.rowHeight else thumbDimensionProvider.rowHeight
         }
+        itemView.findViewById<View>(R.id.layouts_row_separator_line).isVisible = showRowDividers
         itemView.findViewById<RecyclerView>(R.id.layouts_recycler_view).apply {
             layoutManager = LinearLayoutManager(
                     context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -68,7 +68,8 @@ class HomePagePickerFragment : Fragment() {
                 adapter = LayoutCategoryAdapter(
                         viewModel.nestedScrollStates,
                         thumbDimensionProvider,
-                        recommendedDimensionProvider
+                        recommendedDimensionProvider,
+                        showRowDividers = false
                 )
             }
 

--- a/WordPress/src/main/res/layout/modal_layout_picker_layouts_row.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_layouts_row.xml
@@ -5,7 +5,9 @@
     android:layout_height="@dimen/mlp_layouts_row_height"
     android:orientation="vertical">
 
-    <View style="@style/ModalLayoutPickerLayoutsSeparatorLine" />
+    <View
+        android:id="@+id/layouts_row_separator_line"
+        style="@style/ModalLayoutPickerLayoutsSeparatorLine" />
 
     <TextView
         android:id="@+id/subtitle"


### PR DESCRIPTION
Fixes #16487

Hides the gray lines (separators) between the categories on the **Site theme** screen to better align with the Android Material Design look & feel.

The Page Layout Picker (visible when creating a new page) is still showing the gray separators.

To test:

### Theme Picker

1. Start the site creation flow
2. Pick an intent (or skip)
3. Enter a site name (or skip)
4. **Expect** to land on the theme selection screen
   - **Expect** no gray lines separating the rows of theme categories

### Page Picker

1. Navigate to the page list
2. Tap the FAB to create a new page
3. **Expect** to land on the layout selection screen
   - **Expect** gray lines separating the rows of layout categories


### Previews

| Theme Picker | Page Picker |
| --- | --- |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/167157768-7323efa1-1faf-45bc-9d68-363777673748.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/167157784-786288e1-215b-47c1-8627-672b1adc2f59.png"> |

## Regression Notes
1. Potential unintended areas of impact
   Page layout picker.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing both the theme picker and the page layout picker.

4. What automated tests I added (or what prevented me from doing so)
   None - the UI changes imply no unit tests coverage.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
