### PR TITLE
Merge release/20.5 after some tooling improvements

### DIFF
--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -9,13 +9,13 @@ common_params:
 
 steps:
 
-  - label: "Lint WordPress"
+  - label: "🕵️ Lint WordPress"
     command: ".buildkite/commands/lint.sh wordpress"
     key: wplint
     artifact_paths:
       - "**/build/reports/lint-results*.*"
 
-  - label: "🔬 Lint Jetpack"
+  - label: "🕵️ Lint Jetpack"
     command: ".buildkite/commands/lint.sh jetpack"
     key: jplint
     artifact_paths:

--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -15,11 +15,11 @@ steps:
     artifact_paths:
       - "**/build/reports/lint-results*.*"
 
-  # - label: "🔬 Lint Jetpack"
-  #   command: ".buildkite/commands/lint.sh jetpack"
-  #   key: jplint
-  #   artifact_paths:
-  #     - "**/build/reports/lint-results*.*"
+  - label: "🔬 Lint Jetpack"
+    command: ".buildkite/commands/lint.sh jetpack"
+    key: jplint
+    artifact_paths:
+      - "**/build/reports/lint-results*.*"
 
   - label: "🛠 WordPress Beta Build"
     command: ".buildkite/commands/beta-build.sh wordpress"
@@ -30,7 +30,7 @@ steps:
 
   - label: "🛠 Jetpack Beta Build"
     command: ".buildkite/commands/beta-build.sh jetpack"
-    # depends_on: jplint
+    depends_on: jplint
     plugins: *common_plugins
     notify:
       - slack: "#build-and-ship"

--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -8,29 +8,52 @@ common_params:
     - automattic/bash-cache#2.1.0
 
 steps:
+  #################
+  # Lint
+  #################
+  - group: "🕵️ Lint"
+    steps:
 
-  - label: "🕵️ Lint WordPress"
-    command: ".buildkite/commands/lint.sh wordpress"
-    key: wplint
-    artifact_paths:
-      - "**/build/reports/lint-results*.*"
+      - label: "🕵️ Lint WordPress"
+        key: wplint
+        command: ".buildkite/commands/lint.sh wordpress"
+        artifact_paths:
+          - "**/build/reports/lint-results*.*"
 
-  - label: "🕵️ Lint Jetpack"
-    command: ".buildkite/commands/lint.sh jetpack"
-    key: jplint
-    artifact_paths:
-      - "**/build/reports/lint-results*.*"
+      - label: "🕵️ Lint Jetpack"
+        key: jplint
+        command: ".buildkite/commands/lint.sh jetpack"
+        artifact_paths:
+          - "**/build/reports/lint-results*.*"
 
-  - label: "🛠 WordPress Beta Build"
-    command: ".buildkite/commands/beta-build.sh wordpress"
-    depends_on: wplint
+  #################
+  # Beta Builds
+  #################
+  - group: "🚀 Beta Builds"
+    steps:
+
+      - label: "🛠 WordPress Beta Build"
+        key: wpbuild
+        command: ".buildkite/commands/beta-build.sh wordpress"
+        depends_on: wplint
+        plugins: *common_plugins
+        notify:
+          - slack: "#build-and-ship"
+
+      - label: "🛠 Jetpack Beta Build"
+        key: jpbuild
+        command: ".buildkite/commands/beta-build.sh jetpack"
+        depends_on: jplint
+        plugins: *common_plugins
+        notify:
+          - slack: "#build-and-ship"
+
+  #################
+  # GitHub Release
+  #################
+  - label: ":github: Release"
+    depends_on:
+      - wpbuild
+      - jpbuild
+    command: ".buildkite/commands/create-github-release.sh"
     plugins: *common_plugins
-    notify:
-      - slack: "#build-and-ship"
-
-  - label: "🛠 Jetpack Beta Build"
-    command: ".buildkite/commands/beta-build.sh jetpack"
-    depends_on: jplint
-    plugins: *common_plugins
-    notify:
-      - slack: "#build-and-ship"

