### PR TITLE
UI Test: allDayStatsLoad add idle

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -175,6 +175,7 @@ public class MySitesPage {
     public StatsPage goToStats() {
         goToMenuTab();
         clickQuickActionOrSiteMenuItem(R.id.quick_action_stats_button, R.string.stats);
+        idleFor(4000);
         dismissJetpackAdIfPresent();
         waitForElementToBeDisplayedWithoutFailure(R.id.tabLayout);
 


### PR DESCRIPTION
This PR attempts to fix a failing `allDayStatsLoad` instrumentation test by adding an `idleFor(4000);` before checking if a jetpack ad is present in `MySitesPage.goToStats()`

To test:
- Run the StatsTests.allDayStatsLoad() test
- Verify that it passes

## Regression Notes
1. Potential unintended areas of impact
Test fails

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Run the test locally

3. What automated tests I added (or what prevented me from doing so)
This is an automated test

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
