### PR TITLE
Refactor swipeToAvoidGrayOverlay to ignore failures and become reusable

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
@@ -19,6 +19,7 @@ import org.wordpress.android.e2e.pages.PostsListPage;
 import org.wordpress.android.support.BaseTest;
 import org.wordpress.android.support.DemoModeEnabler;
 import org.wordpress.android.ui.WPLaunchActivity;
+import org.wordpress.android.util.UiTestingUtils;
 import org.wordpress.android.util.image.ImageType;
 
 import java.util.Locale;
@@ -46,8 +47,6 @@ import static org.wordpress.android.support.WPSupportUtils.isTabletScreen;
 import static org.wordpress.android.support.WPSupportUtils.isTextDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.pressBackUntilElementIsDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.setNightMode;
-import static org.wordpress.android.support.WPSupportUtils.swipeLeftOnViewPager;
-import static org.wordpress.android.support.WPSupportUtils.swipeRightOnViewPager;
 import static org.wordpress.android.support.WPSupportUtils.waitForAtLeastOneElementWithIdToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
@@ -221,7 +220,7 @@ public class JPScreenshotTest extends BaseTest {
         clickOn(R.id.nav_sites);
         (new MySitesPage()).goToStats().dismissUpdateAlertDialogFragmentIfDisplayed();
 
-        swipeToAvoidGrayOverlay(R.id.statsPager);
+        UiTestingUtils.swipeToAvoidGrayOverlayIgnoringFailures(R.id.statsPager);
 
         if (isElementDisplayed(R.id.button_negative)) {
             clickOn(R.id.button_negative);
@@ -426,17 +425,6 @@ public class JPScreenshotTest extends BaseTest {
 
         takeScreenshot(screenshotName);
         pressBackUntilElementIsDisplayed(R.id.tabLayout);
-    }
-
-    // In some cases there's a gray overlay on view pager screens when taking screenshots
-    // this function swipes left and then right as a workaround to clear it
-    // resourceID should be the ID of the viewPager
-    private void swipeToAvoidGrayOverlay(int resourceID) {
-        // Workaround to avoid gray overlay
-        swipeLeftOnViewPager(resourceID);
-        idleFor(1000);
-        swipeRightOnViewPager(resourceID);
-        idleFor(1000);
     }
 
     private void setNightModeAndWait(boolean isNightMode) {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -18,6 +18,7 @@ import org.wordpress.android.support.BaseTest;
 import org.wordpress.android.support.DemoModeEnabler;
 import org.wordpress.android.ui.WPLaunchActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
+import org.wordpress.android.util.UiTestingUtils;
 import org.wordpress.android.util.image.ImageType;
 
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
@@ -29,8 +30,6 @@ import static org.wordpress.android.support.WPSupportUtils.isTabletScreen;
 import static org.wordpress.android.support.WPSupportUtils.pressBackUntilElementIsDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.setNightMode;
 import static org.wordpress.android.support.WPSupportUtils.swipeDownOnView;
-import static org.wordpress.android.support.WPSupportUtils.swipeLeftOnViewPager;
-import static org.wordpress.android.support.WPSupportUtils.swipeRightOnViewPager;
 import static org.wordpress.android.support.WPSupportUtils.swipeUpOnView;
 import static org.wordpress.android.support.WPSupportUtils.waitForAtLeastOneElementWithIdToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
@@ -152,8 +151,7 @@ public class WPScreenshotTest extends BaseTest {
 
         // Workaround to avoid gray overlay
         try {
-            swipeToAvoidGrayOverlay(R.id.view_pager);
-
+            UiTestingUtils.swipeToAvoidGrayOverlayIgnoringFailures(R.id.view_pager);
             if (isTabletScreen()) {
                 swipeDownOnView(R.id.view_pager, (float) 0.5);
                 idleFor(1000);
@@ -178,7 +176,7 @@ public class WPScreenshotTest extends BaseTest {
         clickOn(R.id.nav_sites);
         (new MySitesPage()).goToStats();
 
-        swipeToAvoidGrayOverlay(R.id.statsPager);
+        UiTestingUtils.swipeToAvoidGrayOverlayIgnoringFailures(R.id.statsPager);
 
         if (isElementDisplayed(R.id.button_negative)) {
             clickOn(R.id.button_negative);
@@ -259,18 +257,6 @@ public class WPScreenshotTest extends BaseTest {
                 "firebase.test.lab"
         );
         return "true".equals(testLabSetting);
-    }
-
-
-    // In some cases there's a gray overlay on view pager screens when taking screenshots
-    // this function swipes left and then right as a workaround to clear it
-    // resourceID should be the ID of the viewPager
-    private void swipeToAvoidGrayOverlay(int resourceID) {
-        // Workaround to avoid gray overlay
-        swipeLeftOnViewPager(resourceID);
-        idleFor(1000);
-        swipeRightOnViewPager(resourceID);
-        idleFor(1000);
     }
 
     private boolean editPostActivityIsNoLongerLoadingImages() {

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/UiTestingUtils.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/UiTestingUtils.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.util
+
+import org.wordpress.android.support.WPSupportUtils
+
+object UiTestingUtils {
+    /**
+     * Workaround to avoid gray overlay.
+     * In some cases there's a gray overlay on view pager screens when taking screenshots.
+     * This function swipes left and then right as a workaround to clear it.
+     * @param resourceID: Int the ID of the viewPager
+     */
+    @JvmStatic
+    fun swipeToAvoidGrayOverlayIgnoringFailures(resourceID: Int) {
+        try {
+            WPSupportUtils.swipeLeftOnViewPager(resourceID)
+            WPSupportUtils.idleFor(1000)
+            WPSupportUtils.swipeRightOnViewPager(resourceID)
+            WPSupportUtils.idleFor(1000)
+        } catch (e: Throwable) {
+            // Fail softly
+            @Suppress("PrintStackTrace")
+            e.printStackTrace()
+        }
+    }
+}


### PR DESCRIPTION
**Fixes** Random failures in the UI tests for screenshots automation. (commonly seen in [wpScreenshotTests](https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.b3d1e88d8b09c8be/matrices/7598614123508913988/details?stepId=bs.8c700d935cab1db4&testCaseId=45))

Refactored `swipeToAvoidGrayOverlay` into `UiTestingUtils.swipeToAvoidGrayOverlayIgnoringFailures`, reused it and made it ignore failures since it's not so critical imho.

**Merging Policy** Can be merged with one review.

To test:
1. CI Checks for instrumented tests should be green 🟢.

## Regression Notes
1. Potential unintended areas of impact
   None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

3. What automated tests I added (or what prevented me from doing so)
   Not applicable - changes are in UI tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
