### PR TITLE
Enable pseudoLocales

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -255,6 +255,7 @@ android {
         debug {
             minifyEnabled false
             buildConfigField "String", "APP_PN_KEY", "\"org.wordpress.android.debug.build\""
+            pseudoLocalesEnabled true
         }
     }
 


### PR DESCRIPTION
### Description

This PR enables [pseudoLocales](https://developer.android.com/guide/topics/resources/pseudolocales) for debug builds. This facilitates testing for and discovery of issues with non-localized strings as well as support for RTL languages / locales during development.


To test:

Enable a pseudoLocale on your device and open the app with that locale selected as primary. Expect the strings (e.g. RTL, accents, etc.) to be displayed properly in places where those locales are supported.


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A


3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
