### PR TITLE
DO NOT MERGE: Tests A/B/n experiment implementation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ExperimentModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ExperimentModule.kt
@@ -1,9 +1,12 @@
 package org.wordpress.android.modules
 
+import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
 import dagger.multibindings.Multibinds
+import org.wordpress.android.util.experiments.ABNTestExperiment
 import org.wordpress.android.util.experiments.Experiment
 
 @InstallIn(SingletonComponent::class)
@@ -13,4 +16,6 @@ interface ExperimentModule {
 
     // Copy and paste the line below to add a new experiment.
     // @Binds @IntoSet fun exampleExperiment(experiment: ExampleExperiment): Experiment
+
+    @Binds @IntoSet fun abnExperiment(experiment: ABNTestExperiment): Experiment
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.mysite
 
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -34,6 +35,7 @@ import org.wordpress.android.ui.mysite.tabs.MySiteTabFragment
 import org.wordpress.android.ui.mysite.tabs.MySiteTabsAdapter
 import org.wordpress.android.ui.posts.QuickStartPromptDialogFragment.QuickStartPromptClickInterface
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.experiments.ABNTestExperiment
 import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR
@@ -49,6 +51,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var meGravatarLoader: MeGravatarLoader
     @Inject lateinit var imageManager: ImageManager
+    @Inject lateinit var abnTestExperiment: ABNTestExperiment
     private lateinit var viewModel: MySiteViewModel
 
     private var binding: MySiteFragmentBinding? = null
@@ -75,6 +78,16 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             setupContentViews()
             setupObservers()
         }
+
+        view.setBackgroundColor(
+                when {
+                    abnTestExperiment.isRedVariant -> Color.RED
+                    abnTestExperiment.isGreenVariant -> Color.GREEN
+                    abnTestExperiment.isBlueVariant -> Color.BLUE
+                    abnTestExperiment.isControl -> Color.YELLOW
+                    else -> Color.BLACK // should never be the case
+                }
+        )
     }
 
     private fun initSoftKeyboard() {

--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/ABNTestExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/ABNTestExperiment.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.util.experiments
+
+import org.wordpress.android.fluxc.model.experiments.Variation.Control
+import javax.inject.Inject
+
+class ABNTestExperiment
+@Inject constructor(exPlat: ExPlat) : Experiment(EXPERIMENT_NAME, exPlat) {
+
+    val isControl: Boolean
+        get() = getVariation() == Control
+
+    val isRedVariant: Boolean
+        get() = getVariation().name == VARIANT_RED
+
+    val isGreenVariant: Boolean
+        get() = getVariation().name == VARIANT_GREEN
+
+    val isBlueVariant: Boolean
+        get() = getVariation().name == VARIANT_BLUE
+
+    companion object {
+        const val EXPERIMENT_NAME = "a_b_n_android_native_test"
+        const val VARIANT_RED = "red_background"
+        const val VARIANT_GREEN = "green_background"
+        const val VARIANT_BLUE = "blue_background"
+    }
+}


### PR DESCRIPTION
**DO NOT MERGE**

This PR was created to verify that the client already supports A/B/n experiments (internal ref: `pbmo2S-1pZ-p2`)

To test:
1. Assign one of the variations of the ExPlat experiment `a_b_n_android_native_test` to your a8c user
2. Open the app (might need to do this twice)
3. Verify that the *My Site* screen has the background assigned from the experiment

|Control|variation: blue_background|variation: green_background|variation: red_background |
|---|---|---|---|
|![Screenshot_20220628_155904](https://user-images.githubusercontent.com/304044/176186060-0a909f83-c70e-4ca1-9af0-ae05f8f1c904.png)|![Screenshot_20220628_155947](https://user-images.githubusercontent.com/304044/176186073-be451da7-d653-432f-a7bc-78689c4b5e29.png)|![Screenshot_20220628_160028](https://user-images.githubusercontent.com/304044/176186080-e5165376-5dfe-40d5-9ab7-43851e0b65b1.png)|![Screenshot_20220628_160127](https://user-images.githubusercontent.com/304044/176186085-ff0ebfee-bd69-4336-9dd0-c02e500b983c.png)|

## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
