### PR TITLE
[UI Tests] Addressing failures in `allDayStatsLoad` and `helpCanBeOpenedWhileEnteringEmail`

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -23,7 +23,7 @@ public class ContactUsTests extends BaseTest {
 
     @After
     public void tearDown() {
-        pressBackUntilElementIsDisplayed(R.id.continue_with_wpcom_button);
+        //pressBackUntilElementIsDisplayed(R.id.continue_with_wpcom_button);
     }
 
     @Test

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -1,16 +1,13 @@
 package org.wordpress.android.e2e;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.wordpress.android.R;
 import org.wordpress.android.e2e.flows.LoginFlow;
 import org.wordpress.android.e2e.pages.ContactSupportScreen;
 import org.wordpress.android.support.BaseTest;
 
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
-import static org.wordpress.android.support.WPSupportUtils.pressBackUntilElementIsDisplayed;
 
 import dagger.hilt.android.testing.HiltAndroidTest;
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -21,11 +21,6 @@ public class ContactUsTests extends BaseTest {
         logoutIfNecessary();
     }
 
-    @After
-    public void tearDown() {
-        //pressBackUntilElementIsDisplayed(R.id.continue_with_wpcom_button);
-    }
-
     @Test
     public void sendButtonEnabledWhenTextIsEntered() {
         try {

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.longClickOn;
+import static org.wordpress.android.support.WPSupportUtils.sleep;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 
 public class MySitesPage {
@@ -86,6 +87,11 @@ public class MySitesPage {
         waitForElementToBeDisplayedWithoutFailure(
                 onView(withId(R.id.tabLayout))
         );
+
+        // Stats are opened with the last selected tab active (or `Insights` by default)
+        // Since we don't know what was the last used tab, we're using a "dumb" wait
+        // instead of the conditional wait (e.g. waiting for a certain tab element to appear).
+        sleep(2);
 
         return new StatsPage();
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -8,6 +8,7 @@ import androidx.test.espresso.ViewInteraction;
 
 import org.hamcrest.Matcher;
 import org.wordpress.android.R;
+import org.wordpress.android.support.WPSupportUtils;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -22,7 +23,6 @@ import static org.hamcrest.Matchers.allOf;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.longClickOn;
-import static org.wordpress.android.support.WPSupportUtils.sleep;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 
 public class MySitesPage {
@@ -91,7 +91,7 @@ public class MySitesPage {
         // Stats are opened with the last selected tab active (or `Insights` by default)
         // Since we don't know what was the last used tab, we're using a "dumb" wait
         // instead of the conditional wait (e.g. waiting for a certain tab element to appear).
-        sleep(2);
+        WPSupportUtils.sleep();
 
         return new StatsPage();
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.java
@@ -23,10 +23,13 @@ import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDis
 
 public class StatsPage {
     public StatsPage openDayStats() {
-        onView(allOf(
+        ViewInteraction daysStatsTab = onView(allOf(
                 withText("Days"),
                 isDescendantOfA(withId(R.id.tabLayout))
-        )).perform(ViewActions.click());
+        ));
+
+        waitForElementToBeDisplayedWithoutFailure(daysStatsTab);
+        daysStatsTab.perform(ViewActions.click());
 
         waitForElementToBeDisplayedWithoutFailure(
                 onView(withText("Posts and Pages"))


### PR DESCRIPTION
### Reason

There's a tendency of [UI tests fails](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/32107/workflows/e60c77cf-c657-4600-ad6c-2f25eca0168a/jobs/125408) in Firebase Test Lab. It appears that the fails occur while executing `StatsTests.allDayStatsLoad()` and `ContactUsTests.helpCanBeOpenedWhileEnteringEmail()` only, from what I've seen.

### Fix

Unfortunately, these fails were never reproducible for me locally, and were not even reproducible on CI while I was running from the current branch. From watching the execution videos and checking the logs, it looks like:

- `allDayStatsLoad` fails because Espresso tries to tap `Days` tab in `Stats` too early after opening `Stats`, which results in the test staying on `Insights` tab instead of the `Days` tab. This was addressed by: (1) Waiting for `Stats` screen to load unconditionally ([explained here why](https://github.com/wordpress-mobile/WordPress-Android/pull/16799/files#r906027184)), (2) waiting for `Days` tab to appear before tapping it (conditional wait).
- `helpCanBeOpenedWhileEnteringEmail` crashes the app during the teardown phase, while tapping back button. It looks like having a teardown is not necessary for `ContactUsTests` tests, because none of them logs in, and the app is relaunched before every test, so `tearDown` was removed for these tests, which hopefully also "removed" the crash on pressing back.

### To test:

- You might want to run all UI tests locally and see them passing
- Alternatively, you can see them passing in the current PR on CI. The Firebase [results](https://console.firebase.google.com/u/1/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670/matrices/8703609483721319743/details?stepId=bs.df8e0d6c368fe26f&testCaseId=26) show no reruns.