### PR TITLE
[Blogging prompts v1] Update currently selected on blogging prompts onboarding site picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModel.kt
@@ -78,6 +78,9 @@ class BloggingPromptsOnboardingViewModel @Inject constructor(
     }
 
     fun onSiteSelected(selectedSiteLocalId: Int) {
+        siteStore.getSiteByLocalId(selectedSiteLocalId)?.let { selectedSiteModel ->
+            selectedSiteRepository.updateSite(selectedSiteModel)
+        }
         _action.value = OpenRemindersIntro(selectedSiteLocalId)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
@@ -128,6 +128,16 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
         verify(actionObserver).onChanged(OpenRemindersIntro(selectedSiteLocalId))
     }
 
+    @Test
+    fun `Should update selected site after site is selected on site picker and onSiteSelected is called`() {
+        val selectedSiteLocalId = 123
+        val siteModel = SiteModel()
+        whenever(siteStore.getSiteByLocalId(selectedSiteLocalId)).thenReturn(siteModel)
+        classToTest.onSiteSelected(selectedSiteLocalId)
+        verify(siteStore).getSiteByLocalId(selectedSiteLocalId)
+        verify(selectedSiteRepository).updateSite(siteModel)
+    }
+
     // INFORMATION dialog type actions
 
     @Test


### PR DESCRIPTION

Fixes #

To test:
- Enable blogging prompts feature flag
- Open blogging prompts onboarding from "My Site" card "Learn more" button or from "?" button in compact card
- Tap on "Remind me" button 
- Select a site different than the one already selected on "My Site" tab
- Selected site on "My Site" tab should be updated matching the one selected on site picker AND reminder flow should be opened

## Regression Notes
1. Potential unintended areas of impact
Side effects on main screen for updating the selected site

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and updated unit tests

3. What automated tests I added (or what prevented me from doing so)
Updated `BloggingPromptsOnboardingViewModelTest.kt`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
