### PR TITLE
[Jetpack focus] Add feature flag for landing screen revamp

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -112,6 +112,7 @@ android {
         buildConfigField "boolean", "READER_COMMENTS_MODERATION", "false"
         buildConfigField "boolean", "SITE_INTENT_QUESTION", "true"
         buildConfigField "boolean", "SITE_NAME", "false"
+        buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "false"
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
         buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration for the landing screen revamp work
+ */
+@FeatureInDevelopment
+class LandingScreenRevampFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.LANDING_SCREEN_REVAMP)


### PR DESCRIPTION
Fixes #17071

To test:
1. Navigate to Debug settings: Me -> App Settings -> Debug settings
2. Expect to see landing screen feature setting (default: `false`)

## Regression Notes
1. Potential unintended areas of impact
There are no user-facing changes.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
