### PR TITLE
QRCode Auth: Enable for Jetpack Only

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -158,6 +158,7 @@ android {
             buildConfigField "boolean", "IS_JETPACK_APP", "false"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"wpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"org.wordpress.android"'
+            buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "false"
 
             manifestPlaceholders = [magicLinkScheme:"wordpress"]
         }
@@ -179,6 +180,7 @@ android {
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
+            buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
 
             manifestPlaceholders = [magicLinkScheme:"jetpack"]
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/QRCodeAuthFlowFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/QRCodeAuthFlowFeatureConfig.kt
@@ -4,9 +4,17 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.annotation.FeatureInDevelopment
 import javax.inject.Inject
 
+// TODO: Uncomment the lines 8 and 14 when the remote field is configured
+//  and remove line 9 and this to-do
+// @Feature(QRCodeAuthFlowFeatureConfig.STATS_REVAMP_V2_REMOTE_FIELD, false)
 @FeatureInDevelopment
 class QRCodeAuthFlowFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
         BuildConfig.QRCODE_AUTH_FLOW
-)
+//      QRCODE_AUTH_FLOW_REMOTE_FIELD
+) {
+    companion object {
+        const val QRCODE_AUTH_FLOW_REMOTE_FIELD = "qrcode_auth_flow_remote_field"
+    }
+}


### PR DESCRIPTION
Parent #16481

**Description**
- Disable the QR Code Auth flow for WordPress variant
- Explicitly enables the QR Code Auth flow for Jetpack variant
- Prepares the feature flag with a remote field as a way to kill the flow if the Google beta scanner library goes awry 

**To test:**
- Download and install the WordPress variant
- Launch the app and log in
- Navigate to Me -> App Settings -> Debug Settings
- Enable QRCodeAuthFlowFeatureConfig
- Restart the app
- Navigate to Me 
- ✅ Verify the Scan Login Code option does not exist
------------------------

- Download and install the Jetpack variant
- Launch the app and log in
- Navigate to Me -> App Settings -> Debug Settings
- Enable QRCodeAuthFlowFeatureConfig
- Restart the app
- Navigate to Me 
- ✅ Verify the Scan Login Code option exists

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
