### PR TITLE
Disable comment notification Approve action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
@@ -473,10 +473,10 @@ public class GCMMessageHandler {
                 // if the comment is lacking approval, offer moderation actions
                 if (note.getCommentStatus() == CommentStatus.UNAPPROVED) {
                     if (note.canModerate()) {
-                        //TODO
+                        // TODO
                         // Enable comment approve action after fixing content lost after approval.
                         // Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/17026
-                        //addCommentApproveActionForCommentNotification(context, builder, noteId);
+                        // addCommentApproveActionForCommentNotification(context, builder, noteId);
                     }
                 } else {
                     // else offer REPLY / LIKE actions

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
@@ -473,7 +473,8 @@ public class GCMMessageHandler {
                 // if the comment is lacking approval, offer moderation actions
                 if (note.getCommentStatus() == CommentStatus.UNAPPROVED) {
                     if (note.canModerate()) {
-                        addCommentApproveActionForCommentNotification(context, builder, noteId);
+                        // TODO enable comment approve action after fixing content lost after approval
+                        // addCommentApproveActionForCommentNotification(context, builder, noteId);
                     }
                 } else {
                     // else offer REPLY / LIKE actions

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
@@ -473,8 +473,10 @@ public class GCMMessageHandler {
                 // if the comment is lacking approval, offer moderation actions
                 if (note.getCommentStatus() == CommentStatus.UNAPPROVED) {
                     if (note.canModerate()) {
-                        // TODO enable comment approve action after fixing content lost after approval
-                        // addCommentApproveActionForCommentNotification(context, builder, noteId);
+                        //TODO
+                        // Enable comment approve action after fixing content lost after approval.
+                        // Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/17026
+                        //addCommentApproveActionForCommentNotification(context, builder, noteId);
                     }
                 } else {
                     // else offer REPLY / LIKE actions


### PR DESCRIPTION
Before changes:
<img width="315" alt="image" src="https://user-images.githubusercontent.com/14964993/185161299-73aec4d6-ef55-4e2b-a652-0e1daf8cdc3c.png">

After changes:
<img width="316" alt="image" src="https://user-images.githubusercontent.com/14964993/185161398-b89f8a63-3377-4517-9009-eccd4bc7f079.png">

"Approve" action on comment notification is making the comment loose its content. Until we have a proper fix, we're disabling the action from comment moderation notification.

To test:
1 - In the app, login with an user that can moderate comments on a certain site
2 - Open a blog post on web (without being logged in) from a site that is moderated by logged in user from step 1
3 - Make a comment
4 - Observe the app: you should receive a comment moderation notification without "Approve" action. "Reply" action should be working as expected.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
