### PR TITLE
[Tooling] Group Buildkite steps by topic

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,7 +46,7 @@ steps:
   #################
   # Unit Tests
   #################
-  - group: "🛠 Unit Tests"
+  - group: "🔬 Unit Tests"
     steps:
       - label: "Test WordPress"
         command: |
@@ -69,7 +69,7 @@ steps:
   #################
   # Instrumented (aka UI) Tests
   #################
-  - label: "Instrumented tests"
+  - label: "🔬 Instrumented tests"
     command: ".buildkite/commands/instrumented-tests.sh"
     plugins: *common_plugins
     artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,31 +5,36 @@ common_params:
     - automattic/bash-cache#2.1.0
 
 steps:
-  - label: "checkstyle"
-    command: |
-      cp gradle.properties-example gradle.properties
-      ./gradlew checkstyle
-    plugins: *common_plugins
-    artifact_paths:
-      - "**/build/reports/checkstyle/checkstyle.*"
+  #################
+  # Linters
+  #################
+  - group: "🕵️‍♂️ Linters"
+    steps:
+      - label: "checkstyle"
+        command: |
+          cp gradle.properties-example gradle.properties
+          ./gradlew checkstyle
+        plugins: *common_plugins
+        artifact_paths:
+          - "**/build/reports/checkstyle/checkstyle.*"
 
-  - label: "detekt"
-    command: |
-      cp gradle.properties-example gradle.properties
-      ./gradlew detekt
-    plugins: *common_plugins
-    artifact_paths:
-      - "**/build/reports/detekt/detekt.html"
+      - label: "detekt"
+        command: |
+          cp gradle.properties-example gradle.properties
+          ./gradlew detekt
+        plugins: *common_plugins
+        artifact_paths:
+          - "**/build/reports/detekt/detekt.html"
 
-  - label: "Lint WordPress"
-    command: ".buildkite/commands/lint.sh wordpress"
-    artifact_paths:
-      - "**/build/reports/lint-results*.*"
+      - label: "Lint WordPress"
+        command: ".buildkite/commands/lint.sh wordpress"
+        artifact_paths:
+          - "**/build/reports/lint-results*.*"
 
-  # - label: "Lint Jetpack"
-  #   command: ".buildkite/commands/lint.sh jetpack"
-  #   artifact_paths:
-  #     - "**/build/reports/lint-results*.*"
+      # - label: "Lint Jetpack"
+      #   command: ".buildkite/commands/lint.sh jetpack"
+      #   artifact_paths:
+      #     - "**/build/reports/lint-results*.*"
 
   - label: "Dependency Tree Diff"
     command: |
@@ -38,36 +43,49 @@ steps:
     if: build.pull_request.id != null
     plugins: *common_plugins
 
-  - label: "Test WordPress"
-    command: |
-      cp gradle.properties-example gradle.properties
-      ./gradlew testWordpressVanillaRelease
-    plugins: *common_plugins
+  #################
+  # Unit Tests
+  #################
+  - group: "🛠 Unit Tests"
+    steps:
+      - label: "Test WordPress"
+        command: |
+          cp gradle.properties-example gradle.properties
+          ./gradlew testWordpressVanillaRelease
+        plugins: *common_plugins
 
-  - label: "Test Processors"
-    command: |
-      cp gradle.properties-example gradle.properties
-      ./gradlew :libs:processors:test
-    plugins: *common_plugins
+      - label: "Test Processors"
+        command: |
+          cp gradle.properties-example gradle.properties
+          ./gradlew :libs:processors:test
+        plugins: *common_plugins
 
-  - label: "Test Image Editor"
-    command: |
-      cp gradle.properties-example gradle.properties
-      ./gradlew :libs:image-editor:test
-    plugins: *common_plugins
+      - label: "Test Image Editor"
+        command: |
+          cp gradle.properties-example gradle.properties
+          ./gradlew :libs:image-editor:test
+        plugins: *common_plugins
 
+  #################
+  # Instrumented (aka UI) Tests
+  #################
   - label: "Instrumented tests"
     command: ".buildkite/commands/instrumented-tests.sh"
     plugins: *common_plugins
     artifact_paths:
       - "**/build/instrumented-tests/**/*"
 
-  - label: "🛠 WordPress Installable Build"
-    command: ".buildkite/commands/installable-build.sh wordpress"
-    if: build.pull_request.id != null
-    plugins: *common_plugins
+  #################
+  # Create Installable Builds for WP and JP
+  #################
+  - group: "🛠 Installable Builds"
+    steps:
+      - label: "🛠 WordPress Installable Build"
+        command: ".buildkite/commands/installable-build.sh wordpress"
+        if: build.pull_request.id != null
+        plugins: *common_plugins
 
-  - label: "🛠 Jetpack Installable Build"
-    command: ".buildkite/commands/installable-build.sh jetpack"
-    if: build.pull_request.id != null
-    plugins: *common_plugins
+      - label: "🛠 Jetpack Installable Build"
+        command: ".buildkite/commands/installable-build.sh jetpack"
+        if: build.pull_request.id != null
+        plugins: *common_plugins


### PR DESCRIPTION
This reorganizes the `.buildkite/pipeline.yml` file to use [Buildkite Groups](https://buildkite.com/docs/pipelines/group-step), which will allow the summary header on the Buildkite dashboard page to look nicer by grouping related steps together in that UI.

<table><tr>
<td>Before</td>
<td><img width="1150" alt="image" src="https://user-images.githubusercontent.com/216089/183174122-ea492f3b-c629-47c0-a092-ba8db759d35f.png"></td>
</tr><tr>
<td><a href="https://buildkite.com/automattic/wordpress-android/builds/6043">After</a></td>
<td>
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/216089/183192550-033f0434-829d-486c-9b7c-8e05145d07f3.png">
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/216089/183192807-fe77e706-86ee-4d78-b91f-0b7ed10588dc.png">
<img width="1154" alt="image" src="https://user-images.githubusercontent.com/216089/183193078-46b260ad-196f-45c2-ad6d-d72ddf3d184e.png">
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/216089/183193308-7f06c83f-a13a-41b9-804e-a7c4ec830c6b.png">
</td>
</tr></table>

> **Note**: This might be easier to review with "Ignore Whitespaces" option turned on, since most of the diff is change in indentation of the existing steps that have not been modified, but just been moved under a `group:` parent step.