### PR TITLE
Fix wrong previous week data on total stats cards

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
@@ -112,7 +112,7 @@ class TotalStatsMapper @Inject constructor(
         }
         val previousWeekDays = dates.subList(
                 dates.lastIndex - DAY_COUNT_TOTAL + 1,
-                dates.lastIndex - DAY_COUNT_FOR_PREVIOUS_WEEK
+                dates.lastIndex - DAY_COUNT_FOR_PREVIOUS_WEEK + 1
         )
         return mapToStatsType(previousWeekDays, type)
     }


### PR DESCRIPTION
Fixes #16860 

This fixes the wrong previous week data on total cards. In the calculation for comparison text, the previous week is taken as 6 days. It should’ve been 7 days.

To test:
1. Launch the Jetpack app.
2. Go Stats
3. Go to Stats either using quick links or menu
4. Switch to the Insights tab if necessary
5. Check the data on Total Likes and Total Comments cards. Compare the current week data, and change data by using stats on WordPress web. Ensure there is no inconsistency.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
