### PR TITLE
Migration: Android 12 Unsafe Intent launches 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -16,6 +16,8 @@ import android.net.http.HttpResponseCache
 import android.os.Build
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
+import android.os.StrictMode
+import android.os.StrictMode.VmPolicy
 import android.os.SystemClock
 import android.preference.PreferenceManager
 import android.text.TextUtils
@@ -311,6 +313,16 @@ class AppInitializer @Inject constructor(
         initAnalyticsExperimentPropertiesIfNeeded()
 
         initialized = true
+
+        StrictMode.setVmPolicy(
+                VmPolicy.Builder()
+                // Other StrictMode checks that you've previously added.
+                // ...
+                .detectUnsafeIntentLaunch()
+                .penaltyLog()
+                .penaltyDeath()
+                // Consider also adding penaltyDeath()
+                .build())
     }
 
     private fun initWorkManager() {

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -16,8 +16,6 @@ import android.net.http.HttpResponseCache
 import android.os.Build
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
-import android.os.StrictMode
-import android.os.StrictMode.VmPolicy
 import android.os.SystemClock
 import android.preference.PreferenceManager
 import android.text.TextUtils
@@ -313,16 +311,6 @@ class AppInitializer @Inject constructor(
         initAnalyticsExperimentPropertiesIfNeeded()
 
         initialized = true
-
-        StrictMode.setVmPolicy(
-                VmPolicy.Builder()
-                // Other StrictMode checks that you've previously added.
-                // ...
-                .detectUnsafeIntentLaunch()
-                .penaltyLog()
-                .penaltyDeath()
-                // Consider also adding penaltyDeath()
-                .build())
     }
 
     private fun initWorkManager() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2006,7 +2006,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     private void saveResult(boolean saved, boolean uploadNotStarted) {
-        Intent i = getIntent();
+        Intent i = new Intent();
         i.putExtra(EXTRA_UPLOAD_NOT_STARTED, uploadNotStarted);
         i.putExtra(EXTRA_HAS_FAILED_MEDIA, hasFailedMedia());
         i.putExtra(EXTRA_IS_PAGE, mIsPage);


### PR DESCRIPTION
Part of #16093 

This PR makes the necessary changes for handling unsafe intent launch `EditPostActivity.java`.

Note: In order to find out if there are any other activities which are launched unsafely, we can run test 2. 

#### To test:

Pre-requisites 
To test this change, add the following code to the app start up and run the app on an Android 12 device. 
```
StrictMode.setVmPolicy(
                VmPolicy.Builder()
                // Other StrictMode checks that you've previously added.
                // ...
                .detectUnsafeIntentLaunch()
                .penaltyLog()
                .penaltyDeath()
                // Consider also adding penaltyDeath()
                .build())
```

Alternatively revert this commit 6036084955400ae983bec0c6390fb0fb28a2b57b

### Test 1
- Launch app 
- Navigate to my site -> posts  
- Edit post from all the tabs draft/scheduled/published
- Verify that the post is updated and everything is working as expected

### Test 2 
A smoke testing of the entire app to launch all the activities might be required to discover the unsafe launches. Also, deep-link navigation launches should be tested for sanity.  

## Regression Notes
1. Potential unintended areas of impact
Edit Posts is not working as expected 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
