### PR TITLE
QR Code Auth: Adjust origin tracking 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModel.kt
@@ -78,7 +78,7 @@ class QRCodeAuthViewModel @Inject constructor(
             trackingOrigin = ORIGIN_DEEPLINK
             process(uri)
         } else {
-            trackingOrigin = ORIGIN_MENU
+            if (trackingOrigin.isNullOrEmpty()) trackingOrigin = ORIGIN_MENU
             startOrRestoreUiState()
         }
     }


### PR DESCRIPTION
Parent: #16481 

This PR adjusts how trackingOrigin is set in `QRCodeAuthViewModel.start` to account for state restores and non-deep link situations.

**To test:**
NOTE: You do not need to run the entire QR Auth code flow to test this PR, so no sandboxing is required

**Pre-req I: Setting the Feature Flag**
-Install the app
-Login using a WP.com account (not an automattic account or one with 2FA)
-Navigate to Me -> App Settings -> Privacy Settings -> Turn on the COllect Information slider
-Navigate back to Me -> App Settings -> Debug Settings
-Enable QRCodeAuthFlowFeatureConfig
-Restart the App

**NOTE**: If you test on an Android 12 device you'll need to set the auto-verify link for the app
**Pre-req II: Auto-verify the Android 12 link - For Android 12 devices ONLY**
- Navigate to the Manage Apps area on your device
- Navigate to WordPress Alpha build from this PR
- Scroll down to the Open By Default and tap to make changes
- Ensure "open Supported Links" is turned on
- Tap the +Add link
- Select 'apps.wordpress.com' from the list

**Test: Run on a physical device**
- Run pre-req
- Background the app or kill the process
- Use one of the following methods to launch the link
(1) Send this device an email or slack DM with the following link: `https:appss.wordpress.com?campaign=login-qr-code#qr-code-login?token=XXXX&data=XXXXX`
(2) Use adb command
- Run adb devices -l (to get the name of the device)
- Run adb -s **NAME_OF_DEVICE** shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d "P7jrAc-i-p2?campaign=login-qr-code#qr-code-login"
- NOTE: This is an invalid code
- Tap Cancel on the `Could not validate the log in code' view 
- ✅ Verify the logs contain 🔵 Tracked: qrlogin_verify_cancelled, Properties: {"origin":"deep_link"}
- Tap the "Scan Again" button
- Scan the attached code (which is invalid) 
- Tap Cancel on the `Could not validate the log in code' view 
- ✅ Verify the logs contain 🔵 Tracked: qrlogin_verify_cancelled, Properties: {"origin":"menu"}


![WP QRCode](https://user-images.githubusercontent.com/506707/174611127-abbc7f97-a7e7-4eb2-88df-20f1963d1f9c.png)


## Regression Notes
1. Potential unintended areas of impact
The wrong value is tracked for origin

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.