### PR TITLE
[Jetpack] Use Jetpack badge instead of banner on sharing screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -3,8 +3,6 @@ package org.wordpress.android.ui.publicize;
 import android.app.ProgressDialog;
 import android.os.Bundle;
 import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup.MarginLayoutParams;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -32,12 +30,10 @@ import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.ScrollableViewInitializedListener;
-import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.services.PublicizeUpdateService;
 import org.wordpress.android.util.JetpackBrandingUtils;
-import org.wordpress.android.util.JetpackBrandingUtils.Screen;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
@@ -81,25 +77,6 @@ public class PublicizeListActivity extends LocaleAwareActivity
         }
 
         mAppBarLayout = findViewById(R.id.appbar_main);
-
-        if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
-            View jetpackBanner = findViewById(R.id.jetpack_banner);
-            jetpackBanner.setVisibility(View.VISIBLE);
-            mJetpackBrandingUtils.setNavigationBarColorForBanner(getWindow());
-
-            // Add bottom margin to content.
-            MarginLayoutParams layoutParams =
-                    (MarginLayoutParams) findViewById(R.id.fragment_container).getLayoutParams();
-            layoutParams.bottomMargin = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
-
-            if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
-                jetpackBanner.setOnClickListener(v -> {
-                    mJetpackBrandingUtils.trackBannerTapped(Screen.SHARE);
-                    new JetpackPoweredBottomSheetFragment()
-                            .show(getSupportFragmentManager(), JetpackPoweredBottomSheetFragment.TAG);
-                });
-            }
-        }
 
         if (savedInstanceState == null) {
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -141,7 +141,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
 
             if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
                 jetpackBadge.setOnClickListener(v -> {
-                    mJetpackBrandingUtils.trackBannerTapped(Screen.SHARE);
+                    mJetpackBrandingUtils.trackBadgeTapped(Screen.SHARE);
                     new JetpackPoweredBottomSheetFragment()
                             .show(requireActivity().getSupportFragmentManager(), JetpackPoweredBottomSheetFragment.TAG);
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -136,7 +136,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
         }
 
         if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
-            View jetpackBadge = rootView.findViewById(R.id.jetpack_badge_sharing);
+            View jetpackBadge = rootView.findViewById(R.id.jetpack_powered_badge);
             jetpackBadge.setVisibility(View.VISIBLE);
 
             if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -6,7 +6,6 @@ import android.text.Spannable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewGroup.MarginLayoutParams;
 import android.view.ViewTreeObserver;
 import android.widget.TextView;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -136,11 +136,11 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
         }
 
         if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
-            View jetpackBadgeFooter = rootView.findViewById(R.id.jetpack_badge_footer);
-            jetpackBadgeFooter.setVisibility(View.VISIBLE);
+            View jetpackBadge = rootView.findViewById(R.id.jetpack_badge_sharing);
+            jetpackBadge.setVisibility(View.VISIBLE);
 
             if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
-                jetpackBadgeFooter.setOnClickListener(v -> {
+                jetpackBadge.setOnClickListener(v -> {
                     mJetpackBrandingUtils.trackBannerTapped(Screen.SHARE);
                     new JetpackPoweredBottomSheetFragment()
                             .show(requireActivity().getSupportFragmentManager(), JetpackPoweredBottomSheetFragment.TAG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -6,6 +6,7 @@ import android.text.Spannable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewGroup.MarginLayoutParams;
 import android.view.ViewTreeObserver;
 import android.widget.TextView;
 
@@ -24,11 +25,14 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository;
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.OnAdapterLoadedListener;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.OnServiceClickListener;
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
 import org.wordpress.android.ui.utils.UiString.UiStringText;
+import org.wordpress.android.util.JetpackBrandingUtils;
+import org.wordpress.android.util.JetpackBrandingUtils.Screen;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.QuickStartUtilsWrapper;
@@ -60,6 +64,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
     @Inject QuickStartUtilsWrapper mQuickStartUtilsWrapper;
     @Inject QuickStartRepository mQuickStartRepository;
     @Inject SnackbarSequencer mSnackbarSequencer;
+    @Inject JetpackBrandingUtils mJetpackBrandingUtils;
 
     public static PublicizeListFragment newInstance(@NonNull SiteModel site) {
         Bundle args = new Bundle();
@@ -128,6 +133,19 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
 
         if (mQuickStartEvent != null) {
             showQuickStartFocusPoint();
+        }
+
+        if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
+            View jetpackBadgeFooter = rootView.findViewById(R.id.jetpack_badge_footer);
+            jetpackBadgeFooter.setVisibility(View.VISIBLE);
+
+            if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                jetpackBadgeFooter.setOnClickListener(v -> {
+                    mJetpackBrandingUtils.trackBannerTapped(Screen.SHARE);
+                    new JetpackPoweredBottomSheetFragment()
+                            .show(requireActivity().getSupportFragmentManager(), JetpackPoweredBottomSheetFragment.TAG);
+                });
+            }
         }
 
         return rootView;

--- a/WordPress/src/main/res/layout/publicize_list_activity.xml
+++ b/WordPress/src/main/res/layout/publicize_list_activity.xml
@@ -24,8 +24,4 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
-
-    <include
-        android:id="@+id/jetpack_banner"
-        layout="@layout/jetpack_banner" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/publicize_list_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_list_fragment.xml
@@ -113,12 +113,26 @@
 
             </RelativeLayout>
 
-            <include
-                android:id="@+id/jetpack_badge_sharing"
-                layout="@layout/jetpack_badge"
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/jetpack_powered_badge"
                 android:visibility="gone"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:importantForAccessibility="no"
+                android:paddingEnd="15dp"
+                android:paddingStart="5dp"
+                android:paddingVertical="5dp"
+                android:text="@string/wp_jetpack_powered"
+                android:textAppearance="?attr/textAppearanceBody1"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_sz_large"
+                app:backgroundTint="@color/jetpack_badge_background"
+                app:cornerRadius="20dp"
+                app:icon="@drawable/ic_jetpack_logo_24dp"
+                app:iconPadding="10dp"
+                app:iconTint="@null"
+                tools:ignore="TextContrastCheck"
                 tools:visibility="visible" />
 
         </LinearLayout>

--- a/WordPress/src/main/res/layout/publicize_list_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_list_fragment.xml
@@ -113,6 +113,12 @@
 
             </RelativeLayout>
 
+            <include
+                android:id="@+id/jetpack_badge_footer"
+                layout="@layout/jetpack_badge_footer"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
         </LinearLayout>
     </RelativeLayout>
 </androidx.core.widget.NestedScrollView>

--- a/WordPress/src/main/res/layout/publicize_list_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_list_fragment.xml
@@ -114,9 +114,11 @@
             </RelativeLayout>
 
             <include
-                android:id="@+id/jetpack_badge_footer"
-                layout="@layout/jetpack_badge_footer"
+                android:id="@+id/jetpack_badge_sharing"
+                layout="@layout/jetpack_badge"
                 android:visibility="gone"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 tools:visibility="visible" />
 
         </LinearLayout>


### PR DESCRIPTION
Fixes #17029 

### Description

This PR uses the Jetpack badge instead of the Jetpack banner on the Sharing screen (publicize).

### To test:

Preconditions: Feature flags can be set in the WordPress app for enabling the badge and the bottomsheet by tapping "Me" -> "App Settings" -> "Debug settings", toggling the values for:

* `jetpack_powered_remote_field`
* `JetpackPoweredBottomSheetConfig`

and then tapping the "RESTART APP" button.

#### Jetpack App + WordPress App (with `jetpack_powered_remote_field` unchecked)

1. Navigate to the Sharing screen: "My Site" -> "Sharing"
2. Expect that the Jetpack badge is _not_ visible

<details>
<summary>Screenshot</summary>

<img src="https://user-images.githubusercontent.com/8507675/184700554-640f9f9b-8849-40b8-bbb3-bf2c3a907627.png" width="360">

</details>

#### WordPress App (with `jetpack_powered_remote_field` checked and `JetpackPoweredBottomSheetConfig` unchecked)

1. Navigate to the Sharing screen: "My Site" -> "Sharing"
2. Expect that the Jetpack badge is visible
4. Tap the Jetpack badge
5. Expect that nothing happens

<details>
<summary>Screenshots</summary>

**Portrait**

| Light Mode | Dark Mode |
|-|-|
|![badge-visible](https://user-images.githubusercontent.com/8507675/184700810-e5b557a9-bcbc-4d3c-8a08-202a521495a8.png)|![badge-visible-dark](https://user-images.githubusercontent.com/8507675/184700837-d6c0772d-ee61-4b56-a63e-ccc1ed03d418.png)|

**Landscape**

![badge-visible-landscape](https://user-images.githubusercontent.com/8507675/184700978-8a87e561-8177-451e-8419-f6044bee2894.png)

</details>

#### WordPress App (with `jetpack_powered_remote_field` checked and `JetpackPoweredBottomSheetConfig` checked)

1. Navigate to the Sharing screen: "My Site" -> "Sharing"
2. Expect that the Jetpack badge is visible
3. Tap the Jetpack badge
4. Expect that the Jetpack bottomsheet opens

<details>
<summary>Screenshot</summary>

<img src="https://user-images.githubusercontent.com/8507675/184701088-19cabeac-649f-47bd-b315-dd75a79aa256.png" width="360">

</details>

#### Tracks

When tapping the button (with both feature flags enabled), the following tracks event should be emitted:

`🔵 Tracked: jetpack_powered_badge_tapped, Properties: {"screen":"share"}`

### Known issue

<s>There is an issue where the badge is not easily tappable in dark mode. Tapping to the left or right of the badge opens the bottomsheet, but for some reason, tapping directly on the badge consumes the event (and the bottomsheet does not open). This should be investigated and resolved before landing this PR.</s>

This has been resolved with: https://github.com/wordpress-mobile/WordPress-Android/pull/17035/commits/337af9e05d8b28aa24fc60e25e4c9d3121b9e0f5

## Regression Notes
1. Potential unintended areas of impact
Sharing screen

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

7. What automated tests I added (or what prevented me from doing so)
New automated tests were not added for this, as the refactor required would be out of scope for the task.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
