### PR TITLE
Turn default blogging reminders FF to ON

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsFeatureConfig.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.annotation.Feature
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig.Companion.BLOGGING_PROMPTS_REMOTE_FIELD
 import javax.inject.Inject
 
-@Feature(BLOGGING_PROMPTS_REMOTE_FIELD, false)
+@Feature(BLOGGING_PROMPTS_REMOTE_FIELD, true)
 class BloggingPromptsFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,


### PR DESCRIPTION
This PR enables Blogging Prompt for Jetpack app.

Congrats 🥳 

To test:
- Install `wordpressVanillaDebug` build variant.
- Confirm that blogging prompt is not available (make sure your site meets requirements for BP).
- Install `jetpackVanillaDebug` variant.
- Confirm that the blogging prompt is available (make sure your site meets requirements for BP).

## Regression Notes
1. Potential unintended areas of impact
Blogging prompt is not available or available for wrong build variant.


3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

4. What automated tests I added (or what prevented me from doing so)
N/A


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
