### PR TITLE
Update grow action card course link

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -244,7 +244,7 @@ class StatsNavigator @Inject constructor(
             is CheckCourse -> {
                 ActivityLauncher.openStatsUrl(
                         activity,
-                        "https://wordpress.com/support/followers/"
+                        "https://wpcourses.com/course/intro-to-blogging/"
                 )
             }
             is SchedulePost -> {


### PR DESCRIPTION
This update the link of CHECK THE COURSE button on the grow action card. The new link is https://wpcourses.com/course/intro-to-blogging/

To test:

Setup:

- Select Debug Settings
- Find StatsRevampV2FeatureConfig under Features in development enable it and restart app
- Launch / Re-Launch app
- Go to Stats either using quick links or menu 
- Switch to Insights tab if necessary
- Make sure **Total Followers** card is visible on Insights tab. If it's not present then add it through stats management using either [+ add new stats card ] at the bottom or clicking ⚙️ icon at the top right hand corner.

Test

- A **Grow action card** as appears below **Total Followers** card 
- Click on the CHECK THE COURSE, it should open https://wpcourses.com/course/intro-to-blogging/
- NOTE: The guide only appears if total followers <= 1

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
