### PR TITLE
Jetpack Focus: Adjust screenshots for site topic

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -8,6 +8,7 @@ import androidx.annotation.IdRes;
 import androidx.annotation.StringRes;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.appcompat.widget.Toolbar;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
 import androidx.test.espresso.ViewInteraction;
@@ -20,6 +21,7 @@ import org.wordpress.android.ui.prefs.WPPreference;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem;
@@ -81,7 +83,14 @@ public class MySitesPage {
 
     public void startNewSite() {
         switchSite();
-        clickOn(R.id.menu_add);
+        // If the device has a narrower display, the menu_add is hidden in the overflow
+        if (isElementDisplayed(R.id.menu_add)) {
+            clickOn(R.id.menu_add);
+        } else {
+            // open the overflow and then click on the item with text
+            openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
+            onView(withText(getTranslatedString(R.string.site_picker_add_site))).perform(click());
+        }
     }
 
     public void goToSettings() {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
@@ -199,8 +199,6 @@ public class JPScreenshotTest extends BaseTest {
         clickOn(R.id.nav_sites);
         (new MySitesPage()).startNewSite();
 
-        waitForElementToBeDisplayedWithoutFailure(R.id.recycler_view);
-
         // Wait for page to load
         idleFor(2000);
 


### PR DESCRIPTION
Parent #16900 


This PR adjusts the `startNewSite` to account for narrower displays.

To test:
1. Checkout the PR branch locally 
2. Switch to `jetpackJalapenoDebug` build variant.
3. Launch an emulator or physical device that has a narrower display. I used a physical Pixel 5 device
4. Run the `jPScreenshotTest` from `JPScreenshotTest` in Android Studio to check that it **succeeds**.

   ⚠️ **Note:** _When running multiple times you may get fails with Hilt or sometimes wiremock. We are starting an investigation into upgrading our wiremock library (we are really, really, really, far behind). Hopefully that will fix the wiremock issues._

   <details>
   <summary>Emulator Setup Guide</summary>

     Ideally we run the tests on an emulator created by fastlane. See the notes in the issue for how this can be done:

     > Follow the guide in `SCREENSHOT_DEVICE_SETUP.md` to create a device like the ones we're using for screenshots automation (this won't be super easy as the guide is a bit outdated and if you're on an M1 Mac you have to change the generated .ini files manually to set the arm64 architecture or else the emultators won't start.
   </details>

5. Close emulator & wipe data
6. Switch to a device with a wider display and rerun from step 4


## Regression Notes
1. Potential unintended areas of impact
JP Screenshot tests no longer work

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually ran the JPScreenshotTest

3. What automated tests I added (or what prevented me from doing so)
This is an automated test

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
