### PR TITLE
#16796 Action bar gets dismissed before the navigation to change user name screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsNavigationHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsNavigationHandler.kt
@@ -20,7 +20,6 @@ class AccountSettingsNavigationHandler @Inject constructor() {
                     .setTitle(R.string.username_changer_title)
                     .setAction(R.string.username_changer_action)
                     .setOnConfirmListener { result -> onConfirm.invoke(result) }
-                    .setHideActivityBar(false)
                     .setIsLifOnScroll(false)
                     .setOnDismissListener { onDismiss.invoke() }
                     .setOnShownListener { onShown.invoke() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsNavigationHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsNavigationHandler.kt
@@ -20,7 +20,7 @@ class AccountSettingsNavigationHandler @Inject constructor() {
                     .setTitle(R.string.username_changer_title)
                     .setAction(R.string.username_changer_action)
                     .setOnConfirmListener { result -> onConfirm.invoke(result) }
-                    .setHideActivityBar(true)
+                    .setHideActivityBar(false)
                     .setIsLifOnScroll(false)
                     .setOnDismissListener { onDismiss.invoke() }
                     .setOnShownListener { onShown.invoke() }


### PR DESCRIPTION
Fixes #16796 

Action bar gets dismissed before the navigation to change user name screen

**Solution** - I've updated a Boolean value inside AccountSettingsNavigationHandler.kt class on builder function setHideActivityBar, which has wrong value and changed to correct.

To test:

1. Login to the app
2. Go to me -> Account settings
3. Click on username

## Regression Notes
1. Potential unintended areas of impact
     None 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manual testing 
3. What automated tests I added (or what prevented me from doing so)
    (N/A)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

before ->
https://www.loom.com/share/a9d42a8938e048ae91b05928b3cc1c3b

after ->
https://www.loom.com/share/39d4016ce0cf4eebbfc1e70fea3eef34