### PR TITLE
Add jetpack banner to various screens

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -297,7 +297,6 @@
         <activity
             android:name=".ui.stats.refresh.StatsActivity"
             android:launchMode="singleTop"
-            android:configChanges="orientation|screenSize"
             android:theme="@style/WordPress.NoActionBar" />
         <activity
             android:name=".ui.stats.refresh.StatsViewAllActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -4,6 +4,10 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup.MarginLayoutParams
+import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ActivityLogListActivityBinding
@@ -16,17 +20,30 @@ import org.wordpress.android.ui.jetpack.backup.download.KEY_BACKUP_DOWNLOAD_REWI
 import org.wordpress.android.ui.jetpack.common.JetpackBackupDownloadActionState
 import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_RESTORE_ID
 import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_REWIND_ID
+import org.wordpress.android.util.extensions.setNavigationBarColorForBanner
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_KEY
 
 class ActivityLogListActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
-        val binding = ActivityLogListActivityBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        binding.checkAndUpdateUiToBackupScreen()
+        with(ActivityLogListActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            checkAndUpdateUiToBackupScreen()
 
-        setSupportActionBar(binding.toolbarMain)
+            setSupportActionBar(toolbarMain)
+
+            if (!BuildConfig.IS_JETPACK_APP) {
+                jetpackBanner.root.isVisible = true
+                window.setNavigationBarColorForBanner()
+
+                // Add bottom margin to content.
+                val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
+                fragment?.view?.updateLayoutParams<MarginLayoutParams> {
+                    bottomMargin = resources.getDimensionPixelSize(R.dimen.jetpack_banner_height)
+                }
+            }
+        }
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.people;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.MenuItem;
+import android.view.View;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -15,6 +16,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -32,6 +34,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.extensions.WindowExtensionsKt;
 
 import java.util.List;
 
@@ -97,6 +100,12 @@ public class PeopleManagementActivity extends LocaleAwareActivity
         mDispatcher.register(this);
 
         setContentView(R.layout.people_management_activity);
+
+        if (!BuildConfig.IS_JETPACK_APP) {
+            findViewById(R.id.jetpack_banner).setVisibility(View.VISIBLE);
+            WindowExtensionsKt.setNavigationBarColorForBanner(getWindow());
+        }
+
         if (savedInstanceState == null) {
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.publicize;
 import android.app.ProgressDialog;
 import android.os.Bundle;
 import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup.MarginLayoutParams;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -19,6 +21,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.jetbrains.annotations.NotNull;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -33,10 +36,11 @@ import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.services.PublicizeUpdateService;
-import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
+import org.wordpress.android.util.extensions.WindowExtensionsKt;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -73,6 +77,16 @@ public class PublicizeListActivity extends LocaleAwareActivity
         }
 
         mAppBarLayout = findViewById(R.id.appbar_main);
+
+        if (!BuildConfig.IS_JETPACK_APP) {
+            findViewById(R.id.jetpack_banner).setVisibility(View.VISIBLE);
+            WindowExtensionsKt.setNavigationBarColorForBanner(getWindow());
+
+            // Add bottom margin to content.
+            MarginLayoutParams layoutParams =
+                    (MarginLayoutParams) findViewById(R.id.fragment_container).getLayoutParams();
+            layoutParams.bottomMargin = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
+        }
 
         if (savedInstanceState == null) {
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -6,10 +6,12 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup.MarginLayoutParams
 import android.widget.TextView
 import androidx.annotation.NonNull
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager2.adapter.FragmentStateAdapter
@@ -19,6 +21,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.WordPress
@@ -83,6 +86,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
         binding = ReaderFragmentLayoutBinding.bind(view).apply {
             initToolbar()
             initViewPager()
+            initJetpackBanner()
             initViewModel()
         }
     }
@@ -144,6 +148,17 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
 
     private fun ReaderFragmentLayoutBinding.initViewPager() {
         viewPager.registerOnPageChangeCallback(viewPagerCallback)
+    }
+
+    private fun ReaderFragmentLayoutBinding.initJetpackBanner() {
+        if (!BuildConfig.IS_JETPACK_APP) {
+            jetpackBanner.root.isVisible = true
+
+            // Add bottom margin to viewPager and interests fragment for the jetpack banner.
+            val margin = resources.getDimensionPixelSize(R.dimen.jetpack_banner_height)
+            viewPager.updateLayoutParams<MarginLayoutParams> { bottomMargin = margin }
+            interestsFragmentContainer.updateLayoutParams<MarginLayoutParams> { bottomMargin = margin }
+        }
     }
 
     private fun ReaderFragmentLayoutBinding.initViewModel() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -2,15 +2,12 @@ package org.wordpress.android.ui.stats.refresh
 
 import android.content.Context
 import android.content.Intent
