### PR TITLE
[UI Tests] Fix flaky `allDayStatsLoad` test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
       parameters:
         jvmargs:
           type: string
-          default: "Xmx4096m"
+          default: "Xmx2048m"
       steps:
         - run:
             name: Update memory setting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
       parameters:
         jvmargs:
           type: string
-          default: "Xmx2048m"
+          default: "Xmx4096m"
       steps:
         - run:
             name: Update memory setting

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -21,7 +21,9 @@ public class SignUpTests extends BaseTest {
     }
 
     @After
-    public void tearDown() { logoutIfNecessary(); }
+    public void tearDown() {
+        logoutIfNecessary();
+    }
 
     @Test
     public void signUpWithMagicLink() {

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.e2e;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.wordpress.android.e2e.flows.SignupFlow;
@@ -18,6 +19,9 @@ public class SignUpTests extends BaseTest {
     public void setUp() {
         logoutIfNecessary();
     }
+
+    @After
+    public void tearDown() { logoutIfNecessary(); }
 
     @Test
     public void signUpWithMagicLink() {

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.java
@@ -4,6 +4,7 @@ import androidx.test.espresso.Espresso;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.wordpress.android.R;
 import org.wordpress.android.e2e.pages.MySitesPage;
 import org.wordpress.android.support.BaseTest;
@@ -36,7 +37,7 @@ public class StatsTests extends BaseTest {
         }
     }
 
-    // @Test
+    @Test
     public void allDayStatsLoad() {
         StatsVisitsData todayVisits = new StatsVisitsData("97", "28", "14", "11");
         List<StatsKeyValueData> postsList = new StatsMocksReader().readDayTopPostsToList();

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.java
@@ -1,8 +1,11 @@
 package org.wordpress.android.e2e.pages;
 
+import android.view.View;
+
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 
+import org.hamcrest.Matcher;
 import org.wordpress.android.R;
 import org.wordpress.android.util.StatsKeyValueData;
 import org.wordpress.android.util.StatsVisitsData;
@@ -15,28 +18,46 @@ import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.hasSibling;
 import static androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.Matchers.allOf;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.wordpress.android.support.WPSupportUtils.dialogExistsWithTitle;
 import static org.wordpress.android.support.WPSupportUtils.scrollIntoView;
 import static org.wordpress.android.support.WPSupportUtils.tapButtonInDialogWithTitle;
-import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
+import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 
 public class StatsPage {
+    // We are interested only in "Stats" screen elements that are descendants of
+    // `coordinator_layout` which is actually shown on screen and contains user data.
+    // For whatever reason, there's also an instance of "Stats" screen template,
+    // which contains the cards headers, but has no user data loaded.
+    // It is located at the "right" of the one we need to work with:
+    //
+    // |--------------------|  |------------------------|
+    // | coordinator_layout |  |   coordinator_layout   |
+    // |Visible Stats Screen|  | Invisible Stats Screen |
+    // |--------------------|  |------------------------|
+    //
+    private static Matcher<View> visibleCoordinatorLayout = allOf(
+            withId(R.id.coordinator_layout),
+            isDisplayed()
+    );
+
     public StatsPage openDayStats() {
         ViewInteraction daysStatsTab = onView(allOf(
-                withText("Days"),
-                isDescendantOfA(withId(R.id.tabLayout))
+                isDescendantOfA(withId(R.id.tabLayout)),
+                withText("Days")
         ));
 
-        waitForElementToBeDisplayedWithoutFailure(daysStatsTab);
+        ViewInteraction postsAndPagesCard = onView(allOf(
+                isDescendantOfA(visibleCoordinatorLayout),
+                withText("Posts and Pages")
+        ));
+
+        waitForElementToBeDisplayed(daysStatsTab);
         daysStatsTab.perform(ViewActions.click());
-
-        waitForElementToBeDisplayedWithoutFailure(
-                onView(withText("Posts and Pages"))
-        );
-
+        waitForElementToBeDisplayed(postsAndPagesCard);
         return this;
     }
 
@@ -77,6 +98,7 @@ public class StatsPage {
 
     public StatsPage assertVisits(StatsVisitsData visitsData) {
             ViewInteraction cardStructure = onView(allOf(
+                    isDescendantOfA(visibleCoordinatorLayout),
                     withId(R.id.stats_block_list),
                     hasDescendant(allOf(
                             withText("Views"),
@@ -112,6 +134,7 @@ public class StatsPage {
             //    |- Has text: post.title
             //    |- Has a sibling with post.views (which means they're shown on same row):
             ViewInteraction cardStructure = onView(allOf(
+                    isDescendantOfA(visibleCoordinatorLayout),
                     withId(R.id.stats_block_list),
                     hasDescendant(withText(cardHeader)),
                     hasDescendant(allOf(
@@ -165,6 +188,7 @@ public class StatsPage {
         // and additionally contains a descendant
         // with needed text:
         ViewInteraction card = onView(allOf(
+                isDescendantOfA(visibleCoordinatorLayout),
                 withId(R.id.stats_block_list),
                 hasDescendant(withText(cardHeader))
                 )

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.java
@@ -129,6 +129,7 @@ public class StatsPage {
     public void assertKeyValuePairs(String cardHeader, List<StatsKeyValueData> list) {
         for (StatsKeyValueData item : list) {
             // Element with ID = stats_block_list
+            // |--Is a descendant of `coordinator_layout` which `isDisplayed()`
             // |--Has child with text: e.g. "Posts and Pages"
             // |--Has descendant that both:
             //    |- Has text: post.title
@@ -184,9 +185,6 @@ public class StatsPage {
     }
 
     private void scrollToCard(String cardHeader) {
-        // A card that has "stats_block_list"
-        // and additionally contains a descendant
-        // with needed text:
         ViewInteraction card = onView(allOf(
                 isDescendantOfA(visibleCoordinatorLayout),
                 withId(R.id.stats_block_list),


### PR DESCRIPTION
### Edit

After the initial PR description was created 3 weeks ago, the PR was blocked from merging because of the [java.lang.OutOfMemoryError: Java heap space](https://github.com/wordpress-mobile/WordPress-Android/pull/16838#issuecomment-1171133746) error. The error was solved after mirgating from CircleCI to Buildkite, however, the test started to fail in a new way (possibly because of app using Compose), which was adressed in d7576688ec9204c448a07edcedfb1f23a4c6a627.

---------------------------
### Why

`allDayStatsLoad` UI test continued to fail after #16799 merge.

### How

I took a look into Firebase videos and could not see the test being even executed. After that, I tried the local execution and finally saw the fail: it appears that `allDayStatsLoad` is executed after `signUpWithMagicLink` test. The latter test left the app in a weird state, my guess is because it emulated using the magic link signup, which probably did not work well with WireMock. The app then crashed after relaunch and opening Settings (to log out). So, in fact, the reason for the fail was in the other test and had nothing to do with `allDayStatsLoad`.

<details>
	<summary>Crash details</summary>

```
2022-06-29 22:59:58.355 15086-15086/org.wordpress.android.prealpha E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.wordpress.android.prealpha, PID: 15086
    java.lang.IllegalStateException: Settings should be hidden when isSettingsSupported returns false.
        at org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.onSettingsActionClicked(ReaderViewModel.kt:223)
        at org.wordpress.android.ui.reader.ReaderFragment.onCreateOptionsMenu$lambda-4$lambda-3(ReaderFragment.kt:120)
        at org.wordpress.android.ui.reader.ReaderFragment.$r8$lambda$rHyWAw1DWBeB0Lu-hW7SiIIOon0(Unknown Source:0)
        at org.wordpress.android.ui.reader.ReaderFragment$$ExternalSyntheticLambda1.onClick(Unknown Source:2)
        at android.view.View.performClick(View.java:6597)
        at android.view.View.performClickInternal(View.java:6574)
        at android.view.View.access$3100(View.java:778)
        at android.view.View$PerformClick.run(View.java:25885)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6669)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```

</details>

I've added a teardown with logout to `signUpWithMagicLink`, which is done while the app was still running after using the magic link, which seems to solve the problem.

### To test

- Optionally, try running the whole package of `e2e` test locally
- CI is green for the last 7 executions (check the commits history) or see the Firebase logs (just me being super paraniod, so I masked the executions IDs 😅) :

<img width="961" alt="Screenshot 2022-06-30 at 10 37 47" src="https://user-images.githubusercontent.com/73365754/176621349-cd9d8d30-03ed-41ae-b9c8-6b54cc24d871.png">
