### PR TITLE
Long title problem on stats cards #16887

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BlockListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BlockListItemViewHolder.kt
@@ -10,7 +10,6 @@ import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.R
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.AVATAR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.EMPTY_SPACE
@@ -41,15 +40,6 @@ open class BlockListItemViewHolder(
             }
             else -> this.visibility = View.GONE
         }
-    }
-
-    protected fun TextView.setTextOrHide(item: BlockListItem.TitleWithMore) {
-        this.visibility = View.VISIBLE
-        if(item.navigationAction == null){
-            this.ellipsize = null
-            this.maxLines = Int.MAX_VALUE
-        }
-        this.setTextOrHide(item.textResource,item.text)
     }
 
     private fun ImageView.setImageOrLoad(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BlockListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BlockListItemViewHolder.kt
@@ -10,6 +10,7 @@ import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.R
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.AVATAR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon.IconStyle.EMPTY_SPACE
@@ -40,6 +41,15 @@ open class BlockListItemViewHolder(
             }
             else -> this.visibility = View.GONE
         }
+    }
+
+    protected fun TextView.setTextOrHide(item: BlockListItem.TitleWithMore) {
+        this.visibility = View.VISIBLE
+        if(item.navigationAction == null){
+            this.ellipsize = null
+            this.maxLines = Int.MAX_VALUE
+        }
+        this.setTextOrHide(item.textResource,item.text)
     }
 
     private fun ImageView.setImageOrLoad(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
@@ -7,7 +7,6 @@ import androidx.core.view.isVisible
 import com.google.android.material.button.MaterialButton
 import org.wordpress.android.R
 import org.wordpress.android.R.id
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
 
 class TitleWithMoreViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
@@ -19,6 +18,7 @@ class TitleWithMoreViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
 
     fun bind(item: TitleWithMore) {
         title.multiLineText(item)
+        title.setTextOrHide(item.textResource,item.text)
         if (item.navigationAction != null) {
             viewMore.isVisible = true
             viewMore.setOnClickListener { item.navigationAction.click() }
@@ -27,12 +27,11 @@ class TitleWithMoreViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         }
     }
 
-    private fun TextView.multiLineText(item: TitleWithMore) {
+    fun TextView.multiLineText(item: TitleWithMore) {
         this.visibility = View.VISIBLE
-        if (item.navigationAction == null) {
+        if(item.navigationAction == null){
             this.ellipsize = null
             this.maxLines = Int.MAX_VALUE
         }
-        this.setTextOrHide(item.textResource, item.text)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 
+import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import com.google.android.material.button.MaterialButton
 import org.wordpress.android.R
@@ -17,12 +17,12 @@ class TitleWithMoreViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     private val viewMore = itemView.findViewById<MaterialButton>(id.view_more_button)
 
     fun bind(item: TitleWithMore) {
-        title.setTextOrHide(item.textResource, item.text)
+        title.setTextOrHide(item)
         if (item.navigationAction != null) {
             viewMore.isVisible = true
             viewMore.setOnClickListener { item.navigationAction.click() }
         } else {
-            viewMore.isInvisible = true
+            viewMore.visibility = View.GONE
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
@@ -17,12 +17,21 @@ class TitleWithMoreViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     private val viewMore = itemView.findViewById<MaterialButton>(id.view_more_button)
 
     fun bind(item: TitleWithMore) {
-        title.setTextOrHide(item)
+        title.multiLineText(item)
         if (item.navigationAction != null) {
             viewMore.isVisible = true
             viewMore.setOnClickListener { item.navigationAction.click() }
         } else {
             viewMore.visibility = View.GONE
         }
+    }
+
+    private fun TextView.multiLineText(item: TitleWithMore) {
+        this.visibility = View.VISIBLE
+        if (item.navigationAction == null) {
+            this.ellipsize = null
+            this.maxLines = Int.MAX_VALUE
+        }
+        this.setTextOrHide(item.textResource, item.text)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
@@ -7,6 +7,7 @@ import androidx.core.view.isVisible
 import com.google.android.material.button.MaterialButton
 import org.wordpress.android.R
 import org.wordpress.android.R.id
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.TitleWithMore
 
 class TitleWithMoreViewHolder(parent: ViewGroup) : BlockListItemViewHolder(


### PR DESCRIPTION
Fixes #16887 


Title:
[Bug] Long title problem on stats cards

Solution:
Removed the view more button to increase the Title visibility on the stats card.
Added extension function TextView.setTextOrHide(item: BlockListItem.TitleWithMore)


To test:
1. Launch Jetpack app.
2. Navigate to stats screen by using quick links or menu.
3. If the cards (mentioned above) are not present, go to the stats management (either through ⚙️ menu at the top right hand corner or Add new stats card at the bottom) and add cards and save, then return to Insights.
4. Check the title in detail screens.
Repeat 1-4 for different languages. We know German has a problem with long titles currently.

## Regression Notes
1. Potential unintended areas of impact: NONE

2. What I did to test those areas of impact (or what existing automated tests I relied on): Tested Visually

3. What automated tests I added (or what prevented me from doing so): None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

How to test: https://www.loom.com/share/b523eb404409491e90ced4c843f776d8