### PR TITLE
Fix duplicate legends problem on the pie chart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/PieChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/PieChartViewHolder.kt
@@ -74,6 +74,7 @@ class PieChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(parent, R.
     }
 
     private fun addLegends(item: PieChartItem) {
+        legends.removeAllViews()
         item.entries.forEachIndexed { index, pie ->
             ItemPieChartLegendBinding.inflate(LayoutInflater.from(legends.context), legends, true).apply {
                 val textView = root.findViewById<TextView>(R.id.text)


### PR DESCRIPTION
This fixes duplicate legends caused when the date picker is changed.

|before|after|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/174665633-038c84c3-5d7b-45ea-a545-20997142a4c3.png" width=320>|<img src="https://user-images.githubusercontent.com/2471769/174665719-3cbdb698-5f43-497d-9bd7-e42ea716810b.png" width=320>|

To test:
Setup:
1. Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings).
2. Select Debug Settings.
3. Find StatsRevampV2FeatureConfig under Features in development enable it and restart app.
4. Launch / Re-Launch app.
5. Go to Stats either using quick links or menu.
6. Switch to Insights tab if necessary.
7. If the Views & Visitors and Total Followers cards are not present, add them through stats management using either [+ add new stats card ] at the bottom or clicking ⚙️ icon at the top right hand corner.

Test:
1. Click on View More on Views & Visitors card.
2. Scroll to Referrers card.
3. Change the date pickers couple of times.
4. Ensure there are only three legends in the pie chart when the date changes.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
