### PR TITLE
Fix: Removes Explore Plan from Quick start list 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '1.42.1'
+    fluxCVersion = '2415-09296d15521be87a560ea26cde35fec8a2ce3948'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '2415-09296d15521be87a560ea26cde35fec8a2ce3948'
+    fluxCVersion = '1.42.1'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '1.42.1'
+    fluxCVersion = '1.42.2'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #16477 

Dependant FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2415

This PR fixes the issue where the explore plans were visible on the Quickstart task list. This PR fixes the following scenario.  which was missed from the previous [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16582) to fix the removal of plans. 

| Quick start in Progress with Explore Plans| Quick start in Progress after Removing Explore plans|  
|---|---|
|<img width="637" alt="Screenshot 2022-05-20 at 5 44 00 PM" src="https://user-images.githubusercontent.com/17463767/169526384-2192df07-79ec-4adc-9bd2-c81075272641.png">| <img width="629" alt="Screenshot 2022-05-20 at 5 44 34 PM" src="https://user-images.githubusercontent.com/17463767/169526404-00dd4289-6159-4a69-a848-df45a985b098.png">
 
Note: The Quick start task title and description for Follow Other Sites and Check your stats has been changed as part of the [QS-V2 Project](https://github.com/wordpress-mobile/WordPress-Android/issues/16349).

### To Test 1

🟢  Test Scenario 1 - Explore Plans + Other tasks pending 
- Install the app having the Explore plans listed (E.g. from release/19.7 branch).
- Login to the app with a quick start in progress.
- Complete all tasks, excluding Explore plans + one task like Check your stats.
- Install the app from the current PR.
- Notice that Quick Start is not completed, and other tasks are shown as Pending
- Notice that Explore Plans is not shown in Quick start task list 

🟢  Test Scenario 2 - Only Explore Plans Pending 
- Install the app having the Explore plans listed (E.g. from release/19.7 branch).
- Login to the app with a quick start in progress.
- Complete all tasks, excluding Explore plans 
- Install the app from the current PR.
- Notice that Quick Start is completed and Notification is shown 


Note: In this PR, we update the database schema version to remove the explore plans with migration. Hence, After installing the build from this branch, when you try to install another build from the trunk or `release/19.7` with the previous schema version. The app will crash. To avoid that, clean and install any build after installing the build from this branch.

### Merge Instructions 
- Make sure dependant PR is merge 
- Update FluxC Version 
- Remove Status not ready to merge label
- Merge 


## Regression Notes
1. Potential unintended areas of impact
Quick start list not being shown properly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