--- a/.buildkite/commands/beta-build.sh
+++ b/.buildkite/commands/beta-build.sh
@@ -7,7 +7,7 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_beta app:$1 skip_confirm:true skip_prechecks:true upload_to_play_store:false
+bundle exec fastlane build_beta app:$1 skip_confirm:true skip_prechecks:true upload_to_play_store:true
 
 echo "--- 💾 Saving Artifact"
 for aab in build/*.aab; do

--- a/.buildkite/commands/beta-build.sh
+++ b/.buildkite/commands/beta-build.sh
@@ -7,7 +7,7 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_beta app:$1 skip_confirm:true skip_prechecks:true upload_to_play_store:true
+bundle exec fastlane build_beta app:$1 skip_confirm:true skip_prechecks:true upload_to_play_store:false
 
 echo "--- 💾 Saving Artifact"
 for aab in build/*.aab; do

--- a/.buildkite/commands/beta-build.sh
+++ b/.buildkite/commands/beta-build.sh
@@ -8,3 +8,9 @@ bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_beta app:$1 skip_confirm:true skip_prechecks:true upload_to_play_store:true
+
+echo "--- 💾 Saving Artifact"
+for aab in build/*.aab; do
+  buildkite-agent artifact upload "$aab"
+  echo "<a href="artifact://$aab">$(basename "$aab")</a>" | buildkite-agent annotate --style info --context "beta-build-$aab"
+done

--- a/.buildkite/commands/create-github-release.sh
+++ b/.buildkite/commands/create-github-release.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -eu
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- ⬇️ Downloading AAB Artefacts"
+mkdir -p build/
+buildkite-agent artifact download "*.aab" build/
+
+echo "--- :github: Create GitHub Release"
+bundle exec fastlane create_gh_release

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -eu
 
-echo "--- DEBUG: Skipping step for CI debugging purposes"
-exit 0
-
 echo "--- :microscope: Linting"
 cp gradle.properties-example gradle.properties
 

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -eu
 
+echo "--- DEBUG: Skipping step for CI debugging purposes"
+exit 0
+
 echo "--- :microscope: Linting"
 cp gradle.properties-example gradle.properties
 

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -7,7 +7,7 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_release app:$1 skip_confirm:true skip_prechecks:true upload_to_play_store:false
+bundle exec fastlane build_and_upload_release app:$1 skip_confirm:true skip_prechecks:true upload_to_play_store:true
 
 echo "--- 💾 Saving Artifact"
 for aab in build/*.aab; do

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -8,3 +8,9 @@ bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_release app:$1 skip_confirm:true skip_prechecks:true upload_to_play_store:true
+
+echo "--- 💾 Saving Artifact"
+for aab in build/*.aab; do
+  buildkite-agent artifact upload "$aab"
+  echo "<a href="artifact://$aab">$(basename "$aab")</a>" | buildkite-agent annotate --style info --context "beta-build-$aab"
+done

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -7,7 +7,7 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_release app:$1 skip_confirm:true skip_prechecks:true upload_to_play_store:true
+bundle exec fastlane build_and_upload_release app:$1 skip_confirm:true skip_prechecks:true upload_to_play_store:false
 
 echo "--- 💾 Saving Artifact"
 for aab in build/*.aab; do

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -12,5 +12,5 @@ bundle exec fastlane build_and_upload_release app:$1 skip_confirm:true skip_prec
 echo "--- 💾 Saving Artifact"
 for aab in build/*.aab; do
   buildkite-agent artifact upload "$aab"
-  echo "<a href="artifact://$aab">$(basename "$aab")</a>" | buildkite-agent annotate --style info --context "beta-build-$aab"
+  echo "<a href="artifact://$aab">$(basename "$aab")</a>" | buildkite-agent annotate --style info --context "release-build-$aab"
 done

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,10 +31,10 @@ steps:
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
-      # - label: "Lint Jetpack"
-      #   command: ".buildkite/commands/lint.sh jetpack"
-      #   artifact_paths:
-      #     - "**/build/reports/lint-results*.*"
+      - label: "Lint Jetpack"
+        command: ".buildkite/commands/lint.sh jetpack"
+        artifact_paths:
+          - "**/build/reports/lint-results*.*"
 
   - label: "Dependency Tree Diff"
     command: |

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
   #################
   - group: "🕵️‍♂️ Linters"
     steps:
