### PR TITLE
Jetpack Focus: Disable bottom sheet 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/MySiteJetpackBadgeViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/MySiteJetpackBadgeViewHolder.kt
@@ -9,7 +9,8 @@ import org.wordpress.android.util.extensions.viewBinding
 class MySiteJetpackBadgeViewHolder(
     parent: ViewGroup,
 ) : MySiteCardAndItemViewHolder<JetpackBadgeBinding>(parent.viewBinding(JetpackBadgeBinding::inflate)) {
+    @Suppress("UnusedPrivateMember")
     fun bind(item: JetpackBadge) {
-        itemView.setOnClickListener { item.onClick.click() }
+//        itemView.setOnClickListener { item.onClick.click() }
     }
 }


### PR DESCRIPTION
This PR disables for now [invoking bottom sheet from Jetpack powered badge on Home tab](https://github.com/wordpress-mobile/WordPress-Android/pull/16910). It will be enabled next in the iteration.



To test:

Setup:

- Launch WordPress app
- Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
- Select Debug Settings
- Find JetpackPoweredFeatureConfig under Features in development
- Re-launch app (scroll down if necessary)

Test 1:

- Make sure the Jetpack powered badge appears on the home tab
- Tap on the Jetpack powered badge, 
- Ensure a bottom sheet does not pop-up 


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Existing tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
