### PR TITLE
QR Code Auth: Part 6 - Save/Restore state and render UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -37,7 +37,7 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
         with(QrcodeauthFragmentBinding.bind(view)) {
             initBackPressHandler()
             observeViewModel()
-            startViewModel()
+            startViewModel(savedInstanceState)
         }
     }
 
@@ -47,8 +47,8 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
         viewModel.uiState.onEach { renderUi(it) }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
-    private fun startViewModel() {
-        viewModel.start()
+    private fun startViewModel(savedInstanceState: Bundle?) {
+        viewModel.start(savedInstanceState)
     }
 
     private fun handleActionEvents(actionEvent: QRCodeAuthActionEvent) {
@@ -102,6 +102,11 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
                         viewModel.onBackPressed()
                     }
                 })
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        viewModel.writeToBundle(outState)
+        super.onSaveInstanceState(outState)
     }
 
     @Suppress("MagicNumber")

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.FinishActivity
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.LaunchDismissDialog
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.LaunchScanner
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Error
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Loading
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Scanning
 import org.wordpress.android.ui.utils.UiHelpers
@@ -26,6 +27,7 @@ import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
 @AndroidEntryPoint
+@Suppress("TooManyFunctions")
 class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
     @Inject lateinit var uiHelpers: UiHelpers
 
