### PR TITLE
[Blogging prompts v1] Filter self-hosted sites from site picker in onboarding dialog flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
@@ -163,7 +163,7 @@ class BloggingPromptsOnboardingDialogFragment : FeatureIntroductionDialogFragmen
                 is OpenSitePicker -> {
                     val intent = Intent(context, SitePickerActivity::class.java).apply {
                         putExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, action.selectedSite)
-                        putExtra(SitePickerActivity.KEY_SITE_PICKER_MODE, SitePickerMode.HIDE_SELF_HOSTED_MODE)
+                        putExtra(SitePickerActivity.KEY_SITE_PICKER_MODE, SitePickerMode.BLOGGING_PROMPTS_MODE)
                     }
                     sitePickerLauncher.launch(intent)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
@@ -163,7 +163,7 @@ class BloggingPromptsOnboardingDialogFragment : FeatureIntroductionDialogFragmen
                 is OpenSitePicker -> {
                     val intent = Intent(context, SitePickerActivity::class.java).apply {
                         putExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, action.selectedSite)
-                        putExtra(SitePickerActivity.KEY_SITE_PICKER_MODE, SitePickerMode.DEFAULT_MODE)
+                        putExtra(SitePickerActivity.KEY_SITE_PICKER_MODE, SitePickerMode.HIDE_SELF_HOSTED_MODE)
                     }
                     sitePickerLauncher.launch(intent)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -254,7 +254,9 @@ public class SitePickerActivity extends LocaleAwareActivity
             return;
         }
 
-        if (getAdapter().getIsInSearchMode() || mSitePickerMode.isReblogMode()) {
+        if (getAdapter().getIsInSearchMode()
+            || mSitePickerMode.isReblogMode()
+            || mSitePickerMode.isBloggingPromptsMode()) {
             mMenuEdit.setVisible(false);
             mMenuAdd.setVisible(false);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -75,14 +75,14 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         DEFAULT_MODE,
         REBLOG_SELECT_MODE,
         REBLOG_CONTINUE_MODE,
-        HIDE_SELF_HOSTED_MODE;
+        BLOGGING_PROMPTS_MODE;
 
         public boolean isReblogMode() {
             return this == REBLOG_SELECT_MODE || this == REBLOG_CONTINUE_MODE;
         }
 
-        public boolean isHideSelfHostedMode() {
-            return this == HIDE_SELF_HOSTED_MODE;
+        public boolean isBloggingPromptsMode() {
+            return this == BLOGGING_PROMPTS_MODE;
         }
     }
 
@@ -684,7 +684,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     public List<SiteModel> getBlogsForCurrentView() {
-        if (mSitePickerMode.isReblogMode() || mSitePickerMode.isHideSelfHostedMode()) {
+        if (mSitePickerMode.isReblogMode() || mSitePickerMode.isBloggingPromptsMode()) {
             // If we are reblogging we only want to select or search into the WPCom visible sites.
             return mSiteStore.getVisibleSitesAccessedViaWPCom();
         } else if (mIsInSearchMode) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -74,10 +74,15 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public enum SitePickerMode {
         DEFAULT_MODE,
         REBLOG_SELECT_MODE,
-        REBLOG_CONTINUE_MODE;
+        REBLOG_CONTINUE_MODE,
+        HIDE_SELF_HOSTED_MODE;
 
         public boolean isReblogMode() {
             return this == REBLOG_SELECT_MODE || this == REBLOG_CONTINUE_MODE;
+        }
+
+        public boolean isHideSelfHostedMode() {
+            return this == HIDE_SELF_HOSTED_MODE;
         }
     }
 
@@ -679,7 +684,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     public List<SiteModel> getBlogsForCurrentView() {
-        if (mSitePickerMode.isReblogMode()) {
+        if (mSitePickerMode.isReblogMode() || mSitePickerMode.isHideSelfHostedMode()) {
             // If we are reblogging we only want to select or search into the WPCom visible sites.
             return mSiteStore.getVisibleSitesAccessedViaWPCom();
         } else if (mIsInSearchMode) {


### PR DESCRIPTION
Fixes #16680

To test:
- Enable blogging prompts feature flag
- Restart the app
- Tap on the blogging prompts onboarding notification
- Tap on "Remind me" button
- The "+" button in the site picker Toolbar should not be visible and there should be no self-hosted sites listed.

## Regression Notes
1. Potential unintended areas of impact
Self-hosted sites being filtered for existing cases

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Currently, the menu visibility and filtered sites logic is tied to the Views. Without moving the logic there is no feasible way to have unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
