### PR TITLE
Integrate gutenberg-mobile release 1.77.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.14.0'
-    gutenbergMobileVersion = 'v1.77.0'
+    gutenbergMobileVersion = '4923-5226e5db59e470967dd301029525f61363890774'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.14.0'
-    gutenbergMobileVersion = '4923-5226e5db59e470967dd301029525f61363890774'
+    gutenbergMobileVersion = '4923-3aa8d467305ccacea0e6a041ed067e40c3d0fc1d'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.77.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4923

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.