-      - label: "checkstyle"
+      - label: "🕵️ checkstyle"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew checkstyle
@@ -18,7 +18,7 @@ steps:
         artifact_paths:
           - "**/build/reports/checkstyle/checkstyle.*"
 
-      - label: "detekt"
+      - label: "🕵️ detekt"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew detekt
@@ -26,12 +26,12 @@ steps:
         artifact_paths:
           - "**/build/reports/detekt/detekt.html"
 
-      - label: "Lint WordPress"
+      - label: "🕵️ Lint WordPress"
         command: ".buildkite/commands/lint.sh wordpress"
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
-      - label: "Lint Jetpack"
+      - label: "🕵️ Lint Jetpack"
         command: ".buildkite/commands/lint.sh jetpack"
         artifact_paths:
           - "**/build/reports/lint-results*.*"
@@ -48,19 +48,19 @@ steps:
   #################
   - group: "🔬 Unit Tests"
     steps:
-      - label: "Test WordPress"
+      - label: "🔬 Test WordPress"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew testWordpressVanillaRelease
         plugins: *common_plugins
 
-      - label: "Test Processors"
+      - label: "🔬 Test Processors"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew :libs:processors:test
         plugins: *common_plugins
 
-      - label: "Test Image Editor"
+      - label: "🔬 Test Image Editor"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew :libs:image-editor:test

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -9,13 +9,13 @@ common_params:
 
 steps:
 
-  - label: "Lint WordPress"
+  - label: "🕵️ Lint WordPress"
     command: ".buildkite/commands/lint.sh wordpress"
     key: wplint
     artifact_paths:
       - "**/build/reports/lint-results*.*"
 
-  - label: "🔬 Lint Jetpack"
+  - label: "🕵️ Lint Jetpack"
     command: ".buildkite/commands/lint.sh jetpack"
     key: jplint
     artifact_paths:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -15,11 +15,11 @@ steps:
     artifact_paths:
       - "**/build/reports/lint-results*.*"
 
-  # - label: "🔬 Lint Jetpack"
-  #   command: ".buildkite/commands/lint.sh jetpack"
-  #   key: jplint
-  #   artifact_paths:
-  #     - "**/build/reports/lint-results*.*"
+  - label: "🔬 Lint Jetpack"
+    command: ".buildkite/commands/lint.sh jetpack"
+    key: jplint
+    artifact_paths:
+      - "**/build/reports/lint-results*.*"
 
   - label: "🛠 WordPress Release Build"
     command: ".buildkite/commands/release-build.sh wordpress"
@@ -30,7 +30,7 @@ steps:
 
   - label: "🛠 Jetpack Release Build"
     command: ".buildkite/commands/release-build.sh jetpack"
-    # depends_on: jplint
+    depends_on: jplint
     plugins: *common_plugins
     notify:
       - slack: "#build-and-ship"

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -41,7 +41,7 @@ steps:
           - slack: "#build-and-ship"
 
       - label: "🛠 Jetpack Release Build"
-        key: j pbuild
+        key: jpbuild
         command: ".buildkite/commands/release-build.sh jetpack"
         depends_on: jplint
         plugins: *common_plugins

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -8,30 +8,52 @@ common_params:
     - automattic/bash-cache#2.1.0
 
 steps:
+  #################
+  # Lint
+  #################
+  - group: "🕵️ Lint"
+    steps:
 
-  - label: "🕵️ Lint WordPress"
-    command: ".buildkite/commands/lint.sh wordpress"
-    key: wplint
-    artifact_paths:
-      - "**/build/reports/lint-results*.*"
+      - label: "🕵️ Lint WordPress"
+        key: wplint
+        command: ".buildkite/commands/lint.sh wordpress"
+        artifact_paths:
+          - "**/build/reports/lint-results*.*"
 
