### PR TITLE
[UI Tests] Added CODEOWNERS for WPAndroid.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Adding `mobile-ui-testing-squad` as codeowners for UI tests related folders
+
+/WordPress/src/androidTest/ @wordpress-mobile/mobile-ui-testing-squad

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,1 @@
-# Adding `mobile-ui-testing-squad` as codeowners for UI tests related folders
-
 /WordPress/src/androidTest/ @wordpress-mobile/mobile-ui-testing-squad


### PR DESCRIPTION
### Description
As mentioned in p1659432783574949-slack-CC7L49W13, there might be a communicational benefit of adding folks from `mobile-ui-testing-squad` as code owners for UI-tests-related folders.

### Testing instructions
Since there's another PR for iOS: wordpress-mobile/WordPress-iOS/pull/19141, where the correctness of same GH organization/team mention is already tested, I thought that creating testing PRs for this one would be redundant. Please LMK if you think otherwise.