### PR TITLE
[Update Detekt Version] Update Detekt to 1.21.0

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/CrashLoggingModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/CrashLoggingModule.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
 @Module
-abstract class CrashLoggingModule {
+interface CrashLoggingModule {
     companion object {
         @Provides
         @Singleton
@@ -27,6 +27,5 @@ abstract class CrashLoggingModule {
         }
     }
 
-    @Binds
-    abstract fun bindCrashLoggingDataProvider(dataProvider: WPCrashLoggingDataProvider): CrashLoggingDataProvider
+    @Binds fun bindCrashLoggingDataProvider(dataProvider: WPCrashLoggingDataProvider): CrashLoggingDataProvider
 }

--- a/WordPress/src/main/java/org/wordpress/android/modules/FluxCModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/FluxCModule.kt
@@ -17,4 +17,4 @@ import org.wordpress.android.fluxc.module.ReleaseToolsModule
             DatabaseModule::class
         ]
 )
-abstract class FluxCModule
+interface FluxCModule

--- a/WordPress/src/main/java/org/wordpress/android/modules/LoginModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/LoginModule.kt
@@ -8,4 +8,4 @@ import org.wordpress.android.login.di.LoginServiceModule
 
 @InstallIn(SingletonComponent::class)
 @Module(includes = [LoginFragmentModule::class, LoginServiceModule::class])
