### PR TITLE
Implement blogging prompts onboarding flag to decide when to show the site picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModel.kt
@@ -56,9 +56,11 @@ class BloggingPromptsOnboardingViewModel @Inject constructor(
             hasTrackedScreenShown = true
             analyticsTracker.trackScreenShown()
         }
+        if (type == ONBOARDING) {
+            isFirstBloggingPromptsOnboarding = getIsFirstBloggingPromptsOnboardingUseCase.execute()
+            saveFirstBloggingPromptsOnboardingUseCase.execute(isFirstTime = false)
+        }
         dialogType = type
-        isFirstBloggingPromptsOnboarding = getIsFirstBloggingPromptsOnboardingUseCase.execute()
-        saveFirstBloggingPromptsOnboardingUseCase.execute(isFirstTime = false)
         _uiState.value = uiStateMapper.mapReady(dialogType, ::onPrimaryButtonClick, ::onSecondaryButtonClick)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModel.kt
@@ -16,6 +16,8 @@ import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboar
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingDialogFragment.DialogType
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingDialogFragment.DialogType.INFORMATION
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingDialogFragment.DialogType.ONBOARDING
+import org.wordpress.android.ui.bloggingprompts.onboarding.usecase.GetIsFirstBloggingPromptsOnboardingUseCase
+import org.wordpress.android.ui.bloggingprompts.onboarding.usecase.SaveFirstBloggingPromptsOnboardingUseCase
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -31,7 +33,9 @@ class BloggingPromptsOnboardingViewModel @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val bloggingPromptsStore: BloggingPromptsStore,
     private val analyticsTracker: BloggingPromptsOnboardingAnalyticsTracker,
