### PR TITLE
[Tooling] Remove zalpha flavor and alpha versioning

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -587,11 +587,7 @@ tasks.register("dependencyTreeDiffCommentToGitHub", ViolationCommentsToGitHubTas
 
 tasks.register("printVersionName") {
     doLast {
-        if (project.hasProperty('alpha')) {
-          println android.productFlavors.zalpha.versionName
-        } else {
-          println android.productFlavors.vanilla.versionName
-        }
+        println android.defaultConfig.versionName
     }
 }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -594,8 +594,7 @@ tasks.register("printVersionName") {
 tasks.register("printAllVersions") {
     doLast {
         android.applicationVariants.all { variant ->
-            def apkData = variant.outputs*.apkData
-            println "${variant.name}: ${apkData*.versionName} (${apkData*.versionCode})"
+            println "${variant.name}: ${variant.versionName} (${variant.versionCode})"
         }
     }
 }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -70,9 +70,14 @@ android {
 
     compileSdkVersion rootProject.compileSdkVersion
 
+    def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
+
     defaultConfig {
         applicationId "org.wordpress.android"
         archivesBaseName = "$applicationId"
+
+        versionName project.findProperty("installableBuildVersionName") ?: versionProperties.getProperty("versionName")
+        versionCode versionProperties.getProperty("versionCode").toInteger()
 
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
@@ -141,8 +146,6 @@ android {
 
     flavorDimensions "app", "buildType"
 
-    def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
-
     productFlavors {
         wordpress {
             isDefault true
@@ -184,23 +187,8 @@ android {
         vanilla {
             dimension "buildType"
 
-            versionName versionProperties.getProperty("versionName")
-            versionCode versionProperties.getProperty("versionCode").toInteger()
-
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
-            buildConfigField "boolean", "ENABLE_DEBUG_SETTINGS", "false"
-        }
-
-        // Used for Alpha builds - testing builds with experimental features enabled.
-        // AppName: WordPress/Jetpack
-        zalpha {
-            dimension "buildType"
-
-            versionName versionProperties.getProperty("alpha.versionName")
-            versionCode versionProperties.getProperty("alpha.versionCode").toInteger()
-
-            buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
             buildConfigField "boolean", "ENABLE_DEBUG_SETTINGS", "false"
         }
 
@@ -209,21 +197,15 @@ android {
         wasabi {
             applicationIdSuffix ".beta"
             dimension "buildType"
-
-            versionName versionProperties.getProperty("alpha.versionName")
-            versionCode versionProperties.getProperty("alpha.versionCode").toInteger()
         }
 
-        // Used for CI builds on PRs (downloadable apks). Can be used locally when a developer needs
+        // Used for CI builds on PRs (aka "Installable Builds"). Can be used locally when a developer needs
         // to install multiple versions of the app on the same device.
         // AppName: WordPress Pre-Alpha/Jetpack Pre-Alpha
         jalapeno {
             isDefault true
             applicationIdSuffix ".prealpha"
             dimension "buildType"
-
-            versionName project.findProperty("installableBuildVersionName") ?: versionProperties.getProperty("alpha.versionName")
-            versionCode 1 // Fixed versionCode because those builds are not meant to be uploaded to the PlayStore.
         }
 
         // Also dynamically add additional `buildConfigFields` to our app flavors from any `wp.`/`jp.`-prefixed property in `gradle.properties`

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -50,42 +50,13 @@ platform :android do
   lane :build_and_upload_pre_releases do |options|
     android_build_prechecks(
       skip_confirm: options[:skip_confirm],
-      alpha: true,
+      alpha: false,
       beta: true,
       final: false
     )
     android_build_preflight() unless options[:skip_prechecks]
     app = get_app_name_option!(options)
-    build_alpha(app: app, skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release])
     build_beta(app: app, skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release])
-  end
-
-  #####################################################################################
-  # build_alpha
-  # -----------------------------------------------------------------------------------
-  # This lane builds the app for internal testing and optionally uploads it
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane build_alpha app:<wordpress|jetpack> [skip_confirm:<true|false>] [upload_to_play_store:<true|false>] [create_release:<true|false>]
-  #
-  # Example:
-  # bundle exec fastlane build_alpha app:wordpress create_release:true
-  # bundle exec fastlane build_alpha app:wordpress skip_confirm:true upload_to_play_store:true
-  # bundle exec fastlane build_alpha app:jetpack
-  #####################################################################################
-  desc 'Builds and updates for distribution'
-  lane :build_alpha do |options|
-    android_build_prechecks(skip_confirm: options[:skip_confirm], alpha: true) unless options[:skip_prechecks]
-    android_build_preflight() unless options[:skip_prechecks]
-
-    # Create the file names
-    app = get_app_name_option!(options)
-    version = android_get_alpha_version()
-    build_bundle(app: app, version: version, flavor: 'Zalpha', buildType: 'Release')
-
-    upload_build_to_play_store(app: app, version: version, track: 'alpha') if options[:upload_to_play_store]
-
-    create_gh_release(app: app, version: version, prerelease: true) if options[:create_release]
   end
 
   #####################################################################################
@@ -112,34 +83,6 @@ platform :android do
     build_bundle(app: app, version: version, flavor: 'Vanilla', buildType: 'Release')
 
     upload_build_to_play_store(app: app, version: version, track: 'beta') if options[:upload_to_play_store]
-
-    create_gh_release(app: app, version: version, prerelease: true) if options[:create_release]
-  end
-
-  #####################################################################################
-  # build_internal
-  # -----------------------------------------------------------------------------------
-  # This lane builds the app for restricted internal testing, and optionally uploads it to PlayStore's Internal track
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane build_internal app:<wordpress|jetpack> [skip_confirm:<true|false>] [upload_to_play_store:<true|false>] [create_release:<true|false>]
-  #
-  # Example:
-  # bundle exec fastlane build_internal app:wordpress
-  # bundle exec fastlane build_internal app:wordpress skip_confirm:true upload_to_play_store:true
-  # bundle exec fastlane build_internal app:jetpack create_release:true
-  #####################################################################################
-  desc 'Builds and updates for internal testing'
-  lane :build_internal do |options|
-    android_build_prechecks(skip_confirm: options[:skip_confirm]) unless options[:skip_prechecks]
-    android_build_preflight() unless options[:skip_prechecks]
-
-    # Create the file names
-    app = get_app_name_option!(options)
-    version = android_get_release_version()
-    build_bundle(app: app, version: version, flavor: 'Zalpha', buildType: 'Debug')
-
-    upload_build_to_play_store(app: app, version: version, track: 'internal') if options[:upload_to_play_store]
 
     create_gh_release(app: app, version: version, prerelease: true) if options[:create_release]
   end

--- a/version.properties
+++ b/version.properties
@@ -1,9 +1,4 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
-# Version Information for Vanilla / Release builds
 versionName=20.5-rc-1
 versionCode=1259
-
-# Version Information for other flavors: zalpha, wasabi, jalapeno
-alpha.versionName=alpha-380
-alpha.versionCode=1260

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 versionName=20.5-rc-1
-versionCode=1259
+versionCode=1260


### PR DESCRIPTION
> **Note**: This PR is targeting the `release/20.5` branch, since I'll benefit from this change especially when I'll do upcoming betas.

## Why

Some more cleanup following the action of us removing the alpha builds when we migrated to Buildkite — [internal ref: paaHJt-3EU-p2]

## How

- Remove `alpha.version{Name,Code}` properties from `version.properties`
- Remove the `zalpha` flavor from `WordPress/build.gradle`
- Rearrange flavors versioning, so that all flavors use the same values of the `versionName` and `versionCode` properties from `version.properties` file (as opposed to some of them using `alpha.version{Name,Code}` before)

## To Test

 - Run `./gradlew printVersionName` and verify it prints the current `versionName` (`20.5-rc-1`)
 - Run `./gradlew printAllVersions` and verify it prints the current `versionName` and `versionCode` of each `{wordpress,jetpack}{Vanilla,Wasabi,Jalapeno}{Debug,Release}` flavor combination (should be `20.5-rc-1 (1259)` for all of them, now that we've unified them all to be the same on all flavors)
 - Test that the version bump still works with our tooling even without an alpha:
    - Cut a test branch named `release-test-17023` from this branch (the test branch **has** to be prefixed `release` for the prechecks of the next step to not reject you)
    - Run `PROJECT_ROOT_FOLDER=. bundle exec fastlane run android_bump_version_beta`
    - Verify that it pushed a new commit named `Bump version number` on your test branch, with `versionName` bumped to `20.5-rc-2` and `versionCode` bumped to `1260` in the `version.properties` file
    - 🧹  Delete your test `release-test-17023` branch, **both locally and from the remote** (since that test `git push`'d it 😒 )

## Additional thoughts to ponder for reviewers

Might also be worth confirming that this `versionCode` uniformization will not impact everyday development, for developers installing the apk on their test devices (and having to uninstall previous versions when `versionCode` is not increasing).

Personally I don't think that change will impact this — not only because developers mostly always work on branches cut from `trunk` and thus will still have increasing `versionCodes`, but also most of them test with the same flavor each time. But just thought it would be still be useful to raise the question to have your thoughts on it, in case I missed a use case.