### PR TITLE
QRCode Auth: Add enable flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -138,6 +138,7 @@ android {
         buildConfigField "boolean", "ENABLE_FOLLOWED_SITES_SETTINGS", "true"
         buildConfigField "boolean", "ENABLE_WHATS_NEW_FEATURE", "true"
         buildConfigField "boolean", "ENABLE_MY_SITE_DASHBOARD_TABS", "true"
+        buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -182,6 +183,7 @@ android {
             buildConfigField "boolean", "ENABLE_FOLLOWED_SITES_SETTINGS", "true"
             buildConfigField "boolean", "ENABLE_WHATS_NEW_FEATURE", "true"
             buildConfigField "boolean", "ENABLE_MY_SITE_DASHBOARD_TABS", "true"
+            buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -171,7 +171,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        if (qrCodeAuthFlowFeatureConfig.isEnabled()) {
+        if (qrCodeAuthFlowFeatureConfig.isEnabled() && BuildConfig.ENABLE_QRCODE_AUTH_FLOW) {
             rowScanLoginCode.isVisible = true
 
             rowScanLoginCode.setOnClickListener {


### PR DESCRIPTION
Parent #16481 

This PR adds the "ENABLE_QRCODE_AUTH_FLOW" build config field. This flags works the same as the other ENABLE flags, which allow us to turn on/off a feature for either the WordPress or Jetpack app. This capability was first added in #15946.

**To test:**

**Default case: true build config flag** 
- Do a fresh install
- Launch the app and login
- Navigate to Me
- ✅  Verify "Scan Login Code" is not visible on the Me View
- From the Me view, navigate to App Settings -> Debug Settings
- Scroll down to QRCodeAuthFlowFeatureConfig and enable it
- Restart the App
- Navigate back to Me
- ✅  Verify "Scan Login Code" is visible on the Me View
- Tap the `Scan Login Code` row
- ✅  Verify `scan login code not available` toast is shown
---------------------------------------

**To test the "false" case**  
- Download the branch
- Set `buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"` in the build.gradle to `buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "false"` *Note: If you want to test JP, then set the flag in the Jetpack section to false
- Run the app
- Navigate to Me -> App Settings -> Debug Settings 
- Scroll down to QRCodeAuthFlowFeatureConfig and enable it
- Restart the App
- Navigate back to Me
- ✅  Verify "Scan Login Code" is not visible on the Me View

## Regression Notes
1. Potential unintended areas of impact
The feature shows when it shouldn't

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual test

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