-abstract class LoginModule
+interface LoginModule

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterAdapter.kt
@@ -14,6 +14,7 @@ private const val activityViewType: Int = 2
 class ActivityLogTypeFilterAdapter(private val uiHelpers: UiHelpers) : Adapter<ActivityLogTypeFilterViewHolder>() {
     private val items = mutableListOf<ListItemUiState>()
 
+    @Suppress("UseCheckOrError")
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ActivityLogTypeFilterViewHolder {
         return when (viewType) {
             headerViewType -> ActivityLogTypeFilterViewHolder.HeaderViewHolder(parent, uiHelpers)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -85,6 +85,7 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
         initAdapter()
     }
 
+    @Suppress("UseCheckOrError")
     private fun ActivityLogTypeFilterFragmentBinding.initViewModel() {
         viewModel = ViewModelProvider(this@ActivityLogTypeFilterFragment, viewModelFactory)
                 .get(ActivityLogTypeFilterViewModel::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -132,7 +132,7 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
     }
 
     private fun onClearClicked() {
-        (_uiState.value as? Content)?.let { it ->
+        (_uiState.value as? Content)?.let {
             _uiState.value = it.copy(items = getAllActivityTypeItemsUnchecked(it.items))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
@@ -90,6 +90,7 @@ class BloggingPromptsOnboardingDialogFragment : FeatureIntroductionDialogFragmen
         viewModel.start(dialogType)
     }
 
+    @Suppress("UseCheckOrError")
     override fun onAttach(context: Context) {
         super.onAttach(context)
         arguments?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -459,6 +459,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
                     as ArrayList<SupportedStateResponse>
         }
 
+        @Suppress("UseCheckOrError")
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             if (targetFragment == null) {
                 throw IllegalStateException("StatePickerDialogFragment is missing a targetFragment ")
@@ -509,6 +510,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
                     as ArrayList<SupportedDomainCountry>
         }
 
+        @Suppress("UseCheckOrError")
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             if (targetFragment == null) {
                 throw IllegalStateException("CountryPickerDialogFragment is missing a targetFragment ")

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -214,6 +214,7 @@ class DomainSuggestionsViewModel @Inject constructor(
         }
     }
 
+    @Suppress("UseCheckOrError")
     fun onSelectDomainButtonClicked() {
         val selectedSuggestion = _selectedSuggestion.value ?: throw IllegalStateException("Selected suggestion is null")
         when (domainRegistrationPurpose) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/CreateCartUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/CreateCartUseCase.kt
@@ -29,6 +29,7 @@ class CreateCartUseCase @Inject constructor(
         dispatcher.unregister(this)
     }
 
+    @Suppress("UseCheckOrError")
     suspend fun execute(
         site: SiteModel,
         productId: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchPlansUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchPlansUseCase.kt
@@ -28,6 +28,7 @@ class FetchPlansUseCase @Inject constructor(
         dispatcher.unregister(this)
     }
 
+    @Suppress("UseCheckOrError")
     suspend fun execute(
         site: SiteModel
     ): OnPlansFetched {

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/ListScenarioUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/ListScenarioUtils.kt
@@ -31,9 +31,7 @@ class ListScenarioUtils @Inject constructor(
     val notificationsUtilsWrapper: NotificationsUtilsWrapper
 ) {
     fun mapLikeNoteToListScenario(note: Note, context: Context): ListScenario {
-        if (!note.isLikeType) throw IllegalArgumentException(
-                "mapLikeNoteToListScenario > unexpected note type ${note.type}"
-        )
+        require(note.isLikeType) { "mapLikeNoteToListScenario > unexpected note type ${note.type}" }
 
         val imageType = AVATAR_WITH_BACKGROUND
         val headerNoteBlock = HeaderNoteBlock(

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/ExoPlayerUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/ExoPlayerUtils.kt
@@ -40,6 +40,7 @@ class ExoPlayerUtils
     private fun buildDefaultDataSourceFactory(httpDataSourceFactory: DefaultHttpDataSourceFactory) =
             DefaultDataSourceFactory(appContext, httpDataSourceFactory)
 
+    @Suppress("UseCheckOrError")
     fun buildMediaSource(uri: Uri): MediaSource? {
         val httpDataSourceFactory = buildHttpDataSourceFactory(uri.toString())
         val defaultDataSourceFactory = buildDefaultDataSourceFactory(httpDataSourceFactory)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
@@ -59,6 +59,7 @@ class PagesActivity : LocaleAwareActivity(),
         return super.onOptionsItemSelected(item)
     }
 
+    @Suppress("UseCheckOrError")
     override fun onPositiveClicked(instanceTag: String) {
         val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
         if (fragment is PagesFragment) {
@@ -68,6 +69,7 @@ class PagesActivity : LocaleAwareActivity(),
         }
     }
 
+    @Suppress("UseCheckOrError")
     override fun onNegativeClicked(instanceTag: String) {
         val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
         if (fragment is PagesFragment) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/WPEditTextWithChipsOutlined.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/WPEditTextWithChipsOutlined.kt
@@ -421,9 +421,7 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
     }
 
     private fun throwExceptionIfChipifyNotEnabled() {
-        if (!chipifyEnabled) throw IllegalArgumentException(
-                "Please set chipifyEnabled to true in order to use chips feature"
-        )
+        require(chipifyEnabled) { "Please set chipifyEnabled to true in order to use chips feature" }
     }
 
     // This should be fast enough for our use case, so we get fresh data always

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
@@ -54,7 +54,7 @@ class GetCategoriesUseCase @Inject constructor(
     private fun formatCategories(categoryList: List<TermModel>): String {
         if (categoryList.isEmpty()) return ""
 
-        val formattedCategories = categoryList.joinToString { it -> it.name }
+        val formattedCategories = categoryList.joinToString { it.name }
         return StringEscapeUtils.unescapeHtml4(formattedCategories)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -323,6 +323,7 @@ class PostActionHandler(
         dispatcher.dispatch(PostActionBuilder.newDeletePostAction(RemotePostPayload(post, site)))
     }
 
+    @Suppress("UseCheckOrError")
     fun handlePostTrashed(localPostId: LocalId, isError: Boolean) {
         val criticalAction = criticalPostActionTracker.get(localPostId)
         if (criticalAction != TRASHING_POST && criticalAction != TRASHING_POST_WITH_LOCAL_CHANGES) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeAdapter.kt
@@ -50,6 +50,7 @@ class PrepublishingHomeAdapter(context: Context) : RecyclerView.Adapter<Prepubli
         diffResult.dispatchUpdatesTo(this)
     }
 
+    @Suppress("UseCheckOrError")
     override fun getItemViewType(position: Int): Int {
         return when (items[position]) {
             is HeaderUiState -> headerViewType

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
@@ -55,6 +55,7 @@ class PostListAdapter(
         }
     }
 
+    @Suppress("UseCheckOrError")
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return when (viewType) {
             VIEW_TYPE_ENDLIST_INDICATOR -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AppendMediaToEditorUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AppendMediaToEditorUseCase.kt
@@ -24,9 +24,7 @@ class AppendMediaToEditorUseCase @Inject constructor(private val fluxCUtilsWrapp
                             AppLog.e(AppLog.T.MEDIA, "Media with remote id ${media.mediaId} not " +
                                     "added to editor.")
                         }
-                        mediaFile?.let { it ->
-                            Pair(urlToUse, it)
-                        }
+                        mediaFile?.let { Pair(urlToUse, it) }
                     }
                 }
                 .toMap()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsViewModel.kt
@@ -140,6 +140,7 @@ class HomepageSettingsViewModel
         return _uiState.value?.isClassicBlogState
     }
 
+    @Suppress("UseCheckOrError")
     fun start(siteId: Int, savedClassicBlogValue: Boolean?, savedPageForPostsId: Long?, savedPageOnFrontId: Long?) {
         dispatcher.register(this)
         launch {
@@ -185,6 +186,7 @@ class HomepageSettingsViewModel
         return remoteId <= 0 || this.any { it.remoteId == remoteId }
     }
 
+    @Suppress("UseCheckOrError")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onSiteChanged(event: OnSiteChanged) {
         val currentUiState = _uiState.value

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/PrefMainSwitchToolbarView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/PrefMainSwitchToolbarView.kt
@@ -212,7 +212,7 @@ class PrefMainSwitchToolbarView @JvmOverloads constructor(
         this.hintOff = hintOff
     }
 
-    @Suppress("MemberVisibilityCanBePrivate")
+    @Suppress("MemberVisibilityCanBePrivate", "UseCheckOrError")
     fun setViewStyle(viewStyleInt: Int) {
         if (viewStyleInt == this.viewStyle?.value) {
             return

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/viewholders/TaskViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/viewholders/TaskViewHolder.kt
@@ -22,6 +22,7 @@ class TaskViewHolder(
     parent: ViewGroup,
     private val binding: QuickStartListItemBinding = parent.viewBinding(QuickStartListItemBinding::inflate)
 ) : ViewHolder(binding.root) {
+    @Suppress("UseCheckOrError")
     fun bind(taskCard: QuickStartTaskCard) {
         val isEnabled = !taskCard.isCompleted
         val quickStartTaskDetails = QuickStartTaskDetails.getDetailsForTask(taskCard.task)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1607,6 +1607,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     /*
      * returns True if the passed URL should be opened in the external browser app
      */
+    @Suppress("ReturnCount")
     private fun shouldOpenExternal(url: String): Boolean {
         // open YouTube videos in external app so they launch the YouTube player
         if (ReaderVideoUtils.isYouTubeVideoLink(url)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -348,6 +348,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private fun buildDateLine(post: ReaderPost) =
             dateTimeUtilsWrapper.javaDateToTimeSpan(post.getDisplayDate(dateTimeUtilsWrapper))
 
+    @Suppress("UseCheckOrError")
     private fun buildDiscoverSectionUiState(
         discoverData: ReaderPostDiscoverData,
         onDiscoverSectionClicked: (Long, Long) -> Unit

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogUseCase.kt
@@ -48,6 +48,7 @@ class ReblogUseCase @Inject constructor(
         }
     }
 
+    @Suppress("UseCheckOrError")
     suspend fun onReblogSiteSelected(siteLocalId: Int, post: ReaderPost?): ReblogState {
         return withContext(bgDispatcher) {
             when {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FetchFollowedTagsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FetchFollowedTagsUseCase.kt
@@ -26,6 +26,7 @@ class FetchFollowedTagsUseCase @Inject constructor(
 ) {
     private var continuation: Continuation<ReaderRepositoryCommunication>? = null
 
+    @Suppress("UseCheckOrError")
     suspend fun fetch(): ReaderRepositoryCommunication {
         if (continuation != null) {
             throw IllegalStateException("Follow tags already in progress.")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FetchInterestTagsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FetchInterestTagsUseCase.kt
@@ -26,6 +26,7 @@ class FetchInterestTagsUseCase @Inject constructor(
 ) {
     private var continuation: Continuation<ReaderRepositoryCommunication>? = null
 
+    @Suppress("UseCheckOrError")
     suspend fun fetch(): ReaderRepositoryCommunication {
         if (continuation != null) {
             throw IllegalStateException("Fetch already in progress.")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FollowInterestTagsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FollowInterestTagsUseCase.kt
@@ -24,6 +24,7 @@ class FollowInterestTagsUseCase @Inject constructor(
 ) {
     private var continuation: Continuation<ReaderRepositoryCommunication>? = null
 
+    @Suppress("UseCheckOrError")
     suspend fun followInterestTags(tags: List<ReaderTag>): ReaderRepositoryCommunication {
         if (continuation != null) {
             throw IllegalStateException("Follow interest tags already in progress.")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
@@ -60,7 +60,7 @@ class ReaderPostBookmarkUseCase @Inject constructor(
         return setToBookmarked
     }
 
-    @Suppress("UseCheckOrError")
+    @Suppress("ComplexMethod", "UseCheckOrError")
     private fun trackEvent(
         bookmarked: Boolean,
         isBookmarkList: Boolean,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
@@ -45,6 +45,7 @@ class ReaderPostBookmarkUseCase @Inject constructor(
         }
     }
 
+    @Suppress("UseCheckOrError")
     private fun updatePostInDb(blogId: Long, postId: Long): Boolean {
         val post = readerPostTableWrapper.getBlogPost(blogId, postId, true)
                 ?: throw IllegalStateException("Post displayed on the UI not found in DB.")
@@ -59,6 +60,7 @@ class ReaderPostBookmarkUseCase @Inject constructor(
         return setToBookmarked
     }
 
+    @Suppress("UseCheckOrError")
     private fun trackEvent(
         bookmarked: Boolean,
         isBookmarkList: Boolean,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -137,8 +137,8 @@ class ReaderViewModel @Inject constructor(
 
     private suspend fun initializeTabSelection(tagList: ReaderTagList) {
         withContext(bgDispatcher) {
-            val selectTab = { it: ReaderTag ->
-                val index = tagList.indexOf(it)
+            val selectTab = { readerTag: ReaderTag ->
+                val index = tagList.indexOf(readerTag)
                 if (index != -1) {
                     _selectTab.postValue(Event(TabNavigation(index, smoothAnimation = false)))
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -221,6 +221,7 @@ class ReaderViewModel @Inject constructor(
         }
     }
 
+    @Suppress("UseCheckOrError")
     fun onSearchActionClicked() {
         if (isSearchSupported()) {
             _showSearch.value = Event(Unit)
@@ -229,6 +230,7 @@ class ReaderViewModel @Inject constructor(
         }
     }
 
+    @Suppress("UseCheckOrError")
     fun onSettingsActionClicked() {
         if (isSettingsSupported()) {
             completeQuickStartFollowSiteTaskIfNeeded()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -31,6 +31,7 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
 
     private var binding: SiteCreationDomainsScreenBinding? = null
 
+    @Suppress("UseCheckOrError")
     override fun onAttach(context: Context) {
         super.onAttach(context)
         if (context !is DomainsScreenListener) {
@@ -45,7 +46,7 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
         return R.layout.site_creation_domains_screen
     }
 
-    override val screenTitle: String
+    @Suppress("UseCheckOrError") override val screenTitle: String
         get() = arguments?.getString(EXTRA_SCREEN_TITLE)
                 ?: throw IllegalStateException("Required argument screen title is missing.")
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -64,6 +64,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
 
     private var binding: SiteCreationPreviewScreenBinding? = null
 
+    @Suppress("UseCheckOrError")
     override fun onAttach(context: Context) {
         super.onAttach(context)
         if (context !is SitePreviewScreenListener) {
@@ -102,7 +103,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
         return R.layout.site_creation_preview_screen
     }
 
-    override val screenTitle: String
+    @Suppress("UseCheckOrError") override val screenTitle: String
         get() = arguments?.getString(EXTRA_SCREEN_TITLE)
                 ?: throw IllegalStateException("Required argument screen title is missing.")
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/SiteDesignRecommendationProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/SiteDesignRecommendationProvider.kt
@@ -65,6 +65,7 @@ class SiteDesignRecommendationProvider @Inject constructor(private val resourceP
         }
     }
 
+    @Suppress("UseCheckOrError")
     private fun getVerticalSlug(vertical: String): String? {
         val slugsArray = resourceProvider.getStringArray(R.array.site_creation_intents_slugs)
         val verticalArray = resourceProvider.getStringArray(R.array.site_creation_intents_strings)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
@@ -26,6 +26,7 @@ class CreateSiteUseCase @Inject constructor(
 ) {
     private var continuation: Continuation<OnNewSiteCreated>? = null
 
+    @Suppress("UseCheckOrError")
     suspend fun createSite(
         siteData: SiteCreationServiceData,
         languageWordPressId: String,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchHomePageLayoutsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchHomePageLayoutsUseCase.kt
@@ -26,6 +26,7 @@ class FetchHomePageLayoutsUseCase @Inject constructor(
     }
     private var continuation: Continuation<OnStarterDesignsFetched>? = null
 
+    @Suppress("UseCheckOrError")
     suspend fun fetchStarterDesigns(): OnStarterDesignsFetched {
         if (continuation != null) {
             throw IllegalStateException("Fetch already in progress.")

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsUseCase.kt
@@ -20,6 +20,7 @@ class FetchSegmentsUseCase @Inject constructor(
 ) {
     private var continuation: Continuation<OnSegmentsFetched>? = null
 
+    @Suppress("UseCheckOrError")
     suspend fun fetchCategories(): OnSegmentsFetched {
         if (continuation != null) {
             throw IllegalStateException("Fetch already in progress.")

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -71,6 +71,7 @@ class SiteCreationIntentsViewModel @Inject constructor(
         _uiState.value = uiState
     }
 
+    @Suppress("UseCheckOrError")
     fun initializeFromResources(resources: Resources) {
         if (isInitialized) return
         val slugsArray = resources.getStringArray(R.array.site_creation_intents_slugs)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/UpdateAlertDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/UpdateAlertDialogFragment.kt
@@ -7,6 +7,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wordpress.android.R
 
 class UpdateAlertDialogFragment : DialogFragment() {
+    @Suppress("UseCheckOrError")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return activity?.let {
             val builder = MaterialAlertDialogBuilder(it)

--- a/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
@@ -172,6 +172,7 @@ fun <S, T, U, V> merge(
  * @param sourceD fourth source
  * @return new data source
  */
+@Suppress("DestructuringDeclarationWithTooManyEntries")
 fun <S, T, U, V, W> merge(
     sourceA: LiveData<S>,
     sourceB: LiveData<T>,
@@ -225,6 +226,7 @@ fun <S, T, U, V, W> merge(
  * @param sourceE fifth source
  * @return new data source
  */
+@Suppress("DestructuringDeclarationWithTooManyEntries")
 fun <S, T, U, V, W, X> merge(
     sourceA: LiveData<S>,
     sourceB: LiveData<T>,

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -194,7 +194,7 @@ object QuickStartUtils {
                 SiteUtils.isAccessedViaWPComRest(siteModel))
     }
 
-    @Suppress("ComplexMethod")
+    @Suppress("ComplexMethod", "UseCheckOrError")
     @JvmStatic
     fun getQuickStartListTappedTracker(task: QuickStartTask): Stat {
         return when (task.string) {
@@ -214,7 +214,7 @@ object QuickStartUtils {
         }
     }
 
-    @Suppress("ComplexMethod")
+    @Suppress("ComplexMethod", "UseCheckOrError")
     @JvmStatic
     fun getQuickStartListSkippedTracker(task: QuickStartTask): Stat {
         return when (task.string) {
@@ -236,7 +236,7 @@ object QuickStartUtils {
         }
     }
 
-    @Suppress("ComplexMethod")
+    @Suppress("ComplexMethod", "UseCheckOrError")
     fun getTaskCompletedTracker(task: QuickStartTask): Stat {
         return when (task.string) {
             QuickStartStore.QUICK_START_CREATE_SITE_LABEL -> Stat.QUICK_START_CREATE_SITE_TASK_COMPLETED

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -80,6 +80,7 @@ class ImageManager @Inject constructor(
      * + [Context] is not null
      * + [Context] is not destroyed (tested with [FragmentActivity.isDestroyed] or [Activity.isDestroyed])
      */
+    @Suppress("ReturnCount")
     private fun Context?.isAvailable(): Boolean {
         if (this == null) {
             return false

--- a/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt
@@ -16,6 +16,7 @@ class WizardManager<T : WizardStep>(
     private val _navigatorLiveData = SingleLiveEvent<T>()
     val navigatorLiveData: LiveData<T> = _navigatorLiveData
 
+    @Suppress("UseCheckOrError")
     fun showNextStep() {
         if (isIndexValid(++currentStepIndex)) {
             _navigatorLiveData.value = steps[currentStepIndex]
@@ -36,6 +37,7 @@ class WizardManager<T : WizardStep>(
         return !isIndexValid(currentStepIndex + 1)
     }
 
+    @Suppress("UseCheckOrError")
     fun stepPosition(T: WizardStep): Int {
         return if (steps.contains(T)) {
             steps.indexOf(T) + 1
@@ -44,6 +46,7 @@ class WizardManager<T : WizardStep>(
         }
     }
 
+    @Suppress("UseCheckOrError")
     fun setCurrentStepIndex(stepIndex: Int) {
         if (!isIndexValid(stepIndex)) {
             throw IllegalStateException("Invalid index.")

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/SingleEventObservable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/SingleEventObservable.kt
@@ -19,6 +19,7 @@ class SingleEventObservable<T>(private val sourceLiveData: LiveData<T>) {
     var lastEvent: T? = null
         private set
 
+    @Suppress("UseCheckOrError")
     fun observe(owner: LifecycleOwner, observer: Observer<T>) {
         if (sourceLiveData.hasObservers()) {
             throw IllegalStateException("SingleEventObservable can be observed only by a single observer.")
@@ -31,6 +32,7 @@ class SingleEventObservable<T>(private val sourceLiveData: LiveData<T>) {
         })
     }
 
+    @Suppress("UseCheckOrError")
     fun observeForever(observer: Observer<T>) {
         if (sourceLiveData.hasObservers()) {
             throw IllegalStateException("SingleEventObservable can be observed only by a single observer.")

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -137,8 +137,8 @@ class HistoryViewModel @Inject constructor(
                 val updatedRevisions = mutableListOf<HistoryListItem>()
                 revisionsList.clear()
 
-                existingRevisions.forEach { it ->
-                    var mutableRevision = it
+                existingRevisions.forEach { existingRevision ->
+                    var mutableRevision = existingRevision
 
                     if (mutableRevision is Revision) {
                         // we shouldn't directly update items in MutableLiveData, as they will be updated downstream

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -340,14 +340,14 @@ class WPMainActivityViewModel @Inject constructor(
 
     fun getCreateContentMessageId(site: SiteModel?): Int {
         return if (SiteUtils.supportsStoriesFeature(site)) {
-            getCreateContentMessageId_StoriesFlagOn(hasFullAccessToContent(site))
+            getCreateContentMessageIdStoriesFlagOn(hasFullAccessToContent(site))
         } else {
-            getCreateContentMessageId_StoriesFlagOff(hasFullAccessToContent(site))
+            getCreateContentMessageIdStoriesFlagOff(hasFullAccessToContent(site))
         }
     }
 
     // create_post_page_fab_tooltip_stories_feature_flag_on
-    private fun getCreateContentMessageId_StoriesFlagOn(hasFullAccessToContent: Boolean): Int {
+    private fun getCreateContentMessageIdStoriesFlagOn(hasFullAccessToContent: Boolean): Int {
         return if (hasFullAccessToContent) {
             R.string.create_post_page_fab_tooltip_stories_enabled
         } else {
@@ -355,7 +355,7 @@ class WPMainActivityViewModel @Inject constructor(
         }
     }
 
-    private fun getCreateContentMessageId_StoriesFlagOff(hasFullAccessToContent: Boolean): Int {
+    private fun getCreateContentMessageIdStoriesFlagOff(hasFullAccessToContent: Boolean): Int {
         return if (hasFullAccessToContent) {
             R.string.create_post_page_fab_tooltip
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButton.kt
@@ -59,7 +59,7 @@ class PostListButton : LinearLayout {
         }
     }
 
-    @Suppress("MemberVisibilityCanBePrivate")
+    @Suppress("MemberVisibilityCanBePrivate", "UseCheckOrError")
     fun setButtonType(buttonTypeInt: Int) {
         if (buttonTypeInt == this.buttonType?.value) {
             return

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaUploadCompletionProcessorPatternsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaUploadCompletionProcessorPatternsTest.kt
@@ -4,9 +4,10 @@ import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.wordpress.android.ui.posts.mediauploadcompletionprocessors.MediaUploadCompletionProcessorPatterns.PATTERN_BLOCK_CAPTURES
 
-const val blockType = "image"
-const val blockJson = """{"url":"file:///image.png","id":123,someObject:{a:1,b:2},someArray:[1,2,3]}"""
-const val blockHTML = """<div class="wp-block-cover has-background-dim" style="background-image:url(file:///image.png)">
+const val BLOCK_TYPE = "image"
+const val BLOCK_JSON = """{"url":"file:///image.png","id":123,someObject:{a:1,b:2},someArray:[1,2,3]}"""
+const val BLOCK_HTML = """
+<div class="wp-block-cover has-background-dim" style="background-image:url(file:///image.png)">
   <div class="wp-block-cover__inner-container">
     <!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
     <p class="has-text-align-center"></p>
@@ -14,38 +15,30 @@ const val blockHTML = """<div class="wp-block-cover has-background-dim" style="b
   </div>
 </div>
 """
-const val blockHeader = """<!-- wp:$blockType $blockJson -->"""
-const val blockClosingComment = """<!-- /wp:$blockType -->"""
-const val rawBlock = """$blockHeader
-$blockHTML
-$blockClosingComment"""
-const val nestedRawBlock = """$blockHeader
-<div class="wp-block-cover has-background-dim" style="background-image:url(file:///image.png)">
-  <div class="wp-block-cover__inner-container">
-  $rawBlock
-  </div>
-</div>
-$blockClosingComment
-"""
+const val BLOCK_HEADER = """<!-- wp:$BLOCK_TYPE $BLOCK_JSON -->"""
+const val BLOCK_CLOSING_COMMENT = """<!-- /wp:$BLOCK_TYPE -->"""
+const val RAW_BLOCK = """$BLOCK_HEADER
+$BLOCK_HTML
+$BLOCK_CLOSING_COMMENT"""
 
 class MediaUploadCompletionProcessorPatternsTest {
     @Test
     fun `PATTERN_BLOCK_CAPTURES captures the block type`() {
-        val matcher = PATTERN_BLOCK_CAPTURES.matcher(rawBlock)
+        val matcher = PATTERN_BLOCK_CAPTURES.matcher(RAW_BLOCK)
         val outcome = matcher.find()
         Assertions.assertThat(outcome).isEqualTo(true)
-        Assertions.assertThat(matcher.group(1)).isEqualTo(blockType)
+        Assertions.assertThat(matcher.group(1)).isEqualTo(BLOCK_TYPE)
     }
     @Test
     fun `PATTERN_BLOCK_CAPTURES captures the block header json`() {
-        val matcher = PATTERN_BLOCK_CAPTURES.matcher(rawBlock)
+        val matcher = PATTERN_BLOCK_CAPTURES.matcher(RAW_BLOCK)
         Assertions.assertThat(matcher.find()).isEqualTo(true)
-        Assertions.assertThat(matcher.group(2)).isEqualTo(blockJson)
+        Assertions.assertThat(matcher.group(2)).isEqualTo(BLOCK_JSON)
     }
     @Test
     fun `PATTERN_BLOCK_CAPTURES captures the block content`() {
-        val matcher = PATTERN_BLOCK_CAPTURES.matcher(rawBlock)
+        val matcher = PATTERN_BLOCK_CAPTURES.matcher(RAW_BLOCK)
         Assertions.assertThat(matcher.find()).isEqualTo(true)
-        Assertions.assertThat(matcher.group(3)).isEqualTo(blockHTML + "\n")
+        Assertions.assertThat(matcher.group(3)).isEqualTo(BLOCK_HTML + "\n")
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModelTest.kt
@@ -37,9 +37,9 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
 import org.wordpress.android.viewmodel.ResourceProvider
 
-private const val mockedDesignSlug = "mockedDesignSlug"
-private const val mockedDesignSegmentId = 1L
-private const val mockedDesignDemoUrl = "mockedDemoUrl"
+private const val MOCKED_DESIGN_SLUG = "mockedDesignSlug"
+private const val MOCKED_DESIGN_SEGMENT_ID = 1L
+private const val MOCKED_DESIGN_DEMO_URL = "mockedDemoUrl"
 
 @RunWith(MockitoJUnitRunner::class)
 @InternalCoroutinesApi
@@ -97,11 +97,11 @@ class HomePagePickerViewModelTest {
         else OnStarterDesignsFetched(
                 listOf(
                         StarterDesign(
-                                mockedDesignSlug,
+                                MOCKED_DESIGN_SLUG,
                                 "title",
-                                mockedDesignSegmentId,
+                                MOCKED_DESIGN_SEGMENT_ID,
                                 listOf(mockCategory),
-                                mockedDesignDemoUrl,
+                                MOCKED_DESIGN_DEMO_URL,
                                 "theme",
                                 listOf("stable", "blog"),
                                 "desktopThumbnail",
@@ -161,18 +161,18 @@ class HomePagePickerViewModelTest {
     @Test
     fun `when the user taps on a layout the preview flow is triggered`() = mockResponse {
         viewModel.start()
-        viewModel.onThumbnailReady(mockedDesignSlug)
-        viewModel.onLayoutTapped(mockedDesignSlug)
+        viewModel.onThumbnailReady(MOCKED_DESIGN_SLUG)
+        viewModel.onLayoutTapped(MOCKED_DESIGN_SLUG)
         val captor = ArgumentCaptor.forClass(DesignPreviewAction::class.java)
         verify(onPreviewActionObserver).onChanged(captor.capture())
-        assertThat(requireNotNull(captor.value as Show).template).isEqualTo(mockedDesignSlug)
-        assertThat(requireNotNull(captor.value as Show).demoUrl).isEqualTo(mockedDesignDemoUrl)
+        assertThat(requireNotNull(captor.value as Show).template).isEqualTo(MOCKED_DESIGN_SLUG)
+        assertThat(requireNotNull(captor.value as Show).demoUrl).isEqualTo(MOCKED_DESIGN_DEMO_URL)
     }
 
     @Test
     fun `when the user taps on a thumbnail that has not loaded, the preview flow is not triggered`() = mockResponse {
         viewModel.start()
-        viewModel.onLayoutTapped(mockedDesignSlug)
+        viewModel.onLayoutTapped(MOCKED_DESIGN_SLUG)
         verify(onPreviewActionObserver, never()).onChanged(isA(Show::class.java))
     }
 
@@ -213,30 +213,30 @@ class HomePagePickerViewModelTest {
     @Test
     fun `when the user chooses a design the design info is passed to the next step`() = mockResponse {
         viewModel.start()
-        viewModel.onThumbnailReady(mockedDesignSlug)
-        viewModel.onLayoutTapped(mockedDesignSlug)
+        viewModel.onThumbnailReady(MOCKED_DESIGN_SLUG)
+        viewModel.onLayoutTapped(MOCKED_DESIGN_SLUG)
         viewModel.onPreviewChooseTapped()
         val captor = ArgumentCaptor.forClass(DesignSelectionAction::class.java)
         verify(onDesignActionObserver).onChanged(captor.capture())
-        assertThat(captor.value.template).isEqualTo(mockedDesignSlug)
+        assertThat(captor.value.template).isEqualTo(MOCKED_DESIGN_SLUG)
     }
 
     @Test
     fun `when the user chooses a recommended design the recommended information is emitted`() = mockResponse {
         viewModel.start()
-        viewModel.onThumbnailReady(mockedDesignSlug)
-        viewModel.onLayoutTapped(mockedDesignSlug, true)
+        viewModel.onThumbnailReady(MOCKED_DESIGN_SLUG)
+        viewModel.onLayoutTapped(MOCKED_DESIGN_SLUG, true)
         viewModel.onPreviewChooseTapped()
-        verify(analyticsTracker).trackSiteDesignSelected(mockedDesignSlug, true)
+        verify(analyticsTracker).trackSiteDesignSelected(MOCKED_DESIGN_SLUG, true)
     }
 
     @Test
     fun `when the user chooses a design that is not recommended the correct information is emitted`() = mockResponse {
         viewModel.start()
-        viewModel.onThumbnailReady(mockedDesignSlug)
-        viewModel.onLayoutTapped(mockedDesignSlug, false)
+        viewModel.onThumbnailReady(MOCKED_DESIGN_SLUG)
+        viewModel.onLayoutTapped(MOCKED_DESIGN_SLUG, false)
         viewModel.onPreviewChooseTapped()
-        verify(analyticsTracker).trackSiteDesignSelected(mockedDesignSlug, false)
+        verify(analyticsTracker).trackSiteDesignSelected(MOCKED_DESIGN_SLUG, false)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCaseTest.kt
@@ -47,8 +47,8 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
 
-private const val itemsToLoad = 6
-private val limitMode = LimitMode.Top(itemsToLoad)
+private const val ITEMS_TO_LOAD = 6
+private val limitMode = LimitMode.Top(ITEMS_TO_LOAD)
 private val statsGranularity = DAYS
 private val selectedDate = Date(0)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/CountryViewsUseCaseTest.kt
@@ -46,11 +46,11 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
 
-private const val itemsToLoad = 6
+private const val ITEMS_TO_LOAD = 6
 private val statsGranularity = DAYS
 private val selectedDate = Date(0)
 
-private val limitMode = Top(itemsToLoad)
+private val limitMode = Top(ITEMS_TO_LOAD)
 
 class CountryViewsUseCaseTest : BaseUnitTest() {
     @Mock lateinit var store: CountryViewsStore

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/FileDownloadsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/FileDownloadsUseCaseTest.kt
@@ -47,7 +47,7 @@ import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 
-private const val itemsToLoad = 6
+private const val ITEMS_TO_LOAD = 6
 private val statsGranularity = DAYS
 
 class FileDownloadsUseCaseTest : BaseUnitTest() {
@@ -106,7 +106,7 @@ class FileDownloadsUseCaseTest : BaseUnitTest() {
                 store.fetchFileDownloads(
                         site,
                         statsGranularity,
-                        Top(itemsToLoad),
+                        Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )
@@ -127,7 +127,7 @@ class FileDownloadsUseCaseTest : BaseUnitTest() {
                 store.fetchFileDownloads(
                         site,
                         statsGranularity,
-                        Top(itemsToLoad),
+                        Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )
@@ -168,7 +168,7 @@ class FileDownloadsUseCaseTest : BaseUnitTest() {
                 store.fetchFileDownloads(
                         site,
                         statsGranularity,
-                        Top(itemsToLoad),
+                        Top(ITEMS_TO_LOAD),
                         pastSelectedDate,
                         forced
                 )
@@ -196,7 +196,7 @@ class FileDownloadsUseCaseTest : BaseUnitTest() {
                 store.getFileDownloads(
                         site,
                         statsGranularity,
-                        Top(itemsToLoad),
+                        Top(ITEMS_TO_LOAD),
                         selectedDate
                 )
         ).thenReturn(model)
@@ -204,7 +204,7 @@ class FileDownloadsUseCaseTest : BaseUnitTest() {
                 store.fetchFileDownloads(
                         site,
                         statsGranularity,
-                        Top(itemsToLoad),
+                        Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )
@@ -237,7 +237,7 @@ class FileDownloadsUseCaseTest : BaseUnitTest() {
                 store.getFileDownloads(
                         site,
                         statsGranularity,
-                        Top(itemsToLoad),
+                        Top(ITEMS_TO_LOAD),
                         selectedDate
                 )
         ).thenReturn(model)
@@ -245,7 +245,7 @@ class FileDownloadsUseCaseTest : BaseUnitTest() {
                 store.fetchFileDownloads(
                         site,
                         statsGranularity,
-                        Top(itemsToLoad),
+                        Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )
@@ -275,7 +275,7 @@ class FileDownloadsUseCaseTest : BaseUnitTest() {
                 store.getFileDownloads(
                         site,
                         statsGranularity,
-                        Top(itemsToLoad),
+                        Top(ITEMS_TO_LOAD),
                         selectedDate
                 )
         ).thenReturn(model)
@@ -283,7 +283,7 @@ class FileDownloadsUseCaseTest : BaseUnitTest() {
                 store.fetchFileDownloads(
                         site,
                         statsGranularity,
-                        Top(itemsToLoad),
+                        Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/PostsAndPagesUseCaseTest.kt
@@ -45,7 +45,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
 
-private const val itemsToLoad = 6
+private const val ITEMS_TO_LOAD = 6
 private val statsGranularity = DAYS
 private val selectedDate = Date(0)
 
@@ -99,7 +99,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.fetchPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )
@@ -120,7 +120,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.fetchPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )
@@ -147,7 +147,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.getPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate
                 )
         ).thenReturn(model)
@@ -155,7 +155,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.fetchPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )
@@ -191,7 +191,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.getPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate
                 )
         ).thenReturn(model)
@@ -199,7 +199,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.fetchPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )
@@ -235,7 +235,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.getPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate
                 )
         ).thenReturn(model)
@@ -243,7 +243,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.fetchPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )
@@ -277,7 +277,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.getPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate
                 )
         ).thenReturn(model)
@@ -285,7 +285,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.fetchPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )
@@ -315,7 +315,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.getPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate
                 )
         ).thenReturn(model)
@@ -323,7 +323,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.fetchPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )
@@ -359,7 +359,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.getPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate
                 )
         ).thenReturn(model)
@@ -367,7 +367,7 @@ class PostsAndPagesUseCaseTest : BaseUnitTest() {
                 store.fetchPostAndPageViews(
                         site,
                         statsGranularity,
-                        LimitMode.Top(itemsToLoad),
+                        LimitMode.Top(ITEMS_TO_LOAD),
                         selectedDate,
                         forced
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCaseTest.kt
@@ -54,12 +54,12 @@ import org.wordpress.android.util.config.StatsRevampV2FeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Date
 
-private const val itemsToLoad = 300
-private const val groupIdWordPress = "WordPress.com Reader"
-private const val groupIdSearch = "Search Engines"
+private const val ITEMS_TO_LOAD = 300
+private const val GROUP_ID_WORDPRESS = "WordPress.com Reader"
+private const val GROUP_ID_SEARCH = "Search Engines"
 private val statsGranularity = DAYS
 private val selectedDate = Date(0)
-private val limitMode = Top(itemsToLoad)
+private val limitMode = Top(ITEMS_TO_LOAD)
 
 @InternalCoroutinesApi
 class ReferrersUseCaseTest : BaseUnitTest() {
@@ -79,7 +79,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
     private val thirdGroupViews = 40
     private val totalViews = firstGroupViews + secondGroupViews + thirdGroupViews
     private val wordPressReferrer = Group(
-            groupIdWordPress,
+            GROUP_ID_WORDPRESS,
             "Group 1",
             "group1.jpg",
             "group1.com",
@@ -88,7 +88,7 @@ class ReferrersUseCaseTest : BaseUnitTest() {
             false
     )
     private val searchReferrer = Group(
-            groupIdSearch,
+            GROUP_ID_SEARCH,
             "Group 2",
             "group2.jpg",
             "group2.com",

--- a/build.gradle
+++ b/build.gradle
@@ -101,11 +101,6 @@ allprojects {
         ignoreFailures = false
         parallel = true
         debug = false
-        reports {
-            html.enabled = true
-            xml.enabled = true
-            txt.enabled = true
-        }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -69,8 +69,6 @@
     <ID>EmptyFunctionBlock:WidgetBlockListProvider.kt$WidgetBlockListProvider${ }</ID>
     <ID>EmptyFunctionBlock:WordPressGlideModule.kt$WordPressGlideModule${}</ID>
     <ID>EmptySecondaryConstructor:WPEditTextWithChipsOutlined.kt$WPEditTextWithChipsOutlined.SavedState${}</ID>
-    <ID>FunctionNaming:WPMainActivityViewModel.kt$WPMainActivityViewModel$// create_post_page_fab_tooltip_stories_feature_flag_on private fun getCreateContentMessageId_StoriesFlagOn(hasFullAccessToContent: Boolean): Int</ID>
-    <ID>FunctionNaming:WPMainActivityViewModel.kt$WPMainActivityViewModel$private fun getCreateContentMessageId_StoriesFlagOff(hasFullAccessToContent: Boolean): Int</ID>
     <ID>FunctionParameterNaming:WizardManager.kt$WizardManager$T: WizardStep</ID>
     <ID>LargeClass:PagesViewModel.kt$PagesViewModel : ScopedViewModel</ID>
     <ID>LargeClass:ReaderPostDetailFragment.kt$ReaderPostDetailFragment : ViewPagerFragmentOnActivityBackPressedListenerScrollDirectionListenerReaderCustomViewListenerReaderWebViewPageFinishedListenerReaderWebViewUrlClickListenerPrivateAtCookieProgressDialogOnDismissListenerAutoHideToolbarListener</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -26,7 +26,6 @@
     <ID>ComplexMethod:PostListActionTracker.kt$fun trackPostListAction(site: SiteModel, buttonType: PostListButtonType, postData: PostModel, statsEvent: Stat)</ID>
     <ID>ComplexMethod:PostListDialogHelper.kt$PostListDialogHelper$fun onPositiveClickedForBasicDialog( instanceTag: String, trashPostWithLocalChanges: (Int) -> Unit, trashPostWithUnsavedChanges: (Int) -> Unit, deletePost: (Int) -> Unit, publishPost: (Int) -> Unit, updateConflictedPostWithRemoteVersion: (Int) -> Unit, editRestoredAutoSavePost: (Int) -> Unit, moveTrashedPostToDraft: (Int) -> Unit, resolveConflictsAndEditPost: (Int) -> Unit )</ID>
     <ID>ComplexMethod:PostListItemUiStateHelper.kt$PostListItemUiStateHelper$private fun createButtonTypes( postStatus: PostStatus, isLocalDraft: Boolean, isLocallyChanged: Boolean, uploadUiState: PostUploadUiState, siteHasCapabilitiesToPublish: Boolean, statsSupported: Boolean ): List&lt;PostListButtonType></ID>
-    <ID>ComplexMethod:ReaderPostBookmarkUseCase.kt$ReaderPostBookmarkUseCase$private fun trackEvent( bookmarked: Boolean, isBookmarkList: Boolean, post: ReaderPost, source: String )</ID>
     <ID>ComplexMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment$private fun ReaderNavigationEvents.handleNavigationEvent()</ID>
     <ID>ComplexMethod:ReferrersUseCase.kt$ReferrersUseCase$override fun buildUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List&lt;BlockListItem></ID>
     <ID>ComplexMethod:SystemNotificationsTracker.kt$SystemNotificationsTracker$private fun NotificationType.toTypeValue(): String</ID>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,4 +1,5 @@
 # Default Config: https://github.com/detekt/detekt/blob/main/detekt-core/src/main/resources/default-detekt-config.yml
+# Formatting Config: https://github.com/detekt/detekt/blob/main/detekt-formatting/src/main/resources/config/config.yml
 
 config:
   warningsAsErrors: true
@@ -6,10 +7,6 @@ config:
 complexity:
   LongParameterList:
     ignoreAnnotated: ['Inject']
-
-formatting:
-  android: true
-  autoCorrect: false
 
 naming:
   FunctionNaming:

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     gradle.ext.kotlinVersion = '1.6.10'
     gradle.ext.agpVersion = '7.2.1'
     gradle.ext.daggerVersion = "2.42"
-    gradle.ext.detektVersion = '1.19.0'
+    gradle.ext.detektVersion = '1.20.0'
     gradle.ext.navComponentVersion = '2.4.2'
 
     plugins {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     gradle.ext.kotlinVersion = '1.6.10'
     gradle.ext.agpVersion = '7.2.1'
     gradle.ext.daggerVersion = "2.42"
-    gradle.ext.detektVersion = '1.20.0'
+    gradle.ext.detektVersion = '1.21.0'
     gradle.ext.navComponentVersion = '2.4.2'
 
     plugins {


### PR DESCRIPTION
Parent: #16892
Closes: #16898
Closes: #16899

This PR:
- Updates Detekt to `1.21.0` (from `1.19.0` via `1.20.0`) (f9803cb85794c96be310bf620f8b33a45b4a544a + bb316e90db785a36a6bf08f5726e9dfd87a255b3).
- Updates Detekt configuration to adhere with the update (6462ecc9f8a1d86808d55ae6b0de3af585fc1d09 + 0b8225936a17bff1bcb7ae072a9ab3260a14d2f0)
- 1.20.0 Related:
    - Resolves `UnnecessaryAbstractClass` warnings (d702ca924b2c56f9c5bc24e8768aaff335b9537c)
    - Resolves `TopLevelPropertyNaming` warnings (4ef2603db97bce726d32fff243c6ba9e72f4770d)
- 1.21.0 Related:
    - Suppresses `UseCheckOrError` warnings (bd4df02300cdfe189fac66141c713fb4ed2e2306)
    - Resolves `ExplicitItLambdaParameter` warnings (3046bb71c7375313b0cdf72d0e6927651867304a)
    - Resolves `UseRequire` warnings (0983a08d2a3d19f5bb56055676dfdca5d8596ca5)
    - Suppresses `DestructuringDeclarationWithTooManyEntries` warnings (e6346527ad5d9796d112094fc3d1ff392bd6c666)
    - Suppresses `ReturnCount` warnings (74baf6ee1ff616c15fa08b7f8d250e80d290614a)
    - Resolves `FunctionNaming` warnings (8ba62d7be11f3f1e29106acf996e2c112233462d)
    - Suppresses `ComplexMethod` warning (bd067b69cbae70d980c50e154dc2b2fb5cdb4005)

PS: I recommend reviewing this PR commit-by-commit.

-----

To test:

- Verify that all the CI checks are successful (especially the detekt check).
- Smoke test the app and verify everything works as expected.

-----

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