-  - label: "🕵️ Lint Jetpack"
-    command: ".buildkite/commands/lint.sh jetpack"
-    key: jplint
-    artifact_paths:
-      - "**/build/reports/lint-results*.*"
+      - label: "🕵️ Lint Jetpack"
+        key: jplint
+        command: ".buildkite/commands/lint.sh jetpack"
+        artifact_paths:
+          - "**/build/reports/lint-results*.*"
 
-  - label: "🛠 WordPress Release Build"
-    command: ".buildkite/commands/release-build.sh wordpress"
-    depends_on: wplint
+  #################
+  # Beta Builds
+  #################
+  - group: "🚀 Beta Builds"
+    steps:
+
+      - label: "🛠 WordPress Release Build"
+        key: wpbuild
+        command: ".buildkite/commands/release-build.sh wordpress"
+        depends_on: wplint
+        plugins: *common_plugins
+        notify:
+          - slack: "#build-and-ship"
+
+      - label: "🛠 Jetpack Release Build"
+        key: j pbuild
+        command: ".buildkite/commands/release-build.sh jetpack"
+        depends_on: jplint
+        plugins: *common_plugins
+        notify:
+          - slack: "#build-and-ship"
+
+  #################
+  # GitHub Release
+  #################
+  - label: ":github: Release"
+    depends_on:
+      - wpbuild
+      - jpbuild
+    command: ".buildkite/commands/create-github-release.sh"
     plugins: *common_plugins
