### PR TITLE
[Tooling] Guess the app version when running update_appstore_strings

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -88,7 +88,7 @@ platform :android do
   # picked by GlotPress for translations.
   # -----------------------------------------------------------------------------------
   # Usage:
-  # fastlane update_appstore_strings version:<version>
+  # fastlane update_appstore_strings [version:<version>]
   #
   # Example:
   # fastlane update_appstore_strings version:10.3
@@ -106,7 +106,7 @@ platform :android do
   # and updates the `.po` file that is then picked by GlotPress for translations.
   # -----------------------------------------------------------------------------------
   # Usage:
-  # fastlane update_wordpress_appstore_strings version:<version>
+  # fastlane update_wordpress_appstore_strings [version:<version>]
   #
   # Example:
   # fastlane update_wordpress_appstore_strings version:10.3
@@ -143,7 +143,7 @@ platform :android do
   # and updates the `.po` file that is then picked by GlotPress for translations.
   # -----------------------------------------------------------------------------------
   # Usage:
-  # fastlane update_jetpack_appstore_strings version:<version>
+  # fastlane update_jetpack_appstore_strings [version:<version>]
   #
   # Example:
   # fastlane update_jetpack_appstore_strings version:10.3

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -114,6 +114,7 @@ platform :android do
   desc 'Updates the PlayStoreStrings.po file for WordPress'
   lane :update_wordpress_appstore_strings do |options|
     metadata_folder = File.join(Dir.pwd, '..', 'WordPress', 'metadata')
+    version = options.fetch(:version, android_get_app_version)
 
     # <key in po file> => <path to txt file to read the content from>
     files = {
@@ -130,8 +131,8 @@ platform :android do
     update_po_file_for_metadata_localization(
       po_path: File.join(metadata_folder, 'PlayStoreStrings.po'),
       sources: files,
-      release_version: options[:version],
-      commit_message: "Update WordPress `PlayStoreStrings.po` for version #{options[:version]}"
+      release_version: version,
+      commit_message: "Update WordPress `PlayStoreStrings.po` for version #{version}"
     )
   end
 
@@ -150,6 +151,7 @@ platform :android do
   desc 'Updates the PlayStoreStrings.po file for Jetpack'
   lane :update_jetpack_appstore_strings do |options|
     metadata_folder = File.join(Dir.pwd, '..', 'WordPress', 'jetpack_metadata')
+    version = options.fetch(:version, android_get_app_version)
 
     files = {
       release_note: File.join(metadata_folder, 'release_notes.txt'),
@@ -162,8 +164,8 @@ platform :android do
     update_po_file_for_metadata_localization(
       po_path: metadata_folder = File.join(metadata_folder, 'PlayStoreStrings.po'),
       sources: files,
-      release_version: options[:version],
-      commit_message: "Update Jetpack `PlayStoreStrings.po` for version #{options[:version]}"
+      release_version: version,
+      commit_message: "Update Jetpack `PlayStoreStrings.po` for version #{version}"
     )
   end
 


### PR DESCRIPTION
When running `fastlane update_appstore_strings` we were always expected to provide the `version:` explicitly in the command line.

Failing to do so would crash the lane (there were no protection against the param missing). Besides, it's easy enough for the lane to extract the value by itself anyway.

This change simply uses `android_get_app_version` to determine the proper version all by itself if we don't provide `version:` explicitly, making that parameter now optional.

