### PR TITLE
Remove Only the Default Initializer to Provide Custom Configuration

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1028,13 +1028,25 @@
                 android:resource="@xml/provider_paths"/>
         </provider>
 
-        <!-- Remove the default WorkManagerInitializer so we can use our own
-        Since WorkManager 2.6, App Startup is used internally within WorkManager.
-        To provide a custom initializer we need to remove the androidx.startup node.-->
+        <!-- Remove only the default initializer to provide a custom configuration.
+             For more info visit: https://developer.android.com/topic/libraries/architecture/
+             workmanager/advanced/custom-configuration
+
+             This change was necessary because of the 'androidx.lifecycle' update to '2.4.1' and
+             the fact that with it the 'lifecycle-process' now uses 'androidx.startup' to
+             initialize the 'ProcessLifecycleOwner'.
+             For more info visit: https://developer.android.com/jetpack/androidx/releases/
+             lifecycle#2.4.1 -->
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
-            tools:node="remove" />
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
 
         <!-- Scanner -->
         <meta-data


### PR DESCRIPTION
Fixes #16867

This PR fixes the story regression.

This change was necessary because of the `androidx.lifecycle` update to `2.4.1` and the fact that with it the `lifecycle-process` now uses `androidx.startup` to initialize the `ProcessLifecycleOwner`. This definitely caused an issue with the `Stories Uploading` functionality, but it might also have caused other issues as well.

As such removing all initializers are no longer an option, as it will also remove the `ProcessLifecycleInitializer` initializer. Instead removing only the default `WorkManagerInitializer`, while keeping the rest with the `tools:node="merge"` option, is recommended for when using a custom configuration.

For more info visit:
- [Custom WorkManager Configuration and Initialization](https://developer.android.com/topic/libraries/architecture/workmanager/advanced/custom-configuration)
- [Lifecycle 2.4.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.4.1)

PS.1: This is the [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16647) and its specific [commit](https://github.com/wordpress-mobile/WordPress-Android/commit/5626d1cf5a02c9ac4cc607e2b67bea008035677d) that introduced this story regression.
PS.2: You will find more details about this story's regression investigation in this Slack discussion here: `C011BKNU1V5/p1657026365958239`

-----

To test:

- Open the app, while on the `My Site` main screen tab click on the 🔵 FAB button on the bottom right.
- Chose `Store post` to compose and publish a story. Make sure the story is `uploading` as well as `published`.
- Chose `Blog post` to compose and publish a post. Make sure the post is `uploading` as well as `published`.
- Chose `Page page` to compose and publish a page. Make sure the page is `uploading` as well as `published`.
- Smoke test the `Posts` and `Pages` related screen and verify that everything works as expected.
- Smoke test anything else that you can think of that might be affecting any `uploading`, `startup` or `work manager` related functionality.

-----

## Regression Notes
1. Potential unintended areas of impact

By removing only the default initializer (using `merge`) vs. removing all initializers (using `remove`) there might be other initializer apart from `WorkManagerInitializer` (that is `removed` anyway), and `ProcessLifecycleInitializer` (that is needed), which we might want removed as well. Thus, by not having them removed this might potentially caused us additional issues. 🤔

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
