### PR TITLE
Enables assignment requests for unauthenticated users with an anonymous_id

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.util.config.ExperimentConfig
 import org.wordpress.android.util.config.FeatureConfig
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 @Reusable
 class AnalyticsTrackerWrapper
 @Inject constructor() {
@@ -47,6 +48,8 @@ class AnalyticsTrackerWrapper
     fun track(stat: Stat, site: SiteModel?, feature: FeatureConfig) {
         AnalyticsUtils.trackWithSiteDetails(this, stat, site, feature.toParams().toMutableMap<String, Any>())
     }
+
+    fun getAnonID(): String? = AnalyticsTracker.getAnonID()
 
     /**
      * A convenience method for logging an error event with some additional meta data.

--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.store.ExperimentStore.Platform
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.APPLICATION_SCOPE
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.experiments.ExPlat.RefreshStrategy.ALWAYS
 import org.wordpress.android.util.experiments.ExPlat.RefreshStrategy.IF_STALE
 import org.wordpress.android.util.experiments.ExPlat.RefreshStrategy.NEVER
@@ -27,6 +28,7 @@ class ExPlat
     private val experimentStore: ExperimentStore,
     private val appLog: AppLogWrapper,
     private val accountStore: AccountStore,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
     @Named(APPLICATION_SCOPE) private val coroutineScope: CoroutineScope
 ) {
     private val platform = Platform.WORDPRESS_ANDROID
@@ -72,7 +74,7 @@ class ExPlat
     }
 
     private fun refresh(refreshStrategy: RefreshStrategy) {
-        if (experimentNames.isNotEmpty() && accountStore.hasAccessToken()) {
+        if (experimentNames.isNotEmpty() && (accountStore.hasAccessToken() || analyticsTracker.getAnonID() != null)) {
             getAssignments(refreshStrategy)
         }
     }
@@ -85,7 +87,8 @@ class ExPlat
         return cachedAssignments
     }
 
-    private suspend fun fetchAssignments() = experimentStore.fetchAssignments(platform, experimentNames).also {
+    private suspend fun fetchAssignments() =
+            experimentStore.fetchAssignments(platform, experimentNames, analyticsTracker.getAnonID()).also {
         if (it.isError) {
             appLog.d(T.API, "ExPlat: fetching assignments failed with result: ${it.error}")
         } else {

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -986,6 +988,19 @@ public final class AnalyticsTracker {
 
         for (Tracker tracker : TRACKERS) {
             tracker.track(stat);
+        }
+    }
+
+    public static @Nullable String getAnonID() {
+        if (TRACKERS.isEmpty()) {
+            return null;
+        }
+        Tracker tracker = TRACKERS.get(0);
+        String anonId = tracker.getAnonID();
+        if (anonId == null) {
+            return tracker.generateNewAnonID();
+        } else {
+            return anonId;
         }
     }
 


### PR DESCRIPTION
Fixes #16577

### Description
This PR  enhances the `WordPress-Android` ExPlat client to allow unauthenticated assignment requests with an `anon_id`. Following the paradigm of the iOS client we use the `Tracks` anonymous id for this purpose. Specifically:

* When a user is not logged in we make a request with only the `anon_id` filled
* If the user login, we make an additional request containing the anon_id and the auth tokens to assign the values from this anonymous user to this logged in user.

Note: A previous fix restricted [the client to only makes assignment requests for authenticated users](https://github.com/wordpress-mobile/WordPress-Android/pull/16363) since the `anon_id` was not passed as a parameter. 

More context at `pbArwn-4lF-p2#comment-5781`

### To test:

#### Note: 

* For testing purposes we can check the `anon_id` parameter passed [by setting a breakpoint at this line](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/d01196fdf46af7597d08e17057633624d8c370fd/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClient.kt#L42).
<img width="728" alt="Screenshot 2022-06-30 at 9 53 31 AM" src="https://user-images.githubusercontent.com/304044/176620967-20d1fa8f-e799-4816-acde-1f90b1d57c2c.png">

* We could add a new experiment or [uncomment the example experiment at this line to trigger fetching the ExPlat assignments](https://github.com/wordpress-mobile/WordPress-Android/blob/44e04b5da3989ef20c11008b8d8c8e39799ea009/WordPress/src/main/java/org/wordpress/android/modules/ExperimentModule.kt#L15).

#### Logged out user
* Start the app
* *Verify* that an assignment request is made with an `anon_id` parameter set
* Login
* *Verify* that an assignment request is made with the same `anon_id`

#### Logged in user
* Start the app
* *Verify* that an assignment request is made with an `anon_id` parameter set

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added test cases in `ExPlatTest.kt`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
