### PR TITLE
Replace deprecated display apis with windowmetrics apis

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -354,7 +354,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
                                                + ViewCompat.getPaddingEnd(tabView));
                         }
 
-                        int displayWidth = DisplayUtils.getDisplayPixelWidth(MediaBrowserActivity.this);
+                        int displayWidth = DisplayUtils.getWindowPixelWidth(MediaBrowserActivity.this);
                         if (tabLayoutWidth < displayWidth) {
                             mTabLayout.setTabMode(TabLayout.MODE_FIXED);
                             mTabLayout.setTabGravity(TabLayout.GRAVITY_FILL);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -115,7 +115,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         mInflater = LayoutInflater.from(context);
         mHandler = new Handler();
 
-        int displayWidth = DisplayUtils.getDisplayPixelWidth(mContext);
+        int displayWidth = DisplayUtils.getWindowPixelWidth(mContext);
         mThumbWidth = displayWidth / getColumnCount(mContext);
         mThumbHeight = (int) (mThumbWidth * 0.75f);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -254,7 +254,7 @@ public class MediaPreviewFragment extends Fragment {
 
         imageView.setVisibility(View.VISIBLE);
         if ((mSite == null || SiteUtils.isPhotonCapable(mSite)) && !UrlUtils.isContentUri(mediaUri)) {
-            int maxWidth = Math.max(DisplayUtils.getDisplayPixelWidth(getActivity()),
+            int maxWidth = Math.max(DisplayUtils.getWindowPixelWidth(getActivity()),
                     DisplayUtils.getDisplayPixelHeight(getActivity()));
 
             boolean isPrivateAtomicSite = mSite != null && mSite.isPrivateWPComAtomic();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -254,8 +254,8 @@ public class MediaPreviewFragment extends Fragment {
 
         imageView.setVisibility(View.VISIBLE);
         if ((mSite == null || SiteUtils.isPhotonCapable(mSite)) && !UrlUtils.isContentUri(mediaUri)) {
-            int maxWidth = Math.max(DisplayUtils.getWindowPixelWidth(getActivity()),
-                    DisplayUtils.getDisplayPixelHeight(getActivity()));
+            int maxWidth = Math.max(DisplayUtils.getWindowPixelWidth(requireActivity()),
+                    DisplayUtils.getWindowPixelHeight(requireActivity()));
 
             boolean isPrivateAtomicSite = mSite != null && mSite.isPrivateWPComAtomic();
             mediaUri = PhotonUtils.getPhotonImageUrl(mediaUri, maxWidth, 0, isPrivateAtomicSite);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -294,7 +294,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
         });
 
         // make image 40% of screen height
-        int displayHeight = DisplayUtils.getDisplayPixelHeight(this);
+        int displayHeight = DisplayUtils.getWindowPixelHeight(this);
         int imageHeight = (int) (displayHeight * 0.4);
         mImageView.getLayoutParams().height = imageHeight;
 
@@ -728,7 +728,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
      */
     private void loadImage() {
         int width = DisplayUtils.getWindowPixelWidth(this);
-        int height = DisplayUtils.getDisplayPixelHeight(this);
+        int height = DisplayUtils.getWindowPixelHeight(this);
         int size = Math.max(width, height);
 
         String mediaUri;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -727,7 +727,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
      * loads and displays a remote or local image
      */
     private void loadImage() {
-        int width = DisplayUtils.getDisplayPixelWidth(this);
+        int width = DisplayUtils.getWindowPixelWidth(this);
         int height = DisplayUtils.getDisplayPixelHeight(this);
         int size = Math.max(width, height);
 
@@ -793,7 +793,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
         new Thread() {
             @Override
             public void run() {
-                int width = DisplayUtils.getDisplayPixelWidth(MediaSettingsActivity.this);
+                int width = DisplayUtils.getWindowPixelWidth(MediaSettingsActivity.this);
                 final Bitmap thumb = ImageUtils.getVideoFrameFromVideo(
                         mMedia.getUrl(),
                         width,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -556,7 +556,7 @@ class MySiteViewModel @Inject constructor(
     private fun buildNoSiteState(): NoSites {
         // Hide actionable empty view image when screen height is under specified min height.
         val shouldShowImage = !buildConfigWrapper.isJetpackApp &&
-                displayUtilsWrapper.getDisplayPixelHeight() >= MIN_DISPLAY_PX_HEIGHT_NO_SITE_IMAGE
+                displayUtilsWrapper.getWindowPixelHeight() >= MIN_DISPLAY_PX_HEIGHT_NO_SITE_IMAGE
         return NoSites(
                 tabsUiState = TabsUiState(showTabs = false, tabUiStates = emptyList()),
                 siteInfoToolbarViewParams = SiteInfoToolbarViewParams(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1908,7 +1908,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         // We're using a separate cache in WPAndroid and RN's Gutenberg editor so we need to reload the image
         // in the preview screen using WPAndroid's image loader. We create a resized url using Photon service and
         // device's max width to display a smaller image that can load faster and act as a placeholder.
-        int displayWidth = Math.max(DisplayUtils.getDisplayPixelWidth(getBaseContext()),
+        int displayWidth = Math.max(DisplayUtils.getWindowPixelWidth(getBaseContext()),
                 DisplayUtils.getDisplayPixelHeight(getBaseContext()));
 
         int margin = getResources().getDimensionPixelSize(R.dimen.preview_image_view_margin);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1909,7 +1909,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         // in the preview screen using WPAndroid's image loader. We create a resized url using Photon service and
         // device's max width to display a smaller image that can load faster and act as a placeholder.
         int displayWidth = Math.max(DisplayUtils.getWindowPixelWidth(getBaseContext()),
-                DisplayUtils.getDisplayPixelHeight(getBaseContext()));
+                DisplayUtils.getWindowPixelHeight(getBaseContext()));
 
         int margin = getResources().getDimensionPixelSize(R.dimen.preview_image_view_margin);
         int maxWidth = displayWidth - (margin * 2);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -135,7 +135,7 @@ class PostListFragment : ViewPagerFragment() {
 
         viewModel = ViewModelProvider(this, viewModelFactory).get(PostListViewModel::class.java)
 
-        val displayWidth = DisplayUtils.getDisplayPixelWidth(context)
+        val displayWidth = DisplayUtils.getWindowPixelWidth(requireContext())
         val contentSpacing = nonNullActivity.resources.getDimensionPixelSize(R.dimen.content_margin)
 
         // since the MainViewModel has been already started, we need to manually update the authorFilterSelection value

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -127,7 +127,7 @@ class EditorPhotoPicker(
             updatePickerContainerHeight(ViewGroup.LayoutParams.MATCH_PARENT)
         } else {
             photoPickerOrientation = Configuration.ORIENTATION_PORTRAIT
-            val displayHeight = DisplayUtils.getDisplayPixelHeight(activity)
+            val displayHeight = DisplayUtils.getWindowPixelHeight(activity)
             updatePickerContainerHeight((displayHeight * 0.5f).toInt())
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerFragment.java
@@ -1,7 +1,7 @@
 package org.wordpress.android.ui.reader;
 
 import android.app.Activity;
-import android.graphics.Point;
+import android.graphics.Rect;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -87,8 +87,8 @@ public class ReaderPhotoViewerFragment extends Fragment {
     private void showImage() {
         if (isAdded() && !TextUtils.isEmpty(mImageUrl)) {
             // use max of width/height so image is cached the same regardless of orientation
-            Point pt = DisplayUtils.getDisplayPixelSize(getActivity());
-            int hiResWidth = Math.max(pt.x, pt.y);
+            Rect pt = DisplayUtils.getWindowSize(requireActivity());
+            int hiResWidth = Math.max(pt.height(), pt.width());
             // don't use AT media proxy here
             mPhotoView.setImageUrl(mImageUrl, hiResWidth, mIsPrivate, false, mPhotoViewListener);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilder.kt
@@ -216,7 +216,7 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
                 ReaderPostFeaturedImageUiState(
                         blogId = post.blogId,
                         url = buildReaderPostFeaturedImageUrl(post),
-                        height = (displayUtilsWrapper.getDisplayPixelHeight() *
+                        height = (displayUtilsWrapper.getWindowPixelHeight() *
                                 READER_POST_FEATURED_IMAGE_HEIGHT_PERCENT).toInt()
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1133,7 +1133,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
         // force the search view to take up as much horizontal space as possible (without this
         // it looks truncated on landscape)
-        int maxWidth = DisplayUtils.getDisplayPixelWidth(getActivity());
+        int maxWidth = DisplayUtils.getWindowPixelWidth(requireActivity());
         mSearchView.setMaxWidth(maxWidth);
 
         // this is hacky, but we want to change the SearchView's autocomplete to show suggestions

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
@@ -35,7 +35,7 @@ class ReaderResourceVars {
     ReaderResourceVars(Context context) {
         Resources resources = context.getResources();
 
-        int displayWidthPx = DisplayUtils.getDisplayPixelWidth(context);
+        int displayWidthPx = DisplayUtils.getWindowPixelWidth(context);
 
         mIsWideDisplay = DisplayUtils.pxToDp(context, displayWidthPx) > 640;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -190,7 +190,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         mPostsSite = mSiteStore.getSiteBySiteId(post.blogId);
 
         // calculate the max width of comment content
-        int displayWidth = DisplayUtils.getDisplayPixelWidth(context);
+        int displayWidth = DisplayUtils.getWindowPixelWidth(context);
         int cardMargin = context.getResources().getDimensionPixelSize(R.dimen.reader_card_margin);
         int contentPadding = context.getResources().getDimensionPixelSize(R.dimen.reader_card_content_padding);
         int mediumMargin = context.getResources().getDimensionPixelSize(R.dimen.margin_medium);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -537,7 +537,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mAvatarSzSmall = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_small);
         mIsMainReader = isMainReader;
 
-        int displayWidth = DisplayUtils.getDisplayPixelWidth(context);
+        int displayWidth = DisplayUtils.getWindowPixelWidth(context);
         int cardMargin = context.getResources().getDimensionPixelSize(R.dimen.reader_card_margin);
         mPhotonWidth = displayWidth - (cardMargin * 2);
         mPhotonHeight = (int) (mPhotonWidth / READER_FEATURED_IMAGE_ASPECT_RATIO);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostTagsUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostTagsUiStateBuilder.kt
@@ -16,7 +16,7 @@ class ReaderPostTagsUiStateBuilder @Inject constructor(
 ) {
     private val maxWidthForChip: Int
         get() {
-            val width = DisplayUtils.getDisplayPixelWidth(contextProvider.getContext()) -
+            val width = DisplayUtils.getWindowPixelWidth(contextProvider.getContext()) -
                     resourceProvider.getDimensionPixelSize(R.dimen.reader_card_margin) * 2
             return (width * MAX_WIDTH_FACTOR).toInt()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ThreadedCommentsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ThreadedCommentsUtils.kt
@@ -16,7 +16,7 @@ class ThreadedCommentsUtils @Inject constructor(
         val context = contextProvider.getContext()
 
         // calculate the max width of comment content
-        val displayWidth = DisplayUtils.getDisplayPixelWidth(context)
+        val displayWidth = DisplayUtils.getWindowPixelWidth(context)
         val cardMargin: Int = context.resources.getDimensionPixelSize(R.dimen.reader_card_margin)
         val contentPadding: Int = context.resources.getDimensionPixelSize(R.dimen.reader_card_content_padding)
         val mediumMargin: Int = context.resources.getDimensionPixelSize(R.dimen.margin_medium)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderThumbnailStrip.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderThumbnailStrip.java
@@ -59,7 +59,7 @@ public class ReaderThumbnailStrip extends LinearLayout {
         mView = (ViewGroup) inflate(context, R.layout.reader_thumbnail_strip, this);
         mThumbnailHeight = context.getResources().getDimensionPixelSize(R.dimen.reader_thumbnail_strip_image_height);
 
-        int displayWidth = DisplayUtils.getDisplayPixelWidth(context);
+        int displayWidth = DisplayUtils.getWindowPixelWidth(context);
         int margins = context.getResources().getDimensionPixelSize(R.dimen.reader_card_content_padding) * 2;
         mThumbnailWidth = (displayWidth - margins) / THUMBNAIL_STRIP_IMG_COUNT;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -133,7 +133,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
             fm.beginTransaction().add(mRetainedFragment, TAG_RETAINED_FRAGMENT).commit();
         }
 
-        int displayWidth = DisplayUtils.getDisplayPixelWidth(this);
+        int displayWidth = DisplayUtils.getWindowPixelWidth(this);
         mThumbWidth = displayWidth / getColumnCount();
         mThumbHeight = (int) (mThumbWidth * 0.75f);
 

--- a/WordPress/src/main/java/org/wordpress/android/util/DisplayUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DisplayUtilsWrapper.kt
@@ -18,7 +18,5 @@ class DisplayUtilsWrapper @Inject constructor(private val contextProvider: Conte
 
     fun getDisplayPixelHeight() = DisplayUtils.getWindowPixelHeight(contextProvider.getContext())
 
-    fun getDisplayPixelHeightOld() = DisplayUtils.getDisplayPixelHeight(contextProvider.getContext())
-
     fun isPhoneLandscape() = isLandscapeBySize() && !isTablet()
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/DisplayUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DisplayUtilsWrapper.kt
@@ -8,14 +8,15 @@ import javax.inject.Inject
 class DisplayUtilsWrapper @Inject constructor(private val contextProvider: ContextProvider) {
     fun getDisplayPixelWidth() = DisplayUtils.getDisplayPixelWidth()
 
-    fun isLandscapeBySize() = getDisplayPixelWidth() > DisplayUtils.getDisplayPixelHeight(contextProvider.getContext())
+    fun isLandscapeBySize() =
+            getDisplayPixelWidth() > DisplayUtils.getWindowPixelHeight(contextProvider.getContext())
 
     fun isLandscape() = DisplayUtils.isLandscape(contextProvider.getContext())
 
     fun isTablet() = DisplayUtils.isTablet(contextProvider.getContext()) ||
             DisplayUtils.isXLargeTablet(contextProvider.getContext())
 
-    fun getDisplayPixelHeight() = DisplayUtils.getDisplayPixelHeight(contextProvider.getContext())
+    fun getDisplayPixelHeight() = DisplayUtils.getWindowPixelHeight(contextProvider.getContext())
 
     fun isPhoneLandscape() = isLandscapeBySize() && !isTablet()
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/DisplayUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DisplayUtilsWrapper.kt
@@ -18,5 +18,7 @@ class DisplayUtilsWrapper @Inject constructor(private val contextProvider: Conte
 
     fun getDisplayPixelHeight() = DisplayUtils.getWindowPixelHeight(contextProvider.getContext())
 
+    fun getDisplayPixelHeightOld() = DisplayUtils.getDisplayPixelHeight(contextProvider.getContext())
+
     fun isPhoneLandscape() = isLandscapeBySize() && !isTablet()
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/DisplayUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DisplayUtilsWrapper.kt
@@ -16,7 +16,7 @@ class DisplayUtilsWrapper @Inject constructor(private val contextProvider: Conte
     fun isTablet() = DisplayUtils.isTablet(contextProvider.getContext()) ||
             DisplayUtils.isXLargeTablet(contextProvider.getContext())
 
-    fun getDisplayPixelHeight() = DisplayUtils.getWindowPixelHeight(contextProvider.getContext())
+    fun getWindowPixelHeight() = DisplayUtils.getWindowPixelHeight(contextProvider.getContext())
 
     fun isPhoneLandscape() = isLandscapeBySize() && !isTablet()
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -642,7 +642,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Test
     fun `given wp app, when no site is selected and screen height is higher than 600 pixels, show empty view image`() {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
-        whenever(displayUtilsWrapper.getDisplayPixelHeight()).thenReturn(600)
+        whenever(displayUtilsWrapper.getWindowPixelHeight()).thenReturn(600)
 
         onSiteSelected.value = null
 
@@ -653,7 +653,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Test
     fun `given wp app, when no site is selected and screen height is lower than 600 pixels, hide empty view image`() {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
-        whenever(displayUtilsWrapper.getDisplayPixelHeight()).thenReturn(500)
+        whenever(displayUtilsWrapper.getWindowPixelHeight()).thenReturn(500)
 
         onSiteSelected.value = null
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
@@ -331,7 +331,7 @@ class ReaderPostDetailUiStateBuilderTest {
         }
 
         whenever(featuredImageUtils.shouldAddFeaturedImage(any())).thenReturn(shouldShowFeaturedImage)
-        whenever(displayUtilsWrapper.getDisplayPixelHeight()).thenReturn(dummyDisplayPixelHeight)
+        whenever(displayUtilsWrapper.getWindowPixelHeight()).thenReturn(dummyDisplayPixelHeight)
         whenever(readerUtilsWrapper.getResizedImageUrl(any(), any(), any(), any(), any()))
                 .thenReturn(dummyFeaturedImageUrl)
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
@@ -45,8 +45,8 @@ public class EditorMediaUtils {
 
     public static int getMaximumThumbnailSizeForEditor(Context context) {
         Rect size = DisplayUtils.getWindowSize(context);
-        int screenWidth = size.height();
-        int screenHeight = size.width();
+        int screenWidth = size.width();
+        int screenHeight = size.height();
         int maximumThumbnailWidthForEditor = Math.min(screenWidth, screenHeight);
         int padding = DisplayUtils.dpToPx(context, 48) * 2;
         maximumThumbnailWidthForEditor -= padding;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
@@ -3,7 +3,7 @@ package org.wordpress.android.editor;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Point;
+import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.VectorDrawable;
@@ -44,10 +44,10 @@ public class EditorMediaUtils {
     }
 
     public static int getMaximumThumbnailSizeForEditor(Context context) {
-        Point size = DisplayUtils.getDisplayPixelSize(context);
-        int screenWidth = size.x;
-        int screenHeight = size.y;
-        int maximumThumbnailWidthForEditor = screenWidth > screenHeight ? screenHeight : screenWidth;
+        Rect size = DisplayUtils.getWindowSize(context);
+        int screenWidth = size.height();
+        int screenHeight = size.width();
+        int maximumThumbnailWidthForEditor = Math.min(screenWidth, screenHeight);
         int padding = DisplayUtils.dpToPx(context, 48) * 2;
         maximumThumbnailWidthForEditor -= padding;
         return maximumThumbnailWidthForEditor;


### PR DESCRIPTION
Parent #16073

As part of the changes for Android 12. This PR replaces the usages of the deprecated functions in `DisplayUtils.kt` in the WordPress Utils library. 

Functions replaced in the PR are 
1. `DisplayUtils.getDisplayPixelWidth(context)`with `DisplayUtils.getWindowPixelWidth(context)`
2. `DisplayUtils.getDisplayPixelHeight(context)` with  `DisplayUtils.getWindowPixelHeight(context)`
3. `DisplayUtils.getDisplayPixelSize(context) `with `DisplayUtils.getWindowSize(context)`

To test:

Testing instructions

The APIs are used in the following places

1. `MediaBrowserActivity.java`
2. `MediaGridAdapter.java`
3. `MediaPreviewFragment.java`
4. `MediaSettingsActivity.java`
5. `MediaSettingsActivity.java`
6. `EditPostActivity.java`
7. `PostListFragment.kt`
8. `EditorPhotoPicker.kt`
9. `ReaderPhotoViewerFragment.java`
10. `ReaderPostListFragment.java`
11. `ReaderResourceVars.java`
12. `ReaderCommentAdapter.java`
13. `ReaderPostAdapter.java`
14. `ReaderPostTagsUiStateBuilder.kt`
15. `HistoryDetailContainerFragment`
16. `EditorMediaUtils.java`
17. `StockMediaPickerActivity.java`
18. `ReaderThumbnailStrip.java`

In order to confirm that there is no regression issue we can test the following places. 

### Test 1 - Test on Android 11 and Android 12
`ReaderPhotoViewerFragment.java`

- Log in to the app 
- Go to the reader tab 
- Click on any reader post with multiple images 
- Click at the image and swipe between the images 
- Click back 
- Switch off the WIFI/Internet 
- Click at the image and swipe between the images 
- Verify that the Image is shown properly in portrait and landscape orientation 

### Test 2
`EditorMediaUtils.java`	

- Log in to the app 
- Go to the My Site Dashboard 
- Create a post with a video 
- Verify that the Video thumbnail is shown properly 

### Test 3
`ReaderCommentAdapter.java`

- Log in to the app 
- Go to a post with comments 
- Verify that the comments and nested comments(replies to the comments) are shown with the correct padding 

## Regression Notes
1. Potential unintended areas of impact

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
