### PR TITLE
Quick start for existing users V2 - Changes to tour completion

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -341,6 +341,6 @@ class QuickStartRepository
 
     companion object {
         private const val QUICK_START_NOTICE_DURATION = 7000
-        private const val QUICK_START_COMPLETED_NOTICE_DELAY = 500L
+        private const val QUICK_START_COMPLETED_NOTICE_DELAY = 5000L
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -184,6 +184,7 @@ class QuickStartRepository
             )
             setTaskDoneAndTrack(task, selectedSite.id)
             if (quickStartUtilsWrapper.isEveryQuickStartTaskDone(selectedSite.id)) {
+                showCompletedQuickStartNotice()
                 quickStartStore.setQuickStartCompleted(selectedSite.id.toLong(), true)
                 analyticsTrackerWrapper.track(Stat.QUICK_START_ALL_TASKS_COMPLETED)
                 val payload = CompleteQuickStartPayload(selectedSite, NEXT_STEPS.toString())
@@ -263,6 +264,20 @@ class QuickStartRepository
                 appPrefsWrapper.isQuickStartNoticeRequired()) {
             showQuickStartNotice(selectedSiteLocalId)
         }
+    }
+
+    private fun showCompletedQuickStartNotice() {
+        val message = htmlMessageUtils.getHtmlMessageFromStringFormat(
+                "<b>${resourceProvider.getString(R.string.quick_start_complete_tour_message)}</b>:" +
+                        " ${resourceProvider.getString(R.string.quick_start_complete_tour_short_message)}"
+        )
+        _onSnackbar.value = Event(
+                SnackbarMessageHolder(
+                        message = UiStringText(message),
+                        duration = QUICK_START_NOTICE_DURATION,
+                        isImportant = false
+                )
+        )
     }
 
     private fun showQuickStartNotice(selectedSiteLocalId: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -268,12 +268,12 @@ class QuickStartRepository
         }
     }
 
