### PR TITLE
Jetpack Focus: Enable self-hosted login on the Jetpack app 

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -166,7 +166,7 @@ android {
             applicationId "com.jetpack.android"
             buildConfigField "boolean", "IS_JETPACK_APP", "true"
             buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"
-            buildConfigField "boolean", "ENABLE_ADD_SELF_HOSTED_SITE", "false"
+            buildConfigField "boolean", "ENABLE_ADD_SELF_HOSTED_SITE", "true"
             buildConfigField "boolean", "ENABLE_SIGNUP", "true"
             buildConfigField "boolean", "ENABLE_READER", "true"
             buildConfigField "boolean", "ENABLE_CREATE_FAB", "true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1441,7 +1441,6 @@ public class ActivityLauncher {
         Intent intent = new Intent(activity, LoginActivity.class);
         intent.setFlags(
                 Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-    // todo: annmarie    JETPACK_LOGIN_ONLY.putInto(intent);
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -137,7 +137,6 @@ import static org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTIC
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_ACCESS_ERROR;
 import static org.wordpress.android.editor.gutenberg.GutenbergEditorFragment.ARG_STORY_BLOCK_ID;
 import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG_EDIT_IMAGE_DATA;
-import static org.wordpress.android.login.LoginMode.JETPACK_LOGIN_ONLY;
 import static org.wordpress.android.login.LoginMode.WPCOM_LOGIN_ONLY;
 import static org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE;
 import static org.wordpress.android.ui.WPWebViewActivity.ENCODING_UTF8;
@@ -1442,7 +1441,7 @@ public class ActivityLauncher {
         Intent intent = new Intent(activity, LoginActivity.class);
         intent.setFlags(
                 Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        JETPACK_LOGIN_ONLY.putInto(intent);
+    // todo: annmarie    JETPACK_LOGIN_ONLY.putInto(intent);
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -155,17 +155,12 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
             switch (getLoginMode()) {
                 case FULL:
                     mUnifiedLoginTracker.setSource(Source.DEFAULT);
-                    mIsSignupFromLoginEnabled = true;
-                    loginFromPrologue();
-                    break;
-                case JETPACK_LOGIN_ONLY:
-                    mUnifiedLoginTracker.setSource(Source.DEFAULT);
                     mIsSignupFromLoginEnabled = mBuildConfigWrapper.isSignupEnabled();
                     loginFromPrologue();
                     break;
                 case WPCOM_LOGIN_ONLY:
                     mUnifiedLoginTracker.setSource(Source.ADD_WORDPRESS_COM_ACCOUNT);
-                    mIsSignupFromLoginEnabled = true;
+                    mIsSignupFromLoginEnabled = mBuildConfigWrapper.isSignupEnabled();
                     checkSmartLockPasswordAndStartLogin();
                     break;
                 case SELFHOSTED_ONLY:
@@ -174,7 +169,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                     break;
                 case JETPACK_STATS:
                     mUnifiedLoginTracker.setSource(Source.JETPACK);
-                    mIsSignupFromLoginEnabled = true;
+                    mIsSignupFromLoginEnabled = mBuildConfigWrapper.isSignupEnabled();
                     checkSmartLockPasswordAndStartLogin();
                     break;
                 case WPCOM_LOGIN_DEEPLINK:
@@ -306,24 +301,6 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
     private void loggedInAndFinish(ArrayList<Integer> oldSitesIds, boolean doLoginUpdate) {
         switch (getLoginMode()) {
-            case JETPACK_LOGIN_ONLY:
-                if (!mSiteStore.hasSite() && !mBuildConfigWrapper.isSiteCreationEnabled()) {
-                    handleNoJetpackSites();
-                } else {
-                    if (!mSiteStore.hasSite()
-                        && AppPrefs.shouldShowPostSignupInterstitial()
-                        && !doLoginUpdate
-                        && mBuildConfigWrapper.isSiteCreationEnabled()
-                        && mBuildConfigWrapper.isSignupEnabled()
-                    ) {
-                        ActivityLauncher.showPostSignupInterstitial(this);
-                    } else {
-                        ActivityLauncher.showMainActivityAndLoginEpilogue(this, oldSitesIds, doLoginUpdate);
-                    }
-                    setResult(Activity.RESULT_OK);
-                    finish();
-                }
-                break;
             case FULL:
             case WPCOM_LOGIN_ONLY:
                 if (!mSiteStore.hasSite() && AppPrefs.shouldShowPostSignupInterstitial() && !doLoginUpdate) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -318,11 +318,6 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         mParentViewModel.onLoginEpilogueResume(mDoLoginUpdate);
     }
 
-    @Override
-    protected boolean isJetpackAppLogin() {
-        return mDoLoginUpdate && mBuildConfigWrapper.isJetpackApp();
-    }
-
     private void bindHeaderViewHolder(LoginHeaderViewHolder holder, SiteList sites) {
         if (!isAdded()) {
             return;

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 ext {
     wordPressUtilsVersion = '2.7.0'
-    wordPressLoginVersion = '94-d4c7112c0af4f8fe6c38af390d155fdca3663878'
+    wordPressLoginVersion = 'trunk-692264f8a2a0efa540b7713d3e1ad7fc09b87d47'
     gutenbergMobileVersion = 'v1.81.0'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 ext {
     wordPressUtilsVersion = '2.7.0'
-    wordPressLoginVersion = '0.18.0'
+    wordPressLoginVersion = '94-d4c7112c0af4f8fe6c38af390d155fdca3663878'
     gutenbergMobileVersion = 'v1.81.0'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'


### PR DESCRIPTION
This PR enables self-hosted site sign in for the Jetpack app

- Removed intent arguments for JETPACK_LOGIN_ONLY login mode
- Set the config flag “ENABLE_ADD_SELF_HOSTED_SITE” to true for Jetpack

**Dependency**: WordPress-Login-Flow [PR](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/94) 

**Note**: The PR only needs 1 reviewer. I probably could have cc'd @ovitrif , but thought you might like to go through what I did in case it impacts tasks you are working on.

**Merge Instructions**
- [x] Merge the WordPress-Login-Flow [PR](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/94) 
- [x] Wait for the [Buildkite Job for trunk](https://buildkite.com/automattic/wordpress-login-flow-android) to finish
       - Then go to the Job details in BuildKite and open subjob with name `Publish to s3`
       - Search for `is successfully published` and **Copy** the value before that text, looking like  `trunk-{commit_sha}`.
       -**Paste** this value in the `./build.gradle` file of `WordPress-Android`, for `ext.wordPressLoginVersion`.
    - [x] Commit & push this change to the `WordPress-Android` PR  - [a3487a7](https://github.com/wordpress-mobile/WordPress-Android/pull/17094/commits/a3487a731a9ead0cc7564f8499ae6fc47e181ce0)
    - Merge the `WordPress-Android` PR.
    
### **Testing instructions**
Tip: Use the "want more options" link & uncheck the Jetpack checkbox when setting up a new site w/o jetpack

#### Log in via self-hosted site address (non-Jetpack connected)
0. Create a Jurassic Ninja site but **don't** set up Jetpack 
1. Build and run the Jetpack app, logout if needed
2. Tap **Enter your existing site address** and login via your site address
3. Once you're logged in, tap **Stats**
4. ✅ Verify: You should see the **Install Jetpack** prompt

#### Log in via self-hosted site address (Jetpack connected)
0. Create a Jurassic Ninja site and set up Jetpack (i.e. connect to your account)
1. Build and run the Jetpack app, logout if needed
2. Tap **Enter your existing site address** and login via your site address
3. Once you're logged in, tap **Stats**
4. ✅ Verify: You should see the **Log in** prompt

#### Already logged in, add self-hosted site (non-Jetpack connected)
0. Create a Jurassic Ninja site but **don't** set up Jetpack 
1. Build and run the Jetpack app, log in via email if needed
2. Go to My Site > down chevron > + > **Add self-hosted site** 
3. Login in via the site address
4. Select the self-hosted site you just added
5. Go to Stats
6. ✅ Verify: You should see the **Install Jetpack** prompt

####  Already logged in, add self-hosted site (Jetpack connected)
0. Create a Jurassic Ninja site and set up Jetpack (i.e. connect to your account)
1. Run the Jetpack Setup from within the admin panel (not within the app)
2. Build and run the Jetpack app, make sure you're logged into the same account as step 0
3. Go to My Site > down chevron > and search or scroll down to the newly connected site
5. Select the self-hosted site you just added
6. Go to Stats
7. ✅ Verify: You can access stats 


## Regression Notes
1. Potential unintended areas of impact
- Login - JP should work the same as WP

3. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing (using above steps)

4. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
