### PR TITLE
Ignore null remote media id after successful image upload

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -431,9 +431,10 @@ public class PostUtils {
 
     public static String replaceMediaFileWithUrlInGutenbergPost(@NonNull String postContent,
                                                  String localMediaId, MediaFile mediaFile, String siteUrl) {
-        if (mediaFile != null && contentContainsGutenbergBlocks(postContent)) {
-            String remoteUrl = org.wordpress.android.util.StringUtils
-                    .notNullStr(Utils.escapeQuotes(mediaFile.getFileURL()));
+        // If for any reason we couldn't obtain a remote mediaId, it's not worth spending time looking to replace
+        // anything in the Post. Skip processing for later in error handling.
+        if (mediaFile != null && !TextUtils.isEmpty(mediaFile.getMediaId())
+            && contentContainsGutenbergBlocks(postContent)) {
             MediaUploadCompletionProcessor processor = new MediaUploadCompletionProcessor(localMediaId, mediaFile,
                     siteUrl);
             postContent = processor.processContent(postContent);


### PR DESCRIPTION
Fixes #17021

### Description

This PR applies the same approach used in this PR: https://github.com/wordpress-mobile/WordPress-Android/pull/13661 to handle the case where the remote media id is `null` when media upload processing takes place. It is not clear why the `id` is null, but in that case, modifying the post content cannot be helpful, since there would be no `id` to replace the local `id` of the uploaded media.

Note: This PR does not "fix" the problem, and it may be worth investigating further to get to the root of why the `id` is null after a successful upload before proceeding with a solution (partly why this PR is left as a draft). At the very least, it may also be helpful to include some additional logging in the case that this state is reached, to potentially shine more light on the steps to reproduce the issue.

To test:
tbd

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
