### PR TITLE
QR Code Auth: Part 4 - Action/events channel for onbackpressed dismiss dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActionEvent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActionEvent.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.ui.qrcodeauth
+
+sealed class QRCodeAuthActionEvent {
+    class LaunchDismissDialog(val dialogModel: QRCodeAuthDialogModel) : QRCodeAuthActionEvent()
+    object LaunchScanner : QRCodeAuthActionEvent()
+    object FinishActivity : QRCodeAuthActionEvent()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthDialogModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthDialogModel.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.ui.qrcodeauth
+
+import androidx.annotation.StringRes
+import org.wordpress.android.R
+
+sealed class QRCodeAuthDialogModel(
+    val tag: String,
+    @StringRes val title: Int,
+    @StringRes open val message: Int,
+    @StringRes val positiveButtonLabel: Int,
+    @StringRes val negativeButtonLabel: Int? = null,
+    @StringRes val cancelButtonLabel: Int? = null
+) {
+    object ShowDismissDialog : QRCodeAuthDialogModel(
+            QRCodeAuthViewModel.TAG_DISMISS_DIALOG,
+            R.string.qrcode_auth_flow_dismiss_dialog_title,
+            R.string.qrcode_auth_flow_dismiss_dialog_message,
+            R.string.ok,
+            R.string.cancel
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiState.kt
@@ -1,0 +1,204 @@
+package org.wordpress.android.ui.qrcodeauth
+
+import androidx.annotation.DrawableRes
+import org.wordpress.android.R
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.DonePrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.DoneSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.AuthenticatingPrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.AuthenticatingSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ErrorPrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ErrorSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ValidatedPrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ValidatedSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.AUTHENTICATING
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.AUTH_FAILED
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.CONTENT
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.DONE
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.ERROR
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.EXPIRED
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.INVALID_DATA
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.LOADING
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.NO_INTERNET
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.SCANNING
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.VALIDATED
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
+
+const val BASE_ALPHA = 1.0f
+const val BLURRED_ALPHA = 0.75f
+
+@Suppress("LongParameterList")
+sealed class QRCodeAuthUiState {
+    open val type: QRCodeAuthUiStateType? = null
+    open val scanningVisibility = false
+    open val loadingVisibility = false
+    open val errorVisibility = false
+    open val contentVisibility = false
+
+    object Scanning : QRCodeAuthUiState() {
+        override val type = SCANNING
+        override val scanningVisibility = true
+    }
+
+    object Loading : QRCodeAuthUiState() {
+        override val type = LOADING
+        override val loadingVisibility = true
+    }
+
+    sealed class Error : QRCodeAuthUiState() {
+        override val type = ERROR
+        override val errorVisibility = true
+        abstract val title: UiString
+        abstract val subtitle: UiString
+        abstract val image: Int
+        open val primaryAction: ErrorPrimaryAction? = null
+        open val secondaryAction: ErrorSecondaryAction? = null
+
+        data class AuthFailed(
+            override val primaryAction: ErrorPrimaryAction,
+            override val secondaryAction: ErrorSecondaryAction
+        ) : Error() {
+            override val type = AUTH_FAILED
+            override val title: UiString = UiStringRes(R.string.qrcode_auth_flow_error_auth_failed_title)
+            override val subtitle: UiString = UiStringRes(R.string.qrcode_auth_flow_error_auth_failed_subtitle)
+            @DrawableRes override val image = R.drawable.img_illustration_empty_results_216dp
+        }
+
+        data class Expired(
+            override val primaryAction: ErrorPrimaryAction,
+            override val secondaryAction: ErrorSecondaryAction
+        ) : Error() {
+            override val type = EXPIRED
+            override val title: UiString = UiStringRes(R.string.qrcode_auth_flow_error_expired_title)
+            override val subtitle: UiString = UiStringRes(R.string.qrcode_auth_flow_error_expired_subtitle)
+            @DrawableRes override val image = R.drawable.img_illustration_empty_results_216dp
+        }
+
+        data class InvalidData(
+            override val primaryAction: ErrorPrimaryAction,
+            override val secondaryAction: ErrorSecondaryAction
+        ) : Error() {
+            override val type = INVALID_DATA
+            override val title: UiString = UiStringRes(R.string.qrcode_auth_flow_error_invalid_data_title)
+            override val subtitle: UiString = UiStringRes(R.string.qrcode_auth_flow_error_invalid_data_subtitle)
+            @DrawableRes override val image = R.drawable.img_illustration_empty_results_216dp
+        }
+
+        data class NoInternet(
+            override val primaryAction: ErrorPrimaryAction,
+            override val secondaryAction: ErrorSecondaryAction
+        ) : Error() {
+            override val type = NO_INTERNET
+            override val title: UiString = UiStringRes(R.string.qrcode_auth_flow_error_no_connection_title)
+            override val subtitle: UiString = UiStringRes(R.string.qrcode_auth_flow_error_no_connection_subtitle)
+            @DrawableRes override val image = R.drawable.img_illustration_cloud_off_152dp
+        }
+    }
+
+    sealed class Content : QRCodeAuthUiState() {
+        override val type = CONTENT
+        override val contentVisibility: Boolean = true
+        open val title: UiString? = null
+        open val subtitle: UiString? = null
+        @DrawableRes open val image: Int? = null
+        open val isProgressShowing: Boolean = false
+        open val alpha: Float = BASE_ALPHA
+        open val primaryAction: Action? = null
+        open val secondaryAction: Action? = null
+        open val browser: String? = null
+        open val location: String? = null
+
+        data class Validated(
+            override val browser: String? = null,
+            override val location: String? = null,
+            override val primaryAction: ValidatedPrimaryAction,
+            override val secondaryAction: ValidatedSecondaryAction
+        ) : Content() {
+            override val type = VALIDATED
+            override val title: UiString = if (browser == null) {
+                UiStringResWithParams(R.string.qrcode_auth_flow_validated_title, listOf(UiStringText(location ?: " ")))
+            } else {
+                UiStringResWithParams(
+                        R.string.qrcode_auth_flow_validated_title,
+                        listOf(UiStringText(browser), UiStringText(location ?: " "))
+                )
+            }
+            override val subtitle: UiString = UiStringRes(R.string.qrcode_auth_flow_validated_subtitle)
+            @DrawableRes override val image = R.drawable.img_illustration_qrcode_auth_validated_152dp
+        }
+
+        data class Authenticating(
+            override val browser: String? = null,
+            override val location: String? = null,
+            override val primaryAction: AuthenticatingPrimaryAction,
+            override val secondaryAction: AuthenticatingSecondaryAction
+        ) : Content() {
+            override val type = AUTHENTICATING
+            override val title: UiString = if (browser == null) {
+                UiStringResWithParams(R.string.qrcode_auth_flow_validated_title, listOf(UiStringText(location ?: " ")))
+            } else {
+                UiStringResWithParams(
+                        R.string.qrcode_auth_flow_validated_title,
+                        listOf(UiStringText(browser), UiStringText(location ?: " "))
+                )
+            }
+            override val subtitle: UiString = UiStringRes(R.string.qrcode_auth_flow_validated_subtitle)
+            @DrawableRes override val image = R.drawable.img_illustration_qrcode_auth_validated_152dp
+            override val alpha: Float = BLURRED_ALPHA
+            override val isProgressShowing: Boolean = true
+        }
+
+        data class Done(
+            override val primaryAction: DonePrimaryAction,
+            override val secondaryAction: DoneSecondaryAction
+        ) : Content() {
+            override val type = DONE
+            override val title: UiString = UiStringRes(R.string.qrcode_auth_flow_done_title)
+            override val subtitle: UiString = UiStringRes(R.string.qrcode_auth_flow_done_subtitle)
+            @DrawableRes override val image = R.drawable.img_illustration_qrcode_auth_login_success_218dp
+        }
+    }
+
+    sealed class Action {
+        open val label: UiString? = null
+        open val isEnabled: Boolean = true
+        open val isVisible: Boolean = true
+        open val clickAction: (() -> Unit)? = null
+
+        data class ValidatedPrimaryAction(override val clickAction: (() -> Unit)) : Action() {
+            override val label: UiString = UiStringRes(R.string.qrcode_auth_flow_validated_primary_action)
+        }
+
+        data class ValidatedSecondaryAction(override val clickAction: (() -> Unit)) : Action() {
+            override val label: UiString = UiStringRes(R.string.cancel)
+        }
+
+        object AuthenticatingPrimaryAction : Action() {
+            override val label: UiString = UiStringRes(R.string.qrcode_auth_flow_validated_primary_action)
+            override val isEnabled = false
+        }
+
+        object AuthenticatingSecondaryAction : Action() {
+            override val label: UiString = UiStringRes(R.string.cancel)
+            override val isEnabled = false
+        }
+
+        data class DonePrimaryAction(override val clickAction: (() -> Unit)) : Action() {
+            override val label: UiString = UiStringRes(R.string.qrcode_auth_flow_dismiss)
+        }
+
+        object DoneSecondaryAction : Action() {
+            override val isVisible = false
+        }
+
+        data class ErrorPrimaryAction(override val clickAction: (() -> Unit)) : Action() {
+            override val label: UiString = UiStringRes(R.string.qrcode_auth_flow_scan_again)
+        }
+
+        data class ErrorSecondaryAction(override val clickAction: (() -> Unit)) : Action() {
+            override val label: UiString = UiStringRes(R.string.cancel)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiStateMapper.kt
@@ -1,0 +1,73 @@
+package org.wordpress.android.ui.qrcodeauth
+
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.DonePrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.DoneSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.AuthenticatingPrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.AuthenticatingSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ErrorPrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ErrorSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ValidatedPrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ValidatedSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Error
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Loading
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Scanning
+import javax.inject.Inject
+
+class QRCodeAuthUiStateMapper @Inject constructor() {
+    fun mapLoading() = Loading
+    fun mapScanning() = Scanning
+    fun mapAuthFailed(onScanAgainClicked: () -> Unit, onCancelClicked: () -> Unit) =
+        Error.AuthFailed(
+                primaryAction = ErrorPrimaryAction(onScanAgainClicked),
+                secondaryAction = ErrorSecondaryAction(onCancelClicked)
+        )
+
+    fun mapExpired(onScanAgainClicked: () -> Unit, onCancelClicked: () -> Unit) =
+            Error.Expired(
+                    primaryAction = ErrorPrimaryAction(onScanAgainClicked),
+                    secondaryAction = ErrorSecondaryAction(onCancelClicked)
+            )
+
+    fun mapInvalidData(onScanAgainClicked: () -> Unit, onCancelClicked: () -> Unit) =
+            Error.InvalidData(
+                    primaryAction = ErrorPrimaryAction(onScanAgainClicked),
+                    secondaryAction = ErrorSecondaryAction(onCancelClicked)
+            )
+
+    fun mapNoInternet(onScanAgainClicked: () -> Unit, onCancelClicked: () -> Unit) =
+            Error.NoInternet(
+                    primaryAction = ErrorPrimaryAction(onScanAgainClicked),
+                    secondaryAction = ErrorSecondaryAction(onCancelClicked)
+            )
+
+    fun mapValidated(location: String?, browser: String?, onAuthenticateClick: () -> Unit, onCancelClick: () -> Unit) =
+        Content.Validated(
+                primaryAction = ValidatedPrimaryAction(onAuthenticateClick),
+                secondaryAction = ValidatedSecondaryAction(onCancelClick),
+                location = location,
+                browser = browser
+        )
+
+    fun mapAuthenticating(fromValidated: Content.Validated) =
+        Content.Authenticating(
+                primaryAction = AuthenticatingPrimaryAction,
+                secondaryAction = AuthenticatingSecondaryAction,
+                location = fromValidated.location,
+                browser = fromValidated.browser
+        )
+
+    fun mapAuthenticating(location: String?, browser: String?) =
+            Content.Authenticating(
+                    primaryAction = AuthenticatingPrimaryAction,
+                    secondaryAction = AuthenticatingSecondaryAction,
+                    location = location,
+                    browser = browser
+            )
+
+    fun mapDone(onDismissClicked: () -> Unit) =
+            Content.Done(
+                    primaryAction = DonePrimaryAction(onDismissClicked),
+                    secondaryAction = DoneSecondaryAction
+            )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiStateType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiStateType.kt
@@ -1,0 +1,31 @@
+package org.wordpress.android.ui.qrcodeauth
+
+enum class QRCodeAuthUiStateType(val label: String) {
+    ERROR("error"),
+    CONTENT("content"),
+    LOADING("loading"),
+    SCANNING("scanning"),
+    VALIDATED("validated"),
+    AUTHENTICATING("authenticating"),
+    DONE("done"),
+    INVALID_DATA("invalid_data"),
+    AUTH_FAILED("auth_failed"),
+    EXPIRED("expired"),
+    NO_INTERNET("no_internet");
+
+    override fun toString() = label
+
+    companion object {
+        @JvmStatic
+        fun fromString(strSource: String?): QRCodeAuthUiStateType? {
+            if (strSource != null) {
+                for (source in values()) {
+                    if (source.name.equals(strSource, ignoreCase = true)) {
+                        return source
+                    }
+                }
+            }
+            return null
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthValidator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthValidator.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.ui.qrcodeauth
+
+import android.net.UrlQuerySanitizer
+import dagger.Reusable
+import org.wordpress.android.util.UriWrapper
+import javax.inject.Inject
+
+@Reusable
+class QRCodeAuthValidator @Inject constructor() {
+    @Suppress("ReturnCount")
+    fun isValidUri(scannedValue: String?): Boolean {
+        if (scannedValue == null) return false
+
+        val uri = UriWrapper(scannedValue)
+        if (uri.host != VALID_HOST) return false
+
+        return true
+    }
+
+    @Suppress("ReturnCount")
+    fun extractQueryParams(scannedValue: String?): Map<String, String> {
+        if (scannedValue == null) return emptyMap()
+
+        val uri = UriWrapper(scannedValue)
+        if (uri.host != VALID_HOST) return emptyMap()
+
+        val queryParams = mutableMapOf<String, String>()
+        uri.fragment?.let {
+            UrlQuerySanitizer(it).parameterList.forEach { pair ->
+                queryParams[pair.mParameter] = pair.mValue
+            }
+        }
+        return queryParams
+    }
+
+    companion object {
+        const val VALID_HOST = "apps.wordpress.com"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -12,4 +12,8 @@ class QRCodeAuthViewModel @Inject constructor() : ViewModel() {
         if (isStarted) return
         isStarted = true
     }
+
+    companion object {
+        const val TAG_DISMISS_DIALOG = "TAG_DISMISS_DIALOG"
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -1,16 +1,48 @@
 package org.wordpress.android.ui.qrcodeauth
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction
+import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Dismissed
+import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Negative
+import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Positive
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.FinishActivity
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.LaunchDismissDialog
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthDialogModel.ShowDismissDialog
 import javax.inject.Inject
 
 @HiltViewModel
 class QRCodeAuthViewModel @Inject constructor() : ViewModel() {
+    private val _actionEvents = Channel<QRCodeAuthActionEvent>(Channel.BUFFERED)
+    val actionEvents = _actionEvents.receiveAsFlow()
+
     private var isStarted = false
 
     fun start() {
         if (isStarted) return
         isStarted = true
+    }
+
+    fun onBackPressed() {
+        postActionEvent(LaunchDismissDialog(ShowDismissDialog))
+    }
+
+    private fun postActionEvent(actionEvent: QRCodeAuthActionEvent) {
+        viewModelScope.launch {
+            _actionEvents.send(actionEvent)
+        }
+    }
+
+    fun onDialogInteraction(interaction: DialogInteraction) {
+        when (interaction) {
+            is Positive -> postActionEvent(FinishActivity)
+            is Negative -> { } // NO OP
+            is Dismissed -> { } // NO OP
+        }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/util/UriWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/UriWrapper.kt
@@ -11,6 +11,7 @@ data class UriWrapper(val uri: Uri) {
     val lastPathSegment: String? = uri.lastPathSegment
     val pathSegments: List<String> = uri.pathSegments
     val host: String? = uri.host
+    val fragment: String? = uri.fragment
 
     override fun toString() = uri.toString()
     fun getQueryParameter(key: String): String? = uri.getQueryParameter(key)

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiStateMapperTest.kt
@@ -1,0 +1,125 @@
+package org.wordpress.android.ui.qrcodeauth
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.AuthenticatingPrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.AuthenticatingSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.DonePrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.DoneSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ErrorPrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ErrorSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ValidatedPrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ValidatedSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content.Authenticating
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content.Done
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content.Validated
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Error.AuthFailed
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Error.Expired
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Error.InvalidData
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Error.NoInternet
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Loading
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Scanning
+
+class QRCodeAuthUiStateMapperTest {
+    private val mapper = QRCodeAuthUiStateMapper()
+
+    @Test
+    fun `when loading requested, then loading should be returned`() {
+        val actual = mapper.mapLoading()
+        val expected = Loading
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when scanning requested, then scanning should be returned`() {
+        val actual = mapper.mapScanning()
+        val expected = Scanning
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when auth failed requested, then auth failed should be returned`() {
+        val actual = mapper.mapAuthFailed(primaryClickAction, secondaryClickAction)
+        val expected = authFailedExpected
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when expired requested, then expired should be returned`() {
+        val actual = mapper.mapExpired(primaryClickAction, secondaryClickAction)
+        val expected = expiredExpected
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when invalid data requested, then invalid data should be returned`() {
+        val actual = mapper.mapInvalidData(primaryClickAction, secondaryClickAction)
+        val expected = invalidDataExpected
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when no internet requested, then no internet should be returned`() {
+        val actual = mapper.mapNoInternet(primaryClickAction, secondaryClickAction)
+        val expected = noInternetExpected
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when validated requested, then validated should be returned`() {
+        val actual = mapper.mapValidated(location, browser, primaryClickAction, secondaryClickAction)
+        val expected = validatedExpected
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when no authenticating requested, then authenticating should be returned`() {
+        val actual = mapper.mapAuthenticating(location = location, browser = browser)
+        val expected = authenticatingExpected
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when done requested, then done should be returned`() {
+        val actual = mapper.mapDone(primaryClickAction)
+        val expected = doneExpected
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    private val primaryClickAction: () -> Unit = {}
+    private val secondaryClickAction: () -> Unit = {}
+    private val browser = "browser"
+    private val location = "location"
+    private val authFailedExpected = AuthFailed(
+            primaryAction = ErrorPrimaryAction(primaryClickAction),
+            secondaryAction = ErrorSecondaryAction(secondaryClickAction))
+
+    private val expiredExpected = Expired(
+            primaryAction = ErrorPrimaryAction(primaryClickAction),
+            secondaryAction = ErrorSecondaryAction(secondaryClickAction))
+
+    private val invalidDataExpected = InvalidData(
+            primaryAction = ErrorPrimaryAction(primaryClickAction),
+            secondaryAction = ErrorSecondaryAction(secondaryClickAction))
+
+    private val noInternetExpected = NoInternet(
+            primaryAction = ErrorPrimaryAction(primaryClickAction),
+            secondaryAction = ErrorSecondaryAction(secondaryClickAction))
+
+    private val validatedExpected = Validated(
+            primaryAction = ValidatedPrimaryAction(primaryClickAction),
+            secondaryAction = ValidatedSecondaryAction(secondaryClickAction),
+            location = location,
+            browser = browser)
+
+    private val authenticatingExpected = Authenticating(
+            primaryAction = AuthenticatingPrimaryAction,
+            secondaryAction = AuthenticatingSecondaryAction,
+            location = location,
+            browser = browser)
+
+    private val doneExpected = Done(
+            primaryAction = DonePrimaryAction(primaryClickAction),
+            secondaryAction = DoneSecondaryAction
+    )
+}


### PR DESCRIPTION
Parent #16481 

This PR adds the following for the QRCodeAuth flow
- QRCodeAuthActionEvent - defines actions/events that take place in the flow
- QRCodeAuthDialogModel - to support the onbackpress dismiss dialog model
- Adds the action event channel to the ViewModel and observes in the fragment
- Adds the initBackPressHandler to the fragment
- Launches the dismiss dialog and handles interactions with it
- Adds QRCodeAuthValidator to validate the scanned code
- Updates the UriWrapper to include the fragment property; it's needed to validate the scanned string

Notes: 
- This PR will be merged to a feature branch and not trunk. Milestone will be set to "future"
- Not all strings declared are used in this PR, but they will be before the feature branch is requested to be merged in to trunk.

**Merge Instructions**
- Ensure that #16708 has been merged to the feature branch
- Merge as normal

**To test:**
- Install the app
- Login using a WP.com account
- Navigate to Me -> App Settings -> Debug Settings
- Enable `QRCodeAuthFlowFeatureConfig`
- Restart the App
- Navigate back to Me
- Tap the "Scan Login Code" row
- Wait for the views to cycle through 
- When on the error view (shows "Scan again") button, swipe the view backwards
- ✅ Verify the dismiss dialog is visible
- Tap the cancel button
- ✅ Verify the dialog closes
- Swipe the view backwards again
- Tap the ok button
- ✅ Verify you are returned to the Me view

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
The viewmodel test is coming in a future PR

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
