### PR TITLE
[UI Tests] Reduce flakiness of Block Editor tests.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.java
@@ -40,7 +40,7 @@ public class BlockEditorTests extends BaseTest {
 
     @Test
     public void publishSimplePost() {
-        String mTitle = new Throwable().getStackTrace()[0].getMethodName();
+        String title = "publishSimplePost";
 
         new MySitesPage()
                 .go()
@@ -48,7 +48,7 @@ public class BlockEditorTests extends BaseTest {
 
         new BlockEditorPage()
                 .waitForTitleDisplayed()
-                .enterTitle(mTitle)
+                .enterTitle(title)
                 .enterParagraphText(mPostText)
                 .publish()
                 .verifyPostPublished();
@@ -56,7 +56,7 @@ public class BlockEditorTests extends BaseTest {
 
     @Test
     public void publishFullPost() {
-        String mTitle = new Throwable().getStackTrace()[0].getMethodName();
+        String title = "publishFullPost";
 
         new MySitesPage()
                 .go()
@@ -64,7 +64,7 @@ public class BlockEditorTests extends BaseTest {
 
         new BlockEditorPage()
                 .waitForTitleDisplayed()
-                .enterTitle(mTitle)
+                .enterTitle(title)
                 .enterParagraphText(mPostText)
                 .addImage()
                 .addPostSettings(mCategory, mTag)
@@ -76,7 +76,7 @@ public class BlockEditorTests extends BaseTest {
 
     @Test
     public void blockEditorCanDisplayElementAddedInHtmlMode() {
-        String mTitle = new Throwable().getStackTrace()[0].getMethodName();
+        String title = "blockEditorCanDisplayElementAddedInHtmlMode";
 
         new MySitesPage()
                 .go()
@@ -84,7 +84,7 @@ public class BlockEditorTests extends BaseTest {
 
         new BlockEditorPage()
                 .waitForTitleDisplayed()
-                .enterTitle(mTitle)
+                .enterTitle(title)
                 .switchToHtmlMode()
                 .enterParagraphText(mHtmlPost)
                 .switchToVisualMode()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.java
@@ -26,7 +26,6 @@ public class BlockEditorTests extends BaseTest {
         wpLogin();
     }
 
-    String mTitle = "Hello Espresso!";
     String mPostText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
     String mCategory = "Wedding";
     String mTag = "Tag " + Instant.now().toEpochMilli();
@@ -41,6 +40,8 @@ public class BlockEditorTests extends BaseTest {
 
     @Test
     public void publishSimplePost() {
+        String mTitle = new Throwable().getStackTrace()[0].getMethodName();
+
         new MySitesPage()
                 .go()
                 .startNewPost();
@@ -55,6 +56,8 @@ public class BlockEditorTests extends BaseTest {
 
     @Test
     public void publishFullPost() {
+        String mTitle = new Throwable().getStackTrace()[0].getMethodName();
+
         new MySitesPage()
                 .go()
                 .startNewPost();
@@ -73,6 +76,8 @@ public class BlockEditorTests extends BaseTest {
 
     @Test
     public void blockEditorCanDisplayElementAddedInHtmlMode() {
+        String mTitle = new Throwable().getStackTrace()[0].getMethodName();
+
         new MySitesPage()
                 .go()
                 .startNewPost();

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
@@ -2,7 +2,6 @@ package org.wordpress.android.e2e.pages;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.ViewInteraction;
-import androidx.test.espresso.action.ViewActions;
 
 import org.wordpress.android.R;
 
@@ -11,7 +10,6 @@ import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.swipeDown;
-import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
@@ -42,13 +40,12 @@ public class BlockEditorPage {
     }
 
     public BlockEditorPage enterTitle(String postTitle) {
-        titleField.perform(typeText(postTitle), ViewActions.closeSoftKeyboard());
+        populateTextField(titleField, postTitle);
         return this;
     }
 
     public BlockEditorPage enterParagraphText(String paragraphText) {
-        onView(withHint(R.string.gutenberg_native_start_writing))
-                .perform(typeText(paragraphText), ViewActions.closeSoftKeyboard());
+        populateTextField(onView(withHint(R.string.gutenberg_native_start_writing)), paragraphText);
         return this;
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
@@ -2,6 +2,7 @@ package org.wordpress.android.e2e.pages;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.ViewInteraction;
+import androidx.test.espresso.action.ViewActions;
 
 import org.wordpress.android.R;
 
@@ -10,6 +11,7 @@ import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.swipeDown;
+import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
@@ -41,7 +43,7 @@ public class BlockEditorPage {
 
     public BlockEditorPage enterTitle(String postTitle) {
         clickOn(titleField);
-        populateTextField(titleField, postTitle);
+        titleField.perform(typeText(postTitle), ViewActions.closeSoftKeyboard());
         return this;
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
@@ -40,12 +40,15 @@ public class BlockEditorPage {
     }
 
     public BlockEditorPage enterTitle(String postTitle) {
+        clickOn(titleField);
         populateTextField(titleField, postTitle);
         return this;
     }
 
     public BlockEditorPage enterParagraphText(String paragraphText) {
-        populateTextField(onView(withHint(R.string.gutenberg_native_start_writing)), paragraphText);
+        ViewInteraction startWritingPrompt = onView(withHint(R.string.gutenberg_native_start_writing));
+        clickOn(startWritingPrompt);
+        populateTextField(startWritingPrompt, paragraphText);
         return this;
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -265,6 +265,7 @@ public class WPSupportUtils {
 
     public static void populateTextField(ViewInteraction element, String text) {
         waitForElementToBeDisplayed(element);
+        clickOn(element);
         element.perform(replaceText(text))
                .perform(closeSoftKeyboard());
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -264,7 +264,7 @@ public class WPSupportUtils {
     }
 
     public static void populateTextField(ViewInteraction element, String text) {
-        clickOn(element);
+        waitForElementToBeDisplayed(element);
         element.perform(replaceText(text))
                .perform(closeSoftKeyboard());
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -264,7 +264,6 @@ public class WPSupportUtils {
     }
 
     public static void populateTextField(ViewInteraction element, String text) {
-        waitForElementToBeDisplayed(element);
         clickOn(element);
         element.perform(replaceText(text))
                .perform(closeSoftKeyboard());


### PR DESCRIPTION
### Why

There was a relatively low, but annoying number of fails related to Block Editor tests, especially `publishSimplePost`. Traditionally, they never failed locally, so debugging wasn't easy. My assumption is that fails were related to general issues caused by low emulator performance, which affected featured images display, state transitions, etc. One example is below (notice that paragraph text is partly typed into the header):
<img width="281" alt="Screenshot 2022-07-28 at 12 51 01" src="https://user-images.githubusercontent.com/73365754/181884382-859e9e8d-017e-4850-a78f-01d21aded42c.png">


### How
- 8dd76e6aacf95b03d7bca7d308cfe89fa5146351: Instead of using `onView(SomeViewInteraction).perform(typeText(text), ViewActions.closeSoftKeyboard())` I went for the `populateTextField` from `WPSupportUtils`, and added a `clickOn` into it, to make sure the input is focused before entering the text. `clickOn` additionally contains a 2-second sleep, which should compensate for slower state transitions. Even with this, the execution became faster, because `populateTextField` uses `replaceText` and not `typeText`.
- 705afc76eba1b8020ee22ed5f8a7bcae7a599155: Solely for easier debugging while watching FTL video recordings, the post header for all three tests now equals the current test name, instead of sharing the same name, which made it hard to know what tests we're looking at.

### To test:
- All executions on CI are green (you can see all but the first two commits being just empty commits to start the tests).

P.S. To be honest, I recreated this PR from scratch in order to have a clean commit history. If you want to see a real mess, here's #16958