### PR TITLE
Issue/do not show next post card when bp card is visible

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
@@ -33,7 +33,7 @@ class CardsBuilder @Inject constructor(
                             ?.let { add(it) }
 
                     // if blogging prompt card is visible and the post card is "Write first/next post" we only show
-                    // blogging prompt, since they are ver similar
+                    // blogging prompt, since they are very similar
                     val postCards = postCardBuilder.build(dashboardCardsBuilderParams.postCardBuilderParams)
                     val hasNextPostPrompt = postCards.find {
                         it.dashboardCardType == POST_CARD_WITHOUT_POST_ITEMS

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
@@ -35,7 +35,9 @@ class CardsBuilder @Inject constructor(
                     // if blogging prompt card is visible and the post card is "Write first/next post" we only show
                     // blogging prompt, since they are ver similar
                     val postCards = postCardBuilder.build(dashboardCardsBuilderParams.postCardBuilderParams)
-                    val hasNextPostPrompt = postCards.find { it.dashboardCardType == POST_CARD_WITHOUT_POST_ITEMS } != null
+                    val hasNextPostPrompt = postCards.find {
+                        it.dashboardCardType == POST_CARD_WITHOUT_POST_ITEMS
+                    } != null
                     val showPostCards = !hasNextPostPrompt || !bloggingPromptCardAdded
 
                     if (showPostCards) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.mysite.cards.dashboard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.DashboardCardType.POST_CARD_WITHOUT_POST_ITEMS
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardsBuilderParams
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardBuilder
@@ -22,11 +23,24 @@ class CardsBuilder @Inject constructor(
                 if (dashboardCardsBuilderParams.showErrorCard) {
                     add(createErrorCard(dashboardCardsBuilderParams.onErrorRetryClick))
                 } else {
+                    var bloggingPromptCardAdded = false
+                    bloggingPromptCardBuilder.build(dashboardCardsBuilderParams.bloggingPromptCardBuilderParams)
+                            ?.let {
+                                bloggingPromptCardAdded = true
+                                add(it)
+                            }
                     todaysStatsCardBuilder.build(dashboardCardsBuilderParams.todaysStatsCardBuilderParams)
                             ?.let { add(it) }
-                    addAll(postCardBuilder.build(dashboardCardsBuilderParams.postCardBuilderParams))
-                    bloggingPromptCardBuilder.build(dashboardCardsBuilderParams.bloggingPromptCardBuilderParams)
-                            ?.let { add(it) }
+
+                    // if blogging prompt card is visible and the post card is "Write first/next post" we only show
+                    // blogging prompt, since they are ver similar
+                    val postCards = postCardBuilder.build(dashboardCardsBuilderParams.postCardBuilderParams)
+                    val hasNextPostPrompt = postCards.find { it.dashboardCardType == POST_CARD_WITHOUT_POST_ITEMS } != null
+                    val showPostCards = !hasNextPostPrompt || !bloggingPromptCardAdded
+
+                    if (showPostCards) {
+                        addAll(postCards)
+                    }
                 }
             }.toList()
     )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -15,9 +15,9 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.BloggingPromptCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.BloggingPromptCard.BloggingPromptCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorCard
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TodaysStatsCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloggingPromptCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardsBuilderParams
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBu
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.TodaysStatsCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardBuilder
+import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType.CREATE_FIRST
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType.DRAFT
 import org.wordpress.android.ui.mysite.cards.dashboard.todaysstats.TodaysStatsCardBuilder
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -63,16 +64,16 @@ class CardsBuilderTest : BaseUnitTest() {
 
     @Test
     fun `given no posts, when cards are built, then post card is not built`() {
-        val cards = buildDashboardCards(hasPosts = false)
+        val cards = buildDashboardCards(hasPostsForPostCard = false)
 
-        assertThat(cards.findPostCard()).isNull()
+        assertThat(cards.findPostCardWithPosts()).isNull()
     }
 
     @Test
     fun `given posts, when cards are built, then post card is built`() {
-        val cards = buildDashboardCards(hasPosts = true)
+        val cards = buildDashboardCards(hasPostsForPostCard = true)
 
-        assertThat(cards.findPostCard()).isNotNull
+        assertThat(cards.findPostCardWithPosts()).isNotNull
     }
 
     /* BLOGGING PROMPT CARD */
@@ -90,6 +91,44 @@ class CardsBuilderTest : BaseUnitTest() {
 
         assertThat(cards.findBloggingPromptCard()).isNotNull
     }
+
+    /* BLOGGING PROMPT AND POST CARD */
+
+    @Test
+    fun `given blogging prompt and posts, both prompt and post cards are visible`() {
+        val cards = buildDashboardCards(hasBlogginPrompt = true, hasPostsForPostCard = true)
+
+        assertThat(cards.findBloggingPromptCard()).isNotNull
+        assertThat(cards.findPostCardWithPosts()).isNotNull
+    }
+
+    @Test
+    fun `given blogging prompt and no posts, prompt card is visible while post and next post cards are not`() {
+        val cards = buildDashboardCards(hasBlogginPrompt = true, hasPostsForPostCard = false)
+
+        assertThat(cards.findBloggingPromptCard()).isNotNull
+        assertThat(cards.findPostCardWithPosts()).isNull()
+        assertThat(cards.findNextPostCard()).isNull()
+    }
+
+    @Test
+    fun `given no blogging prompt and no posts, next post card is visible and prompt card is not`() {
+        val cards = buildDashboardCards(hasBlogginPrompt = false, hasPostsForPostCard = false)
+
+        assertThat(cards.findBloggingPromptCard()).isNull()
+        assertThat(cards.findPostCardWithPosts()).isNull()
+        assertThat(cards.findNextPostCard()).isNotNull
+    }
+
+    @Test
+    fun `given no blogging prompt and posts, next post card is not visible and prompt card is visible`() {
+        val cards = buildDashboardCards(hasBlogginPrompt = false, hasPostsForPostCard = true)
+
+        assertThat(cards.findBloggingPromptCard()).isNull()
+        assertThat(cards.findPostCardWithPosts()).isNotNull
+        assertThat(cards.findNextPostCard()).isNull()
+    }
+
 
     /* ERROR CARD */
 
@@ -110,7 +149,11 @@ class CardsBuilderTest : BaseUnitTest() {
     private fun DashboardCards.findTodaysStatsCard() =
             this.cards.find { it is TodaysStatsCardWithData } as? TodaysStatsCardWithData
 
-    private fun DashboardCards.findPostCard() = this.cards.find { it is PostCard } as? PostCard
+    private fun DashboardCards.findPostCardWithPosts() =
+            this.cards.find { it is PostCardWithPostItems } as? PostCardWithPostItems
+
+    private fun DashboardCards.findNextPostCard() =
+            this.cards.find { it is PostCardWithoutPostItems } as? PostCardWithoutPostItems
 
     private fun DashboardCards.findBloggingPromptCard() =
             this.cards.find { it is BloggingPromptCard } as? BloggingPromptCard
@@ -130,14 +173,25 @@ class CardsBuilderTest : BaseUnitTest() {
             )
     )
 
+    private fun createPostPromptCards() = listOf(
+            PostCardWithoutPostItems(
+                    postCardType = CREATE_FIRST,
+                    title = UiStringText(""),
+                    excerpt = UiStringText(""),
+                    imageRes = 0,
+                    footerLink = FooterLink(UiStringText(""), onClick = mock()),
+                    onClick = mock()
+            )
+    )
+
     private fun buildDashboardCards(
         hasTodaysStats: Boolean = false,
-        hasPosts: Boolean = false,
+        hasPostsForPostCard: Boolean = false,
         hasBlogginPrompt: Boolean = false,
         showErrorCard: Boolean = false
     ): DashboardCards {
         doAnswer { if (hasTodaysStats) todaysStatsCard else null }.whenever(todaysStatsCardBuilder).build(any())
-        doAnswer { if (hasPosts) createPostCards() else emptyList() }.whenever(postCardBuilder).build(any())
+        doAnswer { if (hasPostsForPostCard) createPostCards() else createPostPromptCards() }.whenever(postCardBuilder).build(any())
         doAnswer { if (hasBlogginPrompt) blogingPromptCard else null }.whenever(bloggingPromptCardsBuilder).build(any())
         return cardsBuilder.build(
                 dashboardCardsBuilderParams = DashboardCardsBuilderParams(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -129,7 +129,6 @@ class CardsBuilderTest : BaseUnitTest() {
         assertThat(cards.findNextPostCard()).isNull()
     }
 
-
     /* ERROR CARD */
 
     @Test
@@ -191,7 +190,8 @@ class CardsBuilderTest : BaseUnitTest() {
         showErrorCard: Boolean = false
     ): DashboardCards {
         doAnswer { if (hasTodaysStats) todaysStatsCard else null }.whenever(todaysStatsCardBuilder).build(any())
-        doAnswer { if (hasPostsForPostCard) createPostCards() else createPostPromptCards() }.whenever(postCardBuilder).build(any())
+        doAnswer { if (hasPostsForPostCard) createPostCards() else createPostPromptCards() }.whenever(postCardBuilder)
+                .build(any())
         doAnswer { if (hasBlogginPrompt) blogingPromptCard else null }.whenever(bloggingPromptCardsBuilder).build(any())
         return cardsBuilder.build(
                 dashboardCardsBuilderParams = DashboardCardsBuilderParams(


### PR DESCRIPTION
This PR adds a logic for when to or not to show "Write your first" and "Next post is waiting" cards.

Idea is that BP card serves same purpose as those cards, and we only want to show one at a time.

To test:
- Enabled BP feature flag and restart the app.
- For ease of testing, you probably want to use a site without any drafts or posts.
- Make sure you have no drafts and navigate to My Site screen.
- Confirm that the blogging prompt card is visible and Post Cards are not visible.
- Create a draft, and navigate back to My Site screen.
- Confirm that the card with your Draft post is visible.
- Publish the draft and navigate back to My Site screen.
- Confirm that the post card is gone.

## Regression Notes
1. Potential unintended areas of impact
- card visibility logic is compromised in some way

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
Testing for the card visibility logic.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
