### PR TITLE
Disable Jetpack banner on Notifications if not connected through WP.com

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -48,6 +48,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.NOTIFS
 import org.wordpress.android.util.JetpackBannerUtils
 import org.wordpress.android.util.NetworkUtils
+import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.WPUrlUtils
 import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
@@ -60,6 +61,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
 
     @Inject lateinit var accountStore: AccountStore
     @Inject lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
+    @Inject lateinit var siteUtilsWrapper: SiteUtilsWrapper
 
     private var binding: NotificationsListFragmentBinding? = null
 
@@ -291,7 +293,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
 
     override fun onScrollableViewInitialized(containerId: Int) {
         binding?.appBar?.setLiftOnScrollTargetViewIdAndRequestLayout(containerId)
-        if (jetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
+        if (showJetpackPoweredBanner()) {
             binding?.root?.post {
                 // post is used to create a minimal delay here. containerId changes just before
                 // onScrollableViewInitialized is called, and findViewById can't find the new id before the delay.
@@ -301,5 +303,12 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
                 JetpackBannerUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
             }
         }
+    }
+
+    private fun showJetpackPoweredBanner(): Boolean {
+        val selectedSite = (requireActivity() as? WPMainActivity)?.selectedSite
+        val wpComSite = (selectedSite != null) && siteUtilsWrapper.isAccessedViaWPComRest(selectedSite)
+
+        return wpComSite && jetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP
     }
 }


### PR DESCRIPTION
This PR disables Jetpack powered banner on Notifications for self-hosted sites not connected through WordPress.com


<img width=320 src="https://user-images.githubusercontent.com/990349/180125919-b7fe6927-9175-4b67-81b2-0a58c29ff404.png" />

To test:

Setup:

- Launch the WordPress app
- Go to App Settings (Tap on Avatar at the top right-hand corner on My Site -> Find App Settings)
- Select Debug Settings
- Find JetpackPoweredFeatureConfig under Features in development

Test 1

- Connect the app to a self-hosted site via "Enter your existing site address"
- Do not log into WordPress.com in the app if prompted
- Go to Notifications
- Ensure Jetpack banner doesn't show up when scrolling down.

Test 2

- Log into to the app with a WordPress.com account
- Go to Notifications
- Expect the Jetpack banner to show

Test 1 and Test 2 can also be done potentially by going to My Site -> Me (Avatar) -> Log out of WordPress.com with self-hosted site.

You may be able to create a self-hosted site through https://jurassic.ninja/ and deselecting include Jetpack
 

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
