### PR TITLE
Jetpack focus: Open the app if installed otherwise store link

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1040,5 +1040,7 @@
         <intent>
             <action android:name="android.intent.action.MAIN" />
         </intent>
+        <!-- required for Android 11 (API level 30) or higher -->
+        <package android:name="com.jetpack.android" />
     </queries>
 </manifest>

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
@@ -33,11 +33,19 @@ class ActivityLauncherWrapper @Inject constructor() {
     ) = ActivityLauncher.previewPostOrPageForResult(activity, site, post, remotePreviewType)
 
     fun openPlayStoreLink(context: Context, packageName: String) {
-        val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = Uri.parse("https://play.google.com/store/apps/details?id=$packageName")
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            setPackage("com.android.vending")
+        var intent: Intent? = context.packageManager.getLaunchIntentForPackage(packageName)
+
+        if (intent == null) {
+            intent = Intent(Intent.ACTION_VIEW).apply {
+                data = Uri.parse("https://play.google.com/store/apps/details?id=$packageName")
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                setPackage("com.android.vending")
+            }
         }
         context.startActivity(intent)
+    }
+
+    companion object {
+        const val JETPACK_PACKAGE_NAME = "com.jetpack.android"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredBottomSheetFragment.kt
@@ -15,13 +15,13 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.databinding.JetpackPoweredBottomSheetBinding
 import org.wordpress.android.ui.ActivityLauncherWrapper
+import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.JETPACK_PACKAGE_NAME
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType.MY_SITE
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType.NOTIFS
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType.READER
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredDialogAction.DismissDialog
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredDialogAction.OpenPlayStore
-import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredDialogViewModel.Companion.JETPACK_PACKAGE_NAME
 import org.wordpress.android.util.extensions.disableAnimation
 import org.wordpress.android.util.extensions.exhaustive
 import javax.inject.Inject

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredDialogViewModel.kt
@@ -49,8 +49,4 @@ class JetpackPoweredDialogViewModel @Inject constructor(
     }
 
     data class UiState(val uiItems: List<JetpackPoweredItem>)
-
-    companion object {
-        const val JETPACK_PACKAGE_NAME = "com.jetpack.android"
-    }
 }


### PR DESCRIPTION
This PR implements opening Jetpack app if installed otherwise takes them to Google Play store.

Fixes: #16975 


| Bottom Sheet | Google Play | Jetpack app |
|---|---|---|
|![Screenshot_20220726_124506](https://user-images.githubusercontent.com/990349/180912546-399bd576-12e1-400c-8190-164757936506.png)| ![Screenshot_20220726_124826](https://user-images.githubusercontent.com/990349/180912637-8eab334a-c99b-4ae3-a43a-2a05e1fcb704.png)|![Screenshot_20220726_124553](https://user-images.githubusercontent.com/990349/180912679-af06a12a-b605-4ef0-94c6-e4ea6b0fc8ef.png)|


To test:

- Launch WP app
- Switch to home tab, find Jetpack powered badge, scroll down if necessary
- Tap on **Jetpack powered** badge, ensure it opens up bottom sheet as shown in  first image above
- Tap on **Get the new Jetpack app** button
- Ensure, it opens Google Play store if Jetpack app is not installed, otherwise Jetpack app itself

NOTE: 
- The bottom sheet can also be opened from Stats, Reader and Notifications tabs and it opens in full screen mode
- If Jetpack app is already installed and logged in then the app opens in logged in mode.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested various scenarios

3. What automated tests I added (or what prevented me from doing so)
Existing tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
