### PR TITLE
Quick Start: Fix quick start focus point RTL issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] Site creation: enhances the design selection screen with recommended designs [https://github.com/wordpress-mobile/WordPress-Android/pull/16468]
 * [*] DeepLinks: fix auto-verification of App Links in Android 12 [https://github.com/wordpress-mobile/WordPress-Android/pull/16696]
+* [*] Quick Start: Fix Quick Start focus points in RTL mode [https://github.com/wordpress-mobile/WordPress-Android/pull/16720]
 
 20.0
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1298,7 +1298,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
             int verticalOffset;
             QuickStartTask followSiteTask = mQuickStartRepository
                     .getQuickStartType().getTaskFromString(QuickStartStore.QUICK_START_FOLLOW_SITE_LABEL);
-            if (followSiteTask.equals(activeTask)) {
+            if (followSiteTask.equals(activeTask)
+                || QuickStartExistingSiteTask.CHECK_NOTIFICATIONS.equals(activeTask)) {
                 horizontalOffset = targetView != null ? ((targetView.getWidth() / 2 - size + getResources()
                         .getDimensionPixelOffset(R.dimen.quick_start_focus_point_bottom_nav_offset))) : 0;
                 verticalOffset = 0;

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -11,12 +11,14 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
 import android.text.style.ImageSpan
+import android.util.LayoutDirection
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.text.HtmlCompat
+import androidx.core.text.layoutDirection
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
@@ -31,6 +33,7 @@ import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.quickstart.QuickStartType
 import org.wordpress.android.ui.themes.ThemeBrowserUtils
 import org.wordpress.android.util.extensions.getColorFromAttribute
+import java.util.Locale
 
 @Suppress("TooManyFunctions")
 object QuickStartUtils {
@@ -148,7 +151,12 @@ object QuickStartUtils {
             val focusPointTargetViewLocation = IntArray(2)
             targetedView.getLocationOnScreen(focusPointTargetViewLocation)
 
-            val realFocusPointContainerX = focusPointTargetViewLocation[0] - topLevelParentsHorizontalOffset
+            val realFocusPointContainerX = if (Locale.getDefault().layoutDirection == LayoutDirection.RTL) {
+                (topLevelParentsHorizontalOffset + topLevelParent.width) -
+                        (focusPointTargetViewLocation[0] + targetedView.width)
+            } else {
+                focusPointTargetViewLocation[0] - topLevelParentsHorizontalOffset
+            }
             val realFocusPointOffsetFromTheLeft = targetedView.width - focusPointSize - rightOffset
 
             val focusPointContainerY = focusPointTargetViewLocation[1] - topLevelParentsVerticalOffset
@@ -157,7 +165,7 @@ object QuickStartUtils {
             val y = focusPointContainerY + topOffset
 
             val params = quickStartFocusPointView.layoutParams as MarginLayoutParams
-            params.leftMargin = x
+            params.marginStart = x
             params.topMargin = y
             topLevelParent.addView(quickStartFocusPointView)
 


### PR DESCRIPTION
Fixes #16655

This PR fixes RTL issues for `Quick Start` focus point.

/cc @tiagomar 

**Updated Quick Start Focus Points in RTL** 

https://user-images.githubusercontent.com/1405144/172782311-110f3219-576d-4f52-b9ee-8eca0aaabeee.mp4

https://user-images.githubusercontent.com/1405144/172782443-b5ec2f76-c65a-4825-bf41-ac8714cc46c0.mp4

To test:

Please test the following using both quick start types (i.e. for an existing site and a new site) and for LTR and RTL.
- Enable `Quick Start`. 
- Go through all the `Quick Start` tasks.
- Notice that the `Quick Start` focus points are shown at correct positions. 

**Merge Instructions**

Targets `20.2` but can be merged with `20.1` if it can be reviewed earlier. 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
