### PR TITLE
[Site Creation] Replace Dagger with Hilt for Dependency Injection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -193,7 +193,6 @@ import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderSiteSearchResultView;
 import org.wordpress.android.ui.reader.views.ReaderTagHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderWebView;
-import org.wordpress.android.ui.sitecreation.previews.SiteCreationPreviewFragment;
 import org.wordpress.android.ui.sitecreation.services.SiteCreationService;
 import org.wordpress.android.ui.sitecreation.theme.DesignPreviewFragment;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
@@ -253,9 +252,6 @@ public interface AppComponent {
     void inject(SignupEpilogueFragment object);
 
     void inject(PostSignupInterstitialActivity object);
-
-
-    void inject(SiteCreationPreviewFragment object);
 
     void inject(JetpackConnectionResultActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -196,7 +196,6 @@ import org.wordpress.android.ui.reader.views.ReaderWebView;
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment;
 import org.wordpress.android.ui.sitecreation.previews.SiteCreationPreviewFragment;
 import org.wordpress.android.ui.sitecreation.services.SiteCreationService;
-import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameFragment;
 import org.wordpress.android.ui.sitecreation.theme.DesignPreviewFragment;
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerFragment;
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsFragment;
@@ -544,8 +543,6 @@ public interface AppComponent {
     void inject(ModalLayoutPickerFragment object);
 
     void inject(HomePagePickerFragment object);
-
-    void inject(SiteCreationSiteNameFragment object);
 
     void inject(SubfilterBottomSheetFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -197,7 +197,6 @@ import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment
 import org.wordpress.android.ui.sitecreation.previews.SiteCreationPreviewFragment;
 import org.wordpress.android.ui.sitecreation.services.SiteCreationService;
 import org.wordpress.android.ui.sitecreation.theme.DesignPreviewFragment;
-import org.wordpress.android.ui.sitecreation.theme.HomePagePickerFragment;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
 import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetBlockListProviderFactory;
@@ -540,8 +539,6 @@ public interface AppComponent {
     void inject(MainBottomSheetFragment object);
 
     void inject(ModalLayoutPickerFragment object);
-
-    void inject(HomePagePickerFragment object);
 
     void inject(SubfilterBottomSheetFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -193,7 +193,6 @@ import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderSiteSearchResultView;
 import org.wordpress.android.ui.reader.views.ReaderTagHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderWebView;
-import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment;
 import org.wordpress.android.ui.sitecreation.previews.SiteCreationPreviewFragment;
 import org.wordpress.android.ui.sitecreation.services.SiteCreationService;
 import org.wordpress.android.ui.sitecreation.theme.DesignPreviewFragment;
@@ -255,8 +254,6 @@ public interface AppComponent {
 
     void inject(PostSignupInterstitialActivity object);
 
-
-    void inject(SiteCreationDomainsFragment object);
 
     void inject(SiteCreationPreviewFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -193,7 +193,6 @@ import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderSiteSearchResultView;
 import org.wordpress.android.ui.reader.views.ReaderTagHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderWebView;
-import org.wordpress.android.ui.sitecreation.SiteCreationActivity;
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsFragment;
 import org.wordpress.android.ui.sitecreation.previews.SiteCreationPreviewFragment;
 import org.wordpress.android.ui.sitecreation.services.SiteCreationService;
@@ -259,7 +258,6 @@ public interface AppComponent {
 
     void inject(PostSignupInterstitialActivity object);
 
-    void inject(SiteCreationActivity object);
 
     void inject(SiteCreationDomainsFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -198,7 +198,6 @@ import org.wordpress.android.ui.sitecreation.previews.SiteCreationPreviewFragmen
 import org.wordpress.android.ui.sitecreation.services.SiteCreationService;
 import org.wordpress.android.ui.sitecreation.theme.DesignPreviewFragment;
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerFragment;
-import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsFragment;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
 import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment;
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetBlockListProviderFactory;
@@ -651,7 +650,7 @@ public interface AppComponent {
     void inject(EditCancelDialogFragment object);
 
     void inject(BloggingReminderBottomSheetFragment object);
-    
+
     void inject(LocalePickerBottomSheet object);
 
     void inject(CategoriesListFragment object);

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -545,8 +545,6 @@ public interface AppComponent {
 
     void inject(HomePagePickerFragment object);
 
-    void inject(SiteCreationIntentsFragment object);
-
     void inject(SiteCreationSiteNameFragment object);
 
     void inject(SubfilterBottomSheetFragment object);

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -66,7 +66,6 @@ import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewMode
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel;
 import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewModel;
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerViewModel;
-import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.DaysListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsDetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsListViewModel;
@@ -257,11 +256,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(HistoryViewModel.class)
     abstract ViewModel historyViewModel(HistoryViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(SiteCreationIntentsViewModel.class)
-    abstract ViewModel siteCreationIntentsViewModel(SiteCreationIntentsViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -64,7 +64,6 @@ import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel;
 import org.wordpress.android.ui.reader.viewmodels.SubfilterPageViewModel;
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel;
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel;
-import org.wordpress.android.ui.sitecreation.theme.HomePagePickerViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.DaysListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsDetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsListViewModel;
@@ -330,11 +329,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ModalLayoutPickerViewModel.class)
     abstract ViewModel mlpViewModel(ModalLayoutPickerViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(HomePagePickerViewModel.class)
-    abstract ViewModel hppViewModel(HomePagePickerViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -62,7 +62,6 @@ import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel;
 import org.wordpress.android.ui.reader.viewmodels.SubfilterPageViewModel;
-import org.wordpress.android.ui.sitecreation.SiteCreationMainVM;
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel;
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel;
 import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewModel;
@@ -273,11 +272,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(SiteCreationDomainsViewModel.class)
     abstract ViewModel siteCreationDomainsViewModel(SiteCreationDomainsViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(SiteCreationMainVM.class)
-    abstract ViewModel siteCreationMainVM(SiteCreationMainVM viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -62,7 +62,6 @@ import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel;
 import org.wordpress.android.ui.reader.viewmodels.SubfilterPageViewModel;
-import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel;
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.DaysListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsDetailListViewModel;
@@ -255,10 +254,6 @@ abstract class ViewModelModule {
     @ViewModelKey(HistoryViewModel.class)
     abstract ViewModel historyViewModel(HistoryViewModel viewModel);
 
-    @Binds
-    @IntoMap
-    @ViewModelKey(SiteCreationDomainsViewModel.class)
-    abstract ViewModel siteCreationDomainsViewModel(SiteCreationDomainsViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -62,7 +62,6 @@ import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel;
 import org.wordpress.android.ui.reader.viewmodels.SubfilterPageViewModel;
-import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.DaysListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsDetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsListViewModel;
@@ -253,12 +252,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(HistoryViewModel.class)
     abstract ViewModel historyViewModel(HistoryViewModel viewModel);
-
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(SitePreviewViewModel.class)
-    abstract ViewModel newSitePreviewViewModel(SitePreviewViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -64,7 +64,6 @@ import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel;
 import org.wordpress.android.ui.reader.viewmodels.SubfilterPageViewModel;
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel;
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel;
-import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewModel;
 import org.wordpress.android.ui.sitecreation.theme.HomePagePickerViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.DaysListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsDetailListViewModel;
@@ -256,11 +255,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(HistoryViewModel.class)
     abstract ViewModel historyViewModel(HistoryViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(SiteCreationSiteNameViewModel.class)
-    abstract ViewModel siteCreationSiteNameViewModel(SiteCreationSiteNameViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -7,8 +7,8 @@ import android.view.MenuItem
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.accounts.HelpActivity.Origin
@@ -48,6 +48,7 @@ import org.wordpress.android.util.wizard.WizardNavigationTarget
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
+@AndroidEntryPoint
 class SiteCreationActivity : LocaleAwareActivity(),
         IntentsScreenListener,
         SiteNameScreenListener,
@@ -66,7 +67,6 @@ class SiteCreationActivity : LocaleAwareActivity(),
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (application as WordPress).component().inject(this)
         setContentView(R.layout.site_creation_activity)
         mainViewModel = ViewModelProvider(this, viewModelFactory).get(SiteCreationMainVM::class.java)
         hppViewModel = ViewModelProvider(this, viewModelFactory).get(HomePagePickerViewModel::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
+import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -60,15 +61,14 @@ class SiteCreationActivity : LocaleAwareActivity(),
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject internal lateinit var uiHelpers: UiHelpers
     @Inject internal lateinit var siteNameFeatureConfig: SiteNameFeatureConfig
-    private lateinit var mainViewModel: SiteCreationMainVM
     private lateinit var hppViewModel: HomePagePickerViewModel
     private lateinit var siteCreationIntentsViewModel: SiteCreationIntentsViewModel
     private lateinit var siteCreationSiteNameViewModel: SiteCreationSiteNameViewModel
+    private val mainViewModel: SiteCreationMainVM by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.site_creation_activity)
-        mainViewModel = ViewModelProvider(this, viewModelFactory).get(SiteCreationMainVM::class.java)
         hppViewModel = ViewModelProvider(this, viewModelFactory).get(HomePagePickerViewModel::class.java)
         siteCreationIntentsViewModel = ViewModelProvider(this, viewModelFactory)
                 .get(SiteCreationIntentsViewModel::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -62,16 +62,14 @@ class SiteCreationActivity : LocaleAwareActivity(),
     @Inject internal lateinit var uiHelpers: UiHelpers
     @Inject internal lateinit var siteNameFeatureConfig: SiteNameFeatureConfig
     private lateinit var hppViewModel: HomePagePickerViewModel
-    private lateinit var siteCreationSiteNameViewModel: SiteCreationSiteNameViewModel
     private val mainViewModel: SiteCreationMainVM by viewModels()
     private val siteCreationIntentsViewModel: SiteCreationIntentsViewModel by viewModels()
+    private val siteCreationSiteNameViewModel: SiteCreationSiteNameViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.site_creation_activity)
         hppViewModel = ViewModelProvider(this, viewModelFactory).get(HomePagePickerViewModel::class.java)
-        siteCreationSiteNameViewModel = ViewModelProvider(this, viewModelFactory)
-                .get(SiteCreationSiteNameViewModel::class.java)
         val siteCreationSource = intent.extras?.getString(ARG_CREATE_SITE_SOURCE)
         mainViewModel.start(savedInstanceState, SiteCreationSource.fromString(siteCreationSource))
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -7,7 +7,6 @@ import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
@@ -58,18 +57,16 @@ class SiteCreationActivity : LocaleAwareActivity(),
         OnHelpClickedListener,
         BasicDialogPositiveClickInterface,
         BasicDialogNegativeClickInterface {
-    @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject internal lateinit var uiHelpers: UiHelpers
     @Inject internal lateinit var siteNameFeatureConfig: SiteNameFeatureConfig
-    private lateinit var hppViewModel: HomePagePickerViewModel
     private val mainViewModel: SiteCreationMainVM by viewModels()
+    private val hppViewModel: HomePagePickerViewModel by viewModels()
     private val siteCreationIntentsViewModel: SiteCreationIntentsViewModel by viewModels()
     private val siteCreationSiteNameViewModel: SiteCreationSiteNameViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.site_creation_activity)
-        hppViewModel = ViewModelProvider(this, viewModelFactory).get(HomePagePickerViewModel::class.java)
         val siteCreationSource = intent.extras?.getString(ARG_CREATE_SITE_SOURCE)
         mainViewModel.start(savedInstanceState, SiteCreationSource.fromString(siteCreationSource))
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -62,16 +62,14 @@ class SiteCreationActivity : LocaleAwareActivity(),
     @Inject internal lateinit var uiHelpers: UiHelpers
     @Inject internal lateinit var siteNameFeatureConfig: SiteNameFeatureConfig
     private lateinit var hppViewModel: HomePagePickerViewModel
-    private lateinit var siteCreationIntentsViewModel: SiteCreationIntentsViewModel
     private lateinit var siteCreationSiteNameViewModel: SiteCreationSiteNameViewModel
     private val mainViewModel: SiteCreationMainVM by viewModels()
+    private val siteCreationIntentsViewModel: SiteCreationIntentsViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.site_creation_activity)
         hppViewModel = ViewModelProvider(this, viewModelFactory).get(HomePagePickerViewModel::class.java)
-        siteCreationIntentsViewModel = ViewModelProvider(this, viewModelFactory)
-                .get(SiteCreationIntentsViewModel::class.java)
         siteCreationSiteNameViewModel = ViewModelProvider(this, viewModelFactory)
                 .get(SiteCreationSiteNameViewModel::class.java)
         val siteCreationSource = intent.extras?.getString(ARG_CREATE_SITE_SOURCE)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -7,6 +7,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.R
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleEmpty
@@ -45,6 +46,7 @@ data class SiteCreationState(
 
 typealias NavigationTarget = WizardNavigationTarget<SiteCreationStep, SiteCreationState>
 
+@HiltViewModel
 class SiteCreationMainVM @Inject constructor(
     private val tracker: SiteCreationTracker,
     private val wizardManager: WizardManager<SiteCreationStep>,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -24,7 +24,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
     private var searchInputWithHeader: SearchInputWithHeader? = null
-        private val viewModel: SiteCreationDomainsViewModel by activityViewModels()
+    private val viewModel: SiteCreationDomainsViewModel by activityViewModels()
 
     @Inject internal lateinit var uiHelpers: UiHelpers
     @Inject internal lateinit var displayUtils: DisplayUtilsWrapper

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -4,11 +4,11 @@ import android.content.Context
 import android.os.Bundle
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SiteCreationDomainsScreenBinding
 import org.wordpress.android.databinding.SiteCreationFormScreenBinding
 import org.wordpress.android.ui.accounts.HelpActivity
@@ -21,11 +21,11 @@ import org.wordpress.android.util.DisplayUtilsWrapper
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
+@AndroidEntryPoint
 class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
     private var searchInputWithHeader: SearchInputWithHeader? = null
-    private lateinit var viewModel: SiteCreationDomainsViewModel
+        private val viewModel: SiteCreationDomainsViewModel by activityViewModels()
 
-    @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject internal lateinit var uiHelpers: UiHelpers
     @Inject internal lateinit var displayUtils: DisplayUtilsWrapper
 
@@ -39,11 +39,6 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
         if (context !is OnHelpClickedListener) {
             throw IllegalStateException("Parent activity must implement OnHelpClickedListener.")
         }
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        (requireActivity().application as WordPress).component().inject(this)
     }
 
     override fun getContentLayout(): Int {
@@ -84,9 +79,6 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
     }
 
     private fun SiteCreationDomainsScreenBinding.initViewModel() {
-        viewModel = ViewModelProvider(this@SiteCreationDomainsFragment, viewModelFactory)
-                .get(SiteCreationDomainsViewModel::class.java)
-
         viewModel.uiState.observe(this@SiteCreationDomainsFragment, { uiState ->
             uiState?.let {
                 searchInputWithHeader?.updateHeader(requireActivity(), uiState.headerUiState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -45,6 +46,7 @@ import kotlin.properties.Delegates
 private const val THROTTLE_DELAY = 500L
 private const val ERROR_CONTEXT = "domains"
 
+@HiltViewModel
 class SiteCreationDomainsViewModel @Inject constructor(
     private val networkUtils: NetworkUtilsWrapper,
     private val dispatcher: Dispatcher,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -15,7 +15,9 @@ import android.view.View.OnLayoutChangeListener
 import android.view.animation.DecelerateInterpolator
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.FullscreenErrorWithRetryBinding
@@ -46,6 +48,7 @@ private const val ARG_DATA = "arg_site_creation_data"
 private const val SLIDE_IN_ANIMATION_DURATION = 450L
 
 @Suppress("TooManyFunctions")
+@AndroidEntryPoint
 class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
         ErrorManagedWebViewClientListener {
     /**
@@ -53,12 +56,11 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
      * automatically shows system notifications when site creation is in progress and the app is in the background.
      */
     private var serviceEventConnection: ServiceEventConnection? = null
-    private lateinit var viewModel: SitePreviewViewModel
+    private val viewModel: SitePreviewViewModel by viewModels()
     private var animatorSet: AnimatorSet? = null
     private val isLandscape: Boolean
         get() = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
 
-    @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject internal lateinit var uiHelpers: UiHelpers
 
     private var binding: SiteCreationPreviewScreenBinding? = null
@@ -75,7 +77,6 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (requireNotNull(activity).application as WordPress).component().inject(this)
         if (savedInstanceState == null) {
             // we need to manually clear the SiteCreationService state so we don't for example receive sticky events
             // from the previous run of the SiteCreation flow.
@@ -121,10 +122,6 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
     }
 
     private fun SiteCreationPreviewScreenDefaultBinding.initViewModel() {
-        viewModel = ViewModelProvider(
-                this@SiteCreationPreviewFragment,
-                viewModelFactory
-        ).get(SitePreviewViewModel::class.java)
         viewModel.uiState.observe(this@SiteCreationPreviewFragment, { uiState ->
             uiState?.let {
                 when (uiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -16,7 +16,6 @@ import android.view.animation.DecelerateInterpolator
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.ViewModelProvider
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -6,6 +6,7 @@ import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -67,6 +68,7 @@ private val loadingTexts = listOf(
         UiStringRes(R.string.new_site_creation_creating_site_loading_4)
 )
 
+@HiltViewModel
 class SitePreviewViewModel @Inject constructor(
     private val dispatcher: Dispatcher,
     private val siteStore: SiteStore,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameFragment.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.sitecreation.sitename
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,11 +8,11 @@ import android.view.inputmethod.EditorInfo
 import androidx.core.view.isInvisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.R.color
 import org.wordpress.android.R.string
-import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SiteCreationSiteNameFragmentBinding
 import org.wordpress.android.ui.sitecreation.sitename.SiteCreationSiteNameViewModel.SiteNameUiState
 import org.wordpress.android.ui.utils.HtmlMessageUtils
@@ -27,19 +26,14 @@ import javax.inject.Inject
  * Implements the Site Name UI
  */
 @Suppress("TooManyFunctions")
+@AndroidEntryPoint
 class SiteCreationSiteNameFragment : Fragment() {
-    @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject internal lateinit var uiHelper: UiHelpers
     @Inject internal lateinit var displayUtils: DisplayUtilsWrapper
     @Inject internal lateinit var htmlMessageUtils: HtmlMessageUtils
 
-    private lateinit var viewModel: SiteCreationSiteNameViewModel
+    private val viewModel: SiteCreationSiteNameViewModel by activityViewModels()
     private var binding: SiteCreationSiteNameFragmentBinding? = null
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        (requireActivity().applicationContext as WordPress).component().inject(this)
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -51,9 +45,6 @@ class SiteCreationSiteNameFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(SiteCreationSiteNameViewModel::class.java)
 
         val binding = SiteCreationSiteNameFragmentBinding.bind(view)
         this.binding = binding

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.sitecreation.sitename
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -13,6 +14,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
+@HiltViewModel
 class SiteCreationSiteNameViewModel @Inject constructor(
     private val analyticsTracker: SiteCreationTracker,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.sitecreation.theme
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -8,11 +7,12 @@ import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.appbar.AppBarLayout
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.HomePagePickerFragmentBinding
 import org.wordpress.android.ui.layoutpicker.LayoutCategoryAdapter
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState
@@ -31,6 +31,7 @@ import javax.inject.Inject
  * Implements the Home Page Picker UI
  */
 @Suppress("TooManyFunctions")
+@AndroidEntryPoint
 class HomePagePickerFragment : Fragment() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var displayUtils: DisplayUtilsWrapper
@@ -39,15 +40,10 @@ class HomePagePickerFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var thumbDimensionProvider: SiteDesignPickerDimensionProvider
     @Inject lateinit var recommendedDimensionProvider: SiteDesignRecommendedDimensionProvider
-    private lateinit var viewModel: HomePagePickerViewModel
+    private val viewModel: HomePagePickerViewModel by activityViewModels()
 
     private val siteIntent: String?
         get() = arguments?.getString(ARG_SITE_INTENT)
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        (requireActivity().applicationContext as WordPress).component().inject(this)
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -59,8 +55,6 @@ class HomePagePickerFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(HomePagePickerViewModel::class.java)
 
         savedInstanceState?.let {
             viewModel.loadSavedState(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.sitecreation.theme
 
 import androidx.lifecycle.LiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
@@ -24,6 +25,7 @@ const val defaultTemplateSlug = "default"
 
 private const val ERROR_CONTEXT = "design"
 
+@HiltViewModel
 class HomePagePickerViewModel @Inject constructor(
     override val networkUtils: NetworkUtilsWrapper,
     private val dispatcher: Dispatcher,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsFragment.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.sitecreation.verticals
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -8,10 +7,10 @@ import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
 import com.google.android.material.appbar.AppBarLayout
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SiteCreationIntentsFragmentBinding
 import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewModel.IntentsUiState
 import org.wordpress.android.ui.utils.UiHelpers
@@ -22,18 +21,13 @@ import javax.inject.Inject
  * Implements the Site Intent Question UI
  */
 @Suppress("TooManyFunctions")
+@AndroidEntryPoint
 class SiteCreationIntentsFragment : Fragment() {
-    @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject internal lateinit var uiHelper: UiHelpers
     @Inject internal lateinit var displayUtils: DisplayUtilsWrapper
 
-    private lateinit var viewModel: SiteCreationIntentsViewModel
+    private val viewModel: SiteCreationIntentsViewModel by activityViewModels()
     private var binding: SiteCreationIntentsFragmentBinding? = null
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        (requireActivity().applicationContext as WordPress).component().inject(this)
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -45,9 +39,6 @@ class SiteCreationIntentsFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(SiteCreationIntentsViewModel::class.java)
 
         val binding = SiteCreationIntentsFragmentBinding.bind(view)
         this.binding = binding

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -4,6 +4,7 @@ import android.content.res.Resources
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -17,6 +18,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
+@HiltViewModel
 class SiteCreationIntentsViewModel @Inject constructor(
     private val analyticsTracker: SiteCreationTracker,
     private val searchResultsProvider: VerticalsSearchResultsProvider,


### PR DESCRIPTION
Closes #16574

Refactors dependency injection to use Hilt instead of Dagger for activities, fragments & view models of the Site Creation flow.

To test:
- Run `optional UI/connected tests` CI step (✅ Done - Green).

- Run the following test manual testing scenarios with exploratory touches (pressing back, changing screen orientation randomly on the screens).
  If everything works as before then this PR is ok:

### 1. Site Name feature `off` (default)
1. Start the site creation flow
2. Choose a site intent or skip
3. Tap a theme to preview it
4. Tap `Choose` on the theme preview screen
5. Search for domain suggestions and choose one
6. Tap `Create Site`

### 2. Site Name feature `on`
1. Override `SiteNameFeatureConfig.isEnabled()` to return `true` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/1010c25bcfeac5854d0fcf0a5b89f78050789148/WordPress/src/main/java/org/wordpress/android/util/config/SiteNameFeatureConfig.kt#L19)
2. Start the site creation flow
3. Choose a site intent or skip
4. Enter a site name or skip
5. Tap a theme
6. Tap `Create Site` on the theme preview screen

### 3. Regression Testing - Page Layout Picker
1. Create a new site page using the blue FAB button
2. Tap a layout
3. Tap `Preview`
4. Tap `Create Page`

## Regression Notes
1. Potential unintended areas of impact
   - Page Layout Picker (Create New Page → Choose a layout)
   - Site creation flow (steps before & after the updated screens)

6. What I did to test those areas of impact (or what existing automated tests I relied on)
   - Manual testing

8. What automated tests I added (or what prevented me from doing so)
   - This PR introduces dependency injection changes — this should not incur changes to automated tests.

## Review Notes
- One reviewer should be enough.
- I also requested a review from @irfano for a quick check that everything is ok, but we already discussed these changes before so it's not a must.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
