### PR TITLE
My Site Dashboard: List Scrolling positions are not maintained #16436

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -11,6 +11,7 @@ import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -172,6 +172,15 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
                 htmlCompatWrapper
         ) { viewModel.onBloggingPromptsLearnMoreClicked() }
 
+        adapter.registerAdapterDataObserver(object : AdapterDataObserver() {
+            override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+                super.onItemRangeInserted(positionStart, itemCount)
+                if (itemCount == ONE_ITEM && positionStart == FIRST_ITEM) {
+                    recyclerView.smoothScrollToPosition(0)
+                }
+            }
+        })
+
         savedInstanceState?.getBundle(KEY_NESTED_LISTS_STATES)?.let {
             adapter.onRestoreInstanceState(it)
         }
@@ -607,6 +616,8 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         private const val TAG_QUICK_START_DIALOG = "TAG_QUICK_START_DIALOG"
         private const val KEY_MY_SITE_TAB_TYPE = "key_my_site_tab_type"
         private const val CHECK_REFRESH_DELAY = 300L
+        private const val ONE_ITEM = 1
+        private const val FIRST_ITEM = 0
 
         @JvmStatic
         fun newInstance(mySiteTabType: MySiteTabType) = MySiteTabFragment().apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -11,7 +11,6 @@ import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity
@@ -172,13 +171,6 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
                 bloggingPromptsCardAnalyticsTracker,
                 htmlCompatWrapper
         ) { viewModel.onBloggingPromptsLearnMoreClicked() }
-
-        adapter.registerAdapterDataObserver(object : AdapterDataObserver() {
-            override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-                super.onItemRangeInserted(positionStart, itemCount)
-                recyclerView.smoothScrollToPosition(0)
-            }
-        })
 
         savedInstanceState?.getBundle(KEY_NESTED_LISTS_STATES)?.let {
             adapter.onRestoreInstanceState(it)


### PR DESCRIPTION
Fixes #16436
My Site Dashboard: List Scrolling positions are not maintained after navigating to other pages

Solution : 
Removed the `adapter.registerAdapterDataObserver` method in `MySiteTabFragment.kt`

To test:
- Login to the App
- Open My Site tab and Scroll to a position on either tab
- Navigate to Reader tab
- Return to My Site tab

## Regression Notes
1. Potential unintended areas of impact
NONE

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested visually

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Fix [loom video](https://www.loom.com/share/54ebbbe7dd414d99918fd4b0ec2a0d3b)

Issue link https://github.com/wordpress-mobile/WordPress-Android/issues/16436