### PR TITLE
[Tooling] Make Installable Builds use dedicated `versionName`

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -149,7 +149,8 @@ platform :android do
     gradle(
       task: 'assemble',
       flavor: 'WordPressJalapeno',
-      build_type: 'Debug'
+      build_type: 'Debug',
+      properties: { installableBuildVersionName: generate_installable_build_number }
     )
 
     upload_installable_build(product: 'WordPress')
@@ -170,7 +171,8 @@ platform :android do
     gradle(
       task: 'assemble',
       flavor: 'JetpackJalapeno',
-      build_type: 'Debug'
+      build_type: 'Debug',
+      properties: { installableBuildVersionName: generate_installable_build_number }
     )
 
     upload_installable_build(product: 'Jetpack')


### PR DESCRIPTION
## Why?

The fastlane lane to generate Installable Builds did not use `-PinstallableBuildVersionName` to override the `versionName` for Installable Builds as intended by the `WordPress/build.gradle`'s `versionName` field of `defaultConfig`.

As a result, the Installable Builds were still generated with a `versionName` corresponding to the values in `version.properties` by default, and showed that version name in the Me > About WordPress/Jetpack screens, which was not as helpful as having the `prNum-commit` show up in that screen instead as it was intended.

Note that the file name of the generated `.apk` was still correctly using `prNum-commit` in its filename. Only the `versionName` used when building the APK was not overwritten.

## To Test

 - Download the Installable Builds from this PR
 - Go to the Me > About screen, and check that the version shown in that screen is `prNNN-commit` (and not `20.5` or `20.6-rc-1` or similar.

<details><summary>🖼 Expected Result</summary>
<img src="https://user-images.githubusercontent.com/216089/185906800-d12243b6-1953-4bce-9b1e-e0cd66265994.jpg" />
</details>