### PR TITLE
Fix dark mode issue on countries card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapViewHolder.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Color
 import android.net.http.SslError
 import android.util.Base64
 import android.view.View
@@ -35,6 +36,7 @@ class MapViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
 
     @SuppressLint("SetJavaScriptEnabled")
     fun bind(item: MapItem) {
+        webView.setBackgroundColor(Color.TRANSPARENT)
         coroutineScope.launch {
             delay(100)
             val context = itemView.context

--- a/WordPress/src/main/res/layout/stats_block_web_view_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_web_view_item.xml
@@ -9,6 +9,7 @@
     android:paddingStart="16dp">
 
     <org.wordpress.android.ui.WPWebView
+        android:layerType="software"
         android:id="@+id/web_view"
         android:layout_width="match_parent"
         android:layout_height="200dp"


### PR DESCRIPTION
Fixes #17111
This fixes the white background issue on the countries card in dark mode.
The background of the web view on the Countries card is set to transparent to fix the issue.

NOTE: Please update the milestone to 20.8 if it's not frozen yet.

https://user-images.githubusercontent.com/2471769/190707221-f94bde3d-c6a8-4a2f-8fa4-01ac37c6d885.mp4

To test:
1. Be in dark mode
2. Go to Stats > Days/Weeks/Months/Years
3. Scroll down to find the Countries card
4. Ensure there is no white background on the countries card while loading.
5. Tap "view more" on the Countries card
6. Ensure there is no white loading state.

## Regression Notes
1. Potential unintended areas of impact
Light mode of countries card.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
I didn't add an automated test because it's a small UI fix.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
