### PR TITLE
My Site Dashboard: change Quick Actions order 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonBuilder.kt
@@ -14,48 +14,47 @@ class QuickLinkRibbonBuilder @Inject constructor(
     val quickStartRepository: QuickStartRepository
 ) {
     fun build(params: QuickLinkRibbonBuilderParams) = QuickLinkRibbon(
-        quickLinkRibbonItems = getQuickLinkRibbonItems(params),
-        showPagesFocusPoint = shouldShowPagesFocusPoint(params),
-        showStatsFocusPoint = shouldShowStatsFocusPoint(params),
-        showMediaFocusPoint = shouldShowMediaFocusPoint(params)
+            quickLinkRibbonItems = getQuickLinkRibbonItems(params),
+            showPagesFocusPoint = shouldShowPagesFocusPoint(params),
+            showStatsFocusPoint = shouldShowStatsFocusPoint(params),
+            showMediaFocusPoint = shouldShowMediaFocusPoint(params)
     )
 
     private fun getQuickLinkRibbonItems(params: QuickLinkRibbonBuilderParams): MutableList<QuickLinkRibbonItem> {
         val items = mutableListOf<QuickLinkRibbonItem>()
-        if (params.siteModel.isSelfHostedAdmin || params.siteModel.hasCapabilityEditPages) {
-            val pages = QuickLinkRibbonItem(
-                label = R.string.pages,
-                icon = R.drawable.ic_pages_white_24dp,
-                onClick = ListItemInteraction.create(params.onPagesClick),
-                showFocusPoint = shouldShowPagesFocusPoint(params)
-            )
-            items.add(pages)
-        }
         items.apply {
             add(
-                QuickLinkRibbonItem(
-                    label = R.string.posts,
-                    icon = R.drawable.ic_posts_white_24dp,
-                    onClick = ListItemInteraction.create(params.onPostsClick)
-                )
+                    QuickLinkRibbonItem(
+                            label = R.string.stats,
+                            icon = R.drawable.ic_stats_alt_white_24dp,
+                            onClick = ListItemInteraction.create(params.onStatsClick),
+                            showFocusPoint = shouldShowStatsFocusPoint(params)
+                    )
             )
             add(
-                QuickLinkRibbonItem(
-                    label = R.string.media,
-                    icon = R.drawable.ic_media_white_24dp,
-                    onClick = ListItemInteraction.create(params.onMediaClick),
-                    showFocusPoint = shouldShowMediaFocusPoint(params)
-                )
+                    QuickLinkRibbonItem(
+                            label = R.string.posts,
+                            icon = R.drawable.ic_posts_white_24dp,
+                            onClick = ListItemInteraction.create(params.onPostsClick)
+                    )
             )
-
             add(
-                QuickLinkRibbonItem(
-                    label = R.string.stats,
-                    icon = R.drawable.ic_stats_alt_white_24dp,
-                    onClick = ListItemInteraction.create(params.onStatsClick),
-                    showFocusPoint = shouldShowStatsFocusPoint(params)
-                )
+                    QuickLinkRibbonItem(
+                            label = R.string.media,
+                            icon = R.drawable.ic_media_white_24dp,
+                            onClick = ListItemInteraction.create(params.onMediaClick),
+                            showFocusPoint = shouldShowMediaFocusPoint(params)
+                    )
             )
+        }
+        if (params.siteModel.isSelfHostedAdmin || params.siteModel.hasCapabilityEditPages) {
+            val pages = QuickLinkRibbonItem(
+                    label = R.string.pages,
+                    icon = R.drawable.ic_pages_white_24dp,
+                    onClick = ListItemInteraction.create(params.onPagesClick),
+                    showFocusPoint = shouldShowPagesFocusPoint(params)
+            )
+            items.add(QUICK_LINK_PAGE_INDEX, pages)
         }
         return items
     }
@@ -75,5 +74,9 @@ class QuickLinkRibbonBuilder @Inject constructor(
         return params.enableFocusPoints && params.activeTask == quickStartRepository.quickStartType.getTaskFromString(
                 QuickStartStore.QUICK_START_UPLOAD_MEDIA_LABEL
         )
+    }
+
+    companion object {
+        private const val QUICK_LINK_PAGE_INDEX = 2
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonViewHolder.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.OnItemTouchListener
-import org.wordpress.android.R
 import org.wordpress.android.databinding.QuickLinkRibbonListBinding
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinkRibbon
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
@@ -33,17 +32,13 @@ class QuickLinkRibbonViewHolder(
         setOnTouchItemListener()
         (quickLinkRibbonItemList.adapter as QuickLinkRibbonItemAdapter).update(quickLinkRibbon.quickLinkRibbonItems)
         if (quickLinkRibbon.showStatsFocusPoint) {
-            quickLinkRibbonItemList.smoothScrollToPosition(quickLinkRibbon.quickLinkRibbonItems.size)
-        }
-        if (quickLinkRibbon.showPagesFocusPoint) {
             quickLinkRibbonItemList.smoothScrollToPosition(0)
         }
+        if (quickLinkRibbon.showPagesFocusPoint) {
+            quickLinkRibbonItemList.smoothScrollToPosition(2)
+        }
         if (quickLinkRibbon.showMediaFocusPoint) {
-            val mediaItem = quickLinkRibbon.quickLinkRibbonItems.firstOrNull { it.label == R.string.media }
-            mediaItem?.let {
-                val mediaItemIndex = quickLinkRibbon.quickLinkRibbonItems.indexOf(it)
-                quickLinkRibbonItemList.smoothScrollToPosition(mediaItemIndex)
-            }
+            quickLinkRibbonItemList.smoothScrollToPosition(quickLinkRibbon.quickLinkRibbonItems.size)
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonBuilderTest.kt
@@ -42,9 +42,9 @@ class QuickLinkRibbonBuilderTest : BaseUnitTest() {
         val quickLinkRibbon = buildQuickLinkRibbon(showPages = false)
 
         assertThat(quickLinkRibbon.quickLinkRibbonItems.size).isEqualTo(3)
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[0].label).isEqualTo(R.string.posts)
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[1].label).isEqualTo(R.string.media)
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[2].label).isEqualTo(R.string.stats)
+        assertThat(quickLinkRibbon.quickLinkRibbonItems[0].label).isEqualTo(R.string.stats)
+        assertThat(quickLinkRibbon.quickLinkRibbonItems[1].label).isEqualTo(R.string.posts)
+        assertThat(quickLinkRibbon.quickLinkRibbonItems[2].label).isEqualTo(R.string.media)
     }
 
     /* ACTION CLICKS */
@@ -52,10 +52,10 @@ class QuickLinkRibbonBuilderTest : BaseUnitTest() {
     fun `when card is built, then ribbon click are set on the card`() {
         val quickLinkRibbon = buildQuickLinkRibbon()
 
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[0].onClick).isEqualTo(ListItemInteraction.create(onPagesClick))
+        assertThat(quickLinkRibbon.quickLinkRibbonItems[0].onClick).isEqualTo(ListItemInteraction.create(onStatsClick))
         assertThat(quickLinkRibbon.quickLinkRibbonItems[1].onClick).isEqualTo(ListItemInteraction.create(onPostsClick))
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[2].onClick).isEqualTo(ListItemInteraction.create(onMediaClick))
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[3].onClick).isEqualTo(ListItemInteraction.create(onStatsClick))
+        assertThat(quickLinkRibbon.quickLinkRibbonItems[2].onClick).isEqualTo(ListItemInteraction.create(onPagesClick))
+        assertThat(quickLinkRibbon.quickLinkRibbonItems[3].onClick).isEqualTo(ListItemInteraction.create(onMediaClick))
     }
 
     /* FOCUS POINT*/
