### PR TITLE
Integrate gutenberg-mobile release 1.81.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.18.0'
-    gutenbergMobileVersion = 'v1.81.0'
+    gutenbergMobileVersion = '5119-00178c03a686fc20b28be40187448c606fca9a0b'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.18.0'
-    gutenbergMobileVersion = '5119-cc9cb1d7a670a17fca704c7266092a4a202a90b5'
+    gutenbergMobileVersion = 'v1.81.1'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.18.0'
-    gutenbergMobileVersion = '5119-00178c03a686fc20b28be40187448c606fca9a0b'
+    gutenbergMobileVersion = '5119-cc9cb1d7a670a17fca704c7266092a4a202a90b5'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.81.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5119

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.