### PR TITLE
Added `run_` to `build_and_instrumented_test` lane name.

### DIFF
--- a/.buildkite/commands/instrumented-tests.sh
+++ b/.buildkite/commands/instrumented-tests.sh
@@ -7,4 +7,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- 🧪 Testing"
-bundle exec fastlane build_and_instrumented_test
+bundle exec fastlane build_and_run_instrumented_test

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -2,16 +2,16 @@ GOOGLE_FIREBASE_SECRETS_PATH = File.join(Dir.home, '.configure', 'wordpress-andr
 
 platform :android do
   #####################################################################################
-  # build_and_instrumented_test
+  # build_and_run_instrumented_test
   # -----------------------------------------------------------------------------------
   # Run instrumented tests in Google Firebase Test Lab
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_instrumented_test
+  # bundle exec fastlane build_and_run_instrumented_test
   #
   #####################################################################################
   desc "Build the application and instrumented tests, then run the tests in Firebase Test Lab"
-  lane :build_and_instrumented_test do | options |
+  lane :build_and_run_instrumented_test do | options |
    gradle(tasks: ['WordPress:assembleWordPressVanillaDebug', 'WordPress:assembleWordPressVanillaDebugAndroidTest'])
 
    # Run the instrumented tests in Firebase Test Lab


### PR DESCRIPTION
### Why
See [this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/16915#discussion_r936472205).

### To test
- `Instrumented Tests` are [executed](https://buildkite.com/automattic/wordpress-android/builds/6000#01826985-4ec5-46e9-9804-e84803b8aaab) on Buildkite.
- CI is green.