### PR TITLE
Stats Revamp v2: Update this week's day count

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
@@ -127,7 +127,7 @@ class TotalStatsMapper @Inject constructor(
     private enum class TotalStatsType { LIKES, COMMENTS }
 
     companion object {
-        private const val DAY_COUNT_FOR_CURRENT_WEEK = 8 // Last 7 days + today
+        private const val DAY_COUNT_FOR_CURRENT_WEEK = 7 // Last 7 days
         private const val DAY_COUNT_FOR_PREVIOUS_WEEK = 7 // Last 7 days before the current week
         const val DAY_COUNT_TOTAL = DAY_COUNT_FOR_PREVIOUS_WEEK + DAY_COUNT_FOR_CURRENT_WEEK
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsMapper.kt
@@ -231,7 +231,7 @@ class ViewsAndVisitorsMapper
             value.toInt()
         }
 
-        val hasData = values.isNotEmpty() && values.size > 7
+        val hasData = values.isNotEmpty() && values.size >= 7
 
         val prevWeekData = if (hasData) values.subList(0, 7) else values.subList(0, values.size)
         val thisWeekData = if (hasData) values.subList(7, values.size) else emptyList()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
@@ -45,7 +45,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlin.math.ceil
 
-const val VIEWS_AND_VISITORS_ITEMS_TO_LOAD = 15
+const val VIEWS_AND_VISITORS_ITEMS_TO_LOAD = 14
 const val TOP_TIPS_URL = "https://wordpress.com/support/getting-more-views-and-traffic/"
 
 @Suppress("TooManyFunctions")
@@ -184,7 +184,6 @@ class ViewsAndVisitorsUseCase
             selectedDateProvider.selectDate(selectedDate, availableDates.takeLast(visibleLineCount), statsGranularity)
 
             val selectedItem = domainModel.dates.getOrNull(index) ?: domainModel.dates.last()
-            val previousItem = domainModel.dates.getOrNull(domainModel.dates.indexOf(selectedItem) - 1)
 
             items.add(
                     viewsAndVisitorsMapper.buildTitle(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
@@ -65,7 +65,7 @@ class TotalLikesUseCaseTest : BaseUnitTest() {
     private lateinit var useCase: TotalLikesUseCase
     private val periodData = PeriodData("2018-10-08", 10, 15, 20, 25, 30, 35)
     private val modelPeriod = "2018-10-10"
-    private val limitMode = Top(15)
+    private val limitMode = Top(14)
     private val model = VisitsAndViewsModel(modelPeriod, listOf(periodData))
 
     @InternalCoroutinesApi

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapperTest.kt
@@ -16,7 +16,7 @@ class TotalStatsMapperTest : BaseUnitTest() {
     @Mock lateinit var statsUtils: StatsUtils
     private lateinit var mapper: TotalStatsMapper
     private val previousWeekData = listOf(5L, 10, 15, 20, 25, 30, 35)
-    private val currentWeekData = listOf(40L, 45, 50, 55, 60, 65, 70, 75)
+    private val currentWeekData = listOf(40L, 45, 50, 55, 60, 65, 70)
     private val dates = (previousWeekData + currentWeekData).map {
         PeriodData("", 0, 0, it, 0, it, 0)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCaseTest.kt
@@ -66,7 +66,7 @@ class ViewsAndVisitorsUseCaseTest : BaseUnitTest() {
     private val siteId = 1L
     private val periodData = PeriodData("2018-10-08", 10, 15, 20, 25, 30, 35)
     private val modelPeriod = "2018-10-10"
-    private val limitMode = Top(15)
+    private val limitMode = Top(14)
     private val statsGranularity = DAYS
     private val model = VisitsAndViewsModel(modelPeriod, listOf(periodData))
 


### PR DESCRIPTION
This changes the current week's day count from 8 to 7, for charts in Views & Visitors, Total Likes, and Total Comments cards.

|before|after|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/175428363-6c92fc7a-0d35-4b46-8ee5-7fa0a68aed02.png" width=320>|<img src="https://user-images.githubusercontent.com/2471769/175428418-43e35e7b-41da-4a30-983d-dff43d9f04eb.png" width=320>|


To test:

Setup:

1. Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
2. Select Debug Settings
3. Find StatsRevampV2FeatureConfig under Features in development enable it and restart app
4. Launch / Re-Launch app
5. Go to Stats either using quick links or menu
6. Switch to Insights tab if necessary
7. Make sure Views & Visitors, Total Likes, Total Comments cards are visible on Insights tab. If not present then add it through stats management using either [+ add new stats card ] at the bottom or clicking ⚙️ icon at the top right hand corner.

Test:

1. Ensure the chart in Views & Visitors card has 7 days on the x-axis.
2. Ensure Total Likes card shows 7 days data. You can compare the data with the Overview card in the days tab.
3. Ensure Total Comments card shows 7 days data. You can compare the data with the Overview card in the days tab.

## Regression Notes
1. Potential unintended areas of impact
Charts.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested updated charts manually.

4. What automated tests I added (or what prevented me from doing so)
Only the day count is changed. No new test is added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
