### PR TITLE
Add AppInitializerTest to test ProcessLifecycleOwner

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android
+
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+import org.wordpress.android.support.BaseTest
+
+@HiltAndroidTest
+class AppInitializerTest : BaseTest() {
+    // This tests if ProcessLifecycleOwner observer works at the app startup.
+    @Test
+    fun verifyOnAppComesFromBackgroundCalled() {
+        // WordPress.appIsInTheBackground is set to false when OnAppComesFromBackground() is called.
+        assert(!WordPress.appIsInTheBackground)
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
@@ -1,15 +1,21 @@
 package org.wordpress.android
 
+import androidx.lifecycle.ProcessLifecycleOwner
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
+import org.wordpress.android.AppInitializer.ApplicationLifecycleMonitor
 import org.wordpress.android.support.BaseTest
 
+/**
+ * This tests if [ProcessLifecycleOwner] observer works at the app startup.
+ *
+ * [WordPress.appIsInTheBackground] is set to false when [ApplicationLifecycleMonitor.onAppComesFromBackground] is
+ * called.
+ */
 @HiltAndroidTest
 class AppInitializerTest : BaseTest() {
-    // This tests if ProcessLifecycleOwner observer works at the app startup.
     @Test
     fun verifyOnAppComesFromBackgroundCalled() {
-        // WordPress.appIsInTheBackground is set to false when OnAppComesFromBackground() is called.
         assert(!WordPress.appIsInTheBackground)
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android
 
 import androidx.lifecycle.ProcessLifecycleOwner
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.wordpress.android.AppInitializer.ApplicationLifecycleMonitor
 import org.wordpress.android.support.BaseTest
@@ -16,6 +17,6 @@ import org.wordpress.android.support.BaseTest
 class AppInitializerTest : BaseTest() {
     @Test
     fun verifyOnAppComesFromBackgroundCalled() {
-        assert(!WordPress.appIsInTheBackground)
+        assertFalse(WordPress.appIsInTheBackground)
     }
 }


### PR DESCRIPTION
This adds a test to check if ProcessLifecycleOwner's observer works correctly. In version `20.1`, the observer was broken, and that caused [AppInitializer#onAppComesFromBackground()](https://github.com/wordpress-mobile/WordPress-Android/blob/737af85f63f2a59bac7ecbc1244030b1e779f58e/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt#L693) not to be called.

To test:
**Success case:**
1. Run `AppInitializerTest`.
2. Ensure `verifyOnAppComesFromBackgroundCalled` passes.

**Fail case:**
1. Break the observer by reverting https://github.com/wordpress-mobile/WordPress-Android/commit/c6f5e2ad6f39a5041607ddfe667740782b4f235a locally.
2. Run `AppInitializerTest`.
3. Ensure `verifyOnAppComesFromBackgroundCalled` fails.

## Regression Notes
1. Potential unintended areas of impact
N/A

4. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
`AppInitializerTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
