### PR TITLE
Update FluxC to 1.44.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = 'trunk-f72e5d145dcfcf6e6875863e874496c1866676e7'
+    fluxCVersion = '1.44.0'
 
     appCompatVersion = '1.0.2'
     androidxCoreVersion = '1.3.2'


### PR DESCRIPTION
This PR updates FluxC version to `1.44.0`, the tag created for `20.0` code freeze. We typically do this change in the release branch, without a PR. However, I noticed that FluxC beta fix from https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2426, that's merged to #16651 was not reflected in current WPAndroid `trunk`. While doing WCAndroid code freeze, I wanted to make sure the tag created would include all the beta fixes, so I merged the changes from https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2426 to FluxC's `trunk` in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2430 and created the `1.44.0` tag.

Note that the jump from `1.42.3` to `1.44.0` is because WCAndroid was on `1.43.0` tag. This inconsistency between WPAndroid using `1.42.x` tags and WCAndroid using `1.43.0` in the last code freeze was due to a mishandling of `1.42.0` tag where an earlier beta fix was not included in it. Due to timezone differences, we didn't get a chance to fully sync up when we realized this issue and went on to use different tags. This is actually the biggest reason why I wanted to open this PR in preparation of WPAndroid's `20.0` code freeze, so everything in FluxC and WPAndroid is setup the way it should be. Hopefully I didn't miss anything 🤞 

@ParaskP7 @AliSoftware Unfortunately there isn't a PR that merges final `release/19.9` to `trunk` which includes the changes from #16651. That's why this PR doesn't build and would need to be rebased after `release/19.9` is merged to `trunk`. I think the best way forward is to close this PR and let FluxC update to happen in the `release/20.0` branch when it's created, just like it's usually done. This was mostly a communication PR anyway, so it doesn't matter too much whether it's merged or applied directly. Please let me know if you have any questions or if I missed anything.

**To test:**
* CI checks should be enough, but smoke test is always encouraged

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
