### PR TITLE
Update `compileSdkVersion` (from `29` to `31`) for All Modules

### DIFF
--- a/libs/analytics/build.gradle
+++ b/libs/analytics/build.gradle
@@ -21,11 +21,10 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
     }
 }
-

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -35,7 +35,7 @@ repositories {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -100,4 +100,3 @@ dependencies {
 
     lintChecks 'org.wordpress:lint:1.1.0'
 }
-

--- a/libs/mocks/build.gradle
+++ b/libs/mocks/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion rootProject.compileSdkVersion
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
@@ -20,4 +20,3 @@ dependencies {
     }
     implementation 'org.apache.httpcomponents:httpclient-android:4.3.5.1'
 }
-

--- a/libs/networking/build.gradle
+++ b/libs/networking/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -30,4 +30,3 @@ dependencies {
 
     lintChecks 'org.wordpress:lint:1.1.0'
 }
-


### PR DESCRIPTION
Parent #16562

This PR updates the `compileSdkVersion` (from `29` to `31`) for all modules. No changes were needed to make this update possible. `compileSdkVersion = 31` is the default and root level `compileSdkVersion` that all modules should be pointing to from now. This is done in order to make sure that there is no discrepancy in relation to compile SDK versions being different for different modules. Also, and just as an FYI, for `minSdkVersion` and `targetSdkVersion` this is already the case.

Obviously, the main `WordPress` module was already pointing to `compileSdkVersion = 31`, but so was the `image-editor` module. As such, the below 4 remaining modules got updated in the end:
- `mocks`
- `analytics`
- `networking`
- `editor`

-----

To test:

- Smoke test the app.
    - For the `mocks` module, you could run the `UI Tests` and verify correctness.
    - For the `analytics` module, you could launch the app and verify that you see the `🔵 Tracked: ` logs in logcat.
    - For the `networking` module, you could launch the app and verify that `Reader` -> `DISCOVER` tab works as expected  (`pull-to-refresh`, `scrolling and pagination`, etc).
    - For the `editor` module, you could launch the app and add a new `Post/Story` post and `Site` page. 

## Regression Notes
1. Potential unintended areas of impact

App is not compiling as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
