### PR TITLE
Jetpack focus: Connect Jetpack overlay to banners

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.jetpack.backup.download.KEY_BACKUP_DOWNLOAD_REWI
 import org.wordpress.android.ui.jetpack.common.JetpackBackupDownloadActionState
 import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_RESTORE_ID
 import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_REWIND_ID
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_KEY
 import javax.inject.Inject
@@ -43,6 +44,14 @@ class ActivityLogListActivity : LocaleAwareActivity() {
                 val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
                 fragment?.view?.updateLayoutParams<MarginLayoutParams> {
                     bottomMargin = resources.getDimensionPixelSize(R.dimen.jetpack_banner_height)
+                }
+
+                if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                    jetpackBanner.root.setOnClickListener {
+                        JetpackPoweredBottomSheetFragment
+                                .newInstance()
+                                .show(supportFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
+                    }
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -74,12 +74,15 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
 import static org.wordpress.android.models.Note.NOTE_COMMENT_LIKE_TYPE;
 import static org.wordpress.android.models.Note.NOTE_COMMENT_TYPE;
 import static org.wordpress.android.models.Note.NOTE_FOLLOW_TYPE;
 import static org.wordpress.android.models.Note.NOTE_LIKE_TYPE;
 import static org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter.IS_TAPPED_ON_NOTIFICATION;
 
+@AndroidEntryPoint
 public class NotificationsDetailActivity extends LocaleAwareActivity implements
         CommentActions.OnNoteCommentActionListener,
         BasicFragmentDialog.BasicDialogPositiveClickInterface, ScrollableViewInitializedListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -308,6 +308,14 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
                 val scrollableView = binding?.root?.findViewById<View>(containerId) as? RecyclerView ?: return@post
                 jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
                 jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
+
+                if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                    jetpackBannerView.setOnClickListener {
+                        JetpackPoweredBottomSheetFragment
+                                .newInstance()
+                                .show(childFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
+                    }
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -32,6 +32,7 @@ import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.ScrollableViewInitializedListener;
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.services.PublicizeUpdateService;
@@ -81,13 +82,20 @@ public class PublicizeListActivity extends LocaleAwareActivity
         mAppBarLayout = findViewById(R.id.appbar_main);
 
         if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
-            findViewById(R.id.jetpack_banner).setVisibility(View.VISIBLE);
+            View jetpackBanner = findViewById(R.id.jetpack_banner);
+            jetpackBanner.setVisibility(View.VISIBLE);
             mJetpackBrandingUtils.setNavigationBarColorForBanner(getWindow());
 
             // Add bottom margin to content.
             MarginLayoutParams layoutParams =
                     (MarginLayoutParams) findViewById(R.id.fragment_container).getLayoutParams();
             layoutParams.bottomMargin = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
+
+            if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                jetpackBanner.setOnClickListener(v ->
+                        new JetpackPoweredBottomSheetFragment()
+                                .show(getSupportFragmentManager(), JetpackPoweredBottomSheetFragment.TAG));
+            }
         }
 
         if (savedInstanceState == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -330,6 +330,14 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
                 val scrollableView = binding?.root?.findViewById<View>(containerId) as? RecyclerView ?: return@post
                 jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
                 jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
+
+                if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                    jetpackBannerView.setOnClickListener {
+                        JetpackPoweredBottomSheetFragment
+                                .newInstance()
+                                .show(childFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
+                    }
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -80,6 +80,7 @@ import org.wordpress.android.ui.main.WPMainNavigationView;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository;
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.ui.pages.SnackbarMessageHolder;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderEvents.TagAdded;
@@ -502,7 +503,14 @@ public class ReaderPostListFragment extends ViewPagerFragment
         if (!isAdded() || !isSearching() || getView() == null) return;
         final boolean shouldShow = forceShow && mJetpackBrandingUtils.shouldShowJetpackBranding();
         if (shouldShow) {
-            getView().findViewById(R.id.jetpack_banner).setVisibility(View.VISIBLE);
+            View jetpackBanner = getView().findViewById(R.id.jetpack_banner);
+            jetpackBanner.setVisibility(View.VISIBLE);
+
+            if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                jetpackBanner.setOnClickListener(v ->
+                        new JetpackPoweredBottomSheetFragment()
+                                .show(getChildFragmentManager(), JetpackPoweredBottomSheetFragment.TAG));
+            }
             // Add bottom margin to post list and empty view.
             int jetpackBannerHeight = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
             ((MarginLayoutParams) getView().findViewById(R.id.reader_recycler_view).getLayoutParams())

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSearchActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSearchActivity.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.reader
 
 import android.os.Bundle
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.LocaleAwareActivity
@@ -13,6 +14,7 @@ import javax.inject.Inject
  * ReaderPostListFragment was out-of-scope. This workaround enabled us writing new "discover" and "following" screens
  * into new tested classes without requiring us to change the search behavior.
  */
+@AndroidEntryPoint
 class ReaderSearchActivity : LocaleAwareActivity() {
     @Inject lateinit var readerTracker: ReaderTracker
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.push.NotificationType
 import org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE
 import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.JetpackBrandingUtils
@@ -32,6 +33,14 @@ class StatsActivity : LocaleAwareActivity() {
             if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
                 jetpackBanner.root.isVisible = true
                 jetpackBrandingUtils.setNavigationBarColorForBanner(window)
+
+                if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                    jetpackBanner.root.setOnClickListener {
+                        JetpackPoweredBottomSheetFragment
+                                .newInstance()
+                                .show(supportFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This PR connects Jetpack overlay with all **Jetpack powered** banners on the following

Fixes: #16976 

- Activity Log
- Sharing
- Reader
- Reader search
- Notifications
- Stats


| Bottom Sheet | Google Play | Jetpack app |
|---|---|---|
|![Screenshot_20220726_124506](https://user-images.githubusercontent.com/990349/180912546-399bd576-12e1-400c-8190-164757936506.png)| ![Screenshot_20220726_124826](https://user-images.githubusercontent.com/990349/180912637-8eab334a-c99b-4ae3-a43a-2a05e1fcb704.png)|![Screenshot_20220726_124553](https://user-images.githubusercontent.com/990349/180912679-af06a12a-b605-4ef0-94c6-e4ea6b0fc8ef.png)|

Fixes #

To test:

Setup

- Launch WordPress app
- Go to App Settings (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
- Select Debug Settings
- Find JetpackPoweredBottomSheetFeatureConfig under Features in development [as shown on this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16957)
- Re-launch app (scroll down if necessary)

Test 1

- Find banners [as shown on this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16906) (Except Themes and People that have been removed) 
- Tap on banner.  Ensure, the bottom sheet pops up as above
- CTA should take to Goolgle Play store or open Jepack app if already installed
- You can dismiss the bottom sheet by either clicking anywhere outside or dragging it down

Test 2
- Repeat the steps from Test 1 above on Reader search [as show on this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16920)

Also fixes #16963 

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Update unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
