### PR TITLE
Add package info to release/AndroidManifest to fix crash-on-launch in Jetpack

### DIFF
--- a/WordPress/src/release/AndroidManifest.xml
+++ b/WordPress/src/release/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="org.wordpress.android">
     <!-- This needs to be explictly removed because React Native adds it for all build types
          See https://github.com/facebook/react-native/issues/5886 -->
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:node="remove"/>


### PR DESCRIPTION
This is hotfix for 19.8.1, Jetpack app is crashing at opening. The reason is [hilt migration PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16143)

To test:
Please test WordPress and Jetpack **release** build on your computer, ensure they're not crashing at the opening. I tested debug builds but I couldn't test the release variant because of my missing local configuration.

## Regression Notes
1. Potential unintended areas of impact
Other variants. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested debug builds, but couldn't test release variant.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
