### PR TITLE
[Tooling] [L10n] Add Jetpack-specific strings to localization pipeline

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,13 +3,15 @@ UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Hel
 APP_SPECIFIC_VALUES = {
   wordpress: {
     metadata_dir: 'metadata',
-    gp_url: 'https://translate.wordpress.org/projects/apps/android/release-notes/',
+    glotpress_appstrings_project: 'https://translate.wordpress.org/projects/apps/android/dev/',
+    glotpress_metadata_project: 'https://translate.wordpress.org/projects/apps/android/release-notes/',
     package_name: 'org.wordpress.android',
     bundle_name_prefix: 'wpandroid'
   },
   jetpack: {
     metadata_dir: 'jetpack_metadata',
-    gp_url: 'https://translate.wordpress.com/projects/jetpack/apps/android/release-notes/',
+    glotpress_appstrings_project: 'https://translate.wordpress.com/projects/jetpack/apps/android/',
+    glotpress_metadata_project: 'https://translate.wordpress.com/projects/jetpack/apps/android/release-notes/',
     package_name: 'com.jetpack.android',
     bundle_name_prefix: 'jpandroid'
   }

--- a/fastlane/jetpack_resources/values/strings.xml
+++ b/fastlane/jetpack_resources/values/strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">Jetpack</string>
+    <string name="widgets_enabled" translatable="false">false</string>
+
+    <!-- About View -->
+    <string name="app_title">Jetpack for Android</string>
+
+    <!-- Post-Signup Interstitial -->
+    <string name="post_signup_interstitial_title">Welcome to Jetpack</string>
+
+    <!-- Login Prologue -->
+    <string name="app_tagline">Site security and performance from your pocket</string>
+    <string name="continue_with_wpcom_no_signup">Log in with WordPress.com</string>
+
+    <!-- Login Magic Link -->
+    <string name="login_magic_links_sent_label">Check your email on this device and tap the link in the email you received from Jetpack.com.</string>
+
+    <!-- Contact us -->
+    <!--Note: Support ticket subject, only visible to the end users of the Zendesk support portal, doesn't need a translation -->
+    <string name="support_ticket_subject">Jetpack for Android Support</string>
+
+    <!-- Log out actions in Me -->
+    <string name="me_disconnect_from_wordpress_com">Log out of Jetpack</string>
+    <string name="sign_out_wpcom_confirm_with_no_changes">Log out of Jetpack?</string>
+
+    <!-- About button in Me -->
+    <string name="me_btn_about">About Jetpack</string>
+</resources>

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -383,13 +383,19 @@ platform :android do
   # bundle exec fastlane download_translations
   #####################################################################################
   lane :download_translations do
-    # For now WordPress and Jetpack use the same GlotPress project and share the same `strings.xml`
-    # (the Jetpack-dedicated one, https://translate.wordpress.com/projects/jetpack/apps/android/, is empty anyway for now).
+    # WordPress strings
     android_download_translations(
       res_dir: File.join('WordPress', 'src', 'main', 'res'),
       glotpress_url: 'https://translate.wordpress.org/projects/apps/android/dev/',
       locales: ALL_LOCALES,
-      lint_task: 'lintWordpressVanillaRelease' # TODO: Should we adapt this?
+      lint_task: 'lintWordpressVanillaRelease'
+    )
+    # Jetpack strings
+    android_download_translations(
+      res_dir: File.join('WordPress', 'src', 'jetpack', 'res'),
+      glotpress_url: 'https://translate.wordpress.com/projects/jetpack/apps/android/',
+      locales: ALL_LOCALES,
+      lint_task: 'lintJetpackVanillaRelease'
     )
   end
 

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -223,7 +223,7 @@ platform :android do
     # The case for the source locale (en-US) is pulled in a hacky way, by having an {en-gb => en-US} mapping as part of the RELEASE_NOTES_LOCALES,
     # which is then treated in a special way by gp_downloadmetadata by specifying a `source_locale: 'en-US'` to process it differently from the rest.
     gp_downloadmetadata(
-      project_url: app_values[:gp_url],
+      project_url: app_values[:glotpress_metadata_project],
       target_files: files,
       locales: RELEASE_NOTES_LOCALES,
       source_locale: 'en-US',
@@ -250,7 +250,7 @@ platform :android do
     delete_old_changelogs(app: 'jetpack', build: options[:build_number])
     download_path = File.join(Dir.pwd, app_values[:metadata_dir], 'android')
     gp_downloadmetadata(
-      project_url: app_values[:gp_url],
+      project_url: app_values[:glotpress_metadata_project],
       target_files: files,
       locales: JP_RELEASE_NOTES_LOCALES,
       download_path: download_path
@@ -386,14 +386,14 @@ platform :android do
     # WordPress strings
     android_download_translations(
       res_dir: File.join('WordPress', 'src', 'main', 'res'),
-      glotpress_url: 'https://translate.wordpress.org/projects/apps/android/dev/',
+      glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:glotpress_appstrings_project],
       locales: ALL_LOCALES,
       lint_task: 'lintWordpressVanillaRelease'
     )
     # Jetpack strings
     android_download_translations(
       res_dir: File.join('WordPress', 'src', 'jetpack', 'res'),
-      glotpress_url: 'https://translate.wordpress.com/projects/jetpack/apps/android/',
+      glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:glotpress_appstrings_project],
       locales: ALL_LOCALES,
       lint_task: 'lintJetpackVanillaRelease'
     )

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -31,7 +31,7 @@ ALL_LOCALES = [
   { glotpress: 'vi', android: 'vi',    google_play: 'vi',     promo_config: {} },
   { glotpress: 'zh-cn', android: 'zh-rCN', google_play: 'zh-CN',  promo_config: {} },
   { glotpress: 'zh-tw', android: 'zh-rTW', google_play: 'zh-TW',  promo_config: {} },
-  # From this point are locales that are still used for downloading `strings.xml`… but not for release notes – and thus don't need a `google_play` key. See `RELEASE_NOTES_LOCALES` below.
+  # From this point are locales that are still used for downloading `strings.xml`… but not for release notes – and thus don't need a `google_play` key. See `WP_RELEASE_NOTES_LOCALES` below.
   { glotpress: 'az', android: 'az', promo_config: false },
   { glotpress: 'bg', android: 'bg', promo_config: false },
   { glotpress: 'cs', android: 'cs', promo_config: false },
@@ -62,7 +62,11 @@ ALL_LOCALES = [
   { glotpress: 'zh-tw', android: 'zh-rHK', promo_config: false },
 ].freeze
 
-RELEASE_NOTES_LOCALES = ALL_LOCALES
+WP_APP_LOCALES = ALL_LOCALES
+JP_APP_LOCALES = ALL_LOCALES
+  .select { |h| %w[ar de-DE es-ES fr-FR iw-IL id it-IT ja-JP ko-KR nl-NL pt-BR ru-RU sv-SE tr-TR zh-CN zh-TW].include?(h[:google_play]) }
+
+WP_RELEASE_NOTES_LOCALES = ALL_LOCALES
   .reject { |h| h[:google_play].nil? }
   .map { |h| [h[:glotpress], h[:google_play]] }
 
@@ -220,12 +224,12 @@ platform :android do
 
     delete_old_changelogs(app: 'wordpress', build: options[:build_number])
     download_path = File.join(Dir.pwd, app_values[:metadata_dir], 'android')
-    # The case for the source locale (en-US) is pulled in a hacky way, by having an {en-gb => en-US} mapping as part of the RELEASE_NOTES_LOCALES,
+    # The case for the source locale (en-US) is pulled in a hacky way, by having an {en-gb => en-US} mapping as part of the WP_RELEASE_NOTES_LOCALES,
     # which is then treated in a special way by gp_downloadmetadata by specifying a `source_locale: 'en-US'` to process it differently from the rest.
     gp_downloadmetadata(
       project_url: app_values[:glotpress_metadata_project],
       target_files: files,
-      locales: RELEASE_NOTES_LOCALES,
+      locales: WP_RELEASE_NOTES_LOCALES,
       source_locale: 'en-US',
       download_path: download_path
     )
@@ -387,14 +391,14 @@ platform :android do
     android_download_translations(
       res_dir: File.join('WordPress', 'src', 'main', 'res'),
       glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:glotpress_appstrings_project],
-      locales: ALL_LOCALES,
+      locales: WP_APP_LOCALES,
       lint_task: 'lintWordpressVanillaRelease'
     )
     # Jetpack strings
     android_download_translations(
       res_dir: File.join('WordPress', 'src', 'jetpack', 'res'),
       glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:glotpress_appstrings_project],
-      locales: ALL_LOCALES,
+      locales: JP_APP_LOCALES,
       lint_task: 'lintJetpackVanillaRelease'
     )
   end

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -166,9 +166,16 @@ platform :android do
   end
 
   lane :check_translations_coverage do |options|
