### PR TITLE
Jetpack powered feature config

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -120,6 +120,7 @@ android {
         buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"
         buildConfigField "boolean", "QRCODE_AUTH_FLOW", "false"
         buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"
+        buildConfigField "boolean", "JETPACK_POWERED", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -107,6 +107,7 @@ import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.config.LandOnTheEditorFeatureConfig
 import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
@@ -156,6 +157,7 @@ class MySiteViewModel @Inject constructor(
     private val buildConfigWrapper: BuildConfigWrapper,
     mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig,
     bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig,
+    private val jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val bloggingPromptsCardAnalyticsTracker: BloggingPromptsCardAnalyticsTracker,
     private val quickStartTracker: QuickStartTracker,
@@ -491,7 +493,10 @@ class MySiteViewModel @Inject constructor(
                 )
         )
 
-        val jetpackBadge = JetpackBadge.takeUnless { buildConfigWrapper.isJetpackApp }
+        val jetpackBadge = JetpackBadge.takeUnless {
+            buildConfigWrapper.isJetpackApp
+            !jetpackPoweredFeatureConfig.isEnabled()
+        }
 
         return mapOf(
                 MySiteTabType.ALL to orderForDisplay(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -493,9 +493,8 @@ class MySiteViewModel @Inject constructor(
                 )
         )
 
-        val jetpackBadge = JetpackBadge.takeUnless {
-            buildConfigWrapper.isJetpackApp
-            !jetpackPoweredFeatureConfig.isEnabled()
+        val jetpackBadge = JetpackBadge.takeIf {
+            jetpackPoweredFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
         }
 
         return mapOf(

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredFeatureConfig.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
  *
  * TODO: When it is ready to be rolled out uncomment the lines 12 and 19, remove line 13 and this to-do
  */
-//@Feature(JetpackPoweredFeatureConfig.JETPACK_POWERED_REMOTE_FIELD, true)
+// @Feature(JetpackPoweredFeatureConfig.JETPACK_POWERED_REMOTE_FIELD, true)
 @FeatureInDevelopment
 class JetpackPoweredFeatureConfig @Inject constructor(
     appConfig: AppConfig

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredFeatureConfig.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration for Jetpack Powered indicators
+ *
+ * TODO: When it is ready to be rolled out uncomment the lines 12 and 19, remove line 13 and this to-do
+ */
+//@Feature(JetpackPoweredFeatureConfig.JETPACK_POWERED_REMOTE_FIELD, true)
+@FeatureInDevelopment
+class JetpackPoweredFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.JETPACK_POWERED,
+//        JETPACK_POWERED_REMOTE_FIELD
+) {
+    companion object {
+        const val JETPACK_POWERED_REMOTE_FIELD = "jetpack_powered_remote_field"
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2149,8 +2149,34 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @InternalCoroutinesApi
     @Test
+    fun `given wp app, when the jetpack powered feature flag is false, then no Jetpack badge is visible`() {
+        init(isJetpackPoweredFeatureConfigEnabled = false)
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
+
+        initSelectedSite()
+
+        assertThat(getSiteMenuTabLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+        assertThat(getLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+        assertThat(getDashboardTabLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+    }
+
+    @InternalCoroutinesApi
+    @Test
     fun `given jp app, when the jetpack powered feature flag is true, then no Jetpack badge is visible`() {
         init(isJetpackPoweredFeatureConfigEnabled = true)
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
+
+        initSelectedSite()
+
+        assertThat(getSiteMenuTabLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+        assertThat(getLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+        assertThat(getDashboardTabLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+    }
+
+    @InternalCoroutinesApi
+    @Test
+    fun `given jp app, when the jetpack powered feature flag is false, then no Jetpack badge is visible`() {
+        init(isJetpackPoweredFeatureConfigEnabled = false)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
 
         initSelectedSite()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -141,6 +141,7 @@ import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.config.LandOnTheEditorFeatureConfig
 import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
@@ -182,6 +183,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
     @Mock lateinit var bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig
+    @Mock lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
     @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock lateinit var bloggingPromptsCardAnalyticsTracker: BloggingPromptsCardAnalyticsTracker
     @Mock lateinit var quickStartType: QuickStartType
@@ -333,7 +335,8 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Suppress("LongMethod")
     fun init(
         isMySiteDashboardTabsFeatureFlagEnabled: Boolean = true,
-        isBloggingPromptsFeatureConfigEnabled: Boolean = true
+        isBloggingPromptsFeatureConfigEnabled: Boolean = true,
+        isJetpackPoweredFeatureConfigEnabled: Boolean = true
     ) = test {
         onSiteChange.value = null
         onShowSiteIconProgressBar.value = null
@@ -341,6 +344,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         selectedSite.value = null
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsFeatureConfigEnabled)
         whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsFeatureFlagEnabled)
+        whenever(jetpackPoweredFeatureConfig.isEnabled()).thenReturn(isJetpackPoweredFeatureConfigEnabled)
         whenever(mySiteSourceManager.build(any(), anyOrNull())).thenReturn(partialStates)
         whenever(selectedSiteRepository.siteSelected).thenReturn(onSiteSelected)
         whenever(quickStartRepository.activeTask).thenReturn(activeTask)
@@ -382,6 +386,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 buildConfigWrapper,
                 mySiteDashboardTabsFeatureConfig,
                 bloggingPromptsFeatureConfig,
+                jetpackPoweredFeatureConfig,
                 appPrefsWrapper,
                 bloggingPromptsCardAnalyticsTracker,
                 quickStartTracker,
@@ -2132,6 +2137,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given wp app, when any my site list is shown except site menu, then the Jetpack badge is visible last`() {
+        init(isJetpackPoweredFeatureConfigEnabled = true)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
 
         initSelectedSite()
@@ -2144,6 +2150,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given jp app, when any my site list is shown, then no Jetpack badge is visible`() {
+        init(isJetpackPoweredFeatureConfigEnabled = false)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
 
         initSelectedSite()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2136,7 +2136,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @InternalCoroutinesApi
     @Test
-    fun `given wp app, when any my site list is shown except site menu, then the Jetpack badge is visible last`() {
+    fun `given wp app, when the jetpack powered feature flag is true, then the Jetpack badge is visible`() {
         init(isJetpackPoweredFeatureConfigEnabled = true)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
 
@@ -2149,8 +2149,8 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @InternalCoroutinesApi
     @Test
-    fun `given jp app, when any my site list is shown, then no Jetpack badge is visible`() {
-        init(isJetpackPoweredFeatureConfigEnabled = false)
+    fun `given jp app, when the jetpack powered feature flag is true, then no Jetpack badge is visible`() {
+        init(isJetpackPoweredFeatureConfigEnabled = true)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
 
         initSelectedSite()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2136,7 +2136,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @InternalCoroutinesApi
     @Test
-    fun `given wp app, when the jetpack powered feature flag is true, then the Jetpack badge is visible`() {
+    fun `given wp app, when the jetpack powered feature flag is true, then the Jetpack badge is visible last`() {
         init(isJetpackPoweredFeatureConfigEnabled = true)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
 


### PR DESCRIPTION
This PR adds a local development feature config to toggle Jetpack powered indicators. 

<img width=320 src="https://user-images.githubusercontent.com/990349/178903527-97dd0470-b797-4e9c-845f-38c85997e083.png" />


To test:

1. Launch WordPress app
2. Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
3. Select Debug Settings
4. Find JetpackPoweredFeatureConfig under Features in development as shown in the image above
5. Re-launch app (scroll down if necessary)
6. Make sure the Jetpack powered badge appears on the home tab as shown on the PR #16901 
7. Try enabling and disabling the flag and test that badge appears and disappears.
8. Also, test with Jetpack app to make sure the badge doesn't appear.

NOTE:  This flag is only applied to the above jetpack badge in one place in this PR for testing, this check needs to be applied everywhere.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
Updated unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
