### PR TITLE
Jetpack Focus: Recommend App in Me view

### DIFF
--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -27,7 +27,7 @@
     <!-- About button in Me -->
     <string name="me_btn_about">About Jetpack</string>
 
-    <!-- My SiMte Initial Tab Default value -->
+    <!-- My Site Initial Tab Default value -->
     <string name="initial_screen_entry_value_default_key" translatable="false">@string/initial_screen_entry_value_home</string>
 
     <!-- Share button in Me -->

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -27,6 +27,9 @@
     <!-- About button in Me -->
     <string name="me_btn_about">About Jetpack</string>
 
-    <!-- My Site Initial Tab Default value -->
+    <!-- My SiMte Initial Tab Default value -->
     <string name="initial_screen_entry_value_default_key" translatable="false">@string/initial_screen_entry_value_home</string>
+
+    <!-- Share button in Me -->
+    <string name="me_btn_share">Share Jetpack with a friend</string>
 </resources>

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -126,7 +126,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
                 setTitle(packageManager.getActivityInfo(componentName, PackageManager.GET_META_DATA).labelRes)
             }
         }
-        
+
         if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
             jetpackBadge.isVisible = true
             if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
@@ -244,8 +244,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     }
 
     private fun MeFragmentBinding.initRecommendUiState() {
-        // Limiting the feature to WordPress only in this v1
-        if (recommendTheAppFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
+        if (recommendTheAppFeatureConfig.isEnabled()) {
             setRecommendLoadingState(false)
             recommendTheAppContainer.visibility = View.VISIBLE
             rowRecommendTheApp.setOnClickListener {


### PR DESCRIPTION
This PR enables the recommend or "Share Jetpack with a friend" option for Jetpack on the Me view

Before | After
-- | --
<img width="250" height="500" alt="before" src="https://user-images.githubusercontent.com/506707/190675541-f402be48-c1bc-458b-81d5-bbcc5c46ad57.png"> | <img width="250" height="500" alt="after" src="https://user-images.githubusercontent.com/506707/190675617-c7cf8afa-a874-47c6-b08e-ecef3f81551c.png">


Notes: iOS [PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19174)
To test:
- Install and launch the Jetpack app
- Navigate to My Site -> Me
- ✅ That the "Share Jetpack with a friend" is visible on the view
- Tap the row and verify that you can share the link  

## Regression Notes
1. Potential unintended areas of impact
WP shows Jetpack text

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tested

3. What automated tests I added (or what prevented me from doing so) 
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