@@ -63,7 +63,7 @@ class QuickLinkRibbonBuilderTest : BaseUnitTest() {
     fun `given new site QS + stats active task, when card is built, then stats focus point should be true`() {
         val quickLinkRibbon = buildQuickLinkRibbon(showStatsFocusPoint = true, isNewSiteQuickStart = true)
 
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[3].showFocusPoint).isEqualTo(true)
+        assertThat(quickLinkRibbon.quickLinkRibbonItems[0].showFocusPoint).isEqualTo(true)
         assertThat(quickLinkRibbon.showStatsFocusPoint).isEqualTo(true)
     }
 
@@ -71,7 +71,7 @@ class QuickLinkRibbonBuilderTest : BaseUnitTest() {
     fun `given existing site QS + stats active task, when card is built, then stats focus point should be true`() {
         val quickLinkRibbon = buildQuickLinkRibbon(showStatsFocusPoint = true, isNewSiteQuickStart = false)
 
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[3].showFocusPoint).isEqualTo(true)
+        assertThat(quickLinkRibbon.quickLinkRibbonItems[0].showFocusPoint).isEqualTo(true)
         assertThat(quickLinkRibbon.showStatsFocusPoint).isEqualTo(true)
     }
 
@@ -79,7 +79,7 @@ class QuickLinkRibbonBuilderTest : BaseUnitTest() {
     fun `given pages active task, when card is built, then pages focus point should be true`() {
         val quickLinkRibbon = buildQuickLinkRibbon(showPagesFocusPoint = true)
 
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[0].showFocusPoint).isEqualTo(true)
+        assertThat(quickLinkRibbon.quickLinkRibbonItems[2].showFocusPoint).isEqualTo(true)
         assertThat(quickLinkRibbon.showPagesFocusPoint).isEqualTo(true)
     }
 
