### PR TITLE
[Gutenberg] Prevent x-post icon showing on self-hosted sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 19.9
 -----
-
+* [*] Block Editor: Prevent non-functional '+' icon displaying in toolbar on self-hosted sites [https://github.com/wordpress-mobile/WordPress-Android/pull/16507]
 
 19.8
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2305,7 +2305,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         String wpcomLocaleSlug = languageString.replace("_", "-").toLowerCase(Locale.ENGLISH);
 
         // If this.mIsXPostsCapable has not been set, default to allowing xPosts
-        boolean enableXPosts = mIsXPostsCapable == null || mIsXPostsCapable;
+        boolean enableXPosts = mSite.isUsingWpComRestApi() && (mIsXPostsCapable == null || mIsXPostsCapable);
 
         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);
         Bundle themeBundle = (editorTheme != null) ? editorTheme.getThemeSupport().toBundle() : null;
@@ -2328,7 +2328,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 SiteUtils.supportsEmbedVariationFeature(mSite, SiteUtils.WP_SMARTFRAME_EMBED_JETPACK_VERSION),
                 SiteUtils.supportsStoriesFeature(mSite),
                 mSite.isUsingWpComRestApi(),
-                mSite.isUsingWpComRestApi() && enableXPosts,
+                enableXPosts,
                 isUnsupportedBlockEditorEnabled,
                 unsupportedBlockEditorSwitch,
                 !isFreeWPCom,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2328,7 +2328,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 SiteUtils.supportsEmbedVariationFeature(mSite, SiteUtils.WP_SMARTFRAME_EMBED_JETPACK_VERSION),
                 SiteUtils.supportsStoriesFeature(mSite),
                 mSite.isUsingWpComRestApi(),
-                enableXPosts,
+                mSite.isUsingWpComRestApi() && enableXPosts,
                 isUnsupportedBlockEditorEnabled,
                 unsupportedBlockEditorSwitch,
                 !isFreeWPCom,


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/40546

## Description

The x-post icon — `+` — is currently displaying in the formatting toolbar for text-based blocks on self-hosted sites. The icon is unresponsive when tapped, as x-posts currently only work with P2-based themes (which [can't be self-hosted](https://wordpress.com/p2/faq/) at the time of writing). 

The fix proposed in this PR involves [adding a check for whether a site uses the WP.com rest API](https://github.com/wordpress-mobile/WordPress-Android/blob/d74c2ef97f5ba1338e8375cf033334a5d57f1d30/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L2308) before enabling the icon. This is inline with [the check used to determine whether @mentions are supported](https://github.com/wordpress-mobile/WordPress-Android/blob/96066afc00ede79fa450bf558fa13aadfbadc280/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L2330) on a site.

## Testing Steps

To test:

* Open a post/page on a self-hosted site.
* Add a Paragraph block.
* Scroll the toolbar, located at the bottom of the screen, until reaching the last item.
* Observe that all of the formatting buttons (i.e. bold, italic, etc.) are functional and there's no longer a redundant `+` icon.

## Screenshots

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/167616064-63dea7d5-8221-4bda-8b1c-283d3f80a7f4.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/167614796-60e48d9b-267a-401d-bda4-6a08525ffff5.png" width="100%"> |

## Regression Notes
1. Potential unintended areas of impact

* The x-post icon should still be accessible from the toolbar for sites with the P2 theme enabled. 
* There should be no other changes to the formatting toolbar on self-hosted sites, only the non-functional `+` icon should be removed.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I manually tested the existing x-post functionality on a site with P2 enabled and confirmed it worked as expected. I also tested the formatting toolbar for the paragraph block on a self-hosted site and didn't spot any unexpected regressions/changes.

3. What automated tests I added (or what prevented me from doing so)

As this was a small bug fix, I didn't determine that extra automated tests were necessary.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
