### PR TITLE
[UI Tests] Addressing the `Nuage Laboratoire` issue and accidental(?) JP banner tap.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -38,6 +38,7 @@ public class LoginFlow {
     public LoginFlow enterEmailAddress(String emailAddress) {
         // Email Address Screen – Fill it in and click "Continue"
         // See LoginEmailFragment
+        clickOn(R.id.input);
         populateTextField(R.id.input, emailAddress);
         clickOn(R.id.login_continue_button);
         return this;
@@ -46,6 +47,7 @@ public class LoginFlow {
     public LoginFlow enterPassword(String password) {
         // Password Screen – Fill it in and click "Continue"
         // See LoginEmailPasswordFragment
+        clickOn(R.id.input);
         populateTextField(R.id.input, password);
         clickOn(R.id.bottom_button);
         return this;
@@ -104,7 +106,9 @@ public class LoginFlow {
                 Matchers.instanceOf(EditText.class)));
         ViewInteraction passwordElement = onView(allOf(isDescendantOfA(withId(R.id.login_password_row)),
                 Matchers.instanceOf(EditText.class)));
+        clickOn(usernameElement);
         populateTextField(usernameElement, username + "\n");
+        clickOn(passwordElement);
         populateTextField(passwordElement, password + "\n");
         clickOn(R.id.bottom_button);
         return this;
@@ -120,6 +124,7 @@ public class LoginFlow {
     public LoginFlow enterSiteAddress(String siteAddress) {
         // Site Address Screen – Fill it in and click "Continue"
         // See LoginSiteAddressFragment
+        clickOn(R.id.input);
         populateTextField(R.id.input, siteAddress);
         clickOn(R.id.bottom_button);
         return this;

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -820,10 +820,10 @@ public class WPSupportUtils {
     }
 
     public static void dismissJetpackAdIfPresent() {
-        String jpAdText = "Stats, Reader, Notifications, and other features are powered by Jetpack.";
+        String jetpackAdText = "Stats, Reader, Notifications, and other features are powered by Jetpack.";
 
         // Dismiss Jetpack ad that might be shown after Sign-Up or after opening Stats
-        if (isElementDisplayed(onView(withText(jpAdText)))) {
+        if (isElementDisplayed(onView(withText(jetpackAdText)))) {
             clickOn(onView(withId(R.id.secondary_button)));
         }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -826,5 +826,7 @@ public class WPSupportUtils {
         if (isElementDisplayed(onView(withText(jpAdText)))) {
             clickOn(onView(withId(R.id.secondary_button)));
         }
+
+        idleFor(3000);
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -821,12 +821,16 @@ public class WPSupportUtils {
 
     public static void dismissJetpackAdIfPresent() {
         String jetpackAdText = "Stats, Reader, Notifications, and other features are powered by Jetpack.";
+        ViewInteraction jetpackBanner = onView(withText(jetpackAdText));
 
         // Dismiss Jetpack ad that might be shown after Sign-Up or after opening Stats
-        if (isElementDisplayed(onView(withText(jetpackAdText)))) {
+        if (isElementDisplayed(jetpackBanner)) {
             clickOn(onView(withId(R.id.secondary_button)));
-        }
+            waitForElementToNotBeDisplayed(jetpackBanner);
 
-        idleFor(3000);
+            // Account for potential Emulator slowness on CI: the case of banner text
+            // being already hidden, but top part of banner still sliding away
+            idleFor(1000);
+        }
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -820,8 +820,10 @@ public class WPSupportUtils {
     }
 
     public static void dismissJetpackAdIfPresent() {
+        String jpAdText = "Stats, Reader, Notifications, and other features are powered by Jetpack.";
+
         // Dismiss Jetpack ad that might be shown after Sign-Up or after opening Stats
-        if (isElementDisplayed(onView(withText("Jetpack powered")))) {
+        if (isElementDisplayed(onView(withText(jpAdText)))) {
             clickOn(onView(withId(R.id.secondary_button)));
         }
     }


### PR DESCRIPTION
The initial intention was to fix only one test, but CI blocked from doing so by failing another test too, so the PR contains fixes that hopefully improve the situation for both tests.

### Why?

#### Issue 1: 
In some (not so rare, recently) [cases](https://console.firebase.google.com/u/1/project/api-project-108380595987/testlab/histories/bh.b3d1e88d8b09c8be/matrices/6811417613467581144/details?stepId=bs.a499dbd14c98e8e4&testCaseId=13), this pop-up would appear during log in, when UI tests are executed on FTL:

<img width="288" alt="Screenshot 2022-07-29 at 21 14 25" src="https://user-images.githubusercontent.com/73365754/182352170-a2f35b18-98cd-436d-9163-95b9559ce687.png">

While the reason behind this account presence is likely explained [here](https://stackoverflow.com/questions/40366572/who-owns-this-email-cloudtestlabaccounts-com), the [proposed](https://stackoverflow.com/questions/40366572/who-owns-this-email-cloudtestlabaccounts-com#comment94602176_40366919) solution to disable pre-launch reports is probably not ideal. Moreover, the fact of this user being logged in into the Emulator does not explain the fact of this pop-up being shown. This pop-up should be shown only after the user taps `Continue with Google`, which does not happen in any of our tests.

In FTL videos, in all cases this pop-up is shown, the email is not entered into the email field (which should happen). In such case, the usual `Continue` button is disabled. My _very vague guess_ is that in such a situation, the test runner might try to tap the only available enabled button, which is `Continue with Google` 🤷 , making this pop-up to appear.

#### Issue 2:

I saw multiple fails of `allDayStatsLoad`. Recently, I added a dismissal of this banner (not a video):

<img width="282" alt="Screenshot 2022-08-03 at 13 30 32" src="https://user-images.githubusercontent.com/73365754/182587286-5f25a641-75c2-4255-a481-768c08337b92.png">

Notice that it has two buttons. In the videos of the failing tests, this was shown:

<img width="284" alt="Screenshot 2022-08-03 at 13 30 57" src="https://user-images.githubusercontent.com/73365754/182587316-2df28e6d-79e8-442c-a12c-08b8932d8f74.png">

Notice there are no buttons. This kind of banner is shown when the small green JP button is tapped:

<img width="281" alt="Screenshot 2022-08-03 at 13 30 51" src="https://user-images.githubusercontent.com/73365754/182587342-913b3a68-3b5c-4f74-a4a7-0fe77d3b4dcc.png">

I suspect that for whatever reason (like actual banner locator matching both banners), after the first banner was dismissed, the test runner also tapped the green JP button, which funnily enough is located at the same position as the dismissal button from the first banner (this might be another reason, if the state transitions / events are slow).

### How

#### Issue 1:
3886e917ccfb109921c4f9b09711b3d2bfe78095
Instead of trying to close the pop-up (which will likely be tricky, because it's not a part of the app), I firstly went for increasing the probability of actually entering all data during login, in a very simple way: adding `clickOn` before trying to enter a text into certain input.

#### Issue 2:

abd58bee2b70d2b13716b8b04568d1aca8b27f78
I realized that the locator for the banner I used before was `onView(withText("Jetpack powered"))`. It will correspond not only to the "initial" banner with two buttons, but also to the banner with no buttons, and even to the small green JP button that will initiate buttonless banner display. While I'm still not sure what happened of FTL that those banners get shown interchangeably, I suspected that using a locator that will correspond multiple elements is not a good thing, and went for using something that is unique only to the banner with buttons.

c01559a01bc1ead2508e45f05509f1afc898d0bf
Since the banner slides away when dismissed, I wasn't sure how fast this happened on FTL emulator, so I added a 3-sec idle to wait for that.

### To test

CI is green. 

Since both issues do not appear too often, I see value in merging the PR and seeing if the solution will actually help, instead of having 50 reruns inside the branch.