### PR TITLE
[WIP] [UI Tests] Addressing the unexpected `Nuage Laboratoire` user login on FTL.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -38,6 +38,7 @@ public class LoginFlow {
     public LoginFlow enterEmailAddress(String emailAddress) {
         // Email Address Screen – Fill it in and click "Continue"
         // See LoginEmailFragment
+        clickOn(R.id.input);
         populateTextField(R.id.input, emailAddress);
         clickOn(R.id.login_continue_button);
         return this;
@@ -46,6 +47,7 @@ public class LoginFlow {
     public LoginFlow enterPassword(String password) {
         // Password Screen – Fill it in and click "Continue"
         // See LoginEmailPasswordFragment
+        clickOn(R.id.input);
         populateTextField(R.id.input, password);
         clickOn(R.id.bottom_button);
         return this;
@@ -104,7 +106,9 @@ public class LoginFlow {
                 Matchers.instanceOf(EditText.class)));
         ViewInteraction passwordElement = onView(allOf(isDescendantOfA(withId(R.id.login_password_row)),
                 Matchers.instanceOf(EditText.class)));
+        clickOn(usernameElement);
         populateTextField(usernameElement, username + "\n");
+        clickOn(passwordElement);
         populateTextField(passwordElement, password + "\n");
         clickOn(R.id.bottom_button);
         return this;
@@ -120,6 +124,7 @@ public class LoginFlow {
     public LoginFlow enterSiteAddress(String siteAddress) {
         // Site Address Screen – Fill it in and click "Continue"
         // See LoginSiteAddressFragment
+        clickOn(R.id.input);
         populateTextField(R.id.input, siteAddress);
         clickOn(R.id.bottom_button);
         return this;

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -820,8 +820,10 @@ public class WPSupportUtils {
     }
 
     public static void dismissJetpackAdIfPresent() {
+        String jpAdText = "Stats, Reader, Notifications, and other features are powered by Jetpack.";
+
         // Dismiss Jetpack ad that might be shown after Sign-Up or after opening Stats
-        if (isElementDisplayed(onView(withText("Jetpack powered")))) {
+        if (isElementDisplayed(onView(withText(jpAdText)))) {
             clickOn(onView(withId(R.id.secondary_button)));
         }
     }


### PR DESCRIPTION
### Why?

In some (not so rare, recently) [cases](https://console.firebase.google.com/u/1/project/api-project-108380595987/testlab/histories/bh.b3d1e88d8b09c8be/matrices/6811417613467581144/details?stepId=bs.a499dbd14c98e8e4&testCaseId=13), this pop-up would appear during log in, when UI tests are executed on FTL:

<img width="288" alt="Screenshot 2022-07-29 at 21 14 25" src="https://user-images.githubusercontent.com/73365754/182352170-a2f35b18-98cd-436d-9163-95b9559ce687.png">

While the reason behind this user being present at all is likely explained [here](https://stackoverflow.com/questions/40366572/who-owns-this-email-cloudtestlabaccounts-com), the [proposed](https://stackoverflow.com/questions/40366572/who-owns-this-email-cloudtestlabaccounts-com#comment94602176_40366919) solution to disable pre-launch reports is probably not ideal. Moreover, the fact of this user being logged in into the Emulator does not explain the fact of this pop-up being show. This pop-up should be shown only after the user taps `Continue with Google`, which does not happen in any of our tests.

In FTL videos, in all cases this pop-up is shown, the email is not entered into the email field (which should happen). In such case, the usual `Continue` button is disabled. My very vague guess is that in such situation, the test runner might try to tap the only available enabled button, which is `Continue with Google` 🤷 , making this pop-up to appear.

### How

Instead of trying to close the pop-up (which will likely be tricky, because it's not a part of the app), I firstly went for increasing the probability of actually entering all data during login, in a very simple way: adding `clickOn` before trying to enter a text into certain input.

### To test

CI is green. 

Since the original issue did not appear too often, I see value in merging the PR and seeing if the solution will actually help, instead of having 50 reruns inside the branch.