### PR TITLE
Fix: Cannot choose reader topics in some languages

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 20.2
 -----
 * [*] Added heic/heif image format support [https://github.com/wordpress-mobile/WordPress-Android/pull/16773]
+* [*] Fix reader tags cannot be followed in some languages bug [https://github.com/wordpress-mobile/WordPress-Android/pull/16789]
 
 20.1
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -25,6 +25,7 @@ import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.UrlUtils;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -132,12 +133,27 @@ public class ReaderUtils {
             return "";
         }
 
-        return title.trim()
-                    .replaceAll("&[^\\s]*;", "") // remove html entities
-                    .replaceAll("[\\.\\s]+", "-") // replace periods and whitespace with a dash
-                    .replaceAll("[^\\p{L}\\p{Nd}\\-]+",
-                            "") // remove remaining non-alphanum/non-dash chars (Unicode aware)
-                    .replaceAll("--", "-"); // reduce double dashes potentially added above
+        String trimmedTitle = title.trim();
+        if (isValidUrlEncodedString(trimmedTitle)) {
+            return trimmedTitle;
+        } else {
+            return trimmedTitle
+                        .replaceAll("&[^\\s]*;", "") // remove html entities
+                        .replaceAll("[\\.\\s]+", "-") // replace periods and whitespace with a dash
+                        .replaceAll("[^\\p{L}\\p{Nd}\\-]+",
+                                "") // remove remaining non-alphanum/non-dash chars (Unicode aware)
+                        .replaceAll("--", "-"); // reduce double dashes potentially added above
+        }
+    }
+
+    @NonNull
+    private static boolean isValidUrlEncodedString(String title) {
+        try {
+            URI.create(title);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+        return true;
     }
 
     /*

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
@@ -108,4 +108,25 @@ class ReaderUtilsTest {
         var result = ReaderUtils.isExternalFeed(blogId, feedId)
         assertThat(result).isEqualTo(false)
     }
+
+    @Test
+    fun `given valid url encoded string, when sanitize string is invoked, then string is not sanitized`() {
+        val urlEncodedString = "%e7%be%8e%e9%a3%9f"
+        val result = ReaderUtils.sanitizeWithDashes(urlEncodedString)
+        assertThat(result).isEqualTo(urlEncodedString)
+    }
+
+    @Test
+    fun `given string with spaces, when sanitize string is invoked, then string is sanitized`() {
+        val stringWithSpaces = "string with spaces"
+        val result = ReaderUtils.sanitizeWithDashes(stringWithSpaces)
+        assertThat(result).isEqualTo("string-with-spaces")
+    }
+
+    @Test
+    fun `given non-alphanum string without url encoding, when sanitize string is invoked, then string is sanitized `() {
+        val nonUrlEncodedString = "non%url*encoded<?string"
+        val result = ReaderUtils.sanitizeWithDashes(nonUrlEncodedString)
+        assertThat(result).isEqualTo("nonurlencodedstring")
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
@@ -81,7 +81,7 @@ class ReaderUtilsTest {
     fun `when blogId == feedId then this is a feed`() {
         val feedId: Long = 100
         val blogId: Long = 100
-        var result = ReaderUtils.isExternalFeed(blogId, feedId)
+        val result = ReaderUtils.isExternalFeed(blogId, feedId)
         assertThat(result).isEqualTo(true)
     }
 
@@ -89,7 +89,7 @@ class ReaderUtilsTest {
     fun `when blogId == 0 and feedId is not equal to 0 then this is a feed`() {
         val feedId: Long = 100
         val blogId: Long = 0
-        var result = ReaderUtils.isExternalFeed(blogId, feedId)
+        val result = ReaderUtils.isExternalFeed(blogId, feedId)
         assertThat(result).isEqualTo(true)
     }
 
@@ -97,7 +97,7 @@ class ReaderUtilsTest {
     fun `when blogId is != 0 and feedId !=0 this is not a feed`() {
         val feedId: Long = 100
         val blogId: Long = 150
-        var result = ReaderUtils.isExternalFeed(blogId, feedId)
+        val result = ReaderUtils.isExternalFeed(blogId, feedId)
         assertThat(result).isEqualTo(false)
     }
 
@@ -105,7 +105,7 @@ class ReaderUtilsTest {
     fun `when blogId is != 0 and feedId ==0 this is not a feed`() {
         val feedId: Long = 0
         val blogId: Long = 150
-        var result = ReaderUtils.isExternalFeed(blogId, feedId)
+        val result = ReaderUtils.isExternalFeed(blogId, feedId)
         assertThat(result).isEqualTo(false)
     }
 


### PR DESCRIPTION
Fixes #16237

This PR fixes a bug where a valid URL encoded tag with % symbols was sanitized to remove % symbols making it an invalid URL encoded tag and causing issues in following the tag.

See https://github.com/wordpress-mobile/WordPress-Android/issues/16237#issuecomment-1161776816 for more details.

/cc @thehenrybyrd 

To test:

Test.1 - Follow/ unfollow a topic in a language like Chinese (Taiwan)

1. Head to Reader > ⚙️ > Followed Topics and unfollow any topics you currently follow. (Alternatively, login to an account with no followed topics)
2. Head to My Site > Me > App Settings and change Interface Language to a language reported in the linked issue such as Chinese (Taiwan).
3. Back in Reader, choose the Discover tab (second tab from the left), and tap the "Get Started" button (the blue button in the middle of the tab when no topics are followed).
4. Select a few topics and tap the button at the bottom.
5. Note that the topics are followed.
6. Unfollow a topic.
7. Note that the topic is unfollowed.

https://user-images.githubusercontent.com/1405144/174952935-84fb0d21-448c-45d5-bc6f-69e6329859c2.mp4

Test.2 - Add a topic with invalid characters

1. On the `Reader` tab, tap on the `Setting` menu (⚙️ icon) on the top to open "Manage Topics & Sites" screen.
2. Add a tag with invalid characters on "Manage Topics & Sites" screen.
3. Notice a toast is shown that the tag is invalid.

https://user-images.githubusercontent.com/1405144/174953762-8acda3a4-aaa3-48d9-a561-05bc9897b005.mp4

Test.3 - Add a topic with spaces

1. On the `Reader` tab, tap on the `Setting` menu (⚙️ icon) on the top to open "Manage Topics & Sites" screen.
2. Add a tag with spaces on "Manage Topics & Sites" screen.
3. Notice that the tag is sanitized with dashes and followed. 

https://user-images.githubusercontent.com/1405144/174954943-8973ea9a-995f-47cd-b07a-29b210949555.mp4

## Regression Notes
1. Potential unintended areas of impact
Strings that are not URL encoded should be sanitized with dashes.

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually. See "To test" section.

6. What automated tests I added (or what prevented me from doing so)
Added string sanitization tests in `ReaderUtilsTest`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
