### PR TITLE
Fix stats cached data conflict

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/TotalLikesDetailUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/TotalLikesDetailUseCase.kt
@@ -54,7 +54,7 @@ class TotalLikesDetailUseCase @Inject constructor(
         val cachedData = visitsAndViewsStore.getVisits(
                 site,
                 DAYS,
-                LimitMode.Top(TotalStatsMapper.DAY_COUNT_TOTAL),
+                LimitMode.Top(TOTAL_LIKES_ITEMS_TO_LOAD),
                 selectedDate
         )
         if (cachedData != null) {
@@ -71,7 +71,7 @@ class TotalLikesDetailUseCase @Inject constructor(
         val response = visitsAndViewsStore.fetchVisits(
                 statsSiteProvider.siteModel,
                 DAYS,
-                LimitMode.Top(TotalStatsMapper.DAY_COUNT_TOTAL),
+                LimitMode.Top(TOTAL_LIKES_ITEMS_TO_LOAD),
                 selectedDate,
                 forced
         )
@@ -108,6 +108,10 @@ class TotalLikesDetailUseCase @Inject constructor(
     }
 
     private fun buildTitle() = TitleWithMore(string.stats_view_total_likes)
+
+    companion object {
+        private const val TOTAL_LIKES_ITEMS_TO_LOAD = 15
+    }
 
     class TotalLikesGranularUseCaseFactory
     @Inject constructor(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCase.kt
@@ -65,7 +65,7 @@ class TotalLikesUseCase @Inject constructor(
         val response = visitsAndViewsStore.fetchVisits(
                 statsSiteProvider.siteModel,
                 DAYS,
-                LimitMode.Top(TotalStatsMapper.DAY_COUNT_TOTAL),
+                LimitMode.Top(TOTAL_LIKES_ITEMS_TO_LOAD),
                 forced
         )
         val model = response.model
@@ -148,6 +148,10 @@ class TotalLikesUseCase @Inject constructor(
                         null
                 )
         )
+    }
+
+    companion object {
+        private const val TOTAL_LIKES_ITEMS_TO_LOAD = 15
     }
 
     class TotalLikesUseCaseFactory

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
@@ -128,6 +128,6 @@ class TotalStatsMapper @Inject constructor(
     companion object {
         private const val DAY_COUNT_FOR_CURRENT_WEEK = 7 // Last 7 days
         private const val DAY_COUNT_FOR_PREVIOUS_WEEK = 7 // Last 7 days before the current week
-        const val DAY_COUNT_TOTAL = DAY_COUNT_FOR_PREVIOUS_WEEK + DAY_COUNT_FOR_CURRENT_WEEK
+        private const val DAY_COUNT_TOTAL = DAY_COUNT_FOR_PREVIOUS_WEEK + DAY_COUNT_FOR_CURRENT_WEEK
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalLikesUseCaseTest.kt
@@ -63,7 +63,7 @@ class TotalLikesUseCaseTest : BaseUnitTest() {
     private lateinit var useCase: TotalLikesUseCase
     private val periodData = PeriodData("2018-10-08", 10, 15, 20, 25, 30, 35)
     private val modelPeriod = "2018-10-10"
-    private val limitMode = Top(14)
+    private val limitMode = Top(15)
     private val model = VisitsAndViewsModel(modelPeriod, listOf(periodData))
 
     @InternalCoroutinesApi


### PR DESCRIPTION
Fixes #16971 
This PR fixes the unexpected date range change on Views & Visitors card when the list is refreshed a couple times.

**Technical explanation:**
Total Likes card was using 14 days while fetching visits. Others use cases use 15 days. After fetch, the data is cached. Views & Visitors card was using cached 14 days sometimes when the expected date range is 15 days. 
I changed total likes card's fetching visits limit to 15. It didn't break total likes card, because TotalLikesUseCase uses last 14 days of cached data.

**Note:**
Update milestone of this PR and the [issue](https://github.com/wordpress-mobile/WordPress-Android/issues/16971) to **20.5** before merging, if it's not too late.

**Bug video:**

https://user-images.githubusercontent.com/2471769/183305582-bc57c70b-63f0-4608-89cd-6b7a4e8fd2b1.mp4

To test:
1. Launch Jetpack app.
2. Open Stats from "My Site" tab.
3. Ensure Views & Visitors card is visible. If not, tap the cog button on the top right of the screen and enable Views & Visitors, then tap SAVE.
4. Refresh the screen by using "pull to refresh" feature couple times.
5. Ensure the date range of Views & Visitors card is always the same.

## Regression Notes
1. Potential unintended areas of impact
The data of these cards might be wrong:

- Total Likes detail screen cards,
- Total comments card,
- Views & Visitors card,
- Overview cards in granular tabs (DAYS, WEEKS...)

3. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested manually.

5. What automated tests I added (or what prevented me from doing so)
I update `TotalLikesUseCaseTest`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
