### PR TITLE
My Site Dashboard: Fix persistent loading indicator when blogging prompt feature is disabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
@@ -76,6 +76,8 @@ class BloggingPromptCardSource @Inject constructor(
         if (selectedSite != null && selectedSite.id == siteLocalId) {
             if (bloggingPromptsFeatureConfig.isEnabled()) {
                 fetchPromptsAndPostErrorIfAvailable(coroutineScope, selectedSite)
+            } else {
+                onRefreshedMainThread()
             }
         } else {
             postErrorState()


### PR DESCRIPTION
This PR fixes loading indicator not going away on `My Site` screen when the blogging prompt feature is disabled.

/cc @khaykov 

To test:

Prerequisite: `blogging_prompts_remote_field` feature flag is off in `Me` -> `App Settings` -> `Debug settings` 

1. Launch the app. 
2. Go to` My Site` tab.
3. Notice that the loading indicator is shown and hides after few secs.
4. Pull to refresh.
5. Notice that the loading indicator is shown and hides after few secs.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
