### PR TITLE
[Site Design Revamp] Fix blank theme preview after orientation change

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -78,7 +78,6 @@ class SiteCreationActivity : LocaleAwareActivity(),
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         mainViewModel.writeToBundle(outState)
-        hppViewModel.writeToBundle(outState)
     }
 
     private fun observeVMState() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -81,6 +81,11 @@ class HomePagePickerFragment : Fragment() {
         }
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        viewModel.writeToBundle(outState)
+    }
+
     private fun HomePagePickerFragmentBinding.setupUi() {
         siteCreationThemeHeader.title?.setText(R.string.hpp_title)
         siteCreationThemeHeader.subtitle?.isGone = true


### PR DESCRIPTION
Fixes #16672

### Description

This PR saves the instance state for the home page picker's view model to the _fragment_ bundle, since that is what the fragment loads from when it restarts.

To test:

Follow the steps on the issue description to try to reproduce: https://github.com/wordpress-mobile/WordPress-Android/issues/16672

Expect that the preview is loaded properly after an orientation change event.

#### Note:

I have not tested whether we can remove [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/0abd1f3dfb5fb91574e76f2d69e1a191e6282150/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt#L81) which writes to the activity bundle. In my testing, this resolved the issue, but if removing that line does not introduce regressions, it may be a minor optimization to consider along with these changes.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
