### PR TITLE
Detekt - Resolve/Suppress All Baseline Warnings - max line warnings

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -35,24 +35,12 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="IMPORT_NESTED_CLASSES" value="true" />
       <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
       <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
     </JetCodeStyleSettings>
-    <XML>
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-    </XML>
     <codeStyleSettings language="JAVA">
       <option name="RIGHT_MARGIN" value="120" />
       <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewUsageCategory.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewUsageCategory.kt
@@ -4,8 +4,8 @@ import org.wordpress.android.viewmodel.wpwebview.WPWebViewViewModel
 import org.wordpress.android.viewmodel.wpwebview.WPWebViewViewModel.WebPreviewUiState.WebPreviewFullscreenUiState
 
 /**
- * This enum could be expanded to allow to re-use the WPWebViewActivity (including the direct usage of actionable empty view)
- * in other scenarios with different WebPreviewUiState, also menu can be customized with the same principle.
+ * This enum could be expanded to allow to re-use the WPWebViewActivity (including the direct usage of actionable empty
+ * view) in other scenarios with different WebPreviewUiState, also menu can be customized with the same principle.
  */
 enum class WPWebViewUsageCategory constructor(val value: Int, val menuUiState: WPWebViewMenuUiState) {
     WEBVIEW_STANDARD(0, WPWebViewMenuUiState()),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/XPostsCapabilityChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/XPostsCapabilityChecker.kt
@@ -35,7 +35,8 @@ class XPostsCapabilityChecker @Inject constructor(
                     if (saved.xPosts.isEmpty()) {
                         // Db was empty, so let's make the api call and ensure there aren't any new xpost suggestions.
                         // This call will be made every time the editor opens on sites that don't have any xpost
-                        // suggestions,but because the response will almost always be empty,it's not an expensive call.
+                        // suggestions, but because the response will almost always be empty, it's not an expensive
+                        // call.
                         fetchingReturnsXposts(site)
                     } else {
                         // We have xposts saved in the db, so set capability to true even though

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/XPostsCapabilityChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/XPostsCapabilityChecker.kt
@@ -35,7 +35,7 @@ class XPostsCapabilityChecker @Inject constructor(
                     if (saved.xPosts.isEmpty()) {
                         // Db was empty, so let's make the api call and ensure there aren't any new xpost suggestions.
                         // This call will be made every time the editor opens on sites that don't have any xpost
-                        // suggestions, but because the response will almost always be empty, it's not an expensive call.
+                        // suggestions,but because the response will almost always be empty,it's not an expensive call.
                         fetchingReturnsXposts(site)
                     } else {
                         // We have xposts saved in the db, so set capability to true even though

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
@@ -10,8 +10,8 @@ import javax.inject.Inject
 /**
  * Injectable wrapper around ReaderUtils.
  *
- * ReaderUtils interface is consisted of static methods, which make the client code difficult to test/mock. Main purpose of
- * this wrapper is to make testing easier.
+ * ReaderUtils interface is consisted of static methods, which make the client code difficult to test/mock.
+ * Main purpose of this wrapper is to make testing easier.
  *
  */
 @Reusable

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -266,7 +266,8 @@ class ReaderPostListViewModel @Inject constructor(
         readerViewModel?.selectedTabChange(tag)
     }
 
-    // TODO this is related to tracking time spent in reader - we should move it to the parent but also keep it here for !isTopLevel :(
+    // TODO this is related to tracking time spent in reader -
+    //  we should move it to the parent but also keep it here for !isTopLevel :(
     fun onFragmentResume(
         isTopLevelFragment: Boolean,
         isSearch: Boolean,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -168,7 +168,8 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
                                 gson.fromJson(mediaFilesJsonString, StoryBlockData::class.java)
                         storyBlockData?.let { storyBlockDataNonNull ->
                             val localMediaId = mediaFile.id.toString()
-                            // now replace matching localMediaId with remoteMediaId in the mediaFileObjects, obtain the URLs and replace
+                            // now replace matching localMediaId with remoteMediaId in the mediaFileObjects,
+                            // obtain the URLs and replace
                             val mediaFiles = storyBlockDataNonNull.mediaFiles.filter { it.id == localMediaId }
                             if (mediaFiles.isNotEmpty()) {
                                 mediaFiles[0].apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -619,8 +619,8 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                     frame.id = storyMediaFileData.id
                     storyMediaFileDataList.add(storyMediaFileData)
                 }
-                // if the frame.id is populated and is not a temporary id, this should be an actual MediaModel mediaId so,
-                // let's use that to obtain the mediaFile and then replace it with the temporary frame.id
+                // if the frame.id is populated and is not a temporary id, this should be an actual MediaModel mediaId
+                // so, let's use that to obtain the mediaFile and then replace it with the temporary frame.id
                 else -> {
                     frame.id?.let {
                         if (it.startsWith(TEMPORARY_ID_PREFIX)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
@@ -142,8 +142,8 @@ class StoryMediaSaveUploadBridge @Inject constructor(
                     // in order to support Story editing capabilities, we save a serialized version of the Story slides
                     // after their composedFrameFiles have been processed.
 
-                    // here we change the ids on the actual StoryFrameItems,and also update the flattened/composed image
-                    // urls with the new URLs which may have been replaced after image optimization
+                    // here we change the ids on the actual StoryFrameItems, and also update the flattened / composed
+                    // image urls with the new URLs which may have been replaced after image optimization
                     // find the MediaModel for a given Uri from composedFrameFile
                     for (frame in frames) {
                         // if the old URI in frame.composedFrameFile exists as a key in the passed map, then update that

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
@@ -129,7 +129,8 @@ class StoryMediaSaveUploadBridge @Inject constructor(
 
                 override fun syncPostObjectWithUiAndSaveIt(listener: OnPostUpdatedFromUIListener?) {
                     // no op
-                    // WARNING: don't remove this, we need to call the listener no matter what, so save & upload actually happen
+                    // WARNING: don't remove this, we need to call the listener no matter what,
+                    // so save & upload actually happen
                     listener?.onPostUpdatedFromUI(null)
                 }
 
@@ -141,7 +142,7 @@ class StoryMediaSaveUploadBridge @Inject constructor(
                     // in order to support Story editing capabilities, we save a serialized version of the Story slides
                     // after their composedFrameFiles have been processed.
 
-                    // here we change the ids on the actual StoryFrameItems, and also update the flattened / composed image
+                    // here we change the ids on the actual StoryFrameItems,and also update the flattened/composed image
                     // urls with the new URLs which may have been replaced after image optimization
                     // find the MediaModel for a given Uri from composedFrameFile
                     for (frame in frames) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
@@ -68,8 +68,8 @@ class FeatureAnnouncementViewModel @Inject constructor(
 
     private fun loadFeatures() {
         launch {
+            // fallback to remote just in case. Should not happen.
             val latestAnnouncement = featureAnnouncementProvider.getLatestFeatureAnnouncement(true)
-                  // fallback to remote just in case. Should not happen.
                     ?: featureAnnouncementProvider.getLatestFeatureAnnouncement(false)
             if (latestAnnouncement != null) {
                 appPrefsWrapper.featureAnnouncementShownVersion = latestAnnouncement.announcementVersion

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
@@ -69,7 +69,8 @@ class FeatureAnnouncementViewModel @Inject constructor(
     private fun loadFeatures() {
         launch {
             val latestAnnouncement = featureAnnouncementProvider.getLatestFeatureAnnouncement(true)
-                    ?: featureAnnouncementProvider.getLatestFeatureAnnouncement(false) // fallback to remote just in case. Should not happen.
+                  // fallback to remote just in case. Should not happen.
+                    ?: featureAnnouncementProvider.getLatestFeatureAnnouncement(false)
             if (latestAnnouncement != null) {
                 appPrefsWrapper.featureAnnouncementShownVersion = latestAnnouncement.announcementVersion
                 appPrefsWrapper.lastFeatureAnnouncementAppVersionCode = buildConfigWrapper.getAppVersionCode()

--- a/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
@@ -92,18 +92,22 @@ class AppConfig
     sealed class FeatureState(open val isEnabled: Boolean, val name: String) {
         data class ManuallyOverriden(
             override val isEnabled: Boolean
-            ) : FeatureState(isEnabled, "manually_overriden")
+        ) : FeatureState(isEnabled, "manually_overriden")
+
         data class BuildConfigValue(
             override val isEnabled: Boolean
-            ) : FeatureState(isEnabled, "build_config_value")
+        ) : FeatureState(isEnabled, "build_config_value")
+
         data class RemoteValue(
             override val isEnabled: Boolean
-            ) : FeatureState(isEnabled, "remote_source_value")
+        ) : FeatureState(isEnabled, "remote_source_value")
+
         data class StaticValue(
             override val isEnabled: Boolean
-            ) : FeatureState(isEnabled, "static_source_value")
+        ) : FeatureState(isEnabled, "static_source_value")
+
         data class DefaultValue(
             override val isEnabled: Boolean
-            ) : FeatureState(isEnabled, "default_source_value")
+        ) : FeatureState(isEnabled, "default_source_value")
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
@@ -90,15 +90,20 @@ class AppConfig
     }
 
     sealed class FeatureState(open val isEnabled: Boolean, val name: String) {
-        data class ManuallyOverriden(override val isEnabled: Boolean) :
-                FeatureState(isEnabled, "manually_overriden")
-        data class BuildConfigValue(override val isEnabled: Boolean) :
-                FeatureState(isEnabled, "build_config_value")
-        data class RemoteValue(override val isEnabled: Boolean) :
-                FeatureState(isEnabled, "remote_source_value")
-        data class StaticValue(override val isEnabled: Boolean) :
-                FeatureState(isEnabled, "static_source_value")
-        data class DefaultValue(override val isEnabled: Boolean) :
-                FeatureState(isEnabled, "default_source_value")
+        data class ManuallyOverriden(
+            override val isEnabled: Boolean
+            ) : FeatureState(isEnabled, "manually_overriden")
+        data class BuildConfigValue(
+            override val isEnabled: Boolean
+            ) : FeatureState(isEnabled, "build_config_value")
+        data class RemoteValue(
+            override val isEnabled: Boolean
+            ) : FeatureState(isEnabled, "remote_source_value")
+        data class StaticValue(
+            override val isEnabled: Boolean
+            ) : FeatureState(isEnabled, "static_source_value")
+        data class DefaultValue(
+            override val isEnabled: Boolean
+            ) : FeatureState(isEnabled, "default_source_value")
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
@@ -16,8 +16,8 @@ class AppConfig
     private val manualFeatureConfig: ManualFeatureConfig
 ) {
     /**
-     * We need to keep the value of an already loaded feature flag to make sure the value is not changed while using the app.
-     * We should only reload the flags when the application is created.
+     * We need to keep the value of an already loaded feature flag to make sure the value is not changed
+     * while using the app. We should only reload the flags when the application is created.
      */
     private val experimentValues = mutableMapOf<String, String>()
     private val remoteConfigCheck = RemoteConfigCheck(this)
@@ -38,8 +38,8 @@ class AppConfig
     }
 
     /**
-     * Get the enabled state of a feature flag. If the flag is enabled in the BuildConfig file, it overrides the
-     * remote value. The correct approach is to disable a feature flag for a release version and only enable it remotely.
+     * Get the enabled state of a feature flag. If the flag is enabled in the BuildConfig file, it overrides the remote
+     * value. The correct approach is to disable a feature flag for a release version and only enable it remotely.
      * Once the feature is ready to be fully released, we can enable the BuildConfig value.
      * @param feature feature which we're checking remotely
      */
@@ -90,10 +90,15 @@ class AppConfig
     }
 
     sealed class FeatureState(open val isEnabled: Boolean, val name: String) {
-        data class ManuallyOverriden(override val isEnabled: Boolean) : FeatureState(isEnabled, "manually_overriden")
-        data class BuildConfigValue(override val isEnabled: Boolean) : FeatureState(isEnabled, "build_config_value")
-        data class RemoteValue(override val isEnabled: Boolean) : FeatureState(isEnabled, "remote_source_value")
-        data class StaticValue(override val isEnabled: Boolean) : FeatureState(isEnabled, "static_source_value")
-        data class DefaultValue(override val isEnabled: Boolean) : FeatureState(isEnabled, "default_source_value")
+        data class ManuallyOverriden(override val isEnabled: Boolean) :
+                FeatureState(isEnabled, "manually_overriden")
+        data class BuildConfigValue(override val isEnabled: Boolean) :
+                FeatureState(isEnabled, "build_config_value")
+        data class RemoteValue(override val isEnabled: Boolean) :
+                FeatureState(isEnabled, "remote_source_value")
+        data class StaticValue(override val isEnabled: Boolean) :
+                FeatureState(isEnabled, "static_source_value")
+        data class DefaultValue(override val isEnabled: Boolean) :
+                FeatureState(isEnabled, "default_source_value")
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -333,7 +333,8 @@ class ImageManager @Inject constructor(
     }
 
     /**
-     * Loads an image from the "imgUri" into the ImageView.Doing this allows content and remote URIs to interchangeable.
+     * Loads an image from the "imgUri" into the ImageView. Doing this allows content and remote URIs to
+     * interchangeable.
      * Adds a placeholder and an error placeholder depending
      * on the ImageType. Attaches the ResultListener so the client can manually show/hide progress and error
      * views or add a PhotoViewAttacher(adds support for pinch-to-zoom gesture). Optionally adds

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -333,7 +333,7 @@ class ImageManager @Inject constructor(
     }
 
     /**
-     * Loads an image from the "imgUri" into the ImageView. Doing this allows content and remote URIs to interchangeable.
+     * Loads an image from the "imgUri" into the ImageView.Doing this allows content and remote URIs to interchangeable.
      * Adds a placeholder and an error placeholder depending
      * on the ImageType. Attaches the ResultListener so the client can manually show/hide progress and error
      * views or add a PhotoViewAttacher(adds support for pinch-to-zoom gesture). Optionally adds

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -173,17 +173,6 @@
     <ID>MagicNumber:WPWebView.kt$21</ID>
     <ID>MagicNumber:WPWebView.kt$22</ID>
     <ID>MagicNumber:WidgetUtils.kt$WidgetUtils$300</ID>
-    <ID>MaxLineLength:AppConfig.kt$AppConfig$*</ID>
-    <ID>MaxLineLength:FeatureAnnouncementViewModel.kt$FeatureAnnouncementViewModel$?:</ID>
-    <ID>MaxLineLength:ImageManager.kt$ImageManager$*</ID>
-    <ID>MaxLineLength:ReaderPostListViewModel.kt$ReaderPostListViewModel$// TODO this is related to tracking time spent in reader - we should move it to the parent but also keep it here for !isTopLevel :(</ID>
-    <ID>MaxLineLength:ReaderUtilsWrapper.kt$ReaderUtilsWrapper$*</ID>
-    <ID>MaxLineLength:SaveStoryGutenbergBlockUseCase.kt$SaveStoryGutenbergBlockUseCase.&lt;no name provided>$// now replace matching localMediaId with remoteMediaId in the mediaFileObjects, obtain the URLs and replace</ID>
-    <ID>MaxLineLength:StoryComposerActivity.kt$StoryComposerActivity$// if the frame.id is populated and is not a temporary id, this should be an actual MediaModel mediaId so,</ID>
-    <ID>MaxLineLength:StoryMediaSaveUploadBridge.kt$StoryMediaSaveUploadBridge.&lt;no name provided>$// WARNING: don't remove this, we need to call the listener no matter what, so save &amp; upload actually happen</ID>
-    <ID>MaxLineLength:StoryMediaSaveUploadBridge.kt$StoryMediaSaveUploadBridge.&lt;no name provided>$// here we change the ids on the actual StoryFrameItems, and also update the flattened / composed image</ID>
-    <ID>MaxLineLength:WPWebViewUsageCategory.kt$WPWebViewUsageCategory$*</ID>
-    <ID>MaxLineLength:XPostsCapabilityChecker.kt$XPostsCapabilityChecker$// suggestions, but because the response will almost always be empty, it's not an expensive call.</ID>
     <ID>MemberNameEqualsClassName:ActivityLogTypeFilterViewModel.kt$ActivityLogTypeFilterViewModel.Action$lateinit var action: (() -> Unit)</ID>
     <ID>NestedBlockDepth:AllTimeWidgetBlockListViewModel.kt$AllTimeWidgetBlockListViewModel$override fun onDataSetChanged(context: Context)</ID>
     <ID>NestedBlockDepth:AllTimeWidgetListViewModel.kt$AllTimeWidgetListViewModel$fun onDataSetChanged(onError: (appWidgetId: Int) -> Unit)</ID>


### PR DESCRIPTION
Fixes #

This PR resolves/suppresses all style related warnings for the wordpress module:

`10` x MaxLineLength (Resolve: https://github.com/wordpress-mobile/WordPress-Android/pull/17070/commits/ea0c46e644061ad79847f257d78b72dc6d4ad6e7)

I'm checking Baseline.xml file for files(or loc) that has max line warning and provide the appropriate fix.
you can see conversation https://github.com/wordpress-mobile/WordPress-Android/issues/17010#issuecomment-1209044215 for more info

To test:
Issue link -> https://github.com/wordpress-mobile/WordPress-Android/issues/17010

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
