### PR TITLE
Improve code for applying the Jetpack Powered feature config

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -493,9 +493,8 @@ class MySiteViewModel @Inject constructor(
                 )
         )
 
-        val jetpackBadge = JetpackBadge.takeUnless {
-            buildConfigWrapper.isJetpackApp
-            !jetpackPoweredFeatureConfig.isEnabled()
+        val jetpackBadge = JetpackBadge.takeIf {
+            jetpackPoweredFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
         }
 
         return mapOf(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2149,8 +2149,34 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @InternalCoroutinesApi
     @Test
+    fun `given wp app, when the jetpack powered feature flag is false, then no Jetpack badge is visible`() {
+        init(isJetpackPoweredFeatureConfigEnabled = false)
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
+
+        initSelectedSite()
+
+        assertThat(getSiteMenuTabLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+        assertThat(getLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+        assertThat(getDashboardTabLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+    }
+
+    @InternalCoroutinesApi
+    @Test
     fun `given jp app, when the jetpack powered feature flag is true, then no Jetpack badge is visible`() {
         init(isJetpackPoweredFeatureConfigEnabled = true)
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
+
+        initSelectedSite()
+
+        assertThat(getSiteMenuTabLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+        assertThat(getLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+        assertThat(getDashboardTabLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
+    }
+
+    @InternalCoroutinesApi
+    @Test
+    fun `given jp app, when the jetpack powered feature flag is false, then no Jetpack badge is visible`() {
+        init(isJetpackPoweredFeatureConfigEnabled = false)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
 
         initSelectedSite()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2136,7 +2136,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @InternalCoroutinesApi
     @Test
-    fun `given wp app, when any my site list is shown except site menu, then the Jetpack badge is visible last`() {
+    fun `given wp app, when the jetpack powered feature flag is true, then the Jetpack badge is visible`() {
         init(isJetpackPoweredFeatureConfigEnabled = true)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
 
@@ -2149,8 +2149,8 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @InternalCoroutinesApi
     @Test
-    fun `given jp app, when any my site list is shown, then no Jetpack badge is visible`() {
-        init(isJetpackPoweredFeatureConfigEnabled = false)
+    fun `given jp app, when the jetpack powered feature flag is true, then no Jetpack badge is visible`() {
+        init(isJetpackPoweredFeatureConfigEnabled = true)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
 
         initSelectedSite()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2136,7 +2136,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @InternalCoroutinesApi
     @Test
-    fun `given wp app, when the jetpack powered feature flag is true, then the Jetpack badge is visible`() {
+    fun `given wp app, when the jetpack powered feature flag is true, then the Jetpack badge is visible last`() {
         init(isJetpackPoweredFeatureConfigEnabled = true)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
 


### PR DESCRIPTION
Improves #16908

To test:
Follow the testing steps from #16908:

> 1. Launch WordPress app
> 2. Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
> 3. Select Debug Settings
> 4. Find JetpackPoweredFeatureConfig under Features in development as shown in the image above
> 5. Re-launch app (scroll down if necessary)
> 6. Make sure the Jetpack powered badge appears on the home tab as shown on the PR #16901 
> 7. Try enabling and disabling the flag and test that badge appears and disappears.
> 8. Also, test with Jetpack app to make sure the badge doesn't appear.

## Regression Notes
1. Potential unintended areas of impact
   None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Tested manually & tested using the enhanced unit tests from this PR.

3. What automated tests I added (or what prevented me from doing so)
   Added 2 more unit tests to `MySiteViewModel`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
