### PR TITLE
Stats revamp v2 guide cards

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.DIVIDER
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.EMPTY
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.EXPANDABLE_ITEM
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.GUIDE_CARD
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.HEADER
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.IMAGE_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.INFO
@@ -89,6 +90,7 @@ class BlockDiffCallback(
                 REFERRED_ITEM,
                 QUICK_SCAN_ITEM,
                 DIALOG_BUTTONS,
+                GUIDE_CARD,
                 TAG_ITEM,
                 IMAGE_ITEM,
                 EMPTY -> oldItem == newItem

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Infor
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.LineChartItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemGuideCard
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithImage
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.LoadingItem
@@ -47,6 +48,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.DIVIDER
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.EMPTY
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.EXPANDABLE_ITEM
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.GUIDE_CARD
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.HEADER
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.IMAGE_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.INFO
@@ -85,6 +87,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.Divider
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.EmptyViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ExpandableItemViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.FourColumnsViewHolder
+import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.GuideCardViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.HeaderViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ImageItemViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.InformationViewHolder
@@ -156,6 +159,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
             REFERRED_ITEM -> ReferredItemViewHolder(parent)
             QUICK_SCAN_ITEM -> QuickScanItemViewHolder(parent)
             DIALOG_BUTTONS -> DialogButtonsViewHolder(parent)
+            GUIDE_CARD -> GuideCardViewHolder(parent)
         }
     }
 
@@ -203,6 +207,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
             is ReferredItemViewHolder -> holder.bind(item as ReferredItem)
             is QuickScanItemViewHolder -> holder.bind(item as QuickScanItem)
             is DialogButtonsViewHolder -> holder.bind(item as DialogButtons)
