### PR TITLE
[Hotfix] Show Jetpack Overlay only when the remote flag is enabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -75,9 +75,11 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
 
         if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
             jetpackBadge.root.isVisible = true
-            jetpackBadge.jetpackPoweredBadge.setOnClickListener {
-                jetpackBrandingUtils.trackBadgeTapped(ACTIVITY_LOG_DETAIL)
-                viewModel.showJetpackPoweredBottomSheet()
+            if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                jetpackBadge.jetpackPoweredBadge.setOnClickListener {
+                    jetpackBrandingUtils.trackBadgeTapped(ACTIVITY_LOG_DETAIL)
+                    viewModel.showJetpackPoweredBottomSheet()
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -129,9 +129,11 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
         if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
             jetpackBadge.root.isVisible = true
-            jetpackBadge.footerJetpackBadge.jetpackPoweredBadge.setOnClickListener {
-                jetpackBrandingUtils.trackBadgeTapped(ME)
-                viewModel.showJetpackPoweredBottomSheet()
+            if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                jetpackBadge.footerJetpackBadge.jetpackPoweredBadge.setOnClickListener {
+                    jetpackBrandingUtils.trackBadgeTapped(ME)
+                    viewModel.showJetpackPoweredBottomSheet()
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -277,6 +277,6 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
     }
 
     data class JetpackBadge(
-        val onClick: ListItemInteraction
+        val onClick: ListItemInteraction? = null
     ) : MySiteCardAndItem(JETPACK_BADGE)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -497,7 +497,11 @@ class MySiteViewModel @Inject constructor(
         )
 
         val jetpackBadge = JetpackBadge(
-                ListItemInteraction.create(this::onJetpackBadgeClick)
+                if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                    ListItemInteraction.create(this::onJetpackBadgeClick)
+                } else {
+                    null
+                }
         ).takeIf { jetpackBrandingUtils.shouldShowJetpackBranding() }
 
         return mapOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/MySiteJetpackBadgeViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/MySiteJetpackBadgeViewHolder.kt
@@ -10,6 +10,8 @@ class MySiteJetpackBadgeViewHolder(
     parent: ViewGroup,
 ) : MySiteCardAndItemViewHolder<JetpackBadgeBinding>(parent.viewBinding(JetpackBadgeBinding::inflate)) {
     fun bind(item: JetpackBadge) = with(binding) {
-        jetpackPoweredBadge.setOnClickListener { item.onClick.click() }
+        item.onClick?.run {
+            jetpackPoweredBadge.setOnClickListener { click() }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -249,12 +249,14 @@ public class AppSettingsFragment extends PreferenceFragment
     private void addJetpackBadgeAsFooterIfEnabled(LayoutInflater inflater, ListView listView) {
         if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
             final JetpackBadgeFooterBinding binding = JetpackBadgeFooterBinding.inflate(inflater);
-            binding.footerJetpackBadge.jetpackPoweredBadge.setOnClickListener(v -> {
+            if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                binding.footerJetpackBadge.jetpackPoweredBadge.setOnClickListener(v -> {
                     mJetpackBrandingUtils.trackBadgeTapped(Screen.APP_SETTINGS);
                     new JetpackPoweredBottomSheetFragment().show(
                             ((AppCompatActivity) getActivity()).getSupportFragmentManager(),
                             JetpackPoweredBottomSheetFragment.TAG);
-            });
+                });
+            }
             listView.addFooterView(binding.getRoot(), null, false);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -229,12 +229,14 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
             LayoutInflater inflater = LayoutInflater.from(getContext());
             final JetpackBadgeFooterBinding binding = JetpackBadgeFooterBinding.inflate(inflater);
-            binding.footerJetpackBadge.jetpackPoweredBadge.setOnClickListener(v -> {
-                mJetpackBrandingUtils.trackBadgeTapped(Screen.NOTIFICATIONS_SETTINGS);
-                new JetpackPoweredBottomSheetFragment().show(
-                        ((AppCompatActivity) getActivity()).getSupportFragmentManager(),
-                        JetpackPoweredBottomSheetFragment.TAG);
-            });
+            if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                binding.footerJetpackBadge.jetpackPoweredBadge.setOnClickListener(v -> {
+                    mJetpackBrandingUtils.trackBadgeTapped(Screen.NOTIFICATIONS_SETTINGS);
+                    new JetpackPoweredBottomSheetFragment().show(
+                            ((AppCompatActivity) getActivity()).getSupportFragmentManager(),
+                            JetpackPoweredBottomSheetFragment.TAG);
+                });
+            }
             listView.addFooterView(binding.getRoot(), null, false);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -470,10 +470,9 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
         likeFacesRecycler.addItemDecoration(
                 AvatarItemDecorator(
-                        RtlUtils.isRtl(activity),
-                        contextProvider.getContext(),
-                        AVATAR_LEFT_OFFSET_DIMEN
-                )
+                RtlUtils.isRtl(activity),
+                contextProvider.getContext(),
+                AVATAR_LEFT_OFFSET_DIMEN)
         )
 
         likeFacesRecycler.layoutManager = layoutManager

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -470,9 +470,10 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
         likeFacesRecycler.addItemDecoration(
                 AvatarItemDecorator(
-                RtlUtils.isRtl(activity),
-                contextProvider.getContext(),
-                AVATAR_LEFT_OFFSET_DIMEN)
+                        RtlUtils.isRtl(activity),
+                        contextProvider.getContext(),
+                        AVATAR_LEFT_OFFSET_DIMEN
+                )
         )
 
         likeFacesRecycler.layoutManager = layoutManager
@@ -715,9 +716,11 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
         if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
             binding.jetpackBadge.root.isVisible = true
-            binding.jetpackBadge.jetpackPoweredBadge.setOnClickListener {
-                jetpackBrandingUtils.trackBadgeTapped(READER_POST_DETAIL)
-                viewModel.showJetpackPoweredBottomSheet()
+            if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                binding.jetpackBadge.jetpackPoweredBadge.setOnClickListener {
+                    jetpackBrandingUtils.trackBadgeTapped(READER_POST_DETAIL)
+                    viewModel.showJetpackPoweredBottomSheet()
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredBottomSheetFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredBottomSheetFeatureConfig.kt
@@ -4,7 +4,7 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-@Feature(JetpackPoweredBottomSheetFeatureConfig.JETPACK_POWERED_BOTTOM_SHEET_REMOTE_FIELD, true)
+@Feature(JetpackPoweredBottomSheetFeatureConfig.JETPACK_POWERED_BOTTOM_SHEET_REMOTE_FIELD, false)
 class JetpackPoweredBottomSheetFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredBottomSheetFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackPoweredBottomSheetFeatureConfig.kt
@@ -1,23 +1,16 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-/**
- * Configuration for Jetpack Powered Bottom Sheet
- *
- * TODO: When it is ready to be rolled out uncomment the lines 12 and 19, remove line 13 and this to-do
- */
-// @Feature(JetpackPoweredBottomSheetFeatureConfig.JETPACK_POWERED_BOTTOM_SHEET_REMOTE_FIELD, true)
-@FeatureInDevelopment
-@Suppress("ForbiddenComment")
+@Feature(JetpackPoweredBottomSheetFeatureConfig.JETPACK_POWERED_BOTTOM_SHEET_REMOTE_FIELD, true)
 class JetpackPoweredBottomSheetFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
         appConfig,
-        BuildConfig.JETPACK_POWERED,
-//        JETPACK_POWERED_BOTTOM_SHEET_REMOTE_FIELD
+        BuildConfig.JETPACK_POWERED_BOTTOM_SHEET,
+        JETPACK_POWERED_BOTTOM_SHEET_REMOTE_FIELD
 ) {
     companion object {
         const val JETPACK_POWERED_BOTTOM_SHEET_REMOTE_FIELD = "jetpack_powered_bottom_sheet_remote_field"


### PR DESCRIPTION
Fixes `JetpackPoweredBottomSheetFeatureConfig` to show the Jetpack Overlay only when the remote feature flag is enabled:

- Point to build config field: `JETPACK_POWERED_BOTTOM_SHEET`
- Uncomment the `@Feature` annotation
- Remove the `@FeatureInDevelopment` annotation
- Remove comments and cleanup code
- Make sure tapping on badges doesn't show the "Jetpack Overlay" when the remote feature flag is disabled by conditionally setting the `onClick` listeners.

To test:

**1️⃣ Test Case 1 - Remote feature flag disabled**

0. Go to Firebase Remote Config and make sure the default value of the `jetpack_powered_bottom_sheet_remote_field` feature flag is `false`
1. Launch the WordPress app
2. **Badges** — **Expect** the overlay **not showing** when tapping `Jetpack Powered` **badge** on:
   1. `Dashboard` → `Home` tab
   2. `Me`
   3. `Activity Log` → `Activity Item Detail`
   4. `Me` → `App Settings`
   5. `Notifications` → `Notifications Settings`
   6. `Sharing`
   7. `Reader` → `Reader Detail`
3. **Banners** — **Expect** overlay **not showing** when tapping `Jetpack Powered` **banner** on:
  1. `Reader` list
  2. `Reader` → `Search` (both empty and with search suggestions that show after searching once)
  3. `Reader` → `Search` → `Search results` list
  4. `Notifications` list
  5. `Stats` page
  6. `Activity Log` list

**2️⃣ Test Case 2 - Remote feature flag enabled**

0. Go to Firebase Remote Config, set the default value of the `jetpack_powered_bottom_sheet_remote_field` feature flag to `true` and publish your changes
1. Launch the WordPress app
2. Repeat step 2-3 from `Test Case 1` **expecting** the overlay to **show** when tapping the badges and banners.
3. Go to Firebase Remote Config, set the default value of the `jetpack_powered_bottom_sheet_remote_field` feature flag to `false` and publish your changes

## Regression Notes
1. Potential unintended areas of impact
   Functionality when clicking the `Jetpack Powered` banners and badges.

9. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing

10. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
