### PR TITLE
Show Jetpack banner when searching in Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.reader;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.Html;
@@ -134,7 +133,6 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.config.JetpackPoweredFeatureConfig;
 import org.wordpress.android.util.config.SeenUnseenWithCounterFeatureConfig;
-import org.wordpress.android.util.extensions.WindowExtensionsKt;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel;
 import org.wordpress.android.widgets.AppRatingDialog;
@@ -506,7 +504,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
         final boolean shouldShow = forceShow && mJetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP;
         if (shouldShow) {
             getView().findViewById(R.id.jetpack_banner).setVisibility(View.VISIBLE);
-            WindowExtensionsKt.setNavigationBarColorForBanner(requireActivity().getWindow());
             // Add bottom margin to post list and empty view.
             int jetpackBannerHeight = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
             ((MarginLayoutParams) getView().findViewById(R.id.reader_recycler_view).getLayoutParams())
@@ -515,11 +512,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
                     .bottomMargin = jetpackBannerHeight;
         } else {
             getView().findViewById(R.id.jetpack_banner).setVisibility(View.GONE);
-            // Reset navigation bar color.
-            if (requireContext().getResources().getConfiguration().orientation
-                == Configuration.ORIENTATION_PORTRAIT) {
-                requireActivity().getWindow().setNavigationBarColor(0);
-            }
             // Remove bottom margin from post list and empty view.
             ((MarginLayoutParams) getView().findViewById(R.id.reader_recycler_view).getLayoutParams())
                     .bottomMargin = 0;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -488,7 +488,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
             mSubFilterViewModel.onUserComesToReader();
         }
 
-        if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
+        if (isSearching()) {
             mRecyclerView.showAppBarLayout();
             mSearchMenuItem.expandActionView();
             mRecyclerView.setToolbarScrollFlags(0);
@@ -686,8 +686,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         }
         mWasPaused = true;
 
-        mViewModel.onFragmentPause(mIsTopLevel, getPostListType() == ReaderPostListType.SEARCH_RESULTS,
-                isFilterableScreen());
+        mViewModel.onFragmentPause(mIsTopLevel, isSearching(), isFilterableScreen());
     }
 
     @Override
@@ -719,12 +718,12 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
             // if the user tapped a site to show site preview, it's possible they also changed the follow
             // status so tell the search adapter to check whether it has the correct follow status
-            if (getPostListType() == ReaderPostListType.SEARCH_RESULTS && mLastTappedSiteSearchResult != null) {
+            if (isSearching() && mLastTappedSiteSearchResult != null) {
                 getSiteSearchAdapter().checkFollowStatusForSite(mLastTappedSiteSearchResult);
                 mLastTappedSiteSearchResult = null;
             }
 
-            if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
+            if (isSearching()) {
                 return;
             }
         }
@@ -734,8 +733,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
             showEmptyView();
         }
 
