### PR TITLE
My Site Dashboard: Track tap on "Write first post" and "Write next post"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -173,7 +173,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val title: UiString,
                         val excerpt: UiString,
                         @DrawableRes val imageRes: Int,
-                        override val footerLink: FooterLink
+                        override val footerLink: FooterLink,
+                        val onClick: ListItemInteraction
                     ) : PostCard(
                             dashboardCardType = DashboardCardType.POST_CARD_WITHOUT_POST_ITEMS,
                             footerLink = footerLink

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1149,11 +1149,12 @@ class MySiteViewModel @Inject constructor(
         selectedSiteRepository.getSelectedSite()?.let { site ->
             cardsTracker.trackPostItemClicked(params.postCardType)
             when (params.postCardType) {
+                PostCardType.CREATE_FIRST, PostCardType.CREATE_NEXT -> _onNavigation.value =
+                    Event(SiteNavigationAction.OpenEditorToCreateNewPost(site))
                 PostCardType.DRAFT -> _onNavigation.value =
                         Event(SiteNavigationAction.EditDraftPost(site, params.postId))
                 PostCardType.SCHEDULED -> _onNavigation.value =
                         Event(SiteNavigationAction.EditScheduledPost(site, params.postId))
-                else -> Unit // Do nothing
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -13,6 +13,8 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
+import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType.CREATE_FIRST
+import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType.CREATE_NEXT
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -47,9 +49,9 @@ class PostCardBuilder @Inject constructor(
                 posts?.hasPublished?.takeIf { !posts.hasDraftsOrScheduledPosts() }
                         ?.let { hasPublished ->
                             if (hasPublished) {
-                                add(createNextPostCard(params.onFooterLinkClick))
+                                add(createNextPostCard(params.onPostItemClick, params.onFooterLinkClick))
                             } else {
-                                add(createFirstPostCard(params.onFooterLinkClick))
+                                add(createFirstPostCard(params.onPostItemClick, params.onFooterLinkClick))
                             }
                         }
                 posts?.draft?.takeIf { it.isNotEmpty() }?.let { add(it.createDraftPostsCard(params)) }
@@ -60,29 +62,41 @@ class PostCardBuilder @Inject constructor(
             title = UiStringRes(R.string.posts)
     )
 
-    private fun createFirstPostCard(onFooterLinkClick: (postCardType: PostCardType) -> Unit) =
-            PostCardWithoutPostItems(
-                    postCardType = PostCardType.CREATE_FIRST,
-                    title = UiStringRes(R.string.my_site_create_first_post_title),
-                    excerpt = UiStringRes(R.string.my_site_create_first_post_excerpt),
-                    imageRes = R.drawable.img_write_212dp,
-                    footerLink = FooterLink(
-                            label = UiStringRes(R.string.my_site_post_card_link_create_post),
-                            onClick = onFooterLinkClick
-                    )
+    private fun createFirstPostCard(
+        onPostItemClick: (params: PostItemClickParams) -> Unit,
+        onFooterLinkClick: (postCardType: PostCardType) -> Unit
+    ) = PostCardWithoutPostItems(
+            postCardType = PostCardType.CREATE_FIRST,
+            title = UiStringRes(R.string.my_site_create_first_post_title),
+            excerpt = UiStringRes(R.string.my_site_create_first_post_excerpt),
+            imageRes = R.drawable.img_write_212dp,
+            footerLink = FooterLink(
+                    label = UiStringRes(R.string.my_site_post_card_link_create_post),
+                    onClick = onFooterLinkClick
+            ),
+            onClick = ListItemInteraction.create(
+                    PostItemClickParams(postCardType = CREATE_FIRST, postId = NOT_SET),
+                    onPostItemClick
             )
+    )
 
-    private fun createNextPostCard(onFooterLinkClick: (postCardType: PostCardType) -> Unit) =
-            PostCardWithoutPostItems(
-                    postCardType = PostCardType.CREATE_NEXT,
-                    title = UiStringRes(R.string.my_site_create_next_post_title),
-                    excerpt = UiStringRes(R.string.my_site_create_next_post_excerpt),
-                    imageRes = R.drawable.img_write_212dp,
-                    footerLink = FooterLink(
-                            label = UiStringRes(R.string.my_site_post_card_link_create_post),
-                            onClick = onFooterLinkClick
-                    )
+    private fun createNextPostCard(
+        onPostItemClick: (params: PostItemClickParams) -> Unit,
+        onFooterLinkClick: (postCardType: PostCardType) -> Unit
+    ) = PostCardWithoutPostItems(
+            postCardType = PostCardType.CREATE_NEXT,
+            title = UiStringRes(R.string.my_site_create_next_post_title),
+            excerpt = UiStringRes(R.string.my_site_create_next_post_excerpt),
+            imageRes = R.drawable.img_write_212dp,
+            footerLink = FooterLink(
+                    label = UiStringRes(R.string.my_site_post_card_link_create_post),
+                    onClick = onFooterLinkClick
+            ),
+            onClick = ListItemInteraction.create(
+                    PostItemClickParams(postCardType = CREATE_NEXT, postId = NOT_SET),
+                    onPostItemClick
             )
+    )
 
     private fun List<PostCardModel>.createDraftPostsCard(params: PostCardBuilderParams) =
             PostCardWithPostItems(
@@ -150,5 +164,6 @@ class PostCardBuilder @Inject constructor(
 
     companion object {
         private const val MONTH_DAY_FORMAT = "MMM d"
+        const val NOT_SET = -1
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -13,8 +13,6 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
-import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType.CREATE_FIRST
-import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType.CREATE_NEXT
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -75,7 +73,7 @@ class PostCardBuilder @Inject constructor(
                     onClick = onFooterLinkClick
             ),
             onClick = ListItemInteraction.create(
-                    PostItemClickParams(postCardType = CREATE_FIRST, postId = NOT_SET),
+                    PostItemClickParams(postCardType = PostCardType.CREATE_FIRST, postId = NOT_SET),
                     onPostItemClick
             )
     )
@@ -93,7 +91,7 @@ class PostCardBuilder @Inject constructor(
                     onClick = onFooterLinkClick
             ),
             onClick = ListItemInteraction.create(
-                    PostItemClickParams(postCardType = CREATE_NEXT, postId = NOT_SET),
+                    PostItemClickParams(postCardType = PostCardType.CREATE_NEXT, postId = NOT_SET),
                     onPostItemClick
             )
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardViewHolder.kt
@@ -11,8 +11,8 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.cards.dashboard.CardViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString
-import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.extensions.viewBinding
+import org.wordpress.android.util.image.ImageManager
 
 sealed class PostCardViewHolder<T : ViewBinding>(
     override val binding: T
@@ -35,6 +35,7 @@ sealed class PostCardViewHolder<T : ViewBinding>(
             mySiteCardFooterLink.linkLabel.setOnClickListener {
                 postCard.footerLink.onClick.invoke(card.postCardType)
             }
+            itemView.setOnClickListener { postCard.onClick.click() }
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -95,6 +95,7 @@ import org.wordpress.android.ui.mysite.SiteDialogModel.ShowRemoveNextStepsDialog
 import org.wordpress.android.ui.mysite.cards.CardsBuilder
 import org.wordpress.android.ui.mysite.cards.DomainRegistrationCardShownTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardBuilder.Companion.NOT_SET
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.mysite.cards.dashboard.todaysstats.TodaysStatsCardBuilder.Companion.URL_GET_MORE_VIEWS_AND_TRAFFIC
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
@@ -1479,7 +1480,27 @@ class MySiteViewModelTest : BaseUnitTest() {
         verify(cardsTracker, atLeastOnce()).trackShown(any())
     }
 
-    /* DASHBOARD POST CARD - POST ITEM */
+    /* DASHBOARD POST CARD */
+
+    @Test
+    fun `when create first post card is clicked, then editor is opened to create new post`() =
+            test {
+                initSelectedSite()
+
+                requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.CREATE_FIRST, NOT_SET))
+
+                assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenEditorToCreateNewPost(site))
+            }
+
+    @Test
+    fun `when create next post card is clicked, then editor is opened to create new post`() =
+            test {
+                initSelectedSite()
+
+                requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.CREATE_NEXT, NOT_SET))
+
+                assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenEditorToCreateNewPost(site))
+            }
 
     @Test
     fun `given draft post card, when post item is clicked, then post is opened for edit draft`() =
@@ -1502,12 +1523,39 @@ class MySiteViewModelTest : BaseUnitTest() {
             }
 
     @Test
-    fun `given post card, when item is clicked, then event is tracked`() = test {
+    fun `given scheduled post card, when item is clicked, then event is tracked`() = test {
         initSelectedSite()
 
         requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.SCHEDULED, postId))
 
         verify(cardsTracker).trackPostItemClicked(PostCardType.SCHEDULED)
+    }
+
+    @Test
+    fun `given draft post card, when item is clicked, then event is tracked`() = test {
+        initSelectedSite()
+
+        requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.DRAFT, postId))
+
+        verify(cardsTracker).trackPostItemClicked(PostCardType.DRAFT)
+    }
+
+    @Test
+    fun `given create first post card, when item is clicked, then event is tracked`() = test {
+        initSelectedSite()
+
+        requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.CREATE_FIRST, NOT_SET))
+
+        verify(cardsTracker).trackPostItemClicked(PostCardType.CREATE_FIRST)
+    }
+
+    @Test
+    fun `given create next post card, when item is clicked, then event is tracked`() = test {
+        initSelectedSite()
+
+        requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.CREATE_NEXT, NOT_SET))
+
+        verify(cardsTracker).trackPostItemClicked(PostCardType.CREATE_NEXT)
     }
 
     /* DASHBOARD BLOGGING PROMPT CARD */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
