### PR TITLE
Jetpack banner improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -25,7 +25,6 @@ import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesFragment;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginSiteCheckErrorFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailFragment;
-import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListFragment;
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterFragment;
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingDialogFragment;
@@ -85,7 +84,6 @@ import org.wordpress.android.ui.mysite.tabs.MySiteTabFragment;
 import org.wordpress.android.ui.notifications.DismissNotificationReceiver;
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity;
 import org.wordpress.android.ui.notifications.NotificationsDetailListFragment;
-import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.ui.notifications.NotificationsListFragmentPage;
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter;
 import org.wordpress.android.ui.notifications.receivers.NotificationsPendingDraftsReceiver;
@@ -98,7 +96,6 @@ import org.wordpress.android.ui.pages.SearchListFragment;
 import org.wordpress.android.ui.people.PeopleInviteDialogFragment;
 import org.wordpress.android.ui.people.PeopleInviteFragment;
 import org.wordpress.android.ui.people.PeopleListFragment;
-import org.wordpress.android.ui.people.PeopleManagementActivity;
 import org.wordpress.android.ui.people.PersonDetailFragment;
 import org.wordpress.android.ui.people.RoleChangeDialogFragment;
 import org.wordpress.android.ui.people.RoleSelectDialogFragment;
@@ -135,7 +132,6 @@ import org.wordpress.android.ui.posts.SelectCategoriesActivity;
 import org.wordpress.android.ui.posts.adapters.AuthorSelectionAdapter;
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsFragment;
 import org.wordpress.android.ui.posts.services.AztecVideoLoader;
-import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsFragment;
 import org.wordpress.android.ui.prefs.AppSettingsActivity;
 import org.wordpress.android.ui.prefs.AppSettingsFragment;
 import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
@@ -146,6 +142,7 @@ import org.wordpress.android.ui.prefs.SiteSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.SiteSettingsTagDetailFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsTagListActivity;
+import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsFragment;
 import org.wordpress.android.ui.prefs.categories.detail.CategoryDetailFragment;
 import org.wordpress.android.ui.prefs.categories.list.CategoriesListFragment;
 import org.wordpress.android.ui.prefs.homepage.HomepageSettingsDialog;
@@ -155,7 +152,6 @@ import org.wordpress.android.ui.prefs.timezone.SiteSettingsTimezoneBottomSheet;
 import org.wordpress.android.ui.publicize.PublicizeAccountChooserListAdapter;
 import org.wordpress.android.ui.publicize.PublicizeButtonPrefsFragment;
 import org.wordpress.android.ui.publicize.PublicizeDetailFragment;
-import org.wordpress.android.ui.publicize.PublicizeListActivity;
 import org.wordpress.android.ui.publicize.PublicizeListFragment;
 import org.wordpress.android.ui.publicize.PublicizeWebViewFragment;
 import org.wordpress.android.ui.publicize.adapters.PublicizeConnectionAdapter;
@@ -165,7 +161,6 @@ import org.wordpress.android.ui.quickstart.QuickStartReminderReceiver;
 import org.wordpress.android.ui.reader.CommentNotificationsBottomSheetFragment;
 import org.wordpress.android.ui.reader.ReaderBlogFragment;
 import org.wordpress.android.ui.reader.ReaderCommentListActivity;
-import org.wordpress.android.ui.reader.ReaderFragment;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.ui.reader.ReaderPostListActivity;
 import org.wordpress.android.ui.reader.ReaderPostListFragment;
@@ -212,7 +207,6 @@ import org.wordpress.android.ui.stories.StoryComposerActivity;
 import org.wordpress.android.ui.stories.intro.StoriesIntroDialogFragment;
 import org.wordpress.android.ui.suggestion.SuggestionActivity;
 import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter;
-import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.ui.themes.ThemeBrowserFragment;
 import org.wordpress.android.ui.uploads.MediaUploadHandler;
 import org.wordpress.android.ui.uploads.MediaUploadReadyProcessor;
