### PR TITLE
[Blogging prompts v1] Increase "?" buttons area for compact card and reminder dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewHolder.kt
@@ -179,7 +179,7 @@ sealed class BloggingRemindersViewHolder<T : ViewBinding>(protected val binding:
         fun onBind(item: PromptSwitch) = with(binding) {
             includePromptSwitch.isChecked = item.isToggled
             includePromptSwitch.setOnCheckedChangeListener { _, _ -> item.onClick.click() }
-            promptHelpButton.setOnClickListener { item.onHelpClick.click() }
+            promptHelpButtonContainer.setOnClickListener { item.onHelpClick.click() }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/CompactBloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/CompactBloggingPromptCardViewHolder.kt
@@ -25,7 +25,7 @@ class CompactBloggingPromptCardViewHolder(
         answerButton.setOnClickListener {
             action.onClickAction?.invoke(action.promptId)
         }
-        promptHelpButton.setOnClickListener {
+        promptHelpButtonContainer.setOnClickListener {
             action.onHelpAction?.invoke()
         }
         uiHelpers.updateVisibility(answeredButton, action.isAnswered)

--- a/WordPress/src/main/res/layout/blogging_prompt_card_compact.xml
+++ b/WordPress/src/main/res/layout/blogging_prompt_card_compact.xml
@@ -42,16 +42,24 @@
                 android:textAlignment="viewStart"
                 android:textAppearance="?attr/textAppearanceSubtitle1" />
 
-            <ImageView
-                android:id="@+id/prompt_help_button"
-                android:layout_width="@dimen/blogging_prompt_card_compact_help_button_size"
-                android:layout_height="@dimen/blogging_prompt_card_compact_help_button_size"
-                android:layout_gravity="center_vertical"
+            <LinearLayout
+                android:id="@+id/prompt_help_button_container"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:layout_marginStart="@dimen/margin_small_medium"
                 android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/blogging_reminders_prompt_help_button_desc"
-                android:src="@drawable/ic_help_outline_white_24dp"
-                android:tint="?attr/wpColorOnSurfaceMedium" />
+                android:padding="@dimen/margin_small">
+
+                <ImageView
+                    android:layout_width="@dimen/blogging_prompt_card_compact_help_button_size"
+                    android:layout_height="@dimen/blogging_prompt_card_compact_help_button_size"
+                    android:layout_gravity="center_vertical"
+                    android:contentDescription="@string/blogging_reminders_prompt_help_button_desc"
+                    android:src="@drawable/ic_help_outline_white_24dp"
+                    android:tint="?attr/wpColorOnSurfaceMedium" />
+
+            </LinearLayout>
 
         </LinearLayout>
 

--- a/WordPress/src/main/res/layout/blogging_reminders_prompt_switch.xml
+++ b/WordPress/src/main/res/layout/blogging_reminders_prompt_switch.xml
@@ -38,18 +38,26 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <ImageView
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:contentDescription="@string/blogging_reminders_prompt_help_button_desc"
-        android:id="@+id/prompt_help_button"
-        android:layout_width="@dimen/blogging_reminders_prompt_help_buttons_size"
-        android:layout_height="@dimen/blogging_reminders_prompt_help_buttons_size"
+    <LinearLayout
+        android:id="@+id/prompt_help_button_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
         android:layout_marginStart="@dimen/margin_small_medium"
-        android:src="@drawable/ic_help_outline_white_24dp"
-        android:tint="?attr/wpColorOnSurfaceMedium"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:padding="@dimen/margin_small"
         app:layout_constraintBottom_toBottomOf="@+id/prompt_switch_title"
         app:layout_constraintStart_toEndOf="@+id/prompt_switch_title"
-        app:layout_constraintTop_toTopOf="@+id/prompt_switch_title" />
+        app:layout_constraintTop_toTopOf="@+id/prompt_switch_title">
+
+        <ImageView
+            android:layout_width="@dimen/blogging_reminders_prompt_help_buttons_size"
+            android:layout_height="@dimen/blogging_reminders_prompt_help_buttons_size"
+            android:contentDescription="@string/blogging_reminders_prompt_help_button_desc"
+            android:src="@drawable/ic_help_outline_white_24dp"
+            android:tint="?attr/wpColorOnSurfaceMedium" />
+
+    </LinearLayout>
 
     <View
         android:id="@+id/bottom_divider"


### PR DESCRIPTION
#16801 

To test:
Compact card
- Run JP variant
- Select a site that has blogging prompts enabled
- Open the home screen
- Tap on the FAB
- Tap on the "?" button: it should be easier to tap on it with the increased area

Reminder flow dialog
- Run JP variant
- Select a site that has blogging prompts enabled
- Open the home screen
- Tap on "MENU" tab
- Tap on "Site Settings"
- Tap on "Reminders and prompts"
- Tap on "Set reminders" in case there were no reminders set for this site yet
- Select any day of the week to display the "Include daily prompt" section
- Tap on the "?" button: it should be easier to tap on it with the increased area

## Regression Notes
1. Potential unintended areas of impact
The existing layout should not change because of the increased area of the buttons.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
