### PR TITLE
Fix a typo in a newly-introduced string for 20.1

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1393,7 +1393,7 @@
     <string name="stats_referrer_label">Referrer</string>
     <string name="stats_referrer_views_label">Views</string>
     <string name="stats_referrers_pie_chart_total_label">Views</string>
-    <string name="stats_referrers_pie_chart_wordpress">Wordpress</string>
+    <string name="stats_referrers_pie_chart_wordpress">WordPress</string>
     <string name="stats_referrers_pie_chart_search">Search</string>
     <string name="stats_referrers_pie_chart_others">Others</string>
     <string name="stats_clicks">Clicks</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1393,7 +1393,7 @@
     <string name="stats_referrer_label">Referrer</string>
     <string name="stats_referrer_views_label">Views</string>
     <string name="stats_referrers_pie_chart_total_label">Views</string>
-    <string name="stats_referrers_pie_chart_wordpress">Wordpress</string>
+    <string name="stats_referrers_pie_chart_wordpress">WordPress</string>
     <string name="stats_referrers_pie_chart_search">Search</string>
     <string name="stats_referrers_pie_chart_others">Others</string>
     <string name="stats_clicks">Clicks</string>


### PR DESCRIPTION
## What

@tobifjellner spotted a typo in a newly-introduced string in WPAndroid 20.1 and reported it to us [here in the WPorg slack](https://wordpress.slack.com/archives/C02RQC4LY/p1655277641463669)

> One string contains an error, at least in Android. String ref: stats_referrers_pie_chart_wordpress and contains the string "Wordpress" (with lowercase p)

This PR simply fixes the typo so it gets re-imported into GlotPress.

## How

 - Fixed the typo in `WordPress/src/main/res/values/strings.xml`
 - Re-ran `bundle exec fastlane update_frozen_strings_for_translation` so that the typo gets included in the _frozen_ strings file that are imported by GlotPress (`fastlane/resources/values/strings.xml`) via cron

ℹ️  This PR targets the `release/20.1` since this typo fix will have to be included in the next 20.1 beta and final release.
Once this PR lands in `release/20.1`, I will follow-up with a PR to merge `release/20.1` into `trunk` so that the new `fastlane/resources/values/strings.xml` lands in `trunk` and gets picked up and re-imported by GlotPress

## To test:

Nothing to test, it's just a typo fix. The typo fix will ship in the next beta that we will do later this sprint.