### PR TITLE
Jetpack focus update banner on activity log to scrolling animation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -4,14 +4,13 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup.MarginLayoutParams
-import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
+import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.databinding.ActivityLogListActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.RequestCodes
+import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailActivity
 import org.wordpress.android.ui.jetpack.backup.download.KEY_BACKUP_DOWNLOAD_ACTION_STATE_ID
 import org.wordpress.android.ui.jetpack.backup.download.KEY_BACKUP_DOWNLOAD_DOWNLOAD_ID
@@ -26,29 +25,42 @@ import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ActivityLogListActivity : LocaleAwareActivity() {
+class ActivityLogListActivity : LocaleAwareActivity(), ScrollableViewInitializedListener {
     @Inject lateinit var jetpackBrandingUtils: JetpackBrandingUtils
+    private var binding: ActivityLogListActivityBinding? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         with(ActivityLogListActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
+            binding = this
             checkAndUpdateUiToBackupScreen()
 
             setSupportActionBar(toolbarMain)
+        }
+        supportActionBar?.let {
+            it.setHomeButtonEnabled(true)
+            it.setDisplayHomeAsUpEnabled(true)
+        }
+    }
 
-            if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
-                jetpackBanner.root.isVisible = true
-                jetpackBrandingUtils.setNavigationBarColorForBanner(window)
+    override fun onScrollableViewInitialized(containerId: Int) {
+        initJetpackBanner(containerId)
+    }
 
-                // Add bottom margin to content.
-                val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
-                fragment?.view?.updateLayoutParams<MarginLayoutParams> {
-                    bottomMargin = resources.getDimensionPixelSize(R.dimen.jetpack_banner_height)
-                }
+    private fun initJetpackBanner(scrollableContainerId: Int) {
+        if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
+            binding?.root?.post {
+                val jetpackBannerView = binding?.jetpackBanner?.root ?: return@post
+                val scrollableView = binding?.root?.findViewById<View>(scrollableContainerId) as? RecyclerView
+                        ?: return@post
+
+                jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
+                window?.let { jetpackBrandingUtils.setNavigationBarColorForBanner(it) }
+                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
 
                 if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
-                    jetpackBanner.root.setOnClickListener {
+                    binding?.jetpackBanner?.root?.setOnClickListener {
                         jetpackBrandingUtils.trackBannerTapped(ACTIVITY_LOG)
                         JetpackPoweredBottomSheetFragment
                                 .newInstance()
@@ -56,10 +68,6 @@ class ActivityLogListActivity : LocaleAwareActivity() {
                     }
                 }
             }
-        }
-        supportActionBar?.let {
-            it.setHomeButtonEnabled(true)
-            it.setDisplayHomeAsUpEnabled(true)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -19,11 +19,13 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
+import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.DownloadBackupFile
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowBackupDownload
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRestore
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterFragment
+import org.wordpress.android.ui.prefs.EmptyViewRecyclerView
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
@@ -58,6 +60,7 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
     @Inject lateinit var uiHelpers: UiHelpers
     private lateinit var viewModel: ActivityLogViewModel
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
+    private lateinit var listView: EmptyViewRecyclerView
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -70,6 +73,7 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
         ).get(ActivityLogViewModel::class.java)
 
         with(ActivityLogListFragmentBinding.bind(view)) {
+            listView = logListView
             logListView.layoutManager = LinearLayoutManager(nonNullActivity, RecyclerView.VERTICAL, false)
 
             swipeToRefreshHelper = buildSwipeToRefreshHelper(swipeRefreshLayout) {
@@ -114,6 +118,13 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
         restoreDateRangePickerListeners()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (activity is ScrollableViewInitializedListener) {
+            (activity as ScrollableViewInitializedListener).onScrollableViewInitialized(listView.id)
+        }
     }
 
     private fun restoreDateRangePickerListeners() {


### PR DESCRIPTION
This PR update existing static banner to scroll-able animation on ActivityLog screen


https://user-images.githubusercontent.com/990349/185543967-350ba89d-f298-4d13-b1cb-f1e30d36f5cc.mov




To test:

1. Launch the WordPress app.
2. Open Activity Log screen from My Site.
3. Ensure the Jetpack banner is visible at the bottom of the screen.
4. Scroll the list.
5. Ensure the Jetpack banner hides.
6. Scroll the list to the top again.
7. Ensure the Jetpack banner appears again.


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
