### PR TITLE
Merge Release Notes for 20.3

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -11,6 +11,14 @@ msgstr ""
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_203"
+msgid ""
+"20.3:\n"
+"- When you add an item in the media library to an Image block, the item’s alt text comes with it.\n"
+"- You can insert media from a URL in Video blocks.\n"
+"- Use the block recovery option to bring back unexpected or invalid content in a block.\n"
+msgstr ""
+
 msgctxt "release_note_202"
 msgid ""
 "20.2:\n"
@@ -18,15 +26,6 @@ msgid ""
 "- Sign in with your browser using a QR code in the app’s Me menu.\n"
 "- Upload HEIC/HEIF images through the media picker.\n"
 "- We squashed a bug that affected reader topics in other languages.\n"
-msgstr ""
-
-msgctxt "release_note_201"
-msgid ""
-"20.1:\n"
-"- Get new daily blogging prompts to inspire your posts.\n"
-"- We improved the site design selection screen in the Site Creation process.\n"
-"- WordPress links open in the app, not your default browser.\n"
-"- Quick Start focus points are in the correct spots for right-to-left language users.\n"
 msgstr ""
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,4 +1,3 @@
-* [*] Block Editor: Add 'Insert from URL' option to Video block [https://github.com/WordPress/gutenberg/pull/41493]
-* [*] Block Editor: Image block copies the alt text from the media library when selecting an item [https://github.com/WordPress/gutenberg/pull/41839]
-* [*] Block Editor: Introduce "block recovery" option for invalid blocks [https://github.com/WordPress/gutenberg/pull/41988]
-
+- When you add an item in the media library to an Image block, the item’s alt text comes with it.
+- You can insert media from a URL in Video blocks.
+- Use the block recovery option to bring back unexpected or invalid content in a block.

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -11,19 +11,19 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_203"
+msgid ""
+"20.3:\n"
+"- When you add an item in the media library to an Image block, the item’s alt text comes with it.\n"
+"- You can insert media from a URL in Video blocks.\n"
+"- Use the block recovery option to bring back unexpected or invalid content in a block.\n"
+msgstr ""
+
 msgctxt "release_note_202"
 msgid ""
 "20.2:\n"
 "- You can now upload HEIC and HEIF images to your site through the media picker.\n"
 "- We squashed a bug that removed special characters from reader topics in other languages.\n"
-msgstr ""
-
-msgctxt "release_note_201"
-msgid ""
-"20.1:\n"
-"- We improved the site design selection screen in the Site Creation process.\n"
-"- When you click a WordPress link, it opens in the app instead of your default browser.\n"
-"- We moved Quick Start focus points to the correct spots for right-to-left language users.\n"
 msgstr ""
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,4 +1,3 @@
-* [*] Block Editor: Add 'Insert from URL' option to Video block [https://github.com/WordPress/gutenberg/pull/41493]
-* [*] Block Editor: Image block copies the alt text from the media library when selecting an item [https://github.com/WordPress/gutenberg/pull/41839]
-* [*] Block Editor: Introduce "block recovery" option for invalid blocks [https://github.com/WordPress/gutenberg/pull/41988]
-
+- When you add an item in the media library to an Image block, the item’s alt text comes with it.
+- You can insert media from a URL in Video blocks.
+- Use the block recovery option to bring back unexpected or invalid content in a block.

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -388,19 +388,40 @@ platform :android do
   #####################################################################################
   lane :download_translations do
     # WordPress strings
+    wordpress_res_dir = File.join('WordPress', 'src', 'main', 'res')
     android_download_translations(
-      res_dir: File.join('WordPress', 'src', 'main', 'res'),
+      res_dir: wordpress_res_dir,
       glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:glotpress_appstrings_project],
       locales: WP_APP_LOCALES,
       lint_task: 'lintWordpressVanillaRelease'
     )
+
     # Jetpack strings
+    jetpack_res_dir = File.join('WordPress', 'src', 'jetpack', 'res')
     android_download_translations(
-      res_dir: File.join('WordPress', 'src', 'jetpack', 'res'),
+      res_dir: jetpack_res_dir,
       glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:glotpress_appstrings_project],
       locales: JP_APP_LOCALES,
       lint_task: 'lintJetpackVanillaRelease'
     )
+
+    # [pxLjZ-7b9-p2] For any locale in which Jetpack is not translated in (but WordPress is),
+    # ensure we fallback to an existing locale *in Jetpack* — instead of having the runtime
+    # erroneously fall back to the *WordPress-specific* translation in that missing locale.
+    wp_locales_not_in_jp = WP_APP_LOCALES.map { |l| l[:android] } - JP_APP_LOCALES.map { |l| l[:android] }
+    new_strings_files = wp_locales_not_in_jp.map do |locale|
+      language = locale.split('-').first
+      fallback = JP_APP_LOCALES.any? { |l| l[:android] == language } ? "values-#{language}" : 'values'
+      UI.message "Using `#{fallback}` as a fallback for `values-#{locale}` for the Jetpack app."
+      destination = File.join(jetpack_res_dir, "values-#{locale}", 'strings.xml')
+      Dir.chdir('..') do # To get out of `fastlane/` — which is the `pwd` when running code from Fastfile
+        FileUtils.mkdir_p(File.dirname(destination))
+        FileUtils.cp(File.join(jetpack_res_dir, fallback, 'strings.xml'), destination)
+      end
+      destination
+    end
+    git_add(path: new_strings_files)
+    git_commit(path: new_strings_files, message: 'Update translation fallbacks for Jetpack', allow_nothing_to_commit: true)
   end
 
   # Updates the `.po` file at the given `po_path` using the content of the `sources` files, interpolating `release_version` where appropriate.

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -392,8 +392,7 @@ platform :android do
     android_download_translations(
       res_dir: wordpress_res_dir,
       glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:glotpress_appstrings_project],
-      locales: WP_APP_LOCALES,
-      lint_task: 'lintWordpressVanillaRelease'
+      locales: WP_APP_LOCALES
     )
 
     # Jetpack strings
@@ -401,8 +400,7 @@ platform :android do
     android_download_translations(
       res_dir: jetpack_res_dir,
       glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:glotpress_appstrings_project],
-      locales: JP_APP_LOCALES,
-      lint_task: 'lintJetpackVanillaRelease'
+      locales: JP_APP_LOCALES
     )
 
     # [pxLjZ-7b9-p2] For any locale in which Jetpack is not translated in (but WordPress is),


### PR DESCRIPTION
PR to make sure the Editorialized Release Notes for 20.3 land in `trunk` by end of week.

PS: This PR also includes https://github.com/wordpress-mobile/WordPress-Android/pull/16902 which landed in the release branch recently.