### PR TITLE
Fix line chart color problems

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/LineChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/LineChartViewHolder.kt
@@ -219,6 +219,7 @@ class LineChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             setAvoidFirstLastClipping(true)
             position = BOTTOM
             valueFormatter = LineChartLabelFormatter(thisWeekData)
+            textColor = ContextCompat.getColor(chart.context, R.color.neutral_30)
 
             removeAllLimitLines()
         }
@@ -256,7 +257,9 @@ class LineChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             color = ContextCompat.getColor(chart.context, SelectedType.getColor(selectedType))
 
             setDrawFilled(true)
-            fillDrawable = ContextCompat.getDrawable(chart.context, SelectedType.getFillDrawable(selectedType))
+            fillDrawable = ContextCompat.getDrawable(chart.context, SelectedType.getFillDrawable(selectedType))?.apply {
+                alpha = 26
+            }
         }
 
         val lastWeekDataSet = dataSets.last() as? LineDataSet

--- a/WordPress/src/main/res/drawable/bg_rectangle_stats_line_chart_blue_gradient.xml
+++ b/WordPress/src/main/res/drawable/bg_rectangle_stats_line_chart_blue_gradient.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
+    <corners android:radius="0dp" />
+
     <gradient
         android:angle="0"
-        android:startColor="@color/blue_5"
-        android:endColor="@color/blue_0"
-        android:type="linear"/>
-
-    <corners
-        android:radius="0dp"/>
+        android:endColor="@android:color/transparent"
+        android:startColor="@color/blue"
+        android:type="linear" />
 </shape>

--- a/WordPress/src/main/res/drawable/bg_rectangle_stats_line_chart_purple_gradient.xml
+++ b/WordPress/src/main/res/drawable/bg_rectangle_stats_line_chart_purple_gradient.xml
@@ -3,8 +3,8 @@
     android:shape="rectangle">
     <gradient
         android:angle="0"
-        android:startColor="@color/purple_5"
-        android:endColor="@color/purple_0"
+        android:startColor="@color/purple"
+        android:endColor="@android:color/transparent"
         android:type="linear"/>
 
     <corners

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -357,6 +357,7 @@
         <item name="android:drawablePadding">4dp</item>
         <item name="android:textColor">@color/blue_50</item>
         <item name="android:drawableStart">@drawable/bg_stats_legend_start</item>
+        <item name="android:drawableTint">@color/blue_50</item>
     </style>
     <style name="StatsLegendsPurple" parent="TextAppearance.MaterialComponents.Caption">
         <item name="android:layout_marginTop">24dp</item>


### PR DESCRIPTION
Fixes #16811

This updates line chart colors. It had some problems in dark mode.

|before|after|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/175395306-a640a1a7-ebda-4fe0-a567-d1fa24096784.png" width=320>|<img src="https://user-images.githubusercontent.com/2471769/175395390-3d17dae6-7f5e-4ef6-9f35-144d68afc2a1.png" width=320>|

To test:
1. Launch Jetpack app.
2. Enable StatsRevampv2FeatureConfig from Me > App Settings > Debug Settings and restart the app.
3. Enable dark mode from Me > App Settings > Appearance.
4. Go to Stats either using quick links or menu.
5. Switch to Insights tab if necessary.
6. Make sure Views & Visitors card is visible on Insights tab. If not present then add it through stats management using either [+ add new stats card ] at the bottom or clicking ⚙️ icon at the top right hand corner.
7. Ensure colors are good, and texts are redable.

## Regression Notes
1. Potential unintended areas of impact
Light mode.

8. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested light mode manually.

9. What automated tests I added (or what prevented me from doing so)
Checking colors in automated tests don't make sense.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
