### PR TITLE
QR Code Auth: Part 5 - Implement Scanner

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -390,6 +390,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.10.0'
     kapt 'com.github.bumptech.glide:compiler:4.10.0'
     implementation 'com.github.bumptech.glide:volley-integration:4.6.1@aar'
+    implementation 'com.google.android.gms:play-services-code-scanner:16.0.0-beta1'
 
     testImplementation "junit:junit:$jUnitVersion"
 

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1040,6 +1040,10 @@
             android:authorities="${applicationId}.androidx-startup"
             tools:node="remove" />
 
+        <!-- Scanner -->
+        <meta-data
+            android:name="com.google.mlkit.vision.DEPENDENCIES"
+            android:value="barcode_ui"/>
     </application>
     <queries>
         <intent>

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -7,6 +7,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
@@ -48,7 +49,7 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
     private fun handleActionEvents(actionEvent: QRCodeAuthActionEvent) {
         when (actionEvent) {
             is LaunchDismissDialog -> launchDismissDialog(actionEvent.dialogModel)
-            is LaunchScanner -> { } // TODO
+            is LaunchScanner -> launchScanner()
             is FinishActivity -> requireActivity().finish()
         }
     }
@@ -62,6 +63,15 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
                         model.negativeButtonLabel?.let { label -> getString(label) },
                         model.cancelButtonLabel?.let { label -> getString(label) }
                 ))
+    }
+
+    private fun launchScanner() {
+        val scanner = GmsBarcodeScanning.getClient(requireContext())
+        scanner.startScan()
+                .addOnSuccessListener { barcode -> viewModel.onScanSuccess(barcode.rawValue) }
+                .addOnFailureListener {
+                    viewModel.onScanFailure()
+                }
     }
 
     private fun initBackPressHandler() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -9,10 +9,8 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.databinding.QrcodeauthFragmentBinding
 import org.wordpress.android.ui.posts.BasicDialogViewModel
@@ -32,7 +30,6 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
         with(QrcodeauthFragmentBinding.bind(view)) {
             initBackPressHandler()
             observeViewModel()
-            initView()
             startViewModel()
         }
     }
@@ -87,22 +84,7 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
     }
 
     @Suppress("MagicNumber")
