### PR TITLE
Use shared Gradle dependency cache from dependency catalog

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Note that as the script is sourced, not run directly, the shebang line will be ignored
+# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+
+set -e
+
+restore_gradle_dependency_cache || true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.1.0
+    - automattic/bash-cache#2.4.0
 
 steps:
   - label: "checkstyle"


### PR DESCRIPTION
This PR adds a `pre-command` Buildkite hook which restores the our global Gradle dependency cache we create from https://github.com/Automattic/android-dependency-catalog/ project. It uses the `restore_gradle_dependency_cache` script introduced in https://github.com/Automattic/bash-cache-buildkite-plugin/pull/25 which includes more information about how our caching works. Errors during cache restoration will not halt the builds since it's optional.

**To test:**


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
