### PR TITLE
Issue/site based bp skipping

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1197,20 +1197,24 @@ class MySiteViewModel @Inject constructor(
     }
 
     private fun onBloggingPromptSkipClicked() {
-        appPrefsWrapper.setSkippedPromptDay(Date())
-        mySiteSourceManager.refreshBloggingPrompts(true)
+        selectedSiteRepository.getSelectedSite()?.let { site ->
+            val siteId = site.localId().value
 
-        val snackbar = SnackbarMessageHolder(
-                message = UiStringRes(R.string.my_site_blogging_prompt_card_skipped_snackbar),
-                buttonTitle = UiStringRes(R.string.undo),
-                buttonAction = {
-                    appPrefsWrapper.setSkippedPromptDay(null)
-                    mySiteSourceManager.refreshBloggingPrompts(true)
-                },
-                isImportant = true
-        )
+            appPrefsWrapper.setSkippedPromptDay(Date(), siteId)
+            mySiteSourceManager.refreshBloggingPrompts(true)
 
-        _onSnackbarMessage.postValue(Event(snackbar))
+            val snackbar = SnackbarMessageHolder(
+                    message = UiStringRes(R.string.my_site_blogging_prompt_card_skipped_snackbar),
+                    buttonTitle = UiStringRes(R.string.undo),
+                    buttonAction = {
+                        appPrefsWrapper.setSkippedPromptDay(null, siteId)
+                        mySiteSourceManager.refreshBloggingPrompts(true)
+                    },
+                    isImportant = true
+            )
+
+            _onSnackbarMessage.postValue(Event(snackbar))
+        }
     }
 
     fun isRefreshing() = mySiteSourceManager.isRefreshing()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
@@ -148,7 +148,7 @@ class BloggingPromptCardSource @Inject constructor(
         val isPotentialBloggingSite = selectedSite.isPotentialBloggingSite
         val isPromptReminderOptedIn = bloggingRemindersStore.bloggingRemindersModel(selectedSite.localId().value)
                 .firstOrNull()?.isPromptIncluded == true
-        val promptSkippedDate = appPrefsWrapper.getSkippedPromptDay()
+        val promptSkippedDate = appPrefsWrapper.getSkippedPromptDay(selectedSite.localId().value)
 
         val isPromptSkippedForToday = promptSkippedDate != null && isSameDay(promptSkippedDate, Date())
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -1394,20 +1394,24 @@ public class AppPrefs {
         setBoolean(DeletablePrefKey.MY_SITE_DEFAULT_TAB_EXPERIMENT_VARIANT_ASSIGNED, true);
     }
 
-    public static Date getSkippedPromptDay() {
-        long promptSkippedMillis = getLong(DeletablePrefKey.SKIPPED_BLOGGING_PROMPT_DAY);
+    public static Date getSkippedPromptDay(int siteId) {
+        long promptSkippedMillis = prefs().getLong(getSkippedBloggingPromptDayConfigKey(siteId), 0);
         if (promptSkippedMillis == 0) {
             return null;
         }
         return new Date(promptSkippedMillis);
     }
 
-    public static void setSkippedPromptDay(@Nullable Date date) {
+    public static void setSkippedPromptDay(@Nullable Date date, int siteId) {
         if (date == null) {
-            remove(DeletablePrefKey.SKIPPED_BLOGGING_PROMPT_DAY);
+            prefs().edit().remove(getSkippedBloggingPromptDayConfigKey(siteId)).apply();
             return;
         }
-        setLong(DeletablePrefKey.SKIPPED_BLOGGING_PROMPT_DAY, date.getTime());
+        prefs().edit().putLong(getSkippedBloggingPromptDayConfigKey(siteId), date.getTime()).apply();
+    }
+
+    @NonNull private static String getSkippedBloggingPromptDayConfigKey(int siteId) {
+        return DeletablePrefKey.SKIPPED_BLOGGING_PROMPT_DAY.name() + siteId;
     }
 
     public static void setInitialScreenFromMySiteDefaultTabExperimentVariant(String variant) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -229,9 +229,9 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun getMySiteInitialScreen(): String = AppPrefs.getMySiteInitialScreen()
 
-    fun setSkippedPromptDay(date: Date?) = AppPrefs.setSkippedPromptDay(date)
+    fun setSkippedPromptDay(date: Date?, siteId: Int) = AppPrefs.setSkippedPromptDay(date, siteId)
 
-    fun getSkippedPromptDay(): Date? = AppPrefs.getSkippedPromptDay()
+    fun getSkippedPromptDay(siteId: Int): Date? = AppPrefs.getSkippedPromptDay(siteId)
 
     fun markBloggingPromptOnboardingDialogAsDisplayed() = AppPrefs.setShouldDisplayBloggingPromptOnboarding(false)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1655,7 +1655,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
                 requireNotNull(onBloggingPromptSkipClicked).invoke()
 
-                verify(appPrefsWrapper).setSkippedPromptDay(any())
+                verify(appPrefsWrapper).setSkippedPromptDay(any(), any())
                 verify(mySiteSourceManager).refreshBloggingPrompts(eq(true))
 
                 assertThat(snackbars.size).isEqualTo(1)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompt/BloggingPromptCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompt/BloggingPromptCardSourceTest.kt
@@ -97,7 +97,7 @@ class BloggingPromptCardSourceTest : BaseUnitTest() {
     private fun setUpMocks(isBloggingPromptFeatureEnabled: Boolean) {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(isBloggingPromptFeatureEnabled)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
-        whenever(appPrefsWrapper.getSkippedPromptDay()).thenReturn(null)
+        whenever(appPrefsWrapper.getSkippedPromptDay(any())).thenReturn(null)
         whenever(bloggingRemindersStore.bloggingRemindersModel(any())).thenReturn(flowOf(bloggingReminderSettings))
     }
 
@@ -181,7 +181,7 @@ class BloggingPromptCardSourceTest : BaseUnitTest() {
     @Test
     fun `given build is invoked, when prompt is skipped, then empty state is loaded`() = test {
         val result = mutableListOf<BloggingPromptUpdate>()
-        whenever(appPrefsWrapper.getSkippedPromptDay()).thenReturn(Date())
+        whenever(appPrefsWrapper.getSkippedPromptDay(any())).thenReturn(Date())
         bloggingPromptCardSource.refresh.observeForever { }
 
         bloggingPromptCardSource.build(testScope(), SITE_LOCAL_ID).observeForever { it?.let { result.add(it) } }


### PR DESCRIPTION
This PR allows blogging prompt skipping on per-site basis.
 
To test:
- Using JP app, skip a blogging prompt. Confirm that the card is not visible.
- Switch to a different site and confirm that the blogging prompt card is visible.
- Switch back to original site and confirm that the card is still not visible.
- Move the device clock one day ahead and return to the app.
- Confirm that the blogging prompt card is visible after dashboard refresh.


## Regression Notes
1. Potential unintended areas of impact
Skipping logic is compromised in some way.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing tests.

3. What automated tests I added (or what prevented me from doing so)
Relying on existing tests.


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
