### PR TITLE
[Blogging prompts v1] Fix trailing label item with minimum 2 lines

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/CompactBloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/CompactBloggingPromptCardViewHolder.kt
@@ -32,5 +32,6 @@ class CompactBloggingPromptCardViewHolder(
             action.onHelpAction?.invoke()
         }
         uiHelpers.updateVisibility(answeredButton, action.isAnswered)
+        uiHelpers.updateVisibility(answerButton, !action.isAnswered)
     }
 }

--- a/WordPress/src/main/res/layout/blogging_prompt_card_compact.xml
+++ b/WordPress/src/main/res/layout/blogging_prompt_card_compact.xml
@@ -114,9 +114,10 @@
             android:text="@string/my_site_blogging_prompt_card_answered_prompt"
             android:textColor="@color/success_emphasis_medium_selector"
             android:visibility="gone"
+            tools:visibility="visible"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/prompt_content" />
+            app:layout_constraintTop_toBottomOf="@+id/attribution_container" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WordPress/src/main/res/layout/trailing_label_item.xml
+++ b/WordPress/src/main/res/layout/trailing_label_item.xml
@@ -13,7 +13,6 @@
         android:gravity="center_vertical"
         android:importantForAccessibility="no"
         android:maxLines="4"
-        android:minLines="2"
         android:paddingBottom="@dimen/margin_medium"
         android:paddingTop="@dimen/margin_medium"
         android:textAppearance="?attr/textAppearanceCaption"


### PR DESCRIPTION
Fixes #

1 - Fix trailing label item with minimum 2 lines

To test:
- Enable blogging prompts feature flag and restart app
- Load prompt for June 9th (change device date to June 9th)
- Select "My Site" tab in bottom navigation
- Check the "Prompts" card in dashboard: the answers label (e.g. "3 answers") should be shown in one line instead of two

Before change
<img width="363" alt="Screen Shot 2022-06-09 at 10 43 56 PM" src="https://user-images.githubusercontent.com/14964993/172974012-df3e0e8b-d695-4f76-b662-4d3225e222f0.png">

After change
<img width="362" alt="Screen Shot 2022-06-09 at 10 46 28 PM" src="https://user-images.githubusercontent.com/14964993/172974030-b2ca12f2-55e3-4f88-a53a-2b4d92bf1949.png">

2 - Fix "Answer prompt" button shown in compact card when prompt was already answered

To test:
- Enable blogging prompts feature flag and restart app
- Select "My Site" tab in bottom navigation
- Make sure you have answered the prompt that is shown and then tap on the FAB
- Check the compact card "Prompts" section: "Answer prompt" button should be gone and "Answered" button should be visible
- Change the device date to a day that you haven't answered the prompt and tap on the FAB
- Check the compact card "Prompts" section: "Answer prompt" button should be visible and "Answered" button should be gone

3 - Fix "Answered" button constraints 

To test:
- Enable blogging prompts feature flag and restart app
- Select "My Site" tab in bottom navigation
- Make sure you have answered the prompt that is shown and then tap on the FAB
- Check the compact card "Prompts" section: "Answered" button should not overlap with attribution container ("From DayOne")

Before change
<img width="370" alt="image" src="https://user-images.githubusercontent.com/14964993/172975202-818abfb5-4ef3-4762-8daa-c70778ef546c.png">

After change
<img width="364" alt="image" src="https://user-images.githubusercontent.com/14964993/172975235-32ae912b-2f88-4d9f-b247-95606ce3a994.png">

## Regression Notes
1. Potential unintended areas of impact
Other places using `TrainOfAvatarsAdapter`

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
