### PR TITLE
Language Picker: Picker is mostly below the screen in landscape mode #17033

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/language/LocalePickerBottomSheet.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/language/LocalePickerBottomSheet.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.prefs.language
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.LayoutInflater
@@ -55,6 +56,18 @@ class LocalePickerBottomSheet : BottomSheetDialogFragment() {
         binding?.apply {
             setupContentViews()
             setupObservers()
+
+            val orientation = resources.configuration.orientation
+            if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                val sheet = dialog?.findViewById<View>(
+                    com.google.android.material.R.id.design_bottom_sheet
+                ) as? FrameLayout
+                sheet?.let {
+                    val behavior = BottomSheetBehavior.from(it)
+                    behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                    behavior.skipCollapsed = true
+                }
+            }
         }
     }
 
@@ -151,6 +164,23 @@ class LocalePickerBottomSheet : BottomSheetDialogFragment() {
         super.onDestroyView()
         binding = null
         callback = null
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+
+        if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            bottomSheet?.let {
+                val behavior = BottomSheetBehavior.from(it)
+                behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                behavior.skipCollapsed = true
+            }
+        } else {
+            bottomSheet?.let {
+                val behavior = BottomSheetBehavior.from(it)
+                behavior.skipCollapsed = false
+            }
+        }
     }
 
     private fun expandBottomSheet() {


### PR DESCRIPTION
Fixes  [#17033](https://github.com/wordpress-mobile/WordPress-Android/issues/17033)

To test:

### Steps to re-produce
1- Bring app to landscape mode
2- Tap on User Avatar
3- Tap on App Settings
4- Tap on Interface Language

## Regression Notes
1. Potential unintended areas of impact
    NONE

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Tested manually.

3. What automated tests I added (or what prevented me from doing so)4. st:
    No automated test

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Issue Video:
https://www.loom.com/share/2368c75c71f74091865866aa78627dbd

Demo After fix:
https://www.loom.com/share/576f6c8875814668b23a87eacf6f344c