-        mViewModel.onFragmentResume(mIsTopLevel, getPostListType() == ReaderPostListType.SEARCH_RESULTS,
-                isFilterableScreen(), isFilterableScreen() ? mSubFilterViewModel.getCurrentSubfilterValue() : null);
+        mViewModel.onFragmentResume(mIsTopLevel, isSearching(), isFilterableScreen(),
+                isFilterableScreen() ? mSubFilterViewModel.getCurrentSubfilterValue() : null);
     }
 
     /*
@@ -903,9 +902,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
         if (getPostListType() == ReaderPostListType.TAG_PREVIEW) {
             mTagPreviewHistory.saveInstance(outState);
-        } else if (getPostListType() == ReaderPostListType.SEARCH_RESULTS
-                   && mSearchView != null
-                   && mSearchView.getQuery() != null) {
+        } else if (isSearching() && mSearchView != null && mSearchView.getQuery() != null) {
             String query = mSearchView.getQuery().toString();
             outState.putString(ReaderConstants.ARG_SEARCH_QUERY, query);
         }
@@ -1083,7 +1080,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         }
 
         // add a menu to the filtered recycler's toolbar
-        if (mAccountStore.hasAccessToken() && getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
+        if (mAccountStore.hasAccessToken() && isSearching()) {
             setupRecyclerToolbar();
         }
 
@@ -1190,7 +1187,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         boolean isSearching = getPostListType() == ReaderPostListType.SEARCH_RESULTS;
 
         // prevents suggestions from being shown after the search view has been collapsed
-        if (!isSearching) {
+        if (!isSearching()) {
             return;
         }
 
@@ -1220,6 +1217,10 @@ public class ReaderPostListFragment extends ViewPagerFragment
                 hideSearchSuggestions();
             }
         }
+    }
+
+    private boolean isSearching() {
+        return getPostListType() == ReaderPostListType.SEARCH_RESULTS;
     }
 
     /*
@@ -1564,9 +1565,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         // load the results if the search succeeded and it's the current search - note that success
         // means the search didn't fail, not necessarily that is has results - which is fine because
         // if there aren't results then refreshing will show the empty message
-        if (event.didSucceed()
-            && getPostListType() == ReaderPostListType.SEARCH_RESULTS
-            && event.getQuery().equals(mCurrentSearchQuery)) {
+        if (event.didSucceed() && isSearching() && event.getQuery().equals(mCurrentSearchQuery)) {
             refreshPosts();
             showSearchTabs();
         } else {
@@ -1612,7 +1611,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         } else if (!NetworkUtils.isNetworkAvailable(getActivity())) {
             title = getString(R.string.reader_empty_posts_no_connection);
         } else if (requestFailed) {
-            if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
+            if (isSearching()) {
                 title = getString(R.string.reader_empty_search_request_failed);
             } else {
                 title = getString(R.string.reader_empty_posts_request_failed);
@@ -1818,7 +1817,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
                     AppLog.d(T.READER, "reader post list > restoring position");
                     mRecyclerView.scrollRecycleViewToPosition(mRestorePosition);
                 }
-                if (getPostListType() == ReaderPostListType.SEARCH_RESULTS && !isSearchTabsShowing()) {
+                if (isSearching() && !isSearchTabsShowing()) {
                     showSearchTabs();
                 }
             }
@@ -1921,7 +1920,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
                 mPostAdapter.setCurrentTag(getCurrentTag());
             } else if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
                 mPostAdapter.setCurrentBlogAndFeed(mCurrentBlogId, mCurrentFeedId);
-            } else if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
+            } else if (isSearching()) {
                 ReaderTag searchTag = ReaderUtils.getTagForSearchQuery(mCurrentSearchQuery);
                 mPostAdapter.setCurrentTag(searchTag);
             }
@@ -2168,8 +2167,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
         // don't show new posts if user is searching - posts will automatically
         // appear when search is exited
-        if (isSearchViewExpanded()
-            || getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
+        if (isSearchViewExpanded() || isSearching()) {
             return;
         }
 

--- a/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
@@ -76,4 +76,12 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/jetpack_banner_height"
+        android:layout_alignParentBottom="true"
+        android:visibility="gone"
+        tools:visibility="visible" />
 </RelativeLayout>


### PR DESCRIPTION
Shows the jetpack banner when searching in the Reader (on the empty & suggestions view).

<details>
<summary>Preview (screen recording)</summary>

https://user-images.githubusercontent.com/4588074/179680303-40d5d09c-0fa3-4f6d-920a-b7f3f11dbf63.mp4
</details>


Screenshots:
| Empty Search (🌑 Mode) | Search Suggestions |
| --- | --- |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/179680659-dc092ff5-383a-491c-bd90-6270416bba58.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/179680650-99b316be-0bce-4350-980b-56745ca03be5.png"> |

## To test:

**WP App**
1. Launch **WP** app from PR build or local build of PR branch
2. Make sure the `JetpackPoweredFeatureConfig` flag is **on**
   > Me → App Settings → Debug Settings → check `JetpackPoweredFeatureConfig` & tap `RESTART THE APP`
3. On My Site, tap `Reader` (bottom middle) then tap the search icon (top right)
  ☑️ **Expect** the Jetpack powered banner to be **visible** above the keyboard
4. Type a search query (e.g. "test) then tap the search icon on the keyboard to submit
  ☑️ **Expect** the Jetpack powered banner to **hide**
5. Tap clear icon (`×` in top right) to go back to the searching screen that will show the previous query as suggestion
   ☑️ **Expect** the Jetpack powered banner to be **visible** above the keyboard
6. Make sure the `JetpackPoweredFeatureConfig` flag is **off**
7. Repeat steps 3-5 ☑️ **expecting** the Jetpack powered banner to **not** be visible

**JP App**
1. Launch **JP** app from PR build or local build of PR branch
2. Repeat steps 2-5 from `WP App` section ☑️ **expecting** the Jetpack powered banner to **not** be visible

### Review notes
- One reviewer should be enough to merge this PR 👌 .

## Regression Notes
1. Potential unintended areas of impact
   Unlikely.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing of the affected screen.

6. What automated tests I added (or what prevented me from doing so)
   Not applicable — code changes are in the view, UI tests not warranted by small decorative UI updates.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
