### PR TITLE
[Tooling] Re-enable Jetpack Lint step on Buildkite

### DIFF
--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -9,13 +9,13 @@ common_params:
 
 steps:
 
-  - label: "Lint WordPress"
+  - label: "🕵️ Lint WordPress"
     command: ".buildkite/commands/lint.sh wordpress"
     key: wplint
     artifact_paths:
       - "**/build/reports/lint-results*.*"
 
-  - label: "🔬 Lint Jetpack"
+  - label: "🕵️ Lint Jetpack"
     command: ".buildkite/commands/lint.sh jetpack"
     key: jplint
     artifact_paths:

--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -15,11 +15,11 @@ steps:
     artifact_paths:
       - "**/build/reports/lint-results*.*"
 
-  # - label: "🔬 Lint Jetpack"
-  #   command: ".buildkite/commands/lint.sh jetpack"
-  #   key: jplint
-  #   artifact_paths:
-  #     - "**/build/reports/lint-results*.*"
+  - label: "🔬 Lint Jetpack"
+    command: ".buildkite/commands/lint.sh jetpack"
+    key: jplint
+    artifact_paths:
+      - "**/build/reports/lint-results*.*"
 
   - label: "🛠 WordPress Beta Build"
     command: ".buildkite/commands/beta-build.sh wordpress"
@@ -30,7 +30,7 @@ steps:
 
   - label: "🛠 Jetpack Beta Build"
     command: ".buildkite/commands/beta-build.sh jetpack"
-    # depends_on: jplint
+    depends_on: jplint
     plugins: *common_plugins
     notify:
       - slack: "#build-and-ship"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,10 +31,10 @@ steps:
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
-      # - label: "Lint Jetpack"
-      #   command: ".buildkite/commands/lint.sh jetpack"
-      #   artifact_paths:
-      #     - "**/build/reports/lint-results*.*"
+      - label: "Lint Jetpack"
+        command: ".buildkite/commands/lint.sh jetpack"
+        artifact_paths:
+          - "**/build/reports/lint-results*.*"
 
   - label: "Dependency Tree Diff"
     command: |

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
   #################
   - group: "🕵️‍♂️ Linters"
     steps:
-      - label: "checkstyle"
+      - label: "🕵️ checkstyle"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew checkstyle
@@ -18,7 +18,7 @@ steps:
         artifact_paths:
           - "**/build/reports/checkstyle/checkstyle.*"
 
-      - label: "detekt"
+      - label: "🕵️ detekt"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew detekt
@@ -26,12 +26,12 @@ steps:
         artifact_paths:
           - "**/build/reports/detekt/detekt.html"
 
-      - label: "Lint WordPress"
+      - label: "🕵️ Lint WordPress"
         command: ".buildkite/commands/lint.sh wordpress"
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
-      - label: "Lint Jetpack"
+      - label: "🕵️ Lint Jetpack"
         command: ".buildkite/commands/lint.sh jetpack"
         artifact_paths:
           - "**/build/reports/lint-results*.*"
@@ -48,19 +48,19 @@ steps:
   #################
   - group: "🔬 Unit Tests"
     steps:
-      - label: "Test WordPress"
+      - label: "🔬 Test WordPress"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew testWordpressVanillaRelease
         plugins: *common_plugins
 
-      - label: "Test Processors"
+      - label: "🔬 Test Processors"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew :libs:processors:test
         plugins: *common_plugins
 
-      - label: "Test Image Editor"
+      - label: "🔬 Test Image Editor"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew :libs:image-editor:test

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -9,13 +9,13 @@ common_params:
 
 steps:
 
-  - label: "Lint WordPress"
+  - label: "🕵️ Lint WordPress"
     command: ".buildkite/commands/lint.sh wordpress"
     key: wplint
     artifact_paths:
       - "**/build/reports/lint-results*.*"
 
-  - label: "🔬 Lint Jetpack"
+  - label: "🕵️ Lint Jetpack"
     command: ".buildkite/commands/lint.sh jetpack"
     key: jplint
     artifact_paths:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -15,11 +15,11 @@ steps:
     artifact_paths:
       - "**/build/reports/lint-results*.*"
 
