### PR TITLE
[Gutenberg] - Test disabling FastImage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = 'trunk-657bed28fa735780e3ffcc214503a9e5d1286d6c'
-    gutenbergMobileVersion = 'v1.81.0'
+    gutenbergMobileVersion = '5102-2d4c1c92fc8e90013f0d10155cabe34b80c4b5a9'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 


### PR DESCRIPTION
Do not merge, this is for testing only.

**Related PRs:**
- `Gutenberg Mobile` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/5102
- `Gutenberg` -> https://github.com/WordPress/gutenberg/pull/43322

There's a current issue on Android https://github.com/WordPress/gutenberg/issues/43149 where in some cases the images will disappear with the React Native FastImage library, we will disable it while we work on a fix.

To test check the Gutenberg PR description.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
