### PR TITLE
Remove unused `old_version` var from Fastlane `release.rb`

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -14,7 +14,7 @@ platform :android do
   #####################################################################################
   desc 'Creates a new release branch from the current trunk'
   lane :code_freeze do |options|
-    old_version = android_codefreeze_prechecks(skip_confirm: options[:skip_confirm])
+    android_codefreeze_prechecks(skip_confirm: options[:skip_confirm])
 
     android_bump_version_release()
     new_version = android_get_app_version()


### PR DESCRIPTION
Noticed this unused variable while looking over the WordPress Android localization automation to compare it with the WooCommerce implementation.

## Testing

It should suffice to look over the code and do a search for `old_version`, which should return no match.

Alternatively, you can compare the `rubocop` violations on that file between `trunk` and this branch:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/1218433/171076458-db02b8da-ad5e-41f6-846e-19060b2cc647.png">
 

## Regression Notes
1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
