### PR TITLE
QR Code Auth: Part 1 - Launching the flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1729,8 +1729,7 @@ public class ActivityLauncher {
         context.startActivity(new Intent(context, DebugCookiesActivity.class));
     }
 
-    public static void viewQRCodeAuthFlow(@NonNull Context context) {
-        Intent intent = new Intent(context, QRCodeAuthActivity.class);
-        context.startActivity(intent);
+    public static void startQRCodeAuthFlow(@NonNull Context context) {
+        QRCodeAuthActivity.start(context);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -171,8 +171,9 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        if (qrCodeAuthFlowFeatureConfig.isEnabled() && BuildConfig.ENABLE_QRCODE_AUTH_FLOW
-                && accountStore.hasAccessToken()) {
+        if (qrCodeAuthFlowFeatureConfig.isEnabled() &&
+                BuildConfig.ENABLE_QRCODE_AUTH_FLOW &&
+                accountStore.hasAccessToken()) {
             rowScanLoginCode.isVisible = true
 
             rowScanLoginCode.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -171,7 +171,8 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        if (qrCodeAuthFlowFeatureConfig.isEnabled() && BuildConfig.ENABLE_QRCODE_AUTH_FLOW) {
+        if (qrCodeAuthFlowFeatureConfig.isEnabled() && BuildConfig.ENABLE_QRCODE_AUTH_FLOW
+                && accountStore.hasAccessToken()) {
             rowScanLoginCode.isVisible = true
 
             rowScanLoginCode.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -199,7 +199,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         })
 
         viewModel.showScanLoginCode.observeEvent(viewLifecycleOwner) {
-            ActivityLauncher.viewQRCodeAuthFlow(requireContext())
+            ActivityLauncher.startQRCodeAuthFlow(requireContext())
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.qrcodeauth
 
 import android.os.Bundle
-import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.databinding.QrcodeauthActivityBinding
@@ -13,19 +12,6 @@ class QRCodeAuthActivity : AppCompatActivity() {
 
         with(QrcodeauthActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
-            setSupportActionBar(toolbarMain)
         }
-        supportActionBar?.let {
-            it.setHomeButtonEnabled(true)
-            it.setDisplayHomeAsUpEnabled(true)
-        }
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == android.R.id.home) {
-            onBackPressed()
-            return true
-        }
-        return super.onOptionsItemSelected(item)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.qrcodeauth
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
@@ -12,6 +14,14 @@ class QRCodeAuthActivity : AppCompatActivity() {
 
         with(QrcodeauthActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun start(context: Context) {
+            val intent = Intent(context, QRCodeAuthActivity::class.java)
+            context.startActivity(intent)
         }
     }
 }

--- a/WordPress/src/main/res/layout/qrcodeauth_activity.xml
+++ b/WordPress/src/main/res/layout/qrcodeauth_activity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,20 +9,6 @@
         android:id="@+id/fragment_container"
         android:name="org.wordpress.android.ui.qrcodeauth.QRCodeAuthFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+        android:layout_height="match_parent" />
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/appbar_main"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar_main"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:theme="@style/WordPress.ActionBar" />
-
-    </com.google.android.material.appbar.AppBarLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
-


### PR DESCRIPTION
Parent #16481 

This PR adds the following:
- Restricts scan login code option to WP.com users
- Removes the toolbar from QRCodeAuthActivity and layout file
- Adjusts the intent launch in ActivityLauncher to call companion object

Note: This PR will be merged to a feature branch and not trunk. Milestone will be set to "future"

**To test:**
- Install the app
- Login using a WP.com account
- Navigate to Me -> App Settings -> Debug Settings
- Enable `QRCodeAuthFlowFeatureConfig`
- Restart the App
- Navigate back to Me
- ✅ Verify "Scan Login Code" is visible on the Me View
- Log out
- Log in using a non-wp.com account
- Navigate to Me
- ✅ Verify "Scan Login Code" is not visible on the Me View

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
No unit tests for fragments.

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
