### PR TITLE
Bump Aztec version to v1.5.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.14.0'
-    gutenbergMobileVersion = 'v1.78.1'
+    gutenbergMobileVersion = 'v1.79.0-alpha1'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "org.jetbrains.kotlin.plugin.parcelize"
 }
 
-ext.aztecVersion = 'v1.5.8'
+ext.aztecVersion = 'v1.5.9'
 
 repositories {
     maven {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1306,6 +1306,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
     }
 
+    @Override
+    public void beforeMediaDeleted(@NonNull AztecAttributes aztecAttributes) {
+        // noop implementation for shared interface with block editor
+    }
+
     private static class MediaPredicate implements AztecText.AttributePredicate, Parcelable {
         private final String mId;
         private final String mAttributeName;


### PR DESCRIPTION
This PR updates the version of Aztec to v1.5.9 to incorporate updates to the [AztecAndroid Placeholder API](https://github.com/wordpress-mobile/AztecEditor-Android/pull/990/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

Related PRs:
- https://github.com/WordPress/gutenberg/pull/41828
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/4973

To test:
- Verify editor works as normal.

## Regression Notes
1. Potential unintended areas of impact
Aztec Editor

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
No automated tests added as we have deprecated the Aztec Editor.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