+            is GuideCardViewHolder -> holder.bind(item as ListItemGuideCard)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.DIVIDER
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.EMPTY
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.EXPANDABLE_ITEM
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.GUIDE_CARD
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.HEADER
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.IMAGE_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.INFO
@@ -81,7 +82,8 @@ sealed class BlockListItem(val type: Type) {
         ACTIVITY_ITEM,
         REFERRED_ITEM,
         QUICK_SCAN_ITEM,
-        DIALOG_BUTTONS
+        DIALOG_BUTTONS,
+        GUIDE_CARD
     }
 
     data class Title(
@@ -337,4 +339,6 @@ sealed class BlockListItem(val type: Type) {
         override val itemId: Int
             get() = blocks.fold(0) { acc, block -> acc + block.label.hashCode() }
     }
+
+    data class ListItemGuideCard(val text: String) : BlockListItem(GUIDE_CARD)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -5,6 +5,7 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.NORMAL
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text.Clickable
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.ACTIVITY_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.BAR_CHART
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.BIG_TITLE
@@ -340,5 +341,9 @@ sealed class BlockListItem(val type: Type) {
             get() = blocks.fold(0) { acc, block -> acc + block.label.hashCode() }
     }
 
-    data class ListItemGuideCard(val text: String) : BlockListItem(GUIDE_CARD)
+    data class ListItemGuideCard(
+        val text: String,
+        val links: List<Clickable>? = null,
+        val bolds: List<String>? = null
+    ) : BlockListItem(GUIDE_CARD)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalCommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalCommentsUseCase.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.St
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemGuideCard
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
@@ -27,6 +28,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Calendar
 import javax.inject.Inject
 import javax.inject.Named
@@ -37,6 +39,7 @@ class TotalCommentsUseCase @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val visitsAndViewsStore: VisitsAndViewsStore,
     private val statsSiteProvider: StatsSiteProvider,
+    private val resourceProvider: ResourceProvider,
     private val statsDateFormatter: StatsDateFormatter,
     private val totalStatsMapper: TotalStatsMapper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
@@ -119,6 +122,9 @@ class TotalCommentsUseCase @Inject constructor(
             items.add(buildTitle())
             items.add(totalStatsMapper.buildTotalCommentsValue(domainModel.dates))
             items.add(totalStatsMapper.buildTotalCommentsInformation(domainModel.dates))
+            if (totalStatsMapper.shouldShowCommentsGuideCard(domainModel.dates)) {
+                items.add(ListItemGuideCard(resourceProvider.getString(string.stats_insights_comments_guide_card)))
+            }
         } else {
             AppLog.e(T.STATS, "There is no data to be shown in the total comments block")
         }
@@ -148,6 +154,7 @@ class TotalCommentsUseCase @Inject constructor(
         @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher,
         private val visitsAndViewsStore: VisitsAndViewsStore,
         private val statsSiteProvider: StatsSiteProvider,
+        private val resourceProvider: ResourceProvider,
         private val statsDateFormatter: StatsDateFormatter,
         private val totalStatsMapper: TotalStatsMapper,
         private val analyticsTracker: AnalyticsTrackerWrapper,
@@ -160,6 +167,7 @@ class TotalCommentsUseCase @Inject constructor(
                         backgroundDispatcher,
                         visitsAndViewsStore,
                         statsSiteProvider,
+                        resourceProvider,
                         statsDateFormatter,
                         totalStatsMapper,
                         analyticsTracker,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.TOTAL_FOLLOWERS
 import org.wordpress.android.fluxc.store.stats.insights.SummaryStore
@@ -11,12 +12,14 @@ import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTotalFollower
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemGuideCard
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueWithChartItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -25,6 +28,8 @@ class TotalFollowersUseCase @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val summaryStore: SummaryStore,
     private val statsSiteProvider: StatsSiteProvider,
+    private val resourceProvider: ResourceProvider,
+    private val totalStatsMapper: TotalStatsMapper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val useCaseMode: UseCaseMode
 ) : StatelessUseCase<Int>(TOTAL_FOLLOWERS, mainDispatcher, bgDispatcher) {
@@ -46,8 +51,15 @@ class TotalFollowersUseCase @Inject constructor(
         }
     }
 
-    override fun buildUiModel(domainModel: Int) =
-            listOf(buildTitle(), ValueWithChartItem(domainModel.toString()))
+    override fun buildUiModel(domainModel: Int): List<BlockListItem> {
+        val items = mutableListOf<BlockListItem>()
+        items.add(buildTitle())
+        items.add(ValueWithChartItem(domainModel.toString()))
+        if (totalStatsMapper.shouldShowFollowersGuideCard()) {
+            items.add(ListItemGuideCard(resourceProvider.getString(string.stats_insights_followers_guide_card)))
+        }
+        return items
+    }
 
     private fun buildTitle() = TitleWithMore(
             R.string.stats_view_total_followers,
@@ -67,6 +79,8 @@ class TotalFollowersUseCase @Inject constructor(
         @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher,
         private val summaryStore: SummaryStore,
         private val statsSiteProvider: StatsSiteProvider,
+        private val resourceProvider: ResourceProvider,
+        private val totalStatsMapper: TotalStatsMapper,
         private val analyticsTracker: AnalyticsTrackerWrapper
     ) : InsightUseCaseFactory {
         override fun build(useCaseMode: UseCaseMode) = TotalFollowersUseCase(
@@ -74,6 +88,8 @@ class TotalFollowersUseCase @Inject constructor(
                 backgroundDispatcher,
                 summaryStore,
                 statsSiteProvider,
+                resourceProvider,
+                totalStatsMapper,
                 analyticsTracker,
                 useCaseMode
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
@@ -55,7 +55,7 @@ class TotalFollowersUseCase @Inject constructor(
         val items = mutableListOf<BlockListItem>()
         items.add(buildTitle())
         items.add(ValueWithChartItem(domainModel.toString()))
-        if (totalStatsMapper.shouldShowFollowersGuideCard()) {
+        if (totalStatsMapper.shouldShowFollowersGuideCard(domainModel)) {
             items.add(ListItemGuideCard(resourceProvider.getString(string.stats_insights_followers_guide_card)))
         }
         return items
@@ -71,7 +71,7 @@ class TotalFollowersUseCase @Inject constructor(
                 AnalyticsTracker.Stat.STATS_TOTAL_FOLLOWERS_VIEW_MORE_TAPPED,
                 statsSiteProvider.siteModel
         )
-        navigateTo(ViewTotalFollowersStats) // TODO: Connect this to proper second level navigation later
+        navigateTo(ViewTotalFollowersStats)
     }
 
     class TotalFollowersUseCaseFactory @Inject constructor(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 class TotalStatsMapper @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val statsUtils: StatsUtils
@@ -33,6 +34,20 @@ class TotalStatsMapper @Inject constructor(
         val positive = currentWeekComments.sum() >= previousWeekComments.sum()
 
         return ValueWithChartItem(currentWeekSumFormatted, currentWeekComments, positive)
+    }
+
+    fun shouldShowCommentsGuideCard(dates: List<PeriodData>): Boolean {
+        return getCurrentWeekDays(dates, COMMENTS).sum() > 0
+    }
+
+    @Suppress("FunctionOnlyReturningConstant")
+    fun shouldShowFollowersGuideCard(): Boolean {
+        // TODO: After the card is updated with percentage change
+        return true
+    }
+
+    fun shouldShowLikesGuideCard(dates: List<PeriodData>): Boolean {
+        return getCurrentWeekDays(dates, LIKES).sum() > 0
     }
 
     fun buildTotalLikesInformation(dates: List<PeriodData>) = buildTotalInformation(dates, LIKES)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
@@ -40,10 +40,8 @@ class TotalStatsMapper @Inject constructor(
         return getCurrentWeekDays(dates, COMMENTS).sum() > 0
     }
 
-    @Suppress("FunctionOnlyReturningConstant")
-    fun shouldShowFollowersGuideCard(): Boolean {
-        // TODO: After the card is updated with percentage change
-        return true
+    fun shouldShowFollowersGuideCard(domainModel: Int): Boolean {
+        return domainModel <= 0
     }
 
     fun shouldShowLikesGuideCard(dates: List<PeriodData>): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/GuideCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/GuideCardViewHolder.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
+
+import android.text.Html
+import android.view.ViewGroup
+import androidx.core.text.HtmlCompat
+import org.wordpress.android.databinding.StatsBlockListGuideCardBinding
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemGuideCard
+import org.wordpress.android.util.extensions.viewBinding
+
+class GuideCardViewHolder(
+    val parent: ViewGroup,
+    val binding: StatsBlockListGuideCardBinding = parent.viewBinding(StatsBlockListGuideCardBinding::inflate)
+) : BlockListItemViewHolder(binding.root) {
+    fun bind(
+        item: ListItemGuideCard
+    ) = with(binding) {
+        guideMessage.text = Html.fromHtml(item.text, HtmlCompat.FROM_HTML_MODE_LEGACY)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/GuideCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/GuideCardViewHolder.kt
@@ -1,10 +1,19 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 
-import android.text.Html
+import android.content.Context
+import android.graphics.Typeface
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.TextPaint
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
+import android.text.style.StyleSpan
+import android.view.View
 import android.view.ViewGroup
-import androidx.core.text.HtmlCompat
+import org.wordpress.android.R
 import org.wordpress.android.databinding.StatsBlockListGuideCardBinding
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemGuideCard
+import org.wordpress.android.util.extensions.getColorFromAttribute
 import org.wordpress.android.util.extensions.viewBinding
 
 class GuideCardViewHolder(
@@ -14,6 +23,56 @@ class GuideCardViewHolder(
     fun bind(
         item: ListItemGuideCard
     ) = with(binding) {
-        guideMessage.text = Html.fromHtml(item.text, HtmlCompat.FROM_HTML_MODE_LEGACY)
+        val spannableString = SpannableString(item.text)
+        item.links?.forEach { link ->
+            spannableString.withClickableSpan(root.context, link.link) {
+                link.navigationAction.click()
+            }
+        }
+        item.bolds?.forEach { bold ->
+            spannableString.withBoldSpan(bold)
+        }
+        guideMessage.movementMethod = LinkMovementMethod.getInstance()
+        guideMessage.text = spannableString
     }
+}
+
+private fun SpannableString.withClickableSpan(
+    context: Context,
+    clickablePart: String,
+    onClickListener: (Context) -> Unit
+): SpannableString {
+    val clickableSpan = object : ClickableSpan() {
+        override fun onClick(widget: View) {
+            widget.context?.let { onClickListener.invoke(it) }
+        }
+
+        override fun updateDrawState(ds: TextPaint) {
+            ds.color = context.getColorFromAttribute(R.attr.colorPrimary)
+            ds.typeface = Typeface.create(
+                    Typeface.DEFAULT_BOLD,
+                    Typeface.NORMAL
+            )
+            ds.isUnderlineText = false
+        }
+    }
+    val clickablePartStart = indexOf(clickablePart)
+    setSpan(
+            clickableSpan,
+            clickablePartStart,
+            clickablePartStart + clickablePart.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+    )
+    return this
+}
+
+private fun SpannableString.withBoldSpan(boldPart: String): SpannableString {
+    val boldPartIndex = indexOf(boldPart)
+    setSpan(
+            StyleSpan(Typeface.BOLD),
+            boldPartIndex,
+            boldPartIndex + boldPart.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+    )
+    return this
 }

--- a/WordPress/src/main/res/layout/stats_block_list_guide_card.xml
+++ b/WordPress/src/main/res/layout/stats_block_list_guide_card.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/margin_extra_large"
+    android:backgroundTint="?attr/wpColorSurfaceSecondary"
+    app:cardCornerRadius="@dimen/margin_medium_large">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="@dimen/margin_extra_large">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/guide_message"
+            style="@style/TextAppearance.LoginFlow.Body2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/unknown"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="@string/stats_insights_followers_guide_card" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1355,6 +1355,10 @@
     <string name="stats_insights_management_posts_and_pages">Posts and Pages</string>
     <string name="stats_insights_management_activity">Activity</string>
 
+    <string name="stats_insights_likes_guide_card">⭐️ Your latest post &lt;a href="%1$s" &gt;%2$s &lt;/a&gt; has received &lt;b&gt;%3$s &lt;/b&gt; likes.</string>
+    <string name="stats_insights_comments_guide_card">💡See your top contributors by tapping VIEW MORE.</string>
+    <string name="stats_insights_followers_guide_card">💡You can try leaving a comment as a gesture to encourage blog engagement in return to gain more followers.</string>
+
     <!-- Stats refreshed widgets -->
     <string name="stats_widget_log_in_message">Please log in to the WordPress app to add a widget.</string>
     <string name="stats_widget_weekly_views_name">Views this week</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1355,7 +1355,7 @@
     <string name="stats_insights_management_posts_and_pages">Posts and Pages</string>
     <string name="stats_insights_management_activity">Activity</string>
 
-    <string name="stats_insights_likes_guide_card">⭐️ Your latest post &lt;a href="%1$s" &gt;%2$s &lt;/a&gt; has received &lt;b&gt;%3$s &lt;/b&gt; likes.</string>
+    <string name="stats_insights_likes_guide_card">⭐️ Your latest post %1$s has received %2$s likes.</string>
     <string name="stats_insights_comments_guide_card">💡See your top contributors by tapping VIEW MORE.</string>
     <string name="stats_insights_followers_guide_card">💡You can try leaving a comment as a gesture to encourage blog engagement in return to gain more followers.</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalCommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalCommentsUseCaseTest.kt
@@ -70,6 +70,7 @@ class TotalCommentsUseCaseTest : BaseUnitTest() {
                 TEST_DISPATCHER,
                 store,
                 statsSiteProvider,
+                resourceProvider,
                 statsDateFormatter,
                 totalStatsMapper,
                 analyticsTrackerWrapper,

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCaseTest.kt
@@ -27,10 +27,13 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueWithChartItem
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
 
 class TotalFollowersUseCaseTest : BaseUnitTest() {
     @Mock lateinit var insightsStore: SummaryStore
     @Mock lateinit var statsSiteProvider: StatsSiteProvider
+    @Mock lateinit var totalStatsMapper: TotalStatsMapper
+    @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var site: SiteModel
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
     @Mock lateinit var useCaseMode: UseCaseMode
@@ -45,6 +48,8 @@ class TotalFollowersUseCaseTest : BaseUnitTest() {
                 TEST_DISPATCHER,
                 insightsStore,
                 statsSiteProvider,
+                resourceProvider,
+                totalStatsMapper,
                 analyticsTrackerWrapper,
                 useCaseMode
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.StatsStore.InsightType
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.stats.insights.LatestPostInsightsStore
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.test
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode
@@ -46,6 +47,7 @@ import java.util.Calendar
 class TotalLikesUseCaseTest : BaseUnitTest() {
     @Mock lateinit var store: VisitsAndViewsStore
     @Mock lateinit var statsSiteProvider: StatsSiteProvider
+    @Mock lateinit var latestPostStore: LatestPostInsightsStore
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
     @Mock lateinit var statsDateFormatter: StatsDateFormatter
     @Mock lateinit var totalStatsMapper: TotalStatsMapper
@@ -69,7 +71,9 @@ class TotalLikesUseCaseTest : BaseUnitTest() {
                 Dispatchers.Unconfined,
                 TEST_DISPATCHER,
                 store,
+                latestPostStore,
                 statsSiteProvider,
+                resourceProvider,
                 statsDateFormatter,
                 totalStatsMapper,
                 analyticsTrackerWrapper,


### PR DESCRIPTION
This PR adds guide cards to Comments, Likes and Followers cards based on certain criteria

Fixes #16610 

<img width = 320 src=https://user-images.githubusercontent.com/990349/169511820-71ad2c9d-f79e-4314-98eb-bd586d66620a.png />


To test:

Setup:

- Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
- Select Debug Settings
- Find StatsRevampV2FeatureConfig under Features in development enable it and restart app
- Launch / Re-Launch app
- Go to Stats either using quick links or menu 
- Switch to Insights tab if necessary
- Make sure **Total Likes**, **Total Comments**, **Total Followers** and **Latest Post Summary** cards are visible on Insights tab. If those cards are not present then add them through stats management using either [+ add new stats card ] at the bottom or clicking ⚙️ icon at the top right hand corner.

Test 1: 

- A **guide card** as shown above with latest post and number of likes for that post in bold appears on **Total Likes** card 
- Click on the latest post, it should take to that post
- NOTE: The guide only appears if total likes are one or more

Test 2:
- A **guide card** as shown above appears on **Total Comments** card 
- NOTE: The guide only appears if total followers are one or more

Test 3:
- A **guide card** as shown above appears on **Total Followers** card 
- NOTE: The guide only appears if total followers are 0.  Initially it was supposed to appear when followers %change was negative.  However, it was found out that endpoint only returns total count.


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit texts

3. What automated tests I added (or what prevented me from doing so)
Updated existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
