### PR TITLE
Update our dependencies to AGP 7.2.1 PRs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,11 @@ plugins {
 }
 
 ext {
-    wordPressUtilsVersion = '107-a37619ac2b7703becf2554d31c09c6487c04b56f'
-    wordPressLoginVersion = '86-9966060c0483344c699636ee53def4bcd3603c65'
-    gutenbergMobileVersion = '5002-bb578bb2669cea49f48719ca788931f5ad6591ca'
-    storiesVersion = '722-7cc16bbe2995562cafc2fff1cb4096e84da98077'
-    aboutAutomatticVersion = '36-e6c8e93e564a857b3c1dd3d2588a0114c36fad40'
+    wordPressUtilsVersion = '2.6.0'
+    wordPressLoginVersion = '0.15.0'
+    gutenbergMobileVersion = 'v1.78.1'
+    storiesVersion = '1.4.0'
+    aboutAutomatticVersion = '0.0.6'
 
     minSdkVersion = 24
     compileSdkVersion = 31
@@ -21,7 +21,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '2454-3457772fa66619f4e33ac7bb318c49fc4540500a'
+    fluxCVersion = 'trunk-f44a381615f6d850e9c95071469424fbde6daff8'
 
     appCompatVersion = '1.0.2'
     androidxCoreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,11 @@ plugins {
 }
 
 ext {
-    wordPressUtilsVersion = '2.5.0'
-    wordPressLoginVersion = '0.14.0'
-    gutenbergMobileVersion = 'v1.78.1'
-    storiesVersion = '1.3.0'
-    aboutAutomatticVersion = '0.0.5'
+    wordPressUtilsVersion = '107-a37619ac2b7703becf2554d31c09c6487c04b56f'
+    wordPressLoginVersion = '86-9966060c0483344c699636ee53def4bcd3603c65'
+    gutenbergMobileVersion = '5002-bb578bb2669cea49f48719ca788931f5ad6591ca'
+    storiesVersion = '722-7cc16bbe2995562cafc2fff1cb4096e84da98077'
+    aboutAutomatticVersion = '36-e6c8e93e564a857b3c1dd3d2588a0114c36fad40'
 
     minSdkVersion = 24
     compileSdkVersion = 31
@@ -21,7 +21,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '1.46.0'
+    fluxCVersion = '2454-3457772fa66619f4e33ac7bb318c49fc4540500a'
 
     appCompatVersion = '1.0.2'
     androidxCoreVersion = '1.3.2'

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "org.jetbrains.kotlin.plugin.parcelize"
 }
 
-ext.aztecVersion = '991-c2bd0d94bbecbc6e78d91c8951907e0a9b0bbb7a'
+ext.aztecVersion = 'v1.6.0'
 
 repositories {
     maven {

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "org.jetbrains.kotlin.plugin.parcelize"
 }
 
-ext.aztecVersion = 'v1.5.8'
+ext.aztecVersion = '991-c2bd0d94bbecbc6e78d91c8951907e0a9b0bbb7a'
 
 repositories {
     maven {

--- a/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1298,6 +1298,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
+    public void beforeMediaDeleted(AztecAttributes aztecAttributes) {
+    }
+
+    @Override
     public void onMediaDeleted(AztecAttributes aztecAttributes) {
         String localMediaId = aztecAttributes.getValue(ATTR_ID_WP);
         mUploadingMediaProgressMax.remove(localMediaId);

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.6.10'
     gradle.ext.agpVersion = '7.2.1'
-    gradle.ext.daggerVersion = "2.41"
+    gradle.ext.daggerVersion = "2.42"
     gradle.ext.detektVersion = '1.15.0'
     gradle.ext.navComponentVersion = '2.4.2'
 


### PR DESCRIPTION
We are updating our projects to AGP `7.2.1`. This PR updates these dependency versions from their AGP update PRs, so we can test them all together.

Note that there is a breaking change in Aztec's `v1.5.8` due to the addition of `beforeMediaDeleted` method. I added a blank method as the method seems optional.

**To test:**

Smoke test the app

## Regression Notes
1. Potential unintended areas of impact

Hard to limit this with such a general update.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

We are smoke testing the app, not much else we can do at the moment.

3. What automated tests I added (or what prevented me from doing so)

N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
