### PR TITLE
Quick Start for Existing Users V2: Add release notes 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 * [***] Block Editor: Add drag & drop blocks feature [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4832]
 * [*] Block Editor: Gallery block: Fix broken "Link To" settings and add "Image Size" settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4841]
 * [*] Block Editor: Unsupported Block Editor: Prevent WordPress.com tour banner from displaying. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4820]
+* [*] Quick Start: We are now showing a different set of Quick Start tasks for existing sites and new sites. The existing sites checklist includes new tours such as: "Check your notifications" and "Upload photos or videos". [https://github.com/wordpress-mobile/WordPress-Android/issues/16349, https://github.com/wordpress-mobile/WordPress-Android/issues/16350, https://github.com/wordpress-mobile/WordPress-Android/pull/16505]
 
 19.8
 -----


### PR DESCRIPTION
Parent #16347

This PR adds release notes for quick start for existing users.

To test:
Nothing to test. Release note copied from [iOS release notes](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/RELEASE-NOTES.txt#L5)

## Regression Notes
1. Potential unintended areas of impact 🟢 


2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 


3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
