### PR TITLE
Stats Revamp v2: Update card title style

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
@@ -1,8 +1,9 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 
-import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
 import com.google.android.material.button.MaterialButton
 import org.wordpress.android.R
 import org.wordpress.android.R.id
@@ -14,13 +15,14 @@ class TitleWithMoreViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
 ) {
     private val title = itemView.findViewById<TextView>(id.text)
     private val viewMore = itemView.findViewById<MaterialButton>(id.view_more_button)
+
     fun bind(item: TitleWithMore) {
         title.setTextOrHide(item.textResource, item.text)
         if (item.navigationAction != null) {
-            viewMore.visibility = View.VISIBLE
+            viewMore.isVisible = true
             viewMore.setOnClickListener { item.navigationAction.click() }
         } else {
-            viewMore.visibility = View.GONE
+            viewMore.isInvisible = true
         }
     }
 }

--- a/WordPress/src/main/res/layout/stats_block_title_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_title_item.xml
@@ -9,15 +9,11 @@
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text"
         style="@style/StatsBlockTitle"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
+        android:layout_weight="1"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:text="@string/unknown" />
-
-    <View
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="1" />
 
     <ImageButton
         android:id="@+id/menu"
@@ -27,5 +23,4 @@
         android:contentDescription="@string/stats_item_settings"
         android:src="@drawable/ic_ellipsis_vertical_grey_darken_48dp"
         app:tint="?attr/wpColorOnSurfaceMedium" />
-
 </LinearLayout>

--- a/WordPress/src/main/res/layout/stats_block_title_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_title_item.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     style="@style/StatsBlockLine"
     android:layout_width="match_parent"
+    android:layout_marginTop="@dimen/margin_small"
     android:orientation="horizontal">
 
     <com.google.android.material.textview.MaterialTextView

--- a/WordPress/src/main/res/layout/stats_block_title_with_more_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_title_with_more_item.xml
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
+    android:gravity="center_vertical"
     android:layout_height="wrap_content"
     android:paddingTop="@dimen/margin_extra_large"
-    android:paddingStart="@dimen/margin_extra_large"
-    android:paddingEnd="@dimen/margin_extra_large">
+    android:orientation="horizontal"
+    android:paddingHorizontal="@dimen/margin_extra_large">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text"
+        android:layout_width="0dp"
         style="@style/StatsBlockTitle"
-        android:layout_width="wrap_content"
+        android:layout_marginEnd="@dimen/margin_medium"
         android:layout_height="wrap_content"
         android:text="@string/unknown"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="@string/stats_insights_views_and_visitors"/>
+        android:layout_weight="1"
+        tools:text="@string/stats_insights_views_and_visitors" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/view_more_button"
@@ -26,8 +25,5 @@
         android:background="?attr/selectableItemBackgroundBorderless"
         android:text="@string/stats_insights_view_more"
         android:textColor="?attr/wpColorOnSurfaceMedium"
-        android:textAllCaps="true"
-        app:layout_constraintBaseline_toBaselineOf="@id/text"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:textAllCaps="true" />
+</LinearLayout>

--- a/WordPress/src/main/res/layout/stats_date_selector.xml
+++ b/WordPress/src/main/res/layout/stats_date_selector.xml
@@ -8,7 +8,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/selectedDateTextView"
-        style="@style/StatsBlockTitle"
+        style="@style/StatsDateSelectorTitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -46,7 +46,12 @@
         <item name="android:paddingStart">@dimen/margin_extra_large</item>
     </style>
 
-    <style name="StatsBlockTitle" parent="TextAppearance.MaterialComponents.Subtitle1">
+    <style name="StatsBlockTitle" parent="TextAppearance.MaterialComponents.Headline6">
+        <item name="android:maxLines">1</item>
+        <item name="android:ellipsize">end</item>
+    </style>
+
+    <style name="StatsDateSelectorTitle" parent="TextAppearance.MaterialComponents.Subtitle1">
         <item name="android:textStyle">bold</item>
     </style>
 


### PR DESCRIPTION
- This updates stats card titles according to the stats revamp v2 design. The new title is larger. This new style is applied to all titles even `StatsRevampV2FeatureConfig` is off. Since it's just a small style change, I preferred not to use the feature flag for this. **Please let me know if you have concerns about this decision.**
- Also, there was a problem with long titles in cards, it's fixed.

||before|after|
|-|-|-|
|long title|<img src="https://user-images.githubusercontent.com/2471769/171514967-320a3cd3-ccea-4a26-9eea-1bc3c4a059d4.png" width=280>|<img src="https://user-images.githubusercontent.com/2471769/171515005-c384ba0d-7955-4c15-b3a1-f74c96717949.png" width=280>|
|title style|<img src="https://user-images.githubusercontent.com/2471769/171515646-54282792-7831-4574-af9d-eb15a65a0028.png" width=280>|<img src="https://user-images.githubusercontent.com/2471769/171515665-51d0c19d-0b97-4ca0-bd56-4d37e526e12b.png" width=280>|

To test:
1. Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
2. Select Debug Settings
3. Find StatsRevampV2FeatureConfig under Features in development enable it and restart app
4. Launch / Re-Launch app
5. Go to Stats either using quick links or menu
6. Check titles in the stats cards on all tabs and card detail screens. The title size should be larger as in the design.
7. Check long titles and ensure the title is not over VIEW MORE button. (Views & VIsitors title is long in the Turkish language. Or you change a title in the code and test)

## Regression Notes
1. Potential unintended areas of impact
Layout problems when `StatsRevampV2FeatureConfig` is off.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually when `StatsRevampV2FeatureConfig` is off.

3. What automated tests I added (or what prevented me from doing so)
This contains only style changes. No test is added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
