### PR TITLE
Jetpack Focus:  Jetpack powered bottom sheet feature config

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -116,6 +116,7 @@ android {
         buildConfigField "boolean", "QRCODE_AUTH_FLOW", "false"
         buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"
         buildConfigField "boolean", "JETPACK_POWERED", "true"
+        buildConfigField "boolean", "JETPACK_POWERED_BOTTOM_SHEET", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
@@ -5,8 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.util.BuildConfigWrapper
-import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
+import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -15,19 +14,16 @@ import javax.inject.Named
 @HiltViewModel
 class NotificationsListViewModel@Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-    private val jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig,
-    private val buildConfigWrapper: BuildConfigWrapper
+    private val jetpackBrandingUtils: JetpackBrandingUtils
 ) : ScopedViewModel(mainDispatcher) {
     private val _showJetpackPoweredBottomSheet = MutableLiveData<Event<Boolean>>()
     val showJetpackPoweredBottomSheet: LiveData<Event<Boolean>> = _showJetpackPoweredBottomSheet
 
     init {
-        showJetpackPoweredBottomSheet()
+        if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) showJetpackPoweredBottomSheet()
     }
 
     private fun showJetpackPoweredBottomSheet() {
-        _showJetpackPoweredBottomSheet.value = Event(
-                jetpackPoweredBottomSheetFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
-        )
+        _showJetpackPoweredBottomSheet.value = Event(true)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
@@ -6,7 +6,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.util.BuildConfigWrapper
-import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
+import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -15,7 +15,7 @@ import javax.inject.Named
 @HiltViewModel
 class NotificationsListViewModel@Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-    private val jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig,
+    private val jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig,
     private val buildConfigWrapper: BuildConfigWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private val _showJetpackPoweredBottomSheet = MutableLiveData<Event<Boolean>>()
@@ -27,7 +27,7 @@ class NotificationsListViewModel@Inject constructor(
 
     private fun showJetpackPoweredBottomSheet() {
         _showJetpackPoweredBottomSheet.value = Event(
-                jetpackPoweredFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
+                jetpackPoweredBottomSheetFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -35,10 +35,8 @@ import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState.
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState.ContentUiState.TabUiState
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringText
-import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.SnackbarSequencer
-import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
 import org.wordpress.android.util.distinct
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState.
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
 import org.wordpress.android.util.distinct
@@ -57,8 +58,7 @@ class ReaderViewModel @Inject constructor(
     private val accountStore: AccountStore,
     private val quickStartRepository: QuickStartRepository,
     private val selectedSiteRepository: SelectedSiteRepository,
-    private val jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig,
-    private val buildConfigWrapper: BuildConfigWrapper,
+    private val jetpackBrandingUtils: JetpackBrandingUtils,
     private val snackbarSequencer: SnackbarSequencer
         // todo: annnmarie removed this private val getFollowedTagsUseCase: GetFollowedTagsUseCase
 ) : ScopedViewModel(mainDispatcher) {
@@ -102,13 +102,11 @@ class ReaderViewModel @Inject constructor(
         if (tagsRequireUpdate()) _updateTags.value = Event(Unit)
         if (initialized) return
         loadTabs()
-        showJetpackPoweredBottomSheet()
+        if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) showJetpackPoweredBottomSheet()
     }
 
     private fun showJetpackPoweredBottomSheet() {
-        _showJetpackPoweredBottomSheet.value = Event(
-                jetpackPoweredBottomSheetFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
-        )
+        _showJetpackPoweredBottomSheet.value = Event(true)
     }
 
     private fun loadTabs() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -37,7 +37,7 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.SnackbarSequencer
-import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
+import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
 import org.wordpress.android.util.distinct
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -57,7 +57,7 @@ class ReaderViewModel @Inject constructor(
     private val accountStore: AccountStore,
     private val quickStartRepository: QuickStartRepository,
     private val selectedSiteRepository: SelectedSiteRepository,
-    private val jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig,
+    private val jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig,
     private val buildConfigWrapper: BuildConfigWrapper,
     private val snackbarSequencer: SnackbarSequencer
         // todo: annnmarie removed this private val getFollowedTagsUseCase: GetFollowedTagsUseCase
@@ -107,7 +107,7 @@ class ReaderViewModel @Inject constructor(
 
     private fun showJetpackPoweredBottomSheet() {
         _showJetpackPoweredBottomSheet.value = Event(
-                jetpackPoweredFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
+                jetpackPoweredBottomSheetFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -56,6 +56,7 @@ import org.wordpress.android.ui.stats.refresh.utils.toStatsGranularity
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
@@ -88,8 +89,7 @@ class StatsViewModel
     private val notificationsTracker: SystemNotificationsTracker,
     private val todaysStatsCardFeatureConfig: MySiteDashboardTodaysStatsCardFeatureConfig,
     private val statsRevampV2FeatureConfig: StatsRevampV2FeatureConfig,
-    private val jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig,
-    private val buildConfigWrapper: BuildConfigWrapper
+    private val jetpackBrandingUtils: JetpackBrandingUtils
 ) : ScopedViewModel(mainDispatcher) {
     private val _isRefreshing = MutableLiveData<Boolean>()
     val isRefreshing: LiveData<Boolean> = _isRefreshing
@@ -216,13 +216,11 @@ class StatsViewModel
         }
         if (statsSectionManager.getSelectedSection() == INSIGHTS) showInsightsUpdateAlert()
 
-        showJetpackPoweredBottomSheet()
+        if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) showJetpackPoweredBottomSheet()
     }
 
     private fun showJetpackPoweredBottomSheet() {
-        _showJetpackPoweredBottomSheet.value = Event(
-                jetpackPoweredBottomSheetFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
-        )
+        _showJetpackPoweredBottomSheet.value = Event(true)
     }
 
     private fun showInsightsUpdateAlert() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -58,7 +58,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
+import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
 import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig
 import org.wordpress.android.util.config.StatsRevampV2FeatureConfig
 import org.wordpress.android.util.mapNullable
@@ -88,7 +88,7 @@ class StatsViewModel
     private val notificationsTracker: SystemNotificationsTracker,
     private val todaysStatsCardFeatureConfig: MySiteDashboardTodaysStatsCardFeatureConfig,
     private val statsRevampV2FeatureConfig: StatsRevampV2FeatureConfig,
-    private val jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig,
+    private val jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig,
     private val buildConfigWrapper: BuildConfigWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private val _isRefreshing = MutableLiveData<Boolean>()
@@ -221,7 +221,7 @@ class StatsViewModel
 
     private fun showJetpackPoweredBottomSheet() {
         _showJetpackPoweredBottomSheet.value = Event(
-                jetpackPoweredFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
+                jetpackPoweredBottomSheetFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -9,11 +9,13 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
 import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
 import javax.inject.Inject
 
 class JetpackBrandingUtils @Inject constructor(
     private val jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig,
+    private val jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig,
     private val selectedSiteRepository: SelectedSiteRepository,
     private val siteUtilsWrapper: SiteUtilsWrapper,
     private val buildConfigWrapper: BuildConfigWrapper
@@ -23,6 +25,10 @@ class JetpackBrandingUtils @Inject constructor(
         val isWpComSite = selectedSite != null && siteUtilsWrapper.isAccessedViaWPComRest(selectedSite)
 
         return isWpComSite && jetpackPoweredFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
+    }
+
+    fun shouldShowJetpackPoweredBottomSheet(): Boolean {
+        return jetpackPoweredBottomSheetFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
     }
 
     fun showJetpackBannerIfScrolledToTop(banner: View, scrollableView: RecyclerView) {

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -21,14 +21,11 @@ class JetpackBrandingUtils @Inject constructor(
     private val buildConfigWrapper: BuildConfigWrapper
 ) {
     fun shouldShowJetpackBranding(): Boolean {
-        val selectedSite = selectedSiteRepository.getSelectedSite()
-        val isWpComSite = selectedSite != null && siteUtilsWrapper.isAccessedViaWPComRest(selectedSite)
-
-        return isWpComSite && jetpackPoweredFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
+        return isWpComSite() && jetpackPoweredFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
     }
 
     fun shouldShowJetpackPoweredBottomSheet(): Boolean {
-        return jetpackPoweredBottomSheetFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
+        return isWpComSite() && jetpackPoweredBottomSheetFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
     }
 
     fun showJetpackBannerIfScrolledToTop(banner: View, scrollableView: RecyclerView) {
@@ -75,5 +72,10 @@ class JetpackBrandingUtils @Inject constructor(
         if (window.context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
             window.navigationBarColor = window.context.getColor(R.color.jetpack_banner_background)
         }
+    }
+
+    private fun isWpComSite(): Boolean {
+        val selectedSite = selectedSiteRepository.getSelectedSite()
+        return selectedSite != null && siteUtilsWrapper.isAccessedViaWPComRest(selectedSite)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredBottomSheetFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredBottomSheetFeatureConfig.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration for Jetpack Powered Bottom Sheet
+ *
+ * TODO: When it is ready to be rolled out uncomment the lines 12 and 19, remove line 13 and this to-do
+ */
+// @Feature(JetpackPoweredBottomSheetFeatureConfig.JETPACK_POWERED_BOTTOM_SHEET_REMOTE_FIELD, true)
+@FeatureInDevelopment
+class JetpackPoweredBottomSheetFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.JETPACK_POWERED,
+//        JETPACK_POWERED_BOTTOM_SHEET_REMOTE_FIELD
+) {
+    companion object {
+        const val JETPACK_POWERED_BOTTOM_SHEET_REMOTE_FIELD = "jetpack_powered_bottom_sheet_remote_field"
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -40,7 +40,7 @@ import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState.ContentUiState
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.SnackbarSequencer
-import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
+import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import java.util.Date
 
@@ -65,7 +65,7 @@ class ReaderViewModelTest {
     @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
     @Mock lateinit var quickStartType: QuickStartType
     @Mock lateinit var snackbarSequencer: SnackbarSequencer
-    @Mock lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
+    @Mock lateinit var jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig
     @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
 
     private val emptyReaderTagList = ReaderTagList()
@@ -83,7 +83,7 @@ class ReaderViewModelTest {
                 accountStore,
                 quickStartRepository,
                 selectedSiteRepository,
-                jetpackPoweredFeatureConfig,
+                jetpackPoweredBottomSheetFeatureConfig,
                 buildConfigWrapper,
                 snackbarSequencer,
         )
@@ -464,12 +464,12 @@ class ReaderViewModelTest {
     }
 
     @Test
-    fun `given wp app, when jetpack powered feature is true, then jp powered bottom sheet is shown`() {
+    fun `given wp app, when jp powered bottom sheet feature is true, then jp powered bottom sheet is shown`() {
         val showJetpackPoweredBottomSheetEvent = mutableListOf<Event<Boolean>>()
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)
         }
-        whenever(jetpackPoweredFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(jetpackPoweredBottomSheetFeatureConfig.isEnabled()).thenReturn(true)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
 
         viewModel.start()
@@ -478,12 +478,12 @@ class ReaderViewModelTest {
     }
 
     @Test
-    fun `given wp app, when jetpack powered feature is false, then jp powered bottom sheet is not shown`() {
+    fun `given wp app, when jp powered bottom sheet feature is false, then jp powered bottom sheet is not shown`() {
         val showJetpackPoweredBottomSheetEvent = mutableListOf<Event<Boolean>>()
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)
         }
-        whenever(jetpackPoweredFeatureConfig.isEnabled()).thenReturn(false)
+        whenever(jetpackPoweredBottomSheetFeatureConfig.isEnabled()).thenReturn(false)
 
         viewModel.start()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -38,9 +38,8 @@ import org.wordpress.android.ui.reader.utils.DateProvider
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.QuickStartReaderPrompt
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState.ContentUiState
-import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.SnackbarSequencer
-import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import java.util.Date
 
@@ -65,8 +64,7 @@ class ReaderViewModelTest {
     @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
     @Mock lateinit var quickStartType: QuickStartType
     @Mock lateinit var snackbarSequencer: SnackbarSequencer
-    @Mock lateinit var jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig
-    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
+    @Mock lateinit var jetpackBrandingUtils: JetpackBrandingUtils
 
     private val emptyReaderTagList = ReaderTagList()
     private val nonEmptyReaderTagList = createNonMockedNonEmptyReaderTagList()
@@ -83,8 +81,7 @@ class ReaderViewModelTest {
                 accountStore,
                 quickStartRepository,
                 selectedSiteRepository,
-                jetpackPoweredBottomSheetFeatureConfig,
-                buildConfigWrapper,
+                jetpackBrandingUtils,
                 snackbarSequencer,
         )
 
@@ -469,8 +466,7 @@ class ReaderViewModelTest {
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)
         }
-        whenever(jetpackPoweredBottomSheetFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
+        whenever(jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()).thenReturn(true)
 
         viewModel.start()
 
@@ -479,11 +475,11 @@ class ReaderViewModelTest {
 
     @Test
     fun `given wp app, when jp powered bottom sheet feature is false, then jp powered bottom sheet is not shown`() {
-        val showJetpackPoweredBottomSheetEvent = mutableListOf<Event<Boolean>>()
+        val showJetpackPoweredBottomSheetEvent = mutableListOf<Event<Boolean>>(Event(false))
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)
         }
-        whenever(jetpackPoweredBottomSheetFeatureConfig.isEnabled()).thenReturn(false)
+        whenever(jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()).thenReturn(false)
 
         viewModel.start()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
@@ -40,10 +40,9 @@ import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
 import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig
 import org.wordpress.android.util.config.StatsRevampV2FeatureConfig
 import org.wordpress.android.viewmodel.Event
@@ -65,8 +64,7 @@ class StatsViewModelTest : BaseUnitTest() {
     @Mock lateinit var notificationsTracker: SystemNotificationsTracker
     @Mock lateinit var todaysStatsCardFeatureConfig: MySiteDashboardTodaysStatsCardFeatureConfig
     @Mock lateinit var statsRevampV2FeatureConfig: StatsRevampV2FeatureConfig
-    @Mock lateinit var jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig
-    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
+    @Mock lateinit var jetpackBrandingUtils: JetpackBrandingUtils
     private lateinit var viewModel: StatsViewModel
     private val _liveSelectedSection = MutableLiveData<StatsSection>()
     private val liveSelectedSection: LiveData<StatsSection> = _liveSelectedSection
@@ -91,8 +89,7 @@ class StatsViewModelTest : BaseUnitTest() {
                 notificationsTracker,
                 todaysStatsCardFeatureConfig,
                 statsRevampV2FeatureConfig,
-                jetpackPoweredBottomSheetFeatureConfig,
-                buildConfigWrapper,
+                jetpackBrandingUtils
         )
 
         viewModel.start(1, false, null, null, false, null)
@@ -246,8 +243,7 @@ class StatsViewModelTest : BaseUnitTest() {
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)
         }
-        whenever(jetpackPoweredBottomSheetFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
+        whenever(jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()).thenReturn(true)
 
         startViewModel()
 
@@ -256,11 +252,11 @@ class StatsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given wp app, when jetpack powered bottom sheet feature is off, then jp powered bottom sheet is not shown`() {
-        val showJetpackPoweredBottomSheetEvent = mutableListOf<Event<Boolean>>()
+        val showJetpackPoweredBottomSheetEvent = mutableListOf<Event<Boolean>>(Event(false))
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)
         }
-        whenever(jetpackPoweredBottomSheetFeatureConfig.isEnabled()).thenReturn(false)
+        whenever(jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()).thenReturn(false)
 
         startViewModel()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/StatsViewModelTest.kt
@@ -43,7 +43,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.config.JetpackPoweredFeatureConfig
+import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
 import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig
 import org.wordpress.android.util.config.StatsRevampV2FeatureConfig
 import org.wordpress.android.viewmodel.Event
@@ -65,7 +65,7 @@ class StatsViewModelTest : BaseUnitTest() {
     @Mock lateinit var notificationsTracker: SystemNotificationsTracker
     @Mock lateinit var todaysStatsCardFeatureConfig: MySiteDashboardTodaysStatsCardFeatureConfig
     @Mock lateinit var statsRevampV2FeatureConfig: StatsRevampV2FeatureConfig
-    @Mock lateinit var jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig
+    @Mock lateinit var jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig
     @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     private lateinit var viewModel: StatsViewModel
     private val _liveSelectedSection = MutableLiveData<StatsSection>()
@@ -91,7 +91,7 @@ class StatsViewModelTest : BaseUnitTest() {
                 notificationsTracker,
                 todaysStatsCardFeatureConfig,
                 statsRevampV2FeatureConfig,
-                jetpackPoweredFeatureConfig,
+                jetpackPoweredBottomSheetFeatureConfig,
                 buildConfigWrapper,
         )
 
@@ -241,12 +241,12 @@ class StatsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given wp app, when jetpack powered feature is true, then jp powered bottom sheet is shown`() {
+    fun `given wp app, when jetpack powered bottom sheet feature is on, then jp powered bottom sheet is shown`() {
         val showJetpackPoweredBottomSheetEvent = mutableListOf<Event<Boolean>>()
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)
         }
-        whenever(jetpackPoweredFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(jetpackPoweredBottomSheetFeatureConfig.isEnabled()).thenReturn(true)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
 
         startViewModel()
@@ -255,12 +255,12 @@ class StatsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given wp app, when jetpack powered feature is false, then jp powered bottom sheet is not shown`() {
+    fun `given wp app, when jetpack powered bottom sheet feature is off, then jp powered bottom sheet is not shown`() {
         val showJetpackPoweredBottomSheetEvent = mutableListOf<Event<Boolean>>()
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)
         }
-        whenever(jetpackPoweredFeatureConfig.isEnabled()).thenReturn(false)
+        whenever(jetpackPoweredBottomSheetFeatureConfig.isEnabled()).thenReturn(false)
 
         startViewModel()
 


### PR DESCRIPTION
This PR adds local development feature config for Jetpack powered bottom sheet

Fixes: #16973 

<img width=320 src="https://user-images.githubusercontent.com/990349/181171989-b434980b-ee15-44dd-a18c-508fa2110757.png" />


To test:

1. Launch WordPress app
2. Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
3. Select Debug Settings
4. Find JetpackPoweredBottomFeatureConfig under Features in development as shown in the image above
5. Re-launch app (scroll down if necessary)
6. Tap on Reader tab at the bottom.  Ensure a full screen bottom sheet pops up.
7. Tap on Notifications tab and also open Stats through menu or shortcut.  Ensure bottom sheet shows up.
8. Try enabling and disabling the flag and test that bottom sheet appears when on and doesn't when it is off.
9. Also, test with Jetpack app to make sure the bottom sheet doesn't appear when feature is on.


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
Updated unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.