### PR TITLE
Fixes focus point not being shown with animation after switching tabs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -30,7 +30,7 @@ object MySiteAdapterDiffCallback : DiffUtil.ItemCallback<MySiteCardAndItem>() {
     }
 
     override fun areContentsTheSame(oldItem: MySiteCardAndItem, newItem: MySiteCardAndItem): Boolean {
-        if(oldItem.activeQuickStartItem || newItem.activeQuickStartItem) return false
+        if (oldItem.activeQuickStartItem || newItem.activeQuickStartItem) return false
         return oldItem == newItem
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -30,6 +30,7 @@ object MySiteAdapterDiffCallback : DiffUtil.ItemCallback<MySiteCardAndItem>() {
     }
 
     override fun areContentsTheSame(oldItem: MySiteCardAndItem, newItem: MySiteCardAndItem): Boolean {
+        if(oldItem.activeQuickStartItem || newItem.activeQuickStartItem) return false
         return oldItem == newItem
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonItemAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonItemAdapter.kt
@@ -46,6 +46,11 @@ class QuickLinkRibbonItemAdapter : Adapter<QuickLinkRibbonItemViewHolder>() {
         override fun areContentsTheSame(
             oldItemPosition: Int,
             newItemPosition: Int
-        ): Boolean = oldList[oldItemPosition] == newList[newItemPosition]
+        ): Boolean {
+            return if (oldList[oldItemPosition].showFocusPoint || newList[newItemPosition].showFocusPoint)
+                false
+            else
+                oldList[oldItemPosition] == newList[newItemPosition]
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonItemAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonItemAdapter.kt
@@ -47,10 +47,11 @@ class QuickLinkRibbonItemAdapter : Adapter<QuickLinkRibbonItemViewHolder>() {
             oldItemPosition: Int,
             newItemPosition: Int
         ): Boolean {
-            return if (oldList[oldItemPosition].showFocusPoint || newList[newItemPosition].showFocusPoint)
+            return if (oldList[oldItemPosition].showFocusPoint || newList[newItemPosition].showFocusPoint) {
                 false
-            else
+            } else {
                 oldList[oldItemPosition] == newList[newItemPosition]
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #16603

This PR Fixes focus Point not animating after switching tabs. If a user switches between the tabs while the quick start focus point is shown in the list item in My Site. The quick start focus point animation freezes.

After Fix
https://user-images.githubusercontent.com/17463767/169389502-8b25695e-09c7-40d3-b332-6b38751cd8a0.mp4

To test:
1. Login to the app with a quick start in progress 
2. Start a quick start which has a quick start focus point in Dashboard list or Site Menu list 
3. Notice that the focus point is being displayed
4. Switch to the other tab (if Home then switch to Menu)
5. Switching to the original tab 
6. Verify that the focus point animation is still seen 

## Regression Notes
1. Potential unintended areas of impact
- My Site items(dashboard and menu) not being displayed properly 
- Quick start focus point not being shown properly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
