### PR TITLE
Stats revamp v2 format text of guide card on total likes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/TotalLikesDetailUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/TotalLikesDetailUseCase.kt
@@ -2,36 +2,27 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.granular.usecases
 
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R.string
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_INSIGHTS_TOTAL_LIKES_GUIDE_TAPPED
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.TOTAL_LIKES
-import org.wordpress.android.fluxc.store.stats.insights.LatestPostInsightsStore
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPost
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Empty
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemGuideCard
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Text.Clickable
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularStatefulUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
-import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.LatestPostSummaryUseCase.LinkClickParams
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalStatsMapper
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.ViewsAndVisitorsUseCase.UiState
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
-import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
@@ -42,11 +33,8 @@ class TotalLikesDetailUseCase @Inject constructor(
     statsGranularity: StatsGranularity,
     selectedDateProvider: SelectedDateProvider,
     private val visitsAndViewsStore: VisitsAndViewsStore,
-    private val latestPostStore: LatestPostInsightsStore,
     statsSiteProvider: StatsSiteProvider,
-    private val resourceProvider: ResourceProvider,
     private val totalStatsMapper: TotalStatsMapper,
-    private val analyticsTracker: AnalyticsTrackerWrapper,
     private val statsWidgetUpdaters: StatsWidgetUpdaters
 ) : GranularStatefulUseCase<VisitsAndViewsModel, UiState>(
         TOTAL_LIKES,
@@ -112,9 +100,6 @@ class TotalLikesDetailUseCase @Inject constructor(
             items.add(buildTitle())
             items.add(totalStatsMapper.buildTotalLikesValue(domainModel.dates))
             totalStatsMapper.buildTotalLikesInformation(domainModel.dates)?.let { items.add(it) }
-            if (totalStatsMapper.shouldShowLikesGuideCard(domainModel.dates)) {
-                buildLatestPostGuideCard(items, this::onLinkClicked)
-            }
         } else {
             selectedDateProvider.onDateLoadingFailed(statsGranularity)
             AppLog.e(T.STATS, "There is no data to be shown in the total likes block")
@@ -124,52 +109,14 @@ class TotalLikesDetailUseCase @Inject constructor(
 
     private fun buildTitle() = TitleWithMore(string.stats_view_total_likes)
 
-    private fun buildLatestPostGuideCard(
-        items: MutableList<BlockListItem>,
-        navigationAction: (params: LinkClickParams) -> Unit
-    ) {
-        val postModel = latestPostStore.getLatestPostInsights(statsSiteProvider.siteModel)
-        postModel?.let {
-            if (it.postTitle.isNotBlank()) {
-                items.add(
-                        ListItemGuideCard(
-                                text = resourceProvider.getString(
-                                        string.stats_insights_likes_guide_card,
-                                        it.postTitle,
-                                        it.postLikeCount
-                                ),
-                                links = listOf(
-                                        Clickable(
-                                                link = it.postTitle,
-                                                navigationAction = ListItemInteraction.create(
-                                                        data = LinkClickParams(it.postId, it.postURL),
-                                                        action = navigationAction
-                                                )
-                                        )
-                                ),
-                                bolds = listOf(it.postLikeCount.toString())
-                        )
-                )
-            }
-        }
-    }
-
-    private fun onLinkClicked(params: LinkClickParams) {
-        analyticsTracker.track(STATS_INSIGHTS_TOTAL_LIKES_GUIDE_TAPPED)
-        navigateTo(ViewPost(params.postId, params.postUrl))
-    }
-
     class TotalLikesGranularUseCaseFactory
     @Inject constructor(
         @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
         @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher,
         private val selectedDateProvider: SelectedDateProvider,
         private val visitsAndViewsStore: VisitsAndViewsStore,
-        private val latestPostStore: LatestPostInsightsStore,
         private val statsSiteProvider: StatsSiteProvider,
-        private val resourceProvider: ResourceProvider,
         private val totalStatsMapper: TotalStatsMapper,
-        private val analyticsTracker: AnalyticsTrackerWrapper,
         private val statsWidgetUpdaters: StatsWidgetUpdaters
     ) : GranularUseCaseFactory {
         override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
@@ -179,11 +126,8 @@ class TotalLikesDetailUseCase @Inject constructor(
                         granularity,
                         selectedDateProvider,
                         visitsAndViewsStore,
-                        latestPostStore,
                         statsSiteProvider,
-                        resourceProvider,
                         totalStatsMapper,
-                        analyticsTracker,
                         statsWidgetUpdaters
                 )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCase.kt
@@ -1,12 +1,12 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases
 
+import androidx.core.text.HtmlCompat
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_INSIGHTS_TOTAL_LIKES_GUIDE_TAPPED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_TOTAL_LIKES_ERROR
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
+import org.wordpress.android.fluxc.model.stats.LimitMode.All
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.TOTAL_LIKES
@@ -27,19 +27,15 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.LatestPostSummaryUseCase.LinkClickParams
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters
-import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.trackWithType
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
-import java.util.Calendar
 import javax.inject.Inject
 import javax.inject.Named
-import kotlin.math.ceil
 
 class TotalLikesUseCase @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
@@ -48,11 +44,9 @@ class TotalLikesUseCase @Inject constructor(
     private val latestPostStore: LatestPostInsightsStore,
     private val statsSiteProvider: StatsSiteProvider,
     private val resourceProvider: ResourceProvider,
-    private val statsDateFormatter: StatsDateFormatter,
     private val totalStatsMapper: TotalStatsMapper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val statsWidgetUpdaters: StatsWidgetUpdaters,
-    private val localeManagerWrapper: LocaleManagerWrapper
+    private val statsWidgetUpdaters: StatsWidgetUpdaters
 ) : StatelessUseCase<VisitsAndViewsModel>(TOTAL_LIKES, mainDispatcher, bgDispatcher) {
     override fun buildLoadingItem() = listOf(TitleWithMore(string.stats_view_total_likes))
 
@@ -60,15 +54,11 @@ class TotalLikesUseCase @Inject constructor(
 
     override suspend fun loadCachedData(): VisitsAndViewsModel? {
         statsWidgetUpdaters.updateViewsWidget(statsSiteProvider.siteModel.siteId)
-        val cachedData = visitsAndViewsStore.getVisits(
+        return visitsAndViewsStore.getVisits(
                 statsSiteProvider.siteModel,
                 DAYS,
-                LimitMode.All
+                All
         )
-        if (cachedData != null) {
-            logIfIncorrectData(cachedData, statsSiteProvider.siteModel, false)
-        }
-        return cachedData
     }
 
     override suspend fun fetchRemoteData(forced: Boolean): State<VisitsAndViewsModel> {
@@ -84,42 +74,9 @@ class TotalLikesUseCase @Inject constructor(
         return when {
             error != null -> State.Error(error.message ?: error.type.name)
             model != null && model.dates.isNotEmpty() -> {
-                logIfIncorrectData(model, statsSiteProvider.siteModel, true)
                 State.Data(model)
             }
             else -> State.Empty()
-        }
-    }
-
-    /**
-     * Track the incorrect data shown for some users
-     * see https://github.com/wordpress-mobile/WordPress-Android/issues/11412
-     */
-    @Suppress("MagicNumber")
-    private fun logIfIncorrectData(
-        model: VisitsAndViewsModel,
-        site: SiteModel,
-        fetched: Boolean
-    ) {
-        model.dates.lastOrNull()?.let { lastDayData ->
-            val yesterday = localeManagerWrapper.getCurrentCalendar()
-            yesterday.add(Calendar.DAY_OF_YEAR, -1)
-            val lastDayDate = statsDateFormatter.parseStatsDate(DAYS, lastDayData.period)
-            if (lastDayDate.before(yesterday.time)) {
-                val currentCalendar = localeManagerWrapper.getCurrentCalendar()
-                val lastItemAge = ceil((currentCalendar.timeInMillis - lastDayDate.time) / 86400000.0)
-                analyticsTracker.track(
-                        STATS_TOTAL_LIKES_ERROR,
-                        mapOf(
-                                "stats_last_date" to statsDateFormatter.printStatsDate(lastDayDate),
-                                "stats_current_date" to statsDateFormatter.printStatsDate(currentCalendar.time),
-                                "stats_age_in_days" to lastItemAge.toInt(),
-                                "is_jetpack_connected" to site.isJetpackConnected,
-                                "is_atomic" to site.isWPComAtomic,
-                                "action_source" to if (fetched) "remote" else "cached"
-                        )
-                )
-            }
         }
     }
 
@@ -149,16 +106,21 @@ class TotalLikesUseCase @Inject constructor(
     ) {
         val postModel = latestPostStore.getLatestPostInsights(statsSiteProvider.siteModel)
         postModel?.let {
-            if (it.postTitle.isNotBlank()) {
+            if (it.postTitle.isNotBlank() && it.postLikeCount > 0) {
+                val htmlTitle = HtmlCompat.fromHtml(it.postTitle, HtmlCompat.FROM_HTML_MODE_LEGACY)
                 items.add(
                         ListItemGuideCard(
                                 text = resourceProvider.getString(
-                                        string.stats_insights_likes_guide_card,
-                                        it.postTitle,
+                                        if (it.postLikeCount <= 1) {
+                                            string.stats_insights_like_guide_card
+                                        } else {
+                                            string.stats_insights_likes_guide_card
+                                        },
+                                        htmlTitle,
                                         it.postLikeCount
                                 ),
                                 links = listOf(Clickable(
-                                                link = it.postTitle,
+                                                link = htmlTitle.toString(),
                                                 navigationAction = ListItemInteraction.create(
                                                         data = LinkClickParams(it.postId, it.postURL),
                                                         action = navigationAction
@@ -196,11 +158,9 @@ class TotalLikesUseCase @Inject constructor(
         private val latestPostStore: LatestPostInsightsStore,
         private val statsSiteProvider: StatsSiteProvider,
         private val resourceProvider: ResourceProvider,
-        private val statsDateFormatter: StatsDateFormatter,
         private val totalStatsMapper: TotalStatsMapper,
         private val analyticsTracker: AnalyticsTrackerWrapper,
-        private val statsWidgetUpdaters: StatsWidgetUpdaters,
-        private val localeManagerWrapper: LocaleManagerWrapper
+        private val statsWidgetUpdaters: StatsWidgetUpdaters
     ) : InsightUseCaseFactory {
         override fun build(useCaseMode: UseCaseMode) =
                 TotalLikesUseCase(
@@ -210,11 +170,9 @@ class TotalLikesUseCase @Inject constructor(
                         latestPostStore,
                         statsSiteProvider,
                         resourceProvider,
-                        statsDateFormatter,
                         totalStatsMapper,
                         analyticsTracker,
-                        statsWidgetUpdaters,
-                        localeManagerWrapper
+                        statsWidgetUpdaters
                 )
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1369,6 +1369,7 @@
     <string name="stats_insights_management_posts_and_pages">Posts and Pages</string>
     <string name="stats_insights_management_activity">Activity</string>
 
+    <string name="stats_insights_like_guide_card">⭐️ Your latest post %1$s has received %2$s like.</string>
     <string name="stats_insights_likes_guide_card">⭐️ Your latest post %1$s has received %2$s likes.</string>
     <string name="stats_insights_comments_guide_card">💡Tap \'VIEW MORE\' to see your top commenters.</string>
     <string name="stats_insights_followers_guide_card">💡Commenting on other blogs is a great way to build attention and followers for your new site.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
@@ -76,11 +76,9 @@ class TotalLikesUseCaseTest : BaseUnitTest() {
                 latestPostStore,
                 statsSiteProvider,
                 resourceProvider,
-                statsDateFormatter,
                 totalStatsMapper,
                 analyticsTrackerWrapper,
-                statsWidgetUpdaters,
-                localeManagerWrapper
+                statsWidgetUpdaters
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(totalStatsMapper.buildTotalLikesValue(any())).thenReturn(valueWithChart)
@@ -131,27 +129,6 @@ class TotalLikesUseCaseTest : BaseUnitTest() {
         verify(analyticsTrackerWrapper, never()).track(eq(STATS_TOTAL_LIKES_ERROR), any<Map<String, *>>())
     }
 
-    @Test
-    fun `tracks incorrect data when the last stats item is at least 2 days old`() = test {
-        val forced = false
-        setupCalendar(2)
-        whenever(store.fetchVisits(site, DAYS, limitMode, forced)).thenReturn(OnStatsFetched(model))
-
-        loadData(true, forced)
-
-        verify(analyticsTrackerWrapper).track(
-                STATS_TOTAL_LIKES_ERROR,
-                mapOf(
-                        "stats_last_date" to "2020-12-13",
-                        "stats_current_date" to "2020-12-15",
-                        "stats_age_in_days" to 2,
-                        "is_jetpack_connected" to false,
-                        "is_atomic" to false,
-                        "action_source" to "remote"
-                )
-        )
-    }
-
     private fun assertTitle(item: BlockListItem) {
         assertThat(item.type).isEqualTo(TITLE_WITH_MORE)
         assertThat((item as TitleWithMore).textResource).isEqualTo(R.string.stats_view_total_likes)
@@ -176,11 +153,5 @@ class TotalLikesUseCaseTest : BaseUnitTest() {
         val lastItemDay = todayDay - ageOfLastStatsItemInDays
         lastItemAge.set(Calendar.DAY_OF_MONTH, lastItemDay)
         lastItemAge.set(Calendar.HOUR_OF_DAY, 22)
-        whenever(localeManagerWrapper.getCurrentCalendar()).then {
-            Calendar.getInstance().apply { this.time = today.time }
-        }
-        whenever(statsDateFormatter.parseStatsDate(any(), any())).thenReturn(lastItemAge.time)
-        whenever(statsDateFormatter.printStatsDate(lastItemAge.time)).thenReturn("2020-12-$lastItemDay")
-        whenever(statsDateFormatter.printStatsDate(today.time)).thenReturn("2020-12-$todayDay")
     }
 }


### PR DESCRIPTION
This PR fixes Total Likes Guide Card issues
- Display guide only if post like count is greater than 0
- Remove guide from Total Likes card on Total Likes detail screen
- Handle singular and plural cases e.g. 1 like vs 5 likes
- handle post title format in escaped HTML  
- Refactor and clean-up

Fixes #16870 

To test:

- Launch Jetpack app and go to Stats
- Ensure **Total Likes** card is displayed on **Insights**
- Ensure Total Likes card has Latest Post guide on it (it is displayed when total likes > 0, there's a latest post and post likes are > 0)
- Verify card text matches criteria; **like** vs **likes** and title is properly formatted without any HTML escaped characters like &#; 
- Click on **View More** and go to Total Likes detail screen.  Verify no guide is displayed there on Total Likes card


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested Guide card on Total Likes card on Insights and Total Likes Details screen

3. What automated tests I added (or what prevented me from doing so)
Updated unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
