### PR TITLE
[Site Design Revamp] Updates the UI on vertical change

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
@@ -39,7 +39,7 @@ class HomePagePickerViewModel @Inject constructor(
     private val _onBackButtonPressed = SingleLiveEvent<Unit>()
     val onBackButtonPressed: LiveData<Unit> = _onBackButtonPressed
 
-    private lateinit var vertical: String
+    private var vertical: String = ""
 
     override val useCachedData: Boolean = false
     override val shouldUseMobileThumbnail = true
@@ -60,9 +60,12 @@ class HomePagePickerViewModel @Inject constructor(
     }
 
     fun start(intent: String? = null, isTablet: Boolean = false) {
-        vertical = intent ?: ""
+        val verticalChanged = vertical != intent
+        if (verticalChanged) {
+            vertical = intent ?: ""
+        }
         initializePreviewMode(isTablet)
-        if (uiState.value !is Content) {
+        if (uiState.value !is Content || verticalChanged) {
             analyticsTracker.trackSiteDesignViewed(selectedPreviewMode().key)
             fetchLayouts()
         }


### PR DESCRIPTION
Fixes #16540

## Description
This PR updates the UI when the user revisits the Site Design screen with a different vertical selected.

To test:
1. Start the Site Creation flow
2. Select one of the main topics listed under the input
3. Tap ← to go back
4. Select another main topic
5. *Verify* that the recommended section is updated.

## Regression Notes
1. Potential unintended areas of impact
N/A

6. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

7. What automated tests I added (or what prevented me from doing so)
Added tests with 18c2ac8509ace442367d2584fd085d7ddc139761

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