@@ -300,8 +294,6 @@ public interface AppComponent {
 
     void inject(AppSettingsFragment object);
 
-    void inject(PeopleManagementActivity object);
-
     void inject(PeopleListFragment object);
 
     void inject(PersonDetailFragment object);
@@ -334,8 +326,6 @@ public interface AppComponent {
 
     void inject(SiteSettingsTagDetailFragment object);
 
-    void inject(PublicizeListActivity object);
-
     void inject(PublicizeWebViewFragment object);
 
     void inject(PublicizeDetailFragment object);
@@ -361,8 +351,6 @@ public interface AppComponent {
     void inject(HistoryAdapter object);
 
     void inject(HistoryDetailContainerFragment object);
-
-    void inject(NotificationsListFragment object);
 
     void inject(NotificationsListFragmentPage object);
 
@@ -426,8 +414,6 @@ public interface AppComponent {
 
     void inject(WPWebViewClient object);
 
-    void inject(ThemeBrowserActivity object);
-
     void inject(NotesAdapter object);
 
     void inject(ThemeBrowserFragment object);
@@ -441,8 +427,6 @@ public interface AppComponent {
     void inject(AddCategoryFragment object);
 
     void inject(PluginBrowserActivity object);
-
-    void inject(ActivityLogListActivity object);
 
     void inject(ActivityLogListFragment object);
 
@@ -563,8 +547,6 @@ public interface AppComponent {
     void inject(StoryComposerActivity object);
 
     void inject(StoriesIntroDialogFragment object);
-
-    void inject(ReaderFragment object);
 
     void inject(ReaderDiscoverFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -20,10 +20,14 @@ import org.wordpress.android.ui.jetpack.backup.download.KEY_BACKUP_DOWNLOAD_REWI
 import org.wordpress.android.ui.jetpack.common.JetpackBackupDownloadActionState
 import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_RESTORE_ID
 import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_REWIND_ID
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.extensions.setNavigationBarColorForBanner
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_KEY
+import javax.inject.Inject
 
 class ActivityLogListActivity : LocaleAwareActivity() {
+    @Inject lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
@@ -33,7 +37,7 @@ class ActivityLogListActivity : LocaleAwareActivity() {
 
             setSupportActionBar(toolbarMain)
 
-            if (!BuildConfig.IS_JETPACK_APP) {
+            if (jetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
                 jetpackBanner.root.isVisible = true
                 window.setNavigationBarColorForBanner()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -7,9 +7,9 @@ import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ActivityLogListActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.RequestCodes
@@ -25,12 +25,12 @@ import org.wordpress.android.util.extensions.setNavigationBarColorForBanner
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_KEY
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class ActivityLogListActivity : LocaleAwareActivity() {
     @Inject lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (application as WordPress).component().inject(this)
         with(ActivityLogListActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
             checkAndUpdateUiToBackupScreen()

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -50,6 +50,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.NOTIFS
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.WPUrlUtils
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
 import javax.inject.Inject
 
@@ -58,6 +59,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
     private var lastTabPosition = 0
 
     @Inject lateinit var accountStore: AccountStore
+    @Inject lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
 
     private var binding: NotificationsListFragmentBinding? = null
 
@@ -81,7 +83,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
             toolbarMain.setTitle(R.string.notifications_screen_title)
             (requireActivity() as AppCompatActivity).setSupportActionBar(toolbarMain)
 
-            if (!BuildConfig.IS_JETPACK_APP) {
+            if (jetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
                 jetpackBanner.root.isVisible = true
 
                 // Add bottom margin to viewPager and connectJetpack view for jetpack banner.

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -20,10 +20,10 @@ import androidx.fragment.app.FragmentPagerAdapter
 import com.google.android.material.appbar.AppBarLayout.LayoutParams
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.google.android.material.tabs.TabLayout.Tab
+import dagger.hilt.android.AndroidEntryPoint
 import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL
@@ -54,6 +54,7 @@ import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment), ScrollableViewInitializedListener {
     private var shouldRefreshNotifications = false
     private var lastTabPosition = 0
@@ -72,7 +73,6 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (requireActivity().application as WordPress).component().inject(this)
         shouldRefreshNotifications = true
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -34,6 +34,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig;
 import org.wordpress.android.util.extensions.WindowExtensionsKt;
 
 import java.util.List;
@@ -90,6 +91,7 @@ public class PeopleManagementActivity extends LocaleAwareActivity
 
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
+    @Inject JetpackPoweredFeatureConfig mJetpackPoweredFeatureConfig;
 
     private SiteModel mSite;
 
@@ -101,7 +103,7 @@ public class PeopleManagementActivity extends LocaleAwareActivity
 
         setContentView(R.layout.people_management_activity);
 
-        if (!BuildConfig.IS_JETPACK_APP) {
+        if (mJetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
             findViewById(R.id.jetpack_banner).setVisibility(View.VISIBLE);
             WindowExtensionsKt.setNavigationBarColorForBanner(getWindow());
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -41,6 +41,9 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class PeopleManagementActivity extends LocaleAwareActivity
         implements PeopleListFragment.OnPersonSelectedListener, PeopleListFragment.OnFetchPeopleListener {
     private static final String KEY_PEOPLE_LIST_FRAGMENT = "people-list-fragment";
@@ -98,7 +101,6 @@ public class PeopleManagementActivity extends LocaleAwareActivity
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        ((WordPress) getApplication()).component().inject(this);
         mDispatcher.register(this);
 
         setContentView(R.layout.people_management_activity);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -48,6 +48,9 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class PublicizeListActivity extends LocaleAwareActivity
         implements
         PublicizeActions.OnPublicizeActionListener,
@@ -65,7 +68,6 @@ public class PublicizeListActivity extends LocaleAwareActivity
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        ((WordPress) getApplication()).component().inject(this);
 
         setContentView(R.layout.publicize_list_activity);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -39,6 +39,7 @@ import org.wordpress.android.ui.publicize.services.PublicizeUpdateService;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig;
 import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
 import org.wordpress.android.util.extensions.WindowExtensionsKt;
 
@@ -59,6 +60,7 @@ public class PublicizeListActivity extends LocaleAwareActivity
     private AppBarLayout mAppBarLayout;
 
     @Inject SiteStore mSiteStore;
+    @Inject JetpackPoweredFeatureConfig mJetpackPoweredFeatureConfig;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -78,7 +80,7 @@ public class PublicizeListActivity extends LocaleAwareActivity
 
         mAppBarLayout = findViewById(R.id.appbar_main);
 
-        if (!BuildConfig.IS_JETPACK_APP) {
+        if (mJetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
             findViewById(R.id.jetpack_banner).setVisibility(View.VISIBLE);
             WindowExtensionsKt.setNavigationBarColorForBanner(getWindow());
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -18,13 +18,13 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
+import dagger.hilt.android.AndroidEntryPoint
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.R.string
-import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ReaderFragmentLayoutBinding
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.ui.ScrollableViewInitializedListener
@@ -52,6 +52,7 @@ import org.wordpress.android.widgets.QuickStartFocusPoint
 import java.util.EnumSet
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableViewInitializedListener {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var uiHelpers: UiHelpers
@@ -76,11 +77,6 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
                 }
             }
         }
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        (requireActivity().application as WordPress).component().inject(this)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -46,6 +46,7 @@ import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarItem.Action
 import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.QuickStartFocusPoint
 import java.util.EnumSet
@@ -55,6 +56,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var quickStartUtilsWrapper: QuickStartUtilsWrapper
+    @Inject lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
     @Inject lateinit var snackbarSequencer: SnackbarSequencer
     private lateinit var viewModel: ReaderViewModel
 
@@ -151,7 +153,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
     }
 
     private fun ReaderFragmentLayoutBinding.initJetpackBanner() {
-        if (!BuildConfig.IS_JETPACK_APP) {
+        if (jetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
             jetpackBanner.root.isVisible = true
 
             // Add bottom margin to viewPager and interests fragment for the jetpack banner.

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -16,12 +16,14 @@ import org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATIO
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.extensions.setNavigationBarColorForBanner
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class StatsActivity : LocaleAwareActivity() {
     @Inject lateinit var statsSiteProvider: StatsSiteProvider
+    @Inject lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
     private val viewModel: StatsViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,7 +31,7 @@ class StatsActivity : LocaleAwareActivity() {
 
         with(StatsListActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
-            if (!BuildConfig.IS_JETPACK_APP) {
+            if (jetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
                 jetpackBanner.root.isVisible = true
                 window.setNavigationBarColorForBanner()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -42,6 +42,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.config.JetpackPoweredFeatureConfig;
 import org.wordpress.android.util.extensions.WindowExtensionsKt;
 
 import java.util.HashMap;
@@ -63,6 +64,7 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
 
     @Inject ThemeStore mThemeStore;
     @Inject Dispatcher mDispatcher;
+    @Inject JetpackPoweredFeatureConfig mJetpackPoweredFeatureConfig;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -101,7 +103,7 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
-        if (!BuildConfig.IS_JETPACK_APP) {
+        if (mJetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
             findViewById(R.id.jetpack_banner).setVisibility(View.VISIBLE);
             WindowExtensionsKt.setNavigationBarColorForBanner(getWindow());
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -50,6 +50,9 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBrowserFragmentCallback {
     public static final int ACTIVATE_THEME = 1;
     public static final String THEME_ID = "theme_id";
@@ -69,7 +72,6 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        ((WordPress) getApplication()).component().inject(this);
         mDispatcher.register(this);
 
         if (savedInstanceState == null) {

--- a/WordPress/src/main/res/layout/jetpack_badge.xml
+++ b/WordPress/src/main/res/layout/jetpack_badge.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
+    android:importantForAccessibility="no"
     android:paddingTop="@dimen/margin_large">
 
     <com.google.android.material.button.MaterialButton

--- a/WordPress/src/main/res/layout/jetpack_banner.xml
+++ b/WordPress/src/main/res/layout/jetpack_banner.xml
@@ -8,6 +8,8 @@
     android:background="@color/jetpack_banner_background"
     android:orientation="vertical"
     android:visibility="gone"
+    android:clickable="true"
+    android:focusable="true"
     tools:visibility="visible">
 
     <View


### PR DESCRIPTION
- This makes the jetpack banner clickable to prevent the view under the banner from being clicked (reported here, internal ref: pcdRpT-xc-p2#comment-694).
- The feature flag is added to control showing the banner.
- Updated screens are also migrated to Hilt.

To test:
1. Launch WordPress app.
2. Ensure JetpackPoweredFeatureConfig is disabled. (Check "Me > App Settings > Debug Settings"). If not, disable it and restart the app.
3. Open **Stats** screen from "My Site > MENU > Stats". Ensure the banner is hidden. 
4. Open **Activity** Log screen from "My Site > MENU > Activity Log". Ensure the banner is hidden. (If Activity Log is not in MENU, make some small changes on your site, like title change. Then Activity Log button will appear)
5. Open **Themes** screen from "My Site > MENU > Themes". Ensure the banner is hidden. 
6. Open **People** screen from "My Site > MENU > People". Ensure the banner is hidden. 
7. Open **Sharing** screen from "My Site > MENU > Sharing". Ensure the banner is hidden.
8. Open **Reader** screen. Ensure the banner is hidden.
9. Open **Notifications** screen. Ensure the banner is hidden.
10. Enable the JetpackPoweredFeatureConfig from Me > App Settings > Debug Settings. Repeat 3-9, but this time ensure the banner is visible.

## Regression Notes
1. Potential unintended areas of impact
Migrating to Hilt could break some things.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

6. What automated tests I added (or what prevented me from doing so)
Nothing. This is not a big change for adding an automated test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.