### PR TITLE
Add accessibility label to me button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -94,6 +94,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             toolbar.inflateMenu(R.menu.my_site_menu)
             toolbar.menu.findItem(R.id.me_item)?.let { meMenu ->
                 meMenu.actionView.let { actionView ->
+                    actionView.contentDescription = meMenu.title
                     actionView.setOnClickListener { viewModel.onAvatarPressed() }
                     TooltipCompat.setTooltipText(actionView, meMenu.title)
                 }


### PR DESCRIPTION
Fixes #12522 

This adds "Me" label to me button for accessibility.

To test:
1. Turn on TalkBack from the accessibility settings of the device (You can use the search feature of settings of device)
2. Open the WordPress app and go to My Site.
3. Click on the Me Profile icon in the top right
4. Ensure TalkBack speaks the label of the button as "Me"

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
