### PR TITLE
No network check for saving tags

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -229,6 +229,10 @@ public class SiteSettingsTagListActivity extends LocaleAwareActivity
         if (getFragmentManager().getBackStackEntryCount() > 0) {
             SiteSettingsTagDetailFragment fragment = getDetailFragment();
             if (fragment != null && fragment.hasChanges()) {
+                if (!NetworkUtils.checkConnection(getBaseContext())) {
+                    hideDetailFragment();
+                    return;
+                }
                 saveTag(fragment.getTerm(), fragment.isNewTerm());
             } else {
                 hideDetailFragment();


### PR DESCRIPTION
Fixes #15590 

Added the network check to onResume

To test:

Go into site settings
Open the tags
Go into airplane mode
Go into the app and close the tags section

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
