### PR TITLE
Merge release/20.5 after code freeze (20.5-rc-1)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+20.6
+-----
+
+
 20.5
 -----
 * [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16848]

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,5 +1,5 @@
 * [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16848]
 * [***] [internal] Block Editor: List block: Adds support for V2 behind a feature flag [https://github.com/WordPress/gutenberg/pull/42702]
-* [*] Jetpack App: Use the Jetpack green color for the skip buttons text in site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16994]
+* [*] Use the Jetpack green color for the skip buttons text in site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16994]
 * [**] App Settings: Show a label with the current language of the app under "Interface Language". [https://github.com/wordpress-mobile/WordPress-Android/pull/17004]
 

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,4 +1,5 @@
-- Gallery/Image block performance improvements in the Block Editor.
-- Properly displayed Video blocks (both web and app) for VideoPress-enabled sites.
-- Block inserter allows block types to be better organized in collections.
-- Alt text footnote spacing adjustment in Image blocks.
+* [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16848]
+* [***] [internal] Block Editor: List block: Adds support for V2 behind a feature flag [https://github.com/WordPress/gutenberg/pull/42702]
+* [*] Jetpack App: Use the Jetpack green color for the skip buttons text in site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16994]
+* [**] App Settings: Show a label with the current language of the app under "Interface Language". [https://github.com/wordpress-mobile/WordPress-Android/pull/17004]
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,5 +1,4 @@
 * [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16848]
 * [***] [internal] Block Editor: List block: Adds support for V2 behind a feature flag [https://github.com/WordPress/gutenberg/pull/42702]
-* [*] Jetpack App: Use the Jetpack green color for the skip buttons text in site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16994]
 * [**] App Settings: Show a label with the current language of the app under "Interface Language". [https://github.com/wordpress-mobile/WordPress-Android/pull/17004]
 

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,4 +1,5 @@
-- Gallery/Image block performance improvements in the Block Editor.
-- Properly displayed Video blocks (both web and app) for VideoPress-enabled sites.
-- Block inserter allows block types to be better organized in collections.
-- Alt text footnote spacing adjustment in Image blocks.
+* [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16848]
+* [***] [internal] Block Editor: List block: Adds support for V2 behind a feature flag [https://github.com/WordPress/gutenberg/pull/42702]
+* [*] Jetpack App: Use the Jetpack green color for the skip buttons text in site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16994]
+* [**] App Settings: Show a label with the current language of the app under "Interface Language". [https://github.com/wordpress-mobile/WordPress-Android/pull/17004]
+

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 ext {
-    wordPressUtilsVersion = 'trunk-68e2995962a5134770e6f9e5b9f258a339e123b2'
+    wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.15.0'
     gutenbergMobileVersion = 'v1.81.0'
     storiesVersion = '1.4.0'
@@ -21,7 +21,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = 'trunk-b176f89d8db39be3ef5f2f5f29a21dd9fb3a4ecf'
+    fluxCVersion = '1.49.0'
 
     appCompatVersion = '1.0.2'
     androidxCoreVersion = '1.3.2'

--- a/fastlane/jetpack_resources/values/strings.xml
+++ b/fastlane/jetpack_resources/values/strings.xml
@@ -26,4 +26,7 @@
 
     <!-- About button in Me -->
     <string name="me_btn_about">About Jetpack</string>
+
+    <!-- My Site Initial Tab Default value -->
+    <string name="initial_screen_entry_value_default_key" translatable="false">@string/initial_screen_entry_value_home</string>
 </resources>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1376,10 +1376,6 @@
 
     <!-- Stats Revamp v2 Feature Introduction -->
     <string name="stats_revamp_v2_intro_header_title">Insights update</string>
-    <string name="stats_revamp_v2_intro_content">Insights help you understand how your content is performing and what\'s resonating with your audience.</string>
-    <string name="stats_revamp_v2_intro_content_note">Learn more in My Site &gt; Stats &gt; Insights</string>
-    <string name="stats_revamp_v2_intro_primary_button_text">Try it now</string>
-    <string name="stats_revamp_v2_intro_secondary_button_text">Remind me later</string>
     <string name="stats_revamp_v2_update_alert_message">Updated to New Insights to help you understand how your content is performing and what\'s resonating with your audience.</string>
 
     <!-- Stats refreshed widgets -->
@@ -4207,11 +4203,12 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Jetpack awareness in WordPress App -->
     <string name="wp_jetpack_powered">Jetpack powered</string>
-    <string name="wp_jetpack_powered_features">Stats, Reader, Notifications, and other features are powered by Jetpack.</string>
+    <string name="wp_jetpack_powered_better_with_jetpack">WordPress is better with Jetpack</string>
+    <string name="wp_jetpack_powered_features">The new Jetpack app has Stats, Reader, Notifications, and more that make your WordPress better.</string>
     <string name="wp_jetpack_get_new_jetpack_app">Get the new Jetpack app</string>
     <string name="wp_jetpack_continue_to_reader">Continue to Reader</string>
-    <string name="wp_jetpack_continue_to_stats" tools:ignore="UnusedResources">Continue to Stats</string>
-    <string name="wp_jetpack_continue_to_notifications" tools:ignore="UnusedResources">Continue to Notifications</string>
+    <string name="wp_jetpack_continue_to_stats">Continue to Stats</string>
+    <string name="wp_jetpack_continue_to_notifications">Continue to Notifications</string>
     <string name="gutenberg_native_problem_displaying_block_tap_to_attempt_block_recovery" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Problem displaying block. \nTap to attempt block recovery.</string>
     <string name="gutenberg_native_gradient" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Gradient</string>
     <string name="gutenberg_native_invalid_url" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Invalid URL.</string>

--- a/version.properties
+++ b/version.properties
@@ -1,9 +1,9 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=20.4
-versionCode=1258
+versionName=20.5-rc-1
+versionCode=1259
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno
-alpha.versionName=alpha-379
-alpha.versionCode=1257
+alpha.versionName=alpha-380
+alpha.versionCode=1260


### PR DESCRIPTION
- [x] New empty entry created in `RELEASE-NOTES.txt` for next iteration.
- [x] `{jetpack_}metadata/release_notes.txt` extracted for WordPress and Jetpack.
- [x] `WordPress/jetpack_metadata/release_notes.txt` audited to remove any item not applicable for Jetpack.
- [x] Internal dependencies (FluxC, Utils) bumped to a new stable version in `build.gradle`.
- [x] `WordPress/src/main/res/values/strings.xml` updated with strings from binary dependencies.
- [x] New strings frozen/copied into `fastlane/resources/values/strings.xml`.
- [x] Version bumped in `version.properties`