### PR TITLE
Stats revamp v2: Fix Views & Visitors problems

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import org.wordpress.android.R
-import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.DAY_STATS_USE_CASE
@@ -53,7 +52,7 @@ abstract class StatsListViewModel(
     protected val dateSelector: StatsDateSelector,
     popupMenuHandler: ItemPopupMenuHandler? = null,
     private val newsCardHandler: NewsCardHandler? = null,
-    private val actionCardHandler: ActionCardHandler? = null
+    actionCardHandler: ActionCardHandler? = null
 ) : ScopedViewModel(defaultDispatcher) {
     private var trackJob: Job? = null
     private var isInitialized = false
@@ -101,13 +100,14 @@ abstract class StatsListViewModel(
 
     override fun onCleared() {
         statsUseCase.onCleared()
+        dateSelector.clear()
         super.onCleared()
     }
 
     fun onScrolledToBottom() {
         if (trackJob?.isCompleted != false) {
             trackJob = launch {
-                analyticsTracker.track(AnalyticsTracker.Stat.STATS_SCROLLED_TO_BOTTOM)
+                analyticsTracker.track(Stat.STATS_SCROLLED_TO_BOTTOM)
                 delay(SCROLL_EVENT_DELAY)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCase.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapLegend
-import org.wordpress.android.ui.utils.ListItemInteraction.Companion.create
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularStatelessUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
@@ -32,6 +31,7 @@ import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
+import org.wordpress.android.ui.utils.ListItemInteraction.Companion.create
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
 import javax.inject.Inject
@@ -140,7 +140,7 @@ constructor(
                 )
             }
 
-            if (useCaseMode == BLOCK && domainModel.hasMore) {
+            if (useCaseMode != VIEW_ALL && domainModel.hasMore) {
                 items.add(
                         Link(
                                 text = R.string.stats_insights_view_more,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsMapper.kt
@@ -234,7 +234,7 @@ class ViewsAndVisitorsMapper
         val hasData = values.isNotEmpty() && values.size >= 7
 
         val prevWeekData = if (hasData) values.subList(0, 7) else values.subList(0, values.size)
-        val thisWeekData = if (hasData) values.subList(8, values.size) else emptyList()
+        val thisWeekData = if (hasData) values.subList(7, values.size) else emptyList()
 
         val prevWeekCount = prevWeekData.fold(0L) { acc, next -> acc + next }
         val thisWeekCount = thisWeekData.fold(0L) { acc, next -> acc + next }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
@@ -86,7 +86,7 @@ class ViewsAndVisitorsUseCase
         val cachedData = visitsAndViewsStore.getVisits(
                 statsSiteProvider.siteModel,
                 statsGranularity,
-                LimitMode.All
+                LimitMode.Top(VIEWS_AND_VISITORS_ITEMS_TO_LOAD)
         )
         if (cachedData != null) {
             logIfIncorrectData(cachedData, statsGranularity, statsSiteProvider.siteModel, false)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsMapperTest.kt
@@ -8,7 +8,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodData
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
@@ -25,14 +24,14 @@ class ViewsAndVisitorsMapperTest : BaseUnitTest() {
     @Mock lateinit var statsUtils: StatsUtils
     @Mock lateinit var contentDescriptionHelper: ContentDescriptionHelper
     private lateinit var mapper: ViewsAndVisitorsMapper
-    private val thisWeekViews: Long = 472
+    private val thisWeekViews: Long = 543
     private val prevWeekViews: Long = 323
-    private val thisWeekVisitors: Long = 145
+    private val thisWeekVisitors: Long = 174
     private val prevWeekVisitors: Long = 133
-    private val selectedItem = PeriodData("2022-04-19", 21, 9, 3, 0, 2, 0)
+    private val selectedItem = PeriodData("2022-04-18", 78, 28, 3, 0, 13, 2)
     private val viewsTitle = "Views"
     private val visitorsTitle = "Visitors"
-    private val printedDate = "19. 04. 2022"
+    private val printedDate = "18. 04. 2022"
     @Before
     fun setUp() {
         mapper = ViewsAndVisitorsMapper(statsDateFormatter, resourceProvider, statsUtils, contentDescriptionHelper)
@@ -54,9 +53,9 @@ class ViewsAndVisitorsMapperTest : BaseUnitTest() {
         )
 
         Assertions.assertThat(title.value1).isEqualTo(thisWeekViews.toString())
-        Assertions.assertThat(title.unit1).isEqualTo(R.string.stats_views)
+        Assertions.assertThat(title.unit1).isEqualTo(string.stats_views)
         Assertions.assertThat(title.value2).isEqualTo(prevWeekViews.toString())
-        Assertions.assertThat(title.unit2).isEqualTo(R.string.stats_views)
+        Assertions.assertThat(title.unit2).isEqualTo(string.stats_views)
     }
 
     @Test
@@ -71,9 +70,9 @@ class ViewsAndVisitorsMapperTest : BaseUnitTest() {
         )
 
         Assertions.assertThat(title.value1).isEqualTo(thisWeekVisitors.toString())
-        Assertions.assertThat(title.unit1).isEqualTo(R.string.stats_visitors)
+        Assertions.assertThat(title.unit1).isEqualTo(string.stats_visitors)
         Assertions.assertThat(title.value2).isEqualTo(prevWeekVisitors.toString())
-        Assertions.assertThat(title.unit2).isEqualTo(R.string.stats_visitors)
+        Assertions.assertThat(title.unit2).isEqualTo(string.stats_visitors)
     }
 
     @Test
@@ -87,18 +86,21 @@ class ViewsAndVisitorsMapperTest : BaseUnitTest() {
         whenever(contentDescriptionHelper.buildContentDescription(
                 eq(string.stats_views),
                 eq(0)
-        )).thenReturn(viewsContentDescription)
+        )
+        ).thenReturn(viewsContentDescription)
 
         val visitorsContentDescription = "visitors description"
-        whenever(contentDescriptionHelper.buildContentDescription(
-                eq(string.stats_visitors),
-                eq(1)
-        )).thenReturn(visitorsContentDescription)
+        whenever(
+                contentDescriptionHelper.buildContentDescription(
+                        eq(string.stats_visitors),
+                        eq(1)
+                )
+        ).thenReturn(visitorsContentDescription)
 
         val result = mapper.buildChips(onChipSelected, uiState.selectedPosition)
 
-        result.chips[0].assertChip(R.string.stats_views, viewsContentDescription)
-        result.chips[1].assertChip(R.string.stats_visitors, visitorsContentDescription)
+        result.chips[0].assertChip(string.stats_views, viewsContentDescription)
+        result.chips[1].assertChip(string.stats_visitors, visitorsContentDescription)
 
         Assertions.assertThat(result.selectedColumn).isEqualTo(selectedPosition)
         Assertions.assertThat(result.onColumnSelected).isEqualTo(onChipSelected)
@@ -124,8 +126,7 @@ class ViewsAndVisitorsMapperTest : BaseUnitTest() {
                 PeriodData("2022-04-15", 99, 35, 21, 0, 23, 1),
                 PeriodData("2022-04-16", 8, 5, 1, 0, 0, 0),
                 PeriodData("2022-04-17", 7, 4, 0, 0, 0, 0),
-                PeriodData("2022-04-18", 78, 28, 3, 0, 13, 2),
-                PeriodData("2022-04-19", 21, 9, 3, 0, 2, 0)
+                PeriodData("2022-04-18", 78, 28, 3, 0, 13, 2)
         )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCaseTest.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.R.string
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_VIEWS_AND_VISITORS_ERROR
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.stats.LimitMode.All
 import org.wordpress.android.fluxc.model.stats.LimitMode.Top
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodData
@@ -104,7 +103,7 @@ class ViewsAndVisitorsUseCaseTest : BaseUnitTest() {
     fun `maps domain model to UI model`() = test {
         val forced = false
         setupCalendar()
-        whenever(store.getVisits(site, statsGranularity, All)).thenReturn(model)
+        whenever(store.getVisits(site, statsGranularity, limitMode)).thenReturn(model)
         whenever(store.fetchVisits(site, statsGranularity, limitMode, forced)).thenReturn(
                 OnStatsFetched(
                         model


### PR DESCRIPTION
This updates some problems on Views & Visitors:
- Adds View more button to country card on Views & Visitors detail
- On Views & Visitors screen, if you change the date, go back, and open the detail screen again, date selector was not resetting. Old cards behavior is resetting the date once it's reopened. This PR resets the date selector on Views & Visitors detail screen.
- 8 days were being used for this week. This PR uses 7 days for this week.

To test:

Setup:
1. Go to App Settings on Jetpack app (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
2. Select Debug Settings
3. Find StatsRevampV2FeatureConfig under Features in development enable it and restart app
4. Launch / Re-Launch app
5. Go to Stats either using quick links or menu
6. Switch to Insights tab if necessary
7. Make sure Views & Visitors card is visible on Insights tab. If not present then add it through stats management using either [+ add new stats card ] at the bottom or clicking ⚙️ icon at the top right hand corner.

Test:
- Ensure Views & Visitors card's date range is last 7 days.
- Click on View More on Views & Visitors card.
- Ensure Views & Visitors card's date range is current week  (7 days).
- Change the date selector and navigate back.
- Reopen Views & Visitors detail screen by tapping VIEW MORE button.
- Ensure date pickers shows the current week.

## Regression Notes
1. Potential unintended areas of impact
Date range behavior on other screens.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Updated current tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
