### PR TITLE
Integrate gutenberg-mobile release 1.78.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.14.0'
-    gutenbergMobileVersion = '4961-214827b159cbeea00415ff30727388758e656c4e'
+    gutenbergMobileVersion = 'v1.78.1'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.14.0'
-    gutenbergMobileVersion = 'v1.78.0'
+    gutenbergMobileVersion = '4961-214827b159cbeea00415ff30727388758e656c4e'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.78.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4961

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.