### PR TITLE
Add Jetpack banner to Stats and Notifications screens

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -312,6 +312,7 @@
         <activity
             android:name=".ui.stats.refresh.StatsActivity"
             android:launchMode="singleTop"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/WordPress.NoActionBar" />
         <activity
             android:name=".ui.stats.refresh.StatsViewAllActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -10,7 +10,10 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup.MarginLayoutParams
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
@@ -18,6 +21,7 @@ import com.google.android.material.appbar.AppBarLayout.LayoutParams
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.google.android.material.tabs.TabLayout.Tab
 import org.greenrobot.eventbus.EventBus
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -47,7 +51,6 @@ import org.wordpress.android.util.AppLog.T.NOTIFS
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.WPUrlUtils
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
-import java.util.HashMap
 import javax.inject.Inject
 
 class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment), ScrollableViewInitializedListener {
@@ -77,6 +80,15 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         binding = NotificationsListFragmentBinding.bind(view).apply {
             toolbarMain.setTitle(R.string.notifications_screen_title)
             (requireActivity() as AppCompatActivity).setSupportActionBar(toolbarMain)
+
+            if (!BuildConfig.IS_JETPACK_APP) {
+                jetpackBanner.root.isVisible = true
+
+                // Add bottom margin to viewPager and connectJetpack view for jetpack banner.
+                val margin = resources.getDimensionPixelSize(R.dimen.jetpack_banner_height)
+                viewPager.updateLayoutParams<MarginLayoutParams> { bottomMargin = margin }
+                connectJetpack.updateLayoutParams<MarginLayoutParams> { bottomMargin = margin }
+            }
 
             tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
                 override fun onTabSelected(tab: Tab) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.stats.refresh
 
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
+import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.activity.viewModels
@@ -23,23 +25,35 @@ import javax.inject.Inject
 class StatsActivity : LocaleAwareActivity() {
     @Inject lateinit var statsSiteProvider: StatsSiteProvider
     private val viewModel: StatsViewModel by viewModels()
+    private var initialNavigationBarColor = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         with(StatsListActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
             if (!BuildConfig.IS_JETPACK_APP) {
+                initialNavigationBarColor = window.navigationBarColor
                 jetpackBanner.root.isVisible = true
                 setNavigationBarColorForBanner()
             }
         }
     }
 
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        setNavigationBarColorForBanner()
+    }
+
     /**
-     * Sets the navigation bar color as same as jetpack banner background color.
+     * Sets the navigation bar color as same as Jetpack banner background color in portrait orientation, initial color
+     * in horizontal orientation.
      */
     private fun setNavigationBarColorForBanner() {
-        window.navigationBarColor = getColor(R.color.jetpack_banner_background)
+        window.navigationBarColor = when (resources.configuration.orientation) {
+            ORIENTATION_PORTRAIT -> getColor(R.color.jetpack_banner_background)
+            else -> initialNavigationBarColor
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -5,7 +5,10 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.activity.viewModels
+import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.StatsListActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
@@ -22,7 +25,21 @@ class StatsActivity : LocaleAwareActivity() {
     private val viewModel: StatsViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(StatsListActivityBinding.inflate(layoutInflater).root)
+
+        with(StatsListActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            if (!BuildConfig.IS_JETPACK_APP) {
+                jetpackBanner.root.isVisible = true
+                setNavigationBarColorForBanner()
+            }
+        }
+    }
+
+    /**
+     * Sets the navigation bar color as same as jetpack banner background color.
+     */
+    private fun setNavigationBarColorForBanner() {
+        window.navigationBarColor = getColor(R.color.jetpack_banner_background)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/res/drawable/ic_jetpack_logo_green_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_jetpack_logo_green_24dp.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="25dp"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="25">
+  <path
+      android:fillColor="#ffffff"
+      android:pathData="M12.5,0L12.5,0A12,12 0,0 1,24.5 12L24.5,12A12,12 0,0 1,12.5 24L12.5,24A12,12 0,0 1,0.5 12L0.5,12A12,12 0,0 1,12.5 0z" />
+  <path
+      android:fillColor="#069E08"
+      android:pathData="M12.5,0C5.889,0 0.5,5.374 0.5,12C0.5,18.626 5.874,24 12.5,24C19.126,24 24.5,18.626 24.5,12C24.5,5.374 19.126,0 12.5,0ZM11.882,13.988H5.904L11.882,2.356V13.988ZM13.104,21.615V9.983H19.067L13.104,21.615Z" />
+</vector>

--- a/WordPress/src/main/res/layout/jetpack_banner.xml
+++ b/WordPress/src/main/res/layout/jetpack_banner.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/jetpack_banner_height"
     android:layout_gravity="bottom"
     android:background="@color/jetpack_banner_background"
     android:orientation="vertical"
-    android:visibility="gone">
+    android:visibility="gone"
+    tools:visibility="visible">
 
     <View
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/jetpack_banner.xml
+++ b/WordPress/src/main/res/layout/jetpack_banner.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/jetpack_banner_height"
+    android:layout_gravity="bottom"
+    android:background="@color/jetpack_banner_background"
+    android:orientation="vertical"
+    android:visibility="gone">
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:background="@color/jetpack_banner_divider" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:drawablePadding="10dp"
+        android:gravity="center"
+        android:text="@string/wp_jetpack_powered"
+        android:textAppearance="?attr/textAppearanceBody1"
+        app:drawableStartCompat="@drawable/ic_jetpack_logo_green_24dp" />
+</LinearLayout>

--- a/WordPress/src/main/res/layout/notifications_list_fragment.xml
+++ b/WordPress/src/main/res/layout/notifications_list_fragment.xml
@@ -112,4 +112,7 @@
 
     </LinearLayout>
 
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/stats_list_activity.xml
+++ b/WordPress/src/main/res/layout/stats_list_activity.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:name="org.wordpress.android.ui.stats.refresh.StatsFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
-</FrameLayout>
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
+</LinearLayout>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -21,6 +21,10 @@
 
     <color name="post_history_underlying_background">@color/gray_100</color>
 
+    <!-- Jetpack awareness in WordPress App -->
+    <color name="jetpack_banner_background">@color/jetpack_green_90</color>
+    <color name="jetpack_banner_divider">@color/gray_80</color>
+
     <!-- Reader -->
 
     <!-- Reader Following empty view -->

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -38,6 +38,10 @@
     <color name="prepublishing_action_type_disabled_color">@color/gray_10</color>
     <color name="prepublishing_action_result_disabled_color">@color/gray_10</color>
 
+    <!-- Jetpack awareness in WordPress App -->
+    <color name="jetpack_banner_background">@color/jetpack_green_0</color>
+    <color name="jetpack_banner_divider">@color/gray_5</color>
+
     <!-- Reader -->
 
     <!--Reader Following empty view -->

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -464,6 +464,7 @@
     <dimen name="jetpack_icon_size">32dp</dimen>
     <dimen name="jetpack_icon_margin">0dp</dimen>
     <dimen name="jetpack_button_icon_size">16dp</dimen>
+    <dimen name="jetpack_banner_height">40dp</dimen>
 
     <!-- jetpack backup restore last bullet bottom margin-->
     <dimen name="jetpack_backup_restore_last_bullet_bottom_margin">20dp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4201,4 +4201,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="gutenberg_native_new" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">NEW</string>
     <string name="gutenberg_native_you_can_also_rearrange_blocks_by_tapping_a_block_and_then_tapping" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">You can also rearrange blocks by tapping a block and then tapping the up and down arrows that appear on the bottom left side of the block to move it up or down.</string>
 
+    <!-- Jetpack awareness in WordPress App -->
+    <string name="wp_jetpack_powered">Jetpack powered</string>
+
 </resources>


### PR DESCRIPTION
This adds a Jetpack banner to the bottom of main Stats screen and Notifications screen.

|Notifications|Stats|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/176884436-bc81ff74-be3e-4f5e-9b1b-1a9fd39ca746.png" width=280>|<img src="https://user-images.githubusercontent.com/2471769/176884421-69da11a2-d822-43e5-9453-fa3d1f0c85f6.png" width=280>|
|<img src="https://user-images.githubusercontent.com/2471769/176884876-e62a5605-fa57-48f1-9bb8-2351fafc8b4b.png" width=280>|<img src="https://user-images.githubusercontent.com/2471769/176884831-9fe43bf0-c6aa-4ef7-afdb-71743b596a9d.png" width=280>|

WordPress test:
1. Launch WordPress app.
2. Navigate to Notifications tab.
3. Ensure a Jetpack banner is at the bottom of the notification list.
4. Navigate to My Site > Stats.
5. Ensure a Jetpack banner is at the bottom of the screen, and the navigation bar color is green.

Dark mode test:
- Repeat 1-5 for dark mode.

Jetpack app test:
1. Launch Jetpackapp.
2. Repeat items 1-5 in WordPress test.
3. Ensure there isn't a Jetpack banner on Notifications and Stats screens.

## Regression Notes
1. Potential unintended areas of impact
- Scroll function on Stats and Notifications screens
- Empty list screens
- Connect Jetpack UI

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Since this is a small UI change, I didn't add any tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
