### PR TITLE
[Blogging prompts v1] Update release notes with blogging prompts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 * [*] DeepLinks: fix auto-verification of App Links in Android 12 [https://github.com/wordpress-mobile/WordPress-Android/pull/16696]
 * [*] Quick Start: Fix Quick Start focus points in RTL mode [https://github.com/wordpress-mobile/WordPress-Android/pull/16720]
 * [*] [internal] Block Editor: Bump react-native-gesture-handler to version 2.3.2. [https://github.com/wordpress-mobile/WordPress-Android/pull/16645]
-* [***] Jetpack App: Introducing blogging prompts. Build a writing habit and support creativity with a periodic prompt for inspiration. [#]
+* [***] Jetpack App: Introducing blogging prompts. Build a writing habit and support creativity with a periodic prompt for inspiration. [https://github.com/wordpress-mobile/WordPress-Android/pull/16729]
 
 20.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] DeepLinks: fix auto-verification of App Links in Android 12 [https://github.com/wordpress-mobile/WordPress-Android/pull/16696]
 * [*] Quick Start: Fix Quick Start focus points in RTL mode [https://github.com/wordpress-mobile/WordPress-Android/pull/16720]
 * [*] [internal] Block Editor: Bump react-native-gesture-handler to version 2.3.2. [https://github.com/wordpress-mobile/WordPress-Android/pull/16645]
+* [***] Jetpack App: Introducing blogging prompts. Build a writing habit and support creativity with a periodic prompt for inspiration. [#]
 
 20.0
 -----


### PR DESCRIPTION
This PR updates release notes for new Blogging Prompt feature.

Reporting here below testing steps consolidated from relevant PRs for convenience

## Notes
- If a verify step has (?), it means it's optional.

## Feature Introduction Modal

<details>
  <summary>Click to expand!</summary>

### [1] Display - Initial appearance

**Prerequisites:**

- Freshly installed Jetpack app
- An account with at least 1 blog site in .COM and/or JP

**Steps:**

1. Tap on the button `Continue With WordPress.com`
2. Login to an account
3. Select a site
4. Hit `Skip` on the screen `What would you like to focus on first?`
5. Close and re-open the app

**Verify:**

- `Introducing Prompts` screen appears

### [2] Display - Only shown once

**Prerequisites:**

- Intro modal screen is displayed (See: [[1] Display - Initial Appearance](#1-display---initial-appearance))
- Multiple sites on the account

**(1/2) Steps:**

1. Tap on the 'X' in the top right corner
2. Open the site selector
3. Select another blog

**(1/2) Verify:**

- `Introducing Prompts` screen does **NOT** appear

**(2/2) Steps:**

4. Close the app
5. Reopen the app

**(2/2) Verify:**

- `Introducing Prompts` screen does **NOT** appear

### [3] Button - Try it now

**Prerequisites:**

- Tap on the FAB button in My Site then from the bottom sheet that appears tap on the question mark icon near the top Prompts word to open the feature intro modal 

**Steps:**

1. Tap on the button `Try it now`
2. Select a site if necessary

**Verify:**

- An editor appears with a new post
- The contents of the post contains a blogging prompt
- The post has the tag `dailyprompt` (Top right context menu `...` > Post Settings > Tags)

### [4] Button - Remind me

**Prerequisites:**

- Tap on the FAB button in My Site then from the bottom sheet that appears tap on the question mark icon near the top Prompts word to open the feature intro modal 

**Steps:**

1. Tap on the button `Remind me`
2. Select a site if necessary

**Verify:**

- `Set your blogging reminders` appears and brings you to the blogging reminders screen if the button is tapped

</details>

## Dashboard Card

<details>
  <summary>Click to expand!</summary>

### [1] Display - Appearance

**Prerequisites:**

- Logged into the Jetpack app

**Steps:**

1. Select a "blogging" site if necessary (the site must be a blog for the dashboard to appear)
2. Navigate to the 'My Site' > Home tab

**Verify:**

- Blogging prompts dashboard card is at the top as the first card
- The card has:
  - 'Prompts' header
  - Overflow menu '...'
  - The current day's prompt title
  - [**(?)**](#notes) Avatars of other people who've answered and an answer count - only if other people have answered the prompt
  - [**(?)**](#notes) Attribution - some prompts could be attributed to Day One depending on the current date prompt
  - [**(?)**](#notes) 'Answer Prompt' button - if the prompt isn't answered already
  - [**(?)**](#notes) 'Answered' - if the prompt is answered

### [3] Context Menu - Skip this prompt

**Prerequisites:**

- Logged into the Jetpack app
- Site selected
- On the 'My Site' > Home tab
- Prompts dashboard card is visible

**Steps:**

1. Tap on the context menu `...`
2. Tap on `Skip this prompt`
3. **Verify** the prompts dashboard card is hidden
4. Switch to another "blogging" site (the site must be a blog for the dashboard to appear)
5. **Verify** the prompts dashboard card is visible

### [4] Context Menu - Learn more

**Prerequisites:**

- Logged into the Jetpack app
- Site selected
- On the 'My Site' > Home tab
- Prompts dashboard card is visible

**Steps:**

1. Tap on the context menu `...`
2. Tap on `Learn more`

**Verify:**

- `Introducing Prompts` intro modal appears

### [5] Button - Answer Prompt

**Prerequisites:**

- Logged into the Jetpack app
- Site selected (NOTE: if the site is private the answer is not recorded to avoid publishing the user avatar to answers)
- On the 'My Site' tab
- Prompts dashboard card is visible
- Current day's prompt is **NOT** answered

**Steps:**

1. Tap on the `Answer Prompt` text

**Verify:**

- An editor appears with a new post
- The contents of the post contains a blogging prompt
- The post has the tag `dailyprompt` (Top right context menu `...` > Post Settings > Tags)

### [6] Answering a prompt

**Prerequisites:**

- The editor is open with the current day's prompts (See: [[5] Button - Answer Prompt](#5-button---answer-prompt))

**Steps:**

1. Type anything in the editor
2. Tap `Publish` in the top right
3. Tap `Publish Now`
4. Wait for the post to be published

**Verify:**

- The dashboard card updates with:
  - Your avatar appearing with an incremented answer count
  - Text stating the prompt is answered

### [7] Deleting an answer

**Prerequisites:**

- Prompt is answered (See: [[6] Answering a prompt](#6-answering-a-prompt)) 
- Selected the site which answered the prompt
- On the `My Site` tab

**Steps:**

1. Tap on `Posts`
2. On the post which answers the prompt tap on the context menu `... More`
3. Tap `Move to Trash`
4. Confirm deletion of the post
5. Go back, `< My Site`

**Verify:**

- The dashboard card updates with:
  - The answer count decrementing (or disappearing if you're the only one who answered)
  - `Answer Prompt` button appears
  - `Answered` text is gone

</details>

## Action sheet header

<details>
  <summary>Click to expand!</summary>

### [1] Display - Appearance

**Prerequisites:**

- Logged into the Jetpack app
- Site selected
- On the 'My Site' tab

**Steps:**

1. Tap on the floating action button `+`

**Verify:**

- There's a prompts header above the `Create New` title with:
  - Prompts title
  - `?` help button icon next to title
  - Current day's prompt title
  - [**(?)**](#notes) Attribution - some prompts are attributed to Day One depending on the current date
  - [**(?)**](#notes) 'Answer Prompt' button - if the prompt isn't answered already
  - [**(?)**](#notes) 'Answered' - if the prompt is answered

### [2] Button - Help

**Prerequisites:**

- Action sheet is displayed with prompts header (See: [[1] Display - Appearance](#1-display---appearance-1))

**Steps:**

1. Tap on the button with the `?` icon

**Verify:**

- `Introducing Prompts` intro modal appears

### [3] Button - Answer Prompt

**Prerequisites:**

- Current day's prompt is **NOT** answered
- Action sheet is displayed with prompts header (See: [[1] Display - Appearance](#1-display---appearance-1))

**Steps:**

1. Tap on the `Answer Prompt` text

**Verify:**

- An editor appears with a new post
- The contents of the post contains a blogging prompt
- The post has the tag `dailyprompt` (Top right context menu `...` > Post Settings > Tags)

### [4] Answering a prompt

**Prerequisites:**

- The editor is open with the current day's prompts (See: [[3] Button - Answer Prompt](#3-button---answer-prompt))

**Steps:**

1. Type anything in the editor
2. Tap `Publish` in the top right
3. Tap `Publish Now`
4. Wait for the post to be published

**Verify:**

- The prompts action sheet header in the My Site FAB updates with:
  - Text stating the prompt is answered

### [5] Deleting an answer

**Prerequisites:**

- Prompt is answered (See: [[4] Answering a prompt](#4-answering-a-prompt)) 
- Selected the site which answered the prompt
- On the `My Site` tab

**Steps:**

1. Tap on `Posts`
2. On the post which answers the prompt tap on the context menu `... More`
3. Tap `Move to Trash`
4. Confirm deletion of the post
5. Go back, `< My Site`

**Verify:**

- The prompts action sheet header updates with:
  - `Answer Prompt` button appears
  - `Answered` text is gone

</details>

## Blogging Reminder Settings

<details>
  <summary>Click to expand!</summary>

### [1] Display - Appearance

**Prerequisites:**

- Logged into the Jetpack app
- Site selected
- On the 'My Site' tab

**Steps:**

1. Tap on `Menu`
2. Tap on `Site Settings`
3. Tap on `Reminders and prompts`
4. In the sheet that appears start selecting the day(s) for which you want reminders on

**Verify:**

- A blogging prompts section appears with:
  - A title
  - Info/help button `?`
  - Detail text
  - Switch to enable/disable prompts

### [3] Push notification - Scheduling

**Prerequisites:**

- On the blogging reminders settings screen (See: [[1] Display - Appearance](#1-display---appearance-2))

**Steps:**

1. This is not trivial to trigger but hopefully following steps works. Go to the Date & time settings for your device
2. In Date & time system settings, set the time to be 11.57 PM
3. In the app, go to `My site > Menu` > `Site Settings` > `Reminders and prompts`
4. Set a reminder for tomorrow at 12.01 AM
5. Tap on `Notify me` or `Update`
6. Allow push notification permissions if necessary
7. Follow the screens until you see the done screen
8. Wait for the day to be the next day and the time to be 12.01AM

**Verify:**

- A push notification appears with:
  - `Daily Prompt` title
  - The prompt content
  - Two options:
    - `Answer`
    - `Dismiss`

### [4] Push notification - Answer

**Prerequisites:**

- A push notification appeared (See: [[3] Push notification - Scheduling](#3-push-notification---scheduling))

**Steps:**

1. Tap on the `Answer` button in the notification

**Verify:**

- An editor appears with a new post for the correct site in the notification
- The contents of the post contains a blogging prompt
- The post has the tag `dailyprompt` (Top right context menu `...` > Post Settings > Tags)

### [5] Standard reminders without prompts works as expected in both WP and JP apps

This must be checked in both WPAndroid and JPAndroid apps. 

**Prerequisites:**

- On the blogging reminders settings screen (See: [[1] Display - Appearance](#1-display---appearance-2))

**Steps:**
- In both the WP and JP app
- Follow instructions from `[3] Push notification - Scheduling` but do not enable the prompts toggle (this only applies to JP app, in WP app the toggle should not be present)
- Wait for the notification to be triggered

**Verify:**

- A push notification appears with a generic sentence (and no prompts sentence), also no actions buttons are present in the notification.

</details>

## Regression Notes
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
