### PR TITLE
Add scroll animation to Jetpack banner on stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.activity.viewModels
-import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.StatsListActivityBinding
@@ -13,11 +12,9 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.push.NotificationType
 import org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE
 import org.wordpress.android.ui.LocaleAwareActivity
-import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.JetpackBrandingUtils
-import org.wordpress.android.util.JetpackBrandingUtils.Screen.STATS
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -29,22 +26,7 @@ class StatsActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        with(StatsListActivityBinding.inflate(layoutInflater)) {
-            setContentView(root)
-            if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
-                jetpackBanner.root.isVisible = true
-                jetpackBrandingUtils.setNavigationBarColorForBanner(window)
-
-                if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
-                    jetpackBanner.root.setOnClickListener {
-                        jetpackBrandingUtils.trackBannerTapped(STATS)
-                        JetpackPoweredBottomSheetFragment
-                                .newInstance()
-                                .show(supportFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
-                    }
-                }
-            }
-        }
+        setContentView(StatsListActivityBinding.inflate(layoutInflater).root)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.activityViewModels
+import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.MarginPageTransformer
 import com.google.android.material.snackbar.Snackbar
@@ -40,6 +41,8 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.insights.UpdateAler
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.UpdateAlertDialogFragment.Companion.UPDATE_ALERT_DIALOG_TAG
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider.SiteUpdateResult
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.JetpackBrandingUtils
+import org.wordpress.android.util.JetpackBrandingUtils.Screen.STATS
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.viewmodel.observeEvent
@@ -51,11 +54,14 @@ private val statsSections = listOf(INSIGHTS, DAYS, WEEKS, MONTHS, YEARS)
 @AndroidEntryPoint
 class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializedListener {
     @Inject lateinit var uiHelpers: UiHelpers
+    @Inject lateinit var jetpackBrandingUtils: JetpackBrandingUtils
     private val viewModel: StatsViewModel by activityViewModels()
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
     private lateinit var selectedTabListener: SelectedTabListener
 
     private var restorePreviousSearch = false
+
+    private var binding: StatsFragmentBinding? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -67,6 +73,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
 
         val nonNullActivity = requireActivity()
         with(StatsFragmentBinding.bind(view)) {
+            binding = this
             with(nonNullActivity as AppCompatActivity) {
                 setSupportActionBar(toolbar)
                 supportActionBar?.let {
@@ -253,6 +260,30 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
 
     override fun onScrollableViewInitialized(containerId: Int) {
         StatsFragmentBinding.bind(requireView()).appBarLayout.liftOnScrollTargetViewId = containerId
+        initJetpackBanner(containerId)
+    }
+
+    private fun initJetpackBanner(scrollableContainerId: Int) {
+        if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
+            binding?.root?.post {
+                val jetpackBannerView = binding?.jetpackBanner?.root ?: return@post
+                val scrollableView = binding?.root?.findViewById<View>(scrollableContainerId) as? RecyclerView
+                        ?: return@post
+
+                jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
+                activity?.window?.let { jetpackBrandingUtils.setNavigationBarColorForBanner(it) }
+                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
+
+                if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                    binding?.jetpackBanner?.root?.setOnClickListener {
+                        jetpackBrandingUtils.trackBannerTapped(STATS)
+                        JetpackPoweredBottomSheetFragment
+                                .newInstance()
+                                .show(childFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -75,7 +75,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
                 }
             }
             initializeViewModels(nonNullActivity, savedInstanceState == null, savedInstanceState)
-            initializeViews(nonNullActivity)
+            initializeViews()
         }
     }
 
@@ -85,8 +85,8 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
         super.onSaveInstanceState(outState)
     }
 
-    private fun StatsFragmentBinding.initializeViews(activity: FragmentActivity) {
-        val adapter = StatsPagerAdapter(activity)
+    private fun StatsFragmentBinding.initializeViews() {
+        val adapter = StatsPagerAdapter(this@StatsFragment)
         statsPager.adapter = adapter
         statsPager.setPageTransformer(
                 MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
@@ -256,7 +256,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
     }
 }
 
-class StatsPagerAdapter(val activity: FragmentActivity) : FragmentStateAdapter(activity) {
+class StatsPagerAdapter(private val parent: Fragment) : FragmentStateAdapter(parent) {
     override fun getItemCount(): Int = statsSections.size
 
     override fun createFragment(position: Int): Fragment {
@@ -264,7 +264,7 @@ class StatsPagerAdapter(val activity: FragmentActivity) : FragmentStateAdapter(a
     }
 
     fun getTabTitle(position: Int): CharSequence {
-        return activity.getString(statsSections[position].titleRes)
+        return parent.context?.getString(statsSections[position].titleRes).orEmpty()
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -5,7 +5,6 @@ import android.view.View
 import android.view.View.OnScrollChangeListener
 import android.view.Window
 import androidx.core.view.isVisible
-import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -34,8 +33,7 @@ class JetpackBrandingUtils @Inject constructor(
     fun showJetpackBannerIfScrolledToTop(banner: View, scrollableView: RecyclerView) {
         banner.isVisible = true
 
-        val layoutManager = scrollableView.layoutManager as LinearLayoutManager
-        val isEmpty = layoutManager.itemCount == 0
+        val isEmpty = scrollableView.layoutManager?.itemCount == 0
         val scrollOffset = scrollableView.computeVerticalScrollOffset()
 
         banner.translationY = if (scrollOffset == 0 || isEmpty) {

--- a/WordPress/src/main/res/layout/stats_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_fragment.xml
@@ -26,6 +26,10 @@
 
         </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
+        <include
+            android:id="@+id/jetpack_banner"
+            layout="@layout/jetpack_banner" />
+
         <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/app_bar_layout"
             android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/stats_list_activity.xml
+++ b/WordPress/src/main/res/layout/stats_list_activity.xml
@@ -1,18 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:name="org.wordpress.android.ui.stats.refresh.StatsFragment"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
-
-    <include
-        android:id="@+id/jetpack_banner"
-        layout="@layout/jetpack_banner" />
-</LinearLayout>
+        android:layout_height="match_parent" />
+</FrameLayout>


### PR DESCRIPTION
This adds a scroll animation feature to the Jetpack banner on the stats screen.

This also fixes the lifting app bar problem on the stats screen. Notice the top app bar layout's color on before and after videos. You can also check the same feature on the Reader screen as an example. Now, stats app bar matches with the reader app bar.

<details><summary>before</summary>

https://user-images.githubusercontent.com/2471769/184452987-0c5eb6d8-c2ef-4f23-903b-08f346362535.mp4
</details>

https://user-images.githubusercontent.com/2471769/184453218-fe446efd-a55a-4f89-9b56-22209c89eb36.mp4

**Technical detail:**
```
override fun onScrollableViewInitialized(containerId: Int) {
        StatsFragmentBinding.bind(requireView()).appBarLayout.liftOnScrollTargetViewId = containerId
}
```
This code was not working in `StatsFragment`. c97c1cdea17bb7046a80418a9a0c3820fdadf67c fixed it.

**NOTE:** The navigation bar is still green after hiding the banner. That feature could be updated later in another PR, but first, I'll ask the team's opinion on Slack.

To test:
1. Launch the WordPress app.
2. Open Stats screen from My Site.
3. Ensure the Jetpack banner is visible bottom of the screen.
4. Scroll the list.
5. Ensure the Jetpack banner disappeared.
6. Scroll the list to the top again.
7. Ensure the Jetpack banner appears.
8. Rotate to landscape mode.
9. Ensure the navigation bar color is not green. 
10. Rotate back to portrait mode.
11. Ensure the navigation bar color is green again.

## Regression Notes
1. Potential unintended areas of impact
Since the change I explained in the "Technical detail" section, some features might change on the Stats screen. Landscape orientation mode could be impacted. Empty and error cases could be affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Since I only added a UI animation feature, I didn't add any tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
