### PR TITLE
Remove Jetpack banner from People

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.people;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.MenuItem;
-import android.view.View;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -16,7 +15,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -34,8 +32,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
-import org.wordpress.android.util.config.JetpackPoweredFeatureConfig;
-import org.wordpress.android.util.extensions.WindowExtensionsKt;
 
 import java.util.List;
 
@@ -94,7 +90,6 @@ public class PeopleManagementActivity extends LocaleAwareActivity
 
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
-    @Inject JetpackPoweredFeatureConfig mJetpackPoweredFeatureConfig;
 
     private SiteModel mSite;
 
@@ -104,11 +99,6 @@ public class PeopleManagementActivity extends LocaleAwareActivity
         mDispatcher.register(this);
 
         setContentView(R.layout.people_management_activity);
-
-        if (mJetpackPoweredFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
-            findViewById(R.id.jetpack_banner).setVisibility(View.VISIBLE);
-            WindowExtensionsKt.setNavigationBarColorForBanner(getWindow());
-        }
 
         if (savedInstanceState == null) {
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);

--- a/WordPress/src/main/res/layout/people_management_activity.xml
+++ b/WordPress/src/main/res/layout/people_management_activity.xml
@@ -7,10 +7,5 @@
     <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"/>
-
-    <include
-        android:id="@+id/jetpack_banner"
-        layout="@layout/jetpack_banner" />
+        android:layout_height="match_parent"/>
 </LinearLayout>


### PR DESCRIPTION
This PR removes the Jetpack banner from the People screen.

|before|after|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/180643878-d94a6755-e5fd-480f-bf6d-912649be691d.png" width=320>|<img src="https://user-images.githubusercontent.com/2471769/180643883-37ffe74c-d22b-48d7-986f-b4ea48ae0bd0.png" width=320>|

To test:
1. Launch the WordPress app.
2. Open People from My Site > MENU > People.
3. Ensure there is no banner bottom of the screen.

## Regression Notes
1. Potential unintended areas of impact
Margin problems on People screen.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

5. What automated tests I added (or what prevented me from doing so)
Since this is a small UI change, no test is added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
