### PR TITLE
Fixes bottom navigation bar color and notification badge color

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -90,7 +90,7 @@
         <!-- Main tab activity -->
         <activity
             android:name=".ui.main.WPMainActivity"
-            android:theme="@style/WordPress.NoActionBar"
+            android:theme="@style/Wordpress.BottomBar"
             android:label="" />
 
         <!-- Account activities -->

--- a/WordPress/src/main/res/drawable/bg_nav_badge.xml
+++ b/WordPress/src/main/res/drawable/bg_nav_badge.xml
@@ -4,5 +4,5 @@
     <solid android:color="@color/accent"/>
     <stroke
         android:width="1dp"
-        android:color="@android:color/white"/>
+        android:color="@color/bottom_bar_notification_badge"/>
 </shape>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -5,6 +5,7 @@
     <!-- Switch to attribute after dropping support for api 21-23 -->
     <color name="placeholder">#1AFFFFFF</color>
     <color name="p2_author_bg_stroke">#1E1E1E</color>
+    <color name="bottom_bar_notification_badge">@color/background_dark_elevated</color>
 
     <!-- Login Prologue -->
     <color name="promo_indicator_color_default">@color/white_translucent_20</color>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -128,4 +128,8 @@
 
     <!-- Domains -->
     <style name="Domains.Button.Primary.Unelevated.OnPrimarySurface" parent="WordPress.Button.Primary.Unelevated" />
+
+    <style name="Wordpress.BottomBar" parent="WordPress.NoActionBar">
+        <item name="android:navigationBarColor">@color/background_dark_elevated</item>
+    </style>
 </resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -11,6 +11,7 @@
     <color name="background_snackbar">@color/neutral_80</color>
     <color name="link_reader">@color/primary</color>
     <color name="link_stats">@color/accent</color>
+    <color name="bottom_bar_notification_badge">@android:color/white</color>
 
     <!-- Switch to attribute after dropping support for api 21-23 -->
     <color name="placeholder">#1A000000</color>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -199,6 +199,8 @@
         <!-- We need to keep this here so we can override it in values-vXY -->
     </style>
 
+    <style name="Wordpress.BottomBar" parent="WordPress.NoActionBar"/>
+
     <style name="WordPress.NoActionBar" parent="WordPress">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>


### PR DESCRIPTION
Fixes #14629 & #15927

Fixes the Bottom Navigation bar UI tray color and the Notification badge outline color 

To test:

Test 1 
- Login to the app 
- Go to my site 
- Verify that the area below the bottom bar has the same colour as the bottom bar in dark and light mode 



| Before | After |
|---|---|
|![Screenshot_20220815_190253](https://user-images.githubusercontent.com/17463767/184645041-557704f2-cd01-434a-b33f-a0a10fb95a4b.png)|![Screenshot_20220815_180013](https://user-images.githubusercontent.com/17463767/184643797-d2941d01-77f1-430b-bf5a-afba153de8fb.png)| 

Test 2 
- Login to the app with a notification pending 
- Go to my site 
- Verify that the notification badge outline is the same colour as the bottom bar in the dark and light mode so that it feels like a cut-out like the proposed solution to the issue. 

|Notification badge in Light mode| Notification badge in darkmode|
|---|---|
|![Screenshot_20220815_181438](https://user-images.githubusercontent.com/17463767/184644238-d6f2bb15-e6f1-4b9f-b5b7-3c84bf7a7223.png)| ![Screenshot_20220815_181520](https://user-images.githubusercontent.com/17463767/184644249-1e541a9a-9e5d-4276-9a04-345e118774f3.png) |  

## Regression Notes
1. Potential unintended areas of impact
The area below bottom bar not shown properly in light or dark mode 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