-import android.content.res.Configuration
-import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.StatsListActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
@@ -19,13 +16,13 @@ import org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATIO
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.util.extensions.setNavigationBarColorForBanner
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class StatsActivity : LocaleAwareActivity() {
     @Inject lateinit var statsSiteProvider: StatsSiteProvider
     private val viewModel: StatsViewModel by viewModels()
-    private var initialNavigationBarColor = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,26 +30,9 @@ class StatsActivity : LocaleAwareActivity() {
         with(StatsListActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
             if (!BuildConfig.IS_JETPACK_APP) {
-                initialNavigationBarColor = window.navigationBarColor
                 jetpackBanner.root.isVisible = true
-                setNavigationBarColorForBanner()
+                window.setNavigationBarColorForBanner()
             }
-        }
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        setNavigationBarColorForBanner()
-    }
-
-    /**
-     * Sets the navigation bar color as same as Jetpack banner background color in portrait orientation, initial color
-     * in horizontal orientation.
-     */
-    private fun setNavigationBarColorForBanner() {
-        window.navigationBarColor = when (resources.configuration.orientation) {
-            ORIENTATION_PORTRAIT -> getColor(R.color.jetpack_banner_background)
-            else -> initialNavigationBarColor
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -4,6 +4,8 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup.MarginLayoutParams;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
@@ -16,6 +18,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.jetbrains.annotations.NotNull;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -39,6 +42,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.extensions.WindowExtensionsKt;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -95,6 +99,16 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
         if (actionBar != null) {
             actionBar.setDisplayShowTitleEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+
+        if (!BuildConfig.IS_JETPACK_APP) {
+            findViewById(R.id.jetpack_banner).setVisibility(View.VISIBLE);
+            WindowExtensionsKt.setNavigationBarColorForBanner(getWindow());
+
+            // Add bottom margin to content.
+            MarginLayoutParams layoutParams =
+                    (MarginLayoutParams) findViewById(R.id.fragment_container).getLayoutParams();
+            layoutParams.bottomMargin = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/WindowExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/WindowExtensions.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.util.extensions
 
+import android.content.res.Configuration
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.view.View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
@@ -48,3 +49,12 @@ fun Window.showFullScreen() {
 }
 
 private fun Window.isLightTheme() = !context.resources.configuration.isDarkTheme()
+
+/**
+ * Sets the navigation bar color as same as Jetpack banner background color in portrait orientation.
+ */
+fun Window.setNavigationBarColorForBanner() {
+    if (context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+        navigationBarColor = context.getColor(R.color.jetpack_banner_background)
+    }
+}

--- a/WordPress/src/main/res/layout/activity_log_list_activity.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_activity.xml
@@ -2,7 +2,6 @@
 
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -83,4 +82,7 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/people_management_activity.xml
+++ b/WordPress/src/main/res/layout/people_management_activity.xml
@@ -7,6 +7,10 @@
     <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
 
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/publicize_list_activity.xml
+++ b/WordPress/src/main/res/layout/publicize_list_activity.xml
@@ -25,4 +25,7 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/reader_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_layout.xml
@@ -48,4 +48,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/theme_browser_activity.xml
+++ b/WordPress/src/main/res/layout/theme_browser_activity.xml
@@ -26,4 +26,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
This adds the Jetpack banner to screens below:
- Activity Log
- Themes
- Sharing
- People
- Reader

Note: The scrolling animation of the banner on the Reader screen is not implemented in this PR.

To test:
Test 1:
1. Launch WordPress app.
2. Navigate to screens mentioned above.
3. Ensure the banner is on the screen and looks correct.
4. Change the orientation and repeat 3.
5. Change the theme and repeat 1-4.

Test 2:
1. Launch Jetpack app.
2. Navigate to screens mentioned above.
3. Ensure there is no banner.

### Screenshots

| Activity Log | Themes | Sharing | People | Reader |
| --- | --- | --- | --- | --- |
| ![banner_activityLog](https://user-images.githubusercontent.com/4588074/178937893-4e58f3ff-af45-45b1-9439-193e345af799.png) | ![banner_themes](https://user-images.githubusercontent.com/4588074/178937834-e4421308-259e-4aeb-89d9-73aabcd94796.png) | ![banner_sharing](https://user-images.githubusercontent.com/4588074/178938047-3a572e9d-32a5-4a87-8885-631b1c8935dd.png) | ![banner_people](https://user-images.githubusercontent.com/4588074/178938094-5e1697ee-307a-4253-ba81-ffb96c9a3349.png) | ![banner_reader_night](https://user-images.githubusercontent.com/4588074/178938147-00dd53b1-6754-46b2-bea4-8befafb8faa9.png) |

## Regression Notes
1. Potential unintended areas of impact
Scrolling behavior, dark/light theme problems on screen that the banner added.

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

7. What automated tests I added (or what prevented me from doing so)
None. This is a small UI change, I don't think it's important for UI tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
