### PR TITLE
Color site creation skip buttons green in Jetpack App

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 20.5
 -----
 * [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16848]
-
+* [*] Jetpack App: Use the Jetpack green color for the skip buttons text in site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16994]
 
 20.4
 -----

--- a/WordPress/src/jetpack/res/values/colors.xml
+++ b/WordPress/src/jetpack/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources">
+
+    <!-- Site creation -->
+    <color name="site_creation_skip_button_text">@color/jetpack_green_40</color>
+</resources>

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -86,7 +86,7 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
                 searchInputWithHeader?.updateSearchInput(requireActivity(), uiState.searchInputUiState)
                 updateContentUiState(uiState.contentState)
                 uiHelpers.updateVisibility(createSiteButtonContainer, uiState.createSiteButtonContainerVisibility)
-                uiHelpers.updateVisibility(createSiteButtonShaddow, uiState.createSiteButtonContainerVisibility)
+                uiHelpers.updateVisibility(createSiteButtonShadow, uiState.createSiteButtonContainerVisibility)
                 updateTitleVisibility(uiState.headerUiState == null)
             }
         })

--- a/WordPress/src/main/res/layout/home_page_picker_titlebar.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_titlebar.xml
@@ -25,7 +25,7 @@
 
     <Button
         android:id="@+id/skipButton"
-        style="@style/HomePagePickerSkipButton"
+        style="@style/SiteCreationSkipButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"

--- a/WordPress/src/main/res/layout/site_creation_domains_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_domains_screen.xml
@@ -57,7 +57,7 @@
         app:layout_constraintTop_toBottomOf="@id/site_creation_search_input_item" />
 
     <View
-        android:id="@+id/create_site_button_shaddow"
+        android:id="@+id/create_site_button_shadow"
         android:layout_width="match_parent"
         android:layout_height="@dimen/mlp_bottom_shadow_height"
         android:background="@drawable/modal_layout_picker_bottom_shadow"

--- a/WordPress/src/main/res/layout/site_creation_intents_titlebar.xml
+++ b/WordPress/src/main/res/layout/site_creation_intents_titlebar.xml
@@ -23,8 +23,7 @@
 
     <Button
         android:id="@+id/skipButton"
-        style="@style/Widget.MaterialComponents.Button.TextButton"
-        android:textColor="@color/blue_50"
+        style="@style/SiteCreationSkipButton"
         android:textSize="@dimen/text_sz_medium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/site_creation_intents_titlebar.xml
+++ b/WordPress/src/main/res/layout/site_creation_intents_titlebar.xml
@@ -24,7 +24,6 @@
     <Button
         android:id="@+id/skipButton"
         style="@style/SiteCreationSkipButton"
-        android:textSize="@dimen/text_sz_medium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -123,5 +123,6 @@
     <color name="grey_900">#ff212121</color>
 
     <!-- Site creation  -->
+    <color name="site_creation_skip_button_text">@color/blue_50</color>
     <color name="site_creation_intent_item_emoji_bg">@color/grey_lighten_30</color>
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1512,7 +1512,11 @@
         <item name="android:paddingBottom">@dimen/margin_small_medium</item>
     </style>
 
-    <!-- Site Creation Header Styles -->
+    <!-- Site Creation Styles -->
+    <style name="SiteCreationSkipButton" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textColor">@color/site_creation_skip_button_text</item>
+        <item name="android:textSize">@dimen/text_sz_medium</item>
+    </style>
 
     <style name="SiteCreationHeaderV2Text">
         <item name="android:layout_width">match_parent</item>
@@ -1645,12 +1649,6 @@
 
     <style name="WordPress.PrepubPrimaryButton" parent="WordPress.Button.Primary">
         <item name="android:textAllCaps">true</item>
-    </style>
-
-    <!-- Home Page Picker Styles -->
-    <style name="HomePagePickerSkipButton" parent="Widget.MaterialComponents.Button.TextButton">
-        <item name="android:textColor">@color/blue_50</item>
-        <item name="android:textSize">@dimen/text_sz_medium</item>
     </style>
 
     <!-- Invite Links -->


### PR DESCRIPTION
Fixes #16874

Colors the `SKIP` toolbar buttons in site creation screens to Jetpack Green on the Jetpack App.

To test:

🧪 **Test Case 1 - Jetpack App - Default Site Creation flow**

1. Open the Jetpack App of this PR (via QR-code or local build)
2. Start the site Creation Flow
   **Expect** the `skip` button in the toolbar to be green
3. Press `Skip`
   **Expect** the next `skip` button in the toolbar to be green

🧪 **Test Case 2 - WordPress App - Default Site Creation flow**

1. Open the WordPress App of this PR (via QR-code or local build)
2. Start the site Creation Flow
   **Expect** the `skip` button in the toolbar to be green
3. Press `Skip`
   **Expect** the next `skip` button in the toolbar to be green

🧪 **Test Case 3** (optional) ** - Jetpack App - Site Creation with Site Name flow**

1. Open the Jetpack App of this PR (via QR-code or local build)
2. Find in `./WordPress/build.gradle`: `buildConfigField "boolean", "SITE_NAME", "false"` and replace it with `buildConfigField "boolean", "SITE_NAME", "true"`.
3. Repeat steps 2 - 3 from **Scenario 1**.
4. Repeat until the flow ends (I.e. there's no more skip button).

### Previews
| Day Mode | Night Mode |
| --- | --- |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/182595124-ddc95a35-f44a-47c0-94c4-c324d348fa10.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/182595117-264644d6-0125-47a9-abdc-7b391e3e5e1c.png"> |

## Regression Notes
1. Potential unintended areas of impact
   - Skip buttons color in WordPress App.
   - Site creation flow with Site Name step (disabled by default)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   - Manual testing of WordPress app.
   - Manual testing of Jetpack App with Site Name enabled via `buildConfig`.

3. What automated tests I added (or what prevented me from doing so)
  - N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