-    notify:
-      - slack: "#build-and-ship"
-
-  - label: "🛠 Jetpack Release Build"
-    command: ".buildkite/commands/release-build.sh jetpack"
-    depends_on: jplint
-    plugins: *common_plugins
-    notify:
-      - slack: "#build-and-ship"
-

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -587,11 +587,7 @@ tasks.register("dependencyTreeDiffCommentToGitHub", ViolationCommentsToGitHubTas
 
 tasks.register("printVersionName") {
     doLast {
-        if (project.hasProperty('alpha')) {
-          println android.productFlavors.zalpha.versionName
-        } else {
-          println android.productFlavors.vanilla.versionName
-        }
+        println android.defaultConfig.versionName
     }
 }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -594,8 +594,7 @@ tasks.register("printVersionName") {
 tasks.register("printAllVersions") {
     doLast {
         android.applicationVariants.all { variant ->
-            def apkData = variant.outputs*.apkData
-            println "${variant.name}: ${apkData*.versionName} (${apkData*.versionCode})"
+            println "${variant.name}: ${variant.versionName} (${variant.versionCode})"
         }
     }
 }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -70,9 +70,14 @@ android {
 
     compileSdkVersion rootProject.compileSdkVersion
 
+    def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
+
     defaultConfig {
         applicationId "org.wordpress.android"
         archivesBaseName = "$applicationId"
+
+        versionName project.findProperty("installableBuildVersionName") ?: versionProperties.getProperty("versionName")
+        versionCode versionProperties.getProperty("versionCode").toInteger()
 
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
@@ -141,8 +146,6 @@ android {
 
     flavorDimensions "app", "buildType"
 
-    def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
-
     productFlavors {
         wordpress {
             isDefault true
@@ -184,23 +187,8 @@ android {
         vanilla {
             dimension "buildType"
 
-            versionName versionProperties.getProperty("versionName")
-            versionCode versionProperties.getProperty("versionCode").toInteger()
-
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
-            buildConfigField "boolean", "ENABLE_DEBUG_SETTINGS", "false"
-        }
-
-        // Used for Alpha builds - testing builds with experimental features enabled.
-        // AppName: WordPress/Jetpack
-        zalpha {
-            dimension "buildType"
-
-            versionName versionProperties.getProperty("alpha.versionName")
-            versionCode versionProperties.getProperty("alpha.versionCode").toInteger()
-
-            buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
             buildConfigField "boolean", "ENABLE_DEBUG_SETTINGS", "false"
         }
 
@@ -209,21 +197,15 @@ android {
         wasabi {
             applicationIdSuffix ".beta"
             dimension "buildType"
-
-            versionName versionProperties.getProperty("alpha.versionName")
-            versionCode versionProperties.getProperty("alpha.versionCode").toInteger()
         }
 
-        // Used for CI builds on PRs (downloadable apks). Can be used locally when a developer needs
+        // Used for CI builds on PRs (aka "Installable Builds"). Can be used locally when a developer needs
         // to install multiple versions of the app on the same device.
         // AppName: WordPress Pre-Alpha/Jetpack Pre-Alpha
         jalapeno {
             isDefault true
             applicationIdSuffix ".prealpha"
             dimension "buildType"
-
-            versionName project.findProperty("installableBuildVersionName") ?: versionProperties.getProperty("alpha.versionName")
-            versionCode 1 // Fixed versionCode because those builds are not meant to be uploaded to the PlayStore.
         }
 
         // Also dynamically add additional `buildConfigFields` to our app flavors from any `wp.`/`jp.`-prefixed property in `gradle.properties`

--- a/WordPress/google-services.json-example
+++ b/WordPress/google-services.json-example
@@ -129,6 +129,132 @@
           "status": 1
         }
       }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:123:android:abc",
+        "android_client_info": {
+          "package_name": "com.jetpack.android"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "123-abc.apps.googleusercontent.com",
+          "client_type": 3
+        },
+        {
+          "client_id": "",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.jetpack.android",
+            "certificate_hash": ""
+          }
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": ""
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 2,
+          "analytics_property": {
+            "tracking_id": ""
+          }
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 1
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:123:android:abc",
+        "android_client_info": {
+          "package_name": "com.jetpack.android.prealpha"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "123-abc.apps.googleusercontent.com",
+          "client_type": 3
+        },
+        {
+          "client_id": "",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.jetpack.android.prealpha",
+            "certificate_hash": ""
+          }
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": ""
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 2,
+          "analytics_property": {
+            "tracking_id": ""
+          }
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 1
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:123:android:abc",
+        "android_client_info": {
+          "package_name": "com.jetpack.android.beta"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "123-abc.apps.googleusercontent.com",
+          "client_type": 3
+        },
+        {
+          "client_id": "",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.jetpack.android.beta",
+            "certificate_hash": ""
+          }
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": ""
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 2,
+          "analytics_property": {
+            "tracking_id": ""
+          }
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 1
+        }
+      }
     }
   ],
   "configuration_version": "1"

--- a/WordPress/src/jetpack/res/values/available_languages.xml
+++ b/WordPress/src/jetpack/res/values/available_languages.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Warning: Auto-generated file, do not edit.-->
-<resources>
-  <string-array name="available_languages" translatable="false">
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <string-array name="available_languages" translatable="false" tools:ignore="InconsistentArrays">
     <item>en_US</item>
     <item>ar</item>
     <item>de</item>

--- a/WordPress/src/main/res/values/available_languages.xml
+++ b/WordPress/src/main/res/values/available_languages.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Warning: Auto-generated file, do not edit.-->
-<resources>
-  <string-array name="available_languages" translatable="false">
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <string-array name="available_languages" translatable="false" tools:ignore="InconsistentArrays">
     <item>en_US</item>
     <item>ar</item>
     <item>de</item>

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -50,42 +50,13 @@ platform :android do
   lane :build_and_upload_pre_releases do |options|
     android_build_prechecks(
       skip_confirm: options[:skip_confirm],
-      alpha: true,
+      alpha: false,
       beta: true,
       final: false
     )
     android_build_preflight() unless options[:skip_prechecks]
     app = get_app_name_option!(options)
-    build_alpha(app: app, skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release])
     build_beta(app: app, skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release])
-  end
-
-  #####################################################################################
-  # build_alpha
-  # -----------------------------------------------------------------------------------
-  # This lane builds the app for internal testing and optionally uploads it
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane build_alpha app:<wordpress|jetpack> [skip_confirm:<true|false>] [upload_to_play_store:<true|false>] [create_release:<true|false>]
-  #
-  # Example:
-  # bundle exec fastlane build_alpha app:wordpress create_release:true
-  # bundle exec fastlane build_alpha app:wordpress skip_confirm:true upload_to_play_store:true
-  # bundle exec fastlane build_alpha app:jetpack
-  #####################################################################################
-  desc 'Builds and updates for distribution'
-  lane :build_alpha do |options|
-    android_build_prechecks(skip_confirm: options[:skip_confirm], alpha: true) unless options[:skip_prechecks]
-    android_build_preflight() unless options[:skip_prechecks]
-
-    # Create the file names
-    app = get_app_name_option!(options)
-    version = android_get_alpha_version()
-    build_bundle(app: app, version: version, flavor: 'Zalpha', buildType: 'Release')
-
-    upload_build_to_play_store(app: app, version: version, track: 'alpha') if options[:upload_to_play_store]
-
-    create_gh_release(app: app, version: version, prerelease: true) if options[:create_release]
   end
 
   #####################################################################################
@@ -112,34 +83,6 @@ platform :android do
     build_bundle(app: app, version: version, flavor: 'Vanilla', buildType: 'Release')
 
     upload_build_to_play_store(app: app, version: version, track: 'beta') if options[:upload_to_play_store]
-
-    create_gh_release(app: app, version: version, prerelease: true) if options[:create_release]
-  end
-
-  #####################################################################################
-  # build_internal
-  # -----------------------------------------------------------------------------------
-  # This lane builds the app for restricted internal testing, and optionally uploads it to PlayStore's Internal track
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane build_internal app:<wordpress|jetpack> [skip_confirm:<true|false>] [upload_to_play_store:<true|false>] [create_release:<true|false>]
-  #
-  # Example:
-  # bundle exec fastlane build_internal app:wordpress
-  # bundle exec fastlane build_internal app:wordpress skip_confirm:true upload_to_play_store:true
-  # bundle exec fastlane build_internal app:jetpack create_release:true
-  #####################################################################################
-  desc 'Builds and updates for internal testing'
-  lane :build_internal do |options|
-    android_build_prechecks(skip_confirm: options[:skip_confirm]) unless options[:skip_prechecks]
-    android_build_preflight() unless options[:skip_prechecks]
-
-    # Create the file names
-    app = get_app_name_option!(options)
-    version = android_get_release_version()
-    build_bundle(app: app, version: version, flavor: 'Zalpha', buildType: 'Debug')
-
-    upload_build_to_play_store(app: app, version: version, track: 'internal') if options[:upload_to_play_store]
 
     create_gh_release(app: app, version: version, prerelease: true) if options[:create_release]
   end

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=20.5-rc-1
+versionName=20.5-rc-100
 versionCode=1259
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno

--- a/version.properties
+++ b/version.properties
@@ -1,9 +1,4 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
-# Version Information for Vanilla / Release builds
 versionName=20.5-rc-1
 versionCode=1259
-
-# Version Information for other flavors: zalpha, wasabi, jalapeno
-alpha.versionName=alpha-380
-alpha.versionCode=1260

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 # Version Information for Vanilla / Release builds
-versionName=20.5-rc-100
+versionName=20.5-rc-1
 versionCode=1259
 
 # Version Information for other flavors: zalpha, wasabi, jalapeno

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
 versionName=20.5-rc-1
-versionCode=1259
+versionCode=1260


### PR DESCRIPTION
I recently made a handful of tooling-only PRs to the `release/20.5` branch (#17015, #17018, #17019, #17023), which were made in the release branch because those tooling changes would benefit Release Management duties and automation during this beta.

This PR now lands those tooling improvements into `trunk`:
 - Not only to resync `release/20.5` with `trunk` sooner than later, even if there was no new beta created since
 - But also so that, when it will be time to do a new beta later this sprint, the future `release/20.5` -> `trunk` that will follow would have an easier-to-review diff.

> **Note** All those PRs have already been approved (when then landed in `release/20.5`), so the review of this PR should be straightforward and trivial — no real need to re-review the already-reviewed changes in practice after all 🙃 