### PR TITLE
Remove Jetpack banner from Themes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -4,8 +4,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup.MarginLayoutParams;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
@@ -18,7 +16,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.jetbrains.annotations.NotNull;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -42,8 +39,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
-import org.wordpress.android.util.config.JetpackPoweredFeatureConfig;
-import org.wordpress.android.util.extensions.WindowExtensionsKt;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -67,7 +62,6 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
 
     @Inject ThemeStore mThemeStore;
     @Inject Dispatcher mDispatcher;
-    @Inject JetpackPoweredFeatureConfig mJetpackPoweredFeatureConfig;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -103,16 +97,6 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
         if (actionBar != null) {
             actionBar.setDisplayShowTitleEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
-        }
-
-        if (mJetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
-            findViewById(R.id.jetpack_banner).setVisibility(View.VISIBLE);
-            WindowExtensionsKt.setNavigationBarColorForBanner(getWindow());
-
-            // Add bottom margin to content.
-            MarginLayoutParams layoutParams =
-                    (MarginLayoutParams) findViewById(R.id.fragment_container).getLayoutParams();
-            layoutParams.bottomMargin = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
         }
     }
 

--- a/WordPress/src/main/res/layout/theme_browser_activity.xml
+++ b/WordPress/src/main/res/layout/theme_browser_activity.xml
@@ -25,8 +25,4 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-
-    <include
-        android:id="@+id/jetpack_banner"
-        layout="@layout/jetpack_banner" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
This PR removes the Jetpack banner from the Themes screen.

|before|after|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/180643372-7ead9cef-c3c1-4d25-a48e-e5b9ad400ac1.png" width=320>|!<img src="https://user-images.githubusercontent.com/2471769/180643384-7baa25cf-8ffc-4b16-a1a4-fd236db17a90.png" width=320>|

To test:
1. Launch the WordPress app.
2. Open Themes from My Site > MENU > Themes.
3. Ensure there is no banner bottom of the screen.

## Regression Notes
1. Potential unintended areas of impact
Margin problems on Themes screen.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

5. What automated tests I added (or what prevented me from doing so)
Since this is a small UI change, no test is added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
