### PR TITLE
QRCode Auth: Create skeleton activity, fragment, vm, test

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -759,6 +759,12 @@
             android:label="@string/add_new_category"
             android:theme="@style/WordPress.NoActionBar"/>
 
+        <!-- QR Code Auth Flow -->
+        <activity
+            android:name=".ui.qrcodeauth.QRCodeAuthActivity"
+            android:label="@string/qrcode_auth_flow"
+            android:theme="@style/WordPress.NoActionBar"/>
+
         <!-- Services -->
         <service
             android:name=".ui.uploads.UploadService"

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -93,6 +93,7 @@ import org.wordpress.android.ui.prefs.categories.detail.CategoryDetailActivity;
 import org.wordpress.android.ui.prefs.categories.list.CategoriesListActivity;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsActivity;
 import org.wordpress.android.ui.publicize.PublicizeListActivity;
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActivity;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.sitecreation.SiteCreationActivity;
@@ -1704,5 +1705,10 @@ public class ActivityLauncher {
 
     public static void viewDebugCookies(@NonNull Context context) {
         context.startActivity(new Intent(context, DebugCookiesActivity.class));
+    }
+
+    public static void viewQRCodeAuthFlow(@NonNull Context context) {
+        Intent intent = new Intent(context, QRCodeAuthActivity.class);
+        context.startActivity(intent);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -199,7 +199,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         })
 
         viewModel.showScanLoginCode.observeEvent(viewLifecycleOwner) {
-            ToastUtils.showToast(requireContext(), "Scan login code not available yet")
+            ActivityLauncher.viewQRCodeAuthFlow(requireContext())
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
@@ -4,14 +4,17 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.R
+import org.wordpress.android.databinding.QrcodeauthActivityBinding
 
 @AndroidEntryPoint
 class QRCodeAuthActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setContentView(R.layout.qrcodeauth_activity)
+        with(QrcodeauthActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            setSupportActionBar(toolbarMain)
+        }
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.ui.qrcodeauth
+
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.R
+
+@AndroidEntryPoint
+class QRCodeAuthActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.qrcodeauth_activity)
+        supportActionBar?.let {
+            it.setHomeButtonEnabled(true)
+            it.setDisplayHomeAsUpEnabled(true)
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.R
 import org.wordpress.android.databinding.QrcodeauthFragmentBinding
 
 @AndroidEntryPoint
-class QRCodeAuthFragment : Fragment() {
+class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
     private val viewModel: QRCodeAuthViewModel by viewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.qrcodeauth
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.R
+import org.wordpress.android.databinding.QrcodeauthFragmentBinding
+
+@AndroidEntryPoint
+class QRCodeAuthFragment : Fragment() {
+    private val viewModel: QRCodeAuthViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        with(QrcodeauthFragmentBinding.bind(view)) {
+            initView()
+        }
+    }
+
+    private fun QrcodeauthFragmentBinding.initView() {
+        qrcodeAuthMessage.text = getString(R.string.qrcode_auth_flow)
+        viewModel.start()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.ui.qrcodeauth
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class QRCodeAuthViewModel @Inject constructor() : ViewModel() {
+    private var isStarted = false
+
+    fun start() {
+        if (isStarted) return
+        isStarted = true
+    }
+}

--- a/WordPress/src/main/res/layout/qrcodeauth_activity.xml
+++ b/WordPress/src/main/res/layout/qrcodeauth_activity.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container"
+        android:name="org.wordpress.android.ui.qrcodeauth.QRCodeAuthFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>
+

--- a/WordPress/src/main/res/layout/qrcodeauth_fragment.xml
+++ b/WordPress/src/main/res/layout/qrcodeauth_fragment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <TextView
+        android:id="@+id/qrcode_auth_message"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4141,4 +4141,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
         <item>@string/initial_screen_entry_value_home</item>
         <item>@string/initial_screen_entry_value_menu</item>
     </string-array>
+
+    <!-- QRCode Auth Flow -->
+    <string name="qrcode_auth_flow" translatable="false">Scan Login Code</string>
+
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.ui.qrcodeauth
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class QRCodeAuthViewModelTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    private lateinit var viewModel: QRCodeAuthViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = QRCodeAuthViewModel()
+    }
+
+    @Test
+    fun `sample test`() {
+    } // TODO:
+}


### PR DESCRIPTION
Parent #16481 

This PR creates skeleton activity, fragment, vm, and test classes for the QRCode Auth flow

Me View | Scan Login Code
-- | --
<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/169395215-d86dad6c-c83f-4467-abfc-7c14076ef17c.png"> | <img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/169395220-d783ff42-6998-4c58-ad9c-7c9a92a81929.png">


**To test:**
- Launch the app and login
- Navigate to Me-> App Settings -> Debug Settings
- Scroll down to QRCodeAuthFlowFeatureConfig and enable it
- Restart the App
- Navigate back to Me
- ✅  Verify "Scan Login Code" is visible on the Me View
- Tap the `Scan Login Code` row
- ✅  Verify the `scan login code` view  is visible
- Tap on the back arrow and ✅  Verify returned to the Me view

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
