### PR TITLE
My Site Dashboard: Reduce `feature_flag_value(...)` logs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -140,8 +140,8 @@ class MySiteViewModel @Inject constructor(
     private val siteItemsTracker: SiteItemsTracker,
     private val domainRegistrationCardShownTracker: DomainRegistrationCardShownTracker,
     private val buildConfigWrapper: BuildConfigWrapper,
-    private val mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig,
-    private val bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig,
+    mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig,
+    bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig,
     private val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private var isDefaultABExperimentTabSet: Boolean = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -173,8 +173,11 @@ class MySiteViewModel @Inject constructor(
        as they're already built on site select. */
     private var isSiteSelected = false
 
+    private val isMySiteDashboardTabsFeatureConfigEnabled = mySiteDashboardTabsFeatureConfig.isEnabled()
+    private val isBloggingPromptsFeatureConfigEnabled = bloggingPromptsFeatureConfig.isEnabled()
+
     val isMySiteTabsEnabled: Boolean
-        get() = mySiteDashboardTabsFeatureConfig.isEnabled() &&
+        get() = isMySiteDashboardTabsFeatureConfigEnabled &&
                 buildConfigWrapper.isMySiteTabsEnabled &&
                 selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi ?: true
 
@@ -423,7 +426,7 @@ class MySiteViewModel @Inject constructor(
                         ),
                         bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
                                 // TODO @klymyam fetch the actual blogging prompt
-                                bloggingPrompt = if (bloggingPromptsFeatureConfig.isEnabled()) {
+                                bloggingPrompt = if (isBloggingPromptsFeatureConfigEnabled) {
                                     @Suppress("MagicNumber")
                                     val dummyRespondent = BloggingPromptRespondent(
                                             54279365,
@@ -1173,7 +1176,7 @@ class MySiteViewModel @Inject constructor(
     }
 
     private fun trackWithTabSourceIfNeeded(stat: Stat, properties: HashMap<String, *>? = null) {
-        if (mySiteDashboardTabsFeatureConfig.isEnabled()) {
+        if (isMySiteDashboardTabsFeatureConfigEnabled) {
             _onTrackWithTabSource.postValue(Event(MySiteTrackWithTabSource(stat, properties)))
         } else {
             analyticsTrackerWrapper.track(stat, properties ?: emptyMap())

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -24,9 +24,10 @@ const val REFRESH_DELAY = 500L
 class CardsSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val cardsStore: CardsStore,
-    private val todaysStatsCardFeatureConfig: MySiteDashboardTodaysStatsCardFeatureConfig,
+    todaysStatsCardFeatureConfig: MySiteDashboardTodaysStatsCardFeatureConfig,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : MySiteRefreshSource<CardsUpdate> {
+    private val isTodaysStatsCardFeatureConfigEnabled = todaysStatsCardFeatureConfig.isEnabled()
     override val refresh = MutableLiveData(false)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<CardsUpdate> {
@@ -94,7 +95,7 @@ class CardsSource @Inject constructor(
     }
 
     private fun getCardTypes() = mutableListOf<Type>().apply {
-        if (todaysStatsCardFeatureConfig.isEnabled()) add(Type.TODAYS_STATS)
+        if (isTodaysStatsCardFeatureConfigEnabled) add(Type.TODAYS_STATS)
         add(Type.POSTS)
     }.toList()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteDefaultTabExperiment.kt
@@ -9,13 +9,15 @@ import org.wordpress.android.util.config.MySiteDefaultTabExperimentVariationDash
 import javax.inject.Inject
 
 class MySiteDefaultTabExperiment @Inject constructor(
-    private val mySiteDefaultTabExperimentFeatureConfig: MySiteDefaultTabExperimentFeatureConfig,
+    mySiteDefaultTabExperimentFeatureConfig: MySiteDefaultTabExperimentFeatureConfig,
     private val mySiteDefaultTabExperimentVariationDashboardFeatureConfig:
     MySiteDefaultTabExperimentVariationDashboardFeatureConfig,
-    private val mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig,
+    mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
+    private val isMySiteDashboardTabsFeatureConfigEnabled = mySiteDashboardTabsFeatureConfig.isEnabled()
+    private val isMySiteDefaultTabExperimentFeatureConfigEnabled = mySiteDefaultTabExperimentFeatureConfig.isEnabled()
     fun checkAndSetVariantIfNeeded() {
         if (isExperimentRunning()) {
             if (!isVariantAssigned()) {
@@ -45,7 +47,7 @@ class MySiteDefaultTabExperiment @Inject constructor(
     }
 
     fun isExperimentRunning() =
-            mySiteDashboardTabsFeatureConfig.isEnabled() && mySiteDefaultTabExperimentFeatureConfig.isEnabled()
+            isMySiteDashboardTabsFeatureConfigEnabled && isMySiteDefaultTabExperimentFeatureConfigEnabled
 
     fun isVariantAssigned() = appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteDefaultTabExperimentTest.kt
@@ -36,7 +36,13 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
         init()
     }
 
-    fun init() {
+    fun init(
+        isMySiteDashboardTabsFeatureConfigEnabled: Boolean = true,
+        isMySiteDefaultTabExperimentFeatureConfigEnabled: Boolean = false
+    ) {
+        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsFeatureConfigEnabled)
+        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled())
+                .thenReturn(isMySiteDefaultTabExperimentFeatureConfigEnabled)
         mySiteDefaultTabExperiment = MySiteDefaultTabExperiment(
                 mySiteDefaultTabExperimentFeatureConfig,
                 mySiteDefaultTabExperimentVariationDashboardFeatureConfig,
@@ -48,7 +54,7 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
 
     @Test
     fun `given my site tabs feature flag is enabled, when check and set variant, then app prefs is not set`() {
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(false)
+        init(isMySiteDashboardTabsFeatureConfigEnabled = true)
 
         mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
 
@@ -57,8 +63,10 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
 
     @Test
     fun `given default tab experiment flag is not enabled, when check and set variant, then app prefs is not set`() {
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(false)
+        init(
+                isMySiteDashboardTabsFeatureConfigEnabled = true,
+                isMySiteDefaultTabExperimentFeatureConfigEnabled = false
+        )
 
         mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
 
@@ -67,8 +75,10 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
 
     @Test
     fun `given experiment is running, when variant is not assigned, then assigned prefs is set`() {
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        init(
+                isMySiteDashboardTabsFeatureConfigEnabled = true,
+                isMySiteDefaultTabExperimentFeatureConfigEnabled = true
+        )
         whenever(appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()).thenReturn(false)
 
         mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
@@ -78,8 +88,10 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
 
     @Test
     fun `given experiment is running, when variant is not assigned, then initial screen prefs is set`() {
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        init(
+                isMySiteDashboardTabsFeatureConfigEnabled = true,
+                isMySiteDefaultTabExperimentFeatureConfigEnabled = true
+        )
         whenever(appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()).thenReturn(false)
         whenever(mySiteDefaultTabExperimentVariationDashboardFeatureConfig.isDashboardVariant()).thenReturn(false)
 
@@ -93,8 +105,10 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
 
     @Test
     fun `given experiment is running, when variant is already set, then app prefs is not reset`() {
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        init(
+                isMySiteDashboardTabsFeatureConfigEnabled = true,
+                isMySiteDefaultTabExperimentFeatureConfigEnabled = true
+        )
         whenever(appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()).thenReturn(true)
 
         mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
@@ -104,8 +118,10 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
 
     @Test
     fun `given experiment is running, when variant is not assigned, then experiment inject properties are set`() {
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        init(
+                isMySiteDashboardTabsFeatureConfigEnabled = true,
+                isMySiteDefaultTabExperimentFeatureConfigEnabled = true
+        )
         whenever(appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()).thenReturn(false)
 
         mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
@@ -115,8 +131,10 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
 
     @Test
     fun `given experiment is running, when variant is already set, then experiment inject properties are not set`() {
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        init(
+                isMySiteDashboardTabsFeatureConfigEnabled = true,
+                isMySiteDefaultTabExperimentFeatureConfigEnabled = true
+        )
         whenever(appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()).thenReturn(true)
 
         mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
@@ -126,8 +144,10 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
 
     @Test
     fun `given experiment is running, when variant is not assigned, then assignment is tracked`() {
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        init(
+                isMySiteDashboardTabsFeatureConfigEnabled = true,
+                isMySiteDefaultTabExperimentFeatureConfigEnabled = true
+        )
         whenever(appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()).thenReturn(false)
 
         mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
@@ -137,8 +157,10 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
 
     @Test
     fun `given experiment is running, when variant is assigned, then assignment is not tracked`() {
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        init(
+                isMySiteDashboardTabsFeatureConfigEnabled = true,
+                isMySiteDefaultTabExperimentFeatureConfigEnabled = true
+        )
         whenever(appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()).thenReturn(true)
 
         mySiteDefaultTabExperiment.checkAndSetVariantIfNeeded()
@@ -148,8 +170,10 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
 
     @Test
     fun `given experiment is running and unassigned, when request for reassign, then variant is not reassigned`() {
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        init(
+                isMySiteDashboardTabsFeatureConfigEnabled = true,
+                isMySiteDefaultTabExperimentFeatureConfigEnabled = true
+        )
         whenever(appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()).thenReturn(false)
 
         mySiteDefaultTabExperiment.changeExperimentVariantAssignmentIfNeeded(MySiteTabType.SITE_MENU.trackingLabel)
@@ -162,8 +186,10 @@ class MySiteDefaultTabExperimentTest : BaseUnitTest() {
 
     @Test
     fun `given experiment is running and assigned, when request for reassign, then variant is reassigned`() {
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(mySiteDefaultTabExperimentFeatureConfig.isEnabled()).thenReturn(true)
+        init(
+                isMySiteDashboardTabsFeatureConfigEnabled = true,
+                isMySiteDefaultTabExperimentFeatureConfigEnabled = true
+        )
         whenever(appPrefsWrapper.isMySiteDefaultTabExperimentVariantAssigned()).thenReturn(true)
 
         mySiteDefaultTabExperiment.changeExperimentVariantAssignmentIfNeeded(MySiteTabType.SITE_MENU.trackingLabel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
@@ -94,7 +94,11 @@ class CardsSourceTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        setUpMocks()
+        init()
+    }
+
+    private fun init(isTodaysStatsCardFeatureConfigEnabled: Boolean = false) {
+        setUpMocks(isTodaysStatsCardFeatureConfigEnabled)
         cardSource = CardsSource(
                 selectedSiteRepository,
                 cardsStore,
@@ -103,7 +107,8 @@ class CardsSourceTest : BaseUnitTest() {
         )
     }
 
-    private fun setUpMocks() {
+    private fun setUpMocks(isTodaysStatsCardFeatureConfigEnabled: Boolean) {
+        whenever(todaysStatsCardFeatureConfig.isEnabled()).thenReturn(isTodaysStatsCardFeatureConfigEnabled)
         whenever(siteModel.id).thenReturn(SITE_LOCAL_ID)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
     }
@@ -121,9 +126,9 @@ class CardsSourceTest : BaseUnitTest() {
 
     @Test
     fun `given today's stats feature enabled, when build is invoked, then todays stats from store(database)`() = test {
+        init(isTodaysStatsCardFeatureConfigEnabled = true)
         val result = mutableListOf<CardsUpdate>()
         whenever(cardsStore.getCards(siteModel, STATS_FEATURED_ENABLED_CARD_TYPES)).thenReturn(flowOf(data))
-        whenever(todaysStatsCardFeatureConfig.isEnabled()).thenReturn(true)
 
         cardSource.build(testScope(), SITE_LOCAL_ID).observeForever { it?.let { result.add(it) } }
 
@@ -170,9 +175,9 @@ class CardsSourceTest : BaseUnitTest() {
     @Test
     fun `given today's stats feature enabled, when refresh is invoked, then todays stats are requested from network`() =
             test {
+                init(isTodaysStatsCardFeatureConfigEnabled = true)
                 val result = mutableListOf<CardsUpdate>()
                 whenever(cardsStore.getCards(siteModel, STATS_FEATURED_ENABLED_CARD_TYPES)).thenReturn(flowOf(data))
-                whenever(todaysStatsCardFeatureConfig.isEnabled()).thenReturn(true)
                 whenever(cardsStore.fetchCards(siteModel, STATS_FEATURED_ENABLED_CARD_TYPES)).thenReturn(success)
                 cardSource.refresh.observeForever { }
 


### PR DESCRIPTION
Internal Ref: p5T066-3a9-p2#comment-12184

This PR reduces `feature_flag_value(...)` logs by sparingly checking the feature flag enabled state (usually when a class is initialized as feature flag should be set by the time we launch the app.)

To test:
- Launch the app.
- Go to `My Site` screen.
- Enable tracking from `Me` -> `App Settings` -> `Privacy settings` -> `Collect information`.
- Relaunch the app.
- Go to `My Site` screen.
- Notice reduced `feature_flag_value(...)` logs in logcat.
- Perform few actions like `pull-to-refresh`,  switching between tabs, clicking a card.
- Notice reduced `feature_flag_value(...)` logs in logcat.


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.