### PR TITLE
Fix Editor Toggle

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -191,21 +191,13 @@ public class SiteUtils {
     }
 
     public static void enableBlockEditor(Dispatcher dispatcher, SiteModel siteModel) {
-        // Send the setting to the server
         dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorAction(
                 new DesignateMobileEditorPayload(siteModel, GB_EDITOR_NAME)));
-        // Update the local site
-        siteModel.setMobileEditor(GB_EDITOR_NAME);
-        dispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(siteModel));
     }
 
     public static void disableBlockEditor(Dispatcher dispatcher, SiteModel siteModel) {
-        // Send the setting to the server
         dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorAction(
                 new DesignateMobileEditorPayload(siteModel, AZTEC_EDITOR_NAME)));
-        // Update the local site
-        siteModel.setMobileEditor(AZTEC_EDITOR_NAME);
-        dispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(siteModel));
     }
 
     public static boolean isBlockEditorDefaultForNewPost(@Nullable SiteModel site) {


### PR DESCRIPTION
Fixes #14782

It appears that the toggle was getting "reset" because of a race condition between us dispatching a `DesignateMobileEditorAction` and then immediately also dispatching an `UpdateSiteAction` inside both the [enableBlockEditor](https://github.com/wordpress-mobile/WordPress-Android/blob/2a1a3fd51f720c53e367965e22fc702643cda835/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java#L799-L804) and [disableBlockEditor](https://github.com/wordpress-mobile/WordPress-Android/blob/e590c29cf9395b16ecf6a4b6782a8ee99481d220/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java#L204-L208) methods that the toggle [triggers](https://github.com/wordpress-mobile/WordPress-Android/blob/2a1a3fd51f720c53e367965e22fc702643cda835/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java#L799-L804).

Looking into this a bit, it's not clear to me why when we update the editor we not only dispatch a `DesignateMobileEditor` action , but we then proceed to also update the `siteModel.mobileEditor` value and dispatch an `UpdateSiteAction` with that updated `SiteModel`:

```
        // dispatching update action
        dispatcher.dispatch(SiteActionBuilder.newDesignateMobileEditorAction(
                new DesignateMobileEditorPayload(siteModel, GB_EDITOR_NAME)));
        // Update the local site
        siteModel.setMobileEditor(GB_EDITOR_NAME);
        dispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(siteModel));
```

This surprised me a bit because when I looked at what `DesignateMobileEditor` action [triggers within FluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/cd79ffabce89ceba5437795aec0592020ec4a000/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt#L1249), I saw that it updates the `SiteModel`'s mobileEditor field, persists the update to the db, and emits an `OnSiteEditorsChanged` event with the updated `SiteModel`. So it seemed like we could just remove these calls from the WPAndroid side since FluxC is already updating the site appropriately, and in my testing this change works well.

FWIW, it looks like the code I'm removing [was added for the purpose of persisting the editor setting locally](https://github.com/wordpress-mobile/WordPress-Android/pull/11385/commits/4f01138333572e58267de19c133d5bc4430f78c3), but I don't think we need to do this now because FluxC already handles that when the `DesignateMobileEditor` action is fired.

## To Test

### 1. Local persistence (i.e., Self-Hosted Sites, which do not have remote persistence)

1. Select a self-hosted, non-jetpack connected, site
2. Go to the site settings and flip the block editor toggle a few times
3. Verify that the appropriate editor loads when you open a new post
4. Repeat steps 2 and 3 a few times

### 2. Remote persistence (Atomic Site or a Jetpack connected site)

1. Select an atomic site
2. On another device, open that same site (you can also do this doing two different builds on the same device at the same time)
3. Verify that the same block editor setting is reported on both devices
4. Change the block editor setting on one device
5. Swipe down on the homescreen of the other device to refresh the site information
6. Confirm that the block editor setting has been updated on the other device both in the site settings and if you open a new post (I observed a new post or the site's settings would sometimes initially open with the "old" editor a few of the times I tried, but waiting a couple of seconds and trying again was always enough to "fix" it).

## Regression Notes
1. Potential unintended areas of impact
Failure to properly update the selected editor either locally or remotely

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Adding automated tests didn't seem worth it since we've already deprecated the classic editor (and this toggle) for the vast majority of our users and we plan to deprecate it for the rest of our users in the future.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
