### PR TITLE
Fix possible small crash when copying a page link

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -50,6 +50,7 @@ sealed class PostListAction {
     class DismissPendingNotification(val pushId: Int) : PostListAction()
 }
 
+@Suppress("TooGenericExceptionCaught")
 fun handlePostListAction(
     activity: FragmentActivity,
     action: PostListAction,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -535,6 +535,7 @@ class PagesViewModel
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun copyPageLink(page: Page, context: Context) {
         // Get the link to the page
         val pageLink = postStore.getPostByLocalPostId(page.localId).link

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.fluxc.model.SiteHomepageSettings.ShowOnFront.PAGE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus
-import org.wordpress.android.fluxc.model.page.PageStatus.DRAFT
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.PageStore
@@ -439,7 +438,7 @@ class PagesViewModel
         when (action) {
             VIEW_PAGE -> previewPage(page)
             SET_PARENT -> setParent(page)
-            MOVE_TO_DRAFT -> changePageStatus(page.remoteId, DRAFT)
+            MOVE_TO_DRAFT -> changePageStatus(page.remoteId, PageStatus.DRAFT)
             MOVE_TO_TRASH -> changePageStatus(page.remoteId, PageStatus.TRASHED)
             PUBLISH_NOW -> publishPageNow(page.remoteId)
             DELETE_PERMANENTLY -> deletePage(page)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -540,22 +540,18 @@ class PagesViewModel
         val pageLink = postStore.getPostByLocalPostId(page.localId).link
         try {
             // Copy the link to the clipboard
-            val clipboard = context.clipboardManager
-            val clip = ClipData.newPlainText("${page.localId}", pageLink)
-            if (clipboard != null) {
-                clipboard.setPrimaryClip(clip)
-                _showSnackbarMessage.postValue(SnackbarMessageHolder((UiStringRes(R.string.media_edit_copy_url_toast))))
-            } else {
-                throw NullPointerException("ClipboardManager is not supported on this device")
-            }
-        } catch (e: SecurityException) {
+            context.clipboardManager?.setPrimaryClip(
+                    ClipData.newPlainText("${page.localId}", pageLink)
+            ) ?: throw NullPointerException("ClipboardManager is not supported on this device")
+
+            _showSnackbarMessage.postValue(
+                    SnackbarMessageHolder(UiStringRes(R.string.media_edit_copy_url_toast))
+            )
+        } catch (e: Throwable) {
             /**
              * Ignore any exceptions here as certain devices have bugs and will fail.
              * See https://crrev.com/542cb9cfcc927295615809b0c99917b09a219d9f for more info.
              */
-            AppLog.e(PAGES, e)
-            _showSnackbarMessage.postValue(SnackbarMessageHolder(UiStringRes(R.string.error)))
-        } catch (e: NullPointerException) {
             AppLog.e(PAGES, e)
             _showSnackbarMessage.postValue(SnackbarMessageHolder(UiStringRes(R.string.error)))
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -536,9 +536,9 @@ class PagesViewModel
 
     @Suppress("TooGenericExceptionCaught")
     private fun copyPageLink(page: Page, context: Context) {
-        // Get the link to the page
-        val pageLink = postStore.getPostByLocalPostId(page.localId).link
         try {
+            // Get the link to the page
+            val pageLink = postStore.getPostByLocalPostId(page.localId).link
             // Copy the link to the clipboard
             context.clipboardManager?.setPrimaryClip(
                     ClipData.newPlainText("${page.localId}", pageLink)

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -346,8 +346,6 @@
     <ID>TooGenericExceptionCaught:ColorUnderlineSpan.kt$ColorUnderlineSpan$e: Exception</ID>
     <ID>TooGenericExceptionCaught:GifMediaInsertUseCase.kt$GifMediaInsertUseCase$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MediaPickerActivity.kt$MediaPickerActivity$e: RuntimeException</ID>
-    <ID>TooGenericExceptionCaught:PagesViewModel.kt$PagesViewModel$e: NullPointerException</ID>
-    <ID>TooGenericExceptionCaught:PostListAction.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:UploadStarter.kt$UploadStarter$e: Exception</ID>
     <ID>TooGenericExceptionThrown:ActionableEmptyView.kt$ActionableEmptyView$throw RuntimeException("$context: ActionableEmptyView must have a title (aevTitle)")</ID>
     <ID>TooGenericExceptionThrown:ActivityLogDetailFragment.kt$ActivityLogDetailFragment$throw Throwable("Couldn't initialize Activity Log view model")</ID>


### PR DESCRIPTION
Fixes #16652
Sometimes in different conditions we noticed a small crash when copying the link for a page. We didn't find a stable scenario to reproduce the issue; which also means I wasn't able to test something that I would know fails and then be sure of the fact that it doesn't fail after the fix.

I'm still pretty confident about the fix, since the code aligns now with the `copy post link` code; where we didn't see such a crash.

This PR attempts to fix such cases by catching all exceptions thrown when trying to copy a page link. There's nothing experimental with this approach -- we already had it for `copy link` for posts.

**Remark** This fix was started with the idea of hotfixing the issue on `19.9` (see branch name); but upon testing which was reported in the targeted issue (#16652) we found out it's reproducing quite rarely and the effect of the issue isn't that impactful, because the users can just continue from where they left off.
With that in mind and noticing that `19.9` is already in rollout, I think it's ok to just target the next release.

We could push to include this in `20.0` which is in code freeze at the moment. Otherwise we can go forward with the initial milestone: the `20.1` version.

To test:
1. From `My Site` Go to the `Pages list`
2. Tap the `⋮` next to a page
3. Tap the `Copy link` menu option
4. **Expect** No crash
5. Repeat steps `1 - 3` 10 to 20 times (😅).

## Regression Notes
1. Potential unintended areas of impact
  N/a - This is a safer approach compared to the previous one, since we're catching all exceptions.

6. What I did to test those areas of impact (or what existing automated tests I relied on)
  N/a

7. What automated tests I added (or what prevented me from doing so)
  N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