-  # - label: "🔬 Lint Jetpack"
-  #   command: ".buildkite/commands/lint.sh jetpack"
-  #   key: jplint
-  #   artifact_paths:
-  #     - "**/build/reports/lint-results*.*"
+  - label: "🔬 Lint Jetpack"
+    command: ".buildkite/commands/lint.sh jetpack"
+    key: jplint
+    artifact_paths:
+      - "**/build/reports/lint-results*.*"
 
   - label: "🛠 WordPress Release Build"
     command: ".buildkite/commands/release-build.sh wordpress"
@@ -30,7 +30,7 @@ steps:
 
   - label: "🛠 Jetpack Release Build"
     command: ".buildkite/commands/release-build.sh jetpack"
-    # depends_on: jplint
+    depends_on: jplint
     plugins: *common_plugins
     notify:
       - slack: "#build-and-ship"

--- a/WordPress/google-services.json-example
+++ b/WordPress/google-services.json-example
@@ -129,6 +129,132 @@
           "status": 1
         }
       }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:123:android:abc",
+        "android_client_info": {
+          "package_name": "com.jetpack.android"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "123-abc.apps.googleusercontent.com",
+          "client_type": 3
+        },
+        {
+          "client_id": "",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.jetpack.android",
+            "certificate_hash": ""
+          }
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": ""
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 2,
+          "analytics_property": {
+            "tracking_id": ""
+          }
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 1
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:123:android:abc",
+        "android_client_info": {
+          "package_name": "com.jetpack.android.prealpha"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "123-abc.apps.googleusercontent.com",
+          "client_type": 3
+        },
+        {
+          "client_id": "",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.jetpack.android.prealpha",
+            "certificate_hash": ""
+          }
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": ""
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 2,
+          "analytics_property": {
+            "tracking_id": ""
+          }
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 1
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:123:android:abc",
+        "android_client_info": {
+          "package_name": "com.jetpack.android.beta"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "123-abc.apps.googleusercontent.com",
+          "client_type": 3
+        },
+        {
+          "client_id": "",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.jetpack.android.beta",
+            "certificate_hash": ""
+          }
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": ""
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 2,
+          "analytics_property": {
+            "tracking_id": ""
+          }
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 1
+        }
+      }
     }
   ],
   "configuration_version": "1"

--- a/WordPress/src/jetpack/res/values/available_languages.xml
+++ b/WordPress/src/jetpack/res/values/available_languages.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Warning: Auto-generated file, do not edit.-->
-<resources>
-  <string-array name="available_languages" translatable="false">
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <string-array name="available_languages" translatable="false" tools:ignore="InconsistentArrays">
     <item>en_US</item>
     <item>ar</item>
     <item>de</item>

--- a/WordPress/src/main/res/values/available_languages.xml
+++ b/WordPress/src/main/res/values/available_languages.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Warning: Auto-generated file, do not edit.-->
-<resources>
-  <string-array name="available_languages" translatable="false">
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <string-array name="available_languages" translatable="false" tools:ignore="InconsistentArrays">
     <item>en_US</item>
     <item>ar</item>
     <item>de</item>


### PR DESCRIPTION
The `jplint` Buildkite step [had been commented out during the migration from CircleCI to Buildkite](https://github.com/wordpress-mobile/WordPress-Android/pull/16917#discussion_r935894322), _a priori_ because the lint of the Jetpack flavor failed due to https://github.com/wordpress-mobile/release-toolkit/pull/390.

Now that https://github.com/wordpress-mobile/release-toolkit/pull/390 landed and the linter issue with `available_languages.xml` should be fixed, we should be able to re-enable the lint of the Jetpack target on the Buildkite pipelines.

> **Note**: This targets the `release/20.5` branch because I plan to submit a subsequent PR on top of this work to add the missing `create_gh_release` step to the pipeline — which will be useful to be done on the release branch for subsequent betas during this sprint, so I'll need this PR to land there too.