### PR TITLE
Jetpack focus jetpack banner and nav bar color

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -56,8 +56,7 @@ class ActivityLogListActivity : LocaleAwareActivity(), ScrollableViewInitialized
                         ?: return@post
 
                 jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
-                window?.let { jetpackBrandingUtils.setNavigationBarColorForBanner(it) }
-                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
+                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView, window)
 
                 if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
                     binding?.jetpackBanner?.root?.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -310,7 +310,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
                 val jetpackBannerView = binding?.jetpackBanner?.root ?: return@post
                 val scrollableView = binding?.root?.findViewById<View>(containerId) as? RecyclerView ?: return@post
                 jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
-                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
+                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView, activity?.window)
 
                 if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
                     jetpackBannerView.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -330,7 +330,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
                 val jetpackBannerView = binding?.jetpackBanner?.root ?: return@post
                 val scrollableView = binding?.root?.findViewById<View>(containerId) as? RecyclerView ?: return@post
                 jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
-                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
+                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView, activity?.window)
 
                 if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
                     jetpackBannerView.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -510,7 +510,11 @@ public class ReaderPostListFragment extends ViewPagerFragment
         if (animateOnScroll) {
             RecyclerView scrollView = mRecyclerView.getInternalRecyclerView();
             mJetpackBrandingUtils.showJetpackBannerIfScrolledToTop(mJetpackBanner, scrollView);
-            mJetpackBrandingUtils.setNavigationBarColorForBanner(requireActivity().getWindow());
+            mJetpackBrandingUtils.initJetpackBannerAnimation(
+                    mJetpackBanner,
+                    scrollView,
+                    requireActivity().getWindow()
+            );
             // Return early since the banner visibility was handled by showJetpackBannerIfScrolledToTop
             return;
         }
@@ -1152,7 +1156,11 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
         mJetpackBanner = rootView.findViewById(R.id.jetpack_banner);
         if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
-            mJetpackBrandingUtils.initJetpackBannerAnimation(mJetpackBanner, mRecyclerView.getInternalRecyclerView());
+            mJetpackBrandingUtils.initJetpackBannerAnimation(
+                    mJetpackBanner,
+                    mRecyclerView.getInternalRecyclerView(),
+                    requireActivity().getWindow()
+            );
 
             if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
                 mJetpackBanner.setOnClickListener(v -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -271,8 +271,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
                         ?: return@post
 
                 jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
-                activity?.window?.let { jetpackBrandingUtils.setNavigationBarColorForBanner(it) }
-                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
+                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView, activity?.window)
 
                 if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
                     binding?.jetpackBanner?.root?.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -45,7 +45,7 @@ class JetpackBrandingUtils @Inject constructor(
         }
     }
 
-    fun initJetpackBannerAnimation(banner: View, scrollableView: RecyclerView) {
+    fun initJetpackBannerAnimation(banner: View, scrollableView: RecyclerView, window: Window?) {
         scrollableView.setOnScrollChangeListener(object : OnScrollChangeListener {
             private var isScrollAtTop = true
 
@@ -56,11 +56,13 @@ class JetpackBrandingUtils @Inject constructor(
                     // Show the banner by moving up
                     isScrollAtTop = true
                     banner.animate().translationY(0f).start()
+                    window?.let { setNavigationBarColorForBanner(it) }
                 } else if (scrollOffset != 0 && isScrollAtTop) {
                     // Hide the banner by moving down
                     isScrollAtTop = false
                     val jetpackBannerHeight = banner.resources.getDimension(R.dimen.jetpack_banner_height)
                     banner.animate().translationY(jetpackBannerHeight).start()
+                    window?.let { resetNavigationBarColorForBanner(it) }
                 }
             }
         })
@@ -72,6 +74,12 @@ class JetpackBrandingUtils @Inject constructor(
     fun setNavigationBarColorForBanner(window: Window) {
         if (window.context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
             window.navigationBarColor = window.context.getColor(R.color.jetpack_banner_background)
+        }
+    }
+
+    private fun resetNavigationBarColorForBanner(window: Window) {
+        if (window.context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+            window.navigationBarColor = 0
         }
     }
 


### PR DESCRIPTION
This PR will tint to System Navigation bar if it has 3-button navigation bar when Jetpack powered banner is shown as shown below.


https://user-images.githubusercontent.com/990349/185859239-cf12061a-5af5-4065-a38d-1f8076a818cd.mp4 

https://user-images.githubusercontent.com/990349/185859398-a4497c70-3b93-416d-b041-8957ea4f8a32.mp4

<img width=320 src=https://user-images.githubusercontent.com/990349/185859791-a006e59b-b957-4757-b566-ad495be058fc.png />

Fixes #


To test:

1. Launch the WordPress app.
2. Ensure that 3-button navigation is visible at the bottom, if not go to system settings and enable it
3. Open Stats screen from My Site.
5. Ensure the Jetpack banner is visible at the bottom of the screen.
6. Scroll the list.
7. Ensure the Jetpack banner disappeared.
8. Scroll the list to the top again.
9. Ensure the Jetpack banner appears.
10. Ensure both the banner and nav bar are green and appear and disappear with the banner.


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
