### PR TITLE
[Tooling/CI] Fix typo in pipeline

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -41,7 +41,7 @@ steps:
           - slack: "#build-and-ship"
 
       - label: "🛠 Jetpack Release Build"
-        key: j pbuild
+        key: jpbuild
         command: ".buildkite/commands/release-build.sh jetpack"
         depends_on: jplint
         plugins: *common_plugins


### PR DESCRIPTION
While working on https://github.com/wordpress-mobile/WordPress-Android/pull/17018 I noticed I accidentally inserted an extra space in the `key:` for the `jpbuild` step of the `release-build.yml` pipeline, using `j pbuild` as key (with extra space) instead.

This means that this pipeline would not work as expected and would have failed to find the expected dependency steps when trying to create the GitHub Release for the final build at the end of this sprint.