### PR TITLE
Feature Request: Support "Enter" key for Excerpt editing in Post settings #16479

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -521,11 +521,12 @@ public class EditPostSettingsFragment extends Fragment {
         }
         PostSettingsInputDialogFragment dialog = PostSettingsInputDialogFragment.newInstance(
                 getEditPostRepository().getExcerpt(), getString(R.string.post_settings_excerpt),
-                getString(R.string.post_settings_excerpt_dialog_hint), false);
+                getString(R.string.post_settings_excerpt_dialog_hint), false, true);
         dialog.setPostSettingsInputDialogListener(
                 new PostSettingsInputDialogFragment.PostSettingsInputDialogListener() {
                     @Override
                     public void onInputUpdated(String input) {
+                        input = input.trim();
                         mAnalyticsTrackerWrapper.track(Stat.EDITOR_POST_EXCERPT_CHANGED);
                         updateExcerpt(input);
                     }
@@ -539,7 +540,7 @@ public class EditPostSettingsFragment extends Fragment {
         }
         PostSettingsInputDialogFragment dialog = PostSettingsInputDialogFragment.newInstance(
                 getEditPostRepository().getSlug(), getString(R.string.post_settings_slug),
-                getString(R.string.post_settings_slug_dialog_hint), true);
+                getString(R.string.post_settings_slug_dialog_hint), true, false);
         dialog.setPostSettingsInputDialogListener(
                 new PostSettingsInputDialogFragment.PostSettingsInputDialogListener() {
                     @Override
@@ -666,7 +667,7 @@ public class EditPostSettingsFragment extends Fragment {
         }
         PostSettingsInputDialogFragment dialog = PostSettingsInputDialogFragment.newInstance(
                 getEditPostRepository().getPassword(), getString(R.string.password),
-                getString(R.string.post_settings_password_dialog_hint), false);
+                getString(R.string.post_settings_password_dialog_hint), false, false);
         dialog.setPostSettingsInputDialogListener(
                 new PostSettingsInputDialogFragment.PostSettingsInputDialogListener() {
                     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
@@ -4,6 +4,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.text.Editable;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
@@ -31,10 +32,12 @@ public class PostSettingsInputDialogFragment extends DialogFragment implements T
     private static final String TITLE_TAG = "title";
     private static final String HINT_TAG = "hint";
     private static final String DISABLE_EMPTY_INPUT_TAG = "disable_empty_input";
+    private static final String MULTILINE_INPUT_TAG = "is_multiline_input";
     private String mCurrentInput;
     private String mTitle;
     private String mHint;
     private boolean mDisableEmptyInput;
+    private boolean mIsMultilineInput;
     private PostSettingsInputDialogListener mListener;
     private AlertDialog mDialog;
 
@@ -46,11 +49,13 @@ public class PostSettingsInputDialogFragment extends DialogFragment implements T
             mTitle = savedInstanceState.getString(TITLE_TAG, "");
             mHint = savedInstanceState.getString(HINT_TAG, "");
             mDisableEmptyInput = savedInstanceState.getBoolean(DISABLE_EMPTY_INPUT_TAG, false);
+            mIsMultilineInput = savedInstanceState.getBoolean(MULTILINE_INPUT_TAG, false);
         } else if (getArguments() != null) {
             mCurrentInput = getArguments().getString(INPUT_TAG, "");
             mTitle = getArguments().getString(TITLE_TAG, "");
             mHint = getArguments().getString(HINT_TAG, "");
             mDisableEmptyInput = getArguments().getBoolean(DISABLE_EMPTY_INPUT_TAG, false);
+            mIsMultilineInput = getArguments().getBoolean(MULTILINE_INPUT_TAG, false);
         }
     }
 
@@ -61,16 +66,18 @@ public class PostSettingsInputDialogFragment extends DialogFragment implements T
         outState.putSerializable(TITLE_TAG, mTitle);
         outState.putSerializable(HINT_TAG, mHint);
         outState.putBoolean(DISABLE_EMPTY_INPUT_TAG, mDisableEmptyInput);
+        outState.putBoolean(MULTILINE_INPUT_TAG, mIsMultilineInput);
     }
 
     public static PostSettingsInputDialogFragment newInstance(String currentText, String title, String hint,
-                                                              boolean disableEmptyInput) {
+                                                              boolean disableEmptyInput, boolean isMultiline) {
         PostSettingsInputDialogFragment dialogFragment = new PostSettingsInputDialogFragment();
         Bundle args = new Bundle();
         args.putString(INPUT_TAG, currentText);
         args.putString(TITLE_TAG, title);
         args.putString(HINT_TAG, hint);
         args.putBoolean(DISABLE_EMPTY_INPUT_TAG, disableEmptyInput);
+        args.putBoolean(MULTILINE_INPUT_TAG, isMultiline);
         dialogFragment.setArguments(args);
         return dialogFragment;
     }
@@ -89,6 +96,11 @@ public class PostSettingsInputDialogFragment extends DialogFragment implements T
         View dialogView = layoutInflater.inflate(R.layout.post_settings_input_dialog, null);
         builder.setView(dialogView);
         final EditText editText = dialogView.findViewById(R.id.post_settings_input_dialog_edit_text);
+        if (mIsMultilineInput) {
+            editText.setRawInputType(InputType.TYPE_TEXT_FLAG_MULTI_LINE);
+        } else {
+            editText.setInputType(InputType.TYPE_CLASS_TEXT);
+        }
         if (!TextUtils.isEmpty(mCurrentInput)) {
             editText.setText(mCurrentInput);
             // move the cursor to the end

--- a/WordPress/src/main/res/layout/post_settings_input_dialog.xml
+++ b/WordPress/src/main/res/layout/post_settings_input_dialog.xml
@@ -20,7 +20,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:importantForAutofill="no"
-            android:inputType="text"
             android:maxLines="6"
             tools:targetApi="O" />
 


### PR DESCRIPTION
Fixes #16479

#### Solution
Added new parameter `mIsMultilineInput` in `PostSettingsInputDialogFragment.java` to handle multiline inputs and keep   single line input field if its `false`

To test:
Click on Menu from the navigation
Click on Post
Click on the add button icon at the bottom right of the application
Select Blog Post
Click on the three dots from any of the blog post
Select Post Settings
Scroll down to Excerpt and click on it

## Regression Notes
1. Potential unintended areas of impact

   None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

   Manually tested on **Pixel 4 API 30** and **Nexus 7 API 30**

3. What automated tests I added (or what prevented me from doing so)

    **No automated tests required.**

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


Before fix:
https://www.loom.com/share/a760faa1965d4f6295776bae31dfa51e

Demo After Fix: 
https://www.loom.com/share/4e5ad85d25c64b029fa1dfdc79e61e9e