### PR TITLE
Disables: Autofill for sign up and username screens

### DIFF
--- a/WordPress/src/main/res/layout/signup_epilogue.xml
+++ b/WordPress/src/main/res/layout/signup_epilogue.xml
@@ -40,6 +40,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/margin_extra_large"
                     android:hint="@string/signup_epilogue_hint_username"
+                    android:importantForAutofill="noExcludeDescendants"
                     android:inputType="none" />
 
                 <org.wordpress.android.login.widgets.WPLoginInputRow
@@ -49,6 +50,7 @@
                     android:layout_marginTop="@dimen/margin_extra_large"
                     android:hint="@string/signup_epilogue_hint_password"
                     android:inputType="textPassword"
+                    android:importantForAutofill="noExcludeDescendants"
                     android:visibility="gone"
                     app:passwordToggleEnabled="true"
                     tools:visibility="visible" />

--- a/WordPress/src/main/res/layout/username_changer_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/username_changer_dialog_fragment.xml
@@ -38,6 +38,7 @@
             android:layout_toEndOf="@+id/icon"
             android:background="@android:color/transparent"
             android:digits="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            android:importantForAutofill="noExcludeDescendants"
             android:hint="@string/username_changer_hint"
             android:paddingTop="@dimen/margin_extra_large"
             android:paddingBottom="@dimen/margin_extra_large" />

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 ext {
     wordPressUtilsVersion = '2.7.0'
-    wordPressLoginVersion = 'trunk-1d609e3a84c84e1c88b59830312e747a50916b7f'
+    wordPressLoginVersion = '91-5ac81347e02e435a9d51e5b7e09354b1034607fc'
     gutenbergMobileVersion = 'v1.81.0'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 ext {
     wordPressUtilsVersion = '2.7.0'
-    wordPressLoginVersion = '91-5ac81347e02e435a9d51e5b7e09354b1034607fc'
+    wordPressLoginVersion = 'trunk-657bed28fa735780e3ffcc214503a9e5d1286d6c'
     gutenbergMobileVersion = 'v1.81.0'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'


### PR DESCRIPTION
Parent #16093
Dependant PR - https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/91

Reference for Autofill 
https://developer.android.com/guide/topics/text/autofill-optimize#important

Description
For more details about the change see the p2(internal reference) paqN3M-Gp-p2

## To test:

### Test 1 - Login with Credentials 
- Install a third-party autofill manager 
- Go to the login page
- Verify that the autofill manager doesn’t prompt to fill the email/username 
- Enter username/email
- Verify that the autofill manager doesn’t prompt to fill the password 

### Test 2 - Sign up prompt 
- Install a third-party autofill manager 
- Sign up using a new email 
- Verify that the autofill manager doesn’t prompt to fill the email/username 
- Enter username/email
- Verify that the autofill manager doesn’t prompt to fill the password 

### Test 3 - Change username 
- Install a third-party autofill manager 
- Log in using some credentials 
- Verify that the autofill manager doesn’t prompt to fill the email/username 
- Enter username/email
- Verify that the autofill manager doesn’t prompt to fill the password 

### Test 4 - Login using the site and connect jetpack 
- Install a third-party autofill manager 
- Log in to the app using a non-jetpack site 
- Access stats/notifications which prompt to install jetpack using a wp com account 
- Verify that the autofill manager doesn’t prompt to fill the email/username 

cc: @tiagomar for visibility 

### Merge instructions 
- Make sure the dependent PR is merged 
- Update Login library version 
- Remove the not ready for merge label 
- Merge as usual 


## Regression Notes
1. Potential unintended areas of impact
Login not working as expected 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.