-    UI.message('Checking app strings translation status...')
+    UI.message('Checking WordPress app strings translation status...')
     check_translation_progress(
       glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:glotpress_appstrings_project],
+      abort_on_violations: false,
+      skip_confirm: options[:skip_confirm] || false
+    )
+
+    UI.message('Checking Jetpack app strings translation status...')
+    check_translation_progress(
+      glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:glotpress_appstrings_project],
       abort_on_violations: false,
       skip_confirm: options[:skip_confirm] || false
     )

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -168,21 +168,21 @@ platform :android do
   lane :check_translations_coverage do |options|
     UI.message('Checking app strings translation status...')
     check_translation_progress(
-      glotpress_url: 'https://translate.wordpress.org/projects/apps/android/dev/',
+      glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:glotpress_appstrings_project],
       abort_on_violations: false,
       skip_confirm: options[:skip_confirm] || false
     )
 
     UI.message('Checking WordPress release notes strings translation status...')
     check_translation_progress(
-      glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:gp_url],
+      glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:glotpress_metadata_project],
       abort_on_violations: false,
       skip_confirm: options[:skip_confirm] || false
     )
 
     UI.message('Checking Jetpack release notes strings translation status...')
     check_translation_progress(
-      glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:gp_url],
+      glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:glotpress_metadata_project],
       abort_on_violations: false,
       skip_confirm: options[:skip_confirm] || false
     )

