### PR TITLE
Remove ktlint

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,14 +13,6 @@ steps:
     artifact_paths:
       - "**/build/reports/checkstyle/checkstyle.*"
 
-  - label: "ktlint"
-    command: |
-      cp gradle.properties-example gradle.properties
-      ./gradlew ciktlint
-    plugins: *common_plugins
-    artifact_paths:
-      - "**/build/ktlint.xml"
-
   - label: "detekt"
     command: |
       cp gradle.properties-example gradle.properties

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
@@ -38,7 +38,6 @@ private val RESPONDENTS = listOf(
         "http://avatar3.url"
 )
 
-/* ktlint-disable max-line-length */
 @RunWith(MockitoJUnitRunner::class)
 class BloggingPromptCardBuilderTest : BaseUnitTest() {
     private lateinit var builder: BloggingPromptCardBuilder

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUploadProcessingTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUploadProcessingTest.kt
@@ -12,8 +12,6 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.ui.posts.mediauploadcompletionprocessors.TestContent
 import org.wordpress.android.util.helpers.MediaFile
 
-/* ktlint-disable max-line-length */
-/* ktlint-disable parameter-list-wrapping */
 @RunWith(MockitoJUnitRunner::class)
 class PostUtilsUploadProcessingTest {
     private val mediaFile: MediaFile = mock()

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.ui.posts.mediauploadcompletionprocessors
 
-/* ktlint-disable max-line-length */
-/* ktlint-disable string-template */
 object TestContent {
     const val siteUrl = "https://wordpress.org"
     const val localImageUrl = "file://Screenshot-1-1.png"

--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,6 @@ allprojects {
                 includeVersion "org.jetbrains.kotlinx", "kotlinx-html-jvm", "0.7.2"
                 // Required for lintWordpressVanillaRelease
                 includeVersion "com.jraska", "falcon", "2.1.1"
-                // Required for ktlint
-                includeVersion "com.andreapivetta.kolor", "kolor", "0.0.2"
             }
         }
         flatDir {
@@ -110,35 +108,6 @@ allprojects {
         kotlinOptions {
             jvmTarget = "1.8"
         }
-    }
-}
-
-subprojects {
-
-    configurations {
-        ktlint
-    }
-
-    dependencies {
-        ktlint 'com.github.shyiko:ktlint:0.29.0'
-    }
-
-    tasks.register("ktlint", JavaExec) {
-        main = "com.github.shyiko.ktlint.Main"
-        classpath = configurations.ktlint
-        args "src/**/*.kt"
-    }
-
-    tasks.register("ktlintFormat", JavaExec) {
-        main = "com.github.shyiko.ktlint.Main"
-        classpath = configurations.ktlint
-        args "-F", "src/**/*.kt"
-    }
-
-    tasks.register("ciktlint", JavaExec) {
-        main = "com.github.shyiko.ktlint.Main"
-        classpath = configurations.ktlint
-        args "src/**/*.kt", "--reporter=checkstyle,output=${buildDir}/ktlint.xml"
     }
 }
 

--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -5,8 +5,7 @@ Our code style guidelines are based on the [Android Code Style Guidelines for Co
 * Line length is 120 characters
 * FIXME must not be committed in the repository use TODO instead. FIXME can be used in your own local repository only.
 
-On top of the Android linter rules (best run for this project using `./gradlew lintWordPressVanillaRelease`), we use two linters: [Checkstyle](http://checkstyle.sourceforge.net/) (for Java and some language-independent custom project rules), and [ktlint](https://github.com/pinterest/ktlint) (for Kotlin).
-
+On top of the Android linter rules (best run for this project using `./gradlew lintWordPressVanillaRelease`), we use two linters: [Checkstyle](http://checkstyle.sourceforge.net/) (for Java and some language-independent custom project rules), and [detekt](https://detekt.github.io/detekt/) (for Kotlin).
 ## Checkstyle
 
 You can run checkstyle via a gradle command:
@@ -29,10 +28,6 @@ Once installed, you can configure the plugin here:
 
 From there, add and enable the custom configuration file, located at [config/checkstyle.xml](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/config/checkstyle.xml).
 
-## ktlint
-
-You can run ktlint using `./gradlew ktlint`, and you can also run `./gradlew ktlintFormat` for auto-formatting. There is no IDEA plugin (like Checkstyle's) at this time.
-
 ## Detekt
 
 You can run detekt via a gradle command:
@@ -54,5 +49,7 @@ Once installed, you can configure the plugin here:
 `Android Studio > Preferences... > Tools > Detekt`
 
 From there, add and enable the custom configuration file, located at [config/detekt/detekt.yml](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/config/detekt/detekt.yml).
+
+If you want to use the **AutoCorrect** feature of the plugin, make sure that the option `Enable formatting (ktlint) rules` is enabled in the above settings, then you will be able to reformat any file according to detekt's rules using the refactor menu `AutoCorrect by Detekt Rules`.
 
 Please don’t add a new suppression line to the [baseline.xml](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/config/detekt/baseline.xml). Consider fixing the issue or suppressing locally if it’s necessary.


### PR DESCRIPTION
Fixes #14012

**Why?**
- Ktlint is no friend of the @Composable annotation on parameters (see paqN3M-v8-p2), and we plan to start adopting [Jetpack Compose](https://developer.android.com/jetpack/compose) for building UIs.

+ We also have a point on the Android Roadmap (see paqN3M-C6-p2) to remove KtLint in favor of Detekt. 

📃 Changes:
- Remove ktlint task from CI (buildkite pipeline)
- Remove ktlint configuration & dependency
- Update `coding-style` doc to suggest using detekt instead of ktlint
- Remove ktlint comments for rules suppression

### 🧪 To test:
- Locate the Detekt-related pipeline job in Buildkite and **expect** success.

#### ⚠️ Merge Instructions:
- Make sure @wordpress-mobile/owl-team approved the PR (@ParaskP7).
- Remove the 🔴 **Not Ready for Merge** status label.
- @ParaskP7 will have to delete the `buildkite/wordpress-android/ktlint` [branch protection rule](https://github.com/wordpress-mobile/WordPress-Android/settings/branch_protection_rules/4567122) on `trunk`.
- CI should be 🟢 now.
- Merge 🚀.

## Regression Notes
1. Potential unintended areas of impact
  N/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  N/a

3. What automated tests I added (or what prevented me from doing so)
  N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.