### PR TITLE
fix: Image block preserves alt text from media library

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 20.2
 -----
 * [*] Added heic/heif image format support [https://github.com/wordpress-mobile/WordPress-Android/pull/16773]
+* [*] Block Editor: Image block copies the alt text from the media library when selecting an item [https://github.com/wordpress-mobile/WordPress-Android/pull/16787]
 
 20.1
 -----

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -50,6 +50,7 @@ public class FluxCUtils {
         mediaModel.setTitle(file.getTitle());
         mediaModel.setDescription(file.getDescription());
         mediaModel.setCaption(file.getCaption());
+        mediaModel.setAlt(file.getAlt());
         mediaModel.setMediaId(file.getMediaId() != null ? Long.valueOf(file.getMediaId()) : 0);
         mediaModel.setId(file.getId());
         mediaModel.setUploadState(file.getUploadState());
@@ -75,6 +76,7 @@ public class FluxCUtils {
         mediaFile.setTitle(media.getTitle());
         mediaFile.setDescription(media.getDescription());
         mediaFile.setCaption(media.getCaption());
+        mediaFile.setAlt(media.getAlt());
         mediaFile.setUploadState(media.getUploadState());
         mediaFile.setVideo(org.wordpress.android.fluxc.utils.MediaUtils.isVideoMimeType(media.getMimeType()));
         mediaFile.setVideoPressShortCode(ShortcodeUtils.getVideoPressShortcodeFromId(media.getVideoPressGuid()));

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.14.0'
-    gutenbergMobileVersion = '4976-b19d629a82ec02e26f2edffc06c3b5e50ca5848b'
+    gutenbergMobileVersion = '4976-cabb76159a879bd44e2d55eaa265d85c1dd51048'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.14.0'
-    gutenbergMobileVersion = 'v1.79.0-alpha1'
+    gutenbergMobileVersion = 'v1.79.0-alpha2'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.5.0'
     wordPressLoginVersion = '0.14.0'
-    gutenbergMobileVersion = 'v1.78.1'
+    gutenbergMobileVersion = '4976-b19d629a82ec02e26f2edffc06c3b5e50ca5848b'
     storiesVersion = '1.3.0'
     aboutAutomatticVersion = '0.0.5'
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1249,11 +1249,13 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             int mediaId = isNetworkUrl ? Integer.valueOf(mediaEntry.getValue().getMediaId())
                     : mediaEntry.getValue().getId();
             String url = isNetworkUrl ? mediaEntry.getKey() : "file://" + mediaEntry.getKey();
+            String test = mediaEntry.getValue().getAlt();
             rnMediaList.add(createRNMediaUsingMimeType(mediaId,
                     url,
                     mediaEntry.getValue().getMimeType(),
                     mediaEntry.getValue().getCaption(),
-                    mediaEntry.getValue().getTitle()));
+                    mediaEntry.getValue().getTitle(),
+                    mediaEntry.getValue().getAlt()));
         }
 
         getGutenbergContainerFragment().appendMediaFiles(rnMediaList);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1249,7 +1249,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             int mediaId = isNetworkUrl ? Integer.valueOf(mediaEntry.getValue().getMediaId())
                     : mediaEntry.getValue().getId();
             String url = isNetworkUrl ? mediaEntry.getKey() : "file://" + mediaEntry.getKey();
-            String test = mediaEntry.getValue().getAlt();
             rnMediaList.add(createRNMediaUsingMimeType(mediaId,
                     url,
                     mediaEntry.getValue().getMimeType(),


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4977. When the alt text for a media item is present in the media library, copy the alt text into the Image block when the media item is selected. The changes in this PR ensure the alt text value is exposed to the block editor.

To test: See steps outlined in https://github.com/WordPress/gutenberg/pull/41839.

## Regression Notes
1. Potential unintended areas of impact
  Inserting various types of media may break. 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
  Manually tested inserting various media blocks within the editor. 
3. What automated tests I added (or what prevented me from doing so)
  None, majority of work and automated testing placed in Gutenberg. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
