### PR TITLE
Show Jetpack badge on Me, App Settings, Activity Detail, Notifications Settings & Reader Post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.notifications.utils.FormattableContentClickHandl
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY
@@ -43,6 +44,7 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
     @Inject lateinit var notificationsUtilsWrapper: NotificationsUtilsWrapper
     @Inject lateinit var formattableContentClickHandler: FormattableContentClickHandler
     @Inject lateinit var uiHelpers: UiHelpers
+    @Inject lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
 
     private lateinit var viewModel: ActivityLogDetailViewModel
 
@@ -67,7 +69,7 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
                 val areButtonsVisible = areButtonsVisible(savedInstanceState, activity.intent)
                 val isRestoreHidden = isRestoreHidden(savedInstanceState, activity.intent)
 
-                jetpackBadge.root.isVisible = !BuildConfig.IS_JETPACK_APP
+                jetpackBadge.root.isVisible = jetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP
 
                 viewModel.activityLogItem.observe(viewLifecycleOwner, { activityLogModel ->
                     loadLogItem(activityLogModel, activity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -5,9 +5,11 @@ import android.os.Bundle
 import android.text.SpannableString
 import android.text.method.LinkMovementMethod
 import android.view.View
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ActivityLogItemDetailBinding
@@ -64,6 +66,8 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
                 val (site, activityLogId) = sideAndActivityId(savedInstanceState, activity.intent)
                 val areButtonsVisible = areButtonsVisible(savedInstanceState, activity.intent)
                 val isRestoreHidden = isRestoreHidden(savedInstanceState, activity.intent)
+
+                jetpackBadge.root.isVisible = !BuildConfig.IS_JETPACK_APP
 
                 viewModel.activityLogItem.observe(viewLifecycleOwner, { activityLogModel ->
                     loadLogItem(activityLogModel, activity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -65,6 +65,7 @@ import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import org.wordpress.android.util.WPMediaUtils
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.config.QRCodeAuthFlowFeatureConfig
 import org.wordpress.android.util.config.RecommendTheAppFeatureConfig
 import org.wordpress.android.util.config.UnifiedAboutFeatureConfig
@@ -91,6 +92,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     @Inject lateinit var sequencer: SnackbarSequencer
     @Inject lateinit var unifiedAboutFeatureConfig: UnifiedAboutFeatureConfig
     @Inject lateinit var qrCodeAuthFlowFeatureConfig: QRCodeAuthFlowFeatureConfig
+    @Inject lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
     private lateinit var viewModel: MeViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -120,7 +122,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        jetpackBadge.root.isVisible = !BuildConfig.IS_JETPACK_APP
+        jetpackBadge.root.isVisible = jetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP
 
         val showPickerListener = OnClickListener {
             AnalyticsTracker.track(ME_GRAVATAR_TAPPED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -120,6 +120,8 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
+        jetpackBadge.root.isVisible = !BuildConfig.IS_JETPACK_APP
+
         val showPickerListener = OnClickListener {
             AnalyticsTracker.track(ME_GRAVATAR_TAPPED)
             showPhotoPickerForGravatar()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -62,6 +62,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig;
 import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig;
 import org.wordpress.android.util.config.UnifiedAboutFeatureConfig;
 import org.wordpress.android.viewmodel.ContextProvider;
@@ -104,6 +105,7 @@ public class AppSettingsFragment extends PreferenceFragment
     @Inject UnifiedAboutFeatureConfig mUnifiedAboutFeatureConfig;
     @Inject MySiteDashboardTabsFeatureConfig mMySiteDashboardTabsFeatureConfig;
     @Inject MySiteDefaultTabExperiment mMySiteDefaultTabExperiment;
+    @Inject JetpackPoweredFeatureConfig mJetpackPoweredFeatureConfig;
 
     private static final String TRACK_STYLE = "style";
     private static final String TRACK_ENABLED = "enabled";
@@ -236,16 +238,16 @@ public class AppSettingsFragment extends PreferenceFragment
         final ListView listOfPreferences = view.findViewById(android.R.id.list);
         if (listOfPreferences != null) {
             ViewCompat.setNestedScrollingEnabled(listOfPreferences, true);
-            if (!BuildConfig.IS_JETPACK_APP) {
-                addJetpackBadgeAsFooter(inflater, listOfPreferences);
-            }
+            addJetpackBadgeAsFooterIfEnabled(inflater, listOfPreferences);
         }
         return view;
     }
 
-    private void addJetpackBadgeAsFooter(LayoutInflater inflater, ListView listOfPreferences) {
-        final JetpackBadgeFooterBinding binding = JetpackBadgeFooterBinding.inflate(inflater);
-        listOfPreferences.addFooterView(binding.getRoot(), null, false);
+    private void addJetpackBadgeAsFooterIfEnabled(LayoutInflater inflater, ListView listView) {
+        if (mJetpackPoweredFeatureConfig.isEnabled() && !mBuildConfigWrapper.isJetpackApp()) {
+            final JetpackBadgeFooterBinding binding = JetpackBadgeFooterBinding.inflate(inflater);
+            listView.addFooterView(binding.getRoot(), null, false);
+        }
     }
 
     private void removeExperimentalCategory() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -31,6 +31,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
+import org.wordpress.android.databinding.JetpackBadgeFooterBinding;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
@@ -42,12 +43,12 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.WhatsNewStore.OnWhatsNewFetched;
 import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewAppId;
 import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewFetchPayload;
-import org.wordpress.android.ui.prefs.language.LocalePickerBottomSheet;
-import org.wordpress.android.ui.prefs.language.LocalePickerBottomSheet.LocalePickerCallback;
 import org.wordpress.android.ui.about.UnifiedAboutActivity;
 import org.wordpress.android.ui.debug.DebugSettingsActivity;
 import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment;
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType;
+import org.wordpress.android.ui.prefs.language.LocalePickerBottomSheet;
+import org.wordpress.android.ui.prefs.language.LocalePickerBottomSheet.LocalePickerCallback;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementDialogFragment;
@@ -235,8 +236,16 @@ public class AppSettingsFragment extends PreferenceFragment
         final ListView listOfPreferences = view.findViewById(android.R.id.list);
         if (listOfPreferences != null) {
             ViewCompat.setNestedScrollingEnabled(listOfPreferences, true);
+            if (!BuildConfig.IS_JETPACK_APP) {
+                addJetpackBadgeAsFooter(inflater, listOfPreferences);
+            }
         }
         return view;
+    }
+
+    private void addJetpackBadgeAsFooter(LayoutInflater inflater, ListView listOfPreferences) {
+        final JetpackBadgeFooterBinding binding = JetpackBadgeFooterBinding.inflate(inflater);
+        listOfPreferences.addFooterView(binding.getRoot(), null, false);
     }
 
     private void removeExperimentalCategory() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -16,6 +16,7 @@ import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 import android.provider.Settings;
 import android.text.TextUtils;
+import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -43,6 +44,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
+import org.wordpress.android.databinding.JetpackBadgeFooterBinding;
 import org.wordpress.android.datasets.ReaderBlogTable;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
@@ -72,12 +74,13 @@ import org.wordpress.android.ui.utils.UiString;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.BuildConfigWrapper;
-import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.config.BloggingRemindersFeatureConfig;
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig;
+import org.wordpress.android.util.extensions.ContextExtensionsKt;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -133,6 +136,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     @Inject BuildConfigWrapper mBuildConfigWrapper;
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject BloggingRemindersFeatureConfig mBloggingRemindersFeatureConfig;
+    @Inject JetpackPoweredFeatureConfig mJetpackPoweredFeatureConfig;
     @Inject UiHelpers mUiHelpers;
 
     private BloggingRemindersViewModel mBloggingRemindersViewModel;
@@ -214,10 +218,18 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         final ListView lv = (ListView) view.findViewById(android.R.id.list);
         if (lv != null) {
             ViewCompat.setNestedScrollingEnabled(lv, true);
+            addJetpackBadgeAsFooterIfEnabled(lv);
         }
         initBloggingReminders();
     }
 
+    private void addJetpackBadgeAsFooterIfEnabled(ListView listView) {
+        if (mJetpackPoweredFeatureConfig.isEnabled() && !mBuildConfigWrapper.isJetpackApp()) {
+            LayoutInflater inflater = LayoutInflater.from(getContext());
+            final JetpackBadgeFooterBinding binding = JetpackBadgeFooterBinding.inflate(inflater);
+            listView.addFooterView(binding.getRoot(), null, false);
+        }
+    }
 
     @Override
     public void onStart() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -33,6 +33,7 @@ import androidx.core.graphics.BlendModeColorFilterCompat
 import androidx.core.graphics.BlendModeCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.Factory
@@ -48,6 +49,7 @@ import com.google.android.material.snackbar.Snackbar
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -698,6 +700,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
     private fun renderUiState(state: ReaderPostDetailsUiState, binding: ReaderFragmentPostDetailBinding) {
         onPostExecuteShowPost()
+        binding.jetpackBadge.root.isVisible = !BuildConfig.IS_JETPACK_APP
         binding.headerView.updatePost(state.headerUiState)
         showOrHideMoreMenu(state)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -126,6 +126,7 @@ import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.WPPermissionUtils.READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE
 import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
 import org.wordpress.android.util.config.CommentsSnippetFeatureConfig
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.config.LikesEnhancementsFeatureConfig
 import org.wordpress.android.util.extensions.getColorFromAttribute
 import org.wordpress.android.util.extensions.isDarkTheme
@@ -221,6 +222,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     @Inject lateinit var likesEnhancementsFeatureConfig: LikesEnhancementsFeatureConfig
     @Inject lateinit var contextProvider: ContextProvider
     @Inject lateinit var commentsSnippetFeatureConfig: CommentsSnippetFeatureConfig
+    @Inject lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
 
     private val mSignInClickListener = View.OnClickListener {
         EventBus.getDefault()
@@ -700,7 +702,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
     private fun renderUiState(state: ReaderPostDetailsUiState, binding: ReaderFragmentPostDetailBinding) {
         onPostExecuteShowPost()
-        binding.jetpackBadge.root.isVisible = !BuildConfig.IS_JETPACK_APP
+        binding.jetpackBadge.root.isVisible = jetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP
         binding.headerView.updatePost(state.headerUiState)
         showOrHideMoreMenu(state)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1472,10 +1472,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
         mSearchSuggestionAdapter.setFilter(query);
     }
 
-    private void resetSearchSuggestionAdapter() {
-        mSearchView.setSuggestionsAdapter(null);
-        mSearchSuggestionAdapter = null;
-    }
 
     private void createSearchSuggestionRecyclerAdapter() {
         mSearchSuggestionRecyclerAdapter = new ReaderSearchSuggestionRecyclerAdapter();
@@ -1491,11 +1487,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
             createSearchSuggestionRecyclerAdapter();
         }
         mSearchSuggestionRecyclerAdapter.setQuery(query);
-    }
-
-    private void resetSearchSuggestionRecyclerAdapter() {
-        mRecyclerView.setSearchSuggestionAdapter(null);
-        mSearchSuggestionRecyclerAdapter = null;
     }
 
     private void onSearchSuggestionClicked(String query) {

--- a/WordPress/src/main/res/layout/activity_log_item_detail.xml
+++ b/WordPress/src/main/res/layout/activity_log_item_detail.xml
@@ -188,6 +188,12 @@
             tools:text="Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores. For more information visit our documentation page."
             tools:visibility="visible" />
 
+        <include
+            android:id="@+id/jetpack_badge"
+            layout="@layout/jetpack_badge"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/WordPress/src/main/res/layout/jetpack_badge_footer.xml
+++ b/WordPress/src/main/res/layout/jetpack_badge_footer.xml
@@ -3,7 +3,7 @@
     android:id="@+id/jetpack_badge_footer"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingBottom="@dimen/jetpack_badge_bottom_spacing">
+    android:paddingBottom="@dimen/jetpack_badge_footer_bottom_spacing">
 
     <include
         android:id="@+id/jetpack_badge"

--- a/WordPress/src/main/res/layout/jetpack_badge_footer.xml
+++ b/WordPress/src/main/res/layout/jetpack_badge_footer.xml
@@ -3,7 +3,7 @@
     android:id="@+id/jetpack_badge_footer"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingBottom="@dimen/margin_extra_extra_large">
+    android:paddingBottom="@dimen/jetpack_badge_bottom_spacing">
 
     <include
         android:id="@+id/jetpack_badge"

--- a/WordPress/src/main/res/layout/jetpack_badge_footer.xml
+++ b/WordPress/src/main/res/layout/jetpack_badge_footer.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/jetpack_badge_footer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/margin_extra_extra_large">
+
+    <include
+        android:id="@+id/jetpack_badge"
+        layout="@layout/jetpack_badge"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</FrameLayout>

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -302,6 +302,15 @@
 
             <View style="@style/MeListSectionDividerView" />
 
+            <include
+                android:id="@+id/jetpack_badge"
+                layout="@layout/jetpack_badge"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -304,7 +304,7 @@
 
             <include
                 android:id="@+id/jetpack_badge"
-                layout="@layout/jetpack_badge"
+                layout="@layout/jetpack_badge_footer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_extra_large"

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -72,6 +72,16 @@
                         android:layout_alignStart="@+id/layout_post_detail_content"
                         tools:ignore="UnknownIdInLayout">
 
+                        <include
+                            android:id="@+id/jetpack_badge"
+                            layout="@layout/jetpack_badge"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="@dimen/jetpack_badge_bottom_spacing"
+                            android:layout_marginTop="@dimen/margin_extra_large"
+                            android:visibility="gone"
+                            tools:visibility="visible" />
+
                         <org.wordpress.android.ui.reader.views.ReaderSimplePostContainerView
                             android:id="@+id/related_posts_view_local"
                             android:layout_width="match_parent"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -464,6 +464,7 @@
     <dimen name="jetpack_icon_margin">0dp</dimen>
     <dimen name="jetpack_button_icon_size">16dp</dimen>
     <dimen name="jetpack_banner_height">40dp</dimen>
+    <dimen name="jetpack_badge_bottom_spacing">36dp</dimen>
 
     <!-- jetpack backup restore last bullet bottom margin-->
     <dimen name="jetpack_backup_restore_last_bullet_bottom_margin">20dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -464,7 +464,7 @@
     <dimen name="jetpack_icon_margin">0dp</dimen>
     <dimen name="jetpack_button_icon_size">16dp</dimen>
     <dimen name="jetpack_banner_height">40dp</dimen>
-    <dimen name="jetpack_badge_bottom_spacing">36dp</dimen>
+    <dimen name="jetpack_badge_footer_bottom_spacing">36dp</dimen>
 
     <!-- jetpack backup restore last bullet bottom margin-->
     <dimen name="jetpack_backup_restore_last_bullet_bottom_margin">20dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -465,6 +465,7 @@
     <dimen name="jetpack_button_icon_size">16dp</dimen>
     <dimen name="jetpack_banner_height">40dp</dimen>
     <dimen name="jetpack_badge_footer_bottom_spacing">36dp</dimen>
+    <dimen name="jetpack_badge_bottom_spacing">28dp</dimen>
 
     <!-- jetpack backup restore last bullet bottom margin-->
     <dimen name="jetpack_backup_restore_last_bullet_bottom_margin">20dp</dimen>


### PR DESCRIPTION
Shows the Jetpack Powered Badge in the WP app when the `JetpackPoweredFeatureConfig` flag is enabled on the following screens:
- Me
- App Settings
- Activity Detail
- Notifications Settings
- Reader Post

To test:
**WP App**
1. Launch **WP** app from PR build or local build of PR branch
2. Make sure the `JetpackPoweredFeatureConfig` flag is **on**
   > Me → App Settings → Debug Settings → check `JetpackPoweredFeatureConfig` & tap `RESTART THE APP`
3. Tap `Me` (profile icon in top right corner)
   ☑️ **Expect** the Jetpack powered badge to be **visible**
4. Tap `App Settings` and scroll to the bottom of the screen
   ☑️ **Expect** the Jetpack powered badge to be **visible**
5. Go back 2 times, now on the `MENU` tab of My Site tap `Activity Log` then tap any activity log item
   ⚠️ **Note:** _make sure to have at least one activity: if you don't, you can, for example, change your site title from Site Settings to generate one._
   ☑️ **Expect** the Jetpack powered badge to be **visible**
6. Go back 2 times, now tap `Notifications` (bottom right corner) then tap the `⚙️` (top right corner) to open `Notifications Settings` and scroll to the bottom of the screen
  ☑️ **Expect** the Jetpack powered badge to be **visible**
7. Go back, tap `Reader` (bottom middle) then tap any post to open `Reader Post view` and scroll to the bottom of the posts
  ☑️ **Expect** the Jetpack powered badge to be **visible** below the comments section
8. Make sure the `JetpackPoweredFeatureConfig` flag is **off**
9. Repeat steps 3-7 ☑️ **expecting** the Jetpack powered badge to **not** be visible

**JP App**
1. Launch **JP** app from PR build or local build of PR branch
2. Repeat steps 2-7 from `WP App` section ☑️ **expecting** the Jetpack powered badge to **not** be visible

## Screenshots
| Me (Night) | App Settings | Activity Detail | Notifications Settings | Reader Post |
| --- | --- | --- | --- | --- |
| <img width="130" src="https://user-images.githubusercontent.com/4588074/179174141-9d41cd75-1fe1-4806-b653-b393f85aa4e0.png"> | <img width="130" src="https://user-images.githubusercontent.com/4588074/179174198-c3e935b0-8164-45d3-b07b-d84c2faacf0e.png"> | <img width="130" src="https://user-images.githubusercontent.com/4588074/179174246-a60e9e5d-f0a4-40f4-b10d-4bc133eb8ac2.png"> | <img width="130" src="https://user-images.githubusercontent.com/4588074/179174305-6ff7cd24-e448-4386-975d-5fe3517e63a8.png"> | <img width="130" src="https://user-images.githubusercontent.com/4588074/179294985-68e9eaf5-96e0-4ab5-b0e9-a1cdda8cce8b.png"> |

### Review notes
- One reviewer should be enough to merge 👌 .

## Regression Notes
1. Potential unintended areas of impact
   Any of the screens affected.
3. What I did to test those areas of impact (or what existing automated tests I relied on)
   Tested manually.
9. What automated tests I added (or what prevented me from doing so)
   None, the changes are in code which is not testable with unit tests, and we're not adding UI tests for small UI changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.