### PR TITLE
QRCode Auth: Add Jetpack AndroidManifest 

### DIFF
--- a/WordPress/src/jetpack/AndroidManifest.xml
+++ b/WordPress/src/jetpack/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <!-- Deep Linking Activity -->
-        <activity android:name=".ui.deeplinks.DeepLinkingIntentReceiverActivity">
+        <activity android:name="org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 

--- a/WordPress/src/jetpack/AndroidManifest.xml
+++ b/WordPress/src/jetpack/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <!-- Deep Linking Activity -->
+        <activity android:name=".ui.deeplinks.DeepLinkingIntentReceiverActivity">
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="apps.wordpress.com"
+                    android:pathPattern="/get/.*"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -387,7 +387,7 @@
 
         <!-- Deep Linking Activity -->
         <activity
-            android:name=".ui.deeplinks.DeepLinkingIntentReceiverActivity"
+            android:name="org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity"
             android:theme="@style/WordPress.NoActionBar"
             android:excludeFromRecents="true"
             android:exported="true">

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -390,8 +390,7 @@
             android:name=".ui.deeplinks.DeepLinkingIntentReceiverActivity"
             android:theme="@style/WordPress.NoActionBar"
             android:excludeFromRecents="true"
-            android:exported="true"
-            tools:node="merge">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -390,7 +390,8 @@
             android:name=".ui.deeplinks.DeepLinkingIntentReceiverActivity"
             android:theme="@style/WordPress.NoActionBar"
             android:excludeFromRecents="true"
-            android:exported="true">
+            android:exported="true"
+            tools:node="merge">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -465,13 +466,7 @@
                     android:pathPattern="/notifications/.*"
                     android:scheme="http" />
 
-                <data
-                    android:host="apps.wordpress.com"
-                    android:pathPattern="/get/.*"
-                    android:scheme="https" />
-
             </intent-filter>
-
         </activity>
 
         <!-- Reader Activities -->


### PR DESCRIPTION
Parent #16481 

This PR adds a brand new `AndroidManifest.xml` for Jetpack builds. This is to limit the handling of `apps.wordpress.com` deeplinks to the Jeptack App only. This will support the new qrcode auth flow.

> **NOTE** : Maybe this is a bad idea - opinions and suggestions are welcome, which is why I added a few folks to review. Thanks.

I had coded the solution to support the QRCode auth deeplink into the existing `DeepLinkingIntentReceiverActivity`, but when doing some further testing I noticed that the `apps.wordpress.com` links would also be valid in WordPress which is not the behavior we want.

I chose to implement a new manifest for Jetpack. This works well; however my only concern is that when changing the buildVariant in AS from Jetpack debug to WordPress debug, the Jetpack manifest shows a red line under the `DeepLinkingIntentReceiverActivity` entry. It passes all lint checks locally, once this PR has been submitted, I'll see if CI picks it up. Who knows, maybe this is okay. [Update - no red flags from CI]

Another option is to create a distinct deeplink receiver in Jetpack; however I would still need to add a new manifest for Jetpack. Right now, it feels like it should be handled with a configuration change. Plus as we move forward with the WP to JP migration, we'll need to come up with a robust strategy to handle more than just this single deeplink. Who knows, we may even split JP out of WP code base. 😉 

Other things I tried:
- Replacing the entire `data` elements of the intent filter with manifest placeholder, but that didn't work. Immediately 'Missing data element' errors were displayed. In my brain, this would have been my preferred choice. I might spend a couple of more hours on it, but not sure if I'll be able to change the outcome.
- Replacing the individual pieces of `data` element with manifest placeholders. Empty placeholders for WordPress and valid placeholders for Jetpack. It worked as expected, but it felt hacky to me. This solution would eliminate a separate manifest for Jetpack. 
- `                <data
                    android:host="${apps_deepLinks_host}"
                    android:pathPattern="${apps_deepLinks_path}"
                    android:scheme="${apps_deepLinks_scheme}" />`



**To test:**
- Download an install both versions of the attached APK's (jetpack & wordpress)
- Navigate to the Manage Apps area on your device
- Navigate to WordPress Alpha app
- Scroll down to the Open By Default and tap to make changes
- Ensure "open Supported Links" is turned on
- Tap the +Add link
- ✅ Verify that 'apps.wordpress.com' is not included in the list 
<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/175072539-41ee10ae-b032-4e81-8079-a8a887efc6be.png">

- Return to Manage Apps area on your device
- Navigate to Jetpack Alpha app
- Scroll down to the Open By Default and tap to make changes
- Ensure "open Supported Links" is turned on
- Tap the +Add link
- ✅ Verify that 'apps.wordpress.com' is included in the list 
<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/175072365-b6bc53e8-9d06-4551-b94f-28cec492648e.png">

Further Reading: https://developer.android.com/studio/build/manage-manifests

## Regression Notes
1. Potential unintended areas of impact
Neither app builds correctly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc: @AliSoftware - I added you as a reviewer to see if there would be any impact to the build process with the extra manifest and merge.

