### PR TITLE
Jetpack focus: Connect jetpack powered overlay to badges

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -382,11 +382,6 @@ abstract class ViewModelModule {
 
     @Binds
     @IntoMap
-    @ViewModelKey(MeViewModel.class)
-    abstract ViewModel meViewModel(MeViewModel viewModel);
-
-    @Binds
-    @IntoMap
     @ViewModelKey(PostListCreateMenuViewModel.class)
     abstract ViewModel postListCreateMenuViewModel(PostListCreateMenuViewModel postListCreateMenuViewModel);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -31,7 +31,6 @@ import org.wordpress.android.ui.jetpack.scan.ScanViewModel;
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryListViewModel;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel;
-import org.wordpress.android.ui.main.MeViewModel;
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel;
 import org.wordpress.android.ui.mysite.MySiteViewModel;
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel;
@@ -60,7 +59,6 @@ import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel;
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel;
 import org.wordpress.android.ui.reader.subfilter.SubFilterViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ConversationNotificationsViewModel;
-import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel;
 import org.wordpress.android.ui.reader.viewmodels.SubfilterPageViewModel;
@@ -154,11 +152,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ReaderPostListViewModel.class)
     abstract ViewModel readerPostListViewModel(ReaderPostListViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(ReaderPostDetailViewModel.class)
-    abstract ViewModel readerPostDetailViewModel(ReaderPostDetailViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -86,7 +86,6 @@ import org.wordpress.android.ui.whatsnew.FeatureAnnouncementViewModel;
 import org.wordpress.android.viewmodel.ViewModelFactory;
 import org.wordpress.android.viewmodel.ViewModelKey;
 import org.wordpress.android.viewmodel.accounts.PostSignupInterstitialViewModel;
-import org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModel;
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel;
 import org.wordpress.android.viewmodel.history.HistoryViewModel;
 import org.wordpress.android.viewmodel.main.SitePickerViewModel;
@@ -122,11 +121,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ActivityLogViewModel.class)
     abstract ViewModel activityLogViewModel(ActivityLogViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(ActivityLogDetailViewModel.class)
-    abstract ViewModel activityLogDetailViewModel(ActivityLogDetailViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
@@ -3,10 +3,12 @@ package org.wordpress.android.ui.activitylog.detail
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.databinding.ActivityLogDetailActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.RequestCodes
 
+@AndroidEntryPoint
 class ActivityLogDetailActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -8,7 +8,8 @@ import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ActivityLogItemDetailBinding
@@ -19,6 +20,7 @@ import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEvents.ShowBackupDownload
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEvents.ShowDocumentationPage
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEvents.ShowRestore
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan
 import org.wordpress.android.ui.notifications.utils.FormattableContentClickHandler
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
@@ -37,15 +39,16 @@ import javax.inject.Inject
 private const val DETAIL_TRACKING_SOURCE = "detail"
 private const val FORWARD_SLASH = "/"
 
+@Suppress("TooManyFunctions")
+@AndroidEntryPoint
 class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
-    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var notificationsUtilsWrapper: NotificationsUtilsWrapper
     @Inject lateinit var formattableContentClickHandler: FormattableContentClickHandler
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var jetpackBrandingUtils: JetpackBrandingUtils
 
-    private lateinit var viewModel: ActivityLogDetailViewModel
+    private val viewModel: ActivityLogDetailViewModel by viewModels()
 
     companion object {
         fun newInstance(): ActivityLogDetailFragment {
@@ -53,69 +56,80 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
         }
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        (activity?.application as WordPress).component()?.inject(this)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        with(ActivityLogItemDetailBinding.bind(view)) {
+            setupViews(savedInstanceState)
+            setupObservers()
+        }
+    }
+
+    private fun ActivityLogItemDetailBinding.setupViews(savedInstanceState: Bundle?) {
         activity?.let { activity ->
-            viewModel = ViewModelProvider(activity, viewModelFactory)
-                    .get(ActivityLogDetailViewModel::class.java)
-            with(ActivityLogItemDetailBinding.bind(view)) {
-                val (site, activityLogId) = sideAndActivityId(savedInstanceState, activity.intent)
-                val areButtonsVisible = areButtonsVisible(savedInstanceState, activity.intent)
-                val isRestoreHidden = isRestoreHidden(savedInstanceState, activity.intent)
+            val (site, activityLogId) = sideAndActivityId(savedInstanceState, activity.intent)
+            val areButtonsVisible = areButtonsVisible(savedInstanceState, activity.intent)
+            val isRestoreHidden = isRestoreHidden(savedInstanceState, activity.intent)
 
-                jetpackBadge.root.isVisible = jetpackBrandingUtils.shouldShowJetpackBranding()
+            viewModel.start(site, activityLogId, areButtonsVisible, isRestoreHidden)
+        }
 
-                viewModel.activityLogItem.observe(viewLifecycleOwner, { activityLogModel ->
-                    loadLogItem(activityLogModel, activity)
-                })
-
-                viewModel.restoreVisible.observe(viewLifecycleOwner, { available ->
-                    activityRestoreButton.visibility = if (available == true) View.VISIBLE else View.GONE
-                })
-                viewModel.downloadBackupVisible.observe(viewLifecycleOwner, { available ->
-                    activityDownloadBackupButton.visibility = if (available == true) View.VISIBLE else View.GONE
-                })
-                viewModel.multisiteVisible.observe(viewLifecycleOwner, { available ->
-                    checkAndShowMultisiteMessage(available)
-                })
-
-                viewModel.navigationEvents.observeEvent(viewLifecycleOwner, {
-                    when (it) {
-                        is ShowBackupDownload -> ActivityLauncher.showBackupDownloadForResult(
-                                requireActivity(),
-                                viewModel.site,
-                                it.model.activityID,
-                                RequestCodes.BACKUP_DOWNLOAD,
-                                buildTrackingSource()
-                        )
-                        is ShowRestore -> ActivityLauncher.showRestoreForResult(
-                                requireActivity(),
-                                viewModel.site,
-                                it.model.activityID,
-                                RequestCodes.RESTORE,
-                                buildTrackingSource()
-                        )
-                        is ShowDocumentationPage -> ActivityLauncher.openUrlExternal(requireContext(), it.url)
-                }
-            })
-
-                viewModel.handleFormattableRangeClick.observe(viewLifecycleOwner, { range ->
-                    if (range != null) {
-                        formattableContentClickHandler.onClick(
-                                activity,
-                                range,
-                                ReaderTracker.SOURCE_ACTIVITY_LOG_DETAIL
-                        )
-                    }
-                })
-
-                viewModel.start(site, activityLogId, areButtonsVisible, isRestoreHidden)
+        if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
+            jetpackBadge.root.isVisible = true
+            jetpackBadge.root.setOnClickListener {
+                viewModel.showJetpackPoweredBottomSheet()
             }
+        }
+    }
+
+    private fun ActivityLogItemDetailBinding.setupObservers() {
+        viewModel.activityLogItem.observe(viewLifecycleOwner, { activityLogModel ->
+            loadLogItem(activityLogModel, requireActivity())
+        })
+
+        viewModel.restoreVisible.observe(viewLifecycleOwner, { available ->
+            activityRestoreButton.visibility = if (available == true) View.VISIBLE else View.GONE
+        })
+        viewModel.downloadBackupVisible.observe(viewLifecycleOwner, { available ->
+            activityDownloadBackupButton.visibility = if (available == true) View.VISIBLE else View.GONE
+        })
+        viewModel.multisiteVisible.observe(viewLifecycleOwner, { available ->
+            checkAndShowMultisiteMessage(available)
+        })
+
+        viewModel.navigationEvents.observeEvent(viewLifecycleOwner, {
+            when (it) {
+                is ShowBackupDownload -> ActivityLauncher.showBackupDownloadForResult(
+                        requireActivity(),
+                        viewModel.site,
+                        it.model.activityID,
+                        RequestCodes.BACKUP_DOWNLOAD,
+                        buildTrackingSource()
+                )
+                is ShowRestore -> ActivityLauncher.showRestoreForResult(
+                        requireActivity(),
+                        viewModel.site,
+                        it.model.activityID,
+                        RequestCodes.RESTORE,
+                        buildTrackingSource()
+                )
+                is ShowDocumentationPage -> ActivityLauncher.openUrlExternal(requireContext(), it.url)
+            }
+        })
+
+        viewModel.handleFormattableRangeClick.observe(viewLifecycleOwner, { range ->
+            if (range != null) {
+                formattableContentClickHandler.onClick(
+                        requireActivity(),
+                        range,
+                        ReaderTracker.SOURCE_ACTIVITY_LOG_DETAIL
+                )
+            }
+        })
+
+        viewModel.showJetpackPoweredBottomSheet.observeEvent(viewLifecycleOwner) {
+            JetpackPoweredBottomSheetFragment
+                    .newInstance()
+                    .show(childFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
@@ -3,11 +3,13 @@ package org.wordpress.android.ui.main
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.prefs.AppSettingsFragment.LANGUAGE_CHANGED
 
+@AndroidEntryPoint
 class MeActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -128,7 +128,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
         if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
             jetpackBadge.root.isVisible = true
-            jetpackBadge.root.setOnClickListener {
+            jetpackBadge.jetpackBadge.root.setOnClickListener {
                 viewModel.showJetpackPoweredBottomSheet()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -14,12 +14,14 @@ import android.view.View.OnClickListener
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity
+import dagger.hilt.android.AndroidEntryPoint
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -48,6 +50,7 @@ import org.wordpress.android.ui.accounts.HelpActivity.Origin.ME_SCREEN_HELP
 import org.wordpress.android.ui.main.MeViewModel.RecommendAppUiState
 import org.wordpress.android.ui.main.WPMainActivity.OnScrollToTopListener
 import org.wordpress.android.ui.main.utils.MeGravatarLoader
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
@@ -76,6 +79,7 @@ import org.wordpress.android.viewmodel.observeEvent
 import java.io.File
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     private var disconnectProgressDialog: ProgressDialog? = null
     private var isUpdatingGravatar = false
@@ -93,7 +97,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     @Inject lateinit var unifiedAboutFeatureConfig: UnifiedAboutFeatureConfig
     @Inject lateinit var qrCodeAuthFlowFeatureConfig: QRCodeAuthFlowFeatureConfig
     @Inject lateinit var jetpackBrandingUtils: JetpackBrandingUtils
-    private lateinit var viewModel: MeViewModel
+    private val viewModel: MeViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -122,7 +126,12 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        jetpackBadge.root.isVisible = jetpackBrandingUtils.shouldShowJetpackBranding()
+        if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
+            jetpackBadge.root.isVisible = true
+            jetpackBadge.root.setOnClickListener {
+                viewModel.showJetpackPoweredBottomSheet()
+            }
+        }
 
         val showPickerListener = OnClickListener {
             AnalyticsTracker.track(ME_GRAVATAR_TAPPED)
@@ -157,8 +166,6 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     }
 
     private fun MeFragmentBinding.setupObservers(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(this@MeFragment, viewModelFactory).get(MeViewModel::class.java)
-
         if (savedInstanceState != null) {
             if (savedInstanceState.getBoolean(IS_DISCONNECTING, false)) {
                 viewModel.openDisconnectDialog()
@@ -207,6 +214,12 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
         viewModel.showScanLoginCode.observeEvent(viewLifecycleOwner) {
             ActivityLauncher.startQRCodeAuthFlow(requireContext())
+        }
+
+        viewModel.showJetpackPoweredBottomSheet.observeEvent(viewLifecycleOwner) {
+            JetpackPoweredBottomSheetFragment
+                    .newInstance()
+                    .show(childFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeViewModel.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.map
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -27,6 +28,7 @@ import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
+@HiltViewModel
 class MeViewModel
 @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
@@ -46,6 +48,9 @@ class MeViewModel
 
     private val _showScanLoginCode = MutableLiveData<Event<Boolean>>()
     val showScanLoginCode: LiveData<Event<Boolean>> = _showScanLoginCode
+
+    private val _showJetpackPoweredBottomSheet = MutableLiveData<Event<Boolean>>()
+    val showJetpackPoweredBottomSheet: LiveData<Event<Boolean>> = _showJetpackPoweredBottomSheet
 
     data class RecommendAppUiState(
         val showLoading: Boolean = false,
@@ -88,6 +93,10 @@ class MeViewModel
 
     fun showScanLoginCode() {
         _showScanLoginCode.value = Event(true)
+    }
+
+    fun showJetpackPoweredBottomSheet() {
+        _showJetpackPoweredBottomSheet.value = Event(true)
     }
 
     @SuppressLint("NullSafeMutableLiveData")

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.prefs;
 
-import dagger.hilt.android.AndroidEntryPoint;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
@@ -11,6 +10,8 @@ import androidx.appcompat.widget.Toolbar;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.LocaleAwareActivity;
+
+import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
 public class AppSettingsActivity extends LocaleAwareActivity {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.prefs;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
@@ -11,6 +12,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.LocaleAwareActivity;
 
+@AndroidEntryPoint
 public class AppSettingsActivity extends LocaleAwareActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -45,6 +45,7 @@ import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewAppId;
 import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewFetchPayload;
 import org.wordpress.android.ui.about.UnifiedAboutActivity;
 import org.wordpress.android.ui.debug.DebugSettingsActivity;
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.ui.mysite.tabs.MySiteDefaultTabExperiment;
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType;
 import org.wordpress.android.ui.prefs.language.LocalePickerBottomSheet;
@@ -246,6 +247,11 @@ public class AppSettingsFragment extends PreferenceFragment
     private void addJetpackBadgeAsFooterIfEnabled(LayoutInflater inflater, ListView listView) {
         if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
             final JetpackBadgeFooterBinding binding = JetpackBadgeFooterBinding.inflate(inflater);
+            binding.jetpackBadge.getRoot().setOnClickListener(v ->
+                    new JetpackPoweredBottomSheetFragment().show(
+                            ((AppCompatActivity) getActivity()).getSupportFragmentManager(),
+                            JetpackPoweredBottomSheetFragment.TAG)
+            );
             listView.addFooterView(binding.getRoot(), null, false);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.prefs.notifications;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import android.app.FragmentManager;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -24,7 +25,7 @@ import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.prefs.notifications.PrefMainSwitchToolbarView.MainSwitchToolbarListener;
 
-// Simple wrapper activity for NotificationsSettingsFragment
+@AndroidEntryPoint
 public class NotificationsSettingsActivity extends LocaleAwareActivity
         implements MainSwitchToolbarListener {
     private TextView mMessageTextView;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.prefs.notifications;
 
-import dagger.hilt.android.AndroidEntryPoint;
 import android.app.FragmentManager;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -24,6 +23,8 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.prefs.notifications.PrefMainSwitchToolbarView.MainSwitchToolbarListener;
+
+import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
 public class NotificationsSettingsActivity extends LocaleAwareActivity

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -64,6 +64,7 @@ import org.wordpress.android.models.NotificationsSettings.Type;
 import org.wordpress.android.ui.WPLaunchActivity;
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.PreferenceModel;
@@ -227,6 +228,11 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
             LayoutInflater inflater = LayoutInflater.from(getContext());
             final JetpackBadgeFooterBinding binding = JetpackBadgeFooterBinding.inflate(inflater);
+            binding.jetpackBadge.getRoot().setOnClickListener(v ->
+                    new JetpackPoweredBottomSheetFragment().show(
+                            ((AppCompatActivity) getActivity()).getSupportFragmentManager(),
+                            JetpackPoweredBottomSheetFragment.TAG)
+            );
             listView.addFooterView(binding.getRoot(), null, false);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -35,6 +35,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.Factory
 import androidx.recyclerview.widget.DefaultItemAnimator
@@ -46,6 +47,7 @@ import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.elevation.ElevationOverlayProvider
 import com.google.android.material.snackbar.Snackbar
+import dagger.hilt.android.AndroidEntryPoint
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -77,6 +79,7 @@ import org.wordpress.android.ui.main.SitePickerActivity
 import org.wordpress.android.ui.main.WPMainActivity
 import org.wordpress.android.ui.media.MediaPreviewActivity
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.ReaderActivityLauncher.OpenUrlType
 import org.wordpress.android.ui.reader.ReaderActivityLauncher.PhotoViewerOption
@@ -144,6 +147,7 @@ import java.net.HttpURLConnection
 import java.util.EnumSet
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class ReaderPostDetailFragment : ViewPagerFragment(),
         WPMainActivity.OnActivityBackPressedListener,
         ScrollDirectionListener,
@@ -203,7 +207,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
     private var fileForDownload: String? = null
 
-    private lateinit var viewModel: ReaderPostDetailViewModel
+    private val viewModel: ReaderPostDetailViewModel by viewModels()
     private lateinit var conversationViewModel: ConversationNotificationsViewModel
 
     @Inject internal lateinit var accountStore: AccountStore
@@ -485,7 +489,6 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     }
 
     private fun initViewModel(binding: ReaderFragmentPostDetailBinding, savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(this, viewModelFactory).get(ReaderPostDetailViewModel::class.java)
         conversationViewModel = ViewModelProvider(this, viewModelFactory).get(
                 ConversationNotificationsViewModel::class.java
         )
@@ -502,6 +505,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         viewModel.start(isRelatedPost = isRelatedPost, isFeed = isFeed, interceptedUri = interceptedUri)
     }
 
+    @Suppress("LongMethod")
     private fun initObservers(binding: ReaderFragmentPostDetailBinding) {
         viewModel.uiState.observe(viewLifecycleOwner, {
             uiHelpers.updateVisibility(binding.textError, it.errorVisible)
@@ -566,6 +570,12 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             viewModel.commentSnippetState.observe(viewLifecycleOwner, { state ->
                 manageCommentSnippetUiState(state)
             })
+        }
+
+        viewModel.showJetpackPoweredBottomSheet.observeEvent(viewLifecycleOwner) {
+            JetpackPoweredBottomSheetFragment
+                    .newInstance()
+                    .show(childFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
         }
     }
 
@@ -701,7 +711,14 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
     private fun renderUiState(state: ReaderPostDetailsUiState, binding: ReaderFragmentPostDetailBinding) {
         onPostExecuteShowPost()
-        binding.jetpackBadge.root.isVisible = jetpackBrandingUtils.shouldShowJetpackBranding()
+
+        if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
+            binding.jetpackBadge.root.isVisible = true
+            binding.jetpackBadge.root.setOnClickListener {
+                viewModel.showJetpackPoweredBottomSheet()
+            }
+        }
+
         binding.headerView.updatePost(state.headerUiState)
         showOrHideMoreMenu(state)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader;
 
-import dagger.hilt.android.AndroidEntryPoint;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
@@ -79,6 +78,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.inject.Inject;
+
+import dagger.hilt.android.AndroidEntryPoint;
 
 /*
  * shows reader post detail fragments in a ViewPager - primarily used for easy swiping between

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
@@ -92,6 +93,7 @@ import javax.inject.Inject;
  *
  * Will also handle jumping to the comments section, liking a commend and liking a post directly
  */
+@AndroidEntryPoint
 public class ReaderPostPagerActivity extends LocaleAwareActivity {
     /**
      * Type of URL intercepted

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.withContext
@@ -97,6 +98,7 @@ import javax.inject.Inject
 import javax.inject.Named
 
 @Suppress("LargeClass")
+@HiltViewModel
 class ReaderPostDetailViewModel @Inject constructor(
     private val readerPostCardActionsHandler: ReaderPostCardActionsHandler,
     private val readerUtilsWrapper: ReaderUtilsWrapper,
@@ -148,6 +150,9 @@ class ReaderPostDetailViewModel @Inject constructor(
     val commentSnippetState: LiveData<CommentSnippetUiState> = _commentSnippetState.map { state ->
         postDetailUiStateBuilder.buildCommentSnippetUiState(state, post, ::onCommentSnippetClicked)
     }
+
+    private val _showJetpackPoweredBottomSheet = MutableLiveData<Event<Boolean>>()
+    val showJetpackPoweredBottomSheet: LiveData<Event<Boolean>> = _showJetpackPoweredBottomSheet
 
     /**
      * Post which is about to be reblogged after the user selects a target site.
@@ -288,6 +293,10 @@ class ReaderPostDetailViewModel @Inject constructor(
                 _updateLikesState.value = state
             }
         }
+    }
+
+    fun showJetpackPoweredBottomSheet() {
+        _showJetpackPoweredBottomSheet.value = Event(true)
     }
 
     fun onRefreshCommentsData(blogId: Long, postId: Long) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -55,10 +55,9 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toStatsGranularity
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig
 import org.wordpress.android.util.config.StatsRevampV2FeatureConfig
 import org.wordpress.android.util.mapNullable
@@ -88,8 +87,7 @@ class StatsViewModel
     private val notificationsTracker: SystemNotificationsTracker,
     private val todaysStatsCardFeatureConfig: MySiteDashboardTodaysStatsCardFeatureConfig,
     private val statsRevampV2FeatureConfig: StatsRevampV2FeatureConfig,
-    private val jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig,
-    private val buildConfigWrapper: BuildConfigWrapper
+    private val jetpackpoweredBrandingUtils: JetpackBrandingUtils
 ) : ScopedViewModel(mainDispatcher) {
     private val _isRefreshing = MutableLiveData<Boolean>()
     val isRefreshing: LiveData<Boolean> = _isRefreshing
@@ -220,9 +218,7 @@ class StatsViewModel
     }
 
     private fun showJetpackPoweredBottomSheet() {
-        _showJetpackPoweredBottomSheet.value = Event(
-                jetpackPoweredFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
-        )
+        _showJetpackPoweredBottomSheet.value = Event(jetpackpoweredBrandingUtils.shouldShowJetpackBranding())
     }
 
     private fun showInsightsUpdateAlert() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -7,6 +7,7 @@ import android.view.View
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
@@ -30,6 +31,7 @@ const val ACTIVITY_LOG_ID_KEY: String = "activity_log_id_key"
 const val ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY: String = "activity_log_are_buttons_visible_key"
 const val ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY: String = "activity_log_is_restore_hidden_key"
 
+@HiltViewModel
 class ActivityLogDetailViewModel @Inject constructor(
     val dispatcher: Dispatcher,
     private val activityLogStore: ActivityLogStore,
@@ -64,6 +66,9 @@ class ActivityLogDetailViewModel @Inject constructor(
     private val _multisiteVisible = MutableLiveData<Pair<Boolean, SpannableString?>>()
     val multisiteVisible: LiveData<Pair<Boolean, SpannableString?>>
         get() = _multisiteVisible
+
+    private val _showJetpackPoweredBottomSheet = MutableLiveData<Event<Boolean>>()
+    val showJetpackPoweredBottomSheet: LiveData<Event<Boolean>> = _showJetpackPoweredBottomSheet
 
     fun start(
         site: SiteModel,
@@ -125,6 +130,10 @@ class ActivityLogDetailViewModel @Inject constructor(
         val multisiteSpan = SpannableString(multisiteMessage)
         multisiteSpan.setSpan(clickableSpan, clickableStartIndex, clickableEndIndex, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         return multisiteSpan
+    }
+
+    fun showJetpackPoweredBottomSheet() {
+        _showJetpackPoweredBottomSheet.value = Event(true)
     }
 
     fun onRangeClicked(range: FormattableRange) {

--- a/WordPress/src/main/res/layout/jetpack_badge.xml
+++ b/WordPress/src/main/res/layout/jetpack_badge.xml
@@ -9,7 +9,6 @@
     android:paddingTop="@dimen/margin_large">
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/jetpack_badge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
@@ -40,10 +40,9 @@ import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig
 import org.wordpress.android.util.config.StatsRevampV2FeatureConfig
 import org.wordpress.android.viewmodel.Event
@@ -65,8 +64,7 @@ class StatsViewModelTest : BaseUnitTest() {
     @Mock lateinit var notificationsTracker: SystemNotificationsTracker
     @Mock lateinit var todaysStatsCardFeatureConfig: MySiteDashboardTodaysStatsCardFeatureConfig
     @Mock lateinit var statsRevampV2FeatureConfig: StatsRevampV2FeatureConfig
-    @Mock lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
-    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
+    @Mock lateinit var jetpackBrandingUtils: JetpackBrandingUtils
     private lateinit var viewModel: StatsViewModel
     private val _liveSelectedSection = MutableLiveData<StatsSection>()
     private val liveSelectedSection: LiveData<StatsSection> = _liveSelectedSection
@@ -91,8 +89,7 @@ class StatsViewModelTest : BaseUnitTest() {
                 notificationsTracker,
                 todaysStatsCardFeatureConfig,
                 statsRevampV2FeatureConfig,
-                jetpackPoweredFeatureConfig,
-                buildConfigWrapper,
+                jetpackBrandingUtils
         )
 
         viewModel.start(1, false, null, null, false, null)
@@ -246,8 +243,7 @@ class StatsViewModelTest : BaseUnitTest() {
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)
         }
-        whenever(jetpackPoweredFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
+        whenever(jetpackBrandingUtils.shouldShowJetpackBranding()).thenReturn(true)
 
         startViewModel()
 
@@ -260,7 +256,7 @@ class StatsViewModelTest : BaseUnitTest() {
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)
         }
-        whenever(jetpackPoweredFeatureConfig.isEnabled()).thenReturn(false)
+        whenever(jetpackBrandingUtils.shouldShowJetpackBranding()).thenReturn(false)
 
         startViewModel()
 


### PR DESCRIPTION
This PR connects Jetpack overlay with all **Jetpack powered** badges on the following

Fixes: #16977 

- Home
- Me
- App Settings
- Activity Detail Log
- Notifications Settings
- Reader Post details


| Bottom Sheet | Google Play | Jetpack app |
|---|---|---|
|![Screenshot_20220726_124506](https://user-images.githubusercontent.com/990349/180912546-399bd576-12e1-400c-8190-164757936506.png)| ![Screenshot_20220726_124826](https://user-images.githubusercontent.com/990349/180912637-8eab334a-c99b-4ae3-a43a-2a05e1fcb704.png)|![Screenshot_20220726_124553](https://user-images.githubusercontent.com/990349/180912679-af06a12a-b605-4ef0-94c6-e4ea6b0fc8ef.png)|

To test:

- Launch WP app
- Switch to home tab, find Jetpack powered badge, scroll down if necessary
- Tap on **Jetpack powered** badge, ensure it opens up bottom sheet as shown in  first image above
- Tap on **Get the new Jetpack app** button
- Ensure, it opens Google Play store if Jetpack app is not installed, otherwise Jetpack app itself

Try out tapping on **Jetpack powered** badge on the other places [as shown on this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16911)



## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit tests

3. What automated tests I added (or what prevented me from doing so)
Updated tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
