### PR TITLE
Weekly roundup format notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
@@ -84,44 +84,24 @@ class WeeklyRoundupNotifier @Inject constructor(
         )
     }
 
-    @Suppress("ComplexMethod")
     private fun buildContentText(data: WeeklyRoundupData) = when {
-        data.views > 0 && data.likes <= 0 && data.comments <= 0 -> {
+        data.likes <= 0 && data.comments <= 0 -> {
             resourceProvider.getString(
                     R.string.weekly_roundup_notification_text_views_only,
                     statsUtils.toFormattedString(data.views)
             )
         }
-        data.views <= 0 && data.likes > 0 && data.comments <= 0 -> {
-            resourceProvider.getString(
-                    R.string.weekly_roundup_notification_text_likes_only,
-                    statsUtils.toFormattedString(data.likes)
-            )
-        }
-        data.views <= 0 && data.likes <= 0 && data.comments > 0 -> {
-            resourceProvider.getString(
-                    R.string.weekly_roundup_notification_text_comments_only,
-                    statsUtils.toFormattedString(data.comments)
-            )
-        }
-        data.views > 0 && data.likes > 0 && data.comments <= 0 -> {
+        data.likes > 0 && data.comments <= 0 -> {
             resourceProvider.getString(
                     R.string.weekly_roundup_notification_text_views_and_likes,
                     statsUtils.toFormattedString(data.views),
                     statsUtils.toFormattedString(data.likes)
             )
         }
-        data.views > 0 && data.likes <= 0 && data.comments > 0 -> {
+        data.likes <= 0 && data.comments > 0 -> {
             resourceProvider.getString(
                     R.string.weekly_roundup_notification_text_views_and_comments,
                     statsUtils.toFormattedString(data.views),
-                    statsUtils.toFormattedString(data.comments)
-            )
-        }
-        data.views <= 0 && data.likes > 0 && data.comments > 0 -> {
-            resourceProvider.getString(
-                    R.string.weekly_roundup_notification_text_likes_and_comments,
-                    statsUtils.toFormattedString(data.likes),
                     statsUtils.toFormattedString(data.comments)
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.Organization
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe.WEEK
+import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -29,7 +30,8 @@ class WeeklyRoundupNotifier @Inject constructor(
     private val notificationsTracker: SystemNotificationsTracker,
     private val siteUtils: SiteUtilsWrapper,
     private val weeklyRoundupRepository: WeeklyRoundupRepository,
-    private val appPrefs: AppPrefsWrapper
+    private val appPrefs: AppPrefsWrapper,
+    private val statsUtils: StatsUtils
 ) {
     fun shouldShowNotifications() = accountStore.hasAccessToken() && siteStore.hasSitesAccessedViaWPComRest()
 
@@ -78,13 +80,59 @@ class WeeklyRoundupNotifier @Inject constructor(
                         R.string.weekly_roundup_notification_title,
                         siteUtils.getSiteNameOrHomeURL(site)
                 ),
-                contentText = resourceProvider.getString(
-                        R.string.weekly_roundup_notification_text,
-                        data.views,
-                        data.likes,
-                        data.comments
-                )
+                contentText = buildContentText(data)
         )
+    }
+
+    @Suppress("ComplexMethod")
+    private fun buildContentText(data: WeeklyRoundupData) = when {
+        data.views > 0 && data.likes <= 0 && data.comments <= 0 -> {
+            resourceProvider.getString(
+                    R.string.weekly_roundup_notification_text_views_only,
+                    statsUtils.toFormattedString(data.views)
+            )
+        }
+        data.views <= 0 && data.likes > 0 && data.comments <= 0 -> {
+            resourceProvider.getString(
+                    R.string.weekly_roundup_notification_text_likes_only,
+                    statsUtils.toFormattedString(data.likes)
+            )
+        }
+        data.views <= 0 && data.likes <= 0 && data.comments > 0 -> {
+            resourceProvider.getString(
+                    R.string.weekly_roundup_notification_text_comments_only,
+                    statsUtils.toFormattedString(data.comments)
+            )
+        }
+        data.views > 0 && data.likes > 0 && data.comments <= 0 -> {
+            resourceProvider.getString(
+                    R.string.weekly_roundup_notification_text_views_and_likes,
+                    statsUtils.toFormattedString(data.views),
+                    statsUtils.toFormattedString(data.likes)
+            )
+        }
+        data.views > 0 && data.likes <= 0 && data.comments > 0 -> {
+            resourceProvider.getString(
+                    R.string.weekly_roundup_notification_text_views_and_comments,
+                    statsUtils.toFormattedString(data.views),
+                    statsUtils.toFormattedString(data.comments)
+            )
+        }
+        data.views <= 0 && data.likes > 0 && data.comments > 0 -> {
+            resourceProvider.getString(
+                    R.string.weekly_roundup_notification_text_likes_and_comments,
+                    statsUtils.toFormattedString(data.likes),
+                    statsUtils.toFormattedString(data.comments)
+            )
+        }
+        else -> {
+            resourceProvider.getString(
+                    R.string.weekly_roundup_notification_text_all,
+                    statsUtils.toFormattedString(data.views),
+                    statsUtils.toFormattedString(data.likes),
+                    statsUtils.toFormattedString(data.comments)
+            )
+        }
     }
 
     companion object {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4052,11 +4052,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="weekly_roundup_notification_title">Weekly Roundup: %s</string>
     <string name="weekly_roundup_notification_text_all">Last week you had %1$s views, %2$s likes, and %3$s comments.</string>
     <string name="weekly_roundup_notification_text_views_only">Last week you had %1$s views.</string>
-    <string name="weekly_roundup_notification_text_likes_only">Last week you had %1$s likes.</string>
-    <string name="weekly_roundup_notification_text_comments_only">Last week you had %1$s comments.</string>
     <string name="weekly_roundup_notification_text_views_and_likes">Last week you had %1$s views and %2$s likes</string>
     <string name="weekly_roundup_notification_text_views_and_comments">Last week you had %1$s views and %2$s comments</string>
-    <string name="weekly_roundup_notification_text_likes_and_comments">Last week you had %1$s likes and %2$s comments.</string>
 
     <!-- About -->
     <string name="about_blog">Blog</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4050,7 +4050,13 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <!-- Weekly Roundup Notification -->
     <string name="weekly_roundup">Weekly Roundup</string>
     <string name="weekly_roundup_notification_title">Weekly Roundup: %s</string>
-    <string name="weekly_roundup_notification_text">Your site got %1$d views, %2$d likes, %3$d comments.</string>
+    <string name="weekly_roundup_notification_text_all">Last week you had %1$s views, %2$s likes, and %3$s comments.</string>
+    <string name="weekly_roundup_notification_text_views_only">Last week you had %1$s views.</string>
+    <string name="weekly_roundup_notification_text_likes_only">Last week you had %1$s likes.</string>
+    <string name="weekly_roundup_notification_text_comments_only">Last week you had %1$s comments.</string>
+    <string name="weekly_roundup_notification_text_views_and_likes">Last week you had %1$s views and %2$s likes</string>
+    <string name="weekly_roundup_notification_text_views_and_comments">Last week you had %1$s views and %2$s comments</string>
+    <string name="weekly_roundup_notification_text_likes_and_comments">Last week you had %1$s likes and %2$s comments.</string>
 
     <!-- About -->
     <string name="about_blog">Blog</string>

--- a/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
@@ -12,6 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.stubbing.Answer
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -152,6 +153,74 @@ class WeeklyRoundupNotifierTest {
         val list = weeklyRoundupNotifier.buildNotifications().map { it.id }
 
         assertThat(list).isEqualTo(sortedData.map { WEEKLY_ROUNDUP_NOTIFICATION_ID + (it?.site?.id ?: 0) })
+    }
+
+    @Test
+    fun `buildNotifications should not include likes and comments with 0 count`() = test {
+        val mockSites = buildMockSites()
+        val data = buildMockData(mockSites[0], views = 10, comments = 0, likes = 0)
+
+        whenever(siteStore.sitesAccessedViaWPComRest).thenReturn(mockSites)
+        whenever(weeklyRoundupRepository.fetchWeeklyRoundupData(any())).then { data }
+
+        val list = weeklyRoundupNotifier.buildNotifications()
+
+        assertThat(list.first().contentTitle).isEqualTo(resourceProvider.getString(
+                R.string.weekly_roundup_notification_text_views_only,
+                statsUtils.toFormattedString(data!!.views)
+        ))
+    }
+
+    @Test
+    fun `buildNotifications should not include likes with 0 count`() = test {
+        val mockSites = buildMockSites()
+        val data = buildMockData(mockSites[2], views = 10, comments = 1, likes = 0)
+
+        whenever(siteStore.sitesAccessedViaWPComRest).thenReturn(mockSites)
+        whenever(weeklyRoundupRepository.fetchWeeklyRoundupData(any())).then { data }
+
+        val list = weeklyRoundupNotifier.buildNotifications()
+
+        assertThat(list.first().contentTitle).isEqualTo(resourceProvider.getString(
+                R.string.weekly_roundup_notification_text_views_and_comments,
+                statsUtils.toFormattedString(data!!.views),
+                statsUtils.toFormattedString(data.comments)
+        ))
+    }
+
+    @Test
+    fun `buildNotifications should not include comments with 0 count`() = test {
+        val mockSites = buildMockSites()
+        val data = buildMockData(mockSites[1], views = 9, comments = 0, likes = 8)
+
+        whenever(siteStore.sitesAccessedViaWPComRest).thenReturn(mockSites)
+        whenever(weeklyRoundupRepository.fetchWeeklyRoundupData(any())).then { data }
+
+        val list = weeklyRoundupNotifier.buildNotifications()
+
+        assertThat(list.first().contentTitle).isEqualTo(resourceProvider.getString(
+                R.string.weekly_roundup_notification_text_views_and_likes,
+                statsUtils.toFormattedString(data!!.views),
+                statsUtils.toFormattedString(data.likes)
+        ))
+    }
+
+    @Test
+    fun `buildNotifications should include views, likes, and comments greater than zero`() = test {
+        val mockSites = buildMockSites()
+        val data = buildMockData(mockSites[1], views = 9, comments = 8, likes = 8)
+
+        whenever(siteStore.sitesAccessedViaWPComRest).thenReturn(mockSites)
+        whenever(weeklyRoundupRepository.fetchWeeklyRoundupData(any())).then { data }
+
+        val list = weeklyRoundupNotifier.buildNotifications()
+
+        assertThat(list.first().contentTitle).isEqualTo(resourceProvider.getString(
+                R.string.weekly_roundup_notification_text_all,
+                statsUtils.toFormattedString(data!!.views),
+                statsUtils.toFormattedString(data.likes),
+                statsUtils.toFormattedString(data.comments)
+        ))
     }
 
     private companion object {

--- a/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.push.NotificationType.WEEKLY_ROUNDUP
 import org.wordpress.android.test
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -45,6 +46,7 @@ class WeeklyRoundupNotifierTest {
     private val appPrefs: AppPrefsWrapper = mock {
         on { shouldShowWeeklyRoundupNotification(any()) }.thenReturn(true)
     }
+    private val statsUtils: StatsUtils = mock()
 
     @Before
     fun setUp() {
@@ -57,7 +59,8 @@ class WeeklyRoundupNotifierTest {
                 notificationsTracker,
                 siteUtils,
                 weeklyRoundupRepository,
-                appPrefs
+                appPrefs,
+                statsUtils
         )
     }
 


### PR DESCRIPTION
This PR formats Weekly Roundup notification with the following enhancements. Please see p1656374182709429-slack-C0HTU7HV3 for context
- formats count with comma and abbreviated to K M etc if over 10K
- doesn't include views, likes and comments with 0 count

|Before|After|
|---|---|
|![Screenshot_20220628_140256](https://user-images.githubusercontent.com/990349/176577971-4a450fd8-45bc-4a59-bae0-407023ec69ad.png) |![Screenshot_20220630_100530](https://user-images.githubusercontent.com/990349/176577997-e6a7c14d-14b4-4f4e-9459-2aac68d00a89.png) |


To test:

- Launch Jetpack or WordPress app
- From the Main screen, go to Me > App Settings > Debug settings.
- On the Debug Settings screen, scroll down to the Tools section at the bottom and tap "Force show Weekly Roundup notification".
- Notice the Weekly Roundup notifications (this might take a while).
- There will be up to 5 notifications
- Ensure notifications now do not include values with 0 counts and the values are formatted with comma for below 10K and with K, M etc for above 10K.


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit testing

3. What automated tests I added (or what prevented me from doing so)
Added unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.