### PR TITLE
Stats revamp v2 fix date range issue on views & visitors graph

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCase.kt
@@ -44,7 +44,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlin.math.ceil
 
-const val VIEWS_AND_VISITORS_ITEMS_TO_LOAD = 14
+const val VIEWS_AND_VISITORS_ITEMS_TO_LOAD = 15
 const val TOP_TIPS_URL = "https://wordpress.com/support/getting-more-views-and-traffic/"
 
 @Suppress("TooManyFunctions")
@@ -90,7 +90,6 @@ class ViewsAndVisitorsUseCase
         )
         if (cachedData != null) {
             logIfIncorrectData(cachedData, statsGranularity, statsSiteProvider.siteModel, false)
-            selectedDateProvider.onDateLoadingSucceeded(statsGranularity)
         }
         return cachedData
     }
@@ -107,16 +106,13 @@ class ViewsAndVisitorsUseCase
 
         return when {
             error != null -> {
-                selectedDateProvider.onDateLoadingFailed(statsGranularity)
                 State.Error(error.message ?: error.type.name)
             }
             model != null && model.dates.isNotEmpty() -> {
                 logIfIncorrectData(model, statsGranularity, statsSiteProvider.siteModel, true)
-                selectedDateProvider.onDateLoadingSucceeded(statsGranularity)
                 State.Data(model)
             }
             else -> {
-                selectedDateProvider.onDateLoadingSucceeded(statsGranularity)
                 State.Empty()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/LineChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/LineChartViewHolder.kt
@@ -88,29 +88,16 @@ class LineChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     }
 
     private fun getData(item: LineChartItem): List<ILineDataSet> {
-        val hasData = hasData(item.entries)
-
-        val prevWeekData = if (hasData && item.entries.size > 7) {
-            item.entries.subList(0, 7)
-        } else {
-            item.entries
-        }
-        val hasPrevWeekData = prevWeekData.isNotEmpty() && prevWeekData.any { it.value > 0 }
-        val prevWeekDataSet = if (hasPrevWeekData) {
+        val prevWeekData = getPreviousWeekData(item)
+        val prevWeekDataSet = if (hasData(prevWeekData)) {
             val mappedEntries = prevWeekData.mapIndexed { index, pair -> toLineEntry(pair, index) }
             LineDataSet(mappedEntries, "Previous week data")
         } else {
             buildEmptyDataSet(prevWeekData.size)
         }
 
-        val thisWeekData = if (hasData && item.entries.size > 7) {
-            item.entries.subList(7, item.entries.size)
-        } else {
-            emptyList()
-        }
-
-        val hasThisWeekData = thisWeekData.isNotEmpty() && thisWeekData.any { it.value > 0 }
-        val thisWeekDataSet = if (hasThisWeekData) {
+        val thisWeekData = getThisWeekData(item)
+        val thisWeekDataSet = if (hasData(thisWeekData)) {
             val mappedEntries = thisWeekData.mapIndexed { index, pair -> toLineEntry(pair, index) }
             LineDataSet(mappedEntries, "Current week data")
         } else {
@@ -188,12 +175,7 @@ class LineChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     }
 
     private fun configureXAxis(item: LineChartItem) {
-        val hasData = item.entries.isNotEmpty() && item.entries.any { it.value > 0 }
-        val thisWeekData = if (hasData && item.entries.size > 7) {
-            item.entries.subList(7, item.entries.size)
-        } else {
-            emptyList()
-        }
+        val thisWeekData = getThisWeekData(item)
 
         chart.xAxis.apply {
             granularity = 1f
@@ -278,6 +260,20 @@ class LineChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             isHighlightEnabled = false
         }
     }
+
+    private fun getPreviousWeekData(item: LineChartItem): List<Line> =
+            if (hasData(item.entries) && item.entries.size > 7) {
+                item.entries.subList(1, 8)
+            } else {
+                item.entries
+            }
+
+    private fun getThisWeekData(item: LineChartItem): List<Line> =
+            if (hasData(item.entries) && item.entries.size > 7) {
+                item.entries.subList(8, item.entries.size)
+            } else {
+                emptyList()
+            }
 
     private fun buildEmptyDataSet(count: Int): LineDataSet {
         val emptyValues = (0 until count).map { index -> Entry(index.toFloat(), 0f, "empty") }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/LineChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/LineChartViewHolder.kt
@@ -93,7 +93,7 @@ class LineChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         val prevWeekData = if (hasData && item.entries.size > 7) {
             item.entries.subList(0, 7)
         } else {
-            emptyList()
+            item.entries
         }
         val hasPrevWeekData = prevWeekData.isNotEmpty() && prevWeekData.any { it.value > 0 }
         val prevWeekDataSet = if (hasPrevWeekData) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ViewsAndVisitorsUseCaseTest.kt
@@ -65,7 +65,7 @@ class ViewsAndVisitorsUseCaseTest : BaseUnitTest() {
     private val siteId = 1L
     private val periodData = PeriodData("2018-10-08", 10, 15, 20, 25, 30, 35)
     private val modelPeriod = "2018-10-10"
-    private val limitMode = Top(14)
+    private val limitMode = Top(15)
     private val statsGranularity = DAYS
     private val model = VisitsAndViewsModel(modelPeriod, listOf(periodData))
 


### PR DESCRIPTION
This PR fixes an issue where date range was fluctuating on **Views & Visitors** graph on Insights tab when switching between home and Stats

Item to load count is 14 on ViewsVisitorsUseCase while it is 15 on Day tab OverviewUseCase resulting in mismatch by day while repeatedly switching between home and Insights.  Since next tab data is fetched eagerly on Stats

Fixes #16835 

To test:

- Launch app and navigate to Stats
- Make sure it show the new **Views & Visitors** graph.  Note the date range on x-axis (for e.g. 29-Jun to 5-Jul)
- Switch back to **Home** and return to **Stats** and check the date range
- Switch back and forth between Home and Stats screen multiple times.
- Make sure the date range is same each time.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested repeatedly

3. What automated tests I added (or what prevented me from doing so)
Updated existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
