### PR TITLE
Fixes media controls not visible

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 20.7
 -----
-
+* [*] Fixes Media control toggles difficult to see [https://github.com/wordpress-mobile/WordPress-Android/pull/17068]
 
 20.6
 -----

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -349,7 +349,7 @@
             android:name=".ui.media.MediaPreviewActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/media_settings_image_preview_desc"
-            android:theme="@style/WordPress.NoActionBar" />
+            android:theme="@style/WordPress.Media.Preview" />
         <activity
             android:name=".ui.media.MediaSettingsActivity"
             android:windowSoftInputMode="stateHidden|adjustPan"

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.media;
 
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
@@ -19,7 +18,6 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.ActivityOptionsCompat;
-import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
@@ -196,9 +194,6 @@ public class MediaPreviewActivity extends LocaleAwareActivity implements MediaPr
         }
 
         mToolbar = findViewById(R.id.toolbar);
-        int toolbarColor = ContextCompat.getColor(this, R.color.black_translucent_40);
-        //noinspection deprecation
-        mToolbar.setBackgroundDrawable(new ColorDrawable(toolbarColor));
         setSupportActionBar(mToolbar);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {

--- a/WordPress/src/main/res/layout/media_preview_activity.xml
+++ b/WordPress/src/main/res/layout/media_preview_activity.xml
@@ -20,6 +20,7 @@
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
+        android:background="@color/black_translucent_40"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:elevation="@dimen/appbar_elevation"

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -206,6 +206,10 @@
         <item name="windowNoTitle">true</item>
     </style>
 
+    <style name="WordPress.Media.Preview" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@color/black</item>
+    </style>
+
     <style name="WordPress.Stories.Immersive" parent="WordPress.NoActionBar">
         <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:immersive">true</item>


### PR DESCRIPTION
Fixes #14964 

|Before Light Mode | After Light Mode | 
|---|---|
|![Media_control_before_lightmode](https://user-images.githubusercontent.com/17463767/186116553-875c9387-95ea-4ff8-85af-cc73ef7a5177.png)|![Media_control_light_mode](https://user-images.githubusercontent.com/17463767/186126621-39557b55-18d6-4a42-90c7-4a934188a390.png)|

|Before(Dark Mode) | After (Dark Mode) | 
|---|---|
|![media_control_before_darkmode](https://user-images.githubusercontent.com/17463767/186116518-0cb28e45-fde4-416c-9f92-fdf6a147f874.png)|![Media_controls_dark_mode](https://user-images.githubusercontent.com/17463767/186116811-6e34527c-98bb-4585-b458-e0f1c5ffabf2.png)| 


## To test:
- Open Media Preview Page by clicking on a media on the editor or through the media library 
- Verify that the back button is visible on light and dark mode 

## Regression Notes
1. Potential unintended areas of impact
Back button is not visible on Media preview screen 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
