### PR TITLE
Updates: the scrolling behaviour of the site header

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -165,10 +165,10 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             if (quickStartScrollPosition == -1) {
                 appbarMain.setExpanded(true, true)
                 quickStartScrollPosition = 0
-            } else {
-                appbarMain.setExpanded(false, true)
             }
             binding?.viewPager?.getCurrentFragment()?.handleScrollTo(quickStartScrollPosition)
+            if(quickStartScrollPosition > 0)
+                appbarMain.setExpanded(false, true)
         }
         viewModel.onTrackWithTabSource.observeEvent(viewLifecycleOwner) {
             binding?.viewPager?.getCurrentFragment()?.onTrackWithTabSource(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -166,9 +166,9 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                 appbarMain.setExpanded(true, true)
                 quickStartScrollPosition = 0
             }
-            binding?.viewPager?.getCurrentFragment()?.handleScrollTo(quickStartScrollPosition)
             if(quickStartScrollPosition > 0)
                 appbarMain.setExpanded(false, true)
+            binding?.viewPager?.getCurrentFragment()?.handleScrollTo(quickStartScrollPosition)
         }
         viewModel.onTrackWithTabSource.observeEvent(viewLifecycleOwner) {
             binding?.viewPager?.getCurrentFragment()?.onTrackWithTabSource(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -166,8 +166,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                 appbarMain.setExpanded(true, true)
                 quickStartScrollPosition = 0
             }
-            if(quickStartScrollPosition > 0)
-                appbarMain.setExpanded(false, true)
+            if (quickStartScrollPosition > 0) appbarMain.setExpanded(false, true)
             binding?.viewPager?.getCurrentFragment()?.handleScrollTo(quickStartScrollPosition)
         }
         viewModel.onTrackWithTabSource.observeEvent(viewLifecycleOwner) {


### PR DESCRIPTION
Fixes #16573

This PR updates the scrolling behaviour of the site header when the quick start focus point is shown

cc: @osullivanchris 

To test:
- Login to a site with quick start in progress (New Quick start tour)
- Make sure that App Settings -> Initial Screen is Dashboard
- Start Check your stats/Upload photos or Videos tour
- Notice that the Site header doesn't collapse if it wasn't collapsed earlier when focus point is shown

## Regression Notes
1. Potential unintended areas of impact
Quick start focus point being not shown properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
