### PR TITLE
Display `Quick Start` card on site switch only when `Quick Start` is started

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -85,6 +85,7 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Neg
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Positive
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.quickstart.QuickStartTracker
+import org.wordpress.android.ui.quickstart.QuickStartType.NewSiteQuickStartType
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -1063,6 +1064,15 @@ class MySiteViewModel @Inject constructor(
         selectDefaultTabIfNeeded()
     }
 
+    fun onSitePicked() {
+        selectedSiteRepository.getSelectedSite()?.let {
+            val siteLocalId = it.id.toLong()
+            val lastSelectedQuickStartType = appPrefsWrapper.getLastSelectedQuickStartTypeForSite(siteLocalId)
+            quickStartRepository.checkAndSetQuickStartType(lastSelectedQuickStartType == NewSiteQuickStartType)
+        }
+        mySiteSourceManager.refreshQuickStart()
+    }
+
     fun performFirstStepAfterSiteCreation(
         siteLocalId: Int,
         isSiteTitleTaskCompleted: Boolean,
@@ -1093,7 +1103,7 @@ class MySiteViewModel @Inject constructor(
         isSiteTitleTaskCompleted: Boolean,
         isNewSite: Boolean
     ) {
-        quickStartRepository.checkAndSetQuickStartType(isNewSite)
+        quickStartRepository.checkAndSetQuickStartType(isNewSite = isNewSite)
         if (quickStartDynamicCardsFeatureConfig.isEnabled()) {
             startQuickStart(siteLocalId, isSiteTitleTaskCompleted)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -104,7 +104,10 @@ class QuickStartRepository
     val isQuickStartForExistingUsersV2FeatureEnabled = quickStartForExistingUsersV2FeatureConfig.isEnabled()
     var quickStartTaskOriginTab = if (isMySiteTabsEnabled) MySiteTabType.DASHBOARD else MySiteTabType.ALL
     val quickStartType: QuickStartType
-        get() = appPrefsWrapper.getLastSelectedQuickStartType()
+        get() = selectedSiteRepository.getSelectedSite()?.let {
+            val siteLocalId = it.id.toLong()
+            appPrefsWrapper.getLastSelectedQuickStartTypeForSite(siteLocalId)
+        } ?: NewSiteQuickStartType
     private var pendingTask: QuickStartTask? = null
 
     fun buildQuickStartCategory(siteLocalId: Int, quickStartTaskType: QuickStartTaskType) = QuickStartCategory(
@@ -136,8 +139,11 @@ class QuickStartRepository
 
     fun checkAndSetQuickStartType(isNewSite: Boolean) {
         if (!isQuickStartForExistingUsersV2FeatureEnabled) return
-        val quickStartType = if (isNewSite) NewSiteQuickStartType else ExistingSiteQuickStartType
-        appPrefsWrapper.setLastSelectedQuickStartType(quickStartType)
+        selectedSiteRepository.getSelectedSite()?.let { selectedSite ->
+            val siteLocalId = selectedSite.id.toLong()
+            val quickStartType = if (isNewSite) NewSiteQuickStartType else ExistingSiteQuickStartType
+            appPrefsWrapper.setLastSelectedQuickStartTypeForSite(quickStartType, siteLocalId)
+        }
     }
 
     suspend fun getQuickStartTaskTypes(siteLocalId: Int): List<QuickStartTaskType> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -495,6 +495,8 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
                             data.getBooleanExtra(SitePickerActivity.KEY_SITE_TITLE_TASK_COMPLETED, false),
                             isNewSite = true
                     )
+                } else {
+                    viewModel.onSitePicked()
                 }
             }
             RequestCodes.EDIT_LANDING_PAGE -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -1253,14 +1253,19 @@ public class AppPrefs {
         setString(DeletablePrefKey.LAST_SKIPPED_QUICK_START_TASK, task.toString());
     }
 
-    public static void setLastSelectedQuickStartType(QuickStartType quickStartType) {
-        setString(DeletablePrefKey.LAST_SELECTED_QUICK_START_TYPE, quickStartType.getLabel());
+    public static void setLastSelectedQuickStartTypeForSite(QuickStartType quickStartType, long siteLocalId) {
+        Editor editor = prefs().edit();
+        editor.putString(
+                DeletablePrefKey.LAST_SELECTED_QUICK_START_TYPE + String.valueOf(siteLocalId),
+                quickStartType.getLabel()
+        );
+        editor.apply();
     }
 
-    public static QuickStartType getLastSelectedQuickStartType() {
+    public static QuickStartType getLastSelectedQuickStartTypeForSite(long siteLocalId) {
         return QuickStartType.Companion.fromLabel(
-                getString(
-                        DeletablePrefKey.LAST_SELECTED_QUICK_START_TYPE,
+                prefs().getString(
+                        DeletablePrefKey.LAST_SELECTED_QUICK_START_TYPE + String.valueOf(siteLocalId),
                         NewSiteQuickStartType.INSTANCE.getLabel()
                 )
         );

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -213,10 +213,11 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun setLastSkippedQuickStartTask(task: QuickStartTask) = AppPrefs.setLastSkippedQuickStartTask(task)
 
-    fun getLastSelectedQuickStartType(): QuickStartType = AppPrefs.getLastSelectedQuickStartType()
+    fun getLastSelectedQuickStartTypeForSite(siteLocalId: Long): QuickStartType =
+            AppPrefs.getLastSelectedQuickStartTypeForSite(siteLocalId)
 
-    fun setLastSelectedQuickStartType(quickStartType: QuickStartType) =
-            AppPrefs.setLastSelectedQuickStartType(quickStartType)
+    fun setLastSelectedQuickStartTypeForSite(quickStartType: QuickStartType, siteLocalId: Long) =
+            AppPrefs.setLastSelectedQuickStartTypeForSite(quickStartType, siteLocalId)
 
     fun isMySiteDefaultTabExperimentVariantAssigned() = AppPrefs.isMySiteDefaultTabExperimentVariantAssigned()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTracker.kt
@@ -3,14 +3,17 @@ package org.wordpress.android.ui.quickstart
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.QUICK_START_CARD
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.quickstart.QuickStartType.NewSiteQuickStartType
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 
 class QuickStartTracker @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val appPrefsWrapper: AppPrefsWrapper
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val selectedSiteRepository: SelectedSiteRepository
 ) {
     private val cardsShownTracked = mutableListOf<Pair<MySiteCardAndItem.Type, Map<String, String>>>()
 
@@ -18,7 +21,7 @@ class QuickStartTracker @Inject constructor(
     fun track(stat: Stat, properties: Map<String, Any?>? = null) {
         val props = HashMap<String, Any?>()
         properties?.let { props.putAll(it) }
-        props[SITE_TYPE] = appPrefsWrapper.getLastSelectedQuickStartType().trackingLabel
+        props[SITE_TYPE] = getLastSelectedQuickStartType().trackingLabel
         analyticsTrackerWrapper.track(stat, props)
     }
 
@@ -26,7 +29,7 @@ class QuickStartTracker @Inject constructor(
         if (itemType == QUICK_START_CARD) {
             val props = mapOf(
                     TAB to tabType.trackingLabel,
-                    SITE_TYPE to appPrefsWrapper.getLastSelectedQuickStartType().trackingLabel
+                    SITE_TYPE to getLastSelectedQuickStartType().trackingLabel
             )
             val cardsShownTrackedPair = Pair(itemType, props)
             if (!cardsShownTracked.contains(cardsShownTrackedPair)) {
@@ -38,6 +41,13 @@ class QuickStartTracker @Inject constructor(
 
     fun resetShown() {
         cardsShownTracked.clear()
+    }
+
+    private fun getLastSelectedQuickStartType(): QuickStartType {
+        return selectedSiteRepository.getSelectedSite()?.let {
+            val siteLocalId = it.id.toLong()
+            appPrefsWrapper.getLastSelectedQuickStartTypeForSite(siteLocalId)
+        } ?: NewSiteQuickStartType
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartType.kt
@@ -37,6 +37,7 @@ sealed class QuickStartType(
         siteLocalId: Long,
         isSiteTitleTaskCompleted: Boolean
     ) {
+        quickStartStore.setQuickStartCompleted(siteLocalId, false)
         when (this) {
             is NewSiteQuickStartType -> {
                 quickStartStore.setDoneTask(siteLocalId, QuickStartNewSiteTask.CREATE_SITE, true)
@@ -53,8 +54,8 @@ sealed class QuickStartType(
         return when (this) {
             is NewSiteQuickStartType -> !isQuickStartCompleted &&
                     quickStartStore.hasDoneTask(siteLocalId, QuickStartNewSiteTask.CREATE_SITE)
-            // TODO: ashiagr update isQuickStartInProgress condition for ExistingSiteQuickStartType
-            is ExistingSiteQuickStartType -> !isQuickStartCompleted
+            is ExistingSiteQuickStartType -> quickStartStore.isQuickStartStatusSet(siteLocalId) &&
+                    !isQuickStartCompleted
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
@@ -88,7 +88,7 @@ class QuickStartCardSourceTest : BaseUnitTest() {
         site = SiteModel()
         site.id = siteLocalId
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
-        whenever(appPrefsWrapper.getLastSelectedQuickStartType()).thenReturn(NewSiteQuickStartType)
+        whenever(appPrefsWrapper.getLastSelectedQuickStartTypeForSite(any())).thenReturn(NewSiteQuickStartType)
         whenever(quickStartExistingUsersV2FeatureConfig.isEnabled()).thenReturn(false)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(true)
         quickStartRepository = QuickStartRepository(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -85,7 +85,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Before
     fun setUp() = test {
-        whenever(appPrefsWrapper.getLastSelectedQuickStartType()).thenReturn(quickStartType)
+        whenever(appPrefsWrapper.getLastSelectedQuickStartTypeForSite(any())).thenReturn(quickStartType)
         whenever(quickStartExistingUsersV2FeatureConfig.isEnabled()).thenReturn(false)
         quickStartRepository = QuickStartRepository(
                 TEST_DISPATCHER,

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '2426-b3228f3560fc67691c1deb1a29913202069d7d23'
+    fluxCVersion = '1.42.3'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '1.42.2'
+    fluxCVersion = '2426-b3228f3560fc67691c1deb1a29913202069d7d23'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #16650

This PR displays `Quick Start` card on switching the site from the site-chooser on `My Site` tab *only when* `Quick Start` is started for the site.

Corresponding FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2426

To test:

1. Launch the app.
2. Logout and login.
3. Select an existing site (`Site A`) from the `Login Epilogue` screen.
4. Select "Show me around" on onboarding `Quick Start` dialog.
5. Go to `My Site` tab.
6. ✅ Notice that the `Quick Start` card is shown for the existing site `Site A`.
7. Create a new site (`Site B`)  from the site-chooser.
8. ✅ Notice that the `Quick Start` card is shown for the new site  `Site B`.
9. Re-select `Site A` from the site-chooser.
10. ✅ Notice that the `Quick Start` card is shown for the existing site `Site A` since `Quick Start` was started for `Site A`.
11. Select `Site C` (for which `Quick Start` has not started) from the site-chooser.
12. ✅ Notice that the `Quick Start` card is not shown for `Site C`.

Merge Instructions

1. Wait for corresponding FluxC PR to be merged and create FluxC tag.
2. Replace `FluxC` tag in build.gradle.
3. Wait for regression notes to be filled for 1. 
4. Remove `Not Ready for Merge` label.
5. Merge the PR.

## Regression Notes
1. Potential unintended areas of impact
Please keep in mind while testing that there's a known issue (Internal Ref: p1627036988014500-slack-C027K4MNPGQ), that after re-login, the `Quick Start` card is not shown on switching the site due to using the local site id for saving quick start data. This PR does not fix this issue.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
See `To Test` section.

3. What automated tests I added (or what prevented me from doing so)
To be added later 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.