### PR TITLE
Update Dagger to 2.42

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.6.10'
     gradle.ext.agpVersion = '7.2.1'
-    gradle.ext.daggerVersion = "2.41"
+    gradle.ext.daggerVersion = "2.42"
     gradle.ext.detektVersion = '1.15.0'
     gradle.ext.navComponentVersion = '2.4.2'
 


### PR DESCRIPTION
We updated some of our libraries Dagger version to `2.42` as part of AGP `7.2.1` update in #16878. We'd like to avoid Gradle resolving our dependency versions to a different version from the declared one, so we are also updating WPAndroid's Dagger version.

Here are the release notes for Dagger `2.42`: https://github.com/google/dagger/releases/tag/dagger-2.42

The only breaking change listed would result in a compile time error and technically this update was smoke tested by me and @ParaskP7 in #16878 because as listed by @wpmobilebot's [comment](https://github.com/wordpress-mobile/WordPress-Android/pull/16878#issuecomment-1176494409), Dagger was updated to `2.42` due to our libraries already being updated.

**To test:**

Smoke test the app

## Regression Notes
1. Potential unintended areas of impact
Dagger updates should be limited to compile time, but sometimes transitive dependency updates happen as part of it, so hard to limit its scope.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Our CI stack and smoke testing

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
