### PR TITLE
Use Jetpack branding utils flag to set banner visibility in search

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -507,15 +507,15 @@ public class ReaderPostListFragment extends ViewPagerFragment
     private void toggleJetpackBannerIfEnabled(final boolean showIfEnabled, boolean animateOnScroll) {
         if (!isAdded() || getView() == null || !isSearching()) return;
 
-        if (animateOnScroll) {
-            RecyclerView scrollView = mRecyclerView.getInternalRecyclerView();
-            mJetpackBrandingUtils.showJetpackBannerIfScrolledToTop(mJetpackBanner, scrollView);
-            mJetpackBrandingUtils.setNavigationBarColorForBanner(requireActivity().getWindow());
-            // Return early since the banner visibility was handled by showJetpackBannerIfScrolledToTop
-            return;
-        }
-
         if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
+            if (animateOnScroll) {
+                RecyclerView scrollView = mRecyclerView.getInternalRecyclerView();
+                mJetpackBrandingUtils.showJetpackBannerIfScrolledToTop(mJetpackBanner, scrollView);
+                mJetpackBrandingUtils.setNavigationBarColorForBanner(requireActivity().getWindow());
+                // Return early since the banner visibility was handled by showJetpackBannerIfScrolledToTop
+                return;
+            }
+
             if (showIfEnabled && !mDisplayUtilsWrapper.isPhoneLandscape()) {
                 showJetpackBanner();
             } else {


### PR DESCRIPTION
This fixes the issue described here: https://github.com/wordpress-mobile/WordPress-Android/pull/17028#issuecomment-1222166253

When displaying or hiding the banner during animation, this still uses
the branding utils logic to display or hide the banner.


To test:

1. Open the Jetpack app and go to Reader.
2. Tap search icon (magnifying glass) and enter a search term
3. Scroll the results

The banner should not become visible in the Jetpack app

Repeat the same steps in the WordPress app with the feature flag enabled and disabled.

The banner should show when enabled, and it should not show when disabled.

## Regression Notes
1. Potential unintended areas of impact
Animation banner visibility.

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

6. What automated tests I added (or what prevented me from doing so)
Out of scope for this (pre)beta fix.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
