### PR TITLE
[Site design revamp] Adds margin between recommended design title and subtitle

### DIFF
--- a/WordPress/src/main/res/layout/modal_layout_picker_layouts_row.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_layouts_row.xml
@@ -13,6 +13,7 @@
         android:id="@+id/subtitle"
         style="@style/ModalLayoutPickerLayoutsSubtitle"
         android:layout_marginStart="@dimen/mlp_layout_card_margin_start"
+        android:layout_marginBottom="@dimen/hpp_recommended_subtitle_margin"
         android:text="@string/hpp_recommended_subtitle" />
     <TextView
         android:id="@+id/title"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -662,6 +662,7 @@
     <dimen name="hpp_recommended_card_height">420dp</dimen>
     <dimen name="hpp_recommended_card_width">320dp</dimen>
     <dimen name="hpp_recommended_row_height">500dp</dimen>
+    <dimen name="hpp_recommended_subtitle_margin">5dp</dimen>
 
     <!-- Site Intent Question -->
     <dimen name="siq_header_scroll_snap_threshold">-96dp</dimen>


### PR DESCRIPTION
Fixes #

To test:
1. Start the site creation flow
2. Proceed to the site design picker
3. *Verify* that there is a margin between the recommended title and subtitle

|Before|After|
|---|---|
|![s1](https://user-images.githubusercontent.com/304044/171638653-6c6cb66b-c26b-4b6d-82c2-99dee556fc68.png)|![s3](https://user-images.githubusercontent.com/304044/171638679-6138408d-4e1b-4d3b-910c-0e92f8a3718a.png)|

## Regression Notes
1. Potential unintended areas of impact
Page layout picker

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

|Before|After|
|---|---|
|![l1](https://user-images.githubusercontent.com/304044/171638490-4851cdc9-0487-477f-96a9-6b9d543aebed.png)|![l3](https://user-images.githubusercontent.com/304044/171638509-4fb8c45f-6a49-4e50-b3d4-2c4f774b2a29.png)|

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
