### PR TITLE
Stats revamp v2 total like detail screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -70,6 +70,7 @@ import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewMo
 import org.wordpress.android.ui.stats.refresh.lists.DaysListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.MonthsListViewModel;
+import org.wordpress.android.ui.stats.refresh.lists.TotalLikesDetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.WeeksListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.YearsListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel;
@@ -611,4 +612,9 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(BloggingPromptsOnboardingViewModel.class)
     abstract ViewModel bloggingPromptsOnboardingViewModel(BloggingPromptsOnboardingViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(TotalLikesDetailListViewModel.class)
+    abstract ViewModel totalLikesDetailListViewModel(TotalLikesDetailListViewModel viewModel);
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1492,6 +1492,11 @@ public class ActivityLauncher {
                         post.getLink());
     }
 
+    public static void viewTotalLikesDetail(Context context, SiteModel site) {
+        if (site == null) return;
+        StatsDetailActivity.startForTotalLikesDetail(context, site);
+    }
+
     public static void viewMediaPickerForResult(Activity activity,
                                                 @NonNull SiteModel site,
                                                 @NonNull MediaBrowserType browserType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_LIKES_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider.SiteUpdateResult
@@ -188,8 +189,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
             WEEKS -> 2
             MONTHS -> 3
             YEARS -> 4
-            DETAIL -> null
-            ANNUAL_STATS -> null
+            DETAIL, TOTAL_LIKES_DETAIL, ANNUAL_STATS -> null
         }
         position?.let {
             if (statsPager.currentItem != position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -54,7 +54,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.T
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TodayStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalCommentsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalFollowersUseCase
-import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalLikesUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalLikesUseCase.TotalLikesUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.ViewsAndVisitorsUseCase.ViewsAndVisitorsUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -105,7 +104,7 @@ class StatsModule {
         publicizeUseCaseFactory: PublicizeUseCaseFactory,
         postingActivityUseCase: PostingActivityUseCase,
         followerTotalsUseCase: FollowerTotalsUseCase,
-        totalLikesUseCase: TotalLikesUseCase,
+        totalLikesUseCaseFactory: TotalLikesUseCaseFactory,
         totalCommentsUseCase: TotalCommentsUseCase,
         totalFollowersUseCase: TotalFollowersUseCase,
         annualSiteStatsUseCaseFactory: AnnualSiteStatsUseCaseFactory,
@@ -115,7 +114,7 @@ class StatsModule {
         val useCases = mutableListOf<BaseStatsUseCase<*, *>>()
         if (statsRevampV2FeatureConfig.isEnabled()) {
             useCases.add(viewsAndVisitorsUseCaseFactory.build(BLOCK))
-            useCases.add(totalLikesUseCase)
+            useCases.add(totalLikesUseCaseFactory.build(BLOCK))
             useCases.add(totalCommentsUseCase)
             useCases.add(totalFollowersUseCase)
         } else {
@@ -404,7 +403,7 @@ class StatsModule {
         postsAndPagesUseCaseFactory: PostsAndPagesUseCaseFactory
     ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> {
         return listOf(
-                totalLikesUseCaseFactory.build(DAYS, VIEW_ALL),
+                totalLikesUseCaseFactory.build(VIEW_ALL),
                 postsAndPagesUseCaseFactory.build(DAYS, VIEW_ALL)
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -454,7 +454,7 @@ class StatsModule {
     ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> {
         return listOf(
                 totalLikesUseCaseFactory.build(VIEW_ALL),
-                postsAndPagesUseCaseFactory.build(DAYS, VIEW_ALL)
+                postsAndPagesUseCaseFactory.build(DAYS, BLOCK)
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -166,6 +166,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
     private fun StatsListFragmentBinding.initializeViewModels(activity: FragmentActivity) {
         val viewModelClass = when (statsSection) {
             StatsSection.DETAIL -> DetailListViewModel::class.java
+            StatsSection.TOTAL_LIKES_DETAIL -> TotalLikesDetailListViewModel::class.java
             StatsSection.ANNUAL_STATS,
             StatsSection.INSIGHTS -> InsightsListViewModel::class.java
             StatsSection.DAYS -> DaysListViewModel::class.java

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -17,7 +17,9 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.StatsListFragmentBinding
 import org.wordpress.android.ui.ViewPagerFragment
+import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_LIKES_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel.Empty
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel.Error
@@ -188,7 +190,11 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         })
 
         viewModel.dateSelectorData.observe(viewLifecycleOwner, { dateSelectorUiModel ->
-            drawDateSelector(dateSelectorUiModel)
+            if (statsSection == TOTAL_LIKES_DETAIL) {
+                drawDateSelector(DateSelectorUiModel(false))
+            } else {
+                drawDateSelector(dateSelectorUiModel)
+            }
         })
 
         viewModel.navigationTarget.observeEvent(viewLifecycleOwner, { target ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -18,11 +18,13 @@ import org.wordpress.android.ui.stats.refresh.MONTH_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.NavigationTarget
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewInsightsManagement
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
+import org.wordpress.android.ui.stats.refresh.TOTAL_LIKES_DETAIL_USE_CASE
 import org.wordpress.android.ui.stats.refresh.WEEK_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.YEAR_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DAYS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_LIKES_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
@@ -59,6 +61,7 @@ abstract class StatsListViewModel(
         MONTHS(R.string.stats_timeframe_months),
         YEARS(R.string.stats_timeframe_years),
         DETAIL(R.string.stats),
+        TOTAL_LIKES_DETAIL(R.string.stats_view_total_likes),
         ANNUAL_STATS(R.string.stats_insights_annual_site_stats);
     }
 
@@ -210,3 +213,10 @@ class DaysListViewModel @Inject constructor(
     analyticsTracker: AnalyticsTrackerWrapper,
     dateSelectorFactory: StatsDateSelector.Factory
 ) : StatsListViewModel(mainDispatcher, statsUseCase, analyticsTracker, dateSelectorFactory.build(DAYS))
+
+class TotalLikesDetailListViewModel @Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(TOTAL_LIKES_DETAIL_USE_CASE) statsUseCase: BaseListUseCase,
+    analyticsTracker: AnalyticsTrackerWrapper,
+    dateSelectorFactory: StatsDateSelector.Factory
+) : StatsListViewModel(mainDispatcher, statsUseCase, analyticsTracker, dateSelectorFactory.build(TOTAL_LIKES_DETAIL))

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
@@ -4,6 +4,10 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
+import androidx.fragment.app.add
+import androidx.fragment.app.commit
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.databinding.StatsDetailActivityBinding
@@ -18,11 +22,24 @@ const val POST_TYPE = "POST_TYPE"
 const val POST_TITLE = "POST_TITLE"
 const val POST_URL = "POST_URL"
 
+@AndroidEntryPoint
 class StatsDetailActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val binding = StatsDetailActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        val listType = intent.extras?.get(StatsListFragment.LIST_TYPE)
+
+        if (savedInstanceState == null) {
+            supportFragmentManager.commit {
+                setReorderingAllowed(true)
+                when (listType) {
+                    StatsSection.DETAIL -> add<StatsDetailFragment>(R.id.fragment_container)
+                    StatsSection.TOTAL_LIKES_DETAIL -> add<TotalLikesDetailFragment>(R.id.fragment_container)
+                }
+            }
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -56,6 +73,19 @@ class StatsDetailActivity : LocaleAwareActivity() {
                     site.siteId
             )
             context.startActivity(statsPostViewIntent)
+        }
+
+        @JvmStatic
+        fun startForTotalLikesDetail(
+            context: Context,
+            site: SiteModel
+        ) {
+            val intent = Intent(context, StatsDetailActivity::class.java).apply {
+                putExtra(WordPress.LOCAL_SITE_ID, site.id)
+                putExtra(StatsListFragment.LIST_TYPE, StatsSection.TOTAL_LIKES_DETAIL)
+            }
+            // TODO: Add tracking here
+            context.startActivity(intent)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/TotalLikesDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/TotalLikesDetailFragment.kt
@@ -1,0 +1,64 @@
+package org.wordpress.android.ui.stats.refresh.lists.detail
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.StatsDetailFragmentBinding
+import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.helpers.SwipeToRefreshHelper
+
+@AndroidEntryPoint
+class TotalLikesDetailFragment : Fragment(R.layout.stats_detail_fragment) {
+    private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
+
+    private val viewModel: TotalLikesDetailViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val nonNullActivity = requireActivity()
+        with(StatsDetailFragmentBinding.bind(view)) {
+            with(nonNullActivity as AppCompatActivity) {
+                setSupportActionBar(toolbar)
+                supportActionBar?.let {
+                    it.title = getString(R.string.stats_view_total_likes)
+                    it.setHomeButtonEnabled(true)
+                    it.setDisplayHomeAsUpEnabled(true)
+                }
+            }
+            initializeViewModels(nonNullActivity)
+            initializeViews()
+        }
+    }
+
+    private fun StatsDetailFragmentBinding.initializeViews() {
+        swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
+            viewModel.onPullToRefresh()
+        }
+    }
+
+    private fun initializeViewModels(activity: FragmentActivity) {
+        val siteId = activity.intent?.getIntExtra(WordPress.LOCAL_SITE_ID, 0) ?: 0
+        viewModel.init(siteId)
+        setupObservers(viewModel)
+    }
+
+    private fun setupObservers(viewModel: TotalLikesDetailViewModel) {
+        viewModel.isRefreshing.observe(viewLifecycleOwner) {
+            it?.let { isRefreshing ->
+                swipeToRefreshHelper.isRefreshing = isRefreshing
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/TotalLikesDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/TotalLikesDetailViewModel.kt
@@ -1,0 +1,64 @@
+package org.wordpress.android.ui.stats.refresh.lists.detail
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.R
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.stats.refresh.TOTAL_LIKES_DETAIL_USE_CASE
+import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
+import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.mergeNotNull
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+@HiltViewModel
+class TotalLikesDetailViewModel
+@Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(TOTAL_LIKES_DETAIL_USE_CASE) private val detailUseCase: BaseListUseCase,
+    private val statsSiteProvider: StatsSiteProvider,
+    private val networkUtilsWrapper: NetworkUtilsWrapper
+) : ScopedViewModel(mainDispatcher) {
+    private val _isRefreshing = MutableLiveData<Boolean>()
+    val isRefreshing: LiveData<Boolean> = _isRefreshing
+
+    private val _showSnackbarMessage = mergeNotNull(
+            detailUseCase.snackbarMessage,
+            distinct = true,
+            singleEvent = true
+    )
+    val showSnackbarMessage: LiveData<SnackbarMessageHolder> = _showSnackbarMessage
+
+    fun init(localSiteId: Int) {
+        statsSiteProvider.start(localSiteId)
+    }
+
+    fun refresh() {
+        launch {
+            detailUseCase.refreshData(true)
+            _isRefreshing.value = false
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        detailUseCase.onCleared()
+    }
+
+    fun onPullToRefresh() {
+        _showSnackbarMessage.value = null
+        statsSiteProvider.clear()
+        if (networkUtilsWrapper.isNetworkAvailable()) {
+            refresh()
+        } else {
+            _isRefreshing.value = false
+            _showSnackbarMessage.value = SnackbarMessageHolder(UiStringRes(R.string.no_network_title))
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCase.kt
@@ -46,7 +46,7 @@ import javax.inject.Inject
 import javax.inject.Named
 
 class PostsAndPagesUseCase
-constructor(
+@Inject constructor(
     statsGranularity: StatsGranularity,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCase.kt
@@ -7,7 +7,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_TOTAL_LIKES_E
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
-import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.TOTAL_LIKES
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
@@ -15,10 +14,11 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTotalLikesStats
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
-import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
+import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -41,7 +41,8 @@ class TotalLikesUseCase @Inject constructor(
     private val totalStatsMapper: TotalStatsMapper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val statsWidgetUpdaters: StatsWidgetUpdaters,
-    private val localeManagerWrapper: LocaleManagerWrapper
+    private val localeManagerWrapper: LocaleManagerWrapper,
+    private val useCaseMode: UseCaseMode
 ) : StatelessUseCase<VisitsAndViewsModel>(TOTAL_LIKES, mainDispatcher, bgDispatcher) {
     override fun buildLoadingItem() = listOf(TitleWithMore(string.stats_view_total_likes))
 
@@ -126,7 +127,7 @@ class TotalLikesUseCase @Inject constructor(
 
     private fun buildTitle() = TitleWithMore(
             string.stats_view_total_likes,
-            navigationAction = ListItemInteraction.create(this::onViewMoreClick)
+            navigationAction = if (useCaseMode == VIEW_ALL) null else ListItemInteraction.create(this::onViewMoreClick)
     )
 
     private fun onViewMoreClick() {
@@ -148,8 +149,8 @@ class TotalLikesUseCase @Inject constructor(
         private val analyticsTracker: AnalyticsTrackerWrapper,
         private val statsWidgetUpdaters: StatsWidgetUpdaters,
         private val localeManagerWrapper: LocaleManagerWrapper
-    ) : GranularUseCaseFactory {
-        override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
+    ) : InsightUseCaseFactory {
+        override fun build(useCaseMode: UseCaseMode) =
                 TotalLikesUseCase(
                         mainDispatcher,
                         backgroundDispatcher,
@@ -159,7 +160,8 @@ class TotalLikesUseCase @Inject constructor(
                         totalStatsMapper,
                         analyticsTracker,
                         statsWidgetUpdaters,
-                        localeManagerWrapper
+                        localeManagerWrapper,
+                        useCaseMode
                 )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCase.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_TOTAL_LIKES_E
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.TOTAL_LIKES
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
@@ -17,6 +18,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.St
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -133,5 +135,31 @@ class TotalLikesUseCase @Inject constructor(
                 statsSiteProvider.siteModel
         )
         navigateTo(ViewTotalLikesStats)
+    }
+
+    class TotalLikesUseCaseFactory
+    @Inject constructor(
+        @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+        @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher,
+        private val visitsAndViewsStore: VisitsAndViewsStore,
+        private val statsSiteProvider: StatsSiteProvider,
+        private val statsDateFormatter: StatsDateFormatter,
+        private val totalStatsMapper: TotalStatsMapper,
+        private val analyticsTracker: AnalyticsTrackerWrapper,
+        private val statsWidgetUpdaters: StatsWidgetUpdaters,
+        private val localeManagerWrapper: LocaleManagerWrapper
+    ) : GranularUseCaseFactory {
+        override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
+                TotalLikesUseCase(
+                        mainDispatcher,
+                        backgroundDispatcher,
+                        visitsAndViewsStore,
+                        statsSiteProvider,
+                        statsDateFormatter,
+                        totalStatsMapper,
+                        analyticsTracker,
+                        statsWidgetUpdaters,
+                        localeManagerWrapper
+                )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.ANNUAL_STATS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_LIKES_DETAIL
 import javax.inject.Inject
 
 const val SELECTED_SECTION_KEY = "SELECTED_STATS_SECTION_KEY"
@@ -43,7 +44,7 @@ class SelectedSectionManager
 
 fun StatsSection.toStatsGranularity(): StatsGranularity? {
     return when (this) {
-        ANNUAL_STATS, DETAIL, INSIGHTS -> null
+        ANNUAL_STATS, DETAIL, TOTAL_LIKES_DETAIL, INSIGHTS -> null
         StatsSection.DAYS -> DAYS
         StatsSection.WEEKS -> WEEKS
         StatsSection.MONTHS -> MONTHS

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsAnalyticsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsAnalyticsUtils.kt
@@ -25,6 +25,7 @@ private const val TODAY_WIDGET_PROPERTY = "today"
 private const val WEEKLY_VIEWS_WIDGET_PROPERTY = "weekly_views"
 private const val ALL_TIME_WIDGET_PROPERTY = "all_time"
 private const val MINIFIED_WIDGET_PROPERTY = "minified"
+private const val TOTAL_LIKES_PROPERTY = "total_likes_detail"
 
 fun AnalyticsTrackerWrapper.trackGranular(stat: Stat, granularity: StatsGranularity) {
     val property = when (granularity) {
@@ -45,6 +46,7 @@ fun AnalyticsTrackerWrapper.trackWithSection(stat: Stat, section: StatsSection) 
         StatsSection.INSIGHTS -> INSIGHTS_PROPERTY
         StatsSection.DETAIL -> DETAIL_PROPERTY
         StatsSection.ANNUAL_STATS -> ANNUAL_STATS_PROPERTY
+        StatsSection.TOTAL_LIKES_DETAIL -> TOTAL_LIKES_PROPERTY
     }
     this.track(stat, mapOf(GRANULARITY_PROPERTY to property))
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -73,6 +73,7 @@ constructor(
     private fun toStatsGranularity(): StatsGranularity {
         return when (statsSection) {
             StatsSection.DETAIL,
+            StatsSection.TOTAL_LIKES_DETAIL,
             StatsSection.INSIGHTS,
             StatsSection.DAYS -> DAYS
             StatsSection.WEEKS -> WEEKS

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -45,6 +45,7 @@ import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewReferrers
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewSearchTerms
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTag
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTagsAndCategoriesStats
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTotalLikesStats
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewUrl
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewVideoPlays
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity
@@ -222,6 +223,9 @@ class StatsNavigator @Inject constructor(
                         target.postUrl,
                         readerTracker
                 )
+            }
+            is ViewTotalLikesStats -> {
+                ActivityLauncher.viewTotalLikesDetail(activity, siteProvider.siteModel)
             }
         }
     }

--- a/WordPress/src/main/res/layout/stats_detail_activity.xml
+++ b/WordPress/src/main/res/layout/stats_detail_activity.xml
@@ -7,7 +7,6 @@
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
-        android:name="org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.test
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -54,6 +55,7 @@ class TotalLikesUseCaseTest : BaseUnitTest() {
     @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
     @Mock lateinit var valueWithChart: ValueWithChartItem
     @Mock lateinit var information: Text
+    @Mock lateinit var useCaseMode: UseCaseMode
     private lateinit var useCase: TotalLikesUseCase
     private val periodData = PeriodData("2018-10-08", 10, 15, 20, 25, 30, 35)
     private val modelPeriod = "2018-10-10"
@@ -72,7 +74,8 @@ class TotalLikesUseCaseTest : BaseUnitTest() {
                 totalStatsMapper,
                 analyticsTrackerWrapper,
                 statsWidgetUpdaters,
-                localeManagerWrapper
+                localeManagerWrapper,
+                useCaseMode
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(totalStatsMapper.buildTotalLikesValue(any())).thenReturn(valueWithChart)


### PR DESCRIPTION
This PR implements **Total Likes** detail screen with **Total Likes** and **Posts and Pages** cards

Fixes #16496 

<img src="https://user-images.githubusercontent.com/990349/167521392-b4b36677-cc9d-4515-9c76-9a68910102b7.png" width=320>


To test:

Setup:

-  Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
-  Select Debug Settings
-  Find StatsRevampV2FeatureConfig under Features in development enable it and restart app

Test 1:

- Launch app
- Go to stats either using quick links or menu
- Ensure that it opens in Insights tab otherwise switch to Insights tab
- Notice a new Top Likes card is shown in Insights tab as in the images above (scroll down if necessary)
- If the Total Likes cards is not present, go to the stats management (either through ⚙️ menu at the top right hand corner or Add new stats card at the bottom) and add the card and save, then return to Insights.
- Tap on VIEW_MORE on the top right hand corner on the card
- Ensure it opens the detail screen as shown above (scroll down if necessary) with **Top Likes** and **Posts and Pages** cards


NOTE:

- This PR is only for navigation and detail screen with relevant existing cards
- Cards themselves will be updated in their own PRs
- Date selector is hidden as per discussions. Will add in a separate PR if required


## Regression Notes
1. Potential unintended areas of impact
None, as it is a new screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Unit testing and Manual testing

3. What automated tests I added (or what prevented me from doing so)
existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
