### PR TITLE
[Site Design Revamp] Reduce recommended design thumbnail sizes

### DIFF
--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -659,9 +659,9 @@
     <dimen name="hpp_layout_card_height">260dp</dimen>
     <dimen name="hpp_layout_card_width">200dp</dimen>
     <dimen name="hpp_layouts_row_height">330dp</dimen>
-    <dimen name="hpp_recommended_card_height">416dp</dimen>
-    <dimen name="hpp_recommended_card_width">320dp</dimen>
-    <dimen name="hpp_recommended_row_height">500dp</dimen>
+    <dimen name="hpp_recommended_card_height">260dp</dimen>
+    <dimen name="hpp_recommended_card_width">200dp</dimen>
+    <dimen name="hpp_recommended_row_height">350dp</dimen>
     <dimen name="hpp_recommended_subtitle_margin">5dp</dimen>
 
     <!-- Site Intent Question -->


### PR DESCRIPTION
Fixes #16743

|Before|After|
|---|---|
|![Screenshot_20220615_100225](https://user-images.githubusercontent.com/304044/173764300-9e7c2c55-ab28-480f-8806-1c3454448420.png)|![Screenshot_20220615_100240](https://user-images.githubusercontent.com/304044/173764276-75904444-5ac5-4c83-8ea7-67247aab968f.png)|

To test:
1. Start the Site Creation flow
2. Navigate to the Site Design screen
3. Expect the thumbnails in the recommended section to match the size and quality of the other thumbnails

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