@@ -110,8 +110,9 @@ class CardsShownTrackerTest {
                     title = UiStringText(""),
                     footerLink = FooterLink(UiStringText(""), onClick = mock()),
                     excerpt = UiStringText(""),
-                    imageRes = 0
-            )
+                    imageRes = 0,
+                    onClick = mock()
+                )
             )
 
     private fun buildPostCardsWithItems(postCardType: PostCardType) = listOf(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
@@ -21,6 +21,9 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.DashboardCardType
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DashboardCardType.POST_CARD_ERROR
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
+import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardBuilder.Companion.NOT_SET
+import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType.CREATE_FIRST
+import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
@@ -134,6 +137,10 @@ class PostCardBuilderTest : BaseUnitTest() {
                         footerLink = FooterLink(
                                 label = UiStringRes(R.string.my_site_post_card_link_create_post),
                                 onClick = onPostCardFooterLinkClick
+                        ),
+                        onClick = ListItemInteraction.create(
+                                PostItemClickParams(postCardType = CREATE_FIRST, postId = NOT_SET),
+                                onPostItemClick
                         )
                 )
         )
@@ -192,6 +199,10 @@ class PostCardBuilderTest : BaseUnitTest() {
                         footerLink = FooterLink(
                                 label = UiStringRes(R.string.my_site_post_card_link_create_post),
                                 onClick = onPostCardFooterLinkClick
+                        ),
+                        ListItemInteraction.create(
+                                PostItemClickParams(postCardType = PostCardType.CREATE_NEXT, postId = NOT_SET),
+                                onPostItemClick
                         )
                 )
         )


### PR DESCRIPTION
This PR adds two tracks:

* When tapping "Write your first post": `🔵 Tracked: my_site_dashboard_card_item_tapped, Properties: {"type":"post","default_tab_experiment":"dashboard","subtype":"create_first”}`
* When tapping "Write your next post": `🔵 Tracked: my_site_dashboard_card_item_tapped, Properties: {"type":"post","default_tab_experiment":"dashboard","subtype":"create_next"}`

In order to add these trackings, these cards are made tappable. Now both card tap and footer link tap navigate to the `Editor` from the card. (Internal Ref: p1653284207040309-slack-C0290FLA0RM)

Corresponding iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/18691

### To test

1. Run the app
2. For a site without any posts, tap the "Write your first post" card
3. ✅ Make sure `my_site_dashboard_card_item_tapped` is fired with `sub_type: create_first` prop
4. Publish a post
5. Tap the "Write your next post" card
6. ✅ Make sure `my_site_dashboard_card_item_tapped` is fired with `sub_type: create_next` prop

To test:

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
4. N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.