### PR TITLE
Fix crash in Site Creation flow caused by null designs list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] Login: Fix an issue preventing some users to log-in in with email addresses containing a single quote [https://github.com/wordpress-mobile/WordPress-Android/pull/15526]
 * [*] Fix a possible crash with themes preloading that could be encountered at the start of Site Creation [https://github.com/wordpress-mobile/WordPress-Android/pull/17022]
+
 20.5
 -----
 * [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16848]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 20.6
 -----
 * [*] Login: Fix an issue preventing some users to log-in in with email addresses containing a single quote [https://github.com/wordpress-mobile/WordPress-Android/pull/15526]
-
+* [*] Fix a possible crash with themes preloading that could be encountered at the start of Site Creation [https://github.com/wordpress-mobile/WordPress-Android/pull/17022]
 20.5
 -----
 * [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16848]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 20.6
 -----
 * [*] Login: Fix an issue preventing some users to log-in in with email addresses containing a single quote [https://github.com/wordpress-mobile/WordPress-Android/pull/15526]
-* [*] Fix a possible crash with themes preloading that could be encountered at the start of Site Creation [https://github.com/wordpress-mobile/WordPress-Android/pull/17022]
+* [*] Fix a possible crash with themes preloading at the start of Site Creation [https://github.com/wordpress-mobile/WordPress-Android/pull/17022]
 
 20.5
 -----


### PR DESCRIPTION
Fixes #17020

Proceeds with iterating through the `designs` list in the response only if it's not `null`.

**Remark**
Not sure what's causing the issue, in order to better understand it I added more logging that assume nothing (I.e. Could be an error response, or not).

To test:
1. Verify CI checks are green

## Regression Notes
1. Potential unintended areas of impact
  None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  N/a

3. What automated tests I added (or what prevented me from doing so)
  N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
