### PR TITLE
Fixes: Inconsistency of Light mode and Dark mode in screenshots

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
@@ -117,6 +117,9 @@ public class JPScreenshotTest extends BaseTest {
 
             // Enable Demo Mode
             mDemoModeEnabler.enable();
+
+            setLightModeAndWait();
+
             wpLogin();
 
             generateActivityLog();
@@ -152,7 +155,6 @@ public class JPScreenshotTest extends BaseTest {
 
         waitForElementToBeDisplayedWithoutFailure(R.id.recycler_view);
 
-        setNightModeAndWait(false);
         takeScreenshot(Screenshots.buildScreenshotName(Screenshots.CREATE_NEW_OPTIONS));
 
         // Exit back to the main activity
@@ -175,7 +177,6 @@ public class JPScreenshotTest extends BaseTest {
         clickOn(onView(withText(getTranslatedString(R.string.my_site_bottom_sheet_add_page))));
         idleFor(2000);
 
-        setNightModeAndWait(false);
         takeScreenshot(Screenshots.buildScreenshotName(Screenshots.CHOOSE_A_LAYOUT));
 
         // Exit the view and return
@@ -196,8 +197,6 @@ public class JPScreenshotTest extends BaseTest {
         // Wait for the images to load
         idleFor(6000);
 
-        setNightModeAndWait(false);
-
         takeScreenshot(Screenshots.buildScreenshotName(Screenshots.NOTIFICATIONS));
 
         // Exit the notifications activity
@@ -216,7 +215,6 @@ public class JPScreenshotTest extends BaseTest {
         // Wait for page to load
         idleFor(2000);
 
-        setNightModeAndWait(false);
         takeScreenshot(Screenshots.buildScreenshotName(Screenshots.SITE_TOPIC));
 
         // Exit the view and return
@@ -244,7 +242,6 @@ public class JPScreenshotTest extends BaseTest {
 
         idleFor(8000);
 
-        setNightModeAndWait(false);
         takeScreenshot(Screenshots.buildScreenshotName(Screenshots.STATS));
 
         // Exit the Stats Activity
@@ -266,7 +263,6 @@ public class JPScreenshotTest extends BaseTest {
         // Wait for the activity log to load
         idleFor(8000);
 
-        setNightModeAndWait(false);
         takeScreenshot(Screenshots.buildScreenshotName(Screenshots.ACTIVITY_LOG));
 
         // Exit the Activity Log Activity
@@ -280,7 +276,6 @@ public class JPScreenshotTest extends BaseTest {
 
         waitForElementToBeDisplayedWithoutFailure(R.id.recycler_view);
 
-        setNightModeAndWait(false);
         takeScreenshot(Screenshots.buildScreenshotName(Screenshots.MY_SITE));
     }
 
@@ -316,7 +311,6 @@ public class JPScreenshotTest extends BaseTest {
         linearLayout.perform(click());
 
 
-        setNightModeAndWait(false);
         takeScreenshot(Screenshots.buildScreenshotName(Screenshots.BACKUP_DOWNLOAD));
 
         // Exit the backup download activity
@@ -360,7 +354,6 @@ public class JPScreenshotTest extends BaseTest {
         // Wait for scan to load
         idleFor(8000);
 
-        setNightModeAndWait(false);
         takeScreenshot(Screenshots.buildScreenshotName(Screenshots.BLOGGING_REMINDERS));
 
         // Exit the Activity scan activity
@@ -379,7 +372,6 @@ public class JPScreenshotTest extends BaseTest {
         waitForElementToBeDisplayedWithoutFailure(R.id.media_browser_container);
 
         idleFor(2000);
-        setNightModeAndWait(true);
 
         // To do should add the logic for gallery of images
         // Right now on navigating to the media no images will be present in gallery
@@ -402,7 +394,6 @@ public class JPScreenshotTest extends BaseTest {
         // Wait for scan to load
         idleFor(8000);
 
-        setNightModeAndWait(false);
         takeScreenshot(Screenshots.buildScreenshotName(Screenshots.SCAN));
 
         // Exit the Activity scan activity
@@ -428,8 +419,6 @@ public class JPScreenshotTest extends BaseTest {
             Espresso.closeSoftKeyboard();
         }
 
-        setNightModeAndWait(false);
-
         if (openBlockList) {
             clickOnViewWithTag("add-block-button");
             idleFor(2000);
@@ -439,8 +428,8 @@ public class JPScreenshotTest extends BaseTest {
         pressBackUntilElementIsDisplayed(R.id.tabLayout);
     }
 
-    private void setNightModeAndWait(boolean isNightMode) {
-        setNightMode(isNightMode);
+    private void setLightModeAndWait() {
+        setNightMode(false);
         idleFor(5000);
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -131,7 +131,7 @@ public class WPScreenshotTest extends BaseTest {
             Espresso.closeSoftKeyboard();
         }
 
-        setNightModeAndWait(false);
+        setLightModeAndWait();
 
         if (openBlockList) {
             clickOnViewWithTag("add-block-button");
@@ -173,7 +173,7 @@ public class WPScreenshotTest extends BaseTest {
             e.printStackTrace();
         }
 
-        setNightModeAndWait(true);
+        setLightModeAndWait();
 
         // Wait for the editor to load all images
         idleFor(7000);
@@ -195,7 +195,7 @@ public class WPScreenshotTest extends BaseTest {
             clickOn(R.id.button_negative);
         }
 
-        setNightModeAndWait(true);
+        setLightModeAndWait();
 
         takeScreenshot("3-build-an-audience");
 
@@ -212,7 +212,7 @@ public class WPScreenshotTest extends BaseTest {
             clickOn(R.id.tooltip_message);
         }
 
-        setNightModeAndWait(true);
+        setLightModeAndWait();
 
         takeScreenshot("4-keep-tabs-on-your-site");
     }
@@ -227,7 +227,7 @@ public class WPScreenshotTest extends BaseTest {
         // Wait for the images to load
         idleFor(6000);
 
-        setNightModeAndWait(false);
+        setLightModeAndWait();
 
         takeScreenshot("5-reply-in-real-time");
 
@@ -243,7 +243,7 @@ public class WPScreenshotTest extends BaseTest {
         waitForElementToBeDisplayedWithoutFailure(R.id.media_browser_container);
 
         idleFor(2000);
-        setNightModeAndWait(true);
+        setLightModeAndWait();
 
         takeScreenshot("6-upload-on-the-go");
 
@@ -277,8 +277,8 @@ public class WPScreenshotTest extends BaseTest {
         return editPostActivity.getAztecImageLoader().getNumberOfImagesBeingDownloaded() == 0;
     }
 
-    private void setNightModeAndWait(boolean isNightMode) {
-        setNightMode(isNightMode);
+    private void setLightModeAndWait() {
+        setNightMode(false);
         idleFor(5000);
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -71,6 +71,8 @@ public class WPScreenshotTest extends BaseTest {
             // Enable Demo Mode
             mDemoModeEnabler.enable();
 
+            setLightModeAndWait();
+
             wpLogin();
 
             // Even though the screenshot for edit post is captured without error,
@@ -131,8 +133,6 @@ public class WPScreenshotTest extends BaseTest {
             Espresso.closeSoftKeyboard();
         }
 
-        setLightModeAndWait();
-
         if (openBlockList) {
             clickOnViewWithTag("add-block-button");
             idleFor(2000);
@@ -173,8 +173,6 @@ public class WPScreenshotTest extends BaseTest {
             e.printStackTrace();
         }
 
-        setLightModeAndWait();
-
         // Wait for the editor to load all images
         idleFor(7000);
 
@@ -195,8 +193,6 @@ public class WPScreenshotTest extends BaseTest {
             clickOn(R.id.button_negative);
         }
 
-        setLightModeAndWait();
-
         takeScreenshot("3-build-an-audience");
 
         // Exit the Stats Activity
@@ -212,8 +208,6 @@ public class WPScreenshotTest extends BaseTest {
             clickOn(R.id.tooltip_message);
         }
 
-        setLightModeAndWait();
-
         takeScreenshot("4-keep-tabs-on-your-site");
     }
 
@@ -226,8 +220,6 @@ public class WPScreenshotTest extends BaseTest {
 
         // Wait for the images to load
         idleFor(6000);
-
-        setLightModeAndWait();
 
         takeScreenshot("5-reply-in-real-time");
 
@@ -243,7 +235,6 @@ public class WPScreenshotTest extends BaseTest {
         waitForElementToBeDisplayedWithoutFailure(R.id.media_browser_container);
 
         idleFor(2000);
-        setLightModeAndWait();
 
         takeScreenshot("6-upload-on-the-go");
 


### PR DESCRIPTION
Fixes #17133 

## Changes 

### Updates the logic to make all the screenshots to be in light mode. 

The logic of making the screen dark mode before taking a screenshot was changed to the light mode in `WPScreenshotTest.java` and `JPScreenshotTest.java`. 


## Testing Instructions

### To test:

Test 1 

- Run `WPScreenshotTest.java`
- Verify that all the screenshots are in light mode 


Test 2
- Run `JPScreenshotTest.java`. 
- Verify that all the screenshots are in light mode  


## Regression Notes
1. Potential unintended areas of impact
Screenshots are not in correct mode

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
