### PR TITLE
[Tooling/L10n] Ensure Jetpack does not fallback to WordPress copies for unsupported locales

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -388,19 +388,40 @@ platform :android do
   #####################################################################################
   lane :download_translations do
     # WordPress strings
+    wordpress_res_dir = File.join('WordPress', 'src', 'main', 'res')
     android_download_translations(
-      res_dir: File.join('WordPress', 'src', 'main', 'res'),
+      res_dir: wordpress_res_dir,
       glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:glotpress_appstrings_project],
       locales: WP_APP_LOCALES,
       lint_task: 'lintWordpressVanillaRelease'
     )
+
     # Jetpack strings
+    jetpack_res_dir = File.join('WordPress', 'src', 'jetpack', 'res')
     android_download_translations(
-      res_dir: File.join('WordPress', 'src', 'jetpack', 'res'),
+      res_dir: jetpack_res_dir,
       glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:glotpress_appstrings_project],
       locales: JP_APP_LOCALES,
       lint_task: 'lintJetpackVanillaRelease'
     )
+
+    # [pxLjZ-7b9-p2] For any locale in which Jetpack is not translated in (but WordPress is),
+    # ensure we fallback to an existing locale *in Jetpack* — instead of having the runtime
+    # erroneously fall back to the *WordPress-specific* translation in that missing locale.
+    wp_locales_not_in_jp = WP_APP_LOCALES.map { |l| l[:android] } - JP_APP_LOCALES.map { |l| l[:android] }
+    new_strings_files = wp_locales_not_in_jp.map do |locale|
+      language = locale.split('-').first
+      fallback = JP_APP_LOCALES.any? { |l| l[:android] == language } ? "values-#{language}" : 'values'
+      UI.message "Using `#{fallback}` as a fallback for `values-#{locale}` for the Jetpack app."
+      destination = File.join(jetpack_res_dir, "values-#{locale}", 'strings.xml')
+      Dir.chdir('..') do # To get out of `fastlane/` — which is the `pwd` when running code from Fastfile
+        FileUtils.mkdir_p(File.dirname(destination))
+        FileUtils.cp(File.join(jetpack_res_dir, fallback, 'strings.xml'), destination)
+      end
+      destination
+    end
+    git_add(path: new_strings_files)
+    git_commit(path: new_strings_files, message: 'Update translation fallbacks for Jetpack', allow_nothing_to_commit: true)
   end
 
   # Updates the `.po` file at the given `po_path` using the content of the `sources` files, interpolating `release_version` where appropriate.

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -392,8 +392,7 @@ platform :android do
     android_download_translations(
       res_dir: wordpress_res_dir,
       glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:glotpress_appstrings_project],
-      locales: WP_APP_LOCALES,
-      lint_task: 'lintWordpressVanillaRelease'
+      locales: WP_APP_LOCALES
     )
 
     # Jetpack strings
@@ -401,8 +400,7 @@ platform :android do
     android_download_translations(
       res_dir: jetpack_res_dir,
       glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:glotpress_appstrings_project],
-      locales: JP_APP_LOCALES,
-      lint_task: 'lintJetpackVanillaRelease'
+      locales: JP_APP_LOCALES
     )
 
     # [pxLjZ-7b9-p2] For any locale in which Jetpack is not translated in (but WordPress is),


### PR DESCRIPTION
This is part of request pdnsEh-pY-p2, and addresses the issue raised in pxLjZ-7b9-p2.

> **Note** This PR targets the `release/20.3` branch because we will need it to be applied next time we do a beta.
>
> Jetpack `20.3` will be the first version in which we pull Jetpack-specific translations from the Jetpack GlotPress project — as [the PR to implement the freeze of those strings](https://href.li/?https://github.com/wordpress-mobile/WordPress-Android/pull/16844), as well as the diff to make the cron import them in D83569-code, both landed just before 20.3 was cut. So `release/20.3` will be the first time when we pull those strings, and we want them to work correctly the first time we introduce them.

## Why?

 - The WordPress app is translated in more than 50 locales (see [`WordPress/src/main/res/values-*`](https://github.com/wordpress-mobile/WordPress-Android/tree/0f1f630bb59e05db720e7eea5aa7505a72cb8b39/WordPress/src/main/res) and [the Fastfile](https://github.com/wordpress-mobile/WordPress-Android/blob/0f1f630bb59e05db720e7eea5aa7505a72cb8b39/fastlane/lanes/localization.rb#L10-L65)) by the community.
 - Meanwhile, the Jetpack app is currently only translated in our Mag16 locales (see [`WordPress/src/jetpack/res/values-*`](https://github.com/wordpress-mobile/WordPress-Android/tree/0f1f630bb59e05db720e7eea5aa7505a72cb8b39/WordPress/src/jetpack/res) and [the Fastfile](https://github.com/wordpress-mobile/WordPress-Android/blob/0f1f630bb59e05db720e7eea5aa7505a72cb8b39/fastlane/lanes/localization.rb#L66-L67)) by our translation vendor.
 - Given that [Jetpack is currently technically built as an app variant (product flavor)](https://github.com/wordpress-mobile/WordPress-Android/blob/0f1f630bb59e05db720e7eea5aa7505a72cb8b39/WordPress/build.gradle#L166) of the WordPress codebase, this means that the strings used by the Jetpack app flavor are the result of merging `WordPress/src/jetpack/res/values-*` into `WordPress/src/main/values-*` at compile time.

A consequence of that is that any non-Mag16 locale, not having explicit translations in `src/jetpack/res/` for that locale, will fallback to the translation of that key in `src/main/res`, aka the WordPress-provided translation for that locale.

➡️  This means that [keys in `src/jetpack/res` that are supposed to be explicitly overriding WordPress ones](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/jetpack/res/values/strings.xml), like `app_name` or `app_title` for example, will use the translation from WordPress, e.g. `WordPress for Android` as `app_title`, in non-mag16 locales supported by WordPress but not Jetpack.

## How — The Fix

To ensure the app will use Jetpack-specific copies even in non-Mag16 locales for which Jetpack doesn't provide an explicit translation for, I made sure we copy the `src/jetpack/res/values/strings.xml` files into each `src/jetpack/res/values-*/` folder corresponding to a locale supported by WordPress but not Jetpack.

That way, if the user's device is in a non-Mag16 locale, e.g. `vi`, strings like `app_title` will show `Jetpack for Android` (in English) rather than "WordPress cho Android" (in Vietnamese, from the WordPress strings and not Jetpack)

The fix also tries to find a locale with the same-language-base-without-region as a fallback if it exists in Jetpack, and would prefer it over English. For example, `fr-rCA`, which is not supported by Jetpack, will copy its strings from translations in Jetpack's `values-fr` rather than copying them from the English ones from `values`.

## To Test

 - Cut a test branch from this one
 - Run `bundle exec fastlane download_translations`
 - Verify that it pushed 3 new commits:
    - The usual two `"Update Translations"` (one for WordPress, one for Jetpack), downloading latest translations from GlotPress
    - The new `"Update translation fallbacks for Jetpack"`, which adds the aforementioned fallbacks
 - Check that all the files in the last commit correspond to a locale that is not supported by Jetpack's .com GlotPress project (i.e. is not a Mag16) but is a locale supported/provided by WordPress's .org GlotPress project
 - Check that the translations for locales like `values-sr` are the same / copied from the English ones from `values`
 - Check that the translations for locales like `values-fr-rFR` are the copy from the French ones from `values-fr` rather than falling back to English
