### PR TITLE
Merge **unreleased** 20.7 code freeze and editorialized release notes into `trunk`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+20.8
+-----
+
+
 20.7
 -----
 * [*] Fixes Media control toggles difficult to see [https://github.com/wordpress-mobile/WordPress-Android/pull/17068]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,6 @@
 * [*] Fixes Media control toggles difficult to see [https://github.com/wordpress-mobile/WordPress-Android/pull/17068]
 * [*] Fix night mode text colors on the screens shown after scanning a Login Code [https://github.com/wordpress-mobile/WordPress-Android/pull/17086]
 * [***] Jetpack App: Widgets are now on Jetpack. Long press on app icon to find and add widgets to home screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17100]
-* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [#16968]
 * [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [https://github.com/wordpress-mobile/WordPress-Android/pull/16968]
 
 20.6

--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -11,19 +11,20 @@ msgstr ""
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_207"
+msgid ""
+"20.7:\n"
+"- Jetpack widgets are now available on your device’s home screen\n"
+"- Media preview controls are visible in both light and dark mode\n"
+"- Compose theme’s Login Code screen has better color contrast\n"
+"- Certain elements of the editor and post settings are now WordPress blue\n"
+msgstr ""
+
 msgctxt "release_note_206"
 msgid ""
 "20.6:\n"
 "- You can now log in to the app using an email address that contains a special character.\n"
 "- Preloading themes no longer crash the app during Site Creation. Whew.\n"
-msgstr ""
-
-msgctxt "release_note_205"
-msgid ""
-"20.5:\n"
-"- We added a label in App Settings to show the app’s current interface language.\n"
-"- We bumped up the screenshot size in the site theme picker to go with high-resolution image previews.\n"
-"- In the site creation process, we changed the Skip button text from blue to Jetpack green.\n"
 msgstr ""
 
 #. translators: Title to be displayed in the Play Store. Limit to 30 characters including spaces and commas!

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,6 +1,5 @@
 * [*] Fixes Media control toggles difficult to see [https://github.com/wordpress-mobile/WordPress-Android/pull/17068]
 * [*] Fix night mode text colors on the screens shown after scanning a Login Code [https://github.com/wordpress-mobile/WordPress-Android/pull/17086]
-* [***] Jetpack App: Widgets are now on Jetpack. Long press on app icon to find and add widgets to home screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17100]
-* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [#16968]
-* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [https://github.com/wordpress-mobile/WordPress-Android/pull/16968]
+* [***] Widgets are now on Jetpack. Long press on app icon to find and add widgets to home screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17100]
+* [*] Block Editor: Makes some small changes to the editor's accent colours for consistency. [https://github.com/wordpress-mobile/WordPress-Android/pull/16968]
 

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,5 +1,4 @@
-* [*] Fixes Media control toggles difficult to see [https://github.com/wordpress-mobile/WordPress-Android/pull/17068]
-* [*] Fix night mode text colors on the screens shown after scanning a Login Code [https://github.com/wordpress-mobile/WordPress-Android/pull/17086]
-* [***] Widgets are now on Jetpack. Long press on app icon to find and add widgets to home screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17100]
-* [*] Block Editor: Makes some small changes to the editor's accent colours for consistency. [https://github.com/wordpress-mobile/WordPress-Android/pull/16968]
-
+- Jetpack widgets are now available on your device’s home screen
+- Media preview controls are visible in both light and dark mode
+- Compose theme’s Login Code screen has better color contrast
+- Certain elements of the editor and post settings are now WordPress blue

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,2 +1,6 @@
-- You can now log in to the app using an email address that contains a special character.
-- Preloading themes no longer crash the app during Site Creation. Whew.
+* [*] Fixes Media control toggles difficult to see [https://github.com/wordpress-mobile/WordPress-Android/pull/17068]
+* [*] Fix night mode text colors on the screens shown after scanning a Login Code [https://github.com/wordpress-mobile/WordPress-Android/pull/17086]
+* [***] Jetpack App: Widgets are now on Jetpack. Long press on app icon to find and add widgets to home screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17100]
+* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [#16968]
+* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [https://github.com/wordpress-mobile/WordPress-Android/pull/16968]
+

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -11,19 +11,20 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_207"
+msgid ""
+"20.7:\n"
+"We can see clearly now—media preview controls (like the back button) are now visible in both light and dark mode.\n"
+"\n"
+"The Login Code screen in the Compose theme also has better color contrast for more readable text. Shiny.\n"
+msgstr ""
+
 msgctxt "release_note_206"
 msgid ""
 "20.6:\n"
 "- You can now log in to the app using an email address that contains a special character.\n"
 "- Preloading themes no longer crash the app during Site Creation. Whew.\n"
 "- Power up—the Jetpack Powered banner is shown in lists of search results.\n"
-msgstr ""
-
-msgctxt "release_note_205"
-msgid ""
-"20.5:\n"
-"- We added a new label in App Settings to show the app’s current interface language. Shiny.\n"
-"- Now that the app supports higher-resolution image previews, we bumped up the size of theme screenshots in the site theme picker. No more pixellation, only pixel perfection.\n"
 msgstr ""
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,3 +1,6 @@
-- You can now log in to the app using an email address that contains a special character.
-- Preloading themes no longer crash the app during Site Creation. Whew.
-- Power up—the Jetpack Powered banner is shown in lists of search results.
+* [*] Fixes Media control toggles difficult to see [https://github.com/wordpress-mobile/WordPress-Android/pull/17068]
+* [*] Fix night mode text colors on the screens shown after scanning a Login Code [https://github.com/wordpress-mobile/WordPress-Android/pull/17086]
+* [***] Jetpack App: Widgets are now on Jetpack. Long press on app icon to find and add widgets to home screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17100]
+* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [#16968]
+* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [https://github.com/wordpress-mobile/WordPress-Android/pull/16968]
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,6 +1,3 @@
 * [*] Fixes Media control toggles difficult to see [https://github.com/wordpress-mobile/WordPress-Android/pull/17068]
 * [*] Fix night mode text colors on the screens shown after scanning a Login Code [https://github.com/wordpress-mobile/WordPress-Android/pull/17086]
-* [***] Jetpack App: Widgets are now on Jetpack. Long press on app icon to find and add widgets to home screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17100]
-* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [#16968]
-* [*] [Jetpack-only] Block Editor: Makes some small changes to the editor's accent colours for consistency. [https://github.com/wordpress-mobile/WordPress-Android/pull/16968]
 

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,3 +1,3 @@
-* [*] Fixes Media control toggles difficult to see [https://github.com/wordpress-mobile/WordPress-Android/pull/17068]
-* [*] Fix night mode text colors on the screens shown after scanning a Login Code [https://github.com/wordpress-mobile/WordPress-Android/pull/17086]
+We can see clearly now—media preview controls (like the back button) are now visible in both light and dark mode.
 
+The Login Code screen in the Compose theme also has better color contrast for more readable text. Shiny.

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 ext {
     wordPressUtilsVersion = '2.7.0'
-    wordPressLoginVersion = 'trunk-692264f8a2a0efa540b7713d3e1ad7fc09b87d47'
+    wordPressLoginVersion = '0.19.0'
     gutenbergMobileVersion = 'v1.82.0'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1277,7 +1277,7 @@
     <string name="stats_view_videos">Videos</string>
     <string name="stats_view_comments" translatable="false">@string/comments</string>
     <string name="stats_view_search_terms">Search Terms</string>
-    <string name="stats_view_publicize">Social Media Connections</string>
+    <string name="stats_view_publicize">Jetpack Social Connections</string>
     <string name="stats_view_followers">Followers</string>
     <string name="stats_view_follower_totals">Follower Totals</string>
     <string name="stats_view_total_likes">Total Likes</string>
@@ -1380,6 +1380,7 @@
 
     <!-- Stats refreshed widgets -->
     <string name="stats_widget_log_in_message">Please log in to the WordPress app to add a widget.</string>
+    <string name="stats_widget_log_in_to_add_message">Please log in to the Jetpack app to add a widget.</string>
     <string name="stats_widget_weekly_views_name">Views this week</string>
     <string name="stats_widget_all_time_insights_name">All-time</string>
     <string name="stats_widget_today_insights_name">Today</string>
@@ -1709,7 +1710,7 @@
     <string name="notification_post_will_be_published_in_one_hour">\"%s\" will be published in 1 hour</string>
     <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" will be published in 10 minutes</string>
     <string name="calendar_scheduled_post_title">WordPress Scheduled Post: \"%s\"</string>
-    <string name="calendar_scheduled_post_description">\"%1$s\" scheduled for publishing on \"%2$s\" in your WordPress app \n %3$s</string>
+    <string name="calendar_scheduled_post_description">\"%1$s\" scheduled for publishing on \"%2$s\" in your %3$s app \n %4$s</string>
 
     <!-- Post Status -->
     <string name="post_status_publish_post">Publish</string>
@@ -2368,14 +2369,14 @@
     <string name="previous_button" translatable="false">&lt;</string>
     <string name="next_button" translatable="false">&gt;</string>
 
-    <!-- Publicize and sharing -->
+    <!-- Jetpack Social and sharing -->
     <string name="sharing">Sharing</string>
     <string name="sharing_disabled">Sharing module disabled</string>
     <string name="sharing_disabled_description">You cannot access your sharing settings because your Sharing Jetpack module is disabled.</string>
-    <string name="connections_label">Connections</string>
+    <string name="connections_label">Jetpack Social Connections</string>
     <string name="connections_description">Connect your favorite social media services to automatically share new posts with friends.</string>
     <string name="connected_accounts_label">Connected accounts</string>
-    <string name="connection_service_label">Publicize to %s</string>
+    <string name="connection_service_label">Share post to %s</string>
     <string name="connection_service_description">Connect to automatically share your blog posts to %s.</string>
     <string name="share_btn_connect">Connect</string>
     <string name="share_btn_disconnect">Disconnect</string>
@@ -2427,7 +2428,7 @@
     <string name="sharing_label_message">Change the text of the sharing buttons\' label. This text won\'t appear until you add at least one sharing button.</string>
     <string name="sharing_twitter_message">This will be included in tweets when people share using the Twitter button</string>
     <string name="dialog_title_sharing_facebook_account_must_have_pages">Not Connected</string>
-    <string name="sharing_facebook_account_must_have_pages">The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages.</string>
+    <string name="sharing_facebook_account_must_have_pages">The Facebook connection cannot find any Pages. Jetpack Social cannot connect to Facebook Profiles, only published Pages.</string>
     <string name="sharing_facebook_warning_message">You can connect your Facebook account on the WordPress.com website. When you\'re done, return to the WordPress app to change your Sharing settings.</string>
     <string name="sharing_facebook_warning_positive_button">Go to web</string>
 
@@ -3347,7 +3348,7 @@
     <string name="site_creation_intent_writing_poetry">Writing &amp; Poetry</string>
 
     <!-- App rating dialog -->
-    <string name="app_rating_title">Enjoying WordPress?</string>
+    <string name="app_rating_title">Enjoying %s?</string>
     <string name="app_rating_message">Nice to see you again! If you’re digging the app, we\’d love a rating on the Google Play Store.</string>
     <string name="app_rating_rate_now">Rate now</string>
     <string name="app_rating_rate_later">Later</string>
@@ -3366,7 +3367,7 @@
     <string name="insert_label_with_count">Insert %d</string>
 
     <!-- Feature Announcement -->
-    <string name="feature_announcement_dialog_label">What\'s New In WordPress</string>
+    <string name="feature_announcement_dialog_label">What\'s New In %s</string>
     <string name="feature_announcement_find_out_mode">Find out more</string>
 
     <!-- Prepublishing Nudges -->

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
-versionName=20.6
-versionCode=1266
+versionName=20.7-rc-1
+versionCode=1267


### PR DESCRIPTION
We normally merge the code freeze once the associated first beta build has been submitted to Google Play. In this instance, because of the [20.6.1 hotfix work which still hasn't been merged](https://github.com/wordpress-mobile/WordPress-Android/pull/17136) together with what was most likely a Google Play bug ([as reported by other folks, too](https://www.reddit.com/r/androiddev/comments/x76rgo/anyone_got_this_problem_at_least_one_of_your_apks/)) we haven't been yet able to submit.

It's useful to merge even if the usual requirements haven't been satisfied because we need the frozen strings, see 823986468bb83f67719f9d0911e59fcae46de52e, to be sent up to GlotPress for translation. 

---

- [x] New version header in `RELEASE-NOTE.txt` 
- [x] Version updates in `version.properties`
- [x] `release_notes.txt` updated with notes from `RELEASE-NOTE.txt` for current version 
- [x] `strings.xml` updates via automation merging values from libraries
- [x] Switched `ext` versions to stable releases