### PR TITLE
[Jetpack App] Add deep links from Calypso's app banners

### DIFF
--- a/WordPress/src/jetpack/AndroidManifest.xml
+++ b/WordPress/src/jetpack/AndroidManifest.xml
@@ -14,6 +14,29 @@
                     android:pathPattern="/get/.*"
                     android:scheme="https" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="viewpost"
+                    android:scheme="jetpack" />
+                <data
+                    android:host="stats"
+                    android:scheme="jetpack" />
+                <data
+                    android:host="read"
+                    android:scheme="jetpack" />
+                <data
+                    android:host="post"
+                    android:scheme="jetpack" />
+                <data
+                    android:host="notifications"
+                    android:scheme="jetpack" />
+            </intent-filter>
         </activity>
     </application>
 


### PR DESCRIPTION
## Description

In https://github.com/Automattic/wp-calypso/pull/67013, the URIs for deep links from Calypso's app banners to the Android app were updated for the new Jetpack app:

* **Editor:** `intent://post/#Intent;scheme=jetpack;package=com.jetpack.android;end;`
* **Notifications:** `intent://notifications/#Intent;scheme=jetpack;package=com.jetpack.android;end;`
* **Reader:** `intent://read/#Intent;scheme=jetpack;package=com.jetpack.android;end;`
* **Stats:** `intent://stats/#Intent;scheme=jetpack;package=com.jetpack.android;end;`

These URIs follow the same structure as those used for the WordPress app, except the `scheme` and `package` names have been updated to reflect the Jetpack app.

In order for the deep links to work, I have taken a look at the intents set up [here](https://github.com/wordpress-mobile/WordPress-Android/blob/a96b4ac411f55e287665cc643bcbb31f970ed4eb/WordPress/src/main/AndroidManifest.xml#L80-L91) in the WordPress app's manifest file. These have been [copied to the Jetpack app's manifest file](https://github.com/wordpress-mobile/WordPress-Android/blob/94b5da42926e843a5c9d9c7da162872d308fb775/WordPress/src/jetpack/AndroidManifest.xml#L16-L30), with the only change being that the `scheme` has been updated from `wordpress` to `jetpack`. 

## Testing

With this branch checked out and the Jetpack app running in an emulator, run the following command in Android Studio's terminal to confirm the `jetpack` custom scheme works to open the correct sections: 

* **Editor:** `adb shell am start -a android.intent.action.VIEW -d "jetpack://post" com.jetpack.android.prealpha`
* **Notifications:** `adb shell am start -a android.intent.action.VIEW -d "jetpack://notifications" com.jetpack.android.prealpha` 
* **Reader:** `adb shell am start -a android.intent.action.VIEW -d "jetpack://read" com.jetpack.android.prealpha`
* **Stats:** `adb shell am start -a android.intent.action.VIEW -d "jetpack://stats" com.jetpack.android.prealpha`

## Regression Notes

1. Potential unintended areas of impact

The deep links may work in a way that isn't intended.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing.

3. What automated tests I added (or what prevented me from doing so)

There are existing tests in place for deep links, which should cover these new additions.

<hr />

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
