### PR TITLE
Merge release/19.9 after Code Freeze

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+20.0
+-----
+
+
 19.9
 -----
 * [*] Pages List: Added "Copy Link" button to context menu [https://github.com/wordpress-mobile/WordPress-Android/pull/16321]

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,11 +1,10 @@
 * [*] Pages List: Added "Copy Link" button to context menu [https://github.com/wordpress-mobile/WordPress-Android/pull/16321]
 * [*] Editor: Improved editor performance by reducing memory usage [https://github.com/wordpress-mobile/WordPress-Android/pull/16490]
 * [*] Block Editor: Prevent non-functional '+' icon displaying in toolbar on self-hosted sites [https://github.com/wordpress-mobile/WordPress-Android/pull/16507]
-* [***] Jetpack App: Enable Site Domains purchases for Jetpack app only [https://github.com/wordpress-mobile/WordPress-Android/pull/16417]
+* [***] Enable Site Domains purchases for Jetpack app only [https://github.com/wordpress-mobile/WordPress-Android/pull/16417]
 * [**] Block Editor: Cover Block: Improve color contrast between background and text [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4808]
 * [**] Block Editor: Buttons block: Fix issue related to displaying formatting buttons after closing the block settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4814]
 * [***] Block Editor: Add drag & drop blocks feature [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4832]
 * [*] Block Editor: Gallery block: Fix broken "Link To" settings and add "Image Size" settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4841]
 * [*] Block Editor: Unsupported Block Editor: Prevent WordPress.com tour banner from displaying. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4820]
 * [*] Quick Start: We are now showing a different set of Quick Start tasks for existing sites and new sites. The existing sites checklist includes new tours such as: "Check your notifications" and "Upload photos or videos". [https://github.com/wordpress-mobile/WordPress-Android/issues/16349, https://github.com/wordpress-mobile/WordPress-Android/issues/16350, https://github.com/wordpress-mobile/WordPress-Android/pull/16505]
-

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,6 +1,6 @@
 * [*] Pages List: Added "Copy Link" button to context menu [https://github.com/wordpress-mobile/WordPress-Android/pull/16321]
 * [*] Editor: Improved editor performance by reducing memory usage [https://github.com/wordpress-mobile/WordPress-Android/pull/16490]
-* [***] Enable Site Domains purchases for Jetpack app only [https://github.com/wordpress-mobile/WordPress-Android/pull/16417]
+* [***] Enable Site Domains purchases [https://github.com/wordpress-mobile/WordPress-Android/pull/16417]
 * [**] Block Editor: Cover Block: Improve color contrast between background and text [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4808]
 * [**] Block Editor: Buttons block: Fix issue related to displaying formatting buttons after closing the block settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4814]
 * [***] Block Editor: Add drag & drop blocks feature [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4832]

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,6 +1,5 @@
 * [*] Pages List: Added "Copy Link" button to context menu [https://github.com/wordpress-mobile/WordPress-Android/pull/16321]
 * [*] Editor: Improved editor performance by reducing memory usage [https://github.com/wordpress-mobile/WordPress-Android/pull/16490]
-* [*] Block Editor: Prevent non-functional '+' icon displaying in toolbar on self-hosted sites [https://github.com/wordpress-mobile/WordPress-Android/pull/16507]
 * [***] Enable Site Domains purchases for Jetpack app only [https://github.com/wordpress-mobile/WordPress-Android/pull/16417]
 * [**] Block Editor: Cover Block: Improve color contrast between background and text [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4808]
 * [**] Block Editor: Buttons block: Fix issue related to displaying formatting buttons after closing the block settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4814]

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,8 +1,11 @@
-- Feature image settings in Latest Post block
-- HTML/Visual mode switch notices
-- Full Embed block preview
-- Locale Picker visuals
-- Longer uploads with standalone VideoPress
-- Up-to-date Atomic site previews
-- Media Picker talkback media types
-- Signup magic link URL
+* [*] Pages List: Added "Copy Link" button to context menu [https://github.com/wordpress-mobile/WordPress-Android/pull/16321]
+* [*] Editor: Improved editor performance by reducing memory usage [https://github.com/wordpress-mobile/WordPress-Android/pull/16490]
+* [*] Block Editor: Prevent non-functional '+' icon displaying in toolbar on self-hosted sites [https://github.com/wordpress-mobile/WordPress-Android/pull/16507]
+* [***] Jetpack App: Enable Site Domains purchases for Jetpack app only [https://github.com/wordpress-mobile/WordPress-Android/pull/16417]
+* [**] Block Editor: Cover Block: Improve color contrast between background and text [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4808]
+* [**] Block Editor: Buttons block: Fix issue related to displaying formatting buttons after closing the block settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4814]
+* [***] Block Editor: Add drag & drop blocks feature [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4832]
+* [*] Block Editor: Gallery block: Fix broken "Link To" settings and add "Image Size" settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4841]
+* [*] Block Editor: Unsupported Block Editor: Prevent WordPress.com tour banner from displaying. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4820]
+* [*] Quick Start: We are now showing a different set of Quick Start tasks for existing sites and new sites. The existing sites checklist includes new tours such as: "Check your notifications" and "Upload photos or videos". [https://github.com/wordpress-mobile/WordPress-Android/issues/16349, https://github.com/wordpress-mobile/WordPress-Android/issues/16350, https://github.com/wordpress-mobile/WordPress-Android/pull/16505]
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,7 +1,6 @@
 * [*] Pages List: Added "Copy Link" button to context menu [https://github.com/wordpress-mobile/WordPress-Android/pull/16321]
 * [*] Editor: Improved editor performance by reducing memory usage [https://github.com/wordpress-mobile/WordPress-Android/pull/16490]
 * [*] Block Editor: Prevent non-functional '+' icon displaying in toolbar on self-hosted sites [https://github.com/wordpress-mobile/WordPress-Android/pull/16507]
-* [***] Jetpack App: Enable Site Domains purchases for Jetpack app only [https://github.com/wordpress-mobile/WordPress-Android/pull/16417]
 * [**] Block Editor: Cover Block: Improve color contrast between background and text [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4808]
 * [**] Block Editor: Buttons block: Fix issue related to displaying formatting buttons after closing the block settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4814]
 * [***] Block Editor: Add drag & drop blocks feature [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4832]

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,10 +1,11 @@
-- Unsaved changes preview for draft posts
-- Feature image settings in Latest Post block
-- HTML/Visual mode switch notices
-- Full Embed block preview
-- Locale Picker visuals
-- Longer uploads with standalone VideoPress
-- Up-to-date Atomic site previews
-- Media Picker talkback media types
-- Non-Latin filename uploads
-- Clear feature image in post settings
+* [*] Pages List: Added "Copy Link" button to context menu [https://github.com/wordpress-mobile/WordPress-Android/pull/16321]
+* [*] Editor: Improved editor performance by reducing memory usage [https://github.com/wordpress-mobile/WordPress-Android/pull/16490]
+* [*] Block Editor: Prevent non-functional '+' icon displaying in toolbar on self-hosted sites [https://github.com/wordpress-mobile/WordPress-Android/pull/16507]
+* [***] Jetpack App: Enable Site Domains purchases for Jetpack app only [https://github.com/wordpress-mobile/WordPress-Android/pull/16417]
+* [**] Block Editor: Cover Block: Improve color contrast between background and text [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4808]
+* [**] Block Editor: Buttons block: Fix issue related to displaying formatting buttons after closing the block settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4814]
+* [***] Block Editor: Add drag & drop blocks feature [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4832]
+* [*] Block Editor: Gallery block: Fix broken "Link To" settings and add "Image Size" settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4841]
+* [*] Block Editor: Unsupported Block Editor: Prevent WordPress.com tour banner from displaying. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4820]
+* [*] Quick Start: We are now showing a different set of Quick Start tasks for existing sites and new sites. The existing sites checklist includes new tours such as: "Check your notifications" and "Upload photos or videos". [https://github.com/wordpress-mobile/WordPress-Android/issues/16349, https://github.com/wordpress-mobile/WordPress-Android/issues/16350, https://github.com/wordpress-mobile/WordPress-Android/pull/16505]
+

--- a/WordPress/metadata/release_notes_short.txt
+++ b/WordPress/metadata/release_notes_short.txt
@@ -1,8 +1,0 @@
-- Unsaved changes preview for draft posts
-- Feature image settings in Latest Post block
-- HTML/Visual mode switch notices
-- Full Embed block preview
-- Locale Picker visuals
-- Longer uploads with standalone VideoPress
-- Up-to-date Atomic site previews
-- Non-Latin filename uploads

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -26,6 +26,4 @@
 
     <!-- About button in Me -->
     <string name="me_btn_about">About Jetpack</string>
-
-    <string name="quick_start_sites_type_get_to_know_app">Get to know the Jetpack app</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3134,7 +3134,7 @@
     <string name="quick_start_sites">Next Steps</string>
     <string name="quick_start_sites_type_customize">Customize your site</string>
     <string name="quick_start_sites_type_grow">Grow your audience</string>
-    <string name="quick_start_sites_type_get_to_know_app">Get to know the WordPress app</string>
+    <string name="quick_start_sites_type_get_to_know_app">Get to know the app</string>
     <string name="quick_start_sites_type_tasks_completed">%1$s out of %2$s complete</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
     <string name="quick_start_span_start" translatable="false">&lt;span&gt;</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1266,6 +1266,9 @@
     <string name="stats_view_publicize">Publicize</string>
     <string name="stats_view_followers">Followers</string>
     <string name="stats_view_follower_totals">Follower Totals</string>
+    <string name="stats_view_total_likes">Total Likes</string>
+    <string name="stats_view_total_comments">Total Comments</string>
+    <string name="stats_view_total_followers">Total Followers</string>
 
     <!-- stats: followers -->
     <string name="stats_followers_seconds_ago">seconds ago</string>
@@ -1279,6 +1282,18 @@
     <string name="stats_followers_months">%1$d months</string>
     <string name="stats_followers_a_year">A year</string>
     <string name="stats_followers_years">%1$d years</string>
+
+    <string name="stats_published_seconds_ago">Published seconds ago</string>
+    <string name="stats_published_a_minute_ago">Published a minute ago</string>
+    <string name="stats_published_minutes_ago">Published %1$d minutes ago</string>
+    <string name="stats_published_an_hour_ago">Published an hour ago</string>
+    <string name="stats_published_hours_ago">Published %1$d hours ago</string>
+    <string name="stats_published_a_day_ago">Published a day ago</string>
+    <string name="stats_published_days_ago">Published %1$d days ago</string>
+    <string name="stats_published_a_month_ago">Published a month ago</string>
+    <string name="stats_published_months_ago">Published %1$d months ago</string>
+    <string name="stats_published_a_year_ago">Published a year ago</string>
+    <string name="stats_published_years_ago">Published %1$d years ago</string>
 
     <!-- stats: search terms -->
     <string name="stats_search_terms_unknown_search_terms">Unknown Search Terms</string>
@@ -1303,6 +1318,8 @@
     <string name="stats_insights_total_comments">Total comments</string>
     <string name="stats_insights_average_comments">Avg comments/post</string>
     <string name="stats_insights_total_likes">Total likes</string>
+    <string name="stats_insights_total_stats_positive">%1$s higher than the previous week</string>
+    <string name="stats_insights_total_stats_negative">%1$s lower than the previous week</string>
     <string name="stats_insights_average_likes">Avg likes/post</string>
     <string name="stats_insights_total_words">Total words</string>
     <string name="stats_insights_average_words">Avg words/post</string>
@@ -1349,6 +1366,7 @@
     <string name="stats_months_and_years_views_label">Views</string>
     <string name="stats_detail_average_views_per_day">Avg. Views Per Day</string>
     <string name="stats_detail_recent_weeks">Recent Weeks</string>
+    <string name="stats_details_top_commentators">Top Commentators</string>
 
     <string name="stats_posts_and_pages">Posts and Pages</string>
     <string name="stats_referrers">Referrers</string>
@@ -2730,6 +2748,7 @@
     <string name="photo_picker_use_audio">Use this audio</string>
     <string name="photo_picker_use_media">Use this media</string>
     <string name="photo_picker_image_thumbnail_content_description">Image Thumbnail</string>
+    <string name="photo_picker_video_thumbnail_content_description">Video Thumbnail</string>
     <string name="photo_picker_media_thumbnail_content_description">Media Thumbnail</string>
     <string name="photo_picker_image_thumbnail_selected">Image selected</string>
     <string name="photo_picker_video_thumbnail_selected">Video selected</string>
@@ -3054,7 +3073,9 @@
     <string name="quick_start_dialog_explore_plans_title">Explore plans</string>
     <string name="quick_start_dialog_follow_sites_message" translatable="false">@string/quick_start_list_follow_site_subtitle</string>
     <string name="quick_start_dialog_follow_sites_message_short_reader" tools:ignore="UnusedResources">Select %1$s Reader %2$s to find other sites.</string>
-    <string name="quick_start_dialog_follow_sites_message_short_settings">Select %1$s Settings %2$s to add topics you like.</string>
+    <string name="quick_start_dialog_follow_sites_message_short_discover_and_settings">Use &lt;b&gt; Discover &lt;/b&gt; to find sites and tags. Try selecting %1$s Settings %2$s to add topics you like.</string>
+    <string name="quick_start_dialog_follow_sites_message_short_discover">Use &lt;b&gt; Discover &lt;/b&gt; to find sites and tags.</string>
+    <string name="quick_start_dialog_upload_media_message_short_plus" tools:ignore="UnusedResources">Select %1$s plus %2$s to upload media. You can add it to your posts/ pages from any device.</string>
     <string name="quick_start_dialog_follow_sites_title">Connect with other sites</string>
     <string name="quick_start_dialog_publish_post_message">Draft and publish a post.</string>
     <string name="quick_start_dialog_publish_post_message_short" tools:ignore="UnusedResources">Tap %1$s Create Post %2$s to create a new post</string>
@@ -3074,10 +3095,14 @@
     <string name="quick_start_dialog_edit_homepage_title">Edit your homepage</string>
     <string name="quick_start_dialog_edit_homepage_message">Change, add, or remove content from your site\'s homepage.</string>
     <string name="quick_start_dialog_edit_homepage_message_short" tools:ignore="UnusedResources">Select %1$s Pages %2$s to see your page list.</string>
+    <string name="quick_start_dialog_check_notifications_message_short">Select the %1$s Notifications tab %2$s to get updates on the go.</string>
     <string name="quick_start_dialog_edit_homepage_message_pages_short" tools:ignore="UnusedResources">Select %1$s Homepage %2$s to edit your Homepage.</string>
     <string name="quick_start_dialog_review_pages_title">Review site pages</string>
+    <string name="quick_start_dialog_check_notifications_title">Check your notifications</string>
+    <string name="quick_start_dialog_check_notifications_message">Get real time updates from your pocket.</string>
     <string name="quick_start_dialog_review_pages_message">Change, add, or remove your site\'s pages.</string>
     <string name="quick_start_dialog_review_pages_message_short" tools:ignore="UnusedResources">Select %1$s Pages %2$s to see your page list.</string>
+    <string name="quick_start_dialog_upload_media_message">Select %1$s Media %2$s to see your current library.</string>
     <string name="quick_start_complete_tasks_header">Complete (%d)</string>
     <string name="quick_start_list_check_stats_subtitle" translatable="false">@string/quick_start_dialog_check_stats_message</string>
     <string name="quick_start_list_check_stats_title">Check your site stats</string>
@@ -3102,14 +3127,22 @@
     <string name="quick_start_list_edit_homepage_title" translatable="false">@string/quick_start_dialog_edit_homepage_title</string>
     <string name="quick_start_list_review_pages_subtitle">Check your pages and make changes, or add or remove pages.</string>
     <string name="quick_start_list_review_pages_title" translatable="false">@string/quick_start_dialog_review_pages_title</string>
+    <string name="quick_start_list_check_notification_subtitle">Get real time updates from your pocket</string>
+    <string name="quick_start_list_check_notification_title" translatable="false">@string/quick_start_dialog_check_notifications_title</string>
+    <string name="quick_start_list_upload_media_title">Upload photos or videos</string>
+    <string name="quick_start_list_upload_media_subtitle">Bring media straight from your device or camera to your site</string>
     <string name="quick_start_sites">Next Steps</string>
     <string name="quick_start_sites_type_customize">Customize your site</string>
     <string name="quick_start_sites_type_grow">Grow your audience</string>
+    <string name="quick_start_sites_type_get_to_know_app">Get to know the WordPress app</string>
     <string name="quick_start_sites_type_tasks_completed">%1$s out of %2$s complete</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
     <string name="quick_start_span_start" translatable="false">&lt;span&gt;</string>
     <string name="quick_start_focus_point_description">tap here</string>
     <string name="quick_start_site_menu_tab_message_short">Tap &lt;b&gt;%1$s&lt;/b&gt; to continue.</string>
+
+    <string name="quick_start_completed_tour_title">Congrats! You know your way around&lt;br/&gt;</string>
+    <string name="quick_start_completed_tour_subtitle">Doesn\'t it feel good to cross things off a list?</string>
 
     <string name="quick_start_card_menu_pin">Pin this</string>
     <string name="quick_start_card_menu_unpin">Unpin this</string>
@@ -3147,6 +3180,7 @@
     <string name="pages_item_date_subtitle">%1$s ·</string>
     <string name="pages_item_date_author">%1$s · %2$s</string>
     <string name="pages_item_date_author_subtitle">%1$s · %2$s ·</string>
+    <string name="pages_copy_link">Copy link</string>
 
     <string name="page_status_pending_review" translatable="false">@string/post_status_pending_review</string>
     <string name="page_status_page_private" translatable="false">@string/post_status_post_private</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -3134,7 +3134,7 @@
     <string name="quick_start_sites">Next Steps</string>
     <string name="quick_start_sites_type_customize">Customize your site</string>
     <string name="quick_start_sites_type_grow">Grow your audience</string>
-    <string name="quick_start_sites_type_get_to_know_app">Get to know the WordPress app</string>
+    <string name="quick_start_sites_type_get_to_know_app">Get to know the app</string>
     <string name="quick_start_sites_type_tasks_completed">%1$s out of %2$s complete</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
     <string name="quick_start_span_start" translatable="false">&lt;span&gt;</string>

--- a/version.properties
+++ b/version.properties
@@ -1,9 +1,9 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=19.8
-versionCode=1216
+versionName=19.9-rc-1
+versionCode=1217
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
-alpha.versionName=alpha-362
-alpha.versionCode=1215
+alpha.versionName=alpha-363
+alpha.versionCode=1218


### PR DESCRIPTION
- [x] New empty entry created in `RELEASE-NOTES.txt` for next iteration.
- [x] `{jetpack_}metadata/release_notes.txt` extracted for WordPress and Jetpack.
- [x] `WordPress/jetpack_metadata/release_notes.txt` audited to remove any item not applicable for Jetpack.
- [x] Internal dependencies (FluxC, Login. Stories. About…) bumped to a new stable version in `build.gradle` if necessary.
   - None were necessary, as everything was pointing to a stable version, and FluxC just got a stable release `1.42.0` minutes before the Code Freeze via https://github.com/wordpress-mobile/WordPress-Android/pull/16541
- [x] `WordPress/src/main/res/values/strings.xml` updated with strings from binary dependencies.
   - No new string were necessary, because [the only few library updates / PRs that happened since last code freeze were on `gutenbergMobile` (`1.75.1` -> `1.76.0`) and `fluxC` (`1.41.0` -> `1.42.0`)](https://github.com/wordpress-mobile/WordPress-Android/compare/19.8..release/19.9#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7), and none of those changed (nor introduced) any library strings. Hence no diff on `WordPress/src/main/res/values/strings.xml` post lib-merge showing in this PR.
- [x] New strings frozen/copied into `fastlane/resources/values/strings.xml`.
- [x] Version bumped in `version.properties`

---

[EDIT]
 - This PR now also includes #16559, which has been merged in the `release/19.9` branch very soon _after_ I made the code freeze and built the `19.9-rc-1`. While the changes in that PR were thus not included in the `rc-1`, that's why you're still seeing it in this PR's diff; they will be part of any next beta that I'll likely do later this sprint.
 - As #16559 included changes in the `strings.xml` to update a string copy, I've [updated the frozen the strings (`fastlane update_frozen_strings_for_translation`) on the `release/19.9` branch](https://github.com/wordpress-mobile/WordPress-Android/pull/16561/commits/375541878367a9e1fb64db007661e84105c17bdd) in order to make sure that this new copy got included in the frozen strings that will be sent for translations for 19.9.