### PR TITLE
Remove navigation bar Jetpack branding tint

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -56,7 +56,6 @@ class ActivityLogListActivity : LocaleAwareActivity(), ScrollableViewInitialized
                         ?: return@post
 
                 jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
-                window?.let { jetpackBrandingUtils.setNavigationBarColorForBanner(it) }
                 jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
 
                 if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.reader;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.Html;
@@ -511,7 +510,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
             if (animateOnScroll) {
                 RecyclerView scrollView = mRecyclerView.getInternalRecyclerView();
                 mJetpackBrandingUtils.showJetpackBannerIfScrolledToTop(mJetpackBanner, scrollView);
-                mJetpackBrandingUtils.setNavigationBarColorForBanner(requireActivity().getWindow());
                 // Return early since the banner visibility was handled by showJetpackBannerIfScrolledToTop
                 return;
             }
@@ -526,7 +524,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
     private void showJetpackBanner() {
         mJetpackBanner.setVisibility(View.VISIBLE);
-        mJetpackBrandingUtils.setNavigationBarColorForBanner(requireActivity().getWindow());
 
         // Add bottom margin to search suggestions list and empty view.
         int jetpackBannerHeight = getResources().getDimensionPixelSize(R.dimen.jetpack_banner_height);
@@ -537,10 +534,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
     private void hideJetpackBanner() {
         mJetpackBanner.setVisibility(View.GONE);
-
-        if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
-            requireActivity().getWindow().setNavigationBarColor(0);
-        }
 
         // Remove bottom margin from search suggestions list and empty view.
         ((MarginLayoutParams) mRecyclerView.getSearchSuggestionsRecyclerView().getLayoutParams()).bottomMargin = 0;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -271,7 +271,6 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
                         ?: return@post
 
                 jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
-                activity?.window?.let { jetpackBrandingUtils.setNavigationBarColorForBanner(it) }
                 jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
 
                 if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -1,9 +1,7 @@
 package org.wordpress.android.util
 
-import android.content.res.Configuration
 import android.view.View
 import android.view.View.OnScrollChangeListener
-import android.view.Window
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
@@ -64,15 +62,6 @@ class JetpackBrandingUtils @Inject constructor(
                 }
             }
         })
-    }
-
-    /**
-     * Sets the navigation bar color as same as Jetpack banner background color in portrait orientation.
-     */
-    fun setNavigationBarColorForBanner(window: Window) {
-        if (window.context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
-            window.navigationBarColor = window.context.getColor(R.color.jetpack_banner_background)
-        }
     }
 
     private fun isWpComSite(): Boolean {


### PR DESCRIPTION
This commit removes the feature of changing the navigation bar color below the Jetpack banner.
This was discussed here: p1661181781048839/1660344300.653819-slack-C03MHJFF58A

|before|after|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/185991117-2aa4fef4-69a7-45fd-aece-99f069f707f1.png" width=240>|<img src="https://user-images.githubusercontent.com/2471769/185991249-1dc60566-3f4d-4193-bf16-bec78773ba30.png" width=240>|
|<img src="https://user-images.githubusercontent.com/2471769/185991415-4d6a6603-5847-43e1-a38b-683f4a52bf58.png" width=240>|<img src="https://user-images.githubusercontent.com/2471769/185991481-e11e0911-41ce-4329-97bd-0aee591bd974.png" width=240>|
|<img src="https://user-images.githubusercontent.com/2471769/185991539-a88392d4-4072-4234-bde5-18ad010b1204.png" width=240>|<img src="https://user-images.githubusercontent.com/2471769/185991576-764eb8c1-bc85-43ad-947e-abf20a783c23.png" width=240>|

To test:
1. If the navigation bar is not enabled on your device, search the navigation bar on your device settings menu and enable it. 
2. Launch the WordPress app.
3. Open Stats screen from My Site tab.
4. Ensure the background of the navigation bar is not Jetpack green.
5. Navigate back. Open Activity Log Screen from My Site -> MENU.
6. Ensure the background of the navigation bar is not Jetpack green.
7. Navigate back. Open the Reader tab and tap the 🔍  button on the top right of the screen.
8. Ensure the background of the navigation bar is not Jetpack green.

## Regression Notes
1. Potential unintended areas of impact
I couldn't think of an unintended area but I may miss a screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested screens manually.

3. What automated tests I added (or what prevented me from doing so)
I removed a feature and didn't add any tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.