### PR TITLE
Merge release/20.1 to land a typo fix

### DIFF
--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -659,9 +659,9 @@
     <dimen name="hpp_layout_card_height">260dp</dimen>
     <dimen name="hpp_layout_card_width">200dp</dimen>
     <dimen name="hpp_layouts_row_height">330dp</dimen>
-    <dimen name="hpp_recommended_card_height">416dp</dimen>
-    <dimen name="hpp_recommended_card_width">320dp</dimen>
-    <dimen name="hpp_recommended_row_height">500dp</dimen>
+    <dimen name="hpp_recommended_card_height">260dp</dimen>
+    <dimen name="hpp_recommended_card_width">200dp</dimen>
+    <dimen name="hpp_recommended_row_height">350dp</dimen>
     <dimen name="hpp_recommended_subtitle_margin">5dp</dimen>
 
     <!-- Site Intent Question -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1393,7 +1393,7 @@
     <string name="stats_referrer_label">Referrer</string>
     <string name="stats_referrer_views_label">Views</string>
     <string name="stats_referrers_pie_chart_total_label">Views</string>
-    <string name="stats_referrers_pie_chart_wordpress">Wordpress</string>
+    <string name="stats_referrers_pie_chart_wordpress">WordPress</string>
     <string name="stats_referrers_pie_chart_search">Search</string>
     <string name="stats_referrers_pie_chart_others">Others</string>
     <string name="stats_clicks">Clicks</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1393,7 +1393,7 @@
     <string name="stats_referrer_label">Referrer</string>
     <string name="stats_referrer_views_label">Views</string>
     <string name="stats_referrers_pie_chart_total_label">Views</string>
-    <string name="stats_referrers_pie_chart_wordpress">Wordpress</string>
+    <string name="stats_referrers_pie_chart_wordpress">WordPress</string>
     <string name="stats_referrers_pie_chart_search">Search</string>
     <string name="stats_referrers_pie_chart_others">Others</string>
     <string name="stats_clicks">Clicks</string>


### PR DESCRIPTION
This lands recent fixes made in `release/20.1` into `trunk`:

 - https://github.com/wordpress-mobile/WordPress-Android/pull/16749 (Typo fix which needs to be re-imported in GlotPress)
 - https://github.com/wordpress-mobile/WordPress-Android/pull/16747 (Fix that landed in the release branch, but was not shipped as a new beta yet)

I haven't made a new beta for those, because the code freeze and first beta is very recent and Antonis reported that the fix from https://github.com/wordpress-mobile/WordPress-Android/pull/16747 was not urgent to land in a new beta. But I still need to merge `release/20.1` into `trunk` ASAP to land the typo fix from #16749 so that the new copy gets re-imported in GlotPress.