### PR TITLE
Stats Revamp v2: Pie chart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/BlockDiffCallback.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LOADING_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP_LEGEND
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.PIE_CHART
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.QUICK_SCAN_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.REFERRED_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TABS
@@ -66,6 +67,7 @@ class BlockDiffCallback(
                 COLUMNS,
                 CHIPS,
                 BAR_CHART,
+                PIE_CHART,
                 LINE_CHART,
                 ACTIVITY_ITEM,
                 LIST_ITEM -> oldItem.itemId == newItem.itemId

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.stats.refresh.lists.detail.PostMonthsAndYearsUse
 import org.wordpress.android.ui.stats.refresh.lists.detail.PostRecentWeeksUseCase.PostRecentWeeksUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.AuthorsUseCase.AuthorsUseCaseFactory
@@ -417,7 +418,7 @@ class StatsModule {
     ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> {
         return listOf(
                 viewsAndVisitorsUseCaseFactory.build(VIEW_ALL),
-                referrersUseCaseFactory.build(DAYS, BLOCK),
+                referrersUseCaseFactory.build(DAYS, BLOCK_DETAIL),
                 countryViewsUseCaseFactory.build(DAYS, BLOCK)
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
@@ -277,6 +277,7 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
 
     enum class UseCaseMode {
         BLOCK,
+        BLOCK_DETAIL,
         VIEW_ALL
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListAdapter.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListI
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.LoadingItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapLegend
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.PieChartItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.QuickScanItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ReferredItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TabsItem
@@ -58,6 +59,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LOADING_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP_LEGEND
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.PIE_CHART
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.QUICK_SCAN_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.REFERRED_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TABS
@@ -70,15 +72,15 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.VALUE_WITH_CHART_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.values
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValuesItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueWithChartItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValuesItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ActivityViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.BarChartViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.BigTitleViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.BlockListItemViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ChartLegendViewHolder
-import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ChartLegendsPurpleViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ChartLegendsBlueViewHolder
+import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ChartLegendsPurpleViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ChipsViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.DialogButtonsViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.DividerViewHolder
@@ -96,6 +98,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ListIte
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.LoadingItemViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.MapLegendViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.MapViewHolder
+import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.PieChartViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.QuickScanItemViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.ReferredItemViewHolder
 import org.wordpress.android.ui.stats.refresh.lists.sections.viewholders.TabsViewHolder
@@ -137,6 +140,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
             CHIPS -> ChipsViewHolder(parent)
             LINK -> LinkViewHolder(parent)
             BAR_CHART -> BarChartViewHolder(parent)
+            PIE_CHART -> PieChartViewHolder(parent)
             LINE_CHART -> LineChartViewHolder(parent)
             CHART_LEGEND -> ChartLegendViewHolder(parent)
             CHART_LEGENDS_BLUE -> ChartLegendsBlueViewHolder(parent)
@@ -184,6 +188,7 @@ class BlockListAdapter(val imageManager: ImageManager) : Adapter<BlockListItemVi
             is ChipsViewHolder -> holder.bind(item as Chips)
             is LinkViewHolder -> holder.bind(item as Link)
             is BarChartViewHolder -> holder.bind(item as BarChartItem)
+            is PieChartViewHolder -> holder.bind(item as PieChartItem)
             is LineChartViewHolder -> holder.bind(item as LineChartItem)
             is ChartLegendViewHolder -> holder.bind(item as ChartLegend)
             is ChartLegendsBlueViewHolder -> holder.bind(item as ChartLegendsBlue)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LOADING_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.MAP_LEGEND
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.PIE_CHART
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.QUICK_SCAN_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.REFERRED_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TABS
@@ -67,6 +68,7 @@ sealed class BlockListItem(val type: Type) {
         CHIPS,
         LINK,
         BAR_CHART,
+        PIE_CHART,
         LINE_CHART,
         CHART_LEGEND,
         CHART_LEGENDS_BLUE,
@@ -252,6 +254,18 @@ sealed class BlockListItem(val type: Type) {
         val entryContentDescriptions: List<String>
     ) : BlockListItem(BAR_CHART) {
         data class Bar(val label: String, val id: String, val value: Int)
+
+        override val itemId: Int
+            get() = entries.hashCode()
+    }
+
+    data class PieChartItem(
+        val entries: List<Pie>,
+        val totalLabel: String,
+        val total: Int,
+        val contentDescription: String
+    ) : BlockListItem(PIE_CHART) {
+        data class Pie(val label: String, val value: Int)
 
         override val itemId: Int
             get() = entries.hashCode()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -263,6 +263,7 @@ sealed class BlockListItem(val type: Type) {
         val entries: List<Pie>,
         val totalLabel: String,
         val total: Int,
+        val colors: List<Int>,
         val contentDescription: String
     ) : BlockListItem(PIE_CHART) {
         data class Pie(val label: String, val value: Int)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -262,7 +262,7 @@ sealed class BlockListItem(val type: Type) {
     data class PieChartItem(
         val entries: List<Pie>,
         val totalLabel: String,
-        val total: Int,
+        val total: String,
         val colors: List<Int>,
         val contentDescription: String
     ) : BlockListItem(PIE_CHART) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.widgets.WPSnackbar
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
+import kotlin.math.min
 
 @Suppress("LongParameterList")
 class ReferrersUseCase(
@@ -79,6 +80,7 @@ class ReferrersUseCase(
         SelectedGroup()
 ) {
     private val itemsToLoad = if (useCaseMode == BLOCK) BLOCK_ITEM_COUNT else VIEW_ALL_ITEM_COUNT
+    private val itemsToShow = if (useCaseMode == VIEW_ALL) VIEW_ALL_ITEM_COUNT else BLOCK_ITEM_COUNT
 
     override fun buildLoadingItem(): List<BlockListItem> = listOf(Title(R.string.stats_referrers))
 
@@ -124,7 +126,8 @@ class ReferrersUseCase(
                 items.add(buildPieChartItem(domainModel))
             }
             items.add(header)
-            domainModel.groups.forEachIndexed { index, group ->
+            val itemCount = min(itemsToShow, domainModel.groups.size)
+            domainModel.groups.subList(0, itemCount).forEachIndexed { index, group ->
                 val contentDescription =
                         contentDescriptionHelper.buildContentDescription(
                                 header,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -198,7 +198,9 @@ class ReferrersUseCase(
                 }
             }
 
-            if (useCaseMode == BLOCK && domainModel.hasMore) {
+            val shouldShowViewMore = itemCount < domainModel.groups.size ||
+                    (useCaseMode == BLOCK && domainModel.hasMore)
+            if (shouldShowViewMore) {
                 items.add(
                         Link(
                                 text = R.string.stats_insights_view_more,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -228,6 +228,7 @@ class ReferrersUseCase(
                 pies,
                 totalLabel,
                 totalValue,
+                COLOR_LIST,
                 contentDescriptionHelper.buildContentDescription(
                         R.string.stats_referrers_pie_chart_total_label,
                         totalValue
@@ -342,5 +343,9 @@ class ReferrersUseCase(
                         popupMenuHandler,
                         statsRevampV2FeatureConfig
                 )
+    }
+
+    companion object {
+        private val COLOR_LIST = listOf(R.color.blue, R.color.blue_80, R.color.blue_5)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -227,7 +227,7 @@ class ReferrersUseCase(
         return PieChartItem(
                 pies,
                 totalLabel,
-                totalValue,
+                statsUtils.toFormattedString(totalValue),
                 COLOR_LIST,
                 contentDescriptionHelper.buildContentDescription(
                         R.string.stats_referrers_pie_chart_total_label,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewUrl
 import org.wordpress.android.ui.stats.refresh.lists.BLOCK_ITEM_COUNT
 import org.wordpress.android.ui.stats.refresh.lists.VIEW_ALL_ITEM_COUNT
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK_DETAIL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Divider
@@ -119,7 +120,7 @@ class ReferrersUseCase(
             items.add(Empty(R.string.stats_no_data_for_period))
         } else {
             val header = Header(R.string.stats_referrer_label, R.string.stats_referrer_views_label)
-            if (statsRevampV2FeatureConfig.isEnabled()) {
+            if (statsRevampV2FeatureConfig.isEnabled() && useCaseMode == BLOCK_DETAIL) {
                 items.add(buildPieChartItem(domainModel))
             }
             items.add(header)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTypesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTypesUseCase.kt
@@ -54,21 +54,9 @@ class FollowerTypesUseCase @Inject constructor(
 
     private fun buildDataModel(wpComTotals: Int?, emailTotals: Int?, socialTotals: Int?): Map<FollowerType, Int> {
         val map = mutableMapOf<FollowerType, Int>()
-        wpComTotals?.let {
-            if (it > 0) {
-                map[WP_COM] = it
-            }
-        }
-        emailTotals?.let {
-            if (it > 0) {
-                map[EMAIL] = it
-            }
-        }
-        socialTotals?.let {
-            if (it > 0) {
-                map[SOCIAL] = it
-            }
-        }
+        wpComTotals?.let { map[WP_COM] = it }
+        emailTotals?.let { map[EMAIL] = it }
+        socialTotals?.let { map[SOCIAL] = it }
         return map
     }
 
@@ -174,7 +162,6 @@ class FollowerTypesUseCase @Inject constructor(
     }
 
     private fun mapToPie(domainModel: Map<FollowerType, Int>) = domainModel
-            .filter { it.value != 0 } // Don't add zero values
             .map {
                 val label = resourceProvider.getString(getTitle(it.key))
                 Pie(label, it.value)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTypesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTypesUseCase.kt
@@ -118,6 +118,7 @@ class FollowerTypesUseCase @Inject constructor(
                     pies,
                     totalLabel,
                     totalValue,
+                    COLOR_LIST,
                     contentDescriptionHelper.buildContentDescription(
                             R.string.stats_follower_types_pie_chart_total_label,
                             totalValue
@@ -183,5 +184,6 @@ class FollowerTypesUseCase @Inject constructor(
 
     companion object {
         private const val PERCENT_HUNDRED = 100.0
+        private val COLOR_LIST = listOf(R.color.blue, R.color.blue_5, R.color.orange_30)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTypesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTypesUseCase.kt
@@ -117,7 +117,7 @@ class FollowerTypesUseCase @Inject constructor(
             val pieChartItem = PieChartItem(
                     pies,
                     totalLabel,
-                    totalValue,
+                    statsUtils.toFormattedString(totalValue),
                     COLOR_LIST,
                     contentDescriptionHelper.buildContentDescription(
                             R.string.stats_follower_types_pie_chart_total_label,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/PieChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/PieChartViewHolder.kt
@@ -1,0 +1,93 @@
+package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
+
+import android.content.res.ColorStateList
+import android.text.style.AbsoluteSizeSpan
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.core.text.buildSpannedString
+import androidx.core.text.inSpans
+import androidx.core.view.doOnLayout
+import androidx.core.widget.TextViewCompat
+import com.github.mikephil.charting.charts.PieChart
+import com.github.mikephil.charting.data.PieData
+import com.github.mikephil.charting.data.PieDataSet
+import com.github.mikephil.charting.data.PieEntry
+import org.wordpress.android.R
+import org.wordpress.android.databinding.ItemPieChartLegendBinding
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.PieChartItem
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.PieChartItem.Pie
+import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.widgets.RoundedSlicesPieChartRenderer
+import kotlin.math.max
+
+class PieChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(parent, R.layout.stats_block_pie_chart_item) {
+    private val chart = itemView.findViewById<PieChart>(R.id.chart)
+    private val totalText = itemView.findViewById<TextView>(R.id.total_text)
+    private val legends = itemView.findViewById<LinearLayout>(R.id.legends)
+
+    fun bind(item: PieChartItem) {
+        val sliceWidth = chart.resources.getDimension(R.dimen.stats_pie_chart_slice_width)
+        setHoleRadius(sliceWidth)
+
+        chart.apply {
+            description.isEnabled = false
+            legend.isEnabled = false
+
+            val roundedSlicesPieChartRenderer = RoundedSlicesPieChartRenderer(this)
+            renderer = roundedSlicesPieChartRenderer
+
+            totalText.text = buildSpannedString {
+                append(item.totalLabel)
+                val textSize = context.resources.getDimension(R.dimen.text_sz_extra_extra_extra_large)
+                inSpans(AbsoluteSizeSpan(textSize.toInt())) { append("\n${item.total}") }
+            }
+
+            val entries = mapToPieEntry(item.entries)
+            val dataSet = getDataSet(entries)
+            dataSet.sliceSpace = DisplayUtils.pxToDp(context, sliceWidth.toInt()).toFloat()
+            data = PieData(dataSet)
+
+            addLegends(item.entries)
+        }
+        itemView.contentDescription = item.contentDescription
+    }
+
+    private fun mapToPieEntry(entries: List<Pie>): List<PieEntry> {
+        val sum = entries.sumOf { it.value }
+        val minValue = sum * MIN_PIE_CHART_RATIO
+        return entries.map { PieEntry(max(it.value.toFloat(), minValue)) }
+    }
+
+    private fun setHoleRadius(sliceWidth: Float) {
+        chart.doOnLayout { chart.holeRadius = (1 - 2 * sliceWidth / chart.width) * PERCENT_HUNDRED }
+    }
+
+    private fun getDataSet(entries: List<PieEntry>) = PieDataSet(entries, null).apply {
+        label = null
+        setDrawValues(false)
+        colors = COLOR_LIST.map { ContextCompat.getColor(chart.context, it) }
+
+        selectionShift = 0f // Needed for removing extra highlighting space in chart size
+    }
+
+    private fun addLegends(entries: List<Pie>) {
+        entries.forEachIndexed { index, pie ->
+            ItemPieChartLegendBinding.inflate(LayoutInflater.from(legends.context), legends, true).apply {
+                val textView = root.findViewById<TextView>(R.id.text)
+                textView.text = pie.label
+                val colorRes = COLOR_LIST[index % entries.size]
+                val color = ContextCompat.getColor(root.context, colorRes)
+                TextViewCompat.setCompoundDrawableTintList(textView, ColorStateList.valueOf(color))
+            }
+        }
+    }
+
+    companion object {
+        private const val PERCENT_HUNDRED = 100
+        private const val MIN_PIE_CHART_RATIO = 0.039f
+        private val COLOR_LIST = listOf(R.color.blue, R.color.blue_5, R.color.orange_30)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/PieChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/PieChartViewHolder.kt
@@ -45,12 +45,11 @@ class PieChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(parent, R.
                 inSpans(AbsoluteSizeSpan(textSize.toInt())) { append("\n${item.total}") }
             }
 
-            val entries = mapToPieEntry(item.entries)
-            val dataSet = getDataSet(entries)
+            val dataSet = getDataSet(item)
             dataSet.sliceSpace = DisplayUtils.pxToDp(context, sliceWidth.toInt()).toFloat()
             data = PieData(dataSet)
 
-            addLegends(item.entries)
+            addLegends(item)
         }
         itemView.contentDescription = item.contentDescription
     }
@@ -65,20 +64,19 @@ class PieChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(parent, R.
         chart.doOnLayout { chart.holeRadius = (1 - 2 * sliceWidth / chart.width) * PERCENT_HUNDRED }
     }
 
-    private fun getDataSet(entries: List<PieEntry>) = PieDataSet(entries, null).apply {
+    private fun getDataSet(item: PieChartItem) = PieDataSet(mapToPieEntry(item.entries), null).apply {
         label = null
         setDrawValues(false)
-        colors = COLOR_LIST.map { ContextCompat.getColor(chart.context, it) }
-
+        colors = item.colors.map { ContextCompat.getColor(chart.context, it) }
         selectionShift = 0f // Needed for removing extra highlighting space in chart size
     }
 
-    private fun addLegends(entries: List<Pie>) {
-        entries.forEachIndexed { index, pie ->
+    private fun addLegends(item: PieChartItem) {
+        item.entries.forEachIndexed { index, pie ->
             ItemPieChartLegendBinding.inflate(LayoutInflater.from(legends.context), legends, true).apply {
                 val textView = root.findViewById<TextView>(R.id.text)
                 textView.text = pie.label
-                val colorRes = COLOR_LIST[index % entries.size]
+                val colorRes = item.colors[index % item.entries.size]
                 val color = ContextCompat.getColor(root.context, colorRes)
                 TextViewCompat.setCompoundDrawableTintList(textView, ColorStateList.valueOf(color))
             }
@@ -88,6 +86,5 @@ class PieChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(parent, R.
     companion object {
         private const val PERCENT_HUNDRED = 100
         private const val MIN_PIE_CHART_RATIO = 0.039f
-        private val COLOR_LIST = listOf(R.color.blue, R.color.blue_5, R.color.orange_30)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/PieChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/PieChartViewHolder.kt
@@ -48,9 +48,8 @@ class PieChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(parent, R.
             val dataSet = getDataSet(item)
             dataSet.sliceSpace = DisplayUtils.pxToDp(context, sliceWidth.toInt()).toFloat()
             data = PieData(dataSet)
-
-            addLegends(item)
         }
+        addLegends(item)
         itemView.contentDescription = item.contentDescription
     }
 
@@ -64,11 +63,14 @@ class PieChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(parent, R.
         chart.doOnLayout { chart.holeRadius = (1 - 2 * sliceWidth / chart.width) * PERCENT_HUNDRED }
     }
 
-    private fun getDataSet(item: PieChartItem) = PieDataSet(mapToPieEntry(item.entries), null).apply {
-        label = null
-        setDrawValues(false)
-        colors = item.colors.map { ContextCompat.getColor(chart.context, it) }
-        selectionShift = 0f // Needed for removing extra highlighting space in chart size
+    private fun getDataSet(item: PieChartItem): PieDataSet {
+        val pieChartEntries = item.entries.filter { it.value > 0 }
+        return PieDataSet(mapToPieEntry(pieChartEntries), null).apply {
+            label = null
+            setDrawValues(false)
+            colors = item.colors.map { ContextCompat.getColor(chart.context, it) }
+            selectionShift = 0f // Needed for removing extra highlighting space in chart size
+        }
     }
 
     private fun addLegends(item: PieChartItem) {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/RoundedSlicesPieChartRenderer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/RoundedSlicesPieChartRenderer.kt
@@ -1,0 +1,166 @@
+package org.wordpress.android.widgets
+
+import android.graphics.Canvas
+import android.graphics.Path
+import android.graphics.Path.Direction.CCW
+import android.graphics.Path.Direction.CW
+import android.graphics.RectF
+import com.github.mikephil.charting.charts.PieChart
+import com.github.mikephil.charting.interfaces.datasets.IPieDataSet
+import com.github.mikephil.charting.renderer.PieChartRenderer
+import com.github.mikephil.charting.utils.MPPointF
+import com.github.mikephil.charting.utils.Utils
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.sin
+
+/**
+ * PieChartRenderer draws outer round to the end of the slice and inner round to the start of the slice.
+ * PieChartRenderer#drawDataSet is copied here and edited for a feature which outer round can be drew both start and end
+ * of slices.
+ */
+class RoundedSlicesPieChartRenderer(chart: PieChart) : PieChartRenderer(chart, chart.animator, chart.viewPortHandler) {
+    init {
+        chart.setDrawRoundedSlices(true)
+        chart.isDrawHoleEnabled = false
+    }
+
+    // These are suppressed instead of fixing for keeping the similarity with super class function
+    @Suppress("LongMethod", "ComplexMethod", "NestedBlockDepth", "MagicNumber")
+    override fun drawDataSet(c: Canvas, dataSet: IPieDataSet) {
+        var angle = 0f
+        val rotationAngle = mChart.rotationAngle
+
+        val phaseX = mAnimator.phaseX
+        val phaseY = mAnimator.phaseY
+
+        val circleBox = mChart.circleBox
+
+        val entryCount = dataSet.entryCount
+        val drawAngles = mChart.drawAngles
+        val center = mChart.centerCircleBox
+        val radius = mChart.radius
+        val userInnerRadius = radius * (mChart.holeRadius / 100f)
+        val roundedRadius = (radius - radius * mChart.holeRadius / 100f) / 2f
+        val roundedCircleBox = RectF()
+
+        var visibleAngleCount = 0
+        for (j in 0 until entryCount) {
+            // draw only if the value is greater than zero
+            if (abs(dataSet.getEntryForIndex(j).y) > Utils.FLOAT_EPSILON) {
+                visibleAngleCount++
+            }
+        }
+
+        val sliceSpace = if (visibleAngleCount <= 1) 0f else getSliceSpace(dataSet)
+        val pathBuffer = Path()
+        val innerRectBuffer = RectF()
+
+        for (j in 0 until entryCount) {
+            val sliceAngle = drawAngles[j]
+            var innerRadius = userInnerRadius
+            val e = dataSet.getEntryForIndex(j)
+
+            // draw only if the value is greater than zero
+            if (abs(e.y) <= Utils.FLOAT_EPSILON) {
+                angle += sliceAngle * phaseX
+                continue
+            }
+
+            val accountForSliceSpacing = sliceSpace > 0f && sliceAngle <= 180f
+            mRenderPaint.color = dataSet.getColor(j)
+            val sliceSpaceAngleOuter = if (visibleAngleCount == 1) {
+                0f
+            } else {
+                sliceSpace / (Utils.FDEG2RAD * radius)
+            }
+            val startAngleOuter = rotationAngle + (angle + sliceSpaceAngleOuter / 2f) * phaseY
+            var sweepAngleOuter = (sliceAngle - sliceSpaceAngleOuter) * phaseY
+            if (sweepAngleOuter < 0f) {
+                sweepAngleOuter = 0f
+            }
+            pathBuffer.reset()
+
+            var x = center.x + (radius - roundedRadius) * cos(startAngleOuter * Utils.FDEG2RAD)
+            var y = center.y + (radius - roundedRadius) * sin(startAngleOuter * Utils.FDEG2RAD)
+            roundedCircleBox[x - roundedRadius, y - roundedRadius, x + roundedRadius] = y + roundedRadius
+
+            val arcStartPointX = center.x + radius * cos(startAngleOuter * Utils.FDEG2RAD)
+            val arcStartPointY = center.y + radius * sin(startAngleOuter * Utils.FDEG2RAD)
+            if (sweepAngleOuter >= 360f && sweepAngleOuter % 360f <= Utils.FLOAT_EPSILON) {
+                // Android is doing "mod 360"
+                pathBuffer.addCircle(center.x, center.y, radius, CW)
+            } else {
+                pathBuffer.arcTo(roundedCircleBox, startAngleOuter - 180, 180f)
+                pathBuffer.arcTo(circleBox, startAngleOuter, sweepAngleOuter)
+            }
+
+            // API < 21 does not receive floats in addArc, but a RectF
+            innerRectBuffer[center.x - innerRadius, center.y - innerRadius, center.x + innerRadius] =
+                    center.y + innerRadius
+            if (innerRadius > 0f || accountForSliceSpacing) {
+                if (accountForSliceSpacing) {
+                    var minSpacedRadius = calculateMinimumRadiusForSpacedSlice(
+                            center,
+                            radius,
+                            sliceAngle * phaseY,
+                            arcStartPointX, arcStartPointY,
+                            startAngleOuter,
+                            sweepAngleOuter
+                    )
+                    if (minSpacedRadius < 0f) {
+                        minSpacedRadius = -minSpacedRadius
+                    }
+                    innerRadius = max(innerRadius, minSpacedRadius)
+                }
+                val sliceSpaceAngleInner = if (visibleAngleCount == 1 || innerRadius == 0f) {
+                    0f
+                } else {
+                    sliceSpace / (Utils.FDEG2RAD * innerRadius)
+                }
+                val startAngleInner = rotationAngle + (angle + sliceSpaceAngleInner / 2f) * phaseY
+                var sweepAngleInner = (sliceAngle - sliceSpaceAngleInner) * phaseY
+                if (sweepAngleInner < 0f) {
+                    sweepAngleInner = 0f
+                }
+                val endAngleInner = startAngleInner + sweepAngleInner
+                if (sweepAngleOuter >= 360f && sweepAngleOuter % 360f <= Utils.FLOAT_EPSILON) {
+                    // Android is doing "mod 360"
+                    pathBuffer.addCircle(center.x, center.y, innerRadius, CCW)
+                } else {
+                    x = center.x + (radius - roundedRadius) * cos(endAngleInner * Utils.FDEG2RAD)
+                    y = center.y + (radius - roundedRadius) * sin(endAngleInner * Utils.FDEG2RAD)
+                    roundedCircleBox[x - roundedRadius, y - roundedRadius, x + roundedRadius] = y + roundedRadius
+                    pathBuffer.arcTo(roundedCircleBox, endAngleInner, 180f)
+                    pathBuffer.arcTo(innerRectBuffer, endAngleInner, -sweepAngleInner)
+                }
+            } else {
+                if (sweepAngleOuter % 360f > Utils.FLOAT_EPSILON) {
+                    if (accountForSliceSpacing) {
+                        val angleMiddle = startAngleOuter + sweepAngleOuter / 2f
+                        val sliceSpaceOffset = calculateMinimumRadiusForSpacedSlice(
+                                center,
+                                radius,
+                                sliceAngle * phaseY,
+                                arcStartPointX,
+                                arcStartPointY,
+                                startAngleOuter,
+                                sweepAngleOuter
+                        )
+                        val arcEndPointX = center.x + sliceSpaceOffset * cos(angleMiddle * Utils.FDEG2RAD)
+                        val arcEndPointY = center.y + sliceSpaceOffset * sin(angleMiddle * Utils.FDEG2RAD)
+                        pathBuffer.lineTo(arcEndPointX, arcEndPointY)
+                    } else {
+                        pathBuffer.lineTo(center.x, center.y)
+                    }
+                }
+            }
+            pathBuffer.close()
+            mBitmapCanvas.drawPath(pathBuffer, mRenderPaint)
+            angle += sliceAngle * phaseX
+        }
+
+        MPPointF.recycleInstance(center)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/widgets/RoundedSlicesPieChartRenderer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/RoundedSlicesPieChartRenderer.kt
@@ -24,6 +24,7 @@ class RoundedSlicesPieChartRenderer(chart: PieChart) : PieChartRenderer(chart, c
     init {
         chart.setDrawRoundedSlices(true)
         chart.isDrawHoleEnabled = false
+        chart.setTouchEnabled(false)
     }
 
     // These are suppressed instead of fixing for keeping the similarity with super class function

--- a/WordPress/src/main/res/drawable/ic_dot_white_12dp.xml
+++ b/WordPress/src/main/res/drawable/ic_dot_white_12dp.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <size
+        android:width="12dp"
+        android:height="12dp" />
+    <solid android:color="@color/white" />
+</shape>

--- a/WordPress/src/main/res/layout/item_pie_chart_legend.xml
+++ b/WordPress/src/main/res/layout/item_pie_chart_legend.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_weight="1">
+
+    <TextView
+        android:id="@+id/text"
+        style="@style/StatsPieChartLegends"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:drawablePadding="@dimen/margin_medium"
+        android:ellipsize="end"
+        android:maxLines="1"
+        app:drawableStartCompat="@drawable/ic_dot_white_12dp"
+        tools:text="@string/unknown" />
+</FrameLayout>

--- a/WordPress/src/main/res/layout/stats_block_pie_chart_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_pie_chart_item.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingVertical="@dimen/margin_large">
+
+    <TextView
+        android:id="@+id/total_text"
+        style="@style/StatsPieChartTotalText"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:lineSpacingExtra="3dp"
+        app:layout_constraintBottom_toBottomOf="@id/chart"
+        app:layout_constraintEnd_toEndOf="@id/chart"
+        app:layout_constraintStart_toStartOf="@id/chart"
+        app:layout_constraintTop_toTopOf="@id/chart" />
+
+    <com.github.mikephil.charting.charts.PieChart
+        android:id="@+id/chart"
+        android:layout_width="164dp"
+        android:layout_height="164dp"
+        android:layout_marginTop="@dimen/margin_large"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/legends"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_extra_extra_large"
+        android:layout_marginTop="@dimen/margin_extra_medium_large"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/chart" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -178,6 +178,7 @@
     <dimen name="text_sz_extra_large">20sp</dimen>
     <dimen name="text_sz_double_extra_large">24sp</dimen>
     <dimen name="text_sz_extra_extra_large">32sp</dimen>
+    <dimen name="text_sz_extra_extra_extra_large">34sp</dimen>
 
     <dimen name="avatar_sz_extra_small">24dp</dimen>
     <dimen name="avatar_sz_small">32dp</dimen>
@@ -538,6 +539,7 @@
     <!-- stats -->
     <dimen name="stats_header_height">32dp</dimen>
     <dimen name="stats_bar_chart_height">180dp</dimen>
+    <dimen name="stats_pie_chart_slice_width">16dp</dimen>
     <dimen name="stats_block_icon_size">24dp</dimen>
     <dimen name="stats_list_card_horizontal_spacing">4dp</dimen>
     <dimen name="stats_list_card_top_spacing">4dp</dimen>

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -341,6 +341,10 @@
     <style name="InsightsManagementItem" parent="TextAppearance.MaterialComponents.Body1" />
 
     <!-- Stats Revamp styles -->
+    <style name="StatsPieChartTotalText" parent="TextAppearance.MaterialComponents.Body2" />
+
+    <style name="StatsPieChartLegends" parent="TextAppearance.MaterialComponents.Body2" />
+
     <style name="StatsLegendsBlue" parent="TextAppearance.MaterialComponents.Caption">
         <item name="android:layout_marginTop">24dp</item>
         <item name="android:layout_marginBottom">4dp</item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1374,6 +1374,8 @@
     <string name="stats_referrers">Referrers</string>
     <string name="stats_referrer_label">Referrer</string>
     <string name="stats_referrer_views_label">Views</string>
+    <string name="stats_referrers_pie_chart_total_label">Views</string>
+    <string name="stats_referrers_pie_chart_others">Others</string>
     <string name="stats_clicks">Clicks</string>
     <string name="stats_clicks_link_label">Link</string>
     <string name="stats_clicks_label">Clicks</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1375,6 +1375,8 @@
     <string name="stats_referrer_label">Referrer</string>
     <string name="stats_referrer_views_label">Views</string>
     <string name="stats_referrers_pie_chart_total_label">Views</string>
+    <string name="stats_referrers_pie_chart_wordpress">Wordpress</string>
+    <string name="stats_referrers_pie_chart_search">Search</string>
     <string name="stats_referrers_pie_chart_others">Others</string>
     <string name="stats_clicks">Clicks</string>
     <string name="stats_clicks_link_label">Link</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1394,6 +1394,7 @@
     <string name="stats_file_downloads">File downloads</string>
     <string name="stats_file_downloads_title_label">File</string>
     <string name="stats_file_downloads_value_label">Downloads</string>
+    <string name="stats_follower_types_pie_chart_total_label">Totals</string>
 
     <string name="stats_select_previous_period_description">Select previous period</string>
     <string name="stats_select_next_period_description">Select next period</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTypesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowerTypesUseCaseTest.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.Us
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.PIE_CHART
 import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
@@ -49,6 +50,7 @@ class FollowerTypesUseCaseTest : BaseUnitTest() {
     private val wpComTitle = "WordPress"
     private val emailTitle = "Email"
     private val socialTitle = "Social"
+    private val totalLabel = "Totals"
     private val contentDescriptionValue = "value, percentage of total followers"
     private val contentDescription = "title: $contentDescriptionValue"
 
@@ -84,6 +86,7 @@ class FollowerTypesUseCaseTest : BaseUnitTest() {
         whenever(resourceProvider.getString(R.string.stats_insights_social)).then { socialTitle }
         whenever(resourceProvider.getString(eq(R.string.stats_value_percent), any<String>(), any<String>()))
                 .then { "${it.arguments[1]} (${it.arguments[2]}%)" }
+        whenever(resourceProvider.getString(R.string.stats_follower_types_pie_chart_total_label)).then { totalLabel }
     }
 
     @Test
@@ -99,9 +102,10 @@ class FollowerTypesUseCaseTest : BaseUnitTest() {
 
         assertThat(result.state).isEqualTo(SUCCESS)
         result.data!!.apply {
-            assertThat(this).hasSize(3)
+            assertThat(this).hasSize(4)
+            assertThat(this[0].type).isEqualTo(PIE_CHART)
 
-            for (i in 0..2) {
+            for (i in 1..3) {
                 assertThat(this[i].type).isEqualTo(LIST_ITEM)
                 assertItem(this[i] as ListItem)
             }


### PR DESCRIPTION
Fixes #16552 

This adds a pie chart to follower types card and referrers card.

### Notes
- **Referrers Card:** When the app is in English, WordPress and Search pies are shown in the chart. When the app isn't in English, the top two referrers are shown in the pie chart. (Since the group name is localized in the endpoint, we can't find WordPress or Search in referrers endpoint when the app isn't in English. That's why we don't show them in non-English app.)
- **Follower Types Card:** Always 3 follower types (WordPress, Email, Social) are shown.
- If the slice percent is lower than 3.9%, the percent is rounded up to 3.9% to be able to show the slice in the chart without visual corruption.

|Design|PR|
|-|-|
|<img width="320" src="https://user-images.githubusercontent.com/2471769/169718264-ce761da3-38e4-4563-8ae1-04b3e9ca2dc7.png">|<img src="https://user-images.githubusercontent.com/2471769/170681153-ad1691ae-33dd-4bea-8bf2-f41ebab2e835.png" width="320">|


To test:

Setup:
1. Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
2. Select Debug Settings.
3. Find StatsRevampV2FeatureConfig under Features in development enable it and restart app.

Test 1: 
1. Go to stats either using quick links or menu.
2. Ensure that it opens in Insights tab otherwise switch to Insights tab.
3. Notice a new Total Followers card is shown in Insights tab with Line Chart (scroll down if necessary).
4. Tap on "VIEW MORE" on the top right-hand corner of the card.
5. Ensure it opens the detail screen (scroll down if necessary) with Follower Types card.
6. Notice the pie chart view and check its visual data.
7. Ensure WordPress.com Email and Social slices are in the pie chart.

Test 2: 
1. Ensure your device language is English.
2. Go to stats either using quick links or menu.
3. Ensure that it opens in Insights tab otherwise switch to Insights tab.
4. Notice the new Views & Visitors card is shown in Insights tab with Line Chart (scroll down if necessary).
5. Tap on "VIEW MORE" on the top right-hand corner of the card.
6. Notice the pie chart in the referrers card. Ensure its visual is the same as the design.
7. If you use the app in English, ensure `WordPress, Search and Others` legends are in the pie cart.

Test 3:
1. Change the device language to a language different from English.
2. Repeat steps 2-6 in Test 2.
3. Ensure the top two referrers and Others slices are in the pie chart instead of `WordPress, Search and Others`.

## Regression Notes
1. Potential unintended areas of impact
Current referrers card.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Used feature flag to add a pie chart to referrers card and tested manually.

3. What automated tests I added (or what prevented me from doing so)
I didn't add a new test because there is no new feature.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
