### PR TITLE
[Blogging prompts v1] Add tag "dailyprompt" to prompt answer blog post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3300,9 +3300,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
         // Start VM, load prompt and populate Editor with content after edit IS ready.
         final int promptId = getIntent().getIntExtra(EXTRA_PROMPT_ID, -1);
-        if (promptId >= 0) {
-            mEditorBloggingPromptsViewModel.start(mSite, promptId);
-        }
+        mEditorBloggingPromptsViewModel.start(mSite, promptId);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -918,6 +918,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     mEditPostRepository.updateAsync(postModel -> {
                         postModel.setContent(loadedPrompt.getContent());
                         postModel.setAnsweredPromptId(loadedPrompt.getPromptId());
+                        postModel.setTagNames(loadedPrompt.getTag());
                         return true;
                     }, (postModel, result) -> {
                         refreshEditorContent();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
@@ -36,9 +36,11 @@ class EditorBloggingPromptsViewModel
     private fun loadPrompt(site: SiteModel, promptId: Int) = launch {
         val prompt = bloggingPromptsStore.getPromptById(site, promptId).first().model
         prompt?.let {
-            _onBloggingPromptLoaded.postValue(Event(EditorLoadedPrompt(promptId, it.content)))
+            _onBloggingPromptLoaded.postValue(Event(EditorLoadedPrompt(promptId, it.content, BLOGGING_PROMPT_TAG)))
         }
     }
 
-    data class EditorLoadedPrompt(val promptId: Int, val content: String)
+    data class EditorLoadedPrompt(val promptId: Int, val content: String, val tag: String)
 }
+
+internal const val BLOGGING_PROMPT_TAG = "dailyprompt"

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
@@ -23,6 +23,9 @@ class EditorBloggingPromptsViewModel
     private var isStarted = false
 
     fun start(site: SiteModel, bloggingPromptId: Int) {
+        if (bloggingPromptId < 0) {
+            return
+        }
         if (isStarted) {
             return
         }
@@ -32,7 +35,9 @@ class EditorBloggingPromptsViewModel
 
     private fun loadPrompt(site: SiteModel, promptId: Int) = launch {
         val prompt = bloggingPromptsStore.getPromptById(site, promptId).first().model
-        prompt?.let { _onBloggingPromptLoaded.postValue(Event(EditorLoadedPrompt(promptId, it.content))) }
+        prompt?.let {
+            _onBloggingPromptLoaded.postValue(Event(EditorLoadedPrompt(promptId, it.content)))
+        }
     }
 
     data class EditorLoadedPrompt(val promptId: Int, val content: String)

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/editor/EditorBloggingPromptsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/editor/EditorBloggingPromptsViewModelTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore.BloggingPromptsResult
 import org.wordpress.android.test
+import org.wordpress.android.ui.posts.BLOGGING_PROMPT_TAG
 import org.wordpress.android.ui.posts.EditorBloggingPromptsViewModel
 import org.wordpress.android.ui.posts.EditorBloggingPromptsViewModel.EditorLoadedPrompt
 import java.util.Date
@@ -67,6 +68,7 @@ class EditorBloggingPromptsViewModelTest : BaseUnitTest() {
 
         assertThat(loadedPrompt?.content).isEqualTo(bloggingPrompt.model?.content)
         assertThat(loadedPrompt?.promptId).isEqualTo(bloggingPrompt.model?.id)
+        assertThat(loadedPrompt?.tag).isEqualTo(BLOGGING_PROMPT_TAG)
 
         verify(bloggingPromptsStore, times(1)).getPromptById(any(), any())
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/editor/EditorBloggingPromptsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/editor/EditorBloggingPromptsViewModelTest.kt
@@ -24,7 +24,6 @@ import java.util.Date
 
 @InternalCoroutinesApi
 class EditorBloggingPromptsViewModelTest : BaseUnitTest() {
-    //    @Mock lateinit var bloggingPromptsStore: BloggingPromptsStore
     @Mock lateinit var siteModel: SiteModel
 
     private lateinit var viewModel: EditorBloggingPromptsViewModel
@@ -70,5 +69,11 @@ class EditorBloggingPromptsViewModelTest : BaseUnitTest() {
         assertThat(loadedPrompt?.promptId).isEqualTo(bloggingPrompt.model?.id)
 
         verify(bloggingPromptsStore, times(1)).getPromptById(any(), any())
+    }
+
+    @Test
+    fun `should NOT execute start method if prompt ID is less than 0`() = test {
+        viewModel.start(siteModel, -1)
+        verify(bloggingPromptsStore, times(0)).getPromptById(any(), any())
     }
 }


### PR DESCRIPTION
Fixes #

Adds the tag `"dailyprompt"` to a post answering a blogging prompt.

To test:
- Enable the blogging prompts feature flag
- Open editor with daily prompt  from any entry point (e.g. "Answer prompt" in "My Site" card, "Answer prompt" in add bottom sheet, etc.)
- Tap on the overflow menu and "Preview" item: `"dailyprompt"` tag should be seen in the post preview.
- Go back to editor and publish the post
- Select "My Site" in the bottom navigation 
- Tap on "MENU" tab
- Tap on "Posts"
- Tap on "View" button of the published post:  `"dailyprompt"` tag should be seen in the post

- New posts that are not published in a blogging prompts context should NOT have the `"dailyprompt"` tag added.

## Regression Notes
1. Potential unintended areas of impact
Tag "dailyprompt" added for blog posts without prompt

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and updated unit tests

3. What automated tests I added (or what prevented me from doing so)
Updated `EditorBloggingPromptsViewModelTest.kt`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
