### PR TITLE
QRCode Auth: Launch flow by deep link

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -468,7 +468,7 @@
                 <data
                     android:host="apps.wordpress.com"
                     android:pathPattern="/get/.*"
-                    android:scheme="http" />
+                    android:scheme="https" />
 
             </intent-filter>
 

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -465,6 +465,11 @@
                     android:pathPattern="/notifications/.*"
                     android:scheme="http" />
 
+                <data
+                    android:host="apps.wordpress.com"
+                    android:pathPattern="/get/.*"
+                    android:scheme="http" />
+
             </intent-filter>
 
         </activity>

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1739,4 +1739,8 @@ public class ActivityLauncher {
     public static void startQRCodeAuthFlow(@NonNull Context context) {
         QRCodeAuthActivity.start(context);
     }
+
+    public static void startQRCodeAuthFlowInNewStack(@NonNull Context context, String uri) {
+        // todo: add the flow
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1740,7 +1740,21 @@ public class ActivityLauncher {
         QRCodeAuthActivity.start(context);
     }
 
-    public static void startQRCodeAuthFlowInNewStack(@NonNull Context context, String uri) {
-        // todo: add the flow
+    public static void startQRCodeAuthFlowInNewStack(@NonNull Context context, @NonNull String uri) {
+        TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
+
+        Intent mainActivityIntent = getMainActivityInNewStack(context);
+        mainActivityIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+
+        Intent meIntent = new Intent(context, MeActivity.class);
+        meIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+
+        Intent qrcodeAuthFlowIntent = QRCodeAuthActivity.newIntent(context, uri, true);
+
+        taskStackBuilder.addNextIntent(mainActivityIntent);
+        taskStackBuilder.addNextIntent(meIntent);
+        taskStackBuilder.addNextIntent(qrcodeAuthFlowIntent);
+
+        taskStackBuilder.startActivities();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenI
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenNotifications
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenPages
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenPagesForSite
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenQRCodeAuthFlow
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenReader
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenStats
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenStatsForSite
@@ -72,6 +73,7 @@ class DeepLinkNavigator
             OpenNotifications -> ActivityLauncher.viewNotificationsInNewStack(activity)
             is OpenPagesForSite -> ActivityLauncher.viewPagesInNewStack(activity, navigateAction.site)
             OpenPages -> ActivityLauncher.viewPagesInNewStack(activity)
+            is OpenQRCodeAuthFlow -> ActivityLauncher.startQRCodeAuthFlowInNewStack(activity, navigateAction.uri)
         }
         if (navigateAction != LoginForResult) {
             activity.finish()
@@ -98,5 +100,6 @@ class DeepLinkNavigator
         object OpenNotifications : NavigateAction()
         data class OpenPagesForSite(val site: SiteModel) : NavigateAction()
         object OpenPages : NavigateAction()
+        data class OpenQRCodeAuthFlow(val uri: String) : NavigateAction()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
+@Suppress("LongParameterList")
 class DeepLinkHandlers
 @Inject constructor(
     editorLinkHandler: EditorLinkHandler,

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
@@ -14,7 +14,8 @@ class DeepLinkHandlers
     startLinkHandler: StartLinkHandler,
     readerLinkHandler: ReaderLinkHandler,
     pagesLinkHandler: PagesLinkHandler,
-    notificationsLinkHandler: NotificationsLinkHandler
+    notificationsLinkHandler: NotificationsLinkHandler,
+    qrCodeAuthLinkHandler: QRCodeAuthLinkHandler
 ) {
     private val handlers = listOf(
             editorLinkHandler,
@@ -22,7 +23,8 @@ class DeepLinkHandlers
             startLinkHandler,
             readerLinkHandler,
             pagesLinkHandler,
-            notificationsLinkHandler
+            notificationsLinkHandler,
+            qrCodeAuthLinkHandler
     )
 
     private val _toast by lazy {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeAuthLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeAuthLinkHandler.kt
@@ -1,0 +1,32 @@
+package org.wordpress.android.ui.deeplinks.handlers
+
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenQRCodeAuthFlow
+import org.wordpress.android.util.UriWrapper
+import javax.inject.Inject
+
+class QRCodeAuthLinkHandler @Inject constructor() : DeepLinkHandler {
+    /**
+     * Returns true if the URI looks like `apps.wordpress.com/get`
+     */
+    override fun shouldHandleUrl(uri: UriWrapper): Boolean {
+        // https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=XXXX&data=XXXXX
+        return uri.host == HOST_APPS_WORDPRESS_COM &&
+                uri.pathSegments.firstOrNull() == GET_PATH
+    }
+
+    override fun buildNavigateAction(uri: UriWrapper): NavigateAction {
+        return OpenQRCodeAuthFlow(uri.toString())
+    }
+
+    override fun stripUrl(uri: UriWrapper): String {
+        return buildString {
+            append("$HOST_APPS_WORDPRESS_COM/$GET_PATH")
+        }
+    }
+
+    companion object {
+        private const val GET_PATH = "get"
+        private const val HOST_APPS_WORDPRESS_COM = "apps.wordpress.com"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
@@ -20,8 +20,19 @@ class QRCodeAuthActivity : AppCompatActivity() {
     companion object {
         @JvmStatic
         fun start(context: Context) {
-            val intent = Intent(context, QRCodeAuthActivity::class.java)
-            context.startActivity(intent)
+            context.startActivity(newIntent(context))
         }
+
+        @JvmStatic
+        fun newIntent(context: Context, uri: String? = null, fromDeeplink: Boolean = false): Intent {
+            val intent = Intent(context, QRCodeAuthActivity::class.java).apply {
+                putExtra(DEEP_LINK_URI_KEY, uri)
+                putExtra(IS_DEEP_LINK_KEY, fromDeeplink)
+            }
+            return intent
+        }
+
+        const val IS_DEEP_LINK_KEY = "is_deep_link_key"
+        const val DEEP_LINK_URI_KEY = "deep_link_uri_key"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -19,6 +19,8 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.BasicDialogModel
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.FinishActivity
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.LaunchDismissDialog
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.LaunchScanner
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActivity.Companion.DEEP_LINK_URI_KEY
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActivity.Companion.IS_DEEP_LINK_KEY
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Error
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Loading
@@ -40,7 +42,7 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
         with(QrcodeauthFragmentBinding.bind(view)) {
             initBackPressHandler()
             observeViewModel()
-            startViewModel(savedInstanceState)
+            initViewModel(savedInstanceState)
         }
     }
 
@@ -50,8 +52,14 @@ class QRCodeAuthFragment : Fragment(R.layout.qrcodeauth_fragment) {
         viewModel.uiState.onEach { renderUi(it) }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
-    private fun startViewModel(savedInstanceState: Bundle?) {
-        viewModel.start(savedInstanceState)
+    private fun initViewModel(savedInstanceState: Bundle?) {
+        val(uri, isDeepLink) = requireActivity().intent?.extras?.let {
+            val uri = it.getString(DEEP_LINK_URI_KEY, null)
+            val isDeepLink = it.getBoolean(IS_DEEP_LINK_KEY, false)
+            uri to isDeepLink
+        } ?: (null to false)
+
+        viewModel.start(uri, isDeepLink, savedInstanceState)
     }
 
     private fun handleActionEvents(actionEvent: QRCodeAuthActionEvent) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlersTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlersTest.kt
@@ -19,6 +19,7 @@ class DeepLinkHandlersTest : BaseUnitTest() {
     @Mock lateinit var readerLinkHandler: ReaderLinkHandler
     @Mock lateinit var pagesLinkHandler: PagesLinkHandler
     @Mock lateinit var notificationsLinkHandler: NotificationsLinkHandler
+    @Mock lateinit var qrCodeAuthLinkHandler: QRCodeAuthLinkHandler
     @Mock lateinit var uri: UriWrapper
     private lateinit var deepLinkHandlers: DeepLinkHandlers
     private lateinit var handlers: List<DeepLinkHandler>
@@ -31,7 +32,8 @@ class DeepLinkHandlersTest : BaseUnitTest() {
                 startLinkHandler,
                 readerLinkHandler,
                 pagesLinkHandler,
-                notificationsLinkHandler
+                notificationsLinkHandler,
+                qrCodeAuthLinkHandler
         )
         initDeepLinkHandlers()
     }
@@ -43,7 +45,8 @@ class DeepLinkHandlersTest : BaseUnitTest() {
                 startLinkHandler,
                 readerLinkHandler,
                 pagesLinkHandler,
-                notificationsLinkHandler
+                notificationsLinkHandler,
+                qrCodeAuthLinkHandler
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
@@ -15,6 +15,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.Mockito.times
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthError
 import org.wordpress.android.fluxc.network.rest.wpcom.qrcodeauth.QRCodeAuthErrorType
@@ -42,7 +43,10 @@ import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.BROWSER
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.DATA_KEY
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.LAST_STATE_KEY
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.LOCATION_KEY
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.ORIGIN_DEEPLINK
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.ORIGIN_MENU
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.TOKEN_KEY
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthViewModel.Companion.TRACKING_ORIGIN_KEY
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
@@ -111,7 +115,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
 
         viewModel.writeToBundle(savedInstanceState)
 
-        verify(savedInstanceState).putString(any(), argThat { true })
+        verify(savedInstanceState, times(2)).putString(any(), argThat { true })
     }
 
     @Test
@@ -415,20 +419,25 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     private val authenticateSuccess = QRCodeAuthResult(model = QRCodeAuthAuthenticateResult(authenticated = true))
 
     private fun startViewModel(saveInstanceState: Bundle? = null) {
-        viewModel.start(saveInstanceState)
+        viewModel.start(savedInstanceState = saveInstanceState)
     }
 
     private fun initAndStartVMForState(stateType: QRCodeAuthUiStateType) {
         initSavedInstanceState(stateType)
-        viewModel.start(savedInstanceState)
+        viewModel.start(savedInstanceState = savedInstanceState)
     }
 
-    private fun initSavedInstanceState(stateType: QRCodeAuthUiStateType) {
+    private fun initSavedInstanceState(stateType: QRCodeAuthUiStateType, isDeepLink: Boolean = false) {
         whenever(savedInstanceState.getString(DATA_KEY, null)).thenReturn(DATA)
         whenever(savedInstanceState.getString(TOKEN_KEY, null)).thenReturn(TOKEN)
         whenever(savedInstanceState.getString(LOCATION_KEY, null)).thenReturn(LOCATION)
         whenever(savedInstanceState.getString(BROWSER_KEY, null)).thenReturn(BROWSER)
         whenever(savedInstanceState.getString(LAST_STATE_KEY, null)).thenReturn(stateType.label)
+        if (isDeepLink) {
+            whenever(savedInstanceState.getString(TRACKING_ORIGIN_KEY, ORIGIN_DEEPLINK)).thenReturn(ORIGIN_DEEPLINK)
+        } else {
+            whenever(savedInstanceState.getString(TRACKING_ORIGIN_KEY, ORIGIN_MENU)).thenReturn(ORIGIN_MENU)
+        }
     }
 
     private suspend fun initValidate(


### PR DESCRIPTION
Parent #16481

This PR adds a "deep link" entry point into the QR Code Auth flow.

**To test:**
NOTE: You do not need to run the entire QR Auth code flow to test this PR, so no sandboxing is required

**Pre-req I: Setting the Feature Flag**
-Install the app
-Login using a WP.com account (not an automattic account or one with 2FA)
-Navigate to Me -> App Settings -> Privacy Settings -> Turn on the COllect Information slider
-Navigate back to Me -> App Settings -> Debug Settings
-Enable QRCodeAuthFlowFeatureConfig
-Restart the App

**Pre-req II: Auto-verify the Android 12 link - For Android 12 devices ONLY**
- Because these tests use the alpha version of the apps, we have to manually verify the apps.wordpress.com link for devices running Android 12
- Navigate to the Manage Apps area on your device
- Navigate to WordPress Alpha build from this PR
- Scroll down to the Open By Default and tap to make changes
- Ensure "open Supported Links" is turned on
- Tap the +Add link 
- Select 'apps.wordpress.com' from the list
 
**Repeat the following tests twice: Once with a device/emulator running Android 11 & once with Android 12**
**Test A: Logged in experience**
- Run pre-req
- Background the app or kill the process
- Use one of the following methods to launch the link
- (1) Send this device an email or slack DM with the following link: 
https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=XXXX&data=XXXXX
- (2) Use adb command
Run `adb devices -l` (to get the name of the device)
Run `adb -s **NAME_OF_DEVICE** shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d "https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login"`
NOTE: This is an invalid code 
- ✅ Verify the app launches and you are brought to the `Could not validate the log in code' view
- Tap Cancel
- ✅ Verify you are brought back to the Me View
- ✅ Verify the logs contain 🔵 Tracked: qrlogin_verify_cancelled, Properties: {"origin":"deep_link"}
Note: If you are running an emulator, if you tap the "Scan Again" you will be returned to the Me View; however if you are running on a device, tapping Scan Again will open the scanner

**Test B: Logged out experience**
- Run pre-req
- Log out of the app
- Kill the process or background the app
- Use the methods in "test A" to launch the link
- ✅ Verify you are presented with the login view
- Login as normal. You will see the old style site selection with the Done button, this is okay, so just tap Done
- ✅ Verify the app launches and you are brought to the `Could not validate the log in code' view
- Tap Cancel
- ✅ Verify you are brought back to the Me View
- Tap the back button
- ✅ Verify you are brought back to the dashboard


** Test C: Tap from Menu (Use a real device not emulator)**
- Run pre-req
- Navigate to Me -> Scan Login Code
- Scan the attached qr code (which is invalid)
- ✅ Verify you are brought to the `Could not validate the log in code' view
- Tap Cancel
- ✅ Verify you are brought back to the Me View
- ✅ Verify the logs contain 🔵 Tracked: qrlogin_verify_cancelled, Properties: {"origin":"menu"}

## Regression Notes
1. Potential unintended areas of impact
QR Code Auth flow does not launch

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Updates QRCodeAuthViewModelTest & DeepLinkHandlersTest

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
