### PR TITLE
[Site design revamp] Remove selection border when collapsing themes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutViewHolder.kt
@@ -41,7 +41,7 @@ class LayoutViewHolder(
         }
         binding.preview.contentDescription = parent.context.getString(uiState.contentDescriptionResId, uiState.title)
         binding.preview.context?.let { ctx ->
-            binding.layoutContainer.strokeWidth = if (uiState.selected) {
+            binding.layoutContainer.strokeWidth = if (uiState.selectedOverlayVisible) {
                 ctx.resources.getDimensionPixelSize(R.dimen.picker_header_selection_overlay_width)
             } else {
                 0


### PR DESCRIPTION
Removes the pink selection border when the preview is collapsing (ref: pc8HXX-oi-p2#comment-503)

To test:
1. Start the site creation flow
2. Proceed to the design picker
3. Select a layout
4. slowly dismiss the preview
5. *Verify* that no selection border is visible (like below)
![Screenshot 2022-06-02 at 4 48 14 PM](https://user-images.githubusercontent.com/304044/171644143-8252f139-fc18-4489-9bef-1379edbff1cf.png)

## Regression Notes
1. Potential unintended areas of impact
Page Layout picker

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

7. What automated tests I added (or what prevented me from doing so)
The fix was in the UI layer that would be hard to test with the current code structure

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