@@ -87,7 +87,7 @@ class QuickLinkRibbonBuilderTest : BaseUnitTest() {
     fun `given enable focus point is false, when card is built, then active focus point should false`() {
         val quickLinkRibbon = buildQuickLinkRibbon(showPagesFocusPoint = true, enableFocusPoints = false)
 
-        assertThat(quickLinkRibbon.quickLinkRibbonItems[0].showFocusPoint).isEqualTo(false)
+        assertThat(quickLinkRibbon.quickLinkRibbonItems[2].showFocusPoint).isEqualTo(false)
         assertThat(quickLinkRibbon.showPagesFocusPoint).isEqualTo(false)
         assertThat(quickLinkRibbon.activeQuickStartItem).isEqualTo(false)
     }


### PR DESCRIPTION
Corresponding [IOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/18704#issue-1245434319)

This PR changes the Quick Link Ribbon Items order.

Before: Pages, Posts, Media, Stats
Now: Stats, Posts, Pages, Media

![Screenshot_20220524_152806](https://user-images.githubusercontent.com/17463767/170005315-ab15a735-469c-4869-98c7-044aaf5675ce.png)

To test:

Test 1
- Test that the order of the items is as per the PR description

Test 2 - Old Quickstart focus points are shown correctly 
- Log in to a site having an old quick start in progress
- Set the Initial screen as Dashboard
- Start the "Check your site stats" task
- Make sure the stats button has the spotlight 
- Start any Pages quick start task(Edit your home page/Review Site Pages) 
- Make sure the Pages button has the spotlight 

Test 3 - New Quickstart focus points are shown correctly 
- Log in to a site having a quick start in progress
- Set the Initial screen as Dashboard
- Start the "Check your site stats" task
- Make sure the stats button has the spotlight 
- Start "Upload photos or videos" quick start task 
- Make sure the Media button has the spotlight 


## Regression Notes
1. Potential unintended areas of impact
- Quick start focus point not being displayed properly 
- Quick start link ribbon item order is incorrect 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and Unit tests 

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
