### PR TITLE
Quick Start for Existing Users V2: Adjust "Get to know the app" title

### DIFF
--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -26,6 +26,4 @@
 
     <!-- About button in Me -->
     <string name="me_btn_about">About Jetpack</string>
-
-    <string name="quick_start_sites_type_get_to_know_app">Get to know the Jetpack app</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3134,7 +3134,7 @@
     <string name="quick_start_sites">Next Steps</string>
     <string name="quick_start_sites_type_customize">Customize your site</string>
     <string name="quick_start_sites_type_grow">Grow your audience</string>
-    <string name="quick_start_sites_type_get_to_know_app">Get to know the WordPress app</string>
+    <string name="quick_start_sites_type_get_to_know_app">Get to know the app</string>
     <string name="quick_start_sites_type_tasks_completed">%1$s out of %2$s complete</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
     <string name="quick_start_span_start" translatable="false">&lt;span&gt;</string>


### PR DESCRIPTION
Fixes #16539

Internal Ref: p1652701627530289-slack-C027K4MNPGQ

/cc @osullivanchris, @jostnes  

This PR removes app name from the "Get to know the app" title on the new `Quick Start` card to reduce title length.

PS. Since the app name is removed, there's no need to keep two different strings for `Jetpack` and `WordPress` apps so the corresponding string is removed from the `Jetpack` app.

Card | Dialog
--|--
![Screenshot_20220516_175738](https://user-images.githubusercontent.com/1405144/168592701-e747f773-c58d-4dbc-81d8-7aef98b546a5.png) | ![Screenshot_20220516_175753](https://user-images.githubusercontent.com/1405144/168592719-5a142312-aa1f-4d39-81f0-e0c007e33d77.png)


To test:

1. Launch the app.
2. Logout/login and select "Show me around" when the quick start prompt is shown.
3. Select an existing site.
4. Go to `My Site` tab.
5. ✅ Notice that the new `Quick Start` card has the title `Get to know the app`.
6. Tap on `Get to know the app`.
7. ✅ Notice that the tasks list dialog is opened with the title `Get to know the app`.

## Regression Notes
1. Potential unintended areas of impact 🟢 


2. What I did to test those areas of impact (or what existing automated tests I relied on)  🟢 


3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.