### PR TITLE
Fixes a UI regression by setting the correct height in the Page Layout Picker skeleton view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -98,6 +98,9 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
                 viewModel.onThumbnailModePressed()
             }
 
+            modalLayoutPickerLayoutsSkeleton.layoutsSkeleton.updateLayoutParams {
+                height = thumbDimensionProvider.rowHeight
+            }
             modalLayoutPickerLayoutsSkeleton.skeletonCardView.updateLayoutParams {
                 height = thumbDimensionProvider.previewHeight
                 width = thumbDimensionProvider.previewWidth


### PR DESCRIPTION
## Description
[Fixes a regression](https://github.com/wordpress-mobile/WordPress-Android/pull/16597#pullrequestreview-978202570) introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/16597 by setting the correct height in the Page Layout Picker skeleton view

## To test:
1. Tap the ➕  button on the *My Site* screen
2. Select *Site Page*
3. Rotate the device before while in the loading/skeleton view
4. *Verify* no change in behaviour of this screen

<details>
<summary>Before</summary>

https://user-images.githubusercontent.com/304044/169325369-a035f5ee-f5a9-4f8a-ae5e-8db6e3addf51.mp4
</details>

<details>
<summary>After</summary>

https://user-images.githubusercontent.com/304044/169325473-4fcd00ee-822c-4b9c-9208-55feef050e6c.mp4
</details>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
