### PR TITLE
[Tooling] Remove `upload_to_play_store:true` unused option #trivial

### DIFF
--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -7,7 +7,7 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_release app:$1 skip_confirm:true skip_prechecks:true upload_to_play_store:true
+bundle exec fastlane build_and_upload_release app:$1 skip_confirm:true skip_prechecks:true
 
 echo "--- 💾 Saving Artifact"
 for aab in build/*.aab; do


### PR DESCRIPTION
## Why?

`upload_to_play_store:true` is [not an option taken into account by the `build_and_upload_release` lane](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/fastlane/lanes/build.rb#L26), so it was misleading to have it specified in the Buildkite pipeline here, while in practice setting it to `upload_to_play_store:false` does not prevent the lane from uploading to the Play Store anyway.

## Alternatives Considered

I considered adding the support for such option in the lane (adding `if options[:upload_to_play_store]` on [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/fastlane/lanes/build.rb#L26) instead.
But it felt counter-intuitive to have a lane with "upload" in its name that would be able to not upload; the name of the lane being `build_and_upload` — and in fact this is exactly what it does — such an option would not fit there.

If one needs to build the `aab`, without uploading it to Play Store, we can always just call `build_bundle` directly for such rare cases.