### PR TITLE
Fix content description on total followers list item

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1003,7 +1003,7 @@
     <!-- Stats accessibility strings -->
     <string name="stats_loading_card">Loading selected card data</string>
     <string name="stats_overview_content_description">%1$s %2$s for period: %3$s, change from previous period - %4$s</string>
-    <string name="stats_total_followers_content_description">%1s, %2s of total followers</string>
+    <string name="stats_total_followers_content_description">%1$s, %2$s%% of total followers</string>
     <string name="stats_graph_updated">Graph updated.</string>
     <string name="stats_expand_content_description">Expand</string>
     <string name="stats_collapse_content_description">Collapse</string>


### PR DESCRIPTION
Reported here: https://github.com/wordpress-mobile/WordPress-Android/pull/16554#discussion_r916944140

This fixes the problem on `stats_total_followers_content_description` string. It didn't have a `$` symbol to show the order to the compiler and it was causing a warning on building time. Also, `%` was missing in the string and that was causing Talkback to read the line wrong.

To test:
1. Enable Talkback from device settings. To use TalkBack, tap once on any button to select, and double-tap to press that button.
2. Launch the Jetpack app.
3. Go to Stats either using quick links or menu.
4. Switch to Insights tab if necessary.
5. Make sure Total Followers card is visible on Insights tab. If not present then add it through stats management using either [+ add new stats card ] at the bottom or clicking ⚙️ icon at the top right hand corner.
6. Tap VIEW MORE button on the Total Followers card.
7. Tap any item on the Follower types card (the one with the pie chart).
8. Ensure Talkback is reading the line correctly.


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Nothing

3. What automated tests I added (or what prevented me from doing so)
Just a string change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
