### PR TITLE
Jetpack focus enable widgets on jetpack app

### DIFF
--- a/WordPress/src/jetpack/res/values-en-rAU/strings.xml
+++ b/WordPress/src/jetpack/res/values-en-rAU/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name" translatable="false">Jetpack</string>
-    <string name="widgets_enabled" translatable="false">false</string>
+    <string name="widgets_enabled" translatable="false">true</string>
 
     <!-- About View -->
     <string name="app_title">Jetpack for Android</string>

--- a/WordPress/src/jetpack/res/values-en-rCA/strings.xml
+++ b/WordPress/src/jetpack/res/values-en-rCA/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name" translatable="false">Jetpack</string>
-    <string name="widgets_enabled" translatable="false">false</string>
+    <string name="widgets_enabled" translatable="false">true</string>
 
     <!-- About View -->
     <string name="app_title">Jetpack for Android</string>

--- a/WordPress/src/jetpack/res/values-en-rGB/strings.xml
+++ b/WordPress/src/jetpack/res/values-en-rGB/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name" translatable="false">Jetpack</string>
-    <string name="widgets_enabled" translatable="false">false</string>
+    <string name="widgets_enabled" translatable="false">true</string>
 
     <!-- About View -->
     <string name="app_title">Jetpack for Android</string>

--- a/WordPress/src/jetpack/res/values-eu/strings.xml
+++ b/WordPress/src/jetpack/res/values-eu/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name" translatable="false">Jetpack</string>
-    <string name="widgets_enabled" translatable="false">false</string>
+    <string name="widgets_enabled" translatable="false">true</string>
 
     <!-- About View -->
     <string name="app_title">Jetpack for Android</string>

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name" translatable="false">Jetpack</string>
-    <string name="widgets_enabled" translatable="false">false</string>
+    <string name="widgets_enabled" translatable="false">true</string>
 
     <!-- About View -->
     <string name="app_title">Jetpack for Android</string>


### PR DESCRIPTION
This PR enables home screen stats **widgets** on Jetpack app.  


Fixes #

<img width=320 src=https://user-images.githubusercontent.com/990349/184580136-e149f782-1a8c-4ab5-a5e5-152c3a3e19a2.png />


Fixes #

To test:


- Build and run Jetpack app variant
- Launch Jetpack
- Go to app launcher, find Jetpack app icon and long click on it
- Ensure it opens app shortcuts and includes **Widgets** option now.
- Tap on widget option, make sure it opens Stats widgets selection view
- Tap and hold on a widget, it will open a configuration screen, select a site and color
- Position and resize widget as you like it

NOTE: 
- Additional [strings have been updated](c62cc0c7a1befc5c1185fdd11a6a303f4d5c0c2e) in English locales for testing purposes, otherwise app wouldn't reflect the changes.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
