### PR TITLE
Quick Start for Existing Users V2: Hide quick start for self-hosted sites 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
@@ -26,7 +26,8 @@ class QuickStartCardSource @Inject constructor(
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<QuickStartUpdate> {
         quickStartRepository.resetTask()
-        if (selectedSiteRepository.getSelectedSite()?.showOnFront == ShowOnFront.POSTS.value &&
+        val selectedSite = selectedSiteRepository.getSelectedSite()
+        if (selectedSite?.showOnFront == ShowOnFront.POSTS.value &&
                 !quickStartStore.hasDoneTask(siteLocalId.toLong(), EDIT_HOMEPAGE)) {
             quickStartRepository.setTaskDoneAndTrack(EDIT_HOMEPAGE, siteLocalId)
             refresh()
@@ -41,7 +42,9 @@ class QuickStartCardSource @Inject constructor(
         }
         return merge(quickStartTaskTypes, quickStartRepository.activeTask) { types, activeTask ->
             val categories =
-                    if (quickStartRepository.quickStartType
+                    if (selectedSite != null &&
+                            quickStartUtilsWrapper.isQuickStartAvailableForTheSite(selectedSite) &&
+                            quickStartRepository.quickStartType
                                     .isQuickStartInProgress(quickStartStore, siteLocalId.toLong())) {
                         types?.map { quickStartRepository.buildQuickStartCategory(siteLocalId, it) }
                                 ?.filter { !isEmptyCategory(siteLocalId, it.taskType) } ?: listOf()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
@@ -90,6 +90,7 @@ class QuickStartCardSourceTest : BaseUnitTest() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(appPrefsWrapper.getLastSelectedQuickStartType()).thenReturn(NewSiteQuickStartType)
         whenever(quickStartExistingUsersV2FeatureConfig.isEnabled()).thenReturn(false)
+        whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(true)
         quickStartRepository = QuickStartRepository(
                 TEST_DISPATCHER,
                 quickStartStore,
@@ -365,6 +366,28 @@ class QuickStartCardSourceTest : BaseUnitTest() {
         quickStartCardSource.refresh()
 
         assertThat(isRefreshing.last()).isFalse
+    }
+
+    @Test
+    fun `given quick start available for site, when source is refreshed, then non empty categories returned`() = test {
+        whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(true)
+        initStore()
+
+        quickStartCardSource.refresh()
+
+        val update = result.last()
+        assertThat(update.categories).isNotEmpty
+    }
+
+    @Test
+    fun `given quick start not available for site, when source is refreshed, then empty categories returned`() = test {
+        whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(false)
+        initStore()
+
+        quickStartCardSource.refresh()
+
+        val update = result.last()
+        assertThat(update.categories).isEmpty()
     }
 
     private fun triggerQSRefreshAfterSameTypeTasksAreComplete() {


### PR DESCRIPTION
Parent #16347

This PR hides the `Quick Start` for self-hosted sites not using `wpcom` rest API. While the `Quick Start` card was not shown for self-hosted sites after login, it appeared on refreshing the screen.

Related iOS issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/18547

https://user-images.githubusercontent.com/1405144/168803057-9cba436f-648d-4623-8f3d-de63284689ac.mp4

### To test

1. Launch the app.
2. Login using self-hosted site address.
3. Select the site from the Login Epilogue.
4. Notice that `Quick Start` card is not displayed on the `My Site` screen.
5. Pull-to-refresh.
6. Notice that `Quick Start` card is not displayed on the `My Site` screen.

### Merge Instructions

Targets code-frozen `release/19.9` branch.
/cc @AliSoftware 

## Regression Notes
1. Potential unintended areas of impact 
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
See `To Test` section.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for `QuickStartCardSource` to return non-empty quick start categories (needed for building the card ) only if quick start is available for the selected site.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
