### PR TITLE
Quick Start for Existing Users V2: Mark reader task as done when user taps on a tag 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -102,7 +102,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
 
     override fun onPause() {
         super.onPause()
-        viewModel.onScreenInBackground(activity?.isChangingConfigurations)
+        activity?.let { viewModel.onScreenInBackground(it.isChangingConfigurations) }
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -66,6 +66,7 @@ class ReaderInterestsViewModel @Inject constructor(
         this.currentLanguage = currentLanguage
         this.parentViewModel = parentViewModel
         this.entryPoint = entryPoint
+        parentViewModel?.dismissQuickStartSnackbarIfNeeded()
         loadUserTags()
     }
 
@@ -166,6 +167,8 @@ class ReaderInterestsViewModel @Inject constructor(
                             )
                     )
             )
+
+            parentViewModel?.completeQuickStartFollowSiteTaskIfNeeded()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -238,10 +238,10 @@ class ReaderViewModel @Inject constructor(
         }
     }
 
-    fun onScreenInBackground(isChangingConfigurations: Boolean?) {
+    fun onScreenInBackground(isChangingConfigurations: Boolean) {
         readerTracker.stop(MAIN_READER)
         wasPaused = true
-        if (isChangingConfigurations == false) {
+        if (!isChangingConfigurations) {
             dismissQuickStartSnackbarIfNeeded()
             if (quickStartRepository.isPendingTask(getFollowSiteTask())) {
                 quickStartRepository.clearPendingTask()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -242,6 +242,7 @@ class ReaderViewModel @Inject constructor(
         readerTracker.stop(MAIN_READER)
         wasPaused = true
         if (!isChangingConfigurations) {
+            hideQuickStartFocusPointIfNeeded()
             dismissQuickStartSnackbarIfNeeded()
             if (quickStartRepository.isPendingTask(getFollowSiteTask())) {
                 quickStartRepository.clearPendingTask()
@@ -311,7 +312,7 @@ class ReaderViewModel @Inject constructor(
     fun completeQuickStartFollowSiteTaskIfNeeded() {
         if (quickStartRepository.isPendingTask(getFollowSiteTask())) {
             selectedSiteRepository.getSelectedSite()?.let {
-                updateContentUiState(showQuickStartFocusPoint = false)
+                hideQuickStartFocusPointIfNeeded()
                 quickStartRepository.completeTask(getFollowSiteTask())
             }
         }
@@ -320,6 +321,13 @@ class ReaderViewModel @Inject constructor(
     fun dismissQuickStartSnackbarIfNeeded() {
         if (isQuickStartPromptShown) snackbarSequencer.dismissLastSnackbar()
         isQuickStartPromptShown = false
+    }
+
+    private fun hideQuickStartFocusPointIfNeeded() {
+        val currentUiState = _uiState.value as? ContentUiState
+        if (currentUiState?.settingsMenuItemUiState?.showQuickStartFocusPoint == true) {
+            updateContentUiState(showQuickStartFocusPoint = false)
+        }
     }
 
     private fun getFollowSiteTask() =

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -217,9 +217,7 @@ class ReaderViewModel @Inject constructor(
 
     fun onSettingsActionClicked() {
         if (isSettingsSupported()) {
-            if (quickStartRepository.isPendingTask(getFollowSiteTask())) {
-                selectedSiteRepository.getSelectedSite()?.let { completeQuickStartFollowSiteTask() }
-            }
+            completeQuickStartFollowSiteTaskIfNeeded()
             _showSettings.value = Event(Unit)
         } else if (BuildConfig.DEBUG) {
             throw IllegalStateException("Settings should be hidden when isSettingsSupported returns false.")
@@ -244,9 +242,7 @@ class ReaderViewModel @Inject constructor(
         readerTracker.stop(MAIN_READER)
         wasPaused = true
         if (isChangingConfigurations == false) {
-            updateContentUiState(showQuickStartFocusPoint = false)
-            if (isQuickStartPromptShown) snackbarSequencer.dismissLastSnackbar()
-            isQuickStartPromptShown = false
+            dismissQuickStartSnackbarIfNeeded()
             if (quickStartRepository.isPendingTask(getFollowSiteTask())) {
                 quickStartRepository.clearPendingTask()
             }
@@ -312,9 +308,18 @@ class ReaderViewModel @Inject constructor(
         updateContentUiState(showQuickStartFocusPoint = isSettingsSupported())
     }
 
-    private fun completeQuickStartFollowSiteTask() {
-        updateContentUiState(showQuickStartFocusPoint = false)
-        quickStartRepository.completeTask(getFollowSiteTask())
+    fun completeQuickStartFollowSiteTaskIfNeeded() {
+        if (quickStartRepository.isPendingTask(getFollowSiteTask())) {
+            selectedSiteRepository.getSelectedSite()?.let {
+                updateContentUiState(showQuickStartFocusPoint = false)
+                quickStartRepository.completeTask(getFollowSiteTask())
+            }
+        }
+    }
+
+    fun dismissQuickStartSnackbarIfNeeded() {
+        if (isQuickStartPromptShown) snackbarSequencer.dismissLastSnackbar()
+        isQuickStartPromptShown = false
     }
 
     private fun getFollowSiteTask() =

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -329,6 +329,20 @@ class ReaderInterestsViewModelTest {
             }
 
     @Test
+    fun `when interest tag is toggled, then complete follow site quick start task if needed is invoked`() =
+            testWithEmptyUserTags {
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
+                val selectInterestAtIndex = 2
+
+                initViewModel()
+                viewModel.onInterestAtIndexToggled(index = selectInterestAtIndex, isChecked = true)
+
+                // Then
+                verify(parentViewModel).completeQuickStartFollowSiteTaskIfNeeded()
+            }
+
+    @Test
     fun `done button shown in enabled state if an interest is in selected state`() =
             testWithEmptyUserTags {
                 // Given


### PR DESCRIPTION
Parent #16347

The reader task can now be marked as completed by either tapping the settings button or tapping on any topic in the discover onboarding screen.

Corresponding iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/18590

https://user-images.githubusercontent.com/1405144/169009916-7b19a71e-9dce-4d28-9fa3-21bbf33065af.mp4

## To Test

### Complete reader task on interest tag tap

1. Make sure to have no topics followed
2. Enable Quick Start for an existing site
3. Start the Reader task
4. Navigate to Reader
5. Tap on `Get Started` to follow topics
6. Notice that the notice gets dismissed
7. Tap on any topic
8. Go back and notice that the settings icon doesn't have quick start focus point and the task is marked as complete.

### Complete reader task on settings button tap

1. Enable Quick Start for an existing site
2. Start the Reader task
3. Navigate to Reader
4. Tap on the Settings button
5. Notice that the quick start notice gets dismissed
6. Notice that the quick start focus point on the settings button gets hidden
8. Go back and notice that the task is marked as completed

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
