### PR TITLE
[UI Tests] Added support for `Jetpack powered` ad.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -2,7 +2,6 @@ package org.wordpress.android.e2e;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wordpress.android.e2e.flows.LoginFlow;
 import org.wordpress.android.support.BaseTest;

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -24,7 +24,6 @@ public class LoginTests extends BaseTest {
         logoutIfNecessary();
     }
 
-    @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
     @Test
     public void loginWithEmailPassword() {
         new LoginFlow().chooseContinueWithWpCom()
@@ -33,7 +32,6 @@ public class LoginTests extends BaseTest {
                        .confirmLogin(false);
     }
 
-    @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
     @Test
     public void loginWithPasswordlessAccount() {
         new LoginFlow().chooseContinueWithWpCom()
@@ -51,7 +49,6 @@ public class LoginTests extends BaseTest {
                        .confirmLogin(false);
     }
 
-    @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
     @Test
     public void loginWithMagicLink() {
         new LoginFlow().chooseContinueWithWpCom()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -2,6 +2,7 @@ package org.wordpress.android.e2e;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.wordpress.android.e2e.flows.LoginFlow;
 import org.wordpress.android.support.BaseTest;
@@ -23,6 +24,7 @@ public class LoginTests extends BaseTest {
         logoutIfNecessary();
     }
 
+    @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
     @Test
     public void loginWithEmailPassword() {
         new LoginFlow().chooseContinueWithWpCom()
@@ -31,6 +33,7 @@ public class LoginTests extends BaseTest {
                        .confirmLogin(false);
     }
 
+    @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
     @Test
     public void loginWithPasswordlessAccount() {
         new LoginFlow().chooseContinueWithWpCom()
@@ -49,6 +52,7 @@ public class LoginTests extends BaseTest {
     }
 
     @Test
+    @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
     public void loginWithMagicLink() {
         new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -51,8 +51,8 @@ public class LoginTests extends BaseTest {
                        .confirmLogin(false);
     }
 
-    @Test
     @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
+    @Test
     public void loginWithMagicLink() {
         new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -33,7 +33,7 @@ public class SignUpTests extends BaseTest {
                         .checkEpilogue(E2E_SIGNUP_DISPLAY_NAME, E2E_SIGNUP_USERNAME)
                         .enterPassword(E2E_SIGNUP_PASSWORD)
                         .dismissInterstitial()
-                        .dismissJetpackAd()
+                        .dismissJetpackAdIfPresent()
                         .confirmSignup();
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -30,11 +30,10 @@ public class SignUpTests extends BaseTest {
         new SignupFlow().chooseContinueWithWpCom()
                         .enterEmail(E2E_SIGNUP_EMAIL)
                         .openMagicLink()
-                        .checkEpilogue(
-                                E2E_SIGNUP_DISPLAY_NAME,
-                                E2E_SIGNUP_USERNAME)
+                        .checkEpilogue(E2E_SIGNUP_DISPLAY_NAME, E2E_SIGNUP_USERNAME)
                         .enterPassword(E2E_SIGNUP_PASSWORD)
                         .dismissInterstitial()
+                        .dismissJetpackAd()
                         .confirmSignup();
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -30,7 +30,9 @@ public class SignUpTests extends BaseTest {
         new SignupFlow().chooseContinueWithWpCom()
                         .enterEmail(E2E_SIGNUP_EMAIL)
                         .openMagicLink()
-                        .checkEpilogue(E2E_SIGNUP_DISPLAY_NAME, E2E_SIGNUP_USERNAME)
+                        .checkEpilogue(
+                                E2E_SIGNUP_DISPLAY_NAME,
+                                E2E_SIGNUP_USERNAME)
                         .enterPassword(E2E_SIGNUP_PASSWORD)
                         .dismissInterstitial()
                         .dismissJetpackAd()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -33,7 +33,7 @@ public class SignUpTests extends BaseTest {
                         .checkEpilogue(E2E_SIGNUP_DISPLAY_NAME, E2E_SIGNUP_USERNAME)
                         .enterPassword(E2E_SIGNUP_PASSWORD)
                         .dismissInterstitial()
-                        .dismissJetpackAdIfPresent()
+                        .dismissJetpackAd()
                         .confirmSignup();
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
@@ -15,6 +15,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
+import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 
@@ -83,12 +84,16 @@ public class SignupFlow {
         return this;
     }
 
-    public SignupFlow dismissJetpackAd() {
-        // Dismiss post-signup JP ad
-        clickOn(onView(withId(R.id.secondary_button)));
-
+    public SignupFlow dismissJetpackAdIfPresent() {
+        // Dismiss Jetpack ad that might be shown after sign-up
+        // or after opening Stats
+        if (isElementDisplayed(onView(withText("Jetpack powered")))) {
+            clickOn(onView(withId(R.id.secondary_button)));
+        }
+        
         return this;
     }
+
     public void confirmSignup() {
         // Confirm signup
         waitForElementToBeDisplayed(R.id.nav_sites);

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
@@ -83,6 +83,12 @@ public class SignupFlow {
         return this;
     }
 
+    public SignupFlow dismissJetpackAd() {
+        // Dismiss post-signup JP ad
+        clickOn(onView(withId(R.id.secondary_button)));
+
+        return this;
+    }
     public void confirmSignup() {
         // Confirm signup
         waitForElementToBeDisplayed(R.id.nav_sites);

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
@@ -15,6 +15,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
+import static org.wordpress.android.support.WPSupportUtils.dismissJetpackAdIfPresent;
 import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
@@ -84,13 +85,8 @@ public class SignupFlow {
         return this;
     }
 
-    public SignupFlow dismissJetpackAdIfPresent() {
-        // Dismiss Jetpack ad that might be shown after sign-up
-        // or after opening Stats
-        if (isElementDisplayed(onView(withText("Jetpack powered")))) {
-            clickOn(onView(withId(R.id.secondary_button)));
-        }
-        
+    public SignupFlow dismissJetpackAd() {
+        dismissJetpackAdIfPresent();
         return this;
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
@@ -16,7 +16,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 import static org.wordpress.android.support.WPSupportUtils.dismissJetpackAdIfPresent;
-import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -16,6 +16,7 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.wordpress.android.R;
+import org.wordpress.android.e2e.flows.SignupFlow;
 import org.wordpress.android.ui.prefs.WPPreference;
 
 import static androidx.test.espresso.Espresso.onData;
@@ -162,10 +163,20 @@ public class MySitesPage {
         }
     }
 
+    public MySitesPage dismissJetpackAdIfPresent() {
+        // Dismiss Jetpack ad that might be shown after sign-up
+        // or after opening Stats
+        if (isElementDisplayed(onView(withText("Jetpack powered")))) {
+            clickOn(onView(withId(R.id.secondary_button)));
+        }
+
+        return this;
+    }
+
     public StatsPage goToStats() {
         goToMenuTab();
         clickQuickActionOrSiteMenuItem(R.id.quick_action_stats_button, R.string.stats);
-
+        dismissJetpackAdIfPresent();
         waitForElementToBeDisplayedWithoutFailure(R.id.tabLayout);
 
         // Wait for the stats to load

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -16,7 +16,6 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.wordpress.android.R;
-import org.wordpress.android.e2e.flows.SignupFlow;
 import org.wordpress.android.ui.prefs.WPPreference;
 
 import static androidx.test.espresso.Espresso.onData;

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.isA;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
+import static org.wordpress.android.support.WPSupportUtils.dismissJetpackAdIfPresent;
 import static org.wordpress.android.support.WPSupportUtils.getTranslatedString;
 import static org.wordpress.android.support.WPSupportUtils.idleFor;
 import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
@@ -160,16 +161,6 @@ public class MySitesPage {
         } else {
             clickItemWithText(R.string.backup);
         }
-    }
-
-    public MySitesPage dismissJetpackAdIfPresent() {
-        // Dismiss Jetpack ad that might be shown after sign-up
-        // or after opening Stats
-        if (isElementDisplayed(onView(withText("Jetpack powered")))) {
-            clickOn(onView(withId(R.id.secondary_button)));
-        }
-
-        return this;
     }
 
     public StatsPage goToStats() {

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -818,4 +818,12 @@ public class WPSupportUtils {
             swipeCount += 1;
         }
     }
+
+    public static void dismissJetpackAdIfPresent() {
+        // Dismiss Jetpack ad that might be shown after sign-up
+        // or after opening Stats
+        if (isElementDisplayed(onView(withText("Jetpack powered")))) {
+            clickOn(onView(withId(R.id.secondary_button)));
+        }
+    }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -820,8 +820,7 @@ public class WPSupportUtils {
     }
 
     public static void dismissJetpackAdIfPresent() {
-        // Dismiss Jetpack ad that might be shown after sign-up
-        // or after opening Stats
+        // Dismiss Jetpack ad that might be shown after Sign-Up or after opening Stats
         if (isElementDisplayed(onView(withText("Jetpack powered")))) {
             clickOn(onView(withId(R.id.secondary_button)));
         }


### PR DESCRIPTION
### Why

A new pop-up is now shown after a new signup and also after opening the `Stats` screen:

<img width="255" alt="Screenshot 2022-07-26 at 15 40 06" src="https://user-images.githubusercontent.com/73365754/181038057-a468b58a-9466-4875-82c6-b0277e42c69f.png">

Consequently, `signUpWithMagicLink` and `allDayStatsLoad` UI tests [started to fail](https://buildkite.com/automattic/wordpress-android/builds/5743).

### What was done

- Added a `dismissJetpackAdIfPresent` method, which is called after signup and when opening `Stats`.

### Testing

Either running the tests locally, or checking the [FTL execution](https://console.firebase.google.com/u/1/project/api-project-108380595987/testlab/histories/bh.b3d1e88d8b09c8be/matrices/4671861699730395929/details?stepId=bs.bf993c1ff5b38ac6&testCaseId=22) status below.

## Regression Notes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
