### PR TITLE
QRCode Auth: Add feature flag for qrcode auth flow

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -126,6 +126,7 @@ android {
         buildConfigField "boolean", "MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_DASHBOARD", "false"
         buildConfigField "boolean", "STATS_REVAMP_V2", "false"
         buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"
+        buildConfigField "boolean", "QRCODE_AUTH_FLOW", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/QRCodeAuthFlowFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/QRCodeAuthFlowFeatureConfig.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+@FeatureInDevelopment
+class QRCodeAuthFlowFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.QRCODE_AUTH_FLOW
+)


### PR DESCRIPTION
Parent #16481 

This PR adds support for the QRCode Auth Flow feature flag in `QRCodeAuthFlowFeatureConfig`

<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/168142439-dd14f348-1ad1-4a41-a944-ea5de7dbf14d.png">

**To test:**
1. Launch the app.
2. Go to `My Site` -> `Me` -> `App Settings` -> `Debug settings`.
3. Notice that `QRCodeAuthFlowFeatureConfig` exists under the **Features In Development** section

## Regression Notes
1. Potential unintended areas of impact 🟢
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢
3. What automated tests I added (or what prevented me from doing so) 🟢

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
