### PR TITLE
Stats Revamp v2: Refresh data on insight details

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -87,6 +87,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
         statsPager.setPageTransformer(
                 MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
         )
+        statsPager.offscreenPageLimit = 2
         selectedTabListener = SelectedTabListener(viewModel)
         TabLayoutMediator(tabLayout, statsPager) { tab, position ->
             tab.text = adapter.getTabTitle(position)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
@@ -38,6 +38,7 @@ class InsightsDetailViewModel
 
     fun init(localSiteId: Int) {
         statsSiteProvider.start(localSiteId)
+        refresh()
     }
 
     fun refresh() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
@@ -38,7 +38,6 @@ class InsightsDetailViewModel
 
     fun init(localSiteId: Int) {
         statsSiteProvider.start(localSiteId)
-        refresh()
     }
 
     fun refresh() {


### PR DESCRIPTION
When going from insights cards to it's detail screen, sometimes the cards are not displaying immediately


To test:

- Launch Jetpack app
- Navigate to Stats 
- On Insights tab, tap on View More on Views & Visitors or Total Likes or Total Comments or Total Followers cards
- Ensure it opens respective details screen
- On the respective details screen, all the related cards are displayed if data exists.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested with different use cases

3. What automated tests I added (or what prevented me from doing so)
existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
