### PR TITLE
Stats revamp v2: Total Followers detail screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -72,6 +72,7 @@ import org.wordpress.android.ui.stats.refresh.lists.InsightsDetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.MonthsListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.TotalCommentsDetailListViewModel;
+import org.wordpress.android.ui.stats.refresh.lists.TotalFollowersDetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.TotalLikesDetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.WeeksListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.YearsListViewModel;
@@ -628,5 +629,10 @@ abstract class ViewModelModule {
     @Binds
     @IntoMap
     @ViewModelKey(TotalCommentsDetailListViewModel.class)
-    abstract ViewModel totalCommentssDetailListViewModel(TotalCommentsDetailListViewModel viewModel);
+    abstract ViewModel totalCommentsDetailListViewModel(TotalCommentsDetailListViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(TotalFollowersDetailListViewModel.class)
+    abstract ViewModel totalFollowersDetailListViewModel(TotalFollowersDetailListViewModel viewModel);
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1504,6 +1504,11 @@ public class ActivityLauncher {
         StatsDetailActivity.startForTotalCommentsDetail(context, site);
     }
 
+    public static void viewTotalFollowersDetail(Context context, SiteModel site) {
+        if (site == null) return;
+        StatsDetailActivity.startForTotalFollowersDetail(context, site);
+    }
+
     public static void viewInsightsDetail(Context context, SiteModel site) {
         if (site == null) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHT_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_COMMENTS_DETAIL
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_FOLLOWERS_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_LIKES_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
@@ -191,7 +192,12 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
             WEEKS -> 2
             MONTHS -> 3
             YEARS -> 4
-            DETAIL, INSIGHT_DETAIL, TOTAL_LIKES_DETAIL, TOTAL_COMMENTS_DETAIL, ANNUAL_STATS -> null
+            DETAIL,
+            INSIGHT_DETAIL,
+            TOTAL_LIKES_DETAIL,
+            TOTAL_COMMENTS_DETAIL,
+            TOTAL_FOLLOWERS_DETAIL,
+            ANNUAL_STATS -> null
         }
         position?.let {
             if (statsPager.currentItem != position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -56,7 +56,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.P
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TagsAndCategoriesUseCase.TagsAndCategoriesUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TodayStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalCommentsUseCase.TotalCommentsUseCaseFactory
-import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalFollowersUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalFollowersUseCase.TotalFollowersUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalLikesUseCase.TotalLikesUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.ViewsAndVisitorsUseCase.ViewsAndVisitorsUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -73,6 +73,7 @@ const val BLOCK_DETAIL_USE_CASE = "BlockDetailUseCase"
 const val VIEWS_AND_VISITORS_USE_CASE = "ViewsAndVisitorsUseCase"
 const val TOTAL_LIKES_DETAIL_USE_CASE = "LikesDetailUseCase"
 const val TOTAL_COMMENTS_DETAIL_USE_CASE = "CommentsDetailUseCase"
+const val TOTAL_FOLLOWERS_DETAIL_USE_CASE = "FollowersDetailUseCase"
 
 const val LIST_STATS_USE_CASES = "ListStatsUseCases"
 const val BLOCK_INSIGHTS_USE_CASES = "BlockInsightsUseCases"
@@ -84,6 +85,7 @@ private const val BLOCK_DETAIL_USE_CASES = "BlockDetailUseCases"
 private const val BLOCK_VIEWS_AND_VISITORS_USE_CASES = "BlockViewsAndVisitorsUseCases"
 private const val TOTAL_LIKES_DETAIL_USE_CASES = "LikesDetailUseCases"
 private const val TOTAL_COMMENTS_DETAIL_USE_CASES = "CommentsDetailUseCases"
+private const val TOTAL_FOLLOWERS_DETAIL_USE_CASES = "FollowersDetailUseCases"
 
 /**
  * Module that provides use cases for Stats.
@@ -529,6 +531,39 @@ class StatsModule {
                 uiModelMapper::mapInsights
         )
     }
+
+    /**
+     * Provides a list of use cases for the Total Followers detail screen in Stats. Modify this method when you want to
+     * add more blocks to the followers detail screen.
+     */
+    @Provides
+    @Singleton
+    @Named(TOTAL_FOLLOWERS_DETAIL_USE_CASES)
+    fun provideFollowersDetailUseCases(
+        totalFollowersUseCaseFactory: TotalFollowersUseCaseFactory
+    ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> = listOf(totalFollowersUseCaseFactory.build(VIEW_ALL))
+
+    /**
+     * Provides a singleton usecase that represents the Followers detail screen.
+     * @param useCases build the use cases
+     */
+    @Provides
+    @Singleton
+    @Named(TOTAL_FOLLOWERS_DETAIL_USE_CASE)
+    fun provideFollowersDetailStatsUseCase(
+        @Named(BG_THREAD) bgDispatcher: CoroutineDispatcher,
+        @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+        statsSiteProvider: StatsSiteProvider,
+        @Named(TOTAL_FOLLOWERS_DETAIL_USE_CASES) useCases: List<@JvmSuppressWildcards BaseStatsUseCase<*, *>>,
+        uiModelMapper: UiModelMapper
+    ): BaseListUseCase = BaseListUseCase(
+            bgDispatcher,
+            mainDispatcher,
+            statsSiteProvider,
+            useCases,
+            { listOf(InsightType.TOTAL_FOLLOWERS) },
+            uiModelMapper::mapInsights
+    )
 
     @Provides
     @Singleton

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -540,8 +540,12 @@ class StatsModule {
     @Singleton
     @Named(TOTAL_FOLLOWERS_DETAIL_USE_CASES)
     fun provideFollowersDetailUseCases(
-        totalFollowersUseCaseFactory: TotalFollowersUseCaseFactory
-    ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> = listOf(totalFollowersUseCaseFactory.build(VIEW_ALL))
+        totalFollowersUseCaseFactory: TotalFollowersUseCaseFactory,
+        followersUseCaseFactory: FollowersUseCaseFactory
+    ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> = listOf(
+            totalFollowersUseCaseFactory.build(VIEW_ALL),
+            followersUseCaseFactory.build(BLOCK)
+    )
 
     /**
      * Provides a singleton usecase that represents the Followers detail screen.
@@ -561,7 +565,7 @@ class StatsModule {
             mainDispatcher,
             statsSiteProvider,
             useCases,
-            { listOf(InsightType.TOTAL_FOLLOWERS) },
+            { listOf(InsightType.TOTAL_FOLLOWERS, InsightType.FOLLOWERS) },
             uiModelMapper::mapInsights
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -116,7 +116,7 @@ class StatsModule {
         followerTotalsUseCase: FollowerTotalsUseCase,
         totalLikesUseCaseFactory: TotalLikesUseCaseFactory,
         totalCommentsUseCaseFactory: TotalCommentsUseCaseFactory,
-        totalFollowersUseCase: TotalFollowersUseCase,
+        totalFollowersUseCaseFactory: TotalFollowersUseCaseFactory,
         annualSiteStatsUseCaseFactory: AnnualSiteStatsUseCaseFactory,
         managementControlUseCase: ManagementControlUseCase,
         managementNewsCardUseCase: ManagementNewsCardUseCase
@@ -126,7 +126,7 @@ class StatsModule {
             useCases.add(viewsAndVisitorsUseCaseFactory.build(BLOCK))
             useCases.add(totalLikesUseCaseFactory.build(BLOCK))
             useCases.add(totalCommentsUseCaseFactory.build(BLOCK))
-            useCases.add(totalFollowersUseCase)
+            useCases.add(totalFollowersUseCaseFactory.build(BLOCK))
         } else {
             useCases.add(followerTotalsUseCase)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -30,8 +30,8 @@ import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsNavigator
 import org.wordpress.android.ui.stats.refresh.utils.drawDateSelector
-import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.extensions.setVisible
+import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -173,6 +173,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
             StatsSection.INSIGHT_DETAIL -> InsightsDetailListViewModel::class.java
             StatsSection.TOTAL_LIKES_DETAIL -> TotalLikesDetailListViewModel::class.java
             StatsSection.TOTAL_COMMENTS_DETAIL -> TotalCommentsDetailListViewModel::class.java
+            StatsSection.TOTAL_FOLLOWERS_DETAIL -> TotalFollowersDetailListViewModel::class.java
             StatsSection.ANNUAL_STATS,
             StatsSection.INSIGHTS -> InsightsListViewModel::class.java
             StatsSection.DAYS -> DaysListViewModel::class.java

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHT_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_COMMENTS_DETAIL
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_FOLLOWERS_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_LIKES_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel.Empty
@@ -195,13 +196,11 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         })
 
         viewModel.dateSelectorData.observe(viewLifecycleOwner, { dateSelectorUiModel ->
-            if (statsSection == INSIGHT_DETAIL ||
-                    statsSection == TOTAL_LIKES_DETAIL ||
-                    statsSection == TOTAL_COMMENTS_DETAIL
-            ) {
-                drawDateSelector(DateSelectorUiModel(false))
-            } else {
-                drawDateSelector(dateSelectorUiModel)
+            when (statsSection) {
+                INSIGHT_DETAIL, TOTAL_LIKES_DETAIL, TOTAL_COMMENTS_DETAIL, TOTAL_FOLLOWERS_DETAIL -> {
+                    drawDateSelector(DateSelectorUiModel(false))
+                }
+                else -> drawDateSelector(dateSelectorUiModel)
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.stats.refresh.NavigationTarget
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewInsightsManagement
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.TOTAL_COMMENTS_DETAIL_USE_CASE
+import org.wordpress.android.ui.stats.refresh.TOTAL_FOLLOWERS_DETAIL_USE_CASE
 import org.wordpress.android.ui.stats.refresh.TOTAL_LIKES_DETAIL_USE_CASE
 import org.wordpress.android.ui.stats.refresh.VIEWS_AND_VISITORS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.WEEK_STATS_USE_CASE
@@ -28,6 +29,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHT_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_COMMENTS_DETAIL
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_FOLLOWERS_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_LIKES_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
@@ -68,6 +70,7 @@ abstract class StatsListViewModel(
         INSIGHT_DETAIL(R.string.stats),
         TOTAL_LIKES_DETAIL(R.string.stats_view_total_likes),
         TOTAL_COMMENTS_DETAIL(R.string.stats_view_total_comments),
+        TOTAL_FOLLOWERS_DETAIL(R.string.stats_view_total_followers),
         ANNUAL_STATS(R.string.stats_insights_annual_site_stats);
     }
 
@@ -240,3 +243,15 @@ class TotalCommentsDetailListViewModel @Inject constructor(
     analyticsTracker: AnalyticsTrackerWrapper,
     dateSelectorFactory: StatsDateSelector.Factory
 ) : StatsListViewModel(mainDispatcher, statsUseCase, analyticsTracker, dateSelectorFactory.build(TOTAL_COMMENTS_DETAIL))
+
+class TotalFollowersDetailListViewModel @Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(TOTAL_FOLLOWERS_DETAIL_USE_CASE) statsUseCase: BaseListUseCase,
+    analyticsTracker: AnalyticsTrackerWrapper,
+    dateSelectorFactory: StatsDateSelector.Factory
+) : StatsListViewModel(
+        mainDispatcher,
+        statsUseCase,
+        analyticsTracker,
+        dateSelectorFactory.build(TOTAL_FOLLOWERS_DETAIL)
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
@@ -39,6 +39,7 @@ class StatsDetailActivity : LocaleAwareActivity() {
                     StatsSection.INSIGHT_DETAIL -> add<InsightsDetailFragment>(R.id.fragment_container)
                     StatsSection.TOTAL_LIKES_DETAIL -> add<TotalLikesDetailFragment>(R.id.fragment_container)
                     StatsSection.TOTAL_COMMENTS_DETAIL -> add<TotalCommentsDetailFragment>(R.id.fragment_container)
+                    StatsSection.TOTAL_FOLLOWERS_DETAIL -> add<TotalFollowersDetailFragment>(R.id.fragment_container)
                 }
             }
         }
@@ -112,6 +113,16 @@ class StatsDetailActivity : LocaleAwareActivity() {
                 putExtra(WordPress.LOCAL_SITE_ID, site.id)
                 putExtra(StatsListFragment.LIST_TYPE, StatsSection.TOTAL_COMMENTS_DETAIL)
             }
+            context.startActivity(intent)
+        }
+
+        @JvmStatic
+        fun startForTotalFollowersDetail(context: Context, site: SiteModel) {
+            val intent = Intent(context, StatsDetailActivity::class.java).apply {
+                putExtra(WordPress.LOCAL_SITE_ID, site.id)
+                putExtra(StatsListFragment.LIST_TYPE, StatsSection.TOTAL_FOLLOWERS_DETAIL)
+            }
+            // TODO: Add tracking here
             context.startActivity(intent)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/TotalFollowersDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/TotalFollowersDetailFragment.kt
@@ -1,0 +1,64 @@
+package org.wordpress.android.ui.stats.refresh.lists.detail
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.StatsDetailFragmentBinding
+import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.helpers.SwipeToRefreshHelper
+
+@AndroidEntryPoint
+class TotalFollowersDetailFragment : Fragment(R.layout.stats_detail_fragment) {
+    private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
+
+    private val viewModel: TotalFollowersDetailViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val nonNullActivity = requireActivity()
+        with(StatsDetailFragmentBinding.bind(view)) {
+            with(nonNullActivity as AppCompatActivity) {
+                setSupportActionBar(toolbar)
+                supportActionBar?.let {
+                    it.title = getString(R.string.stats_view_total_followers)
+                    it.setHomeButtonEnabled(true)
+                    it.setDisplayHomeAsUpEnabled(true)
+                }
+            }
+            initializeViewModels(nonNullActivity)
+            initializeViews()
+        }
+    }
+
+    private fun StatsDetailFragmentBinding.initializeViews() {
+        swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
+            viewModel.onPullToRefresh()
+        }
+    }
+
+    private fun initializeViewModels(activity: FragmentActivity) {
+        val siteId = activity.intent?.getIntExtra(WordPress.LOCAL_SITE_ID, 0) ?: 0
+        viewModel.init(siteId)
+        setupObservers(viewModel)
+    }
+
+    private fun setupObservers(viewModel: TotalFollowersDetailViewModel) {
+        viewModel.isRefreshing.observe(viewLifecycleOwner) {
+            it?.let { isRefreshing ->
+                swipeToRefreshHelper.isRefreshing = isRefreshing
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/TotalFollowersDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/TotalFollowersDetailViewModel.kt
@@ -1,0 +1,64 @@
+package org.wordpress.android.ui.stats.refresh.lists.detail
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.R
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.stats.refresh.TOTAL_FOLLOWERS_DETAIL_USE_CASE
+import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
+import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.mergeNotNull
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+@HiltViewModel
+class TotalFollowersDetailViewModel
+@Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(TOTAL_FOLLOWERS_DETAIL_USE_CASE) private val detailUseCase: BaseListUseCase,
+    private val statsSiteProvider: StatsSiteProvider,
+    private val networkUtilsWrapper: NetworkUtilsWrapper
+) : ScopedViewModel(mainDispatcher) {
+    private val _isRefreshing = MutableLiveData<Boolean>()
+    val isRefreshing: LiveData<Boolean> = _isRefreshing
+
+    private val _showSnackbarMessage = mergeNotNull(
+            detailUseCase.snackbarMessage,
+            distinct = true,
+            singleEvent = true
+    )
+    val showSnackbarMessage: LiveData<SnackbarMessageHolder> = _showSnackbarMessage
+
+    fun init(localSiteId: Int) {
+        statsSiteProvider.start(localSiteId)
+    }
+
+    fun refresh() {
+        launch {
+            detailUseCase.refreshData(true)
+            _isRefreshing.value = false
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        detailUseCase.onCleared()
+    }
+
+    fun onPullToRefresh() {
+        _showSnackbarMessage.value = null
+        statsSiteProvider.clear()
+        if (networkUtilsWrapper.isNetworkAvailable()) {
+            refresh()
+        } else {
+            _isRefreshing.value = false
+            _showSnackbarMessage.value = SnackbarMessageHolder(UiStringRes(R.string.no_network_title))
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCase.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.fluxc.store.StatsStore.InsightType.FOLLOWERS
 import org.wordpress.android.fluxc.store.stats.insights.FollowersStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.stats.refresh.utils.StatsSinceLabelFormatter
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewFollowersStats
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
@@ -28,15 +27,17 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.AVATAR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.LoadingItem
-import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TabsItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.FollowersUseCase.FollowersUiState
 import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
+import org.wordpress.android.ui.stats.refresh.utils.StatsSinceLabelFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.StatsRevampV2FeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 import javax.inject.Named
@@ -55,7 +56,8 @@ class FollowersUseCase(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val popupMenuHandler: ItemPopupMenuHandler,
     private val contentDescriptionHelper: ContentDescriptionHelper,
-    private val useCaseMode: UseCaseMode
+    private val useCaseMode: UseCaseMode,
+    private val statsRevampV2FeatureConfig: StatsRevampV2FeatureConfig
 ) : BaseStatsUseCase<Pair<FollowersModel, FollowersModel>, FollowersUiState>(
         FOLLOWERS,
         mainDispatcher,
@@ -177,7 +179,11 @@ class FollowersUseCase(
         return items
     }
 
-    private fun buildTitle() = Title(R.string.stats_view_followers, menuAction = this::onMenuClick)
+    private fun buildTitle() = if (statsRevampV2FeatureConfig.isEnabled()) {
+        Title(R.string.stats_view_followers)
+    } else {
+        Title(R.string.stats_view_followers, menuAction = this::onMenuClick)
+    }
 
     private fun loadMore() {
         launch {
@@ -247,7 +253,8 @@ class FollowersUseCase(
         private val resourceProvider: ResourceProvider,
         private val popupMenuHandler: ItemPopupMenuHandler,
         private val analyticsTracker: AnalyticsTrackerWrapper,
-        private val contentDescriptionHelper: ContentDescriptionHelper
+        private val contentDescriptionHelper: ContentDescriptionHelper,
+        private val statsRevampV2FeatureConfig: StatsRevampV2FeatureConfig
     ) : InsightUseCaseFactory {
         override fun build(useCaseMode: UseCaseMode) =
                 FollowersUseCase(
@@ -260,7 +267,8 @@ class FollowersUseCase(
                         analyticsTracker,
                         popupMenuHandler,
                         contentDescriptionHelper,
-                        useCaseMode
+                        useCaseMode,
+                        statsRevampV2FeatureConfig
                 )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTotalFollowersStats
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueWithChartItem
@@ -24,7 +25,8 @@ class TotalFollowersUseCase @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val summaryStore: SummaryStore,
     private val statsSiteProvider: StatsSiteProvider,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val useCaseMode: UseCaseMode
 ) : StatelessUseCase<Int>(TOTAL_FOLLOWERS, mainDispatcher, bgDispatcher) {
     override fun buildLoadingItem(): List<BlockListItem> = listOf(TitleWithMore(R.string.stats_view_total_followers))
 
@@ -49,7 +51,7 @@ class TotalFollowersUseCase @Inject constructor(
 
     private fun buildTitle() = TitleWithMore(
             R.string.stats_view_total_followers,
-            navigationAction = ListItemInteraction.create(this::onViewMoreClick)
+            navigationAction = if (useCaseMode == VIEW_ALL) null else ListItemInteraction.create(this::onViewMoreClick)
     )
 
     private fun onViewMoreClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.St
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueWithChartItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -57,5 +58,22 @@ class TotalFollowersUseCase @Inject constructor(
                 statsSiteProvider.siteModel
         )
         navigateTo(ViewTotalFollowersStats) // TODO: Connect this to proper second level navigation later
+    }
+
+    class TotalFollowersUseCaseFactory @Inject constructor(
+        @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+        @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher,
+        private val summaryStore: SummaryStore,
+        private val statsSiteProvider: StatsSiteProvider,
+        private val analyticsTracker: AnalyticsTrackerWrapper
+    ) : InsightUseCaseFactory {
+        override fun build(useCaseMode: UseCaseMode) = TotalFollowersUseCase(
+                mainDispatcher,
+                backgroundDispatcher,
+                summaryStore,
+                statsSiteProvider,
+                analyticsTracker,
+                useCaseMode
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_COMMENTS_DETAIL
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_FOLLOWERS_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TOTAL_LIKES_DETAIL
 import javax.inject.Inject
 
@@ -45,7 +46,7 @@ class SelectedSectionManager
 
 fun StatsSection.toStatsGranularity(): StatsGranularity? {
     return when (this) {
-        ANNUAL_STATS, DETAIL, TOTAL_LIKES_DETAIL, TOTAL_COMMENTS_DETAIL, INSIGHTS -> null
+        ANNUAL_STATS, DETAIL, TOTAL_LIKES_DETAIL, TOTAL_COMMENTS_DETAIL, TOTAL_FOLLOWERS_DETAIL, INSIGHTS -> null
         StatsSection.INSIGHT_DETAIL,
         StatsSection.DAYS -> DAYS
         StatsSection.WEEKS -> WEEKS

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsAnalyticsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsAnalyticsUtils.kt
@@ -28,6 +28,7 @@ private const val ALL_TIME_WIDGET_PROPERTY = "all_time"
 private const val MINIFIED_WIDGET_PROPERTY = "minified"
 private const val TOTAL_LIKES_PROPERTY = "total_likes_detail"
 private const val TOTAL_COMMENTS_PROPERTY = "total_comments_detail"
+private const val TOTAL_FOLLOWERS_PROPERTY = "total_followers_detail"
 
 fun AnalyticsTrackerWrapper.trackGranular(stat: Stat, granularity: StatsGranularity) {
     val property = when (granularity) {
@@ -50,6 +51,7 @@ fun AnalyticsTrackerWrapper.trackWithSection(stat: Stat, section: StatsSection) 
         StatsSection.ANNUAL_STATS -> ANNUAL_STATS_PROPERTY
         StatsSection.TOTAL_LIKES_DETAIL -> TOTAL_LIKES_PROPERTY
         StatsSection.TOTAL_COMMENTS_DETAIL -> TOTAL_COMMENTS_PROPERTY
+        StatsSection.TOTAL_FOLLOWERS_DETAIL -> TOTAL_FOLLOWERS_PROPERTY
     }
     this.track(stat, mapOf(GRANULARITY_PROPERTY to property))
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -75,6 +75,7 @@ constructor(
             StatsSection.DETAIL,
             StatsSection.TOTAL_LIKES_DETAIL,
             StatsSection.TOTAL_COMMENTS_DETAIL,
+            StatsSection.TOTAL_FOLLOWERS_DETAIL,
             StatsSection.INSIGHTS,
             StatsSection.INSIGHT_DETAIL,
             StatsSection.DAYS -> DAYS

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -27,13 +27,13 @@ import org.wordpress.android.ui.stats.refresh.NavigationTarget
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.AddNewPost
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.SharePost
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewAnnualStats
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewAttachment
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewAuthors
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewClicks
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewCommentsStats
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewCountries
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewFileDownloads
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewFollowersStats
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewAttachment
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewInsightsManagement
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewMonthsAndYearsStats
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPost
@@ -46,6 +46,7 @@ import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewSearchTerms
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTag
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTagsAndCategoriesStats
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTotalCommentsStats
+import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTotalFollowersStats
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTotalLikesStats
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewUrl
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewVideoPlays
@@ -236,6 +237,9 @@ class StatsNavigator @Inject constructor(
 
             is ViewTotalCommentsStats -> {
                 ActivityLauncher.viewTotalCommentsDetail(activity, siteProvider.siteModel)
+            }
+            is ViewTotalFollowersStats -> {
+                ActivityLauncher.viewTotalFollowersDetail(activity, siteProvider.siteModel)
             }
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCaseTest.kt
@@ -43,6 +43,7 @@ import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.StatsRevampV2FeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Date
 
@@ -55,6 +56,7 @@ class FollowersUseCaseTest : BaseUnitTest() {
     @Mock lateinit var tracker: AnalyticsTrackerWrapper
     @Mock lateinit var popupMenuHandler: ItemPopupMenuHandler
     @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
+    @Mock private lateinit var statsRevampV2FeatureConfig: StatsRevampV2FeatureConfig
     private lateinit var useCaseFactory: FollowersUseCaseFactory
     private lateinit var useCase: FollowersUseCase
     private val avatar = "avatar.jpg"
@@ -83,7 +85,8 @@ class FollowersUseCaseTest : BaseUnitTest() {
                 resourceProvider,
                 popupMenuHandler,
                 tracker,
-                contentDescriptionHelper
+                contentDescriptionHelper,
+                statsRevampV2FeatureConfig
         )
         useCase = useCaseFactory.build(BLOCK)
         whenever(statsSinceLabelFormatter.getSinceLabelLowerCase(dateSubscribed)).thenReturn(sinceLabel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCaseTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.stats.insights.SummaryStore
 import org.wordpress.android.test
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -32,6 +33,7 @@ class TotalFollowersUseCaseTest : BaseUnitTest() {
     @Mock lateinit var statsSiteProvider: StatsSiteProvider
     @Mock lateinit var site: SiteModel
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Mock lateinit var useCaseMode: UseCaseMode
     private lateinit var useCase: TotalFollowersUseCase
     private val followers = 100
 
@@ -43,7 +45,8 @@ class TotalFollowersUseCaseTest : BaseUnitTest() {
                 TEST_DISPATCHER,
                 insightsStore,
                 statsSiteProvider,
-                analyticsTrackerWrapper
+                analyticsTrackerWrapper,
+                useCaseMode
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
     }


### PR DESCRIPTION
Fixes #16518 

This PR implements Total Followers detail screen with Total Followers, and followers cards.

<img src="https://user-images.githubusercontent.com/2471769/168339302-36e58058-da33-4a32-a355-da7f3e74a35c.png" width=320>

To test:

Setup:

- Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
- Select Debug Settings
- Find StatsRevampV2FeatureConfig under Features in development enable it and restart app

Test:

Launch app
- Go to stats either using quick links or menu.
- Ensure that it opens in Insights tab otherwise switch to Insights tab.
- Notice a new Top Followers card is shown in Insights tab as in the images above (scroll down if necessary).
- If the Total Followers card is not present, go to the stats management (either through ⚙️ menu at the top right hand corner or Add new stats card at the bottom) and add the card and save, then return to Insights.
- Tap on "VIEW MORE" on the top right hand corner on the card.
- Ensure it opens the detail screen as shown above (scroll down if necessary) with Total Followers and Top Followers cards.

NOTE:

- This PR is only for navigation and detail screen with relevant existing cards.
- Site Followers card will be added in a separate PR. 
- Date selector is hidden as per discussions. Will add in a separate PR.
- Three dots popup menu is removed from top followers card for consistency.

## Regression Notes
1. Potential unintended areas of impact
None, it is a new screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Unit testing and manual testing

3. What automated tests I added (or what prevented me from doing so)
existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
