### PR TITLE
Integrate gutenberg-mobile release 1.82.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.19.0'
-    gutenbergMobileVersion = 'v1.82.0'
+    gutenbergMobileVersion = '5140-e56d227e8bfbaedab7cf3e5bc87c62298ba8a70e'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.19.0'
-    gutenbergMobileVersion = '5140-e56d227e8bfbaedab7cf3e5bc87c62298ba8a70e'
+    gutenbergMobileVersion = '5140-8faa319ca8f815144547c118da3e7017f58b445d'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.19.0'
-    gutenbergMobileVersion = '5140-8faa319ca8f815144547c118da3e7017f58b445d'
+    gutenbergMobileVersion = '5140-782a3cae8e879276420a0177f495614c7631584d'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.19.0'
-    gutenbergMobileVersion = '5140-782a3cae8e879276420a0177f495614c7631584d'
+    gutenbergMobileVersion = 'v1.82.1'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.82.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5140

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.