### PR TITLE
Stats revamp v2 enable feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [*] Added heic/heif image format support [https://github.com/wordpress-mobile/WordPress-Android/pull/16773]
 * [***] Jetpack App: Allow WP.com users to sign in to their browsers by scanning a QR Code in the Jetpack Android App. [https://github.com/wordpress-mobile/WordPress-Android/issues/16481]
 * [*] Fix reader tags cannot be followed in some languages bug [https://github.com/wordpress-mobile/WordPress-Android/pull/16789]
+* [***] Jetpack App: Stats Insights Update. Helps you understand how your content is performing and what’s resonating with your audience. [https://github.com/wordpress-mobile/WordPress-Android/pull/16703]
 
 20.1
 -----

--- a/WordPress/src/main/java/org/wordpress/android/util/config/StatsRevampV2FeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/StatsRevampV2FeatureConfig.kt
@@ -1,17 +1,15 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-// TODO: Uncomment the lines 8 and 14 when remote field is configured and remove line 9 and this to-do
-// @Feature(StatsRevampV2FeatureConfig.STATS_REVAMP_V2_REMOTE_FIELD, false)
-@FeatureInDevelopment
+@Feature(StatsRevampV2FeatureConfig.STATS_REVAMP_V2_REMOTE_FIELD, true)
 class StatsRevampV2FeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.STATS_REVAMP_V2
-//        STATS_REVAMP_V2_REMOTE_FIELD
+        BuildConfig.STATS_REVAMP_V2,
+        STATS_REVAMP_V2_REMOTE_FIELD
 ) {
     companion object {
         const val STATS_REVAMP_V2_REMOTE_FIELD = "stats_revamp_v2_remote_field"


### PR DESCRIPTION
This PR updates feature config and also RELEASE_NOTES for Stats Revamp v2 project

The release notes only refers to one PR.  However, there are a number of PRs that makeup this feature

Review / Merging instructions:
- Merge this after all outstanding PRs for the feature are merged first 

Fixes #16816 

To test:

Test 1
- Install and Launch Jetpack app
- Navigate to Stats 
- Enure, the new Views and Visitors, Total Likes, Total Comments and Total Followers cards are shown in Insights tab

Test 2
- Install and Launch WordPress app
- Navigate to Stats
- Ensure, none of the new cards show up in Insights tab


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
N/A


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
