### PR TITLE
Fix the lint error caused by a string resource

### DIFF
--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -1564,7 +1564,6 @@ Language: zh_TW
     <string name="navigate_forward_desc">下一個</string>
     <string name="calendar_scheduled_post_title">WordPress 已排程的文章：「%s」</string>
     <string name="notification_post_will_be_published_in_ten_minutes">「%s」將會在 10 分鐘後發表</string>
-    <string name="calendar_scheduled_post_description">排程於「%2$s」在你的 WordPress 應用程式發表「%1$s」\n %3$s</string>
     <string name="notification_post_will_be_published_in_one_hour">「%s」將會在 1 小時後發表</string>
     <string name="notification_post_has_been_published">「%s」已發表</string>
     <string name="notification_scheduled_post_ten_minute_reminder">已排程的文章：10 分鐘提醒</string>


### PR DESCRIPTION
This fixes the lint error caused by https://github.com/wordpress-mobile/WordPress-Android/pull/17103.

To test:
Run `./gradlew lintWordPressVanillaRelease`

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
