### PR TITLE
Fixes: Test failure on Trunk 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts
 import org.wordpress.android.ui.quickstart.QuickStartNoticeDetails
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
+import org.wordpress.android.ui.quickstart.QuickStartType
 import org.wordpress.android.ui.quickstart.QuickStartType.NewSiteQuickStartType
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -97,7 +98,7 @@ class QuickStartRepository
     val activeTask = _activeTask as LiveData<QuickStartTask?>
     val isQuickStartNoticeShown = _isQuickStartNoticeShown
     var quickStartTaskOrigin = if (isMySiteTabsEnabled) MySiteTabType.DASHBOARD else MySiteTabType.ALL
-    val quickStartType = NewSiteQuickStartType
+    var quickStartType: QuickStartType = NewSiteQuickStartType
 
     private var pendingTask: QuickStartTask? = null
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -291,11 +291,10 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     @Test
     fun `when all task are completed, then completed notice is triggered`() = test {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        initStore()
-        whenever(quickStartUtilsWrapper.isEveryQuickStartTaskDone(siteLocalId)).thenReturn(true)
-        quickStartRepository.setActiveTask(QuickStartTask.EXPLORE_PLANS)
+        initStore(QuickStartNewSiteTask.EXPLORE_PLANS)
+        whenever(quickStartType.isEveryQuickStartTaskDone(quickStartStore, site.id.toLong())).thenReturn(true)
 
-        quickStartRepository.completeTask(QuickStartTask.EXPLORE_PLANS)
+        quickStartRepository.completeTask(QuickStartNewSiteTask.EXPLORE_PLANS)
 
         assertThat(snackbars).isNotEmpty
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -31,7 +31,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts
-import org.wordpress.android.ui.quickstart.QuickStartType.NewSiteQuickStartType
+import org.wordpress.android.ui.quickstart.QuickStartType
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.EventBusWrapper
@@ -59,13 +59,13 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     @Mock lateinit var htmlMessageUtils: HtmlMessageUtils
     @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
+    @Mock lateinit var quickStartType: QuickStartType
     private lateinit var site: SiteModel
     private lateinit var quickStartRepository: QuickStartRepository
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
     private lateinit var quickStartPrompts: MutableList<QuickStartMySitePrompts>
     private lateinit var quickStartSiteMenuStep: MutableList<QuickStartSiteMenuStep?>
     private val siteLocalId = 1
-    private val quickStartType = NewSiteQuickStartType
 
     private val siteMenuTasks = listOf(
             QuickStartNewSiteTask.ENABLE_POST_SHARING,
@@ -95,6 +95,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
                 buildConfigWrapper,
                 mySiteDashboardTabsFeatureConfig
         )
+        quickStartRepository.quickStartType = quickStartType
         snackbars = mutableListOf()
         quickStartPrompts = mutableListOf()
         quickStartSiteMenuStep = mutableListOf()
@@ -292,6 +293,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     fun `when all task are completed, then completed notice is triggered`() = test {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         initStore(QuickStartNewSiteTask.EXPLORE_PLANS)
+        quickStartRepository.setActiveTask(QuickStartNewSiteTask.EXPLORE_PLANS)
         whenever(quickStartType.isEveryQuickStartTaskDone(quickStartStore, site.id.toLong())).thenReturn(true)
 
         quickStartRepository.completeTask(QuickStartNewSiteTask.EXPLORE_PLANS)


### PR DESCRIPTION
Fixes test failure after merging #16352

To test:
- Make sure that the test`when all task are completed, then completed notice is triggered` is passing 🟢 
- Make sure that all the tests in `QuickStartRepositoryTest` pass as well 🟢 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
