### PR TITLE
Enables the jetpack powered badge

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] Block Editor: Fix incorrect spacing within Image alt text footnote [https://github.com/WordPress/gutenberg/pull/42504]
 * [***] Block Editor: Gallery and Image block - Performance improvements [https://github.com/WordPress/gutenberg/pull/42178]
 * [**] [WP.com and Jetpack sites with VideoPress] Prevent validation error when viewing VideoPress markup within app [https://github.com/Automattic/jetpack/pull/24548]
+* [*] [internal] Adds the "Jetpack powered" badge to non-core features [https://github.com/wordpress-mobile/WordPress-Android/pull/16940]
 
 20.3
 -----

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -115,7 +115,7 @@ android {
         buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"
         buildConfigField "boolean", "QRCODE_AUTH_FLOW", "false"
         buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"
-        buildConfigField "boolean", "JETPACK_POWERED", "false"
+        buildConfigField "boolean", "JETPACK_POWERED", "true"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredFeatureConfig.kt
@@ -1,22 +1,20 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
 import org.wordpress.android.annotation.FeatureInDevelopment
 import javax.inject.Inject
 
 /**
  * Configuration for Jetpack Powered indicators
- *
- * TODO: When it is ready to be rolled out uncomment the lines 12 and 19, remove line 13 and this to-do
  */
-// @Feature(JetpackPoweredFeatureConfig.JETPACK_POWERED_REMOTE_FIELD, true)
-@FeatureInDevelopment
+@Feature(JetpackPoweredFeatureConfig.JETPACK_POWERED_REMOTE_FIELD, true)
 class JetpackPoweredFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
         appConfig,
         BuildConfig.JETPACK_POWERED,
-//        JETPACK_POWERED_REMOTE_FIELD
+        JETPACK_POWERED_REMOTE_FIELD
 ) {
     companion object {
         const val JETPACK_POWERED_REMOTE_FIELD = "jetpack_powered_remote_field"


### PR DESCRIPTION
This PR:
* enables the Jetpack powered badge on the WordPress app
* adds an internal release note

You can find notes on testing per screen in the linked PRs below:
* [Stats and Notifications](https://github.com/wordpress-mobile/WordPress-Android/pull/16850)
* [My Site](https://github.com/wordpress-mobile/WordPress-Android/pull/16901)
* [Activity Log, Themes, Sharing, People and Reader](https://github.com/wordpress-mobile/WordPress-Android/pull/16906)
* [Reader Search](https://github.com/wordpress-mobile/WordPress-Android/pull/16920)
* [Me, App Settings, Activity Detail, Notifications Settings and Reader Post](https://github.com/wordpress-mobile/WordPress-Android/pull/16911)


# To test:
## WordPress App
1. Install a fresh copy of the WordPress app
2. Signup/Login
3. Verify the the Jetpack powered badge is shown
## Jetpack App
1. Install a fresh copy of the Jetpack app
2. Signup/Login
3. Verify the the Jetpack powered badge is NOT shown

## Regression Notes
1. Potential unintended areas of impact
N/A

4. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
