### PR TITLE
Un-ignore screenshot tests and exclude them properly instead

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 5.2)
+  fastlane-plugin-wpmreleasetoolkit (~> 5.4)
   nokogiri
   rmagick (~> 4.1)
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
@@ -11,7 +11,6 @@ import androidx.test.filters.LargeTest;
 import com.google.android.libraries.cloudtesting.screenshots.ScreenShotter;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
@@ -96,7 +95,6 @@ public class JPScreenshotTest extends BaseTest {
         }
     }
 
-    @Ignore("Ignored until there's a way to exclude tests on FTL properly, via `--test-targets` option.")
     @Test
     public void jPScreenshotTest() {
         if (BuildConfig.IS_JETPACK_APP) {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -9,7 +9,6 @@ import androidx.test.filters.LargeTest;
 import com.google.android.libraries.cloudtesting.screenshots.ScreenShotter;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
@@ -49,7 +48,7 @@ public class WPScreenshotTest extends BaseTest {
 
 
     private DemoModeEnabler mDemoModeEnabler = new DemoModeEnabler();
-    
+
     @Test
     public void wPScreenshotTest() {
         if (!BuildConfig.IS_JETPACK_APP) {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -49,8 +49,7 @@ public class WPScreenshotTest extends BaseTest {
 
 
     private DemoModeEnabler mDemoModeEnabler = new DemoModeEnabler();
-
-    @Ignore
+    
     @Test
     public void wPScreenshotTest() {
         if (!BuildConfig.IS_JETPACK_APP) {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -50,7 +50,7 @@ public class WPScreenshotTest extends BaseTest {
 
     private DemoModeEnabler mDemoModeEnabler = new DemoModeEnabler();
 
-    @Ignore("Ignored until there's a way to exclude tests on FTL properly, via `--test-targets` option.")
+    @Ignore
     @Test
     public void wPScreenshotTest() {
         if (!BuildConfig.IS_JETPACK_APP) {

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -7,4 +7,4 @@ group :screenshots, optional: true do
 end
 
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit.git', branch: 'trunk'
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.2'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.4'

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -28,6 +28,7 @@ platform :android do
      version: 28,
      test_apk_path: File.join(apk_dir, 'androidTest', 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug-androidTest.apk'),
      apk_path: File.join(apk_dir, 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug.apk'),
+     test_targets: 'notPackage org.wordpress.android.ui.screenshots',
      results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests')
    )
   end


### PR DESCRIPTION
### Why ?

When we migrated from CircleCI to Buildkite and created the `android_firebase_test` fastlane action in our release-toolkit to trigger FTL tests from Buildkite, we forgot to include an option in our action to filter the list of test targets to test for.

This means that our Connected Tests ran for all the UI tests… including the screenshot tests, which were failing and marked the whole Connected Tests step red.

A workaround was created by @pachlava at the time in https://github.com/wordpress-mobile/WordPress-Android/pull/16970 to `@Ignore` the screenshot tests until we fixed that in the toolkit.

### How

 - I've fixed this in the `release-toolkit` in https://github.com/wordpress-mobile/release-toolkit/pull/403
 - I've released a version of `release-toolkit` [`5.4.0` which includes that fix](https://github.com/wordpress-mobile/release-toolkit/releases/tag/5.4.0)
 - I've updated the requirement of `release-toolkit` in the `fastlane/Pluginfile` to be `~> 5.4`
 - I've reverted the workaround from #16970 (`git revert 789eb204a533e2f778b4349467045614b4ebbf1a`) — aka removed the `@Ignore` annotations from the screenshot tests
 - I've added `test_targets: 'notPackage org.wordpress.android.ui.screenshots'` to the call to `android_firebase_test` in our Fastfile so that the screenshot tests will be ignored in the proper way, on demand when triggering FTL, allowing us to still run the Screenshot tests on demand on their own side when we need them.

### To Test

 - Ensure the Connected Tests still pass and go green.
 - Verify that they didn't run the `WPScreenshotTest` and `JPScreenshotTest` instrumented tests as part of the test suite run in Firebase Test Lab.