### PR TITLE
Fixes crash occurring when rotating the Site Intent Question screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -76,7 +76,6 @@ class SiteCreationActivity : LocaleAwareActivity(),
                 .get(SiteCreationSiteNameViewModel::class.java)
         val siteCreationSource = intent.extras?.getString(ARG_CREATE_SITE_SOURCE)
         mainViewModel.start(savedInstanceState, SiteCreationSource.fromString(siteCreationSource))
-        hppViewModel.loadSavedState(savedInstanceState)
 
         observeVMState()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -63,6 +63,10 @@ class HomePagePickerFragment : Fragment() {
 
         viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(HomePagePickerViewModel::class.java)
 
+        savedInstanceState?.let {
+            viewModel.loadSavedState(it)
+        }
+
         with(HomePagePickerFragmentBinding.bind(view)) {
             modalLayoutPickerCategoriesSkeleton.root.isGone = true
             categoriesRecyclerView.isGone = true


### PR DESCRIPTION
## Description
Fixes crash occurring when rotating the Site Intent Question screen on the `feature/site-design-revamp` branch

To test:
1. Start the site creation flow
2. Rotate the device
3. *Verify* that no crash occurs
4. Rotate back
5. Proceed to the Site Design screen
6. Rotate the device
7. *Verify* that the screen behaves as expected

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
