### PR TITLE
[Site Design Revamp] Removed small border on top and bottom of recommended design

### DIFF
--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -659,7 +659,7 @@
     <dimen name="hpp_layout_card_height">260dp</dimen>
     <dimen name="hpp_layout_card_width">200dp</dimen>
     <dimen name="hpp_layouts_row_height">330dp</dimen>
-    <dimen name="hpp_recommended_card_height">420dp</dimen>
+    <dimen name="hpp_recommended_card_height">416dp</dimen>
     <dimen name="hpp_recommended_card_width">320dp</dimen>
     <dimen name="hpp_recommended_row_height">500dp</dimen>
     <dimen name="hpp_recommended_subtitle_margin">5dp</dimen>


### PR DESCRIPTION
Fixes #16691

## Description
Tweaks the recommended design preview size to match the aspect ratio (internal ref `pc8HXX-oi-p2#comment-538`) of the other preview thumbs. Since the normal thumbs ratio is `260dp/200dp = 1.3` the recommended thumbs width is changed from `420dp` to `320dp x1.3 = 416dp`.

Note: the limitation on having a different aspect ratio seems to derive from the mShots service

To test:
1. Start the site creation flow
2. Proceed to the site design selection
3. *Verify* that no top or bottom border exists on the recommended designs

|Before|After|
|---|---|
|![Screenshot_20220603_141215](https://user-images.githubusercontent.com/304044/171844248-e952877f-33ff-45e3-880e-65ead0a9307f.png)|![Screenshot_20220603_141258](https://user-images.githubusercontent.com/304044/171844233-358dc21a-e1db-4ef6-b4aa-0656d623f12e.png)|

## Regression Notes

1. Potential unintended areas of impact
N/A

4. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
