### PR TITLE
Show Jetpack banner in search results

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] Login: Fix an issue preventing some users to log-in in with email addresses containing a single quote [https://github.com/wordpress-mobile/WordPress-Android/pull/15526]
 * [*] Fix a possible crash with themes preloading at the start of Site Creation [https://github.com/wordpress-mobile/WordPress-Android/pull/17022]
+* [*] Show Jetpack banner in search results [https://github.com/wordpress-mobile/WordPress-Android/pull/17028]
 
 20.5
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -87,6 +87,11 @@ public class FilteredRecyclerView extends RelativeLayout {
         return mRecyclerView;
     }
 
+    public RecyclerView getSearchSuggestionsRecyclerView() {
+        return mSearchSuggestionsRecyclerView;
+    }
+
+
     public void setRefreshing(boolean refreshing) {
         mSwipeToRefreshHelper.setRefreshing(refreshing);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -72,6 +72,7 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.FilteredRecyclerView;
 import org.wordpress.android.ui.RequestCodes;
+import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.ViewPagerFragment;
 import org.wordpress.android.ui.main.BottomNavController;
 import org.wordpress.android.ui.main.SitePickerActivity;
@@ -771,6 +772,11 @@ public class ReaderPostListFragment extends ViewPagerFragment
         if (shouldShowEmptyViewForSelfHostedCta()) {
             setEmptyTitleDescriptionAndButton(false);
             showEmptyView();
+        }
+
+        if (getActivity() instanceof ScrollableViewInitializedListener) {
+            ((ScrollableViewInitializedListener) getActivity())
+                    .onScrollableViewInitialized(mRecyclerView.getInternalRecyclerView().getId());
         }
 
         mViewModel.onFragmentResume(mIsTopLevel, isSearching(), isFilterableScreen(),
@@ -2651,7 +2657,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
         if (blogId > 0) {
             WPSnackbar.make(getSnackbarParent(), Html.fromHtml(getString(R.string.reader_followed_blog_notifications,
-                    "<b>", blog, "</b>")), Snackbar.LENGTH_LONG)
+                              "<b>", blog, "</b>")), Snackbar.LENGTH_LONG)
                       .setAction(getString(R.string.reader_followed_blog_notifications_action),
                               new View.OnClickListener() {
                                   @Override public void onClick(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -503,7 +503,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
     }
 
     private void toggleJetpackBannerIfEnabled(final boolean forceShow) {
-        if (!isAdded() || getView() == null) return;
+        if (!isAdded() || getView() == null || !isSearching()) return;
 
         if (forceShow && mJetpackBrandingUtils.shouldShowJetpackBranding()) {
             showJetpackBanner();
@@ -523,15 +523,19 @@ public class ReaderPostListFragment extends ViewPagerFragment
                         .show(getChildFragmentManager(), JetpackPoweredBottomSheetFragment.TAG);
             });
         }
-        // Add bottom margin to post list and empty view.
-        int jetpackBannerHeight = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
-        ((MarginLayoutParams) mRecyclerView.getLayoutParams()).bottomMargin = jetpackBannerHeight;
-        ((MarginLayoutParams) mActionableEmptyView.getLayoutParams()).bottomMargin = jetpackBannerHeight;
+
+        if (!isSearching()) {
+            // Add bottom margin to search suggestions post list and empty view.
+            int jetpackBannerHeight = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
+            ((MarginLayoutParams) mRecyclerView.getSearchSuggestionsRecyclerView().getLayoutParams()).bottomMargin
+                    = jetpackBannerHeight;
+            ((MarginLayoutParams) mActionableEmptyView.getLayoutParams()).bottomMargin = jetpackBannerHeight;
+        }
     }
 
     private void hideJetpackBanner() {
         mJetpackBanner.setVisibility(View.GONE);
-        // Remove bottom margin from post list and empty view.
+        // Remove bottom margin from search suggestions post list and empty view
         ((MarginLayoutParams) mRecyclerView.getLayoutParams()).bottomMargin = 0;
         ((MarginLayoutParams) mActionableEmptyView.getLayoutParams()).bottomMargin = 0;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -72,7 +72,6 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.FilteredRecyclerView;
 import org.wordpress.android.ui.RequestCodes;
-import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.ViewPagerFragment;
 import org.wordpress.android.ui.main.BottomNavController;
 import org.wordpress.android.ui.main.SitePickerActivity;
@@ -529,21 +528,11 @@ public class ReaderPostListFragment extends ViewPagerFragment
         mJetpackBrandingUtils.setNavigationBarColorForBanner(requireActivity().getWindow());
         mJetpackBanner.setVisibility(View.VISIBLE);
 
-        if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
-            mJetpackBanner.setOnClickListener(v -> {
-                mJetpackBrandingUtils.trackBannerTapped(Screen.READER_SEARCH);
-                new JetpackPoweredBottomSheetFragment()
-                        .show(getChildFragmentManager(), JetpackPoweredBottomSheetFragment.TAG);
-            });
-        }
-
-        if (!isSearching()) {
-            // Add bottom margin to search suggestions post list and empty view.
-            int jetpackBannerHeight = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
-            ((MarginLayoutParams) mRecyclerView.getSearchSuggestionsRecyclerView().getLayoutParams()).bottomMargin
-                    = jetpackBannerHeight;
-            ((MarginLayoutParams) mActionableEmptyView.getLayoutParams()).bottomMargin = jetpackBannerHeight;
-        }
+        // Add bottom margin to search suggestions list and empty view.
+        int jetpackBannerHeight = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
+        ((MarginLayoutParams) mRecyclerView.getSearchSuggestionsRecyclerView().getLayoutParams()).bottomMargin
+                = jetpackBannerHeight;
+        ((MarginLayoutParams) mActionableEmptyView.getLayoutParams()).bottomMargin = jetpackBannerHeight;
     }
 
     private void hideJetpackBanner() {
@@ -789,11 +778,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
         if (shouldShowEmptyViewForSelfHostedCta()) {
             setEmptyTitleDescriptionAndButton(false);
             showEmptyView();
-        }
-
-        if (getActivity() instanceof ScrollableViewInitializedListener) {
-            ((ScrollableViewInitializedListener) getActivity())
-                    .onScrollableViewInitialized(mRecyclerView.getInternalRecyclerView().getId());
         }
 
         mViewModel.onFragmentResume(mIsTopLevel, isSearching(), isFilterableScreen(),
@@ -1162,6 +1146,17 @@ public class ReaderPostListFragment extends ViewPagerFragment
         mProgress.setVisibility(View.GONE);
 
         mJetpackBanner = rootView.findViewById(R.id.jetpack_banner);
+        if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
+            mJetpackBrandingUtils.initJetpackBannerAnimation(mJetpackBanner, mRecyclerView.getInternalRecyclerView());
+
+            if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                mJetpackBanner.setOnClickListener(v -> {
+                    mJetpackBrandingUtils.trackBannerTapped(Screen.READER_SEARCH);
+                    new JetpackPoweredBottomSheetFragment()
+                            .show(getChildFragmentManager(), JetpackPoweredBottomSheetFragment.TAG);
+                });
+            }
+        }
 
         if (savedInstanceState != null && savedInstanceState.getBoolean(ReaderConstants.KEY_IS_REFRESHING)) {
             mIsUpdating = true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1128,12 +1128,9 @@ public class ReaderPostListFragment extends ViewPagerFragment
         // bar that appears at top after new posts are loaded
         mNewPostsBar = rootView.findViewById(R.id.layout_new_posts);
         mNewPostsBar.setVisibility(View.GONE);
-        mNewPostsBar.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                mRecyclerView.scrollRecycleViewToPosition(0);
-                refreshPosts();
-            }
+        mNewPostsBar.setOnClickListener(view -> {
+            mRecyclerView.scrollRecycleViewToPosition(0);
+            refreshPosts();
         });
 
         // progress bar that appears when loading more posts

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -500,9 +500,9 @@ public class ReaderPostListFragment extends ViewPagerFragment
         }
     }
 
