### PR TITLE
Add JP flag to BP feature config.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsFeatureConfig.kt
@@ -12,6 +12,10 @@ class BloggingPromptsFeatureConfig
         BuildConfig.BLOGGING_PROMPTS,
         BLOGGING_PROMPTS_REMOTE_FIELD
 ) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && BuildConfig.IS_JETPACK_APP
+    }
+
     companion object {
         const val BLOGGING_PROMPTS_REMOTE_FIELD = "blogging_prompts_remote_field"
     }


### PR DESCRIPTION
This PR limits the blogging prompt to JP app only.

All the BP functionality, including network calls are behind the feature flag, so adding JP check to it made the most sense.

To test:
- Using regular WP app, enable BP feature flag and restart the app.
- Confirm that all the UI elements related to BP are not visible.
- Using jetpack wasabi build variant (*make sure to have the latest google-services.json from secret store) enable BP feature flag and restart the app.
- Confirm that the BP are present in the JP app, like they were in regular WP app.

## Regression Notes
1. Potential unintended areas of impact
- BP are visible in WP app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
