### PR TITLE
[UI Tests] Disable `ScreenshotTest `

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
@@ -11,6 +11,7 @@ import androidx.test.filters.LargeTest;
 import com.google.android.libraries.cloudtesting.screenshots.ScreenShotter;
 
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
@@ -95,6 +96,7 @@ public class JPScreenshotTest extends BaseTest {
         }
     }
 
+    @Ignore("Ignored until there's a way to exclude tests on FTL properly, via `--test-targets` option.")
     @Test
     public void jPScreenshotTest() {
         if (BuildConfig.IS_JETPACK_APP) {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -50,7 +50,7 @@ public class WPScreenshotTest extends BaseTest {
 
     private DemoModeEnabler mDemoModeEnabler = new DemoModeEnabler();
 
-    @Ignore
+    @Ignore("Ignored until there's a way to exclude tests on FTL properly, via `--test-targets` option.")
     @Test
     public void wPScreenshotTest() {
         if (!BuildConfig.IS_JETPACK_APP) {


### PR DESCRIPTION
### Why
Screenshots tests should not be a part of Instrumented tests execution on CI, because they are not tests in essence.
While they look like tests, they lack assertions, and their purpose is generating screenshots for Play Store.

### How
Using `@Ignore` annotation. The proper way would have been using the [--test-targets](https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run#--test-targets) option, and passing `notPackage org.wordpress.android.ui.screenshots` with it, however, it's not yet supported by release-toolkit. It's suport is planned to be added, (see p1659005542770259-slack-CC7L49W13), but as long as it's not there, I guess `@Ignore` is the best option.

### To test
- CI is green (the fail in the very first commit is something ultra-rare, it's a JP ad shown without dismiss button 🤔, definitely needs attention if this reappears).
- `jPScreenshotTest` and `wPScreenshotTest` are skipped on CI.