### PR TITLE
[RNMobile] Update code comment for clarity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2305,7 +2305,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
         String languageString = LocaleManager.getLanguage(EditPostActivity.this);
         String wpcomLocaleSlug = languageString.replace("_", "-").toLowerCase(Locale.ENGLISH);
 
-        // If this.mIsXPostsCapable has not been set, default to allowing xPosts
+        // this.mIsXPostsCapable may return true for non-WP.com sites, but the app only supports xPosts for P2-based
+        // WP.com sites.
+        // If the site is using the WP.com API and this.mIsXPostsCapable has not been set, default to allowing xPosts.
         boolean enableXPosts = mSite.isUsingWpComRestApi() && (mIsXPostsCapable == null || mIsXPostsCapable);
 
         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.DragEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -2307,7 +2308,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
         // this.mIsXPostsCapable may return true for non-WP.com sites, but the app only supports xPosts for P2-based
         // WP.com sites.
-        // If the site is using the WP.com API and this.mIsXPostsCapable has not been set, default to allowing xPosts.
+        // If this.mIsXPostsCapable has not been set, default to allowing xPosts.
         boolean enableXPosts = mSite.isUsingWpComRestApi() && (mIsXPostsCapable == null || mIsXPostsCapable);
 
         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2306,7 +2306,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         String wpcomLocaleSlug = languageString.replace("_", "-").toLowerCase(Locale.ENGLISH);
 
         // this.mIsXPostsCapable may return true for non-WP.com sites, but the app only supports xPosts for P2-based
-        // WP.com sites.
+        // WP.com sites so, gate with `isUsingWpComRestApi()`
         // If this.mIsXPostsCapable has not been set, default to allowing xPosts.
         boolean enableXPosts = mSite.isUsingWpComRestApi() && (mIsXPostsCapable == null || mIsXPostsCapable);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -10,7 +10,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.DragEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -2308,7 +2307,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
         // this.mIsXPostsCapable may return true for non-WP.com sites, but the app only supports xPosts for P2-based
         // WP.com sites.
-        // If this.mIsXPostsCapable has not been set, default to allowing xPosts.
+        // If the site is using the WP.com API and this.mIsXPostsCapable has not been set, default to allowing xPosts.
         boolean enableXPosts = mSite.isUsingWpComRestApi() && (mIsXPostsCapable == null || mIsXPostsCapable);
 
         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2307,7 +2307,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
         // this.mIsXPostsCapable may return true for non-WP.com sites, but the app only supports xPosts for P2-based
         // WP.com sites.
-        // If the site is using the WP.com API and this.mIsXPostsCapable has not been set, default to allowing xPosts.
+        // If this.mIsXPostsCapable has not been set, default to allowing xPosts.
         boolean enableXPosts = mSite.isUsingWpComRestApi() && (mIsXPostsCapable == null || mIsXPostsCapable);
 
         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);


### PR DESCRIPTION
Addresses feedback received at https://github.com/wordpress-mobile/WordPress-Android/pull/16507#discussion_r870269435

In https://github.com/wordpress-mobile/WordPress-Android/pull/16507, a conditional that communicates whether xPosts are enabled on a site was updated to check whether a site was hosted on WordPress.com. The reason for this change is that the conditional's `mIsXPostsCapable` boolean returns `true` for .org sites by default. As the app only support xPosts for WordPress.com sites using a P2-based theme, an unresponsive `+` icon was being displayed in the editor's toolbar for .org sites.

The updated conditional, including comment, was as follows:

```
// If this.mIsXPostsCapable has not been set, default to allowing xPosts
boolean enableXPosts = mSite.isUsingWpComRestApi() && (mIsXPostsCapable == null || mIsXPostsCapable);
```

[This feedback](https://github.com/wordpress-mobile/WordPress-Android/pull/16507#discussion_r870269435) suggested that the comment could be updated for clarity, given the change. As such, this PR proposes the following change:  

```
// this.mIsXPostsCapable may return true for non-WP.com sites, but the app only supports xPosts for P2-based
// WP.com sites so, gate with `isUsingWpComRestApi()`
// If this.mIsXPostsCapable has not been set, default to allowing xPosts.
```
## Regression Notes
1. Potential unintended areas of impact

As this is a change to a code comment, no user-facing regressions are predicted. The only negative, unintentional impact would be developer confusion, if the comment isn't clear.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
