### PR TITLE
Stats Revamp v2: Fix date problem on line chart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsMapper.kt
@@ -123,8 +123,9 @@ class ViewsAndVisitorsMapper
                 Visitors -> it.visitors
                 else -> 0L
             }
+            val date = statsDateFormatter.parseStatsDate(statsGranularity, it.period)
             Line(
-                    statsDateFormatter.printGranularDate(it.period, statsGranularity),
+                    statsDateFormatter.printDayWithoutYear(date),
                     it.period,
                     value.toInt()
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LineChartLabelFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LineChartLabelFormatter.kt
@@ -3,10 +3,6 @@ package org.wordpress.android.ui.stats.refresh.utils
 import com.github.mikephil.charting.components.AxisBase
 import com.github.mikephil.charting.formatter.ValueFormatter
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.LineChartItem.Line
-import java.text.ParseException
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import javax.inject.Inject
 
 class LineChartLabelFormatter @Inject constructor(
@@ -15,27 +11,9 @@ class LineChartLabelFormatter @Inject constructor(
     override fun getAxisLabel(value: Float, axis: AxisBase?): String {
         val index = value.toInt()
         return if (index < entries.size) {
-            formatLabelDate(parseLabelDate(entries[index].label))
+            entries[index].label
         } else {
             ""
         }
-    }
-
-    // 12 Apr 2022
-    private fun parseLabelDate(label: String): Date? {
-        var labelDate: Date? = null
-        val labelParser = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
-        try {
-            labelDate = labelParser.parse(label)
-        } catch (e: ParseException) {
-            e.printStackTrace()
-        }
-        return labelDate
-    }
-
-    // Apr 12
-    private fun formatLabelDate(date: Date?): String {
-        val labelFormatter = SimpleDateFormat("MMM d", Locale.getDefault())
-        return date?.let { labelFormatter.format(it) }.toString()
     }
 }


### PR DESCRIPTION
Line chart dates were showing as "null" on some devices. I tried to find the reason by using different languages, locales, but every time it was null. It's not showing as null on @ravishanker 's device.
|before|after|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/173917826-5b46810b-fc2a-4ffa-857a-0b65e026abcc.png" width=320>|<img src="https://user-images.githubusercontent.com/2471769/173917934-02f6977c-9088-4cf2-a2c4-d178eee3b9e6.png" width=320>|

To test:
1. Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
2. Select Debug Settings
3. Find StatsRevampV2FeatureConfig under Features in development enable it and restart app
4. Launch app
5. Go to stats either using quick links or menu
6. Notice a new Views & Visitors card is shown in Insights tab as in the images above (scroll down if necessary)
7. Ensure the dates labels on the line chart are not "null", appearing correctly.

## Regression Notes
1. Potential unintended areas of impact
The date label might be changed incorrectly on other devices which don't show null before.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I could test only on my device. I'll ask Ravi to test in his environment. His device wasn't shown null before.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
