### PR TITLE
[Tooling] Annotate Installable Builds info in Buildkite jobs

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -329,6 +329,11 @@ platform :android do
       reuse_identifier: "#{product.downcase}-installable-build-link",
       body: comment_body
     )
+
+    if ENV['BUILDKITE']
+      message = "#{product} Installable Build: [#{filename}](#{install_url})"
+      sh('buildkite-agent', 'annotate', message, '--style', 'info', '--context', "installable-build-#{product}")
+    end
   end
 
   # This function is Buildkite-specific


### PR DESCRIPTION
Use [`buildkite-agent annotate`](https://buildkite.com/docs/agent/v3/cli-annotate) to annotate information about the Installable Builds directly in the Buildkite log pages.

_This was initially mostly an experiment to see how we can use `buildkite-agent annotate` in more places in our Buildkite pipelines to get them nicer to navigate; but even if I'm not entirely sure for the case of Installable Builds this will be super useful to have the info on the build page… I figured it wouldn't hurt to keep it after all_ 🙃 