### PR TITLE
Merge Editorialized Release Notes for release/20.5

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -11,6 +11,14 @@ msgstr ""
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_205"
+msgid ""
+"20.5:\n"
+"- We added a label in App Settings to show the app’s current interface language.\n"
+"- We bumped up the screenshot size in the site theme picker to go with high-resolution image previews.\n"
+"- In the site creation process, we changed the Skip button text from blue to Jetpack green.\n"
+msgstr ""
+
 msgctxt "release_note_204"
 msgid ""
 "20.4:\n"
@@ -18,14 +26,6 @@ msgid ""
 "- Properly displayed Video blocks (both web and app) for VideoPress-enabled sites.\n"
 "- Block inserter allows block types to be better organized in collections.\n"
 "- Alt text footnote spacing adjustment in Image blocks.\n"
-msgstr ""
-
-msgctxt "release_note_203"
-msgid ""
-"20.3:\n"
-"- When you add an item in the media library to an Image block, the item’s alt text comes with it.\n"
-"- You can insert media from a URL in Video blocks.\n"
-"- Use the block recovery option to bring back unexpected or invalid content in a block.\n"
 msgstr ""
 
 #. translators: Title to be displayed in the Play Store. Limit to 30 characters including spaces and commas!

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,5 +1,3 @@
-* [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16848]
-* [***] [internal] Block Editor: List block: Adds support for V2 behind a feature flag [https://github.com/WordPress/gutenberg/pull/42702]
-* [*] Use the Jetpack green color for the skip buttons text in site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16994]
-* [**] App Settings: Show a label with the current language of the app under "Interface Language". [https://github.com/wordpress-mobile/WordPress-Android/pull/17004]
-
+- We added a label in App Settings to show the app’s current interface language.
+- We bumped up the screenshot size in the site theme picker to go with high-resolution image previews.
+- In the site creation process, we changed the Skip button text from blue to Jetpack green.

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -11,6 +11,13 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_205"
+msgid ""
+"20.5:\n"
+"- We added a new label in App Settings to show the app’s current interface language. Shiny.\n"
+"- Now that the app supports higher-resolution image previews, we bumped up the size of theme screenshots in the site theme picker. No more pixellation, only pixel perfection.\n"
+msgstr ""
+
 msgctxt "release_note_204"
 msgid ""
 "20.4:\n"
@@ -18,14 +25,6 @@ msgid ""
 "- Properly displayed Video blocks (both web and app) for VideoPress-enabled sites.\n"
 "- Block inserter allows block types to be better organized in collections.\n"
 "- Alt text footnote spacing adjustment in Image blocks.\n"
-msgstr ""
-
-msgctxt "release_note_203"
-msgid ""
-"20.3:\n"
-"- When you add an item in the media library to an Image block, the item’s alt text comes with it.\n"
-"- You can insert media from a URL in Video blocks.\n"
-"- Use the block recovery option to bring back unexpected or invalid content in a block.\n"
 msgstr ""
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,4 +1,2 @@
-* [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16848]
-* [***] [internal] Block Editor: List block: Adds support for V2 behind a feature flag [https://github.com/WordPress/gutenberg/pull/42702]
-* [**] App Settings: Show a label with the current language of the app under "Interface Language". [https://github.com/wordpress-mobile/WordPress-Android/pull/17004]
-
+- We added a new label in App Settings to show the app’s current interface language. Shiny.
+- Now that the app supports higher-resolution image previews, we bumped up the size of theme screenshots in the site theme picker. No more pixellation, only pixel perfection.


### PR DESCRIPTION
Make sure the Editorialized Release Notes land in `trunk` ASAP so that they can be picked up by the cron job and uploaded into GlotPress and start being translated.