### PR TITLE
Stats revamp v2: Fix total card problems

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/NavigationTarget.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/NavigationTarget.kt
@@ -47,7 +47,7 @@ sealed class NavigationTarget {
     data class ViewInsightDetails(
         val statsSection: StatsSection,
         val statsViewType: StatsViewType,
-        val statsGranularity: StatsGranularity,
+        val statsGranularity: StatsGranularity?,
         val selectedDate: Date?
     ) : NavigationTarget()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.O
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.PostsAndPagesUseCase.PostsAndPagesUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.ReferrersUseCase.ReferrersUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.SearchTermsUseCase.SearchTermsUseCaseFactory
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.TotalLikesDetailUseCase.TotalLikesGranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.VideoPlaysUseCase.VideoPlaysUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases.ViewsAndVisitorsDetailUseCase.ViewsAndVisitorsGranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.ActionCardGrowUseCase
@@ -61,10 +62,8 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.P
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.PublicizeUseCase.PublicizeUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TagsAndCategoriesUseCase.TagsAndCategoriesUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TodayStatsUseCase
-import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalCommentsUseCase.TotalCommentsGranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalCommentsUseCase.TotalCommentsUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalFollowersUseCase.TotalFollowersUseCaseFactory
-import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalLikesUseCase.TotalLikesGranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalLikesUseCase.TotalLikesUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.ViewsAndVisitorsUseCase.ViewsAndVisitorsUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -511,12 +510,12 @@ class StatsModule {
     @Singleton
     @Named(TOTAL_COMMENTS_DETAIL_USE_CASES)
     fun provideCommentsDetailUseCases(
-        totalCommentsGranularUseCaseFactory: TotalCommentsGranularUseCaseFactory,
+        totalCommentsUseCaseFactory: TotalCommentsUseCaseFactory,
         authorsCommentsUseCase: AuthorsCommentsUseCase,
         postsCommentsUseCase: PostsCommentsUseCase
     ): List<@JvmSuppressWildcards BaseStatsUseCase<*, *>> {
         return listOf(
-                totalCommentsGranularUseCaseFactory.build(WEEKS, BLOCK_DETAIL),
+                totalCommentsUseCaseFactory.build(BLOCK_DETAIL),
                 authorsCommentsUseCase,
                 postsCommentsUseCase
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.commit
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.databinding.StatsDetailActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
@@ -77,7 +76,7 @@ class StatsDetailActivity : LocaleAwareActivity() {
                 statsPostViewIntent.putExtra(POST_URL, postUrl)
             }
             AnalyticsUtils.trackWithSiteId(
-                    AnalyticsTracker.Stat.STATS_SINGLE_POST_ACCESSED,
+                    Stat.STATS_SINGLE_POST_ACCESSED,
                     site.siteId
             )
             context.startActivity(statsPostViewIntent)
@@ -104,8 +103,6 @@ class StatsDetailActivity : LocaleAwareActivity() {
                     putExtra(StatsViewAllFragment.ARGS_SELECTED_DATE, selectedDate)
                 }
             }
-            // TODO: Update tracking here
-            AnalyticsTracker.track(Stat.STATS_VIEW_ALL_ACCESSED)
             context.startActivity(intent)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/TotalLikesDetailUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/TotalLikesDetailUseCase.kt
@@ -1,129 +1,112 @@
-package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
+package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R.string
-import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_INSIGHTS_TOTAL_LIKES_GUIDE_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_TOTAL_LIKES_ERROR
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.TOTAL_LIKES
 import org.wordpress.android.fluxc.store.stats.insights.LatestPostInsightsStore
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.stats.StatsViewType
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewInsightDetails
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPost
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
-import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemGuideCard
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text.Clickable
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
-import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularStatefulUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.LatestPostSummaryUseCase.LinkClickParams
+import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalStatsMapper
+import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.ViewsAndVisitorsUseCase.UiState
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
-import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
-import org.wordpress.android.ui.stats.refresh.utils.trackWithType
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
-import java.util.Calendar
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
-import kotlin.math.ceil
 
-class TotalLikesUseCase @Inject constructor(
+class TotalLikesDetailUseCase @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    statsGranularity: StatsGranularity,
+    selectedDateProvider: SelectedDateProvider,
     private val visitsAndViewsStore: VisitsAndViewsStore,
     private val latestPostStore: LatestPostInsightsStore,
-    private val statsSiteProvider: StatsSiteProvider,
+    statsSiteProvider: StatsSiteProvider,
     private val resourceProvider: ResourceProvider,
-    private val statsDateFormatter: StatsDateFormatter,
     private val totalStatsMapper: TotalStatsMapper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val statsWidgetUpdaters: StatsWidgetUpdaters,
-    private val localeManagerWrapper: LocaleManagerWrapper
-) : StatelessUseCase<VisitsAndViewsModel>(TOTAL_LIKES, mainDispatcher, bgDispatcher) {
+    private val statsWidgetUpdaters: StatsWidgetUpdaters
+) : GranularStatefulUseCase<VisitsAndViewsModel, UiState>(
+        TOTAL_LIKES,
+        mainDispatcher,
+        bgDispatcher,
+        statsSiteProvider,
+        selectedDateProvider,
+        statsGranularity,
+        UiState()
+) {
     override fun buildLoadingItem() = listOf(TitleWithMore(string.stats_view_total_likes))
 
     override fun buildEmptyItem() = listOf(buildTitle(), Empty())
 
-    override suspend fun loadCachedData(): VisitsAndViewsModel? {
+    override suspend fun loadCachedData(selectedDate: Date, site: SiteModel): VisitsAndViewsModel? {
         statsWidgetUpdaters.updateViewsWidget(statsSiteProvider.siteModel.siteId)
         val cachedData = visitsAndViewsStore.getVisits(
-                statsSiteProvider.siteModel,
+                site,
                 DAYS,
-                LimitMode.All
+                LimitMode.Top(TotalStatsMapper.DAY_COUNT_TOTAL),
+                selectedDate
         )
         if (cachedData != null) {
-            logIfIncorrectData(cachedData, statsSiteProvider.siteModel, false)
+            selectedDateProvider.onDateLoadingSucceeded(statsGranularity)
         }
         return cachedData
     }
 
-    override suspend fun fetchRemoteData(forced: Boolean): State<VisitsAndViewsModel> {
+    override suspend fun fetchRemoteData(
+        selectedDate: Date,
+        site: SiteModel,
+        forced: Boolean
+    ): State<VisitsAndViewsModel> {
         val response = visitsAndViewsStore.fetchVisits(
                 statsSiteProvider.siteModel,
                 DAYS,
                 LimitMode.Top(TotalStatsMapper.DAY_COUNT_TOTAL),
+                selectedDate,
                 forced
         )
         val model = response.model
         val error = response.error
 
         return when {
-            error != null -> State.Error(error.message ?: error.type.name)
+            error != null -> {
+                selectedDateProvider.onDateLoadingFailed(statsGranularity)
+                State.Error(error.message ?: error.type.name)
+            }
             model != null && model.dates.isNotEmpty() -> {
-                logIfIncorrectData(model, statsSiteProvider.siteModel, true)
+                selectedDateProvider.onDateLoadingSucceeded(statsGranularity)
                 State.Data(model)
             }
-            else -> State.Empty()
-        }
-    }
-
-    /**
-     * Track the incorrect data shown for some users
-     * see https://github.com/wordpress-mobile/WordPress-Android/issues/11412
-     */
-    @Suppress("MagicNumber")
-    private fun logIfIncorrectData(
-        model: VisitsAndViewsModel,
-        site: SiteModel,
-        fetched: Boolean
-    ) {
-        model.dates.lastOrNull()?.let { lastDayData ->
-            val yesterday = localeManagerWrapper.getCurrentCalendar()
-            yesterday.add(Calendar.DAY_OF_YEAR, -1)
-            val lastDayDate = statsDateFormatter.parseStatsDate(DAYS, lastDayData.period)
-            if (lastDayDate.before(yesterday.time)) {
-                val currentCalendar = localeManagerWrapper.getCurrentCalendar()
-                val lastItemAge = ceil((currentCalendar.timeInMillis - lastDayDate.time) / 86400000.0)
-                analyticsTracker.track(
-                        STATS_TOTAL_LIKES_ERROR,
-                        mapOf(
-                                "stats_last_date" to statsDateFormatter.printStatsDate(lastDayDate),
-                                "stats_current_date" to statsDateFormatter.printStatsDate(currentCalendar.time),
-                                "stats_age_in_days" to lastItemAge.toInt(),
-                                "is_jetpack_connected" to site.isJetpackConnected,
-                                "is_atomic" to site.isWPComAtomic,
-                                "action_source" to if (fetched) "remote" else "cached"
-                        )
-                )
+            else -> {
+                selectedDateProvider.onDateLoadingSucceeded(statsGranularity)
+                State.Empty()
             }
         }
     }
 
-    override fun buildUiModel(domainModel: VisitsAndViewsModel): List<BlockListItem> {
+    override fun buildUiModel(domainModel: VisitsAndViewsModel, uiState: UiState): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
         if (domainModel.dates.isNotEmpty()) {
             items.add(buildTitle())
@@ -133,15 +116,13 @@ class TotalLikesUseCase @Inject constructor(
                 buildLatestPostGuideCard(items, this::onLinkClicked)
             }
         } else {
+            selectedDateProvider.onDateLoadingFailed(statsGranularity)
             AppLog.e(T.STATS, "There is no data to be shown in the total likes block")
         }
         return items
     }
 
-    private fun buildTitle() = TitleWithMore(
-            string.stats_view_total_likes,
-            navigationAction = ListItemInteraction.create(this::onViewMoreClick)
-    )
+    private fun buildTitle() = TitleWithMore(string.stats_view_total_likes)
 
     private fun buildLatestPostGuideCard(
         items: MutableList<BlockListItem>,
@@ -157,7 +138,8 @@ class TotalLikesUseCase @Inject constructor(
                                         it.postTitle,
                                         it.postLikeCount
                                 ),
-                                links = listOf(Clickable(
+                                links = listOf(
+                                        Clickable(
                                                 link = it.postTitle,
                                                 navigationAction = ListItemInteraction.create(
                                                         data = LinkClickParams(it.postId, it.postURL),
@@ -166,7 +148,8 @@ class TotalLikesUseCase @Inject constructor(
                                         )
                                 ),
                                 bolds = listOf(it.postLikeCount.toString())
-                        ))
+                        )
+                )
             }
         }
     }
@@ -176,45 +159,32 @@ class TotalLikesUseCase @Inject constructor(
         navigateTo(ViewPost(params.postId, params.postUrl))
     }
 
-    private fun onViewMoreClick() {
-        analyticsTracker.trackWithType(AnalyticsTracker.Stat.STATS_INSIGHTS_VIEW_MORE, TOTAL_LIKES)
-        navigateTo(
-                ViewInsightDetails(
-                        StatsSection.TOTAL_LIKES_DETAIL,
-                        StatsViewType.TOTAL_LIKES,
-                        null,
-                        null
-                )
-        )
-    }
-
-    class TotalLikesUseCaseFactory
+    class TotalLikesGranularUseCaseFactory
     @Inject constructor(
         @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
         @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher,
+        private val selectedDateProvider: SelectedDateProvider,
         private val visitsAndViewsStore: VisitsAndViewsStore,
         private val latestPostStore: LatestPostInsightsStore,
         private val statsSiteProvider: StatsSiteProvider,
         private val resourceProvider: ResourceProvider,
-        private val statsDateFormatter: StatsDateFormatter,
         private val totalStatsMapper: TotalStatsMapper,
         private val analyticsTracker: AnalyticsTrackerWrapper,
-        private val statsWidgetUpdaters: StatsWidgetUpdaters,
-        private val localeManagerWrapper: LocaleManagerWrapper
-    ) : InsightUseCaseFactory {
-        override fun build(useCaseMode: UseCaseMode) =
-                TotalLikesUseCase(
+        private val statsWidgetUpdaters: StatsWidgetUpdaters
+    ) : GranularUseCaseFactory {
+        override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
+                TotalLikesDetailUseCase(
                         mainDispatcher,
                         backgroundDispatcher,
+                        granularity,
+                        selectedDateProvider,
                         visitsAndViewsStore,
                         latestPostStore,
                         statsSiteProvider,
                         resourceProvider,
-                        statsDateFormatter,
                         totalStatsMapper,
                         analyticsTracker,
-                        statsWidgetUpdaters,
-                        localeManagerWrapper
+                        statsWidgetUpdaters
                 )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/FollowersUseCase.kt
@@ -161,7 +161,7 @@ class FollowersUseCase(
             }
 
             if (wpComModel.hasMore && uiState.selectedTab == 0 || emailModel.hasMore && uiState.selectedTab == 1) {
-                if (useCaseMode == BLOCK) {
+                if (useCaseMode != VIEW_ALL) {
                     val buttonText = R.string.stats_insights_view_more
                     items.add(
                             Link(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
@@ -1,33 +1,25 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 
 import kotlinx.coroutines.CoroutineDispatcher
-import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
-import org.wordpress.android.fluxc.network.utils.StatsGranularity
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType
-import org.wordpress.android.fluxc.store.StatsStore.StatsType
-import org.wordpress.android.fluxc.store.StatsStore.TimeStatsType
+import org.wordpress.android.fluxc.store.StatsStore.InsightType.TOTAL_FOLLOWERS
 import org.wordpress.android.fluxc.store.stats.insights.SummaryStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.StatsViewType
 import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewInsightDetails
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
-import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemGuideCard
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueWithChartItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
-import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
-import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.ViewsAndVisitorsUseCase.UiState
 import org.wordpress.android.ui.stats.refresh.utils.ActionCardHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
-import org.wordpress.android.ui.stats.refresh.utils.toStatsSection
 import org.wordpress.android.ui.stats.refresh.utils.trackWithType
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -38,9 +30,6 @@ import javax.inject.Named
 class TotalFollowersUseCase @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
-    statsType: StatsType,
-    private val statsGranularity: StatsGranularity,
-    private val selectedDateProvider: SelectedDateProvider,
     private val summaryStore: SummaryStore,
     private val statsSiteProvider: StatsSiteProvider,
     private val resourceProvider: ResourceProvider,
@@ -48,16 +37,10 @@ class TotalFollowersUseCase @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val actionCardHandler: ActionCardHandler,
     private val useCaseMode: UseCaseMode
-) : BaseStatsUseCase<Int, UiState>(
-        statsType,
-        mainDispatcher,
-        bgDispatcher,
-        UiState(),
-        uiUpdateParams = listOf(UseCaseParam.SelectedDateParam(statsGranularity.toStatsSection()))
-) {
-    override fun buildLoadingItem(): List<BlockListItem> = listOf(TitleWithMore(R.string.stats_view_total_followers))
+) : StatelessUseCase<Int>(TOTAL_FOLLOWERS, mainDispatcher, bgDispatcher) {
+    override fun buildLoadingItem(): List<BlockListItem> = listOf(TitleWithMore(string.stats_view_total_followers))
 
-    override fun buildEmptyItem() = buildUiModel(0, UiState())
+    override fun buildEmptyItem() = buildUiModel(0)
 
     override suspend fun loadCachedData() = summaryStore.getSummary(statsSiteProvider.siteModel)?.followers
 
@@ -73,7 +56,7 @@ class TotalFollowersUseCase @Inject constructor(
         }
     }
 
-    override fun buildUiModel(domainModel: Int, uiState: UiState): List<BlockListItem> {
+    override fun buildUiModel(domainModel: Int): List<BlockListItem> {
         addActionCard(domainModel)
         val items = mutableListOf<BlockListItem>()
         items.add(buildTitle())
@@ -89,18 +72,18 @@ class TotalFollowersUseCase @Inject constructor(
     }
 
     private fun buildTitle() = TitleWithMore(
-            R.string.stats_view_total_followers,
+            string.stats_view_total_followers,
             navigationAction = if (useCaseMode == VIEW_ALL) null else ListItemInteraction.create(this::onViewMoreClick)
     )
 
     private fun onViewMoreClick() {
-        analyticsTracker.trackWithType(AnalyticsTracker.Stat.STATS_INSIGHTS_VIEW_MORE, InsightType.TOTAL_FOLLOWERS)
+        analyticsTracker.trackWithType(AnalyticsTracker.Stat.STATS_INSIGHTS_VIEW_MORE, TOTAL_FOLLOWERS)
         navigateTo(
                 ViewInsightDetails(
                         StatsSection.TOTAL_FOLLOWERS_DETAIL,
                         StatsViewType.TOTAL_FOLLOWERS,
-                        statsGranularity,
-                        selectedDateProvider.getSelectedDate(statsGranularity)
+                        null,
+                        null
                 )
         )
     }
@@ -108,7 +91,6 @@ class TotalFollowersUseCase @Inject constructor(
     class TotalFollowersUseCaseFactory @Inject constructor(
         @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
         @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher,
-        private val selectedDateProvider: SelectedDateProvider,
         private val summaryStore: SummaryStore,
         private val statsSiteProvider: StatsSiteProvider,
         private val resourceProvider: ResourceProvider,
@@ -119,9 +101,6 @@ class TotalFollowersUseCase @Inject constructor(
         override fun build(useCaseMode: UseCaseMode) = TotalFollowersUseCase(
                 mainDispatcher,
                 backgroundDispatcher,
-                InsightType.TOTAL_FOLLOWERS,
-                WEEKS,
-                selectedDateProvider,
                 summaryStore,
                 statsSiteProvider,
                 resourceProvider,
@@ -129,34 +108,6 @@ class TotalFollowersUseCase @Inject constructor(
                 analyticsTracker,
                 actionCardHandler,
                 useCaseMode
-        )
-    }
-
-    class TotalFollowersGranularUseCaseFactory @Inject constructor(
-        @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
-        @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher,
-        private val selectedDateProvider: SelectedDateProvider,
-        private val summaryStore: SummaryStore,
-        private val statsSiteProvider: StatsSiteProvider,
-        private val resourceProvider: ResourceProvider,
-        private val totalStatsMapper: TotalStatsMapper,
-        private val analyticsTracker: AnalyticsTrackerWrapper,
-        private val actionCardHandler: ActionCardHandler
-    ) : GranularUseCaseFactory {
-        override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
-                TotalFollowersUseCase(
-                        mainDispatcher,
-                        backgroundDispatcher,
-                        TimeStatsType.OVERVIEW,
-                        granularity,
-                        selectedDateProvider,
-                        summaryStore,
-                        statsSiteProvider,
-                        resourceProvider,
-                        totalStatsMapper,
-                        analyticsTracker,
-                        actionCardHandler,
-                        useCaseMode
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -233,7 +233,9 @@ class StatsNavigator @Inject constructor(
                         target.statsSection,
                         target.statsViewType,
                         target.statsGranularity,
-                        selectedDateProvider.getSelectedDateState(target.statsGranularity),
+                        target.statsGranularity?.let {
+                            selectedDateProvider.getSelectedDateState(target.statsGranularity)
+                        },
                         siteProvider.siteModel.id
                 )
             }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1277,7 +1277,7 @@
     <string name="stats_view_videos">Videos</string>
     <string name="stats_view_comments" translatable="false">@string/comments</string>
     <string name="stats_view_search_terms">Search Terms</string>
-    <string name="stats_view_publicize">Publicize</string>
+    <string name="stats_view_publicize">Social Media Connections</string>
     <string name="stats_view_followers">Followers</string>
     <string name="stats_view_follower_totals">Follower Totals</string>
     <string name="stats_view_total_likes">Total Likes</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalCommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalCommentsUseCaseTest.kt
@@ -21,9 +21,7 @@ import org.wordpress.android.fluxc.model.stats.LimitMode.Top
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodData
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType
-import org.wordpress.android.fluxc.store.StatsStore.InsightType.TOTAL_COMMENTS
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
@@ -72,9 +70,6 @@ class TotalCommentsUseCaseTest : BaseUnitTest() {
         useCase = TotalCommentsUseCase(
                 Dispatchers.Unconfined,
                 TEST_DISPATCHER,
-                TOTAL_COMMENTS,
-                WEEKS,
-                selectedDateProvider,
                 store,
                 statsSiteProvider,
                 resourceProvider,

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCaseTest.kt
@@ -12,8 +12,6 @@ import org.wordpress.android.R
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.SummaryModel
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
-import org.wordpress.android.fluxc.store.StatsStore.InsightType.TOTAL_FOLLOWERS
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
@@ -27,7 +25,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE_WITH_MORE
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.VALUE_WITH_CHART_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueWithChartItem
-import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.utils.ActionCardHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -42,7 +39,6 @@ class TotalFollowersUseCaseTest : BaseUnitTest() {
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
     @Mock lateinit var useCaseMode: UseCaseMode
     @Mock lateinit var actionCardHandler: ActionCardHandler
-    @Mock lateinit var selectedDateProvider: SelectedDateProvider
     private lateinit var useCase: TotalFollowersUseCase
     private val followers = 100
 
@@ -52,9 +48,6 @@ class TotalFollowersUseCaseTest : BaseUnitTest() {
         useCase = TotalFollowersUseCase(
                 Dispatchers.Unconfined,
                 TEST_DISPATCHER,
-                TOTAL_FOLLOWERS,
-                WEEKS,
-                selectedDateProvider,
                 insightsStore,
                 statsSiteProvider,
                 resourceProvider,

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
@@ -21,8 +21,6 @@ import org.wordpress.android.fluxc.model.stats.LimitMode.Top
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodData
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
-import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
-import org.wordpress.android.fluxc.store.StatsStore.InsightType
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.TOTAL_LIKES
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
@@ -74,9 +72,6 @@ class TotalLikesUseCaseTest : BaseUnitTest() {
         useCase = TotalLikesUseCase(
                 Dispatchers.Unconfined,
                 TEST_DISPATCHER,
-                TOTAL_LIKES,
-                WEEKS,
-                selectedDateProvider,
                 store,
                 latestPostStore,
                 statsSiteProvider,
@@ -85,8 +80,7 @@ class TotalLikesUseCaseTest : BaseUnitTest() {
                 totalStatsMapper,
                 analyticsTrackerWrapper,
                 statsWidgetUpdaters,
-                localeManagerWrapper,
-                useCaseMode
+                localeManagerWrapper
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(totalStatsMapper.buildTotalLikesValue(any())).thenReturn(valueWithChart)
@@ -102,7 +96,7 @@ class TotalLikesUseCaseTest : BaseUnitTest() {
 
         val result = loadData(true, forced)
 
-        assertThat(result.type).isEqualTo(InsightType.TOTAL_LIKES)
+        assertThat(result.type).isEqualTo(TOTAL_LIKES)
 
         assertThat(result.state).isEqualTo(UseCaseState.SUCCESS)
         result.data!!.apply {


### PR DESCRIPTION
This fixes problems on total cards:
- Adds view more button to Followers card on Total Followers detail screen (This button is on current iOS version and in Figma design),
- Removes the date picker from Total Followers and Total Comments cards (my commit caf9893d11720fc55187d8fc320d68b54c47d0cc message is wrong)
- Adds date picker functionality to Total Likes card on the detail screen.
- Renames Publicize to Social Media Connections.

To test:

Setup:
1. Go to App Settings on Jetpack app (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
2. Select Debug Settings
3. Find StatsRevampV2FeatureConfig under Features in development enable it and restart app
4. Launch / Re-Launch app
5. Go to Stats either using quick links or menu
6. Switch to Insights tab if necessary
7. Make sure Total Likes, Total Followers and Total Comments cards are visible on Insights tab. If not present then add ithem through stats management using either [+ add new stats card ] at the bottom or clicking ⚙️ icon at the top right hand corner.

Test:

- Click on View More on Total Followers card.
- Ensure there is view more button bottom of Followers card. (It only appears if there are more than 6 followers)
- Navigate back and tap VIEW MORE on Total Followers card.
- Ensure there is no date picker on top of the screen.
- Navigate back and tap VIEW MORE on Total Comments card.
- Ensure there is no date picker on top of the screen. 

## Regression Notes
1. Potential unintended areas of impact
Total cards blocks, and their detail screens.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Updated current unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
