### PR TITLE
Integrate gutenberg-mobile release 1.80.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = 'trunk-68e2995962a5134770e6f9e5b9f258a339e123b2'
     wordPressLoginVersion = '0.15.0'
-    gutenbergMobileVersion = '5067-eb9d57c2311077183e4e70da77afbe2c8f92b63c'
+    gutenbergMobileVersion = 'v1.80.1'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = 'trunk-68e2995962a5134770e6f9e5b9f258a339e123b2'
     wordPressLoginVersion = '0.15.0'
-    gutenbergMobileVersion = 'v1.80.0'
+    gutenbergMobileVersion = '5067-eb9d57c2311077183e4e70da77afbe2c8f92b63c'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.80.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5067

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.