### PR TITLE
Update Fluxc and Login Libraries to Latest Trunk Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 ext {
     wordPressUtilsVersion = '2.7.0'
-    wordPressLoginVersion = 'trunk-657bed28fa735780e3ffcc214503a9e5d1286d6c'
+    wordPressLoginVersion = 'trunk-e11535105725e02dd1e8aa8065314ceb67079278'
     gutenbergMobileVersion = 'v1.81.0'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '1.49.0'
+    fluxCVersion = 'trunk-eb1d39ad095c01367af03c4259ab93cda14c675e'
 
     appCompatVersion = '1.0.2'
     androidxCoreVersion = '1.3.2'


### PR DESCRIPTION
Relates To:
- Login: [Update FluxC to Latest Trunk Hash #92](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/92)
- WCAndroid: [Update login library version #7240](https://github.com/woocommerce/woocommerce-android/pull/7240)

This PR is about updating both, the `FluxC` and `Login` libraries, to their corresponding latest `trunk` version. This is mainly done because of a crash that was identified on the WCAndroid site due to the `RefreshSitesXMLRPCPayload` data class becoming immutable as part of a `FluxC` update. However, the `Login` library was pointing to a previous version of `FluxC`, which didn't have the same change, thus causing that specific flow which was utilizing the previous version of `RefreshSitesXMLRPCPayload` to crash.

This update is done in order to make sure that both, this WPAndroid client and its `Login` library dependency, are pointing to that `FluxC` version where everything works as expected, without crashes or weird behaviors.

-----

👋 @zwarm , I shamelessly added you as an extra reviewer. Can you help @AliSoftware with the smoke testing part, just to verify that everything works as expected before he starts with the `20.6` code freeze on Monday? 🙇 

-----

To test:

- Verify that all the CI checks are successful.
- Smoke test the apps, both WordPress and Jetpack, and verify everything works as expected (like `Login` functionality, `My Site/Reader/Notification` tabs, `Stats/Media/Posts/Pages/Comments/Me/Jetpack` screens, create `Story/Post/Page`, etc).
- Additionally, you can follow the testing instructions within this related [WCAndroid PR](https://github.com/woocommerce/woocommerce-android/pull/7240) PR, and connect with a self-hosted site on a Jetpack connection and verify that the app isn't crashing.

## Regression Notes
1. Potential unintended areas of impact

Since this `FluxC` version comes with lots of small changes, like models becoming immutable (`var` -> `val`, etc), it might be the case that either the app is not complilying (can be easily verified by CI) or the app might be crashing on specific scenarios (thus needing manual smoke testing) due to transitive dependencies on various libraries that point to a different version of `FluxC` (like the `Login` library).

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
