### PR TITLE
Reader: "Manage Topics & Sites" not translated #17112

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -553,7 +553,6 @@
             android:theme="@style/WordPress.NoActionBar" />
         <activity
             android:name=".ui.reader.ReaderSubsActivity"
-            android:label="@string/reader_title_subs"
             android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="stateHidden" />
         <activity
@@ -565,7 +564,6 @@
             android:theme="@style/ReaderMediaViewerTheme" />
         <activity
             android:name=".ui.reader.discover.interests.ReaderInterestsActivity"
-            android:label="@string/reader_title_interests"
             android:theme="@style/WordPress.NoActionBar" />
 
         <!-- Gutenberg activities -->

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -106,6 +106,7 @@ public class ReaderSubsActivity extends LocaleAwareActivity
 
         Toolbar toolbar = findViewById(R.id.toolbar_main);
         if (toolbar != null) {
+            toolbar.setTitle(R.string.reader_title_subs);
             setSupportActionBar(toolbar);
             toolbar.setNavigationOnClickListener(v -> onBackPressed());
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsActivity.kt
@@ -2,10 +2,11 @@ package org.wordpress.android.ui.reader.discover.interests
 
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.appcompat.app.AppCompatActivity
+import org.wordpress.android.R
 import org.wordpress.android.databinding.ReaderInterestsActivityBinding
+import org.wordpress.android.ui.LocaleAwareActivity
 
-class ReaderInterestsActivity : AppCompatActivity() {
+class ReaderInterestsActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -16,6 +17,7 @@ class ReaderInterestsActivity : AppCompatActivity() {
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)
+            it.title = getString(R.string.reader_title_interests)
         }
     }
 
@@ -25,5 +27,9 @@ class ReaderInterestsActivity : AppCompatActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    override fun onResume() {
+        super.onResume()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsActivity.kt
@@ -28,8 +28,4 @@ class ReaderInterestsActivity : LocaleAwareActivity() {
         }
         return super.onOptionsItemSelected(item)
     }
-
-    override fun onResume() {
-        super.onResume()
-    }
 }


### PR DESCRIPTION
Fixes [#17112](https://github.com/wordpress-mobile/WordPress-Android/issues/17112)

Solution:
`Title` needs to be set from `Activity`, instead `label` from `manifest`. As `label` is not get updated during runtime.

To test:

1. In Me > App Settings, change Interface Language to one of the Mag16 languages.
2. Head into Reader and tap the "gear" icon.
3. Note that "Manage Topics & Sites" is in English.

## Regression Notes
1. Potential unintended areas of impact
None
2. What I did to test those areas of impact (or what existing automated tests I relied on)
Visual testing
3. What automated tests I added (or what prevented me from doing so)
None, visual testing was enough

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Demo
[Video Demo](https://jmp.sh/vbJB4Zh)
