### PR TITLE
Quick Start for Existing Users V2 - Jetpack app - Replace app name in "Get to know the app" quick start card

### DIFF
--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -26,4 +26,6 @@
 
     <!-- About button in Me -->
     <string name="me_btn_about">About Jetpack</string>
+
+    <string name="quick_start_sites_type_get_to_know_app">Get to know the Jetpack app</string>
 </resources>


### PR DESCRIPTION
Parent #16347

This PR replaces the app name for the `Jetpack` app in "Get to know the app" quick start card.

Quick Start Card |  Quick Start Tasks List
--|--
![Screenshot_20220513_180019](https://user-images.githubusercontent.com/1405144/168283853-d051072b-52d5-4852-9fee-466f8c76aabf.png) | ![Screenshot_20220513_180100](https://user-images.githubusercontent.com/1405144/168283878-b3e5f900-8229-49d3-b81f-2527653dfd6b.png)

To test:

1. Install `Jetpack` app.
2. Launch the app.
3. Enable to `Me` -> `App Settings` -> `Debug settings` -> `QuickStartForExistingUsersV2FeatureConfig`.
4. Restart the app.
5. Logout/login and select "Show me around" when the quick start prompt is shown.
6. Select an existing site.
7. Go to `My Site` tab.
8. ✅ Notice that the new `Quick Start` card is shown with `Get to know the Jetpack app` title.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
