### PR TITLE
[Site Creation] Fix screen titles visibility on tablet for the new & updated screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
@@ -80,7 +80,6 @@ class SiteCreationSiteNameFragment : Fragment() {
         siteCreationSiteNameHeader.title?.text = headerTitleWithIntentColoredBlueIfSpecified
         siteCreationSiteNameHeader.subtitle?.setText(R.string.new_site_creation_site_name_header_subtitle)
         siteCreationSiteNameTitlebar.appBarTitle.setText(R.string.new_site_creation_site_name_title)
-        siteCreationSiteNameTitlebar.appBarTitle.isInvisible = !displayUtils.isPhoneLandscape()
         viewModel.uiState.value?.siteName.let { input.setText(it) }
         input.requestFocus()
         ActivityUtils.showKeyboard(input)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isGone
-import androidx.core.view.isInvisible
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -87,7 +86,6 @@ class HomePagePickerFragment : Fragment() {
     }
 
     private fun HomePagePickerFragmentBinding.setupUi() {
-        homePagePickerTitlebar.title.isInvisible = !displayUtils.isPhoneLandscape()
         with(modalLayoutPickerHeaderSection) {
             modalLayoutPickerTitleRow?.header?.apply {
                 textAlignment = View.TEXT_ALIGNMENT_TEXT_START

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
@@ -68,7 +67,6 @@ class SiteCreationIntentsFragment : Fragment() {
     }
 
     private fun SiteCreationIntentsFragmentBinding.setupUi() {
-        siteCreationIntentsTitlebar.appBarTitle.isInvisible = !displayUtils.isPhoneLandscape()
         recyclerView.itemAnimator = null
         recyclerView.adapter = SiteCreationIntentsAdapter()
         siteCreationIntentsHeader.title?.setText(R.string.new_site_creation_intents_header_title)


### PR DESCRIPTION
Fixes #16464

Screen titles of the new and updated screens in the site creation flow were hidden on tablet.
This pull request fixes the bug by removing a line of code which apparently didn't change anything except for introducing this bug on tablets.

<details>
<summary>Preview</summary>

![preview](https://user-images.githubusercontent.com/4588074/168326878-637b9c43-4174-4d80-86c7-bbc526c8dc52.png)
</details>

To test:
### On Tablet
1. Start the site creation flow
   - **expect** the screen title `Site topic` to be displayed.
2. Choose or enter a site topic

<details>
<summary>3. Optional</summary>

if `SiteNameFeatureConfig` is enabled via manually returning `true` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/1010c25bcfeac5854d0fcf0a5b89f78050789148/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt#L19):
   - **expect** the screen title `Site name` to be displayed.
   - Enter a site name
</details>

4. **expect** to land on the `Choose a theme` with the screen title displayed.

## Regression Notes
1. Potential unintended areas of impact
   All 3 affected screens (Site Topic, Site Name, Site Theme) on mobile (portrait or landscape).

6. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

7. What automated tests I added (or what prevented me from doing so)
   N/a - Only UI changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