-    @Named(BG_THREAD) val bgDispatcher: CoroutineDispatcher
+    @Named(BG_THREAD) val bgDispatcher: CoroutineDispatcher,
+    private val getIsFirstBloggingPromptsOnboardingUseCase: GetIsFirstBloggingPromptsOnboardingUseCase,
+    private val saveFirstBloggingPromptsOnboardingUseCase: SaveFirstBloggingPromptsOnboardingUseCase
 ) : ScopedViewModel(bgDispatcher) {
     private val _uiState = MutableLiveData<BloggingPromptsOnboardingUiState>()
     val uiState: LiveData<BloggingPromptsOnboardingUiState> = _uiState
@@ -45,14 +49,21 @@ class BloggingPromptsOnboardingViewModel @Inject constructor(
     private lateinit var dialogType: DialogType
     private var hasTrackedScreenShown = false
 
+    private var isFirstBloggingPromptsOnboarding = false
+
     fun start(type: DialogType) {
         if (!hasTrackedScreenShown) {
             hasTrackedScreenShown = true
             analyticsTracker.trackScreenShown()
         }
         dialogType = type
-
+        isFirstBloggingPromptsOnboarding = getIsFirstBloggingPromptsOnboardingUseCase.execute()
+        saveFirstBloggingPromptsOnboardingUseCase.execute(isFirstTime = false)
         _uiState.value = uiStateMapper.mapReady(dialogType, ::onPrimaryButtonClick, ::onSecondaryButtonClick)
+    }
+
+    fun onSiteSelected(selectedSiteLocalId: Int) {
+        _action.value = OpenRemindersIntro(selectedSiteLocalId)
     }
 
     private fun onPrimaryButtonClick() = launch {
@@ -84,16 +95,12 @@ class BloggingPromptsOnboardingViewModel @Inject constructor(
 
     private fun onSecondaryButtonClick() {
         analyticsTracker.trackRemindMeClicked()
-        if (siteStore.sitesCount > 1) {
+        if (siteStore.sitesCount > 1 && isFirstBloggingPromptsOnboarding) {
             _action.value = OpenSitePicker(selectedSiteRepository.getSelectedSite())
         } else {
             siteStore.sites.firstOrNull()?.let {
                 _action.value = OpenRemindersIntro(it.id)
             }
         }
-    }
-
-    fun onSiteSelected(selectedSiteLocalId: Int) {
-        _action.value = OpenRemindersIntro(selectedSiteLocalId)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/usecase/GetIsFirstBloggingPromptsOnboardingUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/usecase/GetIsFirstBloggingPromptsOnboardingUseCase.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.ui.bloggingprompts.onboarding.usecase
+
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import javax.inject.Inject
+
+class GetIsFirstBloggingPromptsOnboardingUseCase @Inject constructor(
+    private val appPrefsWrapper: AppPrefsWrapper
+) {
+    fun execute(): Boolean = appPrefsWrapper.getIsFirstBloggingPromptsOnboarding()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/usecase/SaveFirstBloggingPromptsOnboardingUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/usecase/SaveFirstBloggingPromptsOnboardingUseCase.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.ui.bloggingprompts.onboarding.usecase
+
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import javax.inject.Inject
+
+class SaveFirstBloggingPromptsOnboardingUseCase @Inject constructor(
+    private val appPrefsWrapper: AppPrefsWrapper
+) {
+    fun execute(isFirstTime: Boolean) {
+        appPrefsWrapper.saveFirstBloggingPromptsOnboarding(isFirstTime)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -276,7 +276,10 @@ public class AppPrefs {
         // Used to identify the App Settings for initial screen that is updated when the variant is assigned
         wp_pref_initial_screen,
 
-        STATS_REVAMP2_FEATURE_ANNOUNCEMENT_DISPLAYED
+        STATS_REVAMP2_FEATURE_ANNOUNCEMENT_DISPLAYED,
+
+        // Indicates if this is the first time the user sees the blogging prompts onboarding dialog
+        IS_FIRST_TIME_BLOGGING_PROMPTS_ONBOARDING
     }
 
     private static SharedPreferences prefs() {
@@ -1429,5 +1432,13 @@ public class AppPrefs {
                 UndeletablePrefKey.wp_pref_initial_screen,
                 MySiteTabType.SITE_MENU.getLabel()
         );
+    }
+
+    public static Boolean getIsFirstBloggingPromptsOnboarding() {
+        return getBoolean(UndeletablePrefKey.IS_FIRST_TIME_BLOGGING_PROMPTS_ONBOARDING, true);
+    }
+
+    public static void saveFirstBloggingPromptsOnboarding(final boolean isFirstTime) {
+        setBoolean(UndeletablePrefKey.IS_FIRST_TIME_BLOGGING_PROMPTS_ONBOARDING, isFirstTime);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -235,6 +235,12 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun markStatsRevampFeatureAnnouncementAsDisplayed() = AppPrefs.setShouldDisplayStatsRevampFeatureAnnouncement(false)
 
+    fun getIsFirstBloggingPromptsOnboarding(): Boolean = AppPrefs.getIsFirstBloggingPromptsOnboarding()
+
+    fun saveFirstBloggingPromptsOnboarding(isFirstTime: Boolean) {
+        AppPrefs.saveFirstBloggingPromptsOnboarding(isFirstTime)
+    }
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
@@ -32,6 +32,8 @@ import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboar
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingDialogFragment.DialogType.INFORMATION
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingDialogFragment.DialogType.ONBOARDING
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingUiState.Ready
+import org.wordpress.android.ui.bloggingprompts.onboarding.usecase.GetIsFirstBloggingPromptsOnboardingUseCase
+import org.wordpress.android.ui.bloggingprompts.onboarding.usecase.SaveFirstBloggingPromptsOnboardingUseCase
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -45,6 +47,8 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
     private val selectedSiteRepository: SelectedSiteRepository = mock()
     private val bloggingPromptsStore: BloggingPromptsStore = mock()
     private val analyticsTracker: BloggingPromptsOnboardingAnalyticsTracker = mock()
+    private val getIsFirstBloggingPromptsOnboardingUseCase: GetIsFirstBloggingPromptsOnboardingUseCase = mock()
+    private val saveFirstBloggingPromptsOnboardingUseCase: SaveFirstBloggingPromptsOnboardingUseCase = mock()
 
     private val bloggingPrompt = BloggingPromptsResult(
             model = BloggingPromptModel(
@@ -66,7 +70,9 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
             selectedSiteRepository,
             bloggingPromptsStore,
             analyticsTracker,
-            TEST_DISPATCHER
+            TEST_DISPATCHER,
+            getIsFirstBloggingPromptsOnboardingUseCase,
+            saveFirstBloggingPromptsOnboardingUseCase
     )
     private val actionObserver: Observer<BloggingPromptsOnboardingAction> = mock()
     private val snackbarObserver: Observer<Event<SnackbarMessageHolder>> = mock()
@@ -105,16 +111,18 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should trigger OpenSitePicker if Remind Me is clicked and user has more than 1 site`() = runBlocking {
-        classToTest.start(ONBOARDING)
-        val selectedSiteModel = SiteModel()
-        whenever(siteStore.sitesCount).thenReturn(2)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(selectedSiteModel)
-
-        val startState = viewStates[0]
-        (startState as Ready).onPrimaryButtonClick()
-        startState.onSecondaryButtonClick()
-        verify(actionObserver).onChanged(OpenSitePicker(selectedSiteModel))
+    fun `Should trigger OpenSitePicker if Remind Me is clicked, user has more than 1 site and is first onboarding`() {
+        runBlocking {
+            val selectedSiteModel = SiteModel()
+            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(selectedSiteModel)
+            whenever(siteStore.sitesCount).thenReturn(2)
+            whenever(getIsFirstBloggingPromptsOnboardingUseCase.execute()).thenReturn(true)
+            classToTest.start(ONBOARDING)
+            val startState = viewStates[0]
+            (startState as Ready).onPrimaryButtonClick()
+            startState.onSecondaryButtonClick()
+            verify(actionObserver).onChanged(OpenSitePicker(selectedSiteModel))
+        }
     }
 
     @Test
@@ -124,6 +132,19 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
         whenever(siteStore.sitesCount).thenReturn(1)
         whenever(siteStore.sites).thenReturn(listOf(siteModel))
 
+        val startState = viewStates[0]
+        (startState as Ready).onPrimaryButtonClick()
+        startState.onSecondaryButtonClick()
+        verify(actionObserver).onChanged(OpenRemindersIntro(123))
+    }
+
+    @Test
+    fun `Should trigger OpenRemindersIntro if Remind Me is clicked and is NOT first onboarding`() = runBlocking {
+        val siteModel = SiteModel().apply { id = 123 }
+        whenever(siteStore.sitesCount).thenReturn(1)
+        whenever(siteStore.sites).thenReturn(listOf(siteModel))
+        whenever(getIsFirstBloggingPromptsOnboardingUseCase.execute()).thenReturn(false)
+        classToTest.start(ONBOARDING)
         val startState = viewStates[0]
         (startState as Ready).onPrimaryButtonClick()
         startState.onSecondaryButtonClick()
@@ -205,5 +226,29 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
         val startState = viewStates[0]
         (startState as Ready).onSecondaryButtonClick()
         verify(analyticsTracker).trackRemindMeClicked()
+    }
+
+    @Test
+    fun `Should get is first blogging prompts onboarding when start is called with INFORMATION`() {
+        classToTest.start(INFORMATION)
+        verify(getIsFirstBloggingPromptsOnboardingUseCase).execute()
+    }
+
+    @Test
+    fun `Should save first blogging prompts onboarding when start is called with INFORMATION`() {
+        classToTest.start(INFORMATION)
+        verify(saveFirstBloggingPromptsOnboardingUseCase).execute(false)
+    }
+
+    @Test
+    fun `Should get is first blogging prompts onboarding when start is called with ONBOARDING`() {
+        classToTest.start(ONBOARDING)
+        verify(getIsFirstBloggingPromptsOnboardingUseCase).execute()
+    }
+
+    @Test
+    fun `Should save first blogging prompts onboarding when start is called with ONBOARDING`() {
+        classToTest.start(ONBOARDING)
+        verify(saveFirstBloggingPromptsOnboardingUseCase).execute(false)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
@@ -229,15 +229,15 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should get is first blogging prompts onboarding when start is called with INFORMATION`() {
+    fun `Should NOT get is first blogging prompts onboarding when start is called with INFORMATION`() {
         classToTest.start(INFORMATION)
-        verify(getIsFirstBloggingPromptsOnboardingUseCase).execute()
+        verify(getIsFirstBloggingPromptsOnboardingUseCase, times(0)).execute()
     }
 
     @Test
-    fun `Should save first blogging prompts onboarding when start is called with INFORMATION`() {
+    fun `Should NOT save first blogging prompts onboarding when start is called with INFORMATION`() {
         classToTest.start(INFORMATION)
-        verify(saveFirstBloggingPromptsOnboardingUseCase).execute(false)
+        verify(saveFirstBloggingPromptsOnboardingUseCase, times(0)).execute(any())
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/usecase/GetIsFirstBloggingPromptsOnboardingUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/usecase/GetIsFirstBloggingPromptsOnboardingUseCaseTest.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.ui.bloggingprompts.onboarding.usecase
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Test
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+
+class GetIsFirstBloggingPromptsOnboardingUseCaseTest {
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
+    private val classToTest = GetIsFirstBloggingPromptsOnboardingUseCase(appPrefsWrapper)
+
+    @Test
+    fun `Should get is first blogging prompts onboarding when execute is called`() {
+        classToTest.execute()
+        verify(appPrefsWrapper).getIsFirstBloggingPromptsOnboarding()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/usecase/SaveFirstBloggingPromptsOnboardingUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/usecase/SaveFirstBloggingPromptsOnboardingUseCaseTest.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.bloggingprompts.onboarding.usecase
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Test
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+
+class SaveFirstBloggingPromptsOnboardingUseCaseTest {
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
+    private val classToTest = SaveFirstBloggingPromptsOnboardingUseCase(appPrefsWrapper)
+
+    @Test
+    fun `Should save first blogging prompts onboarding when execute is called with TRUE`() {
+        classToTest.execute(true)
+        verify(appPrefsWrapper).saveFirstBloggingPromptsOnboarding(true)
+    }
+
+    @Test
+    fun `Should save first blogging prompts onboarding when execute is called with FALSE`() {
+        classToTest.execute(false)
+        verify(appPrefsWrapper).saveFirstBloggingPromptsOnboarding(false)
+    }
+}


### PR DESCRIPTION
Fixes #16801 

To test:
Opening dialog with `DialogType.INFORMATION` should not change the onboarding flag:
- Select a site that has blogging prompts enabled
- Tap on "MENU"
- Tap on "Site Settings"
- Tap on "Reminders and prompts"
- Tap on "Set reminders"
- Select any day of the week so that the "Include daily prompt" section is shown
- Tap on the "?" button
- The onboarding flag should not be changed, which means that if you open the onboarding dialog with `DialogType.ONBOARDING` for the first time after this, the site picker should appear.

Opening dialog with `DialogType.ONBOARDING` (which changes the onboarding flag)
- Select a site that has blogging prompts enabled
- Tap on "HOME"
- Find the `Prompts` card and tap on the overflow menu
- Tap on "Learn more"
- Tap on "Remind me": if you have a clear install and this is the first time you open this screen, the site picker should be shown. 
- Repeat the steps above again. After tapping on "Remind me" this time the reminders dialog should be opened directly instead of the site picker.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests

3. What automated tests I added (or what prevented me from doing so)
`BloggingPromptsOnboardingViewModelTest.kt`, `GetIsFirstBloggingPromptsOnboardingUseCaseTest.kt` and `SaveFirstBloggingPromptsOnboardingUseCaseTest.kt`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
