### PR TITLE
Fixed category title in RTL languages

### DIFF
--- a/WordPress/src/main/res/layout/modal_layout_picker_layouts_row.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_layouts_row.xml
@@ -18,6 +18,7 @@
         android:text="@string/hpp_recommended_subtitle" />
     <TextView
         android:id="@+id/title"
+        android:layout_width="match_parent"
         style="@style/ModalLayoutPickerLayoutsTitle"
         android:layout_marginEnd="@dimen/mlp_layout_card_margin_end"
         android:layout_marginStart="@dimen/mlp_layout_card_margin_start"

--- a/WordPress/src/main/res/layout/modal_layout_picker_layouts_row.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_layouts_row.xml
@@ -13,11 +13,13 @@
         android:id="@+id/subtitle"
         style="@style/ModalLayoutPickerLayoutsSubtitle"
         android:layout_marginStart="@dimen/mlp_layout_card_margin_start"
+        android:layout_marginEnd="@dimen/mlp_layout_card_margin_end"
         android:layout_marginBottom="@dimen/hpp_recommended_subtitle_margin"
         android:text="@string/hpp_recommended_subtitle" />
     <TextView
         android:id="@+id/title"
         style="@style/ModalLayoutPickerLayoutsTitle"
+        android:layout_marginEnd="@dimen/mlp_layout_card_margin_end"
         android:layout_marginStart="@dimen/mlp_layout_card_margin_start"
         tools:text="Some layout title" />
 
@@ -27,8 +29,8 @@
         android:layout_height="0dp"
         android:layout_weight="1"
         android:clipToPadding="false"
-        android:paddingStart="@dimen/mlp_layout_card_margin_start"
-        android:paddingEnd="@dimen/mlp_layout_card_margin_end"
+        android:paddingStart="@dimen/mlp_layout_card_padding_start"
+        android:paddingEnd="@dimen/mlp_layout_card_padding_end"
         android:descendantFocusability="beforeDescendants"
         android:orientation="horizontal"
         android:scrollbars="none" />

--- a/WordPress/src/main/res/layout/modal_layout_picker_layouts_row.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_layouts_row.xml
@@ -11,6 +11,7 @@
 
     <TextView
         android:id="@+id/subtitle"
+        android:layout_width="match_parent"
         style="@style/ModalLayoutPickerLayoutsSubtitle"
         android:layout_marginStart="@dimen/mlp_layout_card_margin_start"
         android:layout_marginEnd="@dimen/mlp_layout_card_margin_end"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -638,6 +638,7 @@
     <dimen name="mlp_layout_card_height">240dp</dimen>
     <dimen name="mlp_layout_card_width">160dp</dimen>
     <dimen name="mlp_layout_card_margin_start">20dp</dimen>
+    <dimen name="mlp_layout_card_margin_end">20dp</dimen>
     <dimen name="mlp_layouts_category_radius">40dp</dimen>
     <dimen name="mlp_layouts_category_height">36dp</dimen>
     <dimen name="mlp_category_horizontal_margin">@dimen/margin_large</dimen>
@@ -646,7 +647,8 @@
     <dimen name="mlp_categories_emoji_size">18dp</dimen>
     <dimen name="mlp_titles_top_margin">14dp</dimen>
     <dimen name="mlp_titles_bottom_margin">28dp</dimen>
-    <dimen name="mlp_layout_card_margin_end">@dimen/margin_medium</dimen>
+    <dimen name="mlp_layout_card_padding_start">20dp</dimen>
+    <dimen name="mlp_layout_card_padding_end">@dimen/margin_medium</dimen>
     <dimen name="mlp_layout_card_margin_top">@dimen/margin_extra_large</dimen>
     <dimen name="mlp_layout_card_elevation">@dimen/margin_small</dimen>
     <dimen name="mlp_layout_card_radius">@dimen/margin_small</dimen>


### PR DESCRIPTION
Fixes #

Fixed the category titles (and subtitles) displayed in RTL languages for the theme picker and the page picker.

To test:

Set the app's language to an RTL language. (pseudoLocales can be used for ease in testing).

#### LTR

Make sure there are no regression for the theme picker and the page picker.

1. Enable LTR locale (U.S. English)
2. Start site creation flow
3. Choose an intent (e.g. Food)
4. Expect to see the theme picker screen next
5. Make sure category titles (and subtitles) are displayed correctly
   - [x] There should be no changes from this PR
6. Exit the theme picker and go to the pages list
7. Tap the FAB to create a new page
8. Expect to see the page picker screen next
9. Make sure category titles (and subtitles) are displayed correctly
   - [x] There should be no changes from this PR

####  RTL

Make sure there are no regression for the theme picker and the page picker.

1. Enable RTL locale (Arabic, English pseudoLocale)
2. Start site creation flow
3. Choose an intent (e.g. Food)
4. Expect to see the theme picker screen next
5. Make sure category titles (and subtitles) are displayed correctly
   - [x] Categories should be on the right side with proper padding
6. Exit the theme picker and go to the pages list
7. Tap the FAB to create a new page
8. Expect to see the page picker screen next
9. Make sure category titles (and subtitles) are displayed correctly
   - [x] Categories should be on the right side with proper padding

## Regression Notes
1. Potential unintended areas of impact
Page and theme pickers

12. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

13. What automated tests I added (or what prevented me from doing so)
Out of scope for this task.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
