### PR TITLE
UI tweaks to the Quick Start Card and Site header 

### DIFF
--- a/WordPress/src/main/res/layout/my_site_info_header_card.xml
+++ b/WordPress/src/main/res/layout/my_site_info_header_card.xml
@@ -77,7 +77,6 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/margin_extra_large"
         android:minHeight="@dimen/my_site_blavatar_sz"
-        android:paddingTop="@dimen/margin_small"
         app:layout_constraintBottom_toBottomOf="@+id/blavatar_container"
         app:layout_constraintEnd_toStartOf="@id/switch_site"
         app:layout_constraintStart_toEndOf="@id/blavatar_container"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -448,7 +448,7 @@
     <dimen name="quick_start_task_card_corner_radius">8dp</dimen>
     <dimen name="quick_start_task_card_overlay_alpha" format="float" type="dimen">0.8</dimen>
 
-    <dimen name="new_quick_start_card_illustration_image_width">54dp</dimen>
+    <dimen name="new_quick_start_card_illustration_image_width">48dp</dimen>
     <dimen name="new_quick_start_card_task_completed_icon_size">16dp</dimen>
     <dimen name="new_quick_start_card_progress_bar_height">5dp</dimen>
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -448,7 +448,7 @@
     <dimen name="quick_start_task_card_corner_radius">8dp</dimen>
     <dimen name="quick_start_task_card_overlay_alpha" format="float" type="dimen">0.8</dimen>
 
-    <dimen name="new_quick_start_card_illustration_image_width">48dp</dimen>
+    <dimen name="new_quick_start_card_illustration_image_width">54dp</dimen>
     <dimen name="new_quick_start_card_task_completed_icon_size">16dp</dimen>
     <dimen name="new_quick_start_card_progress_bar_height">5dp</dimen>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -481,8 +481,8 @@
 
     <style name="MySiteSubtitleLabel" parent="@style/Widget.MaterialComponents.Button.TextButton.Icon">
         <item name="android:ellipsize">end</item>
-        <item name="android:insetTop">0dp</item>
-        <item name="android:insetBottom">0dp</item>
+        <item name="android:insetTop">2dp</item>
+        <item name="android:insetBottom">2dp</item>
         <item name="android:minHeight">0dp</item>
         <item name="android:padding">0dp</item>
         <item name="android:maxLines">1</item>


### PR DESCRIPTION
This PR adds two tweaks to the UI of the My Site Dashboard 

1. Sets the illustration width of the new Quickstart card to 48dp as pointed out in the comment - https://github.com/wordpress-mobile/WordPress-Android/pull/16629#issuecomment-1140952170
2. Makes the necessary changes to the site title and site URL height as described in the comment (Internal reference) - p5T066-3dy#comment-12411

To test:
As there are only minor changes to dimens for both the changes, a design review itself would be sufficient. 
cc: @ashiagr 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