-    private fun showCompletedQuickStartNotice() {
+    fun showCompletedQuickStartNotice() {
         launch {
             delay(QUICK_START_COMPLETED_NOTICE_DELAY)
             val message = htmlMessageUtils.getHtmlMessageFromStringFormat(
-                    "<b>${resourceProvider.getString(R.string.quick_start_complete_tour_message)}</b>:" +
-                            " ${resourceProvider.getString(R.string.quick_start_complete_tour_short_message)}"
+                    "<b>${resourceProvider.getString(R.string.quick_start_completed_tour_title)}</b>" +
+                            " ${resourceProvider.getString(R.string.quick_start_completed_tour_subtitle)}"
             )
             _onSnackbar.postValue(Event(
                     SnackbarMessageHolder(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -6,6 +6,8 @@ import com.google.android.material.snackbar.Snackbar.Callback.DISMISS_EVENT_SWIP
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
@@ -184,11 +186,11 @@ class QuickStartRepository
             )
             setTaskDoneAndTrack(task, selectedSite.id)
             if (quickStartUtilsWrapper.isEveryQuickStartTaskDone(selectedSite.id)) {
-                showCompletedQuickStartNotice()
                 quickStartStore.setQuickStartCompleted(selectedSite.id.toLong(), true)
                 analyticsTrackerWrapper.track(Stat.QUICK_START_ALL_TASKS_COMPLETED)
                 val payload = CompleteQuickStartPayload(selectedSite, NEXT_STEPS.toString())
                 dispatcher.dispatch(SiteActionBuilder.newCompleteQuickStartAction(payload))
+                showCompletedQuickStartNotice()
             }
         }
     }
@@ -267,17 +269,20 @@ class QuickStartRepository
     }
 
     private fun showCompletedQuickStartNotice() {
-        val message = htmlMessageUtils.getHtmlMessageFromStringFormat(
-                "<b>${resourceProvider.getString(R.string.quick_start_complete_tour_message)}</b>:" +
-                        " ${resourceProvider.getString(R.string.quick_start_complete_tour_short_message)}"
-        )
-        _onSnackbar.value = Event(
-                SnackbarMessageHolder(
-                        message = UiStringText(message),
-                        duration = QUICK_START_NOTICE_DURATION,
-                        isImportant = false
-                )
-        )
+        launch {
+            delay(QUICK_START_COMPLETED_NOTICE_DELAY)
+            val message = htmlMessageUtils.getHtmlMessageFromStringFormat(
+                    "<b>${resourceProvider.getString(R.string.quick_start_complete_tour_message)}</b>:" +
+                            " ${resourceProvider.getString(R.string.quick_start_complete_tour_short_message)}"
+            )
+            _onSnackbar.postValue(Event(
+                    SnackbarMessageHolder(
+                            message = UiStringText(message),
+                            duration = QUICK_START_NOTICE_DURATION,
+                            isImportant = false
+                    )
+            ))
+        }
     }
 
     private fun showQuickStartNotice(selectedSiteLocalId: Int) {
@@ -336,5 +341,6 @@ class QuickStartRepository
 
     companion object {
         private const val QUICK_START_NOTICE_DURATION = 7000
+        private const val QUICK_START_COMPLETED_NOTICE_DELAY = 500L
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3134,7 +3134,6 @@
     <string name="quick_start_completed_tour_title">Congrats! You know your way around&lt;br/&gt;</string>
     <string name="quick_start_completed_tour_subtitle">Doesn\'t it feel good to cross things off a list?</string>
 
-
     <string name="quick_start_card_menu_pin">Pin this</string>
     <string name="quick_start_card_menu_unpin">Unpin this</string>
     <string name="quick_start_card_menu_hide">Hide for now</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3131,8 +3131,8 @@
     <string name="quick_start_focus_point_description">tap here</string>
     <string name="quick_start_site_menu_tab_message_short">Tap &lt;b&gt;%1$s&lt;/b&gt; to continue.</string>
 
-    <string name="quick_start_complete_tour_short_message">Congrats! You know your way around</string>
-    <string name="quick_start_complete_tour_message">Doesn\'t it feel good to cross things off a list?</string>
+    <string name="quick_start_completed_tour_title">Congrats! You know your way around&lt;br/&gt;</string>
+    <string name="quick_start_completed_tour_subtitle">Doesn\'t it feel good to cross things off a list?</string>
 
 
     <string name="quick_start_card_menu_pin">Pin this</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3131,6 +3131,10 @@
     <string name="quick_start_focus_point_description">tap here</string>
     <string name="quick_start_site_menu_tab_message_short">Tap &lt;b&gt;%1$s&lt;/b&gt; to continue.</string>
 
+    <string name="quick_start_complete_tour_short_message">Congrats! You know your way around</string>
+    <string name="quick_start_complete_tour_message">Doesn\'t it feel good to cross things off a list?</string>
+
+
     <string name="quick_start_card_menu_pin">Pin this</string>
     <string name="quick_start_card_menu_unpin">Unpin this</string>
     <string name="quick_start_card_menu_hide">Hide for now</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -284,6 +284,18 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 verify(appPrefsWrapper, never()).setLastSkippedQuickStartTask(QuickStartTask.PUBLISH_POST)
             }
 
+    @Test
+    fun `when all task are completed, then completed notice is triggered`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        initStore()
+        whenever(quickStartUtilsWrapper.isEveryQuickStartTaskDone(siteLocalId)).thenReturn(true)
+        quickStartRepository.setActiveTask(QuickStartTask.EXPLORE_PLANS)
+
+        quickStartRepository.completeTask(QuickStartTask.EXPLORE_PLANS)
+
+        assertThat(snackbars).isNotEmpty
+    }
+
     private fun initQuickStartInProgress() {
         initStore()
     }


### PR DESCRIPTION
Parent #16352 

Description
Added a Congrats notice that's displayed when all tours are complete

Final Screenshot 
![Screenshot_20220510_153902](https://user-images.githubusercontent.com/17463767/167605204-3f8cb351-f34a-4996-8edc-61f44461d1aa.png)

---
### Pre requisites 

Since the plans feature is removed from the site menu and not from the quick start(https://github.com/wordpress-mobile/WordPress-Android/issues/16477), there is no way to complete the Explore Plans task at present. In order to complete the quick start tasks, we will have to skip the Explore plans feature from the quick start tour. 

We can do that by going to the quick start prompt and long-pressing on Explore plan and selecting skip tasks.  The below video capture shows the steps to skip the Plans tasks as well as the Completed tour notice being displayed. 

Video Capture : Time stamp
0:03 - Skipping Explore Plans Task 
0:15-0:20 - Completed tour notice being shown

https://user-images.githubusercontent.com/17463767/167681712-3cc9812e-cc21-4efc-897b-a7183353b12f.mp4

### Known Issue 
[Quick Start showing Plans item despite app not showing plan information](https://github.com/wordpress-mobile/WordPress-Android/issues/16477)

To test
- Login to a Site with quick start in Progress
- Go through all the tours
- Verify: once you're back on the My Site screen, the congrats notice is displayed
- Verify: The congrats notice is automatically dismissed after 5 seconds (or you can manually dismiss it by tapping on it)

**Continue and Verify that Completed Notice is not displayed again** 
- Switch to the Reader tab
- Switch back to the My Site tab
- Verify: The congrats notice isn't displayed
- Force quit the app
- Open the app
- Verify: The congrats notice isn't displayed

## Regression Notes
1. Potential unintended areas of impact
Completed Notice being shown incorrectly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Unit tests and manual tests 

3. What automated tests I added (or what prevented me from doing so)
Unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
