### PR TITLE
Support HEIC/ HEIF files in media picker 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 20.2
 -----
-
+* [*] Added heic/heif image format support [https://github.com/wordpress-mobile/WordPress-Android/pull/16773]
 
 20.1
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '2444-b0a15820270eb078375c3184f0d99057203be7be'
+    fluxCVersion = 'trunk-be807d3717b0b0b9b4c812a65026504096d5615e'
 
     appCompatVersion = '1.0.2'
     androidxCoreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '1.45.0'
+    fluxCVersion = '2444-b0a15820270eb078375c3184f0d99057203be7be'
 
     appCompatVersion = '1.0.2'
     androidxCoreVersion = '1.3.2'


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/16367

This PR only points to FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2444 which enables support for HEIC/ HEIF files.

Before | After 
----|-----
<img height="700" alt="Before" src="https://user-images.githubusercontent.com/1405144/174588530-aaab83d1-8429-4a92-b23e-fbb437123f82.png"> | <img height="700" src="https://user-images.githubusercontent.com/1405144/174588736-058329fe-0d67-43ba-a918-7ecec6df65a5.png"/>


To test:

1. Download HEIC/ HEIF image on your test device.
2. Install apk from this PR.
3. Login using `wpcom` account and go to `My Site` tab.
4. Click + button to create a post and add an image block.
5. Select "Choose from device" option to add an image.
6. Notice that HEIC/ HEIF images on your test device are selectable.
7. Select a HEIC/ HEIF image.
8. Notice that the image is added to the image block.

**Review/ Merge Instructions**

1. Review corresponding `FluxC` PR.
2. Make sure the corresponding `FluxC` PR is merged to `trunk`.
3. Replace `FluxC` `trunk-<hash>` in `build.gradle`.
4. Remove `Not Ready for Merge` label.
5. Merge the PR.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
