### PR TITLE
[Site design revamp] Use the custom Glide loader for preloading the thumbnails

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.bumptech.glide.Glide
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -17,6 +17,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.networking.MShot
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
@@ -30,6 +31,7 @@ import org.wordpress.android.ui.sitecreation.usecases.FetchHomePageLayoutsUseCas
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.experiments.SiteNameABExperiment
+import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
 import org.wordpress.android.util.wizard.WizardState
@@ -62,7 +64,8 @@ class SiteCreationMainVM @Inject constructor(
     private val siteNameABExperiment: SiteNameABExperiment,
     private val networkUtils: NetworkUtilsWrapper,
     private val dispatcher: Dispatcher,
-    private val fetchHomePageLayoutsUseCase: FetchHomePageLayoutsUseCase
+    private val fetchHomePageLayoutsUseCase: FetchHomePageLayoutsUseCase,
+    private val imageManager: ImageManager
 ) : ViewModel() {
     init {
         dispatcher.register(fetchHomePageLayoutsUseCase)
@@ -126,11 +129,7 @@ class SiteCreationMainVM @Inject constructor(
                 if (networkUtils.isNetworkAvailable()) {
                     val response = fetchHomePageLayoutsUseCase.fetchStarterDesigns()
                     for (design in response.designs) {
-                        Glide.with(context)
-                                .downloadOnly()
-                                .load(design.previewMobile)
-                                .submit()
-                                .get() // This makes each call blocking, so subsequent calls can be cancelled if needed.
+                        imageManager.preload(context, MShot(design.previewMobile))
                     }
                 }
                 preloadingJob = null

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -297,6 +297,21 @@ class ImageManager @Inject constructor(
     }
 
     /**
+     * Preloads an [MShot].
+     *
+     * This is needed because the mshot service redirects to a loading gif image when the thumbnail is not ready.
+     * The loading is handled by [org.wordpress.android.networking.GlideMShotsLoader]
+     */
+    fun preload(context: Context, design: MShot) {
+        if (!context.isAvailable()) return
+        GlideApp.with(context)
+                .downloadOnly()
+                .load(design)
+                .submit()
+                .get() // This makes each call blocking, so subsequent calls can be cancelled if needed.
+    }
+
+    /**
      * Loads an [MShot] into an [ImageView] and attaches a [RequestListener].
      *
      * This is needed because the mshot service redirects to a loading gif image when the thumbnail is not ready.

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.Creat
 import org.wordpress.android.ui.sitecreation.usecases.FetchHomePageLayoutsUseCase
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.experiments.SiteNameABExperiment
+import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.DialogHolder
@@ -64,6 +65,7 @@ class SiteCreationMainVMTest {
     @Mock lateinit var networkUtils: NetworkUtilsWrapper
     @Mock lateinit var dispatcher: Dispatcher
     @Mock lateinit var fetchHomePageLayoutsUseCase: FetchHomePageLayoutsUseCase
+    @Mock lateinit var imageManager: ImageManager
     private val wizardManagerNavigatorLiveData = SingleLiveEvent<SiteCreationStep>()
 
     private lateinit var viewModel: SiteCreationMainVM
@@ -286,6 +288,7 @@ class SiteCreationMainVMTest {
             siteNameABExperiment,
             networkUtils,
             dispatcher,
-            fetchHomePageLayoutsUseCase
+            fetchHomePageLayoutsUseCase,
+            imageManager
     )
 }


### PR DESCRIPTION
# Description
Wraps the thumbnail url `String` in an [`MShot` object so that the retries are handled correctly](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/networking/GlideMShotsLoader.kt) when the server redirects to a loading gif image when the thumbnail is not ready. This is a continuation of the thumbnail preloading implementation from https://github.com/wordpress-mobile/WordPress-Android/pull/16584

# To test:
* Uninstall and reinstall the app or clear the app data from the Settings. You can try to fetch uncached MShots by changing the requested dimensions (`hpp_layout_card_height`, `hpp_layout_card_width`) or changing the interface language.
* Follow the instruction on https://github.com/wordpress-mobile/WordPress-Android/pull/16584#issue-1239691137

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
