### PR TITLE
[Fix] Remove Only the Default Initializer to Provide Custom Configuration

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1028,13 +1028,25 @@
                 android:resource="@xml/provider_paths"/>
         </provider>
 
-        <!-- Remove the default WorkManagerInitializer so we can use our own
-        Since WorkManager 2.6, App Startup is used internally within WorkManager.
-        To provide a custom initializer we need to remove the androidx.startup node.-->
+        <!-- Remove only the default initializer to provide a custom configuration.
+             For more info visit: https://developer.android.com/topic/libraries/architecture/
+             workmanager/advanced/custom-configuration
+
+             This change was necessary because of the 'androidx.lifecycle' update to '2.4.1' and
+             the fact that with it the 'lifecycle-process' now uses 'androidx.startup' to
+             initialize the 'ProcessLifecycleOwner'.
+             For more info visit: https://developer.android.com/jetpack/androidx/releases/
+             lifecycle#2.4.1 -->
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
-            tools:node="remove" />
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
 
         <!-- Scanner -->
         <meta-data


### PR DESCRIPTION
This PR cherry-picks the fix commit from #16876 that removes only the default initializer to provide custom configuration and as such fix the story regression.

To test:

- See [original PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16876).

## Regression Notes
1. Potential unintended areas of impact

See [original PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16876).

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
