### PR TITLE
Adds feature config for fetching beta site designs

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -127,6 +127,7 @@ android {
         buildConfigField "boolean", "STATS_REVAMP_V2", "false"
         buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"
         buildConfigField "boolean", "QRCODE_AUTH_FLOW", "false"
+        buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchHomePageLayoutsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchHomePageLayoutsUseCase.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.store.ThemeStore
 import org.wordpress.android.fluxc.store.ThemeStore.FetchStarterDesignsPayload
 import org.wordpress.android.fluxc.store.ThemeStore.OnStarterDesignsFetched
 import org.wordpress.android.ui.layoutpicker.ThumbDimensionProvider
+import org.wordpress.android.util.config.BetaSiteDesignsFeatureConfig
 import javax.inject.Inject
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
@@ -16,7 +17,8 @@ import kotlin.coroutines.suspendCoroutine
 class FetchHomePageLayoutsUseCase @Inject constructor(
     val dispatcher: Dispatcher,
     @Suppress("unused") val themeStore: ThemeStore,
-    private val thumbDimensionProvider: ThumbDimensionProvider
+    private val thumbDimensionProvider: ThumbDimensionProvider,
+    private val betaSiteDesigns: BetaSiteDesignsFeatureConfig
 ) {
     private var continuation: Continuation<OnStarterDesignsFetched>? = null
 
@@ -24,7 +26,12 @@ class FetchHomePageLayoutsUseCase @Inject constructor(
         if (continuation != null) {
             throw IllegalStateException("Fetch already in progress.")
         }
-        val payload = FetchStarterDesignsPayload(
+        val payload = if (betaSiteDesigns.isEnabled()) FetchStarterDesignsPayload(
+                thumbDimensionProvider.previewWidth.toFloat(),
+                thumbDimensionProvider.previewHeight.toFloat(),
+                thumbDimensionProvider.scale.toFloat(),
+                "stable", "beta"
+        ) else FetchStarterDesignsPayload(
                 thumbDimensionProvider.previewWidth.toFloat(),
                 thumbDimensionProvider.previewHeight.toFloat(),
                 thumbDimensionProvider.scale.toFloat()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchHomePageLayoutsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchHomePageLayoutsUseCase.kt
@@ -20,6 +20,10 @@ class FetchHomePageLayoutsUseCase @Inject constructor(
     private val thumbDimensionProvider: ThumbDimensionProvider,
     private val betaSiteDesigns: BetaSiteDesignsFeatureConfig
 ) {
+    enum class GROUP(val key: String) {
+        STABLE("stable"),
+        BETA("beta")
+    }
     private var continuation: Continuation<OnStarterDesignsFetched>? = null
 
     suspend fun fetchStarterDesigns(): OnStarterDesignsFetched {
@@ -30,7 +34,7 @@ class FetchHomePageLayoutsUseCase @Inject constructor(
                 thumbDimensionProvider.previewWidth.toFloat(),
                 thumbDimensionProvider.previewHeight.toFloat(),
                 thumbDimensionProvider.scale.toFloat(),
-                "stable", "beta"
+                GROUP.STABLE.key, GROUP.BETA.key
         ) else FetchStarterDesignsPayload(
                 thumbDimensionProvider.previewWidth.toFloat(),
                 thumbDimensionProvider.previewHeight.toFloat(),

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BetaSiteDesignsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BetaSiteDesignsFeatureConfig.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration of the Site Name step in the Site Creation flow
+ */
+@FeatureInDevelopment
+class BetaSiteDesignsFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.BETA_SITE_DESIGNS)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/FetchHomePageLayoutsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/FetchHomePageLayoutsUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
@@ -17,10 +18,12 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
 import org.wordpress.android.fluxc.store.ThemeStore
+import org.wordpress.android.fluxc.store.ThemeStore.FetchStarterDesignsPayload
 import org.wordpress.android.fluxc.store.ThemeStore.OnStarterDesignsFetched
 import org.wordpress.android.test
 import org.wordpress.android.ui.layoutpicker.ThumbDimensionProvider
 import org.wordpress.android.ui.sitecreation.usecases.FetchHomePageLayoutsUseCase
+import org.wordpress.android.util.config.BetaSiteDesignsFeatureConfig
 
 @RunWith(MockitoJUnitRunner::class)
 class FetchHomePageLayoutsUseCaseTest {
@@ -30,6 +33,7 @@ class FetchHomePageLayoutsUseCaseTest {
     @Mock lateinit var dispatcher: Dispatcher
     @Mock lateinit var store: ThemeStore
     @Mock lateinit var thumbDimensionProvider: ThumbDimensionProvider
+    @Mock lateinit var betaSiteDesigns: BetaSiteDesignsFeatureConfig
 
     private lateinit var useCase: FetchHomePageLayoutsUseCase
     private lateinit var dispatchCaptor: KArgumentCaptor<Action<SuggestDomainsPayload>>
@@ -37,7 +41,7 @@ class FetchHomePageLayoutsUseCaseTest {
 
     @Before
     fun setUp() {
-        useCase = FetchHomePageLayoutsUseCase(dispatcher, store, thumbDimensionProvider)
+        useCase = FetchHomePageLayoutsUseCase(dispatcher, store, thumbDimensionProvider, betaSiteDesigns)
         dispatchCaptor = argumentCaptor()
     }
 
@@ -47,5 +51,30 @@ class FetchHomePageLayoutsUseCaseTest {
         val resultEvent = useCase.fetchStarterDesigns()
         verify(dispatcher).dispatch(dispatchCaptor.capture())
         Assert.assertEquals(event, resultEvent)
+    }
+
+    @Test
+    fun `when beta site designs are enabled the stable and beta groups are passed to the call`() = test {
+        whenever(dispatcher.dispatch(any())).then { useCase.onStarterDesignsFetched(event) }
+        whenever(betaSiteDesigns.isEnabled()).thenReturn(true)
+        useCase.fetchStarterDesigns()
+        verify(dispatcher).dispatch(dispatchCaptor.capture())
+        assertThat(requireNotNull(dispatchCaptor.firstValue.payload as FetchStarterDesignsPayload).groups).isEqualTo(
+                arrayOf(
+                        "stable",
+                        "beta"
+                )
+        )
+    }
+
+    @Test
+    fun `when beta site designs are disabled no groups are passed to the call`() = test {
+        whenever(dispatcher.dispatch(any())).then { useCase.onStarterDesignsFetched(event) }
+        whenever(betaSiteDesigns.isEnabled()).thenReturn(false)
+        useCase.fetchStarterDesigns()
+        verify(dispatcher).dispatch(dispatchCaptor.capture())
+        assertThat(requireNotNull(dispatchCaptor.firstValue.payload as FetchStarterDesignsPayload).groups).isEqualTo(
+                emptyArray<String>()
+        )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/FetchHomePageLayoutsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/FetchHomePageLayoutsUseCaseTest.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.store.ThemeStore.OnStarterDesignsFetched
 import org.wordpress.android.test
 import org.wordpress.android.ui.layoutpicker.ThumbDimensionProvider
 import org.wordpress.android.ui.sitecreation.usecases.FetchHomePageLayoutsUseCase
+import org.wordpress.android.ui.sitecreation.usecases.FetchHomePageLayoutsUseCase.GROUP
 import org.wordpress.android.util.config.BetaSiteDesignsFeatureConfig
 
 @RunWith(MockitoJUnitRunner::class)
@@ -61,8 +62,8 @@ class FetchHomePageLayoutsUseCaseTest {
         verify(dispatcher).dispatch(dispatchCaptor.capture())
         assertThat(requireNotNull(dispatchCaptor.firstValue.payload as FetchStarterDesignsPayload).groups).isEqualTo(
                 arrayOf(
-                        "stable",
-                        "beta"
+                        GROUP.STABLE.key,
+                        GROUP.BETA.key
                 )
         )
     }


### PR DESCRIPTION
## Description
Adds feature config for fetching beta site designs

To test:
1. Enable the BetaSiteDesignsFeature from the Debug settings of the app
2. Start the site creation
3. Verify that the correct designs are fetched

Note:
* You can test with a sandbox pointing at `D80579-code`
* Testing with the site design revamp feature can be performed from https://github.com/wordpress-mobile/WordPress-Android/pull/16592

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

6. What automated tests I added (or what prevented me from doing so)
Added tests unit tests validating that the correct `group` value is passed to the API

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
