### PR TITLE
Stats Revamp v2: Fix detail screen not loading

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -87,6 +87,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
         statsPager.setPageTransformer(
                 MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
         )
+        statsPager.offscreenPageLimit = 2
         selectedTabListener = SelectedTabListener(viewModel)
         TabLayoutMediator(tabLayout, statsPager) { tab, position ->
             tab.text = adapter.getTabTitle(position)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -87,7 +87,6 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
         statsPager.setPageTransformer(
                 MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
         )
-        statsPager.offscreenPageLimit = 2
         selectedTabListener = SelectedTabListener(viewModel)
         TabLayoutMediator(tabLayout, statsPager) { tab, position ->
             tab.text = adapter.getTabTitle(position)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -100,7 +100,6 @@ abstract class StatsListViewModel(
 
     override fun onCleared() {
         statsUseCase.onCleared()
-        dateSelector.clear()
         super.onCleared()
     }
 


### PR DESCRIPTION
This PR fixes [an issue reported during beta testing](p5T066-3mc-p2#comment-12772).  Date Selector was being cleared which was affecting reload


To test:

- Launch the App and navigate to Insights tab on Stats
- Make sure _Views & Visitors_ card is displayed.  Tap on **View More**
- Ensure it opens detail screen and loads _Views & Visitors_, _Referrers_ and _Country_ view cards
- Press ⟵ and return to Insights, Tap on **View More** again
- Ensure detail screen loads with the cards
- Return to Insights and tap on **View More** on _Views & Visitors_ again
- Ensure detail screen loads with the cards

Test 2
- Repeat the above steps on _Total Likes_ card and ensure it loads its detail screen with the cards


## Regression Notes
1. Potential unintended areas of impact
None 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested various cards

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.