### PR TITLE
QRCode Auth: Additional track events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiState.kt
@@ -11,11 +11,11 @@ import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.ActionButton.ErrorS
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.ActionButton.ValidatedPrimaryActionButton
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.ActionButton.ValidatedSecondaryActionButton
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.AUTHENTICATING
-import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.AUTH_FAILED
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.AUTHENTICATION_FAILED
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.CONTENT
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.DONE
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.ERROR
-import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.EXPIRED
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.EXPIRED_TOKEN
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.INVALID_DATA
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.LOADING
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiStateType.NO_INTERNET
@@ -60,7 +60,7 @@ sealed class QRCodeAuthUiState {
             override val primaryActionButton: ErrorPrimaryActionButton,
             override val secondaryActionButton: ErrorSecondaryActionButton
         ) : Error() {
-            override val type = AUTH_FAILED
+            override val type = AUTHENTICATION_FAILED
             override val title: UiString = UiStringRes(R.string.qrcode_auth_flow_error_auth_failed_title)
             override val subtitle: UiString = UiStringRes(R.string.qrcode_auth_flow_error_auth_failed_subtitle)
             @DrawableRes override val image = R.drawable.img_illustration_empty_results_216dp
@@ -70,7 +70,7 @@ sealed class QRCodeAuthUiState {
             override val primaryActionButton: ErrorPrimaryActionButton,
             override val secondaryActionButton: ErrorSecondaryActionButton
         ) : Error() {
-            override val type = EXPIRED
+            override val type = EXPIRED_TOKEN
             override val title: UiString = UiStringRes(R.string.qrcode_auth_flow_error_expired_title)
             override val subtitle: UiString = UiStringRes(R.string.qrcode_auth_flow_error_expired_subtitle)
             @DrawableRes override val image = R.drawable.img_illustration_empty_results_216dp

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiStateType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiStateType.kt
@@ -9,8 +9,8 @@ enum class QRCodeAuthUiStateType(val label: String) {
     AUTHENTICATING("authenticating"),
     DONE("done"),
     INVALID_DATA("invalid_data"),
-    AUTH_FAILED("auth_failed"),
-    EXPIRED("expired"),
+    AUTHENTICATION_FAILED("authentication_failed"),
+    EXPIRED_TOKEN("expired_token"),
     NO_INTERNET("no_internet");
 
     override fun toString() = label

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -941,7 +941,9 @@ public final class AnalyticsTracker {
         QRLOGIN_VERIFY_CANCELLED,
         QRLOGIN_VERIFY_APPROVED,
         QRLOGIN_AUTHENTICATED,
-        QRLOGIN_VERIFY_DISMISS
+        QRLOGIN_VERIFY_DISMISS,
+        QRLOGIN_VERIFY_FAILED,
+        QRLOGIN_VERIFY_SCAN_AGAIN
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2381,6 +2381,10 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "qrlogin_authenticated";
             case QRLOGIN_VERIFY_DISMISS:
                 return "qrlogin_verify_dismiss";
+            case QRLOGIN_VERIFY_FAILED:
+                return "qrlogin_verify_failed";
+            case QRLOGIN_VERIFY_SCAN_AGAIN:
+                return "qrlogin_verify_scan_again";
         }
         return null;
     }


### PR DESCRIPTION
Parent #16481 

This PR updates tracking for the QR Code Auth flow.
- Adds two new events
  -- Scan Again taps `qrlogin_verify_scan_again`
  -- Failure messages with error `qrlogin_verify_failed` with `error` property
- Moves the collection location for `qrlogin_verify_displayed`  


**Prior to testing this PR you will need to**
- Laptop needs to be sandboxed (Android device does not need to be sandboxed)
- Have access to the "Calypso live (direct link)" in the related Calypso PR: https://github.com/Automattic/wp-calypso/pull/63257
- Access to a test account that is whitelisted for the above - **DM me and we can pair on this**
- A physical device for testing

**To Test**
Pre-req I: Setting the Feature Flag
-Install the **Jetpack** app (The feature is disabled on WordPress)
-Login using a WP.com account (not an automattic account or one with 2FA)
-Navigate to Me -> App Settings -> Privacy Settings -> Turn on the Collect Information slider
-Navigate back to Me -> App Settings -> Debug Settings
-Enable QRCodeAuthFlowFeatureConfig
-Restart the App

Pre-req II: Auto-verify the Android 12 link (if you are using an Android 12 devices for testing)
Because these tests use the alpha version of the apps, we have to manually verify the apps.wordpress.com link for devices running Android 12
- Navigate to the Manage Apps area on your device
- Navigate to **Jeptack** Alpha build from this PR
- Scroll down to the Open By Default and tap to make changes
- Ensure "open Supported Links" is turned on
- Tap the +Add link
- Select 'apps.wordpress.com' from the list


Test A: Entry to flow from deep link tap
- Run pre-req
- Background the app or kill the process
- Use one of the following methods to launch the link
- (1) Send this device an email or slack DM with the following link: P7jrAc-g-p2?campaign=login-qr-code#qr-code-login?token=XXXX&data=XXXXX
- (2) Use adb command
- Run adb devices -l (to get the name of the device)
- Run adb -s **NAME_OF_DEVICE** shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d "P7jrAc-i-p2?campaign=login-qr-code#qr-code-login"
- NOTE: This is an invalid code and doesn't matter for this portion of the test
- The app will display `Could not validate the log in code' view
- ✅ Verify the logs contain 🔵 Tracked: qrlogin_verify_displayed, Properties: {"origin":"deep_link"}
- ✅ Verify the logs contain 🔵 Tracked: qrlogin_verify_failed, Properties: {"error":"invalid_data","origin":"deep_link"}
- Click on *Scan Again*
- ✅ Verify the logs contain 🔵 Tracked: qrlogin_verify_scan_again, Properties: {"origin":"deep_link"}

Test B:  Entry to flow from menu tap
- Run pre-req
- Navigate to Me
- Tap the Scan Login Code option
- Scan the attached (invalid) qr code
- The app will display `Could not validate the log in code' view
- ✅ Verify the logs contain 🔵 Tracked: qrlogin_verify_displayed, Properties: {"origin":"menu"}
- ✅ Verify the logs contain 🔵 Tracked: qrlogin_verify_failed, Properties: {"error":"invalid_data","origin":"menu"}
- Click on *Scan Again*
- ✅ Verify the logs contain 🔵 Tracked: qrlogin_verify_scan_again, Properties: {"origin":"menu"}

![WP QRCode](https://user-images.githubusercontent.com/506707/174796920-589f98ba-14e0-413c-a579-1bb7830c53e0.png)


## Regression Notes
1. Potential unintended areas of impact
The wrong events are collected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and automated tests

3. What automated tests I added (or what prevented me from doing so)
Added new tests to QRCodeAuthViewModelTest

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.