### PR TITLE
Fix PR link in 20.7 release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 * [*] Fixes Media control toggles difficult to see [https://github.com/wordpress-mobile/WordPress-Android/pull/17068]
 * [*] Fix night mode text colors on the screens shown after scanning a Login Code [https://github.com/wordpress-mobile/WordPress-Android/pull/17086]
-* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [#16968]
+* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [https://github.com/wordpress-mobile/WordPress-Android/pull/16968]
 
 20.6
 -----


### PR DESCRIPTION
This PR fixes a mistake in the 20.7 release notes. Specifically, it replaces a PR reference (`#16968`) with a complete link (`https://github.com/wordpress-mobile/WordPress-Android/pull/16968 `).

h/t to @thehenrybyrd for spotting this.

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A

3. What automated tests I added (or what prevented me from doing so)

N/A 

<hr />

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
