### PR TITLE
Fix wrong scope of StatsViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -7,7 +7,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.MarginPageTransformer
 import com.google.android.material.snackbar.Snackbar
@@ -47,7 +47,7 @@ private val statsSections = listOf(INSIGHTS, DAYS, WEEKS, MONTHS, YEARS)
 @AndroidEntryPoint
 class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializedListener {
     @Inject lateinit var uiHelpers: UiHelpers
-    private val viewModel: StatsViewModel by viewModels()
+    private val viewModel: StatsViewModel by activityViewModels()
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
     private lateinit var selectedTabListener: SelectedTabListener
 


### PR DESCRIPTION
The problem was introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/16431. Before, `StatsActivity` and `StatsFragment` were using the same instance of `StatsViewModel`. With https://github.com/wordpress-mobile/WordPress-Android/pull/16431, there are two different `StatsViewModel` instances in `StatsFragment` and `StatsActivity`. Because `StatsViewModel` was scoped to the fragment in `StatsFragment`. Now, it's scoped to the `StatsActivity`.  

I couldn't find any issue in the app caused by this problem. Two view model instances are working fine coincidentally in this case. But it's better to fix that.

To test:
Since there is no feature change, this can be tested only by debugging.
1. Place two breakpoints in `StatsActivity` and `StatsFragment` where you can check `StatsViewModel` instances.
2. Launch the app.
3. Open the stats screen from My Site -> HOME -> Go to stats or My Site -> MENU -> Stats.
4. Check if both `StatsViewModel` instances in `StatsFragment` and `StatsActivity` are the same, like `StatsViewModel@356353b` and `StatsViewModel@356353b`.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
