### PR TITLE
Integrate gutenberg-mobile release 1.81.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.18.0'
-    gutenbergMobileVersion = '5136-b4904076d045f99969d2a0dda6ae74630c8e1e95'
+    gutenbergMobileVersion = 'v1.81.2'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.18.0'
-    gutenbergMobileVersion = 'v1.81.1'
+    gutenbergMobileVersion = '5136-98dd1353211791a4a92cbec9ba2ca71717291e46'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.18.0'
-    gutenbergMobileVersion = '5136-98dd1353211791a4a92cbec9ba2ca71717291e46'
+    gutenbergMobileVersion = '5136-b4904076d045f99969d2a0dda6ae74630c8e1e95'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.81.2 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5136

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.