-    private fun QrcodeauthFragmentBinding.initView() {
-        viewModel.start()
-        // Temporarily show each view
-        lifecycleScope.launch {
-            loadingLayout.loadingContainer.visibility = View.VISIBLE
-            contentLayout.contentContainer.visibility = View.GONE
-            errorLayout.errorContainer.visibility = View.GONE
-            delay(2000L)
-            loadingLayout.loadingContainer.visibility = View.GONE
-            contentLayout.contentContainer.visibility = View.VISIBLE
-            errorLayout.errorContainer.visibility = View.GONE
-            delay(2000L)
-            loadingLayout.loadingContainer.visibility = View.GONE
-            contentLayout.contentContainer.visibility = View.GONE
-            errorLayout.errorContainer.visibility = View.VISIBLE
-        }
+    private fun temp() {
         // Temporarily reference all strings from file so CI wont complain.
         // This will be removed in an upcoming PR
         var temp = R.string.qrcode_auth_flow_validated_default_title

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -18,10 +18,17 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.BasicDialogModel
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.FinishActivity
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.LaunchDismissDialog
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.LaunchScanner
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Loading
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Scanning
+import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.viewmodel.observeEvent
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
+    @Inject lateinit var uiHelpers: UiHelpers
+
     private val viewModel: QRCodeAuthViewModel by viewModels()
     private val dialogViewModel: BasicDialogViewModel by activityViewModels()
 
@@ -37,6 +44,7 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
     private fun QrcodeauthFragmentBinding.observeViewModel() {
         viewModel.actionEvents.onEach { handleActionEvents(it) }.launchIn(viewLifecycleOwner.lifecycleScope)
         dialogViewModel.onInteraction.observeEvent(viewLifecycleOwner) { viewModel.onDialogInteraction(it) }
+        viewModel.uiState.onEach { renderUi(it) }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     private fun startViewModel() {
@@ -48,6 +56,19 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
             is LaunchDismissDialog -> launchDismissDialog(actionEvent.dialogModel)
             is LaunchScanner -> launchScanner()
             is FinishActivity -> requireActivity().finish()
+        }
+    }
+
+    private fun QrcodeauthFragmentBinding.renderUi(uiState: QRCodeAuthUiState) {
+        uiHelpers.updateVisibility(contentLayout.contentContainer, uiState.contentVisibility)
+        uiHelpers.updateVisibility(errorLayout.errorContainer, uiState.errorVisibility)
+        uiHelpers.updateVisibility(loadingLayout.loadingContainer, uiState.loadingVisibility)
+        when (uiState) {
+            is Content -> { } // TODO
+            is Error -> { } // TODO
+            is Loading -> { } // NO OP
+            is Scanning -> { } // NO OP
+            else -> { } // NO OP
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -87,9 +87,7 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
         val scanner = GmsBarcodeScanning.getClient(requireContext())
         scanner.startScan()
                 .addOnSuccessListener { barcode -> viewModel.onScanSuccess(barcode.rawValue) }
-                .addOnFailureListener {
-                    viewModel.onScanFailure()
-                }
+                .addOnFailureListener { viewModel.onScanFailure() }
     }
 
     private fun initBackPressHandler() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -70,7 +70,7 @@ class QRCodeAuthViewModel @Inject constructor(
         extractQueryParamsIfValid(scannedValue)
 
         if (data.isNullOrEmpty() || token.isNullOrEmpty()) {
-           // todo: handle error
+            // todo: handle error
         } else {
             postUiState(uiStateMapper.mapLoading())
             validateScan(data = data.toString(), token = token.toString())
@@ -79,16 +79,19 @@ class QRCodeAuthViewModel @Inject constructor(
 
     private fun validateScan(data: String, token: String) {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
-           // todo: handle error
+            // todo: handle error
             return
         }
 
         // todo: add authStore.validate and remove below
-        postUiState(uiStateMapper.mapValidated(
-                "location",
-                "browser",
-                this::authenticateClicked,
-                this::cancelClicked))
+        postUiState(
+                uiStateMapper.mapValidated(
+                        "location",
+                        "browser",
+                        this::authenticateClicked,
+                        this::cancelClicked
+                )
+        )
     }
 
     private fun extractQueryParamsIfValid(scannedValue: String?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -17,11 +17,13 @@ import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.LaunchDismissDi
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.LaunchScanner
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthDialogModel.ShowDismissDialog
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Loading
+import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
 
 @HiltViewModel
 class QRCodeAuthViewModel @Inject constructor(
     private val uiStateMapper: QRCodeAuthUiStateMapper,
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val validator: QRCodeAuthValidator
 ) : ViewModel() {
     private val _actionEvents = Channel<QRCodeAuthActionEvent>(Channel.BUFFERED)
@@ -66,12 +68,21 @@ class QRCodeAuthViewModel @Inject constructor(
     private fun handleScan(scannedValue: String?) {
         extractQueryParamsIfValid(scannedValue)
 
-        // todo: implement the remainder of handle scan to account for error
-        validateScan()
+        if (data.isNullOrEmpty() || token.isNullOrEmpty()) {
+           // todo: handle error
+        } else {
+            postUiState(uiStateMapper.mapLoading())
+            validateScan(data = data.toString(), token = token.toString())
+        }
     }
 
-    private fun validateScan() {
-        // todo: implement validate scan call instead of this fake call
+    private fun validateScan(data: String, token: String) {
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+           // todo: handle error
+            return
+        }
+
+        // todo: add authStore.validate and remove below
         postUiState(uiStateMapper.mapValidated(
                 "location",
                 "browser",

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -58,11 +58,11 @@ class QRCodeAuthViewModel @Inject constructor(
         postActionEvent(LaunchDismissDialog(ShowDismissDialog))
     }
 
-    private fun cancelClicked() {
+    private fun onCancelClicked() {
         postActionEvent(FinishActivity)
     }
 
-    private fun authenticateClicked() {
+    private fun onAuthenticateClicked() {
         // todo: implement
     }
 
@@ -72,7 +72,7 @@ class QRCodeAuthViewModel @Inject constructor(
         if (data.isNullOrEmpty() || token.isNullOrEmpty()) {
             // todo: handle error
         } else {
-            postUiState(uiStateMapper.mapLoading())
+            postUiState(uiStateMapper.mapToLoading())
             validateScan(data = data.toString(), token = token.toString())
         }
     }
@@ -85,11 +85,11 @@ class QRCodeAuthViewModel @Inject constructor(
 
         // todo: add authStore.validate and remove below
         postUiState(
-                uiStateMapper.mapValidated(
+                uiStateMapper.mapToValidated(
                         "location",
                         "browser",
-                        this::authenticateClicked,
-                        this::cancelClicked
+                        this::onAuthenticateClicked,
+                        this::onCancelClicked
                 )
         )
     }
@@ -105,7 +105,7 @@ class QRCodeAuthViewModel @Inject constructor(
     }
 
     private fun updateUiStateAndLaunchScanner() {
-        postUiState(uiStateMapper.mapScanning())
+        postUiState(uiStateMapper.mapToScanning())
         postActionEvent(LaunchScanner)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Loading
 import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 @HiltViewModel
 class QRCodeAuthViewModel @Inject constructor(
     private val uiStateMapper: QRCodeAuthUiStateMapper,

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -16,10 +16,14 @@ import org.wordpress.android.ui.qrcodeauth.QRCodeAuthDialogModel.ShowDismissDial
 import javax.inject.Inject
 
 @HiltViewModel
-class QRCodeAuthViewModel @Inject constructor() : ViewModel() {
+class QRCodeAuthViewModel @Inject constructor(
+    private val validator: QRCodeAuthValidator
+) : ViewModel() {
     private val _actionEvents = Channel<QRCodeAuthActionEvent>(Channel.BUFFERED)
     val actionEvents = _actionEvents.receiveAsFlow()
 
+    private var data: String? = null
+    private var token: String? = null
     private var isStarted = false
 
     fun start() {
@@ -27,8 +31,32 @@ class QRCodeAuthViewModel @Inject constructor() : ViewModel() {
         isStarted = true
     }
 
+    //  https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=asdfadsfa&data=asdfasdf
+    fun onScanSuccess(scannedValue: String?) {
+        handleScan(scannedValue)
+    }
+
+    fun onScanFailure() {
+        // Note: This is a result of the tap on "X" within the scanner view
+        postActionEvent(FinishActivity)
+    }
+
     fun onBackPressed() {
         postActionEvent(LaunchDismissDialog(ShowDismissDialog))
+    }
+
+    private fun handleScan(scannedValue: String?) {
+        extractQueryParamsIfValid(scannedValue)
+    }
+
+    private fun extractQueryParamsIfValid(scannedValue: String?) {
+        if (!validator.isValidUri(scannedValue)) return
+
+        val queryParams = validator.extractQueryParams(scannedValue)
+        if (queryParams.containsKey(DATA_KEY) && queryParams.containsKey(TOKEN_KEY)) {
+            this.data = queryParams[DATA_KEY].toString()
+            this.token = queryParams[TOKEN_KEY].toString()
+        }
     }
 
     private fun postActionEvent(actionEvent: QRCodeAuthActionEvent) {
@@ -47,5 +75,7 @@ class QRCodeAuthViewModel @Inject constructor() : ViewModel() {
 
     companion object {
         const val TAG_DISMISS_DIALOG = "TAG_DISMISS_DIALOG"
+        const val TOKEN_KEY = "token"
+        const val DATA_KEY = "data"
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
@@ -5,18 +5,23 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.util.NetworkUtilsWrapper
 
 @RunWith(MockitoJUnitRunner::class)
 class QRCodeAuthViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
+    @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    @Mock lateinit var validator: QRCodeAuthValidator
+    private val uiStateMapper = QRCodeAuthUiStateMapper()
 
     private lateinit var viewModel: QRCodeAuthViewModel
 
     @Before
     fun setUp() {
-        viewModel = QRCodeAuthViewModel()
+        viewModel = QRCodeAuthViewModel(uiStateMapper, networkUtilsWrapper, validator)
     }
 
     @Test


### PR DESCRIPTION
Parent #16481 

This PR adds the following for the QRCodeAuth flow
- Dependencies for the Google scanner (build.gradle files and AndroidManifest.xml)
- Launch the scanner on tap of the "Scan Login Code" from the me fragment
- Scan success and failure click handlers
- Low-level scan validation with temp logic for verifying this PR
- Hooked in uiState MutableStateFlow and observers so the scanner can be launched 
- Injected the uiState mapper to assist with launching the scanner
- Injected NetworkUtilsWrapper to assist with network connectivity checks
- Basic ui rendering in QRCodeAuthFragment

Notes: 
- This PR will be merged to a feature branch and not trunk. Milestone will be set to "future"
- Not all strings declared are used in this PR, but they will be before the feature branch is requested to be merged in to trunk.

**Merge Instructions**
- Ensure that #16709 has been merged to the feature branch
- Merge as normal

**To test:**
- Install the app
- Login using a WP.com account
- Navigate to Me -> App Settings -> Debug Settings
- Enable `QRCodeAuthFlowFeatureConfig`
- Restart the App
- Navigate back to Me
- Tap the "Scan Login Code" row
- ✅ Verify the scanner view is shown
- Tap the "X" on the scanner view
- ✅ Verify the scanner is closed
- Tap the "Scan Login Code" row to launch the scanner again
- Scan the attached mock qr code
- ✅ Verify the "Yes, log me in" button is shown on the content view
Note: The view is not all visible and the buttons are not wired up yet.
- Use the swipe back gesture to bring up the dismiss dialog and choose OK to exit the qr code auth flow

![WP QRCode](https://user-images.githubusercontent.com/506707/171970351-7ac1ec69-a2c2-4ed7-b646-b7803c806930.png)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
The viewmodel test is coming in a future PR

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
