### PR TITLE
QRCode Auth: Add scan login code to Me view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -175,7 +175,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             rowScanLoginCode.isVisible = true
 
             rowScanLoginCode.setOnClickListener {
-                viewModel.showQrcodeScan()
+                viewModel.showScanLoginCode()
             }
         }
 
@@ -198,8 +198,8 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             manageRecommendUiState(it)
         })
 
-        viewModel.showQrcodeScan.observeEvent(viewLifecycleOwner) {
-            ToastUtils.showToast(requireContext(), "Scan qrcode not available yet")
+        viewModel.showScanLoginCode.observeEvent(viewLifecycleOwner) {
+            ToastUtils.showToast(requireContext(), "Scan login code not available yet")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -172,9 +172,9 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         }
 
         if (qrCodeAuthFlowFeatureConfig.isEnabled()) {
-            rowQrcodeScan.isVisible = true
+            rowScanLoginCode.isVisible = true
 
-            rowQrcodeScan.setOnClickListener {
+            rowScanLoginCode.setOnClickListener {
                 viewModel.showQrcodeScan()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -64,6 +64,7 @@ import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import org.wordpress.android.util.WPMediaUtils
+import org.wordpress.android.util.config.QRCodeAuthFlowFeatureConfig
 import org.wordpress.android.util.config.RecommendTheAppFeatureConfig
 import org.wordpress.android.util.config.UnifiedAboutFeatureConfig
 import org.wordpress.android.util.extensions.getColorFromAttribute
@@ -88,6 +89,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     @Inject lateinit var recommendTheAppFeatureConfig: RecommendTheAppFeatureConfig
     @Inject lateinit var sequencer: SnackbarSequencer
     @Inject lateinit var unifiedAboutFeatureConfig: UnifiedAboutFeatureConfig
+    @Inject lateinit var qrCodeAuthFlowFeatureConfig: QRCodeAuthFlowFeatureConfig
     private lateinit var viewModel: MeViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -169,6 +171,14 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
+        if (qrCodeAuthFlowFeatureConfig.isEnabled()) {
+            rowQrcodeScan.isVisible = true
+
+            rowQrcodeScan.setOnClickListener {
+                viewModel.showQrcodeScan()
+            }
+        }
+
         initRecommendUiState()
 
         viewModel.showUnifiedAbout.observeEvent(viewLifecycleOwner, {
@@ -187,6 +197,10 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
             manageRecommendUiState(it)
         })
+
+        viewModel.showQrcodeScan.observeEvent(viewLifecycleOwner) {
+            ToastUtils.showToast(requireContext(), "Scan qrcode not available yet")
+        }
     }
 
     private fun MeFragmentBinding.setRecommendLoadingState(startShimmer: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
@@ -43,8 +43,8 @@ class MeViewModel
     private val _showUnifiedAbout = MutableLiveData<Event<Boolean>>()
     val showUnifiedAbout: LiveData<Event<Boolean>> = _showUnifiedAbout
 
-    private val _showQrcodeScan = MutableLiveData<Event<Boolean>>()
-    val showQrcodeScan: LiveData<Event<Boolean>> = _showQrcodeScan
+    private val _showScanLoginCode = MutableLiveData<Event<Boolean>>()
+    val showScanLoginCode: LiveData<Event<Boolean>> = _showScanLoginCode
 
     data class RecommendAppUiState(
         val showLoading: Boolean = false,
@@ -85,8 +85,8 @@ class MeViewModel
         _showUnifiedAbout.value = Event(true)
     }
 
-    fun showQrcodeScan() {
-        _showQrcodeScan.value = Event(true)
+    fun showScanLoginCode() {
+        _showScanLoginCode.value = Event(true)
     }
 
     fun onRecommendTheApp() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
@@ -43,6 +43,9 @@ class MeViewModel
     private val _showUnifiedAbout = MutableLiveData<Event<Boolean>>()
     val showUnifiedAbout: LiveData<Event<Boolean>> = _showUnifiedAbout
 
+    private val _showQrcodeScan = MutableLiveData<Event<Boolean>>()
+    val showQrcodeScan: LiveData<Event<Boolean>> = _showQrcodeScan
+
     data class RecommendAppUiState(
         val showLoading: Boolean = false,
         val error: String? = null,
@@ -80,6 +83,10 @@ class MeViewModel
 
     fun showUnifiedAbout() {
         _showUnifiedAbout.value = Event(true)
+    }
+
+    fun showQrcodeScan() {
+        _showQrcodeScan.value = Event(true)
     }
 
     fun onRecommendTheApp() {

--- a/WordPress/src/main/res/drawable/ic_baseline_qr_code_scanner_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_baseline_qr_code_scanner_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9.5,6.5v3h-3v-3H9.5M11,5H5v6h6V5L11,5zM9.5,14.5v3h-3v-3H9.5M11,13H5v6h6V13L11,13zM17.5,6.5v3h-3v-3H17.5M19,5h-6v6h6V5L19,5zM13,13h1.5v1.5H13V13zM14.5,14.5H16V16h-1.5V14.5zM16,13h1.5v1.5H16V13zM13,16h1.5v1.5H13V16zM14.5,17.5H16V19h-1.5V17.5zM16,16h1.5v1.5H16V16zM17.5,14.5H19V16h-1.5V14.5zM17.5,17.5H19V19h-1.5V17.5zM22,7h-2V4h-3V2h5V7zM22,22v-5h-2v3h-3v2H22zM2,22h5v-2H4v-3H2V22zM2,2v5h2V4h3V2H2z"/>
+</vector>

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -163,21 +163,21 @@
             <View style="@style/MeListSectionDividerView" />
 
             <LinearLayout
-                android:id="@+id/row_qrcode_scan"
+                android:id="@+id/row_scan_login_code"
                 style="@style/MeListRowLayout"
                 android:visibility="gone"
                 tools:visibility="visible">
 
                 <ImageView
-                    android:id="@+id/me_qrcode_scan_icon"
+                    android:id="@+id/me_scan_login_code_icon"
                     style="@style/MeListRowIcon"
                     android:contentDescription="@null"
                     android:src="@drawable/ic_baseline_qr_code_scanner_white_24dp" />
 
                 <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/me_app_qrcode_scan_text_view"
+                    android:id="@+id/me_scan_login_code_text_view"
                     style="@style/MeListRowTextView"
-                    android:text="@string/me_btn_qrcode_scan" />
+                    android:text="@string/me_btn_scan_login_code" />
 
             </LinearLayout>
 

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -163,25 +163,6 @@
             <View style="@style/MeListSectionDividerView" />
 
             <LinearLayout
-                android:id="@+id/row_app_settings"
-                style="@style/MeListRowLayout">
-
-                <ImageView
-                    android:id="@+id/me_app_settings_icon"
-                    style="@style/MeListRowIcon"
-                    android:contentDescription="@null"
-                    android:src="@drawable/ic_phone_white_24dp" />
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/me_app_settings_text_view"
-                    style="@style/MeListRowTextView"
-                    android:text="@string/me_btn_app_settings" />
-
-            </LinearLayout>
-
-            <View style="@style/MeListSectionDividerView" />
-
-            <LinearLayout
                 android:id="@+id/row_qrcode_scan"
                 style="@style/MeListRowLayout"
                 android:visibility="gone"
@@ -200,6 +181,24 @@
 
             </LinearLayout>
 
+            <View style="@style/MeListSectionDividerView" />
+
+            <LinearLayout
+                android:id="@+id/row_app_settings"
+                style="@style/MeListRowLayout">
+
+                <ImageView
+                    android:id="@+id/me_app_settings_icon"
+                    style="@style/MeListRowIcon"
+                    android:contentDescription="@null"
+                    android:src="@drawable/ic_phone_white_24dp" />
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/me_app_settings_text_view"
+                    style="@style/MeListRowTextView"
+                    android:text="@string/me_btn_app_settings" />
+
+            </LinearLayout>
 
             <View style="@style/MeListSectionDividerView" />
 

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -182,6 +182,28 @@
             <View style="@style/MeListSectionDividerView" />
 
             <LinearLayout
+                android:id="@+id/row_qrcode_scan"
+                style="@style/MeListRowLayout"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <ImageView
+                    android:id="@+id/me_qrcode_scan_icon"
+                    style="@style/MeListRowIcon"
+                    android:contentDescription="@null"
+                    android:src="@drawable/ic_baseline_qr_code_scanner_white_24dp" />
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/me_app_qrcode_scan_text_view"
+                    style="@style/MeListRowTextView"
+                    android:text="@string/me_btn_qrcode_scan" />
+
+            </LinearLayout>
+
+
+            <View style="@style/MeListSectionDividerView" />
+
+            <LinearLayout
                 android:id="@+id/row_support"
                 style="@style/MeListRowLayout">
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2323,7 +2323,7 @@
     <string name="me_btn_login_logout">Login/Logout</string>
     <string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
     <string name="me_disconnect_from_wordpress_com">Log out of WordPress.com</string>
-    <string name="me_btn_qrcode_scan">Scan QR code</string>
+    <string name="me_btn_qrcode_scan">Scan Login Code</string>
 
     <!--TabBar Accessibility Labels-->
     <string name="tabbar_accessibility_label_my_site">My Site. View your site and manage it, including stats.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2323,7 +2323,7 @@
     <string name="me_btn_login_logout">Login/Logout</string>
     <string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
     <string name="me_disconnect_from_wordpress_com">Log out of WordPress.com</string>
-    <string name="me_btn_qrcode_scan">Scan Login Code</string>
+    <string name="me_btn_scan_login_code">Scan Login Code</string>
 
     <!--TabBar Accessibility Labels-->
     <string name="tabbar_accessibility_label_my_site">My Site. View your site and manage it, including stats.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2323,6 +2323,7 @@
     <string name="me_btn_login_logout">Login/Logout</string>
     <string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
     <string name="me_disconnect_from_wordpress_com">Log out of WordPress.com</string>
+    <string name="me_btn_qrcode_scan">Scan QR code</string>
 
     <!--TabBar Accessibility Labels-->
     <string name="tabbar_accessibility_label_my_site">My Site. View your site and manage it, including stats.</string>


### PR DESCRIPTION
Parent #16481 

This PR adds the "Scan Login Code" option to the me view to support WP.com logins. This introduces the foundation for starting the Scan Login Code Auth flow, but does not implement it. That will come in a later PR once the scanning methodology has been decided upon.

Note: There is an opportunity to refactor the MeFragment so that feature flag checks happen in the VM for testability, but it was out of scope for this PR. I added this as a "nice to have" item to the parent issue.

**To test:**
- Do a fresh install
- Launch the app and login
- Navigate to Me
- ✅  Verify "Scan Login Code" is not visible on the Me View
- From the Me view, navigate to App Settings -> Debug Settings
- Scroll down to QRCodeAuthFlowFeatureConfig and enable it
- Restart the App
- Navigate back to Me
- ✅  Verify "Scan Login Code" is visible on the Me View
- Tap the `Scan Login Code` row
- ✅  Verify `scan login code not available` toast is shown


## Regression Notes
1. Potential unintended areas of impact
The Scan Row shows when it shouldn't

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
No testing on fragment. 

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
