### PR TITLE
Remove Unnecessary Kotlin StdLib Dependency from All Modules

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -322,7 +322,6 @@ dependencies {
     implementation "$gradle.ext.storiesAndroidMp4ComposePath:$storiesVersion"
     testImplementation "$gradle.ext.storiesAndroidPhotoEditorPath:$storiesVersion"
     implementation project(path:':libs:image-editor')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$gradle.ext.kotlinVersion"
 
     // Provided by maven central
     implementation 'com.google.code.gson:gson:2.6.2'

--- a/libs/annotations/build.gradle
+++ b/libs/annotations/build.gradle
@@ -2,10 +2,6 @@ plugins {
     id "org.jetbrains.kotlin.jvm"
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$gradle.ext.kotlinVersion"
-}
-
 sourceCompatibility = "7"
 targetCompatibility = "7"
 

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -65,7 +65,6 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'com.android.volley:volley:1.1.1'
     implementation "org.wordpress:utils:$wordPressUtilsVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$gradle.ext.kotlinVersion"
     api ("$gradle.ext.aztecAndroidAztecPath") {
         exclude group: "com.android.volley"
         exclude group: 'org.wordpress', module: 'utils'
@@ -95,7 +94,6 @@ dependencies {
     implementation "$rootProject.gradle.ext.gutenbergMobileBinaryPath:$rootProject.ext.gutenbergMobileVersion"
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$gradle.ext.kotlinVersion"
     implementation "org.jsoup:jsoup:1.10.3"
 
     implementation 'com.google.code.gson:gson:2.6.2'

--- a/libs/image-editor/build.gradle
+++ b/libs/image-editor/build.gradle
@@ -45,8 +45,6 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    // Kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$gradle.ext.kotlinVersion"
 
     // UI
     implementation "androidx.appcompat:appcompat:$appCompatVersion"

--- a/libs/processors/build.gradle
+++ b/libs/processors/build.gradle
@@ -8,7 +8,6 @@ ext.autoServiceVersion = '1.0'
 
 dependencies {
     implementation project(':libs:annotations')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$gradle.ext.kotlinVersion"
     implementation "com.google.auto.service:auto-service:$autoServiceVersion"
     kapt "com.google.auto.service:auto-service:$autoServiceVersion"
     implementation "com.squareup:kotlinpoet:$kotlinPoetVersion"


### PR DESCRIPTION
Parent #16562
Relates to #15314 (see [comment](https://github.com/wordpress-mobile/WordPress-Android/pull/15314#discussion_r775477847))

This PR removes the unnecessary Kotlin `stdlib` standard library dependency from all modules. From now on, and as per the recommendation, [the version of the standard library used should be the same as the version of the Kotlin Gradle plugin.](https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library)

-----

To test:

- Smoke test the app.

-----

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

N/A

-----

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
