### PR TITLE
Integrate gutenberg-mobile release 1.82.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] Fixes Media control toggles difficult to see [https://github.com/wordpress-mobile/WordPress-Android/pull/17068]
 * [*] Fix night mode text colors on the screens shown after scanning a Login Code [https://github.com/wordpress-mobile/WordPress-Android/pull/17086]
+* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [#16968]
 
 20.6
 -----
@@ -13,7 +14,6 @@
 
 20.5
 -----
-* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [#16968]
 * [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16848]
 * [***] [internal] Block Editor: List block: Adds support for V2 behind a feature flag [https://github.com/WordPress/gutenberg/pull/42702]
 * [*] Jetpack App: Use the Jetpack green color for the skip buttons text in site creation [https://github.com/wordpress-mobile/WordPress-Android/pull/16994]

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = 'trunk-692264f8a2a0efa540b7713d3e1ad7fc09b87d47'
-    gutenbergMobileVersion = '5130-797eeaa9af0c9ad4b5ac61ea2a4fda896ad194b3'
+    gutenbergMobileVersion = 'v1.82.0'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = 'trunk-692264f8a2a0efa540b7713d3e1ad7fc09b87d47'
-    gutenbergMobileVersion = 'v1.82.0-alpha1'
+    gutenbergMobileVersion = '5130-0f96000c05809a358b8c747ffa347c2ce4120e0a'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = 'trunk-692264f8a2a0efa540b7713d3e1ad7fc09b87d47'
-    gutenbergMobileVersion = '5130-0f96000c05809a358b8c747ffa347c2ce4120e0a'
+    gutenbergMobileVersion = '5130-797eeaa9af0c9ad4b5ac61ea2a4fda896ad194b3'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.82.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5130

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.