--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -146,7 +146,7 @@ platform :android do
       .select { |hsh| hsh[:promo_config] != false }
       .map {| hsh | [ hsh[:glotpress], hsh[:google_play] ]}
 
-    gp_downloadmetadata(project_url: "https://translate.wordpress.org/projects/apps/android/release-notes/",
+    gp_downloadmetadata(project_url: APP_SPECIFIC_VALUES[:wordpress][:glotpress_metadata_project],
       target_files: files,
       locales: locales,
       source_locale: "en-US",


### PR DESCRIPTION
This PR adds the `WordPress/src/jetpack/res/values*/strings.xml` to the translation pipeline lanes

## Why?

Ref: pdnsEh-pY-p2 

So far the WordPress and Jetpack app both only used `Wordpress/src/main/res/values*/strings.xml` as their shared set of common strings, since both apps are built on the same codebase and shared the same strings. So we only sent those strings.xml files to GlotPress for translation and back.

Since recently though, we've started to need Jetpack-specific strings for the Jetpack app to override some strings from the WordPress variant, and used `WordPress/src/jetpack/res/values*/strings.xml` for that. But those new files had never been added to our translation pipeline, which means they never been sent to GlotPress to get translated and back (and indeed we only have `WordPress/src/jetpack/res/values/` but no other locale-specific `values-{locale}` folder there so far). This PR fixes that.

## What's Next

In addition to this, I have submitted a diff to update our cron job importing the new frozen jetpack file into GlotPress. See D83569-code

## To Test

Start by cutting a test branch from this PR's branch, to run the following tests

### Checking Translations Coverage

* Run `bundle exec fastlane check_translations_coverage`
* Reply `y` each 4 times it asks you if you want to continue.
* Confirm that the output shows that all locales for the Jetpack app strings are 0%

### Freezing Strings

* Edit `WordPress/src/jetpack/res/values/strings.xml` to change a value of one of the strings (or add a new entry)
* Run `bundle exec fastlane update_frozen_strings_for_translation`
* Verify that the lane created a commit containing a change to the `fastlane/jetpack_resources/values/strings.xml` file with the change you made to the main file

### Downloading App Translations

* _[Optional] Edit `fastlane/lanes/localization.rb` and replace the value for the two `lint_task:` parameter on line 395 and 402 with empty strings. That will allow you to avoid waiting forever for the lint to run when the goal is only to test the lane._
* Run `bundle exec fastlane download_translations`
* Ensure that it downloads the latest translations for WordPress… and tries to do so for Jetpack as well — but because it's currently at 0%, won't find anything to download and won't create the files for now.
* Especially, ensure that the logs show the right list of locales it tries to download for the Jetpack app strings (i.e. our Mag16), which is not the same subset as the locales we have for WordPress app strings (where we have way more)

### Downloading Metadata Translations

* Run `bundle exec fastlane download_metadata_strings version:20.2 build_number:1241`
* Validate it still downloads both WP and JP metadata translations like it always has. Note that there might not be many new metadata in GlotPress at the time, and thus (m)any `.txt` file modified in that created commit — except the old changelog being deleted