### PR TITLE
Merge Release Notes for 20.4

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -11,21 +11,21 @@ msgstr ""
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_204"
+msgid ""
+"20.4:\n"
+"- Gallery/Image block performance improvements in the Block Editor.\n"
+"- Properly displayed Video blocks (both web and app) for VideoPress-enabled sites.\n"
+"- Block inserter allows block types to be better organized in collections.\n"
+"- Alt text footnote spacing adjustment in Image blocks.\n"
+msgstr ""
+
 msgctxt "release_note_203"
 msgid ""
 "20.3:\n"
 "- When you add an item in the media library to an Image block, the item’s alt text comes with it.\n"
 "- You can insert media from a URL in Video blocks.\n"
 "- Use the block recovery option to bring back unexpected or invalid content in a block.\n"
-msgstr ""
-
-msgctxt "release_note_202"
-msgid ""
-"20.2:\n"
-"- We updated the Insights view in your site’s Stats.\n"
-"- Sign in with your browser using a QR code in the app’s Me menu.\n"
-"- Upload HEIC/HEIF images through the media picker.\n"
-"- We squashed a bug that affected reader topics in other languages.\n"
 msgstr ""
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,6 +1,4 @@
-* [*] [internal] Block Editor: Add React Native FastImage [https://github.com/WordPress/gutenberg/pull/42009]
-* [*] Block Editor: Inserter displays block collections [https://github.com/WordPress/gutenberg/pull/42405]
-* [*] Block Editor: Fix incorrect spacing within Image alt text footnote [https://github.com/WordPress/gutenberg/pull/42504]
-* [***] Block Editor: Gallery and Image block - Performance improvements [https://github.com/WordPress/gutenberg/pull/42178]
-* [**] [WP.com and Jetpack sites with VideoPress] Prevent validation error when viewing VideoPress markup within app [https://github.com/Automattic/jetpack/pull/24548]
-
+- Gallery/Image block performance improvements in the Block Editor.
+- Properly displayed Video blocks (both web and app) for VideoPress-enabled sites.
+- Block inserter allows block types to be better organized in collections.
+- Alt text footnote spacing adjustment in Image blocks.

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -11,19 +11,21 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_204"
+msgid ""
+"20.4:\n"
+"- Gallery/Image block performance improvements in the Block Editor.\n"
+"- Properly displayed Video blocks (both web and app) for VideoPress-enabled sites.\n"
+"- Block inserter allows block types to be better organized in collections.\n"
+"- Alt text footnote spacing adjustment in Image blocks.\n"
+msgstr ""
+
 msgctxt "release_note_203"
 msgid ""
 "20.3:\n"
 "- When you add an item in the media library to an Image block, the item’s alt text comes with it.\n"
 "- You can insert media from a URL in Video blocks.\n"
 "- Use the block recovery option to bring back unexpected or invalid content in a block.\n"
-msgstr ""
-
-msgctxt "release_note_202"
-msgid ""
-"20.2:\n"
-"- You can now upload HEIC and HEIF images to your site through the media picker.\n"
-"- We squashed a bug that removed special characters from reader topics in other languages.\n"
 msgstr ""
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,7 +1,4 @@
-* [*] [internal] Block Editor: Add React Native FastImage [https://github.com/WordPress/gutenberg/pull/42009]
-* [*] Block Editor: Inserter displays block collections [https://github.com/WordPress/gutenberg/pull/42405]
-* [*] Block Editor: Fix incorrect spacing within Image alt text footnote [https://github.com/WordPress/gutenberg/pull/42504]
-* [***] Block Editor: Gallery and Image block - Performance improvements [https://github.com/WordPress/gutenberg/pull/42178]
-* [**] [WP.com and Jetpack sites with VideoPress] Prevent validation error when viewing VideoPress markup within app [https://github.com/Automattic/jetpack/pull/24548]
-* [*] [internal] Adds the "Jetpack powered" badge to non-core features [https://github.com/wordpress-mobile/WordPress-Android/pull/16940]
-
+- Gallery/Image block performance improvements in the Block Editor.
+- Properly displayed Video blocks (both web and app) for VideoPress-enabled sites.
+- Block inserter allows block types to be better organized in collections.
+- Alt text footnote spacing adjustment in Image blocks.

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -74,12 +74,15 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
 import static org.wordpress.android.models.Note.NOTE_COMMENT_LIKE_TYPE;
 import static org.wordpress.android.models.Note.NOTE_COMMENT_TYPE;
 import static org.wordpress.android.models.Note.NOTE_FOLLOW_TYPE;
 import static org.wordpress.android.models.Note.NOTE_LIKE_TYPE;
 import static org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter.IS_TAPPED_ON_NOTIFICATION;
 
+@AndroidEntryPoint
 public class NotificationsDetailActivity extends LocaleAwareActivity implements
         CommentActions.OnNoteCommentActionListener,
         BasicFragmentDialog.BasicDialogPositiveClickInterface, ScrollableViewInitializedListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -74,15 +74,12 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import dagger.hilt.android.AndroidEntryPoint;
-
 import static org.wordpress.android.models.Note.NOTE_COMMENT_LIKE_TYPE;
 import static org.wordpress.android.models.Note.NOTE_COMMENT_TYPE;
 import static org.wordpress.android.models.Note.NOTE_FOLLOW_TYPE;
 import static org.wordpress.android.models.Note.NOTE_LIKE_TYPE;
 import static org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter.IS_TAPPED_ON_NOTIFICATION;
 
-@AndroidEntryPoint
 public class NotificationsDetailActivity extends LocaleAwareActivity implements
         CommentActions.OnNoteCommentActionListener,
         BasicFragmentDialog.BasicDialogPositiveClickInterface, ScrollableViewInitializedListener {


### PR DESCRIPTION
PR to make sure the Editorialized Release Notes for 20.4 land in `trunk` by end of week.

@wordpress-mobile/owl-team could you please double check these 2 commits (91a72e54a7a269165b0d5df52b762696e3072d50 + f2d58a8e4449398d08820ace9a956bc595708b8a) that I ended-up committing manually due to a time out issue with [RubyGems](https://rubygems.org/). You can read the description on both those commits for more details on all that.

~~PS: Yesterday, I updated my Mac to the latest macOS (Monterey 12.5), maybe that's has something to do with it... Apart from that I don't know why [RubyGems](https://rubygems.org/) started timing out on my end, maybe this is temporary outage on their end. 🤔~~

UPDATE: Today I tried running `bundle exec fastlane update_appstore_strings version:20.4` again. This time it worked!

It seems that there was indeed a problem with [RubyGems](https://rubygems.org/) yesterday. So, after me running this `update_appstore_strings` fastlane command I got the following today, note the `Nothing to commit, working tree clean ✅.` output, the manual commits I did yesterday completely match the result that I would be getting my running `update_appstore_strings` anyway as nothing new was committed (or pushed afterwards):

<details>
  <summary>Click to expand!</summary>
  
  `bundle exec fastlane update_appstore_strings version:20.4`
  ```
[11:52:54]: ----------------------------------------------------------------------
[11:52:54]: --- Step: Switch to android update_wordpress_appstore_strings lane ---
[11:52:54]: ----------------------------------------------------------------------
[11:52:54]: Cruising over to lane 'android update_wordpress_appstore_strings' 🚖
[11:52:54]: -------------------------------------
[11:52:54]: --- Step: android_get_app_version ---
[11:52:54]: -------------------------------------
[11:52:54]: -------------------------------------
[11:52:54]: --- Step: ensure_git_status_clean ---
[11:52:54]: -------------------------------------
[11:52:54]: $ git status --porcelain
[11:52:54]: Git status is clean, all good! 💪
[11:52:54]: ---------------------------------------
[11:52:54]: --- Step: an_update_metadata_source ---
[11:52:54]: ---------------------------------------
[11:52:54]: Parameter .po file path: /Users/petros.paraskevopoulos/AndroidStudioProjects/automattic/WordPress-Android/fastlane/../WordPress/metadata/PlayStoreStrings.po
[11:52:54]: Release version: 20.4
[11:52:54]: File /Users/petros.paraskevopoulos/AndroidStudioProjects/automattic/WordPress-Android/fastlane/../WordPress/metadata/PlayStoreStrings.po updated!
[11:52:54]: ---------------------
[11:52:54]: --- Step: git_add ---
[11:52:54]: ---------------------
[11:52:54]: Successfully added "/Users/petros.paraskevopoulos/AndroidStudioProjects/automattic/WordPress-Android/fastlane/../WordPress/metadata/PlayStoreStrings.po" 💾.
[11:52:54]: ------------------------
[11:52:54]: --- Step: git_commit ---
[11:52:54]: ------------------------
[11:52:54]: $ git status /Users/petros.paraskevopoulos/AndroidStudioProjects/automattic/WordPress-Android/fastlane/../WordPress/metadata/PlayStoreStrings.po --porcelain
[11:52:54]: Nothing to commit, working tree clean ✅.
[11:52:54]: Cruising back to lane 'android update_appstore_strings' 🚘
[11:52:54]: --------------------------------------------------------------------
[11:52:54]: --- Step: Switch to android update_jetpack_appstore_strings lane ---
[11:52:54]: --------------------------------------------------------------------
[11:52:54]: Cruising over to lane 'android update_jetpack_appstore_strings' 🚖
[11:52:54]: -------------------------------------
[11:52:54]: --- Step: android_get_app_version ---
[11:52:54]: -------------------------------------
[11:52:54]: -------------------------------------
[11:52:54]: --- Step: ensure_git_status_clean ---
[11:52:54]: -------------------------------------
[11:52:54]: $ git status --porcelain
[11:52:54]: Git status is clean, all good! 💪
[11:52:54]: ---------------------------------------
[11:52:54]: --- Step: an_update_metadata_source ---
[11:52:54]: ---------------------------------------
[11:52:54]: Parameter .po file path: /Users/petros.paraskevopoulos/AndroidStudioProjects/automattic/WordPress-Android/fastlane/../WordPress/jetpack_metadata/PlayStoreStrings.po
[11:52:54]: Release version: 20.4
[11:52:54]: File /Users/petros.paraskevopoulos/AndroidStudioProjects/automattic/WordPress-Android/fastlane/../WordPress/jetpack_metadata/PlayStoreStrings.po updated!
[11:52:54]: ---------------------
[11:52:54]: --- Step: git_add ---
[11:52:54]: ---------------------
[11:52:54]: Successfully added "/Users/petros.paraskevopoulos/AndroidStudioProjects/automattic/WordPress-Android/fastlane/../WordPress/jetpack_metadata/PlayStoreStrings.po" 💾.
[11:52:54]: ------------------------
[11:52:54]: --- Step: git_commit ---
[11:52:54]: ------------------------
[11:52:54]: $ git status /Users/petros.paraskevopoulos/AndroidStudioProjects/automattic/WordPress-Android/fastlane/../WordPress/jetpack_metadata/PlayStoreStrings.po --porcelain
[11:52:54]: Nothing to commit, working tree clean ✅.
[11:52:54]: Cruising back to lane 'android update_appstore_strings' 🚘
  ```

</details>

So, all in all, we are good to go with the release notes and this PR can be safely reviewed now! 🎉 