### PR TITLE
Stats Revamp v2: No data states for total cards

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalCommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalCommentsUseCase.kt
@@ -121,7 +121,7 @@ class TotalCommentsUseCase @Inject constructor(
         if (domainModel.dates.isNotEmpty()) {
             items.add(buildTitle())
             items.add(totalStatsMapper.buildTotalCommentsValue(domainModel.dates))
-            items.add(totalStatsMapper.buildTotalCommentsInformation(domainModel.dates))
+            totalStatsMapper.buildTotalCommentsInformation(domainModel.dates)?.let { items.add(it) }
             if (totalStatsMapper.shouldShowCommentsGuideCard(domainModel.dates)) {
                 items.add(ListItemGuideCard(resourceProvider.getString(string.stats_insights_comments_guide_card)))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCase.kt
@@ -127,7 +127,7 @@ class TotalLikesUseCase @Inject constructor(
         if (domainModel.dates.isNotEmpty()) {
             items.add(buildTitle())
             items.add(totalStatsMapper.buildTotalLikesValue(domainModel.dates))
-            items.add(totalStatsMapper.buildTotalLikesInformation(domainModel.dates))
+            totalStatsMapper.buildTotalLikesInformation(domainModel.dates)?.let { items.add(it) }
             if (totalStatsMapper.shouldShowLikesGuideCard(domainModel.dates)) {
                 buildLatestPostGuideCard(items, this::onLinkClicked)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
@@ -52,9 +52,12 @@ class TotalStatsMapper @Inject constructor(
 
     fun buildTotalCommentsInformation(dates: List<PeriodData>) = buildTotalInformation(dates, COMMENTS)
 
-    private fun buildTotalInformation(dates: List<PeriodData>, type: TotalStatsType): Text {
+    private fun buildTotalInformation(dates: List<PeriodData>, type: TotalStatsType): Text? {
         val value = getCurrentWeekDays(dates, type).sum()
         val previousValue = getPreviousWeekDays(dates, type).sum()
+        if (value == 0L && previousValue == 0L) {
+            return null
+        }
         val positive = value >= previousValue
         val change = statsUtils.buildChange(previousValue, value, positive, true).toString()
         val stringRes = if (positive) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ValueWithChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ValueWithChartViewHolder.kt
@@ -43,11 +43,6 @@ class ValueWithChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                 } else {
                     R.color.blue_50
                 }
-                val drawableRes = if (item.positive == true) {
-                    R.drawable.bg_rectangle_total_stats_line_chart_green_gradient
-                } else {
-                    R.drawable.bg_rectangle_total_stats_line_chart_blue_gradient
-                }
                 val dataSet = LineDataSet(entries, null).apply {
                     setDrawCircles(false)
                     setDrawValues(false)
@@ -55,14 +50,28 @@ class ValueWithChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                     lineWidth = 2f
                     mode = CUBIC_BEZIER
                     cubicIntensity = CUBIC_INTENSITY
-                    setDrawFilled(true)
-                    val drawable = ContextCompat.getDrawable(context, drawableRes)
-                    drawable?.alpha = FILL_ALPHA
-                    fillDrawable = drawable
+                    fillBelowLine(this, item)
                 }
                 data = LineData(dataSet)
                 isVisible = true
             }
+        }
+    }
+
+    private fun fillBelowLine(dataSet: LineDataSet, item: ValueWithChartItem) {
+        if (item.values?.sum() == 0L) {
+            return
+        } else {
+            val drawableRes = if (item.positive == true) {
+                R.drawable.bg_rectangle_total_stats_line_chart_green_gradient
+            } else {
+                R.drawable.bg_rectangle_total_stats_line_chart_blue_gradient
+            }
+            val drawable = ContextCompat.getDrawable(chart.context, drawableRes)
+            drawable?.alpha = FILL_ALPHA
+
+            dataSet.setDrawFilled(true)
+            dataSet.fillDrawable = drawable
         }
     }
 


### PR DESCRIPTION
Fixes #16633 

This hides comparison text in total likes and total comments cards in these cases:
- If the total count is 0,
- and the difference is 0.

<img src="https://user-images.githubusercontent.com/2471769/170895075-53ce0b19-c8dd-4edc-bfbd-2f5b17b171a8.png" width=280>

To test:
Setup:

1. Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
2. Select Debug Settings.
3. Find StatsRevampV2FeatureConfig under Features in development enable it and restart app.
4. Make sure Total Likes and Total Comments cards are visible on Insights tab. If those cards are not present then add them through stats management using either [+ add new stats card ] at the bottom or clicking ⚙️ icon at the top right hand corner.

Test 1:
1. Select a site that received 0 likes and 0 comments in the last 8 days.
2. Go to stats either using quick links or menu.
3. Ensure that it opens in Insights tab otherwise switch to Insights tab.
4. Notice comparison text is not visible.

Test 2:
1. Select a site that received more than 0 likes and more than 0 comments in the last 8 days.
2. Go to stats either using quick links or menu.
3. Ensure that it opens in Insights tab otherwise switch to Insights tab.
4. Notice comparison text is visible.

## Regression Notes
1. Potential unintended areas of impact
Other states for total cards.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested.

3. What automated tests I added (or what prevented me from doing so)
Used current unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
