### PR TITLE
Disable unused exported property from EditPostActivity

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -247,10 +247,6 @@
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".ui.posts.PostsListActivity" />
-
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-            </intent-filter>
         </activity>
 
         <!-- Story composer activity -->

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -243,7 +243,7 @@
             android:name=".ui.posts.EditPostActivity"
             android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="stateHidden|adjustResize"
-            android:exported="true">
+            android:exported="false">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".ui.posts.PostsListActivity" />


### PR DESCRIPTION
This PR cherry-picks commits from https://github.com/wordpress-mobile/WordPress-Android/pull/16851 that removes exported property from `EditPostActivity`.

To test:
See original PR.

**Merge Instructions**

- Wait for approval from @AliSoftware since it targets release branch.
- Remove "Not Ready for Merge" label.
- Merge the PR.

## Regression Notes
1. Potential unintended areas of impact
- `QuickPress` shortcut functionality since `android.intent.action.MAIN` intent filter is removed.
- Sharing media through the device.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
