### PR TITLE
QR Code Auth: Part 7 - Implement FluxC Validate and Authenticate calls

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -70,7 +70,6 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
             is Error -> { applyErrorState(uiState) }
             is Loading -> { } // NO OP
             is Scanning -> { } // NO OP
-            else -> { } // NO OP
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -146,26 +146,4 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
         viewModel.writeToBundle(outState)
         super.onSaveInstanceState(outState)
     }
-
-    @Suppress("MagicNumber")
-    private fun temp() {
-        // Temporarily reference all strings from file so CI wont complain.
-        // This will be removed in an upcoming PR
-        var temp = R.string.qrcode_auth_flow_validated_default_title
-        temp = R.string.qrcode_auth_flow_done_title
-        temp = R.string.qrcode_auth_flow_done_subtitle
-        temp = R.string.qrcode_auth_flow_dismiss
-        temp = R.string.qrcode_auth_flow_scan_again
-        temp = R.string.qrcode_auth_flow_error_no_connection_title
-        temp = R.string.qrcode_auth_flow_error_no_connection_subtitle
-        temp = R.string.qrcode_auth_flow_error_invalid_data_title
-        temp = R.string.qrcode_auth_flow_error_invalid_data_subtitle
-        temp = R.string.qrcode_auth_flow_error_expired_title
-        temp = R.string.qrcode_auth_flow_error_expired_subtitle
-        temp = R.string.qrcode_auth_flow_error_auth_failed_title
-        temp = R.string.qrcode_auth_flow_error_auth_failed_subtitle
-        temp = R.string.qrcode_auth_flow_dismiss_dialog_title
-        temp = R.string.qrcode_auth_flow_dismiss_dialog_message
-        var image = R.drawable.img_illustration_qrcode_auth_login_success_218dp
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiState.kt
@@ -118,7 +118,7 @@ sealed class QRCodeAuthUiState {
         ) : Content() {
             override val type = VALIDATED
             override val title: UiString = if (browser == null) {
-                UiStringResWithParams(R.string.qrcode_auth_flow_validated_title, listOf(UiStringText(location ?: " ")))
+                UiStringResWithParams(R.string.qrcode_auth_flow_validated_default_title, listOf(UiStringText(location ?: " ")))
             } else {
                 UiStringResWithParams(
                         R.string.qrcode_auth_flow_validated_title,

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiState.kt
@@ -2,10 +2,10 @@ package org.wordpress.android.ui.qrcodeauth
 
 import androidx.annotation.DrawableRes
 import org.wordpress.android.R
-import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.DonePrimaryAction
-import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.DoneSecondaryAction
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.AuthenticatingPrimaryAction
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.AuthenticatingSecondaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.DonePrimaryAction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.DoneSecondaryAction
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ErrorPrimaryAction
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ErrorSecondaryAction
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Action.ValidatedPrimaryAction
@@ -118,7 +118,10 @@ sealed class QRCodeAuthUiState {
         ) : Content() {
             override val type = VALIDATED
             override val title: UiString = if (browser == null) {
-                UiStringResWithParams(R.string.qrcode_auth_flow_validated_default_title, listOf(UiStringText(location ?: " ")))
+                UiStringResWithParams(
+                        R.string.qrcode_auth_flow_validated_default_title,
+                        listOf(UiStringText(location ?: " "))
+                )
             } else {
                 UiStringResWithParams(
                         R.string.qrcode_auth_flow_validated_title,

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -64,7 +64,7 @@ class QRCodeAuthViewModel @Inject constructor(
     private var lastState: QRCodeAuthUiStateType? = null
     private var isStarted = false
 
-    fun start(savedInstanceState: Bundle?) {
+    fun start(savedInstanceState: Bundle? = null) {
         if (isStarted) return
         isStarted = true
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -94,13 +94,13 @@ class QRCodeAuthViewModel @Inject constructor(
                     )
             )
             AUTHENTICATING -> postUiState(uiStateMapper.mapToAuthenticating(location = location, browser = browser))
-            DONE -> postUiState(uiStateMapper.mapToDone(this::dismissClicked))
+            DONE -> postUiState(uiStateMapper.mapToDone(this::onDismissClicked))
             // errors
-            INVALID_DATA -> postUiState(uiStateMapper.mapToInvalidData(this::scanAgainClicked, this::onCancelClicked))
-            AUTH_FAILED -> postUiState(uiStateMapper.mapToAuthFailed(this::scanAgainClicked, this::onCancelClicked))
-            EXPIRED -> postUiState(uiStateMapper.mapToExpired(this::scanAgainClicked, this::onCancelClicked))
+            INVALID_DATA -> postUiState(uiStateMapper.mapToInvalidData(this::onScanAgainClicked, this::onCancelClicked))
+            AUTH_FAILED -> postUiState(uiStateMapper.mapToAuthFailed(this::onScanAgainClicked, this::onCancelClicked))
+            EXPIRED -> postUiState(uiStateMapper.mapToExpired(this::onScanAgainClicked, this::onCancelClicked))
             NO_INTERNET -> {
-                postUiState(uiStateMapper.mapToNoInternet(this::scanAgainClicked, this::onCancelClicked))
+                postUiState(uiStateMapper.mapToNoInternet(this::onScanAgainClicked, this::onCancelClicked))
             }
             else -> updateUiStateAndLaunchScanner()
         }
@@ -124,18 +124,18 @@ class QRCodeAuthViewModel @Inject constructor(
         postActionEvent(FinishActivity)
     }
 
-    private fun scanAgainClicked() {
+    private fun onScanAgainClicked() {
         postActionEvent(LaunchScanner)
     }
 
-    private fun dismissClicked() {
+    private fun onDismissClicked() {
         postActionEvent(FinishActivity)
     }
 
     private fun onAuthenticateClicked() {
         postUiState(uiStateMapper.mapToAuthenticating(_uiState.value as Validated))
         if (data.isNullOrEmpty() || token.isNullOrEmpty()) {
-            postUiState(uiStateMapper.mapToInvalidData(this::scanAgainClicked, this::onCancelClicked))
+            postUiState(uiStateMapper.mapToInvalidData(this::onScanAgainClicked, this::onCancelClicked))
         } else {
             authenticate(data = data.toString(), token = token.toString())
         }
@@ -145,7 +145,7 @@ class QRCodeAuthViewModel @Inject constructor(
         extractQueryParamsIfValid(scannedValue)
 
         if (data.isNullOrEmpty() || token.isNullOrEmpty()) {
-            postUiState(uiStateMapper.mapToInvalidData(this::scanAgainClicked, this::onCancelClicked))
+            postUiState(uiStateMapper.mapToInvalidData(this::onScanAgainClicked, this::onCancelClicked))
         } else {
             postUiState(uiStateMapper.mapToLoading())
             validateScan(data = data.toString(), token = token.toString())
@@ -154,7 +154,7 @@ class QRCodeAuthViewModel @Inject constructor(
 
     private fun validateScan(data: String, token: String) {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
-            postUiState(uiStateMapper.mapToNoInternet(this::scanAgainClicked, this::onCancelClicked))
+            postUiState(uiStateMapper.mapToNoInternet(this::onScanAgainClicked, this::onCancelClicked))
             return
         }
 
@@ -179,14 +179,14 @@ class QRCodeAuthViewModel @Inject constructor(
             )
 
     private fun mapScanErrorToErrorState(error: QRCodeAuthError) = when (error.type) {
-        DATA_INVALID -> uiStateMapper.mapToExpired(this::scanAgainClicked, this::onCancelClicked)
-        NOT_AUTHORIZED -> uiStateMapper.mapToAuthFailed(this::scanAgainClicked, this::onCancelClicked)
+        DATA_INVALID -> uiStateMapper.mapToExpired(this::onScanAgainClicked, this::onCancelClicked)
+        NOT_AUTHORIZED -> uiStateMapper.mapToAuthFailed(this::onScanAgainClicked, this::onCancelClicked)
         GENERIC_ERROR,
         INVALID_RESPONSE,
         REST_INVALID_PARAM,
         API_ERROR,
         AUTHORIZATION_REQUIRED,
-        TIMEOUT -> uiStateMapper.mapToInvalidData(this::scanAgainClicked, this::onCancelClicked)
+        TIMEOUT -> uiStateMapper.mapToInvalidData(this::onScanAgainClicked, this::onCancelClicked)
     }
 
     private fun extractQueryParamsIfValid(scannedValue: String?) {
@@ -202,7 +202,7 @@ class QRCodeAuthViewModel @Inject constructor(
     @Suppress("MagicNumber")
     private fun authenticate(data: String, token: String) {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
-            postUiState(uiStateMapper.mapToNoInternet(this::scanAgainClicked, this::onCancelClicked))
+            postUiState(uiStateMapper.mapToNoInternet(this::onScanAgainClicked, this::onCancelClicked))
             return
         }
 
@@ -215,13 +215,13 @@ class QRCodeAuthViewModel @Inject constructor(
                 if (result.model?.authenticated == true) {
                     postUiState(mapAuthenticateSuccessToDoneState())
                 } else {
-                    postUiState(uiStateMapper.mapToAuthFailed(::scanAgainClicked, ::onCancelClicked))
+                    postUiState(uiStateMapper.mapToAuthFailed(::onScanAgainClicked, ::onCancelClicked))
                 }
             }
         }
     }
 
-    private fun mapAuthenticateSuccessToDoneState() = uiStateMapper.mapToDone(this::dismissClicked)
+    private fun mapAuthenticateSuccessToDoneState() = uiStateMapper.mapToDone(this::onDismissClicked)
 
     private fun updateUiStateAndLaunchScanner() {
         postUiState(uiStateMapper.mapToScanning())

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -181,12 +181,12 @@ class QRCodeAuthViewModel @Inject constructor(
 
     private fun mapScanErrorToErrorState(error: QRCodeAuthError) = when (error.type) {
         DATA_INVALID -> uiStateMapper.mapToExpired(this::onScanAgainClicked, this::onCancelClicked)
-        NOT_AUTHORIZED -> uiStateMapper.mapToAuthFailed(this::onScanAgainClicked, this::onCancelClicked)
+        NOT_AUTHORIZED,
+        AUTHORIZATION_REQUIRED -> uiStateMapper.mapToAuthFailed(this::onScanAgainClicked, this::onCancelClicked)
         GENERIC_ERROR,
         INVALID_RESPONSE,
         REST_INVALID_PARAM,
         API_ERROR,
-        AUTHORIZATION_REQUIRED,
         TIMEOUT -> uiStateMapper.mapToInvalidData(this::onScanAgainClicked, this::onCancelClicked)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -142,6 +142,7 @@ class QRCodeAuthViewModel @Inject constructor(
     }
 
     private fun handleScan(scannedValue: String?) {
+        clearProperties()
         extractQueryParamsIfValid(scannedValue)
 
         if (data.isNullOrEmpty() || token.isNullOrEmpty()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -180,13 +180,19 @@ class QRCodeAuthViewModel @Inject constructor(
             )
 
     private fun mapScanErrorToErrorState(error: QRCodeAuthError) = when (error.type) {
-        DATA_INVALID -> uiStateMapper.mapToExpired(this::onScanAgainClicked, this::onCancelClicked)
-        NOT_AUTHORIZED,
-        AUTHORIZATION_REQUIRED -> uiStateMapper.mapToAuthFailed(this::onScanAgainClicked, this::onCancelClicked)
+        NOT_AUTHORIZED -> uiStateMapper.mapToAuthFailed(this::onScanAgainClicked, this::onCancelClicked)
+        AUTHORIZATION_REQUIRED -> {
+            if (error.message?.lowercase().equals(EXPIRED_MESSAGE)) {
+                uiStateMapper.mapToExpired(this::onScanAgainClicked, this::onCancelClicked)
+            } else {
+                uiStateMapper.mapToAuthFailed(this::onScanAgainClicked, this::onCancelClicked)
+            }
+        }
         GENERIC_ERROR,
         INVALID_RESPONSE,
         REST_INVALID_PARAM,
         API_ERROR,
+        DATA_INVALID,
         TIMEOUT -> uiStateMapper.mapToInvalidData(this::onScanAgainClicked, this::onCancelClicked)
     }
 
@@ -271,5 +277,6 @@ class QRCodeAuthViewModel @Inject constructor(
         const val BROWSER_KEY = "browser"
         const val LOCATION_KEY = "location"
         const val LAST_STATE_KEY = "last_state"
+        const val EXPIRED_MESSAGE = "qr code data expired"
     }
 }

--- a/WordPress/src/main/res/layout/qrcodeauth_error_view.xml
+++ b/WordPress/src/main/res/layout/qrcodeauth_error_view.xml
@@ -27,7 +27,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/error_image"
-        tools:text="No internet connection" />
+        tools:text="@string/qrcode_auth_flow_error_no_connection_title" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/error_subtitle"
@@ -36,7 +36,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/error_title"
-        tools:text="Need an internet connection to scan a qr code" />
+        tools:text="@string/qrcode_auth_flow_error_no_connection_subtitle" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/error_primary_action"

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthError
 import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType.AUTHORIZATION_REQUIRED
-import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType.DATA_INVALID
 import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType.INVALID_RESPONSE
 import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType.NOT_AUTHORIZED

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
@@ -1,25 +1,553 @@
 package org.wordpress.android.ui.qrcodeauth
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import android.os.Bundle
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthError
+import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType.DATA_INVALID
+import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType.NOT_AUTHORIZED
+import org.wordpress.android.fluxc.store.qrcodeauth.QRCodeAuthStore
+import org.wordpress.android.fluxc.store.qrcodeauth.QRCodeAuthStore.QRCodeAuthAuthenticateResult
+import org.wordpress.android.fluxc.store.qrcodeauth.QRCodeAuthStore.QRCodeAuthResult
+import org.wordpress.android.fluxc.store.qrcodeauth.QRCodeAuthStore.QRCodeAuthValidateResult
+import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content.Done
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content.Validated
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Error.InvalidData
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Error.NoInternet
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.AUTHENTICATING
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.AUTH_FAILED
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.DONE
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.EXPIRED
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.INVALID_DATA
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.NO_INTERNET
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.VALIDATED
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.BROWSER_KEY
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.DATA_KEY
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.LAST_STATE_KEY
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.LOCATION_KEY
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.TOKEN_KEY
+import org.wordpress.android.util.NetworkUtilsWrapper
 
-@RunWith(MockitoJUnitRunner::class)
-class QRCodeAuthViewModelTest {
-    @Rule
-    @JvmField val rule = InstantTaskExecutorRule()
-
+@InternalCoroutinesApi
+@ExperimentalCoroutinesApi
+@Suppress("LargeClass")
+class QRCodeAuthViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: QRCodeAuthViewModel
+    @Mock lateinit var store: QRCodeAuthStore
+    @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    @Mock lateinit var savedInstanceState: Bundle
+    @Mock lateinit var validator: QRCodeAuthValidator
+    private val uiStateMapper = QRCodeAuthUiStateMapper()
 
+    private val data = "data"
+    private val location = "location"
+    private val browser = "browser"
+    private val token = "token"
+    private val scannedValue =
+            "https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=scannedtoken&data=scanneddata"
+
+    private val validQueryParams = mapOf(DATA_KEY to data, TOKEN_KEY to token)
+    private val invalidQueryParams = mapOf("invalid_key" to data, TOKEN_KEY to token)
     @Before
     fun setUp() {
-        viewModel = QRCodeAuthViewModel()
+        viewModel = QRCodeAuthViewModel(
+                store,
+                uiStateMapper,
+                networkUtilsWrapper,
+                validator
+        )
+
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(validator.isValidUri(scannedValue)).thenReturn(true)
+        whenever(validator.extractQueryParams(scannedValue)).thenReturn(validQueryParams)
     }
 
     @Test
-    fun `sample test`() {
-    } // TODO:
+    fun `given empty instance state, when vm started, then loading is followed by scanning`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        viewModel.start()
+
+        assert(result.first().loadingVisibility)
+        assertThat(result.last()).isInstanceOf(QRCodeAuthUiState.Scanning::class.java)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given non empty instance state, when vm started, then state is restored`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        initAndStartVMForState(NO_INTERNET)
+
+        assert(result.first().loadingVisibility)
+        assertThat(result.last().type).isEqualTo(NO_INTERNET)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given onSavedInstanceState, when writeToBundle is invoked, then properties are written To Bundle`() {
+        startViewModel()
+
+        viewModel.writeToBundle(savedInstanceState)
+
+        verify(savedInstanceState).putString(any(), argThat { true })
+    }
+
+    @Test
+    fun `given validate state, when primary action is clicked, then state is authenticating`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        initAndStartVMForState(VALIDATED)
+
+        (result.last() as Validated).primaryAction.clickAction()
+
+        assertThat(result.last().type).isEqualTo(AUTHENTICATING)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given validate state, when secondary action is clicked, then activity finished event`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
+        val job1 = launch {
+            viewModel.uiState.toList(result)
+        }
+        val job2 = launch {
+            viewModel.actionEvents.collect {
+                actionEvents.add(it)
+            }
+        }
+
+        initAndStartVMForState(VALIDATED)
+
+        (result.last() as Validated).secondaryAction.clickAction()
+
+        assertThat(actionEvents.last()).isInstanceOf(QRCodeAuthActionEvent.FinishActivity::class.java)
+
+        job1.cancel()
+        job2.cancel()
+    }
+
+    @Test
+    fun `given valid qr code, when scanned qrcode, then validated is shown`() = runBlockingTest {
+        initValidate()
+
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        viewModel.start()
+        viewModel.onScanSuccess(scannedValue)
+
+        assertThat(result.last().type).isEqualTo(VALIDATED)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given invalid host, when scanned qrcode, then error is shown`() = runBlockingTest {
+        whenever(validator.isValidUri(scannedValue)).thenReturn(false)
+
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        viewModel.start()
+        viewModel.onScanSuccess(scannedValue)
+
+        assertThat(result.last().type).isEqualTo(INVALID_DATA)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given invalid query params, when scanned qrcode, then error is shown`() = runBlockingTest {
+        whenever(validator.isValidUri(scannedValue)).thenReturn(true)
+        whenever(validator.extractQueryParams(scannedValue)).thenReturn(invalidQueryParams)
+
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        viewModel.start()
+        viewModel.onScanSuccess(scannedValue)
+
+        assertThat(result.last().type).isEqualTo(INVALID_DATA)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given not authorized error, when validate failure, then auth failed is shown`() = runBlockingTest {
+        initValidate(false, NOT_AUTHORIZED)
+
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        viewModel.start()
+        viewModel.onScanSuccess(scannedValue)
+
+        assertThat(result.last().type).isEqualTo(AUTH_FAILED)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given error, when validate failure, then invalid data is shown`() = runBlockingTest {
+        initValidate(false, GENERIC_ERROR)
+
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        viewModel.start()
+        viewModel.onScanSuccess(scannedValue)
+
+        assertThat(result.last().type).isEqualTo(INVALID_DATA)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given data invalid, when validate failure, then expired is shown`() = runBlockingTest {
+        initValidate(false, DATA_INVALID)
+
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        viewModel.start()
+        viewModel.onScanSuccess(scannedValue)
+
+        assertThat(result.last().type).isEqualTo(EXPIRED)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given validated state, when authenticate invoked, then authenticating followed by done`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        initAuthenticate()
+        initAndStartVMForState(VALIDATED)
+
+        val initialState = result.last()
+        result.clear()
+        (initialState as Validated).primaryAction.clickAction()
+
+        assertThat(result.first().type).isEqualTo(AUTHENTICATING)
+        assertThat(result.last().type).isEqualTo(DONE)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given not authorized error, when authenticate failure, then auth failed is shown`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        initAuthenticate(false, NOT_AUTHORIZED)
+        initAndStartVMForState(VALIDATED)
+
+        (result.last() as Validated).primaryAction.clickAction()
+
+        assertThat(result.last().type).isEqualTo(AUTH_FAILED)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given error, when authenticate failure, then invalid data is shown`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        initAuthenticate(false, GENERIC_ERROR)
+        initAndStartVMForState(VALIDATED)
+
+        (result.last() as Validated).primaryAction.clickAction()
+
+        assertThat(result.last().type).isEqualTo(INVALID_DATA)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given data invalid, when authenticate failure, then expired is shown`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        initAuthenticate(false, DATA_INVALID)
+        initAndStartVMForState(VALIDATED)
+
+        (result.last() as Validated).primaryAction.clickAction()
+
+        assertThat(result.last().type).isEqualTo(EXPIRED)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given done, when primary action is clicked, then finish activity is raised`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
+        val job1 = launch {
+            viewModel.uiState.toList(result)
+        }
+        val job2 = launch {
+            viewModel.actionEvents.collect {
+                actionEvents.add(it)
+            }
+        }
+
+        initAndStartVMForState(DONE)
+
+        (result.last() as Done).primaryAction.clickAction()
+
+        assertThat(actionEvents.last()).isInstanceOf(QRCodeAuthActionEvent.FinishActivity::class.java)
+
+        job1.cancel()
+        job2.cancel()
+    }
+
+    @Test
+    fun `given error, when primary action clicked, then launch scanner is raised`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
+        val job1 = launch {
+            viewModel.uiState.toList(result)
+        }
+        val job2 = launch {
+            viewModel.actionEvents.collect {
+                actionEvents.add(it)
+            }
+        }
+
+        initAndStartVMForState(INVALID_DATA)
+
+        (result.last() as InvalidData).primaryAction.clickAction()
+
+        assertThat(actionEvents.last()).isInstanceOf(QRCodeAuthActionEvent.LaunchScanner::class.java)
+
+        job1.cancel()
+        job2.cancel()
+    }
+
+    @Test
+    fun `given error, when secondary action clicked, then finish activity is raised`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
+        val job1 = launch {
+            viewModel.uiState.toList(result)
+        }
+        val job2 = launch {
+            viewModel.actionEvents.collect {
+                actionEvents.add(it)
+            }
+        }
+
+        initAndStartVMForState(INVALID_DATA)
+
+        (result.last() as InvalidData).secondaryAction.clickAction()
+
+        assertThat(actionEvents.last()).isInstanceOf(QRCodeAuthActionEvent.FinishActivity::class.java)
+
+        job1.cancel()
+        job2.cancel()
+    }
+
+    @Test
+    fun `given any state, when back is pressed, then dismiss dialog event is raised`() = runBlockingTest {
+        val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
+        val job = launch {
+            viewModel.actionEvents.collect {
+                actionEvents.add(it)
+            }
+        }
+
+        viewModel.onBackPressed()
+
+        assertThat(actionEvents.last()).isInstanceOf(QRCodeAuthActionEvent.LaunchDismissDialog::class.java)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `when scan fails, then finish activity event is raised`() = runBlockingTest {
+        val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
+        val job = launch {
+            viewModel.actionEvents.collect {
+                actionEvents.add(it)
+            }
+        }
+
+        viewModel.onScanFailure()
+
+        assertThat(actionEvents.last()).isInstanceOf(QRCodeAuthActionEvent.FinishActivity::class.java)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given valid scan, when no network connection, then no internet error is shown`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+        startViewModel()
+        viewModel.onScanSuccess(scannedValue)
+
+        assertThat(result.last()).isInstanceOf(NoInternet::class.java)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given authenticating, when no network connection, then error view is shown`() = runBlockingTest {
+        val result = mutableListOf<QRCodeAuthUiState>()
+        val job = launch {
+            viewModel.uiState.toList(result)
+        }
+
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+        initAndStartVMForState(VALIDATED)
+
+        (result.last() as Validated).primaryAction.clickAction()
+
+        assertThat(result.last().type).isEqualTo(NO_INTERNET)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given dismiss dialog showing, when ok clicked, then finish activity event is raised`() = runBlockingTest {
+        val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
+        val job = launch {
+            viewModel.actionEvents.collect {
+                actionEvents.add(it)
+            }
+        }
+
+        viewModel.onDialogInteraction(DialogInteraction.Positive("positive"))
+
+        assertThat(actionEvents.last()).isInstanceOf(QRCodeAuthActionEvent.FinishActivity::class.java)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `given dismiss dialog showing, when cancel clicked, then no event is raised`() = runBlockingTest {
+        val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
+        val job = launch {
+            viewModel.actionEvents.collect {
+                actionEvents.add(it)
+            }
+        }
+
+        viewModel.onDialogInteraction(DialogInteraction.Negative("negative"))
+
+        assertThat(actionEvents.isEmpty())
+
+        job.cancel()
+    }
+
+    private fun buildValidateError(errorType: QRCodeAuthErrorType) =
+            QRCodeAuthResult<QRCodeAuthValidateResult>(QRCodeAuthError(errorType))
+
+    private fun buildValidateSuccess() =
+            QRCodeAuthResult(model = QRCodeAuthValidateResult(browser = this.browser, location = this.location))
+
+    private fun buildAuthenticateError(errorType: QRCodeAuthErrorType) =
+            QRCodeAuthResult<QRCodeAuthAuthenticateResult>(QRCodeAuthError(errorType))
+
+    private val authenticateSuccess = QRCodeAuthResult(model = QRCodeAuthAuthenticateResult(authenticated = true))
+
+    private fun startViewModel(saveInstanceState: Bundle? = null) {
+        viewModel.start(saveInstanceState)
+    }
+
+    private fun initAndStartVMForState(stateType: QRCodeAuthUiStateType) {
+        initSavedInstanceState(stateType)
+        viewModel.start(savedInstanceState)
+    }
+
+    private fun initSavedInstanceState(stateType: QRCodeAuthUiStateType) {
+        whenever(savedInstanceState.getString(DATA_KEY, null)).thenReturn(data)
+        whenever(savedInstanceState.getString(TOKEN_KEY, null)).thenReturn(token)
+        whenever(savedInstanceState.getString(LOCATION_KEY, null)).thenReturn(location)
+        whenever(savedInstanceState.getString(BROWSER_KEY, null)).thenReturn(browser)
+        whenever(savedInstanceState.getString(LAST_STATE_KEY, null)).thenReturn(stateType.label)
+    }
+
+    private suspend fun initValidate(
+        successResponse: Boolean = true,
+        errorType: QRCodeAuthErrorType? = INVALID_RESPONSE
+    ) {
+        whenever(store.validate(any(), any())).thenReturn(
+                if (successResponse) {
+                    buildValidateSuccess()
+                } else {
+                    buildValidateError(errorType as QRCodeAuthErrorType)
+                }
+        )
+    }
+
+    private suspend fun initAuthenticate(
+        successResponse: Boolean = true,
+        errorType: QRCodeAuthErrorType? = INVALID_RESPONSE
+    ) {
+        whenever(store.authenticate(any(), any())).thenReturn(
+                if (successResponse) {
+                    authenticateSuccess
+                } else {
+                    buildAuthenticateError(errorType as QRCodeAuthErrorType)
+                }
+        )
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
@@ -45,6 +45,13 @@ import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.LOCATIO
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.TOKEN_KEY
 import org.wordpress.android.util.NetworkUtilsWrapper
 
+const val DATA = "data"
+const val LOCATION = "location"
+const val BROWSER = "browser"
+const val TOKEN = "token"
+const val SCANNED_VALUE =
+        "https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=scannedtoken&data=scanneddata"
+
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 @Suppress("LargeClass")
@@ -56,15 +63,8 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Mock lateinit var validator: QRCodeAuthValidator
     private val uiStateMapper = QRCodeAuthUiStateMapper()
 
-    private val data = "data"
-    private val location = "location"
-    private val browser = "browser"
-    private val token = "token"
-    private val scannedValue =
-            "https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=scannedtoken&data=scanneddata"
-
-    private val validQueryParams = mapOf(DATA_KEY to data, TOKEN_KEY to token)
-    private val invalidQueryParams = mapOf("invalid_key" to data, TOKEN_KEY to token)
+    private val validQueryParams = mapOf(DATA_KEY to DATA, TOKEN_KEY to TOKEN)
+    private val invalidQueryParams = mapOf("invalid_key" to DATA, TOKEN_KEY to TOKEN)
     @Before
     fun setUp() {
         viewModel = QRCodeAuthViewModel(
@@ -75,8 +75,8 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         )
 
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
-        whenever(validator.isValidUri(scannedValue)).thenReturn(true)
-        whenever(validator.extractQueryParams(scannedValue)).thenReturn(validQueryParams)
+        whenever(validator.isValidUri(SCANNED_VALUE)).thenReturn(true)
+        whenever(validator.extractQueryParams(SCANNED_VALUE)).thenReturn(validQueryParams)
     }
 
     @Test
@@ -167,7 +167,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         }
 
         viewModel.start()
-        viewModel.onScanSuccess(scannedValue)
+        viewModel.onScanSuccess(SCANNED_VALUE)
 
         assertThat(result.last().type).isEqualTo(VALIDATED)
 
@@ -176,7 +176,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given invalid host, when scanned qrcode, then error is shown`() = runBlockingTest {
-        whenever(validator.isValidUri(scannedValue)).thenReturn(false)
+        whenever(validator.isValidUri(SCANNED_VALUE)).thenReturn(false)
 
         val result = mutableListOf<QRCodeAuthUiState>()
         val job = launch {
@@ -184,7 +184,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         }
 
         viewModel.start()
-        viewModel.onScanSuccess(scannedValue)
+        viewModel.onScanSuccess(SCANNED_VALUE)
 
         assertThat(result.last().type).isEqualTo(INVALID_DATA)
 
@@ -193,8 +193,8 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given invalid query params, when scanned qrcode, then error is shown`() = runBlockingTest {
-        whenever(validator.isValidUri(scannedValue)).thenReturn(true)
-        whenever(validator.extractQueryParams(scannedValue)).thenReturn(invalidQueryParams)
+        whenever(validator.isValidUri(SCANNED_VALUE)).thenReturn(true)
+        whenever(validator.extractQueryParams(SCANNED_VALUE)).thenReturn(invalidQueryParams)
 
         val result = mutableListOf<QRCodeAuthUiState>()
         val job = launch {
@@ -202,7 +202,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         }
 
         viewModel.start()
-        viewModel.onScanSuccess(scannedValue)
+        viewModel.onScanSuccess(SCANNED_VALUE)
 
         assertThat(result.last().type).isEqualTo(INVALID_DATA)
 
@@ -219,7 +219,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         }
 
         viewModel.start()
-        viewModel.onScanSuccess(scannedValue)
+        viewModel.onScanSuccess(SCANNED_VALUE)
 
         assertThat(result.last().type).isEqualTo(AUTH_FAILED)
 
@@ -236,7 +236,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         }
 
         viewModel.start()
-        viewModel.onScanSuccess(scannedValue)
+        viewModel.onScanSuccess(SCANNED_VALUE)
 
         assertThat(result.last().type).isEqualTo(INVALID_DATA)
 
@@ -253,7 +253,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         }
 
         viewModel.start()
-        viewModel.onScanSuccess(scannedValue)
+        viewModel.onScanSuccess(SCANNED_VALUE)
 
         assertThat(result.last().type).isEqualTo(EXPIRED)
 
@@ -441,7 +441,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
 
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
         startViewModel()
-        viewModel.onScanSuccess(scannedValue)
+        viewModel.onScanSuccess(SCANNED_VALUE)
 
         assertThat(result.last()).isInstanceOf(NoInternet::class.java)
 
@@ -501,7 +501,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
             QRCodeAuthResult<QRCodeAuthValidateResult>(QRCodeAuthError(errorType))
 
     private fun buildValidateSuccess() =
-            QRCodeAuthResult(model = QRCodeAuthValidateResult(browser = this.browser, location = this.location))
+            QRCodeAuthResult(model = QRCodeAuthValidateResult(browser = BROWSER, location = LOCATION))
 
     private fun buildAuthenticateError(errorType: QRCodeAuthErrorType) =
             QRCodeAuthResult<QRCodeAuthAuthenticateResult>(QRCodeAuthError(errorType))
@@ -518,10 +518,10 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     }
 
     private fun initSavedInstanceState(stateType: QRCodeAuthUiStateType) {
-        whenever(savedInstanceState.getString(DATA_KEY, null)).thenReturn(data)
-        whenever(savedInstanceState.getString(TOKEN_KEY, null)).thenReturn(token)
-        whenever(savedInstanceState.getString(LOCATION_KEY, null)).thenReturn(location)
-        whenever(savedInstanceState.getString(BROWSER_KEY, null)).thenReturn(browser)
+        whenever(savedInstanceState.getString(DATA_KEY, null)).thenReturn(DATA)
+        whenever(savedInstanceState.getString(TOKEN_KEY, null)).thenReturn(TOKEN)
+        whenever(savedInstanceState.getString(LOCATION_KEY, null)).thenReturn(LOCATION)
+        whenever(savedInstanceState.getString(BROWSER_KEY, null)).thenReturn(BROWSER)
         whenever(savedInstanceState.getString(LAST_STATE_KEY, null)).thenReturn(stateType.label)
     }
 


### PR DESCRIPTION
Parent #16481 

This PR adds the following:
- Hooks in the FluxC call to QRCodeAuthStore.Validate call. This returns the location/browser that will be shown in the validated view.
- Hooks in the FluxC call to QRCodeAuthStore.Authenticate call
Note: The FluxC PR is https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2392
- Adds tests into QRCodeAuthViewModelTest 

Notes: 
- This PR will be merged to a feature branch and not trunk. Milestone will be set to "future"

**Merge Instructions**
- Ensure that #16711 has been merged to the feature branch
- Merge as normal

Prior to testing this PR you will need to
- Make sure your **real device** is sandboxed 
- Make sure your sandbox is pointed to D79766-code (apply the patch)
- Have access to the "Calypso live (direct link)" in the related Calypso PR: 
    - https://github.com/Automattic/wp-calypso/pull/63257
    

**Tests** (These tests were lifted from the iOS [PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/18756) and modified where needed for Android)

**Pre-req**
- Install the app
- Login using a WP.com account
- Navigate to Me -> App Settings -> Debug Settings
- Enable `QRCodeAuthFlowFeatureConfig`
- Restart the App

Test A: Scanning a token with invalid data
![invalid-qrlogin-code](https://user-images.githubusercontent.com/793774/170778949-f8b47a11-ce27-4db0-87f5-85f5be09ec07.png)
1. Launch the app
2. Navigate to My Site > Me > Scan Login Code
3. Scan the QR code image from above
4. ✅ Verify you see the "Could not validate" error view
5. ✅ Verify tapping Scan again takes you to the scanning view again

Test B: Scanning a valid but expired token
![qrlogin-expired](https://user-images.githubusercontent.com/793774/170781480-d8fc1f46-6052-4e67-94e7-257b96689562.png)
1. Launch the app
2. Navigate to My Site > Me > Scan Login Code
3. Scan the QR code image from above
4. ✅  Verify you see the "Expired log in code" error view
5. ✅ Verify tapping Scan again takes you to the scanning view again

Test C: Scanning a valid token
1. Launch the app and login with a wp.com account
2. Navigate to My Site > Me > Scan Login Code
3. Scan the QR Code from the "Calypso live (direct link)" in the Calypso PR (See above). **Make sure you are not logged in to WP.com when you go to the direct link. If you use an incognito window to open the link, the you can't verify step 12.
4. ✅  Verify you see a "Are you trying to login" message that displays your web browser and approximate location
5. "Are you trying to login to Chrome near Los Angeles, California?"
6. ✅  Verify tapping Cancel exits out of the flow and nothing else happens
7. Scan the valid code again
8. Tap the 'Yes, log me in' button
9. ✅  Verify you see a loading indicator with the current view faded out
10. ✅  Verify after a second you see the "You're logged in!" message
11. ✅  Verify tapping Dismiss exits the flow
12. ✅  Verify you are logged in on your web browser

Test D: Testing no internet error
1. Launch the app
3. Navigate to My Site > Me > Scan Login Code
4. Turn on Airplane mode
5. Scan the QR Code from the related Calypso PR (See above)
6. ✅ Verify you see a "No connection" error state
7. ✅ Tapping Scan again brings you back to the scanning view
8. Enable your internet and scan again
9. ✅  Verify the scanning works correctly 


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

3. What automated tests I added (or what prevented me from doing so)
QRCodeAuthViewModelTest

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
