### PR TITLE
Add Proguard rules for React Native's Reanimated library

### DIFF
--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -72,6 +72,9 @@
 
 -keep class com.facebook.hermes.unicode.** { *; }
 -keep class com.facebook.jni.** { *; }
+
+-keep class com.swmansion.reanimated.** { *; }
+-keep class com.facebook.react.turbomodule.** { *; }
 ###### React Native - end
 
 ###### Encrypted Logs - begin


### PR DESCRIPTION
This PR fixes a crash related to dragging a block in the editor.

- [Sentry event](https://sentry.io/share/issue/f054f67767cc4ee8ba3815cc9d0fb233/)

## To test

**Preparation:**

Proguard rules are only applied in the release version, so in order to test the change properly, it's required either to build the app in release mode or build the app locally and enable Proguard by applying the following patch.

```diff
diff --git a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
index 2958b8947312f5fad0aa26edf94d6b52855961c2..12c3f2e9d20c0a878545b27277fa74c4452abc0f 100644
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -126,7 +126,7 @@ public class GutenbergContainerFragment extends Fragment {
         mWPAndroidGlueCode.onCreateView(
                 getContext(),
                 getActivity().getApplication(),
-                BuildConfig.DEBUG,
+                false,
                 getContext().getResources().getColor(R.color.background_color),
                 exceptionLogger,
                 breadcrumbLogger,
diff --git a/WordPress/build.gradle b/WordPress/build.gradle
index c2ffda71dc2f6c77f3f16218e0a25d7c034338cd..303a8f8704238d937fafd87a963c9b17fb4703fd 100644
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -250,8 +250,8 @@ android {
         }
 
         debug {
-            minifyEnabled false
-            buildConfigField "String", "APP_PN_KEY", "\"org.wordpress.android.debug.build\""
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
         }
     }
 
@@ -666,4 +666,4 @@ if (project.hasProperty("debugStoreFile")) {
 
 // Keep this at the bottom (https://stackoverflow.com/a/37565535)
 apply plugin: 'com.google.gms.google-services'
-apply plugin: 'io.sentry.android.gradle'
+// apply plugin: 'io.sentry.android.gradle'
```

**Testing instructions:**

1. Open a post/page
2. Add some blocks.
3. Long-press over a block to start the drag mode.
4. Observe that **the app does not crash**.
5. Observe that the block can be moved around the block list.
6. Drop the block in the desired location.
7. Observe that the block is moved to the desired location.

## Regression Notes
1. Potential unintended areas of impact
This PR only adds a couple of Proguard rules so there are no potential unintended areas of impact.

8. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

9. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
