### PR TITLE
Merge release/20.8 after Code Freeze (20.8-rc-1)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+20.9
+-----
+
+
 20.8
 -----
 * [**] Stats: Always use Western Arabic numerals in Arabic languages (previously there was a mix of Eastern and Western Arabic numerals) [https://github.com/wordpress-mobile/WordPress-Android/pull/17160]

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,4 +1,4 @@
-- Jetpack widgets are now available on your device’s home screen
-- Media preview controls are visible in both light and dark mode
-- Compose theme’s Login Code screen has better color contrast
-- Certain elements of the editor and post settings are now WordPress blue
+* [**] Stats: Always use Western Arabic numerals in Arabic languages (previously there was a mix of Eastern and Western Arabic numerals) [https://github.com/wordpress-mobile/WordPress-Android/pull/17160]
+* [*] [Jetpack-only] Adds more widgets, At a glance, All-time and Today widgets with dynamic previews [https://github.com/wordpress-mobile/WordPress-Android/pull/17140]
+* [**] Added author button to the post settings and the author of the post can be changed with it. [https://github.com/wordpress-mobile/WordPress-Android/pull/17120]
+

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,4 +1,3 @@
 * [**] Stats: Always use Western Arabic numerals in Arabic languages (previously there was a mix of Eastern and Western Arabic numerals) [https://github.com/wordpress-mobile/WordPress-Android/pull/17160]
-* [*] [Jetpack-only] Adds more widgets, At a glance, All-time and Today widgets with dynamic previews [https://github.com/wordpress-mobile/WordPress-Android/pull/17140]
+* [*] Add more widgets: "At a glance", "All-time" and "Today" widgets, with dynamic previews [https://github.com/wordpress-mobile/WordPress-Android/pull/17140]
 * [**] Added author button to the post settings and the author of the post can be changed with it. [https://github.com/wordpress-mobile/WordPress-Android/pull/17120]
-

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,4 +1,2 @@
 * [**] Stats: Always use Western Arabic numerals in Arabic languages (previously there was a mix of Eastern and Western Arabic numerals) [https://github.com/wordpress-mobile/WordPress-Android/pull/17160]
-* [*] [Jetpack-only] Adds more widgets, At a glance, All-time and Today widgets with dynamic previews [https://github.com/wordpress-mobile/WordPress-Android/pull/17140]
 * [**] Added author button to the post settings and the author of the post can be changed with it. [https://github.com/wordpress-mobile/WordPress-Android/pull/17120]
-

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,3 +1,4 @@
-We can see clearly now—media preview controls (like the back button) are now visible in both light and dark mode.
+* [**] Stats: Always use Western Arabic numerals in Arabic languages (previously there was a mix of Eastern and Western Arabic numerals) [https://github.com/wordpress-mobile/WordPress-Android/pull/17160]
+* [*] [Jetpack-only] Adds more widgets, At a glance, All-time and Today widgets with dynamic previews [https://github.com/wordpress-mobile/WordPress-Android/pull/17140]
+* [**] Added author button to the post settings and the author of the post can be changed with it. [https://github.com/wordpress-mobile/WordPress-Android/pull/17120]
 
-The Login Code screen in the Compose theme also has better color contrast for more readable text. Shiny.

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = 'trunk-680831260e3dc875608473d05bf79f0d019cfe20'
+    fluxCVersion = '1.54.0'
 
     appCompatVersion = '1.0.2'
     androidxCoreVersion = '1.3.2'

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1663,6 +1663,7 @@
     <!-- Post Settings -->
     <string name="post_settings">Post settings</string>
     <string name="post_settings_status" translatable="false">@string/status_and_visibility</string>
+    <string name="post_settings_author">Author</string>
     <string name="post_settings_categories_and_tags">Categories &amp; Tags</string>
     <string name="post_settings_publish">Publish</string>
     <string name="post_settings_mark_as_sticky_options_header">Mark as sticky</string>
@@ -1946,6 +1947,7 @@
     <string name="error_fetch_remote_site_settings">Couldn\'t retrieve site info</string>
     <string name="error_post_remote_site_settings">Couldn\'t save site info</string>
     <string name="error_fetch_users_list">Couldn\'t retrieve site users</string>
+    <string name="error_fetch_authors_list">Couldn\'t retrieve authors</string>
     <string name="error_fetch_followers_list">Couldn\'t retrieve site followers</string>
     <string name="error_fetch_email_followers_list">Couldn\'t retrieve site email followers</string>
     <string name="error_fetch_viewers_list">Couldn\'t retrieve site viewers</string>

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
-versionName=20.7
-versionCode=1272
+versionName=20.8-rc-1
+versionCode=1273


### PR DESCRIPTION
- [x] New empty entry created in `RELEASE-NOTES.txt` for next iteration.
- [x] `{jetpack_}metadata/release_notes.txt` extracted for WordPress and Jetpack.
- [x] `WordPress/jetpack_metadata/release_notes.txt` audited to remove any item not applicable for Jetpack.
- [x] Internal dependencies (FluxC, Login. Stories. About…) bumped to a new stable version in `build.gradle` if necessary.
- [x] ~`WordPress/src/main/res/values/strings.xml` updated with strings from binary dependencies.~ No new string in updated libs this time.
- [x] New strings frozen/copied into `fastlane/resources/values/strings.xml`.
- [x] Version bumped in `version.properties`