### PR TITLE
[Tooling] Use custom message for Buildkite Beta/Release builds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,25 @@
+GIT
+  remote: git@github.com:wordpress-mobile/release-toolkit.git
+  revision: 55bdc9bf6de1670b25d759a95a9579b8fe1491ec
+  branch: builkite_trigger/custom_message
+  specs:
+    fastlane-plugin-wpmreleasetoolkit (5.1.0)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -116,22 +138,6 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (5.0.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
     git (1.11.0)
       rchardet (~> 1.8)
@@ -200,7 +206,7 @@ GEM
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    oj (3.13.17)
+    oj (3.13.19)
     optimist (3.0.1)
     options (2.3.2)
     optparse (0.1.1)
@@ -247,7 +253,7 @@ GEM
     tty-screen (0.8.1)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
-    tzinfo (1.2.9)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     uber (0.1.0)
     unf (0.1.4)
@@ -273,9 +279,9 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 5.0)
+  fastlane-plugin-wpmreleasetoolkit!
   nokogiri
   rmagick (~> 4.1)
 
 BUNDLED WITH
-   2.3.9
+   2.3.16

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,3 @@
-GIT
-  remote: git@github.com:wordpress-mobile/release-toolkit.git
-  revision: 55bdc9bf6de1670b25d759a95a9579b8fe1491ec
-  branch: builkite_trigger/custom_message
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (5.1.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -138,6 +116,22 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-wpmreleasetoolkit (5.2.0)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
     git (1.11.0)
       rchardet (~> 1.8)
@@ -279,7 +273,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 5.2)
   nokogiri
   rmagick (~> 4.1)
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', branch: 'builkite_trigger/custom_message'
-# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.0'
+# gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', branch: 'trunk'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.2'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-# gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', branch: 'trunk'
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', branch: 'builkite_trigger/custom_message'
+# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.0'

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -209,7 +209,8 @@ platform :android do
       buildkite_organization: 'automattic',
       buildkite_pipeline: 'wordpress-android',
       branch: options[:branch_to_build] || git_branch,
-      pipeline_file: 'beta-builds.yml'
+      pipeline_file: 'beta-builds.yml',
+      message: 'Beta Builds'
     )
   end
 
@@ -228,7 +229,8 @@ platform :android do
       buildkite_organization: 'automattic',
       buildkite_pipeline: 'wordpress-android',
       branch: options[:branch_to_build] || git_branch,
-      pipeline_file: 'release-builds.yml'
+      pipeline_file: 'release-builds.yml',
+      message: 'Release Builds'
     )
   end
 


### PR DESCRIPTION
This makes use of https://github.com/wordpress-mobile/release-toolkit/pull/392 to provide a custom message for Beta and Release builds on Buildkite, instead of Buildkite using the HEAD commit's message for those.

This will help better identify Buildkite builds triggered from API for Beta and Release Builds during release management, avoiding to confuse them with regular builds triggered by webhook on new commits.

### To Test

I've tested this by calling `bundle exec fastlane trigger_beta_build` while on this branch, then immediately going to Buildkite's dashboard to cancel the build as soon as I confirmed that the message was properly used:

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/216089/183141565-66bb11ed-a3d9-4422-bbea-08fe0c223775.png">
