### PR TITLE
Fixes a crash when rotating the site design picker on a slow network connection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
@@ -304,6 +304,7 @@ abstract class LayoutPickerViewModel(
     }
 
     private fun resetState(selected: String?, selectedCategories: ArrayList<String>, previewMode: String) {
+        if (isLoading) return
         val state = uiState.value as? Content ?: Content()
         updateUiState(
                 state.copy(


### PR DESCRIPTION
## Description
Fixes a crash when rotating the site design picker on a slow network connection by preventing reseting the `Loading` state

## To test:
The below can be tested on a really slow network connection or by [setting a breakpoint at this line](https://github.com/wordpress-mobile/WordPress-Android/blob/a2218f0ea74ff4ee996b6266f09b290c43bc6aa1/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchHomePageLayoutsUseCase.kt#L34) and rotating the device.
### Site Design Picker
1. Start the site creation flow
2. Proceed to the Site design picker
3. Rotate the device before while in the loading/skeleton view
4. *Verify* that no crash occurs
5. *Verify* that the designs load when fetched

### Regresion
1. Tap the ➕  button on the *My Site* screen
2. Select *Site Page*
3. Rotate the device before while in the loading/skeleton view
4. *Verify* no change in behaviour of this screen

## Regression Notes
1. Potential unintended areas of impact
Page Layout Picker

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
