### PR TITLE
[Site Design Revamp] Sets the loading skeleton to the size of the recommended row

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -83,9 +83,12 @@ class HomePagePickerFragment : Fragment() {
     private fun HomePagePickerFragmentBinding.setupUi() {
         siteCreationThemeHeader.title?.setText(R.string.hpp_title)
         siteCreationThemeHeader.subtitle?.isGone = true
+        modalLayoutPickerLayoutsSkeleton.layoutsSkeleton.updateLayoutParams {
+            height = recommendedDimensionProvider.rowHeight
+        }
         modalLayoutPickerLayoutsSkeleton.skeletonCardView.updateLayoutParams {
-            height = thumbDimensionProvider.previewHeight
-            width = thumbDimensionProvider.previewWidth
+            height = recommendedDimensionProvider.previewHeight
+            width = recommendedDimensionProvider.previewWidth
         }
     }
 

--- a/WordPress/src/main/res/layout/modal_layout_picker_layouts_skeleton.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_layouts_skeleton.xml
@@ -15,7 +15,7 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="@dimen/mlp_layouts_row_height"
+            android:layout_height="match_parent"
             android:orientation="vertical">
 
             <View style="@style/ModalLayoutPickerLayoutsSeparatorLine"


### PR DESCRIPTION
## Description
Sets the loading skeleton view to the size of the recommended row

## To test:
### Site Design Picker
1. Start the site creation flow
2. Proceed to the Site design picker
3. *Verify* that the loading skeleton has the correct size

https://user-images.githubusercontent.com/304044/169238601-5a48f8cc-670c-4df7-8456-c456afb37d3a.mp4

### Regresion
1. Tap the ➕  button on the *My Site* screen
2. Select *Site Page*
3. *Verify* that the loading skeleton has the correct size

## Regression Notes
1. Potential unintended areas of impact
Page layout picker

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

6. What automated tests I added (or what prevented me from doing so)
This type of UI fix can not be easily unit tested

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
