### PR TITLE
Fix WordPress app namings on Jetpack app

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsViewModel.kt
@@ -187,10 +187,12 @@ constructor(
                 R.string.calendar_scheduled_post_title,
                 postRepository.title
         )
+        val appName = resourceProvider.getString(R.string.app_name)
         val description = resourceProvider.getString(
                 R.string.calendar_scheduled_post_description,
                 postRepository.title,
                 site?.name ?: site?.url ?: "",
+                appName,
                 postRepository.link
         )
         _onAddToCalendar.value = Event(CalendarEvent(title, description, startTime))

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
@@ -52,6 +52,11 @@ class FeatureAnnouncementDialogFragment : DialogFragment() {
         val featureAdapter = FeatureAnnouncementListAdapter(this)
         recyclerView.adapter = featureAdapter
 
+        val titleTextView = view.findViewById<TextView>(R.id.feature_announcement_dialog_label)
+        val appName = getString(R.string.app_name)
+        val title = getString(R.string.feature_announcement_dialog_label, appName)
+        titleTextView.text = title
+
         viewModel.uiModel.observe(this, Observer {
             it?.let { uiModel ->
                 progressIndicator.visibility = if (uiModel.isProgressVisible) View.VISIBLE else View.GONE

--- a/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialog.kt
@@ -121,12 +121,14 @@ object AppRatingDialog {
         @Suppress("SwallowedException")
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             val builder = MaterialAlertDialogBuilder(activity)
-            builder.setTitle(R.string.app_rating_title)
+            val appName = getString(R.string.app_name)
+            val title = getString(R.string.app_rating_title, appName)
+            builder.setTitle(title)
                     .setMessage(R.string.app_rating_message)
                     .setCancelable(true)
                     .setPositiveButton(R.string.app_rating_rate_now) { _, _ ->
                         val appPackage = activity.packageName
-                        val url: String? = "market://details?id=$appPackage"
+                        val url = "market://details?id=$appPackage"
                         try {
                             activity.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
                         } catch (e: ActivityNotFoundException) {

--- a/WordPress/src/main/res/layout/feature_announcement_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/feature_announcement_dialog_fragment.xml
@@ -25,7 +25,6 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/feature_announcement_top_margin"
                 android:fontFamily="serif"
-                android:text="@string/feature_announcement_dialog_label"
                 android:textAppearance="?attr/textAppearanceHeadline4"
                 android:textColor="?attr/colorOnSurface"
                 app:layout_constraintTop_toTopOf="parent" />

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -1237,7 +1237,6 @@ Language: ar
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">الضغط ضغطًا مزدوجًا للانتقال إلى إعدادات الألوان</string>
     <string name="reader_empty_followed_blogs_description">عندما تتابع المواقع، سترى محتواها هنا</string>
     <string name="feature_announcement_find_out_mode">اكتشاف المزيد</string>
-    <string name="feature_announcement_dialog_label">ما الجديد في ووردبريس</string>
     <string name="crop">قص</string>
     <string name="error_failed_to_load_into_file">فشل التحميل إلى الملف، يرجى المحاولة مرة أخرى.</string>
     <string name="preview_image_thumbnail_description">معاينة الصورة المصغَّرة</string>
@@ -1565,7 +1564,6 @@ Language: ar
     <string name="navigate_forward_desc">التقدم للأمام</string>
     <string name="notification_post_will_be_published_in_ten_minutes">سيتم نشر \"%s\" خلال 10 دقائق</string>
     <string name="calendar_scheduled_post_title">مقالة ووردبريس مجدولة: \"%s\"</string>
-    <string name="calendar_scheduled_post_description">تمت جدولة \"⁦%1$s⁩\" للنشر في \"⁦%2$s⁩\" في تطبيق ووردبريس الخاص بك\n %3$s</string>
     <string name="notification_scheduled_post">مقالة مجدولة</string>
     <string name="notification_scheduled_post_one_hour_reminder">مقالة مجدولة: تذكير ساعة واحدة</string>
     <string name="notification_scheduled_post_ten_minute_reminder">مقالة مجدولة: تذكير 10 دقائق</string>
@@ -1735,7 +1733,6 @@ Language: ar
     <string name="app_rating_rate_later">لاحقًا</string>
     <string name="app_rating_rate_now">التقييم الآن</string>
     <string name="app_rating_message">جميل أن نراك مرة أخرى! إذا راجعت التطبيق، فيسعدنا تقييمك لنا على متجر Google Play.</string>
-    <string name="app_rating_title">مستمتع بـ ووردبريس؟</string>
     <string name="editor_post_converted_back_to_draft">تم تحويل المقالة مرة أخرى إلى مسودّة</string>
     <string name="stats_insights_posting_activity">نشاط النشر</string>
     <string name="stats_site_not_loaded_yet">الموقع لم يتم تحميله بعد</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -1127,7 +1127,6 @@ Language: cs_CZ
     <string name="error_failed_to_load_into_file">Načtení do souboru se nezdařilo, zkuste to znovu.</string>
     <string name="crop">oříznutí</string>
     <string name="insert_label_with_count">Vložit %d</string>
-    <string name="feature_announcement_dialog_label">Co je nového na WordPressu</string>
     <string name="feature_announcement_find_out_mode">Zjistit více</string>
     <string name="sitepicker_continue_flow">Pokračovat</string>
     <string name="whats_new_in_version_title">Co je nového</string>
@@ -1447,7 +1446,6 @@ Language: cs_CZ
     <string name="navigate_forward_desc">Jít vpřed</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" bude publikován za 10 minut</string>
     <string name="calendar_scheduled_post_title">Naplánovaný příspěvek WordPress: \"%s\"</string>
-    <string name="calendar_scheduled_post_description">Publikování \"%1$s\" je naplánováno na \"%2$s\" ve vaší aplikaci WordPress \"%3$s\"</string>
     <string name="post_notification_when_published">Při zveřejnění</string>
     <string name="post_notification_error">Nelze vytvořit oznámení, pokud je datum publikování v minulosti.</string>
     <string name="notification_scheduled_post">Naplánovaný příspěvek</string>
@@ -1617,7 +1615,6 @@ Language: cs_CZ
     <string name="app_rating_rate_later">Později</string>
     <string name="app_rating_rate_now">Ohodnotit teď</string>
     <string name="app_rating_message">Nice to see you again! If you’re digging the app, we’d love a rating on the Google Play Store.</string>
-    <string name="app_rating_title">Enjoying WordPress?</string>
     <string name="stats_more_posts">Více příspěvků</string>
     <string name="stats_fewer_posts">Méně příspěvků</string>
     <string name="editor_post_converted_back_to_draft">Příspěvek byl převeden zpět na koncept</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -1237,7 +1237,6 @@ Language: de
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Zum Wechseln zu den Farbeinstellungen zweimal tippen</string>
     <string name="reader_empty_followed_blogs_description">Wenn du Websites folgst, wirst du ihren Inhalt hier sehen</string>
     <string name="feature_announcement_find_out_mode">Mehr erfahren</string>
-    <string name="feature_announcement_dialog_label">Was ist neu in WordPress?</string>
     <string name="insert_label_with_count">%d einfügen</string>
     <string name="crop">zuschneiden</string>
     <string name="error_failed_to_load_into_file">Laden in die Datei fehlgeschlagen, bitte versuche es erneut.</string>
@@ -1563,7 +1562,6 @@ Language: de
     <string name="share_desc">Teilen</string>
     <string name="navigate_back_desc">Zurück gehen</string>
     <string name="navigate_forward_desc">Vorwärts gehen</string>
-    <string name="calendar_scheduled_post_description">„%1$s“ ist für die Veröffentlichung auf „%2$s“ in deiner WordPress-App geplant \n %3$s</string>
     <string name="calendar_scheduled_post_title">Von WordPress geplanter Beitrag: „%s“</string>
     <string name="notification_post_will_be_published_in_ten_minutes">„%s“ wird in 10 Minuten veröffentlicht</string>
     <string name="notification_post_will_be_published_in_one_hour">„%s“ wird in 1 Stunde veröffentlicht</string>
@@ -1735,7 +1733,6 @@ Language: de
     <string name="app_rating_rate_later">Später</string>
     <string name="app_rating_rate_now">Jetzt bewerten</string>
     <string name="app_rating_message">Schön, dich wiederzusehen! Falls du die App magst, würden wir uns über eine Bewertung im Google Play Store sehr freuen.</string>
-    <string name="app_rating_title">Gefällt dir WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Beitrag zurück auf Entwurf geändert</string>
     <string name="stats_insights_posting_activity">Beitrags-Aktivität</string>
     <string name="stats_site_not_loaded_yet">Website noch nicht geladen</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -250,7 +250,6 @@ Language: en_AU
     <string name="app_rating_rate_later">Later</string>
     <string name="app_rating_rate_now">Rate now</string>
     <string name="app_rating_message">Nice to see you again! If you’re digging the app, we’d love a rating on the Google Play Store.</string>
-    <string name="app_rating_title">Enjoying WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Post converted back to draft</string>
     <string name="stats_insights_posting_activity">Posting Activity</string>
     <string name="stats_site_not_loaded_yet">Site not loaded yet</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -1208,7 +1208,6 @@ Language: en_CA
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Double tap to go to colour settings</string>
     <string name="reader_empty_followed_blogs_description">When you follow sites, you\'ll see their content here</string>
     <string name="feature_announcement_find_out_mode">Find out more</string>
-    <string name="feature_announcement_dialog_label">What\'s New In WordPress</string>
     <string name="insert_label_with_count">Insert %d</string>
     <string name="crop">crop</string>
     <string name="error_failed_to_load_into_file">Failed to load into file, please try again.</string>
@@ -1534,7 +1533,6 @@ Language: en_CA
     <string name="share_desc">Share</string>
     <string name="navigate_back_desc">Go back</string>
     <string name="navigate_forward_desc">Go forward</string>
-    <string name="calendar_scheduled_post_description">\"%1$s\" scheduled for publishing on \"%2$s\" in your WordPress app \n %3$s</string>
     <string name="calendar_scheduled_post_title">WordPress Scheduled Post: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" will be published in 10 minutes</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" will be published in 1 hour</string>
@@ -1706,7 +1704,6 @@ Language: en_CA
     <string name="app_rating_rate_later">Later</string>
     <string name="app_rating_rate_now">Rate now</string>
     <string name="app_rating_message">Nice to see you again! If you’re digging the app, we’d love a rating on the Google Play Store.</string>
-    <string name="app_rating_title">Enjoying WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Post converted back to draft</string>
     <string name="stats_insights_posting_activity">Posting Activity</string>
     <string name="stats_site_not_loaded_yet">Site not loaded yet</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -1237,7 +1237,6 @@ Language: en_GB
     <string name="reader_empty_followed_blogs_description">When you follow sites, you\'ll see their content here</string>
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Double tap to go to colour settings</string>
     <string name="feature_announcement_find_out_mode">Find out more</string>
-    <string name="feature_announcement_dialog_label">What\'s New In WordPress</string>
     <string name="insert_label_with_count">Insert %d</string>
     <string name="crop">crop</string>
     <string name="error_failed_to_load_into_file">Failed to load into file, please try again.</string>
@@ -1565,7 +1564,6 @@ Language: en_GB
     <string name="navigate_forward_desc">Go forward</string>
     <string name="calendar_scheduled_post_title">WordPress Scheduled Post: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" will be published in 10 minutes</string>
-    <string name="calendar_scheduled_post_description">\"%1$s\" scheduled for publishing on \"%2$s\" in your WordPress app \n %3$s</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" will be published in 1 hour</string>
     <string name="notification_post_has_been_published">\"%s\" has been published</string>
     <string name="notification_scheduled_post_ten_minute_reminder">Scheduled post: 10 minute reminder</string>
@@ -1735,7 +1733,6 @@ Language: en_GB
     <string name="app_rating_rate_later">Later</string>
     <string name="app_rating_rate_now">Rate now</string>
     <string name="app_rating_message">Nice to see you again! If you’re digging the app, we’d love a rating on the Google Play Store.</string>
-    <string name="app_rating_title">Enjoying WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Post converted back to draft</string>
     <string name="stats_insights_posting_activity">Posting Activity</string>
     <string name="stats_site_not_loaded_yet">Site not loaded yet</string>

--- a/WordPress/src/main/res/values-es-rCL/strings.xml
+++ b/WordPress/src/main/res/values-es-rCL/strings.xml
@@ -42,7 +42,6 @@ Language: es_CL
     <string name="app_rating_rate_later">Más tarde</string>
     <string name="app_rating_rate_now">Califica ahora</string>
     <string name="app_rating_message">¡Encantado de verte de nuevo! Si está cavando la aplicación, nos encantaría una calificación en la Google Play Store.</string>
-    <string name="app_rating_title">¿Disfrutando de WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Post convertido de nuevo a borrador</string>
     <string name="stats_insights_posting_activity">Actividad de Publicación</string>
     <string name="stats_site_not_loaded_yet">Sitio aún no cargado</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -1216,7 +1216,6 @@ Language: es_CO
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Toca dos veces para ir a los ajustes del color</string>
     <string name="reader_empty_followed_blogs_description">Cuando sigas sitios, verás aquí su contenido</string>
     <string name="feature_announcement_find_out_mode">Saber más</string>
-    <string name="feature_announcement_dialog_label">Qué hay de nuevo en WordPress</string>
     <string name="insert_label_with_count">Insertar %d</string>
     <string name="crop">recortar</string>
     <string name="error_failed_to_load_into_file">Fallo al cargar en el archivo, por favor, inténtalo de nuevo.</string>
@@ -1542,7 +1541,6 @@ Language: es_CO
     <string name="share_desc">Compartir</string>
     <string name="navigate_back_desc">Volver</string>
     <string name="navigate_forward_desc">Avanzar</string>
-    <string name="calendar_scheduled_post_description">«%1$s» programado para publicar el «%2$s» en tu aplicación de WordPress\n%3$s</string>
     <string name="calendar_scheduled_post_title">Entrada programada de WordPress: «%s»</string>
     <string name="notification_post_will_be_published_in_ten_minutes">«%s» se publicará en 10 minutos</string>
     <string name="notification_post_will_be_published_in_one_hour">«%s» se publicará en 1 hora</string>
@@ -1714,7 +1712,6 @@ Language: es_CO
     <string name="app_rating_rate_later">Más tarde</string>
     <string name="app_rating_rate_now">Valorar ahora</string>
     <string name="app_rating_message">¡Qué gusto verte de nuevo! Si estás trabajando con la aplicación nos encantaría que nos puntuases en la Google Play Store.</string>
-    <string name="app_rating_title">¿Disfrutas de WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Entrada devuelta a borrador</string>
     <string name="stats_insights_posting_activity">Actividad de publicación</string>
     <string name="stats_site_not_loaded_yet">El sitio no se ha cargado todavía</string>

--- a/WordPress/src/main/res/values-es-rMX/strings.xml
+++ b/WordPress/src/main/res/values-es-rMX/strings.xml
@@ -405,7 +405,6 @@ Language: es_MX
     <string name="reader_empty_followed_blogs_description">Cuando sigas sitios, verás aquí su contenido</string>
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Toca dos veces para ir a los ajustes del color</string>
     <string name="feature_announcement_find_out_mode">Saber más</string>
-    <string name="feature_announcement_dialog_label">Qué hay de nuevo en WordPress</string>
     <string name="insert_label_with_count">Insertar %d</string>
     <string name="crop">recortar</string>
     <string name="error_failed_to_load_into_file">Fallo al cargar en el archivo, por favor, inténtalo de nuevo.</string>
@@ -895,7 +894,6 @@ Language: es_MX
     <string name="app_rating_rate_later">Más tarde</string>
     <string name="app_rating_rate_now">Valorar ahora</string>
     <string name="app_rating_message">¡Qué gusto verte de nuevo! Si te está gustando la aplicación, nos encantaría que nos puntuases en la Google Play Store.</string>
-    <string name="app_rating_title">¿Estás disfrutando de WordPress?</string>
     <string name="stats_site_not_loaded_yet">Sitio aún no cargado</string>
     <string name="editor_post_converted_back_to_draft">Entrada convertida de nuevo a borrador</string>
     <string name="stats_fewer_posts">Menos entradas</string>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -1237,7 +1237,6 @@ Language: es_VE
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Toca dos veces para ir a los ajustes del color</string>
     <string name="reader_empty_followed_blogs_description">Cuando sigas sitios, verás aquí su contenido</string>
     <string name="feature_announcement_find_out_mode">Saber más</string>
-    <string name="feature_announcement_dialog_label">Qué hay de nuevo en WordPress</string>
     <string name="insert_label_with_count">Insertar %d</string>
     <string name="crop">recortar</string>
     <string name="error_failed_to_load_into_file">Fallo al cargar en el archivo, por favor, inténtalo de nuevo.</string>
@@ -1563,7 +1562,6 @@ Language: es_VE
     <string name="share_desc">Compartir</string>
     <string name="navigate_back_desc">Volver</string>
     <string name="navigate_forward_desc">Avanzar</string>
-    <string name="calendar_scheduled_post_description">«%1$s» programado para publicar el «%2$s» en tu aplicación de WordPress\n%3$s</string>
     <string name="calendar_scheduled_post_title">Entrada programada de WordPress: «%s»</string>
     <string name="notification_post_will_be_published_in_ten_minutes">«%s» se publicará en 10 minutos</string>
     <string name="notification_post_will_be_published_in_one_hour">«%s» se publicará en 1 hora</string>
@@ -1735,7 +1733,6 @@ Language: es_VE
     <string name="app_rating_rate_later">Más tarde</string>
     <string name="app_rating_rate_now">Valorar ahora</string>
     <string name="app_rating_message">¡Qué gusto verte de nuevo! Si estás trabajando con la aplicación nos encantaría que nos puntuases en la Google Play Store.</string>
-    <string name="app_rating_title">¿Disfrutas de WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Entrada devuelta a borrador</string>
     <string name="stats_insights_posting_activity">Actividad de publicación</string>
     <string name="stats_site_not_loaded_yet">El sitio no se ha cargado todavía</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -1237,7 +1237,6 @@ Language: es
     <string name="reader_empty_followed_blogs_description">Cuando sigas sitios, verás aquí su contenido</string>
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Toca dos veces para ir a los ajustes del color</string>
     <string name="feature_announcement_find_out_mode">Saber más</string>
-    <string name="feature_announcement_dialog_label">Qué hay de nuevo en WordPress</string>
     <string name="insert_label_with_count">Insertar %d</string>
     <string name="crop">recortar</string>
     <string name="error_failed_to_load_into_file">Fallo al cargar en el archivo, por favor, inténtalo de nuevo.</string>
@@ -1565,7 +1564,6 @@ Language: es
     <string name="navigate_forward_desc">Avanzar</string>
     <string name="calendar_scheduled_post_title">Entrada programada de WordPress: «%s»</string>
     <string name="notification_post_will_be_published_in_ten_minutes">«%s» se publicará en 10 minutos</string>
-    <string name="calendar_scheduled_post_description">«%1$s» programado para publicar el «%2$s» en tu aplicación de WordPress\n%3$s</string>
     <string name="notification_post_will_be_published_in_one_hour">«%s» se publicará en 1 hora</string>
     <string name="notification_post_has_been_published">«%s» ha sido publicado</string>
     <string name="notification_scheduled_post_ten_minute_reminder">Entrada programada: recordatorio de 10 minutos</string>
@@ -1740,7 +1738,6 @@ Language: es
     <string name="stats_more_posts">Más entradas</string>
     <string name="stats_insights_posting_activity">Actividad de publicación</string>
     <string name="stats_fewer_posts">Menos entradas</string>
-    <string name="app_rating_title">¿Disfrutas de WordPress?</string>
     <string name="new_site_creation_preview_back_pressed_warning">Puedes perder lo que llevas hecho. ¿Estás seguro de que quieres salir?</string>
     <string name="plans_loading_error_with_cache_button">Ver los planes</string>
     <string name="plans_loading_error_with_cache_subtitle">Se requiere una conexión a Internet para ver los planes, así que los detalles podrían estar desactualizados.</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -1236,7 +1236,6 @@ Language: fr
     <string name="gutenberg_native_select_a_color">Sélectionnez une couleur</string>
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Toucher deux fois pour aller aux réglages de couleur</string>
     <string name="reader_empty_followed_blogs_description">Lorsque vous suivez des sites, vous verrez leur contenu ici</string>
-    <string name="feature_announcement_dialog_label">Quoi de neuf dans WordPress</string>
     <string name="insert_label_with_count">Insérer %d</string>
     <string name="crop">rogner</string>
     <string name="error_failed_to_load_into_file">Erreur de chargement dans le fichier, veuillez réessayer.</string>
@@ -1565,7 +1564,6 @@ Language: fr
     <string name="navigate_forward_desc">Continuer</string>
     <string name="calendar_scheduled_post_title">Articles WordPress planifiés « %s »</string>
     <string name="notification_post_will_be_published_in_ten_minutes">« %s » sera publié dans 10 minutes</string>
-    <string name="calendar_scheduled_post_description">L’article « %1$s » sera publié le « %2$s » sur l’application WordPress \n %3$s</string>
     <string name="notification_post_will_be_published_in_one_hour">« %s » sera publié dans 1 heure</string>
     <string name="notification_post_has_been_published">« %s » a été publié</string>
     <string name="notification_scheduled_post_ten_minute_reminder">Article planifié : rappel 10 minutes avant</string>
@@ -1735,7 +1733,6 @@ Language: fr
     <string name="app_rating_rate_later">Plus tard</string>
     <string name="app_rating_rate_now">Évaluer maintenant</string>
     <string name="app_rating_message">Ravi de vous revoir! Si vous creusez l\'application, nous aimerions une évaluation sur le Google Play Store.</string>
-    <string name="app_rating_title">Vous aimez WordPress ?</string>
     <string name="editor_post_converted_back_to_draft">Article reconverti en brouillon</string>
     <string name="stats_insights_posting_activity">Activité de publication</string>
     <string name="stats_site_not_loaded_yet">Site non encore chargé</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -1236,7 +1236,6 @@ Language: fr
     <string name="gutenberg_native_select_a_color">Sélectionnez une couleur</string>
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Toucher deux fois pour aller aux réglages de couleur</string>
     <string name="reader_empty_followed_blogs_description">Lorsque vous suivez des sites, vous verrez leur contenu ici</string>
-    <string name="feature_announcement_dialog_label">Quoi de neuf dans WordPress</string>
     <string name="insert_label_with_count">Insérer %d</string>
     <string name="crop">rogner</string>
     <string name="error_failed_to_load_into_file">Erreur de chargement dans le fichier, veuillez réessayer.</string>
@@ -1565,7 +1564,6 @@ Language: fr
     <string name="navigate_forward_desc">Continuer</string>
     <string name="calendar_scheduled_post_title">Articles WordPress planifiés « %s »</string>
     <string name="notification_post_will_be_published_in_ten_minutes">« %s » sera publié dans 10 minutes</string>
-    <string name="calendar_scheduled_post_description">L’article « %1$s » sera publié le « %2$s » sur l’application WordPress \n %3$s</string>
     <string name="notification_post_will_be_published_in_one_hour">« %s » sera publié dans 1 heure</string>
     <string name="notification_post_has_been_published">« %s » a été publié</string>
     <string name="notification_scheduled_post_ten_minute_reminder">Article planifié : rappel 10 minutes avant</string>
@@ -1735,7 +1733,6 @@ Language: fr
     <string name="app_rating_rate_later">Plus tard</string>
     <string name="app_rating_rate_now">Évaluer maintenant</string>
     <string name="app_rating_message">Ravi de vous revoir! Si vous creusez l\'application, nous aimerions une évaluation sur le Google Play Store.</string>
-    <string name="app_rating_title">Vous aimez WordPress ?</string>
     <string name="editor_post_converted_back_to_draft">Article reconverti en brouillon</string>
     <string name="stats_insights_posting_activity">Activité de publication</string>
     <string name="stats_site_not_loaded_yet">Site non encore chargé</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -1237,7 +1237,6 @@ Language: gl_ES
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Toca dúas veces para ir aos axustes da cor</string>
     <string name="reader_empty_followed_blogs_description">Cando sigas sitios, verás aquí o seu contido</string>
     <string name="feature_announcement_find_out_mode">Saber máis</string>
-    <string name="feature_announcement_dialog_label">Que hai de novo en WordPress</string>
     <string name="insert_label_with_count">Insertar %d</string>
     <string name="crop">recortar</string>
     <string name="error_failed_to_load_into_file">Erro ao cargar no arquivo, por favor, inténtao de novo.</string>
@@ -1563,7 +1562,6 @@ Language: gl_ES
     <string name="share_desc">Compartir</string>
     <string name="navigate_back_desc">Volver</string>
     <string name="navigate_forward_desc">Avanzar</string>
-    <string name="calendar_scheduled_post_description">«%1$s» programado para publicar o «%2$s» na túa aplicación de WordPress\n%3$s</string>
     <string name="calendar_scheduled_post_title">Entrada programada de WordPress: «%s»</string>
     <string name="notification_post_will_be_published_in_ten_minutes">«%s» publicarase en 10 minutos</string>
     <string name="notification_post_will_be_published_in_one_hour">«%s» publicarase en 1 hora</string>
@@ -1735,7 +1733,6 @@ Language: gl_ES
     <string name="app_rating_rate_later">Máis tarde</string>
     <string name="app_rating_rate_now">Valorar agora</string>
     <string name="app_rating_message">Que gusto verte de novo! Se estás traballando coa aplicación encantaríanos que nos puntuases na Google Play Store.</string>
-    <string name="app_rating_title">Estás gozando de WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Entrada devolta a borrador</string>
     <string name="stats_insights_posting_activity">Actividade de publicación</string>
     <string name="stats_site_not_loaded_yet">O sitio aínda non se cargou</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -1237,7 +1237,6 @@ Language: he_IL
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">יש להקיש פעמיים כדי לעבור להגדרות הצבע</string>
     <string name="reader_empty_followed_blogs_description">כאשר יש לך אתרים במעקב, התוכן שלהם יופיע כאן</string>
     <string name="feature_announcement_find_out_mode">למידע נוסף</string>
-    <string name="feature_announcement_dialog_label">מה חדש ב-WordPress</string>
     <string name="insert_label_with_count">להוסיף %d</string>
     <string name="crop">לחתוך</string>
     <string name="error_failed_to_load_into_file">הטעינה לתוך הקובץ נכשלה, יש לנסות שוב.</string>
@@ -1563,7 +1562,6 @@ Language: he_IL
     <string name="share_desc">שיתוף</string>
     <string name="navigate_back_desc">Go back</string>
     <string name="navigate_forward_desc">Go forward</string>
-    <string name="calendar_scheduled_post_description">הפוסט \"⁦%1$s⁩\" תוזמן לפרסום בתאריך \"⁦%2$s⁩\" באפליקציה שלך ב-WordPress \n %3$s</string>
     <string name="calendar_scheduled_post_title">WordPress Scheduled Post: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" will be published in 10 minutes</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" will be published in 1 hour</string>
@@ -1735,7 +1733,6 @@ Language: he_IL
     <string name="app_rating_rate_later">מאוחר יותר</string>
     <string name="app_rating_rate_now">לדרג כעת</string>
     <string name="app_rating_message">שמחים לראות אותך שוב! אם אהבת את האפליקציה, נשמח לראות את הדירוג שלך בחנות Google Play.</string>
-    <string name="app_rating_title">מרוצה מ-WordPress?</string>
     <string name="editor_post_converted_back_to_draft">הפוסט הומר בחזרה למצב טיוטה</string>
     <string name="stats_insights_posting_activity">פעילות פרסום</string>
     <string name="stats_site_not_loaded_yet">האתר עדיין לא נטען</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -1237,7 +1237,6 @@ Language: id
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Ketuk dua kali untuk membuka pengaturan warna</string>
     <string name="reader_empty_followed_blogs_description">Saat Anda mengikuti situs, Anda akan melihat kontennya di sini</string>
     <string name="feature_announcement_find_out_mode">Cari tahu selengkapnya</string>
-    <string name="feature_announcement_dialog_label">Apa yang Baru di WordPress</string>
     <string name="insert_label_with_count">Sisipkan %d</string>
     <string name="crop">pangkas</string>
     <string name="error_failed_to_load_into_file">Gagal memuat ke file, harap coba lagi.</string>
@@ -1563,7 +1562,6 @@ Language: id
     <string name="share_desc">Bagikan</string>
     <string name="navigate_back_desc">Kembali</string>
     <string name="navigate_forward_desc">Selanjutnya</string>
-    <string name="calendar_scheduled_post_description">\"%1$s\" dijadwalkan untuk diterbitkan di \"%2$s\" di aplikasi WordPress Anda \n %3$s</string>
     <string name="calendar_scheduled_post_title">Pos Terjadwal WordPress: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" akan dipublikasikan dalam 10 menit</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" akan dipublikasikan dalam 1 jam</string>
@@ -1735,7 +1733,6 @@ Language: id
     <string name="app_rating_rate_later">Nanti</string>
     <string name="app_rating_rate_now">Beri penilaian sekarang</string>
     <string name="app_rating_message">Senang bertemu Anda lagi! Jika Anda suka aplikasi ini, kami menantikan penilaian Anda di Google Play Store.</string>
-    <string name="app_rating_title">Suka WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Pos dikembalikan ke format konsep</string>
     <string name="stats_insights_posting_activity">Aktivitas Posting</string>
     <string name="stats_site_not_loaded_yet">Situs belum dimuat</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -1237,7 +1237,6 @@ Language: it
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Tocca due volte per andare alle impostazioni del colore</string>
     <string name="reader_empty_followed_blogs_description">Quando segui i siti, visualizzerai i contenuti qui</string>
     <string name="feature_announcement_find_out_mode">Scopri di più</string>
-    <string name="feature_announcement_dialog_label">Novità in WordPress</string>
     <string name="insert_label_with_count">Inserisci %d</string>
     <string name="crop">ritaglia</string>
     <string name="error_failed_to_load_into_file">Impossibile caricare nel file, riprova.</string>
@@ -1563,7 +1562,6 @@ Language: it
     <string name="share_desc">Condividi</string>
     <string name="navigate_back_desc">Torna indietro</string>
     <string name="navigate_forward_desc">Vai avanti</string>
-    <string name="calendar_scheduled_post_description">\"%1$s\" pianificato per la pubblicazione il giorno \"%2$s\" nella tua app WordPress \n %3$s</string>
     <string name="calendar_scheduled_post_title">Articolo programmato WordPress: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" verrà pubblicato tra 10 minuti</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" verrà pubblicato tra 1 ora</string>
@@ -1735,7 +1733,6 @@ Language: it
     <string name="app_rating_rate_later">Più tardi</string>
     <string name="app_rating_rate_now">Valuta ora</string>
     <string name="app_rating_message">È un piacere rivederti. Se apprezzi l\'app, ci piacerebbe ricevere una valutazione sul Google Play Store.</string>
-    <string name="app_rating_title">Ti piace WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Articolo riconvertito in bozza</string>
     <string name="stats_insights_posting_activity">Attività di pubblicazione</string>
     <string name="stats_site_not_loaded_yet">Sito non ancora caricato</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -1236,7 +1236,6 @@ Language: ja_JP
     <string name="gutenberg_native_select_a_color">色を選択</string>
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">ダブルタップして色設定に移動</string>
     <string name="reader_empty_followed_blogs_description">サイトをフォローすると、こちらにコンテンツが表示されます</string>
-    <string name="feature_announcement_dialog_label">WordPress の新機能</string>
     <string name="insert_label_with_count">%d を挿入</string>
     <string name="crop">切り取り</string>
     <string name="error_failed_to_load_into_file">ファイルに読み込めませんでした。もう一度お試しください。</string>
@@ -1565,7 +1564,6 @@ Language: ja_JP
     <string name="navigate_forward_desc">進む</string>
     <string name="calendar_scheduled_post_title">WordPress の予約済み投稿 :「%s」</string>
     <string name="notification_post_will_be_published_in_ten_minutes">「%s」は10分後に公開されます</string>
-    <string name="calendar_scheduled_post_description">「%1$s」は WordPress アプリの「%2$s」での公開が予定されています\n %3$s</string>
     <string name="notification_post_will_be_published_in_one_hour">「%s」は1時間後に公開されます</string>
     <string name="notification_post_has_been_published">「%s」が公開されました</string>
     <string name="notification_scheduled_post_ten_minute_reminder">予約済みの投稿 :10分前のリマインダー</string>
@@ -1735,7 +1733,6 @@ Language: ja_JP
     <string name="app_rating_rate_later">後で評価する</string>
     <string name="app_rating_rate_now">今すぐ評価する</string>
     <string name="app_rating_message">ご利用ありがとうございます。アプリをご利用いただきありがとうございます。Google Play ストアでの評価をお願いいたします。</string>
-    <string name="app_rating_title">WordPress の感想をお聞かせください</string>
     <string name="editor_post_converted_back_to_draft">下書きに戻した投稿</string>
     <string name="stats_insights_posting_activity">投稿アクティビティ</string>
     <string name="stats_site_not_loaded_yet">まだ読み込まれていないサイト</string>

--- a/WordPress/src/main/res/values-kmr/strings.xml
+++ b/WordPress/src/main/res/values-kmr/strings.xml
@@ -311,7 +311,6 @@ Language: ku_TR
     <string name="photo_picker_photo_or_video_title">Medya hilbijêre</string>
     <string name="photo_picker_video_title">Vîdyo Hilbijêre</string>
     <string name="site_picker_ask_site_select">Malper nehat bijartin. Jkx, dîsa biceribîne.</string>
-    <string name="feature_announcement_dialog_label">Di WordPress\'ê De Çi Nû Ne</string>
     <string name="crop">biqusîne</string>
     <string name="preview_image_thumbnail_description">Pêşdîtina Wêneyê Biçûk</string>
     <string name="insert_label_with_count">%d\'ê tevlî bike</string>
@@ -780,7 +779,6 @@ Language: ku_TR
     <string name="app_rating_rate_later">Piştre</string>
     <string name="app_rating_rate_now">Aniha deng bidê</string>
     <string name="app_rating_message">Çavê me li rêya betilî! Heke kêfa te ji sepanê re hatibe, ji dengdayîna te ya li Google Play Storeê em ê kêfxweş bibin.</string>
-    <string name="app_rating_title">Kêfa te ji WordPressê re hat?</string>
     <string name="stats_site_not_loaded_yet">Malper hîn nehatiye barkirin</string>
     <string name="stats_fewer_posts">Şandiyên kêmtir</string>
     <string name="editor_post_converted_back_to_draft">Şandî veguherî rewşa reşnivîsê</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -1237,7 +1237,6 @@ Language: ko_KR
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">색상 설정으로 이동하려면 두 번 탭하세요.</string>
     <string name="reader_empty_followed_blogs_description">사이트를 팔로우하면 여기에 해당 콘텐츠가 표시됩니다.</string>
     <string name="feature_announcement_find_out_mode">더 알아보기</string>
-    <string name="feature_announcement_dialog_label">워드프레스의 새로운 기능</string>
     <string name="insert_label_with_count">%d 삽입</string>
     <string name="crop">자르기</string>
     <string name="error_failed_to_load_into_file">파일을 로드하지 못했습니다. 다시 시도하십시오.</string>
@@ -1563,7 +1562,6 @@ Language: ko_KR
     <string name="share_desc">공유</string>
     <string name="navigate_back_desc">뒤로 가기</string>
     <string name="navigate_forward_desc">앞으로 가기</string>
-    <string name="calendar_scheduled_post_description">워드프레스 앱 \n에서 \"%2$s\"에 \"%1$s\" 발행 예약됨 %3$s</string>
     <string name="calendar_scheduled_post_title">예약된 워드프레스 글: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\"이(가) 10분 후에 게시됩니다.</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\"이(가) 1시간 후에 게시됩니다.</string>
@@ -1735,7 +1733,6 @@ Language: ko_KR
     <string name="app_rating_rate_later">나중에</string>
     <string name="app_rating_rate_now">지금 평가</string>
     <string name="app_rating_message">다시 만나서 반가워요! 앱을 알아보고 있다면 Google Play 스토어에서 평가를 확인하는 것이 좋습니다.</string>
-    <string name="app_rating_title">워드프레스가 마음에 드시나요?</string>
     <string name="editor_post_converted_back_to_draft">글을 임시글로 되돌림</string>
     <string name="stats_insights_posting_activity">게시 활동</string>
     <string name="stats_site_not_loaded_yet">사이트가 아직 로드되지 않음</string>

--- a/WordPress/src/main/res/values-nb/strings.xml
+++ b/WordPress/src/main/res/values-nb/strings.xml
@@ -562,7 +562,6 @@ Language: nb_NO
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Dobbelttrykk for å gå til fargeinnstillinger</string>
     <string name="reader_empty_followed_blogs_description">Når du følger nettsteder vil du se innholdet her</string>
     <string name="feature_announcement_find_out_mode">Finn ut mer</string>
-    <string name="feature_announcement_dialog_label">Hva er nytt i WordPress?</string>
     <string name="insert_label_with_count">Sett inn %d</string>
     <string name="crop">klipp</string>
     <string name="preview_image_thumbnail_description">Forhåndsvis miniatyrbilde</string>
@@ -868,7 +867,6 @@ Language: nb_NO
     <string name="share_desc">Del</string>
     <string name="navigate_back_desc">Gå tilbake</string>
     <string name="navigate_forward_desc">Gå forover</string>
-    <string name="calendar_scheduled_post_description">\"%1$s\" planlagt for publisering den \"%2$s\" i din WordPress-app\n%3$s</string>
     <string name="calendar_scheduled_post_title">WordPress planlagt innlegg: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" vil bli publiser om 10 minutter</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" vil bli publisert om en time</string>
@@ -1038,7 +1036,6 @@ Language: nb_NO
     <string name="app_rating_rate_later">Senere</string>
     <string name="app_rating_rate_now">Vurder nå</string>
     <string name="app_rating_message">Hyggelig å se deg igjen! Om du liker appen skulle vi gjerne ha en vurdering på Google Play-butikken.</string>
-    <string name="app_rating_title">Har du glede av WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Innlegg konvertert tilbake til kladd</string>
     <string name="stats_insights_posting_activity">Publiseringsaktivitet</string>
     <string name="stats_site_not_loaded_yet">Nettstedet er ikke lastet inn ennå</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -1236,7 +1236,6 @@ Language: nl
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Twee keer tikken om naar de kleurinstellingen te gaan</string>
     <string name="reader_empty_followed_blogs_description">Wanneer je sites volgt, zie je hier de inhoud ervan</string>
     <string name="feature_announcement_find_out_mode">Meer informatie</string>
-    <string name="feature_announcement_dialog_label">Wat is er nieuw in WordPress</string>
     <string name="insert_label_with_count">Invoegen %d</string>
     <string name="crop">bijsnijden</string>
     <string name="error_failed_to_load_into_file">Kan niet laden in bestand, probeer het opnieuw.</string>
@@ -1562,7 +1561,6 @@ Language: nl
     <string name="share_desc">Delen</string>
     <string name="navigate_back_desc">Terugkeren</string>
     <string name="navigate_forward_desc">Doorgaan</string>
-    <string name="calendar_scheduled_post_description">\'%1$s\' ingepland voor publicatie op \'%2$s\' in uw WordPress-app \n %3$s</string>
     <string name="calendar_scheduled_post_title">Ingepland WordPress bericht: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" wordt over 10 minuten gepubliceerd</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" wordt over 1 uur gepubliceerd</string>
@@ -1734,7 +1732,6 @@ Language: nl
     <string name="app_rating_rate_later">Later</string>
     <string name="app_rating_rate_now">Nu beoordelen</string>
     <string name="app_rating_message">Goed je te weer zien! Als je deze app tof vindt, vergeet dan niet een beoordeling te geven in de Google Play Store.</string>
-    <string name="app_rating_title">Geniet je van WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Bericht teruggezet naar concept</string>
     <string name="stats_insights_posting_activity">Berichtactiviteiten</string>
     <string name="stats_site_not_loaded_yet">Site nog niet geladen</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -964,7 +964,6 @@ Language: pl
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Stuknij dwukrotnie, by przejść do ustawień kolorów</string>
     <string name="reader_empty_followed_blogs_description">Gdy zaczniesz śledzić inne witryny, zobaczysz tutaj ich treść</string>
     <string name="feature_announcement_find_out_mode">Dowiedz się więcej</string>
-    <string name="feature_announcement_dialog_label">Co nowego w WordPressie</string>
     <string name="insert_label_with_count">Wstaw %d</string>
     <string name="crop">przytnij</string>
     <string name="photo_picker_video_title">Wybierz wideo</string>
@@ -1292,7 +1291,6 @@ Language: pl
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" zostanie opublikowany za 10 minut</string>
     <string name="navigate_back_desc">Wróć</string>
     <string name="web_preview_desktop">Komputer stacjonarny</string>
-    <string name="calendar_scheduled_post_description">Wpis „%1$s” został zaplanowany do publikacji w dniu „%2$s” w twojej aplikacji WordPressowej\n%3$s</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" zostanie opublikowany za godzinę</string>
     <string name="notification_post_has_been_published">\"%s\" został opublikowany</string>
     <string name="notification_scheduled_post_ten_minute_reminder">Zaplanowany wpis: przypomnienie 10 minutowe</string>
@@ -1462,7 +1460,6 @@ Language: pl
     <string name="app_rating_rate_now">Oceń teraz</string>
     <string name="app_rating_message">Miło widzieć ciebie ponownie! Jeśli używasz aplikacji, prosimy o ocenę w sklepie Google Play.</string>
     <string name="app_rating_rate_never">Nie, dziękuję</string>
-    <string name="app_rating_title">Lubisz WordPressa?</string>
     <string name="editor_post_converted_back_to_draft">Wpis z powrotem zamieniony na wpis</string>
     <string name="stats_insights_posting_activity">Aktywność publikowania wpisów</string>
     <string name="stats_site_not_loaded_yet">Witryna jeszcze nie załadowana</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -1228,7 +1228,6 @@ Language: pt_BR
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Toque duas vezes para ir para as configurações de cor</string>
     <string name="reader_empty_followed_blogs_description">Ao seguir sites, você verá o conteúdo deles aqui</string>
     <string name="feature_announcement_find_out_mode">Saiba mais</string>
-    <string name="feature_announcement_dialog_label">O que há de novo no WordPress</string>
     <string name="insert_label_with_count">Inserir %d</string>
     <string name="crop">recortar</string>
     <string name="error_failed_to_load_into_file">Falha ao carregar para um arquivo. Tente novamente.</string>
@@ -1554,7 +1553,6 @@ Language: pt_BR
     <string name="share_desc">Compartilhar</string>
     <string name="navigate_back_desc">Voltar</string>
     <string name="navigate_forward_desc">Avançar</string>
-    <string name="calendar_scheduled_post_description">\"%1$s\" agendado para publicação em \"%2$s\" em seu aplicativo do WordPress \n%3$s</string>
     <string name="calendar_scheduled_post_title">Post do WordPress agendado: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" será publicado em 10 minutos</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" será publicado em uma hora</string>
@@ -1726,7 +1724,6 @@ Language: pt_BR
     <string name="app_rating_rate_later">Mais tarde</string>
     <string name="app_rating_rate_now">Avalie agora</string>
     <string name="app_rating_message">Bom te ver de novo! Se você estiver gostando do aplicativo, deixe uma avaliação no Google Play Store.</string>
-    <string name="app_rating_title">Curtindo o WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Post convertido para rascunho</string>
     <string name="stats_insights_posting_activity">Atividade de publicações</string>
     <string name="stats_site_not_loaded_yet">O site não foi carregado ainda</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -1244,7 +1244,6 @@ Language: ro
     <string name="photo_picker_use_media">Folosește acest element media</string>
     <string name="photo_picker_use_video">Folosește acest video</string>
     <string name="photo_picker_photo_or_video_title">Alege un element media</string>
-    <string name="feature_announcement_dialog_label">Care sunt noutățile în WordPress</string>
     <string name="site_picker_ask_site_select">Nu am putut selecta site-ul. Te rog reîncearcă.</string>
     <string name="photo_picker_video_title">Alege videoul</string>
     <string name="sitepicker_continue_flow">Continuă</string>
@@ -1565,7 +1564,6 @@ Language: ro
     <string name="navigate_forward_desc">Du-te înainte</string>
     <string name="calendar_scheduled_post_title">Articol programat în WordPress: „%s”</string>
     <string name="notification_post_will_be_published_in_ten_minutes">„%s” va fi publicat în 10 minute</string>
-    <string name="calendar_scheduled_post_description">„%1$s” este programat pentru publicare pe „%2$s” în aplicația ta WordPress \n %3$s</string>
     <string name="notification_post_will_be_published_in_one_hour">„%s” va fi publicat după o oră</string>
     <string name="notification_post_has_been_published">„%s” a fost publicat</string>
     <string name="notification_scheduled_post_ten_minute_reminder">Articol programat: reamintire în 10 minute</string>
@@ -1735,7 +1733,6 @@ Language: ro
     <string name="app_rating_rate_later">Mai târziu</string>
     <string name="app_rating_rate_now">Evaluează acum</string>
     <string name="app_rating_message">Ne bucurăm să te revedem! Dacă apreciezi aplicația, ne-ar plăcea s-o evaluezi în Magazinul Google Play.</string>
-    <string name="app_rating_title">Îți place WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Articolul a fost convertit înapoi la ciornă</string>
     <string name="stats_insights_posting_activity">Activitate de publicare</string>
     <string name="stats_more_posts">Mai multe articole</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -1237,7 +1237,6 @@ Language: ru
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Нажмите дважды для перехода в настройки цветов</string>
     <string name="reader_empty_followed_blogs_description">При подписке на сайты вы увидите их содержимое здесь</string>
     <string name="feature_announcement_find_out_mode">Подробнее</string>
-    <string name="feature_announcement_dialog_label">Что нового в WordPress</string>
     <string name="insert_label_with_count">Вставить %d</string>
     <string name="crop">обрезать</string>
     <string name="error_failed_to_load_into_file">Ошибка загрузки в файл, повторите попытку.</string>
@@ -1563,7 +1562,6 @@ Language: ru
     <string name="share_desc">Поделиться</string>
     <string name="navigate_back_desc">Назад</string>
     <string name="navigate_forward_desc">Вперед</string>
-    <string name="calendar_scheduled_post_description">Публикация \"%1$s\" запланирована на \"%2$s\" в приложении WordPress \n %3$s</string>
     <string name="calendar_scheduled_post_title">Запланирована запись: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" будет опубликована через 10 минут</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" будет опубликована через 1 час</string>
@@ -1735,7 +1733,6 @@ Language: ru
     <string name="app_rating_rate_later">Позже</string>
     <string name="app_rating_rate_now">Оценить сейчас</string>
     <string name="app_rating_message">Рады видеть вас снова! Если вы пользуетесь приложением, то будет отлично если вы оцените его в магазине Google Play.</string>
-    <string name="app_rating_title">Нравится WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Запись переведена назад в черновики</string>
     <string name="stats_insights_posting_activity">Активность публикации</string>
     <string name="stats_site_not_loaded_yet">Сайт еще не загружен</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -1219,7 +1219,6 @@ Language: sq_AL
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Prekeni dyfish që të kaloni te rregullimet e ngjyrave</string>
     <string name="reader_empty_followed_blogs_description">Kur ndiqni sajte, lëndën e tyre do ta shihni këtu</string>
     <string name="feature_announcement_find_out_mode">Shihni më tepër</string>
-    <string name="feature_announcement_dialog_label">Ç’ka të Re Në WordPress</string>
     <string name="insert_label_with_count">Fut %d</string>
     <string name="crop">qethe</string>
     <string name="error_failed_to_load_into_file">S’u arrit të ngarkohej në kartelë, ju lutemi, riprovoni.</string>
@@ -1545,7 +1544,6 @@ Language: sq_AL
     <string name="share_desc">Ndajeni me të tjerë</string>
     <string name="navigate_back_desc">Shko mbrapa</string>
     <string name="navigate_forward_desc">Shko përpara</string>
-    <string name="calendar_scheduled_post_description">“%1$s” u vu në plan për botim më “%2$s” te aplikacioni juaj WordPress \n %3$s</string>
     <string name="calendar_scheduled_post_title">Postim WordPress i Vënë Në Plan: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" do të botohet brenda 10 minutash</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" do të botohet pas 1 ore</string>
@@ -1717,7 +1715,6 @@ Language: sq_AL
     <string name="app_rating_rate_later">Më vonë</string>
     <string name="app_rating_rate_now">Vlerësojeni tani</string>
     <string name="app_rating_message">Na bëhet qejfi t’ju rishohim! Nëse jua ka ënda aplikacionin, do të na pëlqente të vlerësim te Google Play Store.</string>
-    <string name="app_rating_title">Ju pëlqen WordPress-i?</string>
     <string name="editor_post_converted_back_to_draft">Postimi i shndërrua sërish në skicë</string>
     <string name="stats_insights_posting_activity">Veprimtari Postimi</string>
     <string name="stats_site_not_loaded_yet">Sajt ende i pangarkuar</string>

--- a/WordPress/src/main/res/values-sr/strings.xml
+++ b/WordPress/src/main/res/values-sr/strings.xml
@@ -335,7 +335,6 @@ Language: sr_RS
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Додирни двапут за подешавања боја</string>
     <string name="reader_empty_followed_blogs_description">Када пратите веб локације, овде ћете видети њихов садржај</string>
     <string name="crop">исеци</string>
-    <string name="feature_announcement_dialog_label">Шта има ново у Вордпресу</string>
     <string name="feature_announcement_find_out_mode">Сазнај више</string>
     <string name="insert_label_with_count">Убаци %d</string>
     <string name="photo_picker_use_video">Користи овај видео запис</string>
@@ -638,7 +637,6 @@ Language: sr_RS
     <string name="app_rating_rate_later">Касније</string>
     <string name="app_rating_rate_now">Оцените сада</string>
     <string name="app_rating_message">Лепо је видети те опет! Ако копате по апликацији, волели бисмо оцену у Гугл Плеј продавници.</string>
-    <string name="app_rating_title">Уживате у Вордпресу?</string>
     <string name="stats_more_posts">Више чланака</string>
     <string name="stats_fewer_posts">Мање чланака</string>
     <string name="stats_site_not_loaded_yet">Сајт још увек није учитан</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -1237,7 +1237,6 @@ Language: sv_SE
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Dubbeltryck för att gå till färginställningarna</string>
     <string name="reader_empty_followed_blogs_description">Om du följer några webbplatser kan du se deras innehåll här</string>
     <string name="feature_announcement_find_out_mode">Ta reda på mer</string>
-    <string name="feature_announcement_dialog_label">Nyheter i WordPress</string>
     <string name="insert_label_with_count">Infoga %d</string>
     <string name="crop">beskär</string>
     <string name="error_failed_to_load_into_file">Lyckades inte ladda in i filen, försök igen.</string>
@@ -1563,7 +1562,6 @@ Language: sv_SE
     <string name="share_desc">Dela</string>
     <string name="navigate_back_desc">Gå tillbaka</string>
     <string name="navigate_forward_desc">Gå framåt</string>
-    <string name="calendar_scheduled_post_description">”%1$s” har schemalagts för publicering den ”%2$s” i din WordPress-app \n%3$s</string>
     <string name="calendar_scheduled_post_title">Schemalagt WordPress-inlägg: ”%s”</string>
     <string name="notification_post_will_be_published_in_ten_minutes">”%s” kommer att publiceras om 10 minuter</string>
     <string name="notification_post_will_be_published_in_one_hour">”%s” kommer att publiceras om en timme</string>
@@ -1735,7 +1733,6 @@ Language: sv_SE
     <string name="app_rating_rate_later">Senare</string>
     <string name="app_rating_rate_now">Betygsätt nu</string>
     <string name="app_rating_message">Kul att se dig igen! Om du gillar appen vore det härligt om du kunde betygsätta den i Google Play-butiken.</string>
-    <string name="app_rating_title">Gillar du WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Inlägget har konverterats tillbaka till ett utkast</string>
     <string name="stats_insights_posting_activity">Publiceringsaktivitet</string>
     <string name="stats_site_not_loaded_yet">Webbplatsen har inte laddats klart</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -1228,7 +1228,6 @@ Language: tr
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Renk ayarlarına gitmek için çift dokunun</string>
     <string name="reader_empty_followed_blogs_description">Siteleri takip ettiğinizde, içeriklerini burada görürsünüz</string>
     <string name="feature_announcement_find_out_mode">Daha fazlasını bul</string>
-    <string name="feature_announcement_dialog_label">WordPress\'de neler yeni</string>
     <string name="insert_label_with_count">%d ekle</string>
     <string name="crop">kırp</string>
     <string name="error_failed_to_load_into_file">Dosyaya yüklenemedi, lütfen tekrar deneyin.</string>
@@ -1554,7 +1553,6 @@ Language: tr
     <string name="share_desc">Paylaş</string>
     <string name="navigate_back_desc">Geri dön</string>
     <string name="navigate_forward_desc">İleri git</string>
-    <string name="calendar_scheduled_post_description">\"%1$s\", \n WordPress uygulamanızda \"%2$s\" tarihinde yayınlanmak üzere zamanlandı %3$s</string>
     <string name="calendar_scheduled_post_title">WordPress Zamanlanmış Gönderi: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" 10 dakika içinde yayımlanacak</string>
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" 1 saat içinde yayımlanacak</string>
@@ -1726,7 +1724,6 @@ Language: tr
     <string name="app_rating_rate_later">Sonra</string>
     <string name="app_rating_rate_now">Şimdi puanla</string>
     <string name="app_rating_message">Seni tekrar görmek güzel! Eğer uygulamayı sonuna kadar kullandıysan, Google Play mağazasında bir derecelendirmeye bayılırız.</string>
-    <string name="app_rating_title">WordPress hoşunuza gitti mi?</string>
     <string name="editor_post_converted_back_to_draft">Yazı taslağa geri dönderildi</string>
     <string name="stats_insights_posting_activity">Yazma etkinliği</string>
     <string name="stats_site_not_loaded_yet">Site henüz yüklenmedi</string>

--- a/WordPress/src/main/res/values-vi/strings.xml
+++ b/WordPress/src/main/res/values-vi/strings.xml
@@ -1178,7 +1178,6 @@ Language: vi_VN
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">Nhấn hai lần để thiết lập màu</string>
     <string name="reader_empty_followed_blogs_description">Khi bạn theo dõi blog nào đó, bạn sẽ thấy nội dung của họ ở đây</string>
     <string name="feature_announcement_find_out_mode">Tìm hiểu thêm</string>
-    <string name="feature_announcement_dialog_label">WordPress có gì mới?</string>
     <string name="insert_label_with_count">Chèn %d</string>
     <string name="crop">cắt</string>
     <string name="error_failed_to_load_into_file">Tải thông tin tập tin thất bại, xin thử lại.</string>
@@ -1504,7 +1503,6 @@ Language: vi_VN
     <string name="share_desc">Chia sẻ</string>
     <string name="navigate_back_desc">Trở lại</string>
     <string name="navigate_forward_desc">Quay lại</string>
-    <string name="calendar_scheduled_post_description">\"%1$s\" đã lên lịch đăng cho \"%2$s\" bằng WordPress app \n %3$s</string>
     <string name="calendar_scheduled_post_title">Bài viết WordPress đã lên lịch: \"%s\"</string>
     <string name="notification_post_will_be_published_in_ten_minutes">Sẽ đăng \"%s\" trong 10 phút nữa</string>
     <string name="notification_post_will_be_published_in_one_hour">Sẽ đăng \"%s\" trong 1 giờ nữa</string>
@@ -1676,7 +1674,6 @@ Language: vi_VN
     <string name="app_rating_rate_later">Để sau</string>
     <string name="app_rating_rate_now">Đánh giá</string>
     <string name="app_rating_message">Rất vui gặp lại bạn! Nếu bạn thích ứng dụng, hãy đánh giá trên Google Play Store.</string>
-    <string name="app_rating_title">Yêu thích WordPress?</string>
     <string name="editor_post_converted_back_to_draft">Đã chuyển bài viết về nháp</string>
     <string name="stats_insights_posting_activity">Hoạt động</string>
     <string name="stats_site_not_loaded_yet">Chưa tải blog xong</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -1237,7 +1237,6 @@ Language: zh_CN
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">点击两下以进入颜色设置</string>
     <string name="reader_empty_followed_blogs_description">在您关注站点时，您会在这里看到其内容</string>
     <string name="feature_announcement_find_out_mode">了解更多</string>
-    <string name="feature_announcement_dialog_label">WordPress 的新变化</string>
     <string name="insert_label_with_count">插入 %d</string>
     <string name="crop">裁剪</string>
     <string name="error_failed_to_load_into_file">无法加载进文件，请再试一次。</string>
@@ -1563,7 +1562,6 @@ Language: zh_CN
     <string name="share_desc">共享</string>
     <string name="navigate_back_desc">返回</string>
     <string name="navigate_forward_desc">前进</string>
-    <string name="calendar_scheduled_post_description">“%1$s”计划于“%2$s”在您的 WordPress 应用程序中发布\n %3$s</string>
     <string name="calendar_scheduled_post_title">WordPress 定时文章：“%s”</string>
     <string name="notification_post_will_be_published_in_ten_minutes">“%s”将于 10 分钟后发布</string>
     <string name="notification_post_will_be_published_in_one_hour">“%s”将于 1 小时后发布</string>
@@ -1735,7 +1733,6 @@ Language: zh_CN
     <string name="app_rating_rate_later">以后再说</string>
     <string name="app_rating_rate_now">立即评分</string>
     <string name="app_rating_message">欢迎您再次到来！如果您喜欢此应用，我们希望您能在Google Play Store上给我们一个评价。</string>
-    <string name="app_rating_title">喜欢 WordPress 吗?</string>
     <string name="editor_post_converted_back_to_draft">文章已转换回草稿</string>
     <string name="stats_insights_posting_activity">文章发布活动</string>
     <string name="stats_site_not_loaded_yet">站点尚未加载</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -1237,7 +1237,6 @@ Language: zh_TW
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">點選兩次即可前往顏色設定</string>
     <string name="reader_empty_followed_blogs_description">關注網站後，網站內容就會顯示於此</string>
     <string name="feature_announcement_find_out_mode">瞭解更多</string>
-    <string name="feature_announcement_dialog_label">WordPress 新功能</string>
     <string name="insert_label_with_count">插入 %d 個</string>
     <string name="crop">裁剪</string>
     <string name="error_failed_to_load_into_file">無法載入檔案，請再試一次。</string>
@@ -1563,7 +1562,6 @@ Language: zh_TW
     <string name="share_desc">分享</string>
     <string name="navigate_back_desc">返回</string>
     <string name="navigate_forward_desc">下一個</string>
-    <string name="calendar_scheduled_post_description">排程於「%2$s」在你的 WordPress 應用程式發表「%1$s」\n %3$s</string>
     <string name="calendar_scheduled_post_title">WordPress 已排程的文章：「%s」</string>
     <string name="notification_post_will_be_published_in_ten_minutes">「%s」將會在 10 分鐘後發表</string>
     <string name="notification_post_will_be_published_in_one_hour">「%s」將會在 1 小時後發表</string>
@@ -1735,7 +1733,6 @@ Language: zh_TW
     <string name="app_rating_rate_later">稍後再做</string>
     <string name="app_rating_rate_now">立即評分</string>
     <string name="app_rating_message">很高興再次與你見面！如果你喜歡我們的應用程式，歡迎前往 Google Play 商店幫忙評分。</string>
-    <string name="app_rating_title">享受 WordPress 使用體驗嗎？</string>
     <string name="editor_post_converted_back_to_draft">貼文已重新轉換為草稿</string>
     <string name="stats_insights_posting_activity">張貼活動</string>
     <string name="stats_site_not_loaded_yet">尚未載入網站</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -1237,7 +1237,6 @@ Language: zh_TW
     <string name="gutenberg_native_double_tap_to_go_to_color_settings">點選兩次即可前往顏色設定</string>
     <string name="reader_empty_followed_blogs_description">關注網站後，網站內容就會顯示於此</string>
     <string name="feature_announcement_find_out_mode">瞭解更多</string>
-    <string name="feature_announcement_dialog_label">WordPress 新功能</string>
     <string name="insert_label_with_count">插入 %d 個</string>
     <string name="crop">裁剪</string>
     <string name="error_failed_to_load_into_file">無法載入檔案，請再試一次。</string>
@@ -1563,7 +1562,6 @@ Language: zh_TW
     <string name="share_desc">分享</string>
     <string name="navigate_back_desc">返回</string>
     <string name="navigate_forward_desc">下一個</string>
-    <string name="calendar_scheduled_post_description">排程於「%2$s」在你的 WordPress 應用程式發表「%1$s」\n %3$s</string>
     <string name="calendar_scheduled_post_title">WordPress 已排程的文章：「%s」</string>
     <string name="notification_post_will_be_published_in_ten_minutes">「%s」將會在 10 分鐘後發表</string>
     <string name="notification_post_will_be_published_in_one_hour">「%s」將會在 1 小時後發表</string>
@@ -1735,7 +1733,6 @@ Language: zh_TW
     <string name="app_rating_rate_later">稍後再做</string>
     <string name="app_rating_rate_now">立即評分</string>
     <string name="app_rating_message">很高興再次與你見面！如果你喜歡我們的應用程式，歡迎前往 Google Play 商店幫忙評分。</string>
-    <string name="app_rating_title">享受 WordPress 使用體驗嗎？</string>
     <string name="editor_post_converted_back_to_draft">貼文已重新轉換為草稿</string>
     <string name="stats_insights_posting_activity">張貼活動</string>
     <string name="stats_site_not_loaded_yet">尚未載入網站</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3366,7 +3366,7 @@
     <string name="insert_label_with_count">Insert %d</string>
 
     <!-- Feature Announcement -->
-    <string name="feature_announcement_dialog_label">What\'s New In WordPress</string>
+    <string name="feature_announcement_dialog_label">What\'s New In %s</string>
     <string name="feature_announcement_find_out_mode">Find out more</string>
 
     <!-- Prepublishing Nudges -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3347,7 +3347,7 @@
     <string name="site_creation_intent_writing_poetry">Writing &amp; Poetry</string>
 
     <!-- App rating dialog -->
-    <string name="app_rating_title">Enjoying WordPress?</string>
+    <string name="app_rating_title">Enjoying %s?</string>
     <string name="app_rating_message">Nice to see you again! If you’re digging the app, we\’d love a rating on the Google Play Store.</string>
     <string name="app_rating_rate_now">Rate now</string>
     <string name="app_rating_rate_later">Later</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1709,7 +1709,7 @@
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" will be published in 1 hour</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" will be published in 10 minutes</string>
     <string name="calendar_scheduled_post_title">WordPress Scheduled Post: \"%s\"</string>
-    <string name="calendar_scheduled_post_description">\"%1$s\" scheduled for publishing on \"%2$s\" in your WordPress app \n %3$s</string>
+    <string name="calendar_scheduled_post_description">\"%1$s\" scheduled for publishing on \"%2$s\" in your %3$s app \n %4$s</string>
 
     <!-- Post Status -->
     <string name="post_status_publish_post">Publish</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PublishSettingsViewModelTest.kt
@@ -361,6 +361,9 @@ class PublishSettingsViewModelTest : BaseUnitTest() {
             calendarEvent = it?.getContentIfNotHandled()
         }
 
+        val appName = "App name"
+        whenever(resourceProvider.getString(R.string.app_name)).thenReturn(appName)
+
         val eventTitle = "Event title"
         val eventDescription = "Event description"
         whenever(resourceProvider.getString(
@@ -371,6 +374,7 @@ class PublishSettingsViewModelTest : BaseUnitTest() {
                 R.string.calendar_scheduled_post_description,
                 postTitle,
                 siteTitle,
+                appName,
                 postLink
         )).thenReturn(eventDescription)
 


### PR DESCRIPTION
Fixes #17102 

This fixes WordPress naming on the Jetpack app for these screens:
||before|after|
|-|-|-|
|Rating dialog|<img src="https://user-images.githubusercontent.com/2471769/187421378-47bee339-c70e-43a1-bdb7-1a5d534ee074.png" height=640>|<img src="https://user-images.githubusercontent.com/2471769/187509337-f867ee1a-79cb-45ed-a28a-3545738f3a5e.png" height=640>|
|Calendar event|<img src="https://user-images.githubusercontent.com/2471769/187511645-9dd11913-63cc-4710-9626-9e13a6b493a1.png" height=640>|<img src="https://user-images.githubusercontent.com/2471769/187509378-4c6e37a0-50ed-4d67-8db6-f5cb84d87a86.png" height=640>|
|Feature announcement|<img src="https://user-images.githubusercontent.com/2471769/187512153-cf158886-917b-4865-b521-df94b2ac7acc.png" height=640>|<img src="https://user-images.githubusercontent.com/2471769/187510639-ded211da-1f4c-4fd1-b46e-d9367f105f86.png" height=640>|

Note: Screenshots are captured from my development environment. "Jetpack Beta" will be "Jetpack" on the public version.

To test:
**Rating dialog test:**
- Rating dialog logic is a bit complex. There need 10 app launches and 10 interactions (media upload, check notification, publish, open reader post) to show the rating dialog.
Alternatively, you can edit [line 74 of AppRatingDialog](https://github.com/wordpress-mobile/WordPress-Android/blob/e759375f2e177734c4058618c647bd4a302dae91/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialog.kt#L74), `return if (shouldShowRateDialog()) {` → `return if (true) {` and build Jetpack app from Android studio to see the rating dialog. Then ensure the title doesn't contain "WordPress".
- Also, test for the WordPress app and ensure the title is "Enjoying WordPress?":.

**Calendar event for scheduling post test:**
1. Launch the Jetpack app.
2. Navigate My Site.
3. Tap the green button at the bottom right of the screen to publish a post.
4. Tap Blog post.
5. Tap "PUBLISH" button.
6. Tap "Publish Date" to schedule the post.
7. Set "Date and Time" to a later date, then Add to calendar button will be available.
8. Tap add to calendar.
9. The calendar app will be opened.
10. Ensure the description of the event doesn't contain WordPress app.
11. Repeat 2-9 for the WordPress app and ensure the app name is WordPress on the description.

**Feature announcement test:**
You need to edit version data and build from Android Studio to see the feature announcement dialog. 
1. Update versionName in [version.properties](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/version.properties) to `79.0`. There is a sample announcement on the announce tool for version 79.0.
2. Launch the Jetpack app.
3. Open Me → App Settings → What's New. The feature announcement dialog will appear. 
4. Ensure the title doesn't contain WordPress.
5. Repeat 3-4 for the WordPress app and ensure the title is "What's New In WordPress".

## Regression Notes
1. Potential unintended areas of impact
Texts on WordPress app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested related screens on the WordPress app.

3. What automated tests I added (or what prevented me from doing so)
No test is added because this is only a change of a word.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