@@ -65,7 +67,7 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
         uiHelpers.updateVisibility(loadingLayout.loadingContainer, uiState.loadingVisibility)
         when (uiState) {
             is Content -> { applyContentState(uiState) }
-            is Error -> { } // TODO
+            is Error -> { applyErrorState(uiState) }
             is Loading -> { } // NO OP
             is Scanning -> { } // NO OP
             else -> { } // NO OP
@@ -90,6 +92,21 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
             uiHelpers.updateVisibility(contentLayout.contentSecondaryAction, action.isVisible)
             contentLayout.contentSecondaryAction.setOnClickListener { action.clickAction?.invoke() }
             contentLayout.contentSecondaryAction.isEnabled = action.isEnabled
+        }
+    }
+
+    private fun QrcodeauthFragmentBinding.applyErrorState(uiState: Error) {
+        uiHelpers.updateVisibility(errorLayout.errorContainer, uiState.errorVisibility)
+        uiHelpers.setImageOrHide(errorLayout.errorImage, uiState.image)
+        uiHelpers.setTextOrHide(errorLayout.errorTitle, uiState.title)
+        uiHelpers.setTextOrHide(errorLayout.errorSubtitle, uiState.subtitle)
+        uiState.primaryAction?.let { action ->
+            uiHelpers.setTextOrHide(errorLayout.errorPrimaryAction, action.label)
+            errorLayout.errorPrimaryAction.setOnClickListener { action.clickAction.invoke() }
+        }
+        uiState.secondaryAction?.let { action ->
+            uiHelpers.setTextOrHide(errorLayout.errorSecondaryAction, action.label)
+            errorLayout.errorSecondaryAction.setOnClickListener { action.clickAction.invoke() }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -64,11 +64,32 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
         uiHelpers.updateVisibility(errorLayout.errorContainer, uiState.errorVisibility)
         uiHelpers.updateVisibility(loadingLayout.loadingContainer, uiState.loadingVisibility)
         when (uiState) {
-            is Content -> { } // TODO
+            is Content -> { applyContentState(uiState) }
             is Error -> { } // TODO
             is Loading -> { } // NO OP
             is Scanning -> { } // NO OP
             else -> { } // NO OP
+        }
+    }
+
+    private fun QrcodeauthFragmentBinding.applyContentState(uiState: Content) {
+        uiHelpers.updateVisibility(contentLayout.contentContainer, uiState.contentVisibility)
+        uiHelpers.updateVisibility(contentLayout.progress, uiState.isProgressShowing)
+        uiHelpers.setTextOrHide(contentLayout.contentTitle, uiState.title)
+        uiHelpers.setTextOrHide(contentLayout.contentSubtitle, uiState.subtitle)
+        uiHelpers.setImageOrHide(contentLayout.contentImage, uiState.image)
+        contentLayout.contentContainer.alpha = uiState.alpha
+        uiState.primaryAction?.let { action ->
+            uiHelpers.setTextOrHide(contentLayout.contentPrimaryAction, action.label)
+            uiHelpers.updateVisibility(contentLayout.contentPrimaryAction, action.isVisible)
+            contentLayout.contentPrimaryAction.setOnClickListener { action.clickAction?.invoke() }
+            contentLayout.contentPrimaryAction.isEnabled = action.isEnabled
+        }
+        uiState.secondaryAction?.let { action ->
+            uiHelpers.setTextOrHide(contentLayout.contentSecondaryAction, action.label)
+            uiHelpers.updateVisibility(contentLayout.contentSecondaryAction, action.isVisible)
+            contentLayout.contentSecondaryAction.setOnClickListener { action.clickAction?.invoke() }
+            contentLayout.contentSecondaryAction.isEnabled = action.isEnabled
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -172,7 +173,12 @@ class QRCodeAuthViewModel @Inject constructor(
             return
         }
 
-        // todo: authStore.authenticate call
+        clearProperties()
+        // todo: authStore.authenticate call and remove below
+        viewModelScope.launch {
+            delay(2000L)
+            postUiState(uiStateMapper.mapDone(::dismissClicked))
+        }
     }
 
     private fun updateUiStateAndLaunchScanner() {
@@ -197,6 +203,14 @@ class QRCodeAuthViewModel @Inject constructor(
             is Negative -> { } // NO OP
             is Dismissed -> { } // NO OP
         }
+    }
+
+    private fun clearProperties() {
+        data = null
+        token = null
+        browser = null
+        location = null
+        lastState = null
     }
 
     fun writeToBundle(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -167,6 +167,7 @@ class QRCodeAuthViewModel @Inject constructor(
         }
     }
 
+    @Suppress("MagicNumber")
     private fun authenticate(data: String, token: String) {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             postUiState(uiStateMapper.mapNoInternet(this::scanAgainClicked, this::cancelClicked))

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.FinishActivity
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.LaunchDismissDialog
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.LaunchScanner
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthDialogModel.ShowDismissDialog
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content.Validated
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Loading
 import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
@@ -67,7 +68,12 @@ class QRCodeAuthViewModel @Inject constructor(
     }
 
     private fun authenticateClicked() {
-        // todo: implement
+        postUiState(uiStateMapper.mapAuthenticating(_uiState.value as Validated))
+        if (data.isNullOrEmpty() || token.isNullOrEmpty()) {
+            postUiState(uiStateMapper.mapInvalidData(this::scanAgainClicked, this::cancelClicked))
+        } else {
+            authenticate(data = data.toString(), token = token.toString())
+        }
     }
 
     private fun handleScan(scannedValue: String?) {
@@ -106,6 +112,15 @@ class QRCodeAuthViewModel @Inject constructor(
             this.data = queryParams[DATA_KEY].toString()
             this.token = queryParams[TOKEN_KEY].toString()
         }
+    }
+
+    private fun authenticate(data: String, token: String) {
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+            postUiState(uiStateMapper.mapNoInternet(this::scanAgainClicked, this::cancelClicked))
+            return
+        }
+
+        // todo: authStore.authenticate call
     }
 
     private fun updateUiStateAndLaunchScanner() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -62,6 +62,10 @@ class QRCodeAuthViewModel @Inject constructor(
         postActionEvent(FinishActivity)
     }
 
+    private fun scanAgainClicked() {
+        postActionEvent(LaunchScanner)
+    }
+
     private fun authenticateClicked() {
         // todo: implement
     }
@@ -70,7 +74,7 @@ class QRCodeAuthViewModel @Inject constructor(
         extractQueryParamsIfValid(scannedValue)
 
         if (data.isNullOrEmpty() || token.isNullOrEmpty()) {
-            // todo: handle error
+            postUiState(uiStateMapper.mapInvalidData(this::scanAgainClicked, this::cancelClicked))
         } else {
             postUiState(uiStateMapper.mapLoading())
             validateScan(data = data.toString(), token = token.toString())
@@ -79,7 +83,7 @@ class QRCodeAuthViewModel @Inject constructor(
 
     private fun validateScan(data: String, token: String) {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
-            // todo: handle error
+            postUiState(uiStateMapper.mapNoInternet(this::scanAgainClicked, this::cancelClicked))
             return
         }
 


### PR DESCRIPTION
Parent #16481 

This PR adds the following for the QRCodeAuth flow
- Saving and restoring from savedInstanceState
- Hook in error state handlers
- Render UI for content and error

Notes: 
- This PR will be merged to a feature branch and not trunk. Milestone will be set to "future"

**Merge Instructions**
- Ensure that #16710 has been merged to the feature branch
- Merge as normal

Validated View | Done View
-- | --
<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/171972045-0b6c625f-0cc2-4f3e-9b7e-c3e9490632a9.png"> | <img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/171972048-6feb8e0a-032e-4aa1-a377-4e7fdb67ff46.png">

**To test:**
Tests A-B-C are one sequential path
Test A: Validate View - Cancel button
- Install the app
- Login using a WP.com account
- Navigate to Me -> App Settings -> Debug Settings
- Enable `QRCodeAuthFlowFeatureConfig`
- Restart the App
- Navigate back to Me
- Tap the "Scan Login Code" row to launch the scanner
- Scan the attached mock qr code
- ✅ Verify the "Validated" content view is shown
- Tap the "cancel" button
-  ✅ Verify you are returned to the Me view

Test B: Validate View - Log me in button
- Navigate back to Me
- Tap the "Scan Login Code" row to launch the scanner again
- Scan the attached mock qr code
- ✅ Verify the "Validated" content view is shown
- Tap the "Yes, Log me in" button
- ✅ Verify you see the progress overlay on the view 
- ✅ Verify you see the "done" view

Test C: Done view - Dismiss button
- Tap the dismiss button
-  ✅ Verify you are returned to the Me view

Test D: Kill process + restoring state
- Follow test A, but do not tap the "cancel" button
- Background the app
- From the logcat window, tap the "Stop" button to kill the process
- Relaunch the app and you should be taken back to the Validated view
- Tap the "Yes, Log me in" button
- Background the app
- From the logcat window, tap the "Stop" button to kill the process
- Relaunch the app and you should be taken back to the Done view

![WP QRCode](https://user-images.githubusercontent.com/506707/171970351-7ac1ec69-a2c2-4ed7-b646-b7803c806930.png)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
The viewmodel test is coming in a future PR

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