-    private void toggleJetpackBannerIfEnabled(boolean forceShow) {
-        if (!isAdded() || !isSearching() || getView() == null) return;
-        final boolean shouldShow = forceShow && mJetpackBrandingUtils.shouldShowJetpackBranding();
+    private void toggleJetpackBannerIfEnabled() {
+        if (!isAdded() || getView() == null) return;
+        final boolean shouldShow = mJetpackBrandingUtils.shouldShowJetpackBranding();
         if (shouldShow) {
             View jetpackBanner = getView().findViewById(R.id.jetpack_banner);
             jetpackBanner.setVisibility(View.VISIBLE);
@@ -1220,7 +1220,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         boolean hasQuery = !isSearchViewEmpty();
         boolean hasPerformedSearch = !TextUtils.isEmpty(mCurrentSearchQuery);
 
-        toggleJetpackBannerIfEnabled(true);
+        toggleJetpackBannerIfEnabled();
 
         // prevents suggestions from being shown after the search view has been collapsed
         if (!isSearching()) {
@@ -1309,7 +1309,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         updatePostsInCurrentSearch(0);
         updateSitesInCurrentSearch(0);
 
-        toggleJetpackBannerIfEnabled(false);
+        toggleJetpackBannerIfEnabled();
 
         // track that the user performed a search
         if (!trimQuery.equals("")) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -512,6 +512,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
     }
 
     private void showJetpackBanner() {
+        mJetpackBrandingUtils.setNavigationBarColorForBanner(requireActivity().getWindow());
         mJetpackBanner.setVisibility(View.VISIBLE);
 
         if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1867,6 +1867,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
                 }
                 if (isSearching() && !isSearchTabsShowing()) {
                     showSearchTabs();
+                } else if (isSearching()) {
+                    toggleJetpackBannerIfEnabled(true);
                 }
             }
             mRestorePosition = 0;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.reader;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.Html;
@@ -506,16 +507,15 @@ public class ReaderPostListFragment extends ViewPagerFragment
     private void toggleJetpackBannerIfEnabled(final boolean showIfEnabled, boolean animateOnScroll) {
         if (!isAdded() || getView() == null || !isSearching()) return;
 
-        if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
-            if (animateOnScroll) {
-                mJetpackBrandingUtils.showJetpackBannerIfScrolledToTop(
-                        mJetpackBanner,
-                        mRecyclerView.getInternalRecyclerView()
-                );
-                // Return early since the visibility was handled by showJetpackBannerIfScrolledToTop
-                return;
-            }
+        if (animateOnScroll) {
+            RecyclerView scrollView = mRecyclerView.getInternalRecyclerView();
+            mJetpackBrandingUtils.showJetpackBannerIfScrolledToTop(mJetpackBanner, scrollView);
+            mJetpackBrandingUtils.setNavigationBarColorForBanner(requireActivity().getWindow());
+            // Return early since the banner visibility was handled by showJetpackBannerIfScrolledToTop
+            return;
+        }
 
+        if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
             if (showIfEnabled && !mDisplayUtilsWrapper.isPhoneLandscape()) {
                 showJetpackBanner();
             } else {
@@ -525,8 +525,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
     }
 
     private void showJetpackBanner() {
-        mJetpackBrandingUtils.setNavigationBarColorForBanner(requireActivity().getWindow());
         mJetpackBanner.setVisibility(View.VISIBLE);
+        mJetpackBrandingUtils.setNavigationBarColorForBanner(requireActivity().getWindow());
 
         // Add bottom margin to search suggestions list and empty view.
         int jetpackBannerHeight = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
@@ -537,8 +537,13 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
     private void hideJetpackBanner() {
         mJetpackBanner.setVisibility(View.GONE);
-        // Remove bottom margin from search suggestions post list and empty view
-        ((MarginLayoutParams) mRecyclerView.getLayoutParams()).bottomMargin = 0;
+
+        if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
+            requireActivity().getWindow().setNavigationBarColor(0);
+        }
+
+        // Remove bottom margin from search suggestions list and empty view.
+        ((MarginLayoutParams) mRecyclerView.getSearchSuggestionsRecyclerView().getLayoutParams()).bottomMargin = 0;
         ((MarginLayoutParams) mActionableEmptyView.getLayoutParams()).bottomMargin = 0;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -503,10 +503,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
     private void toggleJetpackBannerIfEnabled(final boolean forceShow) {
         if (!isAdded() || getView() == null) return;
-        final boolean shouldShow = mJetpackBrandingUtils.shouldShowJetpackBranding();
-        if (shouldShow) {
-            View jetpackBanner = getView().findViewById(R.id.jetpack_banner);
-            jetpackBanner.setVisibility(View.VISIBLE);
 
         if (forceShow && mJetpackBrandingUtils.shouldShowJetpackBranding()) {
             showJetpackBanner();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSearchActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSearchActivity.kt
@@ -61,7 +61,6 @@ class ReaderSearchActivity : LocaleAwareActivity(),
                 val scrollableView = fragmentView.findViewById<View>(containerId) as RecyclerView
 
                 if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
-                    jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
                     jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSearchActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSearchActivity.kt
@@ -1,13 +1,10 @@
 package org.wordpress.android.ui.reader
 
 import android.os.Bundle
-import android.view.View
-import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.LocaleAwareActivity
-import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.tracker.ReaderTrackerType.MAIN_READER
 import org.wordpress.android.util.JetpackBrandingUtils
@@ -19,8 +16,7 @@ import javax.inject.Inject
  * into new tested classes without requiring us to change the search behavior.
  */
 @AndroidEntryPoint
-class ReaderSearchActivity : LocaleAwareActivity(),
-        ScrollableViewInitializedListener {
+class ReaderSearchActivity : LocaleAwareActivity() {
     @Inject lateinit var readerTracker: ReaderTracker
     @Inject lateinit var jetpackBrandingUtils: JetpackBrandingUtils
 
@@ -46,24 +42,5 @@ class ReaderSearchActivity : LocaleAwareActivity(),
     override fun onPause() {
         super.onPause()
         readerTracker.stop(MAIN_READER)
-    }
-
-    override fun onScrollableViewInitialized(containerId: Int) {
-        val fragmentContainer = supportFragmentManager.findFragmentById(R.id.fragment_container)
-
-        if (fragmentContainer is ReaderPostListFragment) {
-            val fragmentView = fragmentContainer.view ?: return
-
-            fragmentView.post {
-                // post is used to create a minimal delay here. containerId changes just before
-                // onScrollableViewInitialized is called, and findViewById can't find the new id before the delay.
-                val jetpackBannerView = fragmentView.findViewById<View>(R.id.jetpack_banner)
-                val scrollableView = fragmentView.findViewById<View>(containerId) as RecyclerView
-
-                if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
-                    jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
-                }
-            }
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/DisplayUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DisplayUtilsWrapper.kt
@@ -6,10 +6,12 @@ import javax.inject.Inject
 
 @Reusable
 class DisplayUtilsWrapper @Inject constructor(private val contextProvider: ContextProvider) {
+    private val windowWidth get() = DisplayUtils.getWindowPixelWidth(contextProvider.getContext())
+    private val windowHeight get() = DisplayUtils.getWindowPixelHeight(contextProvider.getContext())
+
     fun getDisplayPixelWidth() = DisplayUtils.getDisplayPixelWidth()
 
-    fun isLandscapeBySize() =
-            getDisplayPixelWidth() > DisplayUtils.getWindowPixelHeight(contextProvider.getContext())
+    fun isLandscapeBySize() = windowWidth > windowHeight
 
     fun isLandscape() = DisplayUtils.isLandscape(contextProvider.getContext())
 


### PR DESCRIPTION
Show the Jetpack banner in search results to match iOS version.

To test:
Test Case 1 (Phone)
1. Launch WordPress App (in portrait orientation)
2. Go to Reader → Search
3. Enter a search query & submit (e.g. `Jetpack`)
4. **Expect** the Jetpack Powered banner to **hide** when the search is in progress. 
5. **Expect** the banner **show** when the search results appear.
6. Scroll down & **expect** the banner to **slide-out** of the view
7. Scroll back to the top and **expect** the banner to **slide-in** into the view
8. Rotate the phone to landscape
9. Tap the search input in the toolbar and change the search query (e.g. `Jetpack powered`)
10. **Expect** the banner to hide
11. Rotate the phone to portrait
12. **Expect** the banner to show 

Test Case 2 (Tablet)
- Repeat Test Case 1 but **expect** the banner to **show** when hidden in landscape orientation on a phone.
  Specifically that is when updating the search query.

<img width="314" src="https://user-images.githubusercontent.com/4588074/184150810-7515970c-a12c-4c94-b9e7-474bf2aac4e2.png">

## Regression Notes
1. Potential unintended areas of impact
   Site creation - Domain search **on a phone** → I've updated a function that wasn't working correctly to detect a phone in landscape orientation; making it not reusable in other places.
   That function was reused afterwards to hide the banner in reader search on a phone seen in landscape.

13. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

14. What automated tests I added (or what prevented me from doing so)
   N/a → UI code that doesn't warrant automated tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
