### PR TITLE
Fix prompts answers string localization

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingUiStateMapper.kt
@@ -27,7 +27,9 @@ class BloggingPromptsOnboardingUiStateMapper @Inject constructor() {
         )
 
         val trailingLabel = UiStringPluralRes(
-                R.plurals.my_site_blogging_prompt_card_number_of_answers,
+                0,
+                R.string.my_site_blogging_prompt_card_number_of_answers_one,
+                R.string.my_site_blogging_prompt_card_number_of_answers_other,
                 dummyRespondents.size
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
@@ -13,7 +13,9 @@ import javax.inject.Inject
 class BloggingPromptCardBuilder @Inject constructor() {
     fun build(params: BloggingPromptCardBuilderParams) = params.bloggingPrompt?.let {
         val trailingLabel = UiStringPluralRes(
-                R.plurals.my_site_blogging_prompt_card_number_of_answers,
+                0,
+                R.string.my_site_blogging_prompt_card_number_of_answers_one,
+                R.string.my_site_blogging_prompt_card_number_of_answers_other,
                 params.bloggingPrompt.respondentsCount
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AniUtils.Duration
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.util.StringUtils
 import javax.inject.Inject
 
 class UiHelpers @Inject constructor() {
@@ -41,9 +42,14 @@ class UiHelpers @Inject constructor() {
                             )
                         }.toTypedArray()
                 )
-                is UiStringPluralRes -> context.resources.getQuantityString(
-                        uiString.pluralsRes,
-                        uiString.count,
+                // Current localization process does not support <plurals> resource strings,
+                // so we need to use multiple string resources. Switch to @PluralRes in UiStringPluralRes and
+                // use context.resources.getQuantityString here when <plurals> is supported by localization process.
+                is UiStringPluralRes -> StringUtils.getQuantityString(
+                        context,
+                        uiString.zeroRes,
+                        uiString.oneRes,
+                        uiString.otherRes,
                         uiString.count
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.utils
 
-import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 
 /**
@@ -11,5 +10,12 @@ sealed class UiString {
     data class UiStringText(val text: CharSequence) : UiString()
     data class UiStringRes(@StringRes val stringRes: Int) : UiString()
     data class UiStringResWithParams(@StringRes val stringRes: Int, val params: List<UiString>) : UiString()
-    data class UiStringPluralRes(@PluralsRes val pluralsRes: Int, val count: Int) : UiString()
+    // Current localization process does not support <plurals> resource strings,
+    // so we need to use multiple string resources. Switch to @PluralsRes when it is supported by localization process.
+    data class UiStringPluralRes(
+        @StringRes val zeroRes: Int,
+        @StringRes val oneRes: Int,
+        @StringRes val otherRes: Int,
+        val count: Int
+    ) : UiString()
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2324,10 +2324,8 @@
     <string name="my_site_blogging_prompt_card_attribution_dayone">From <b>DayOne</b></string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Learn more</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Skipped today\'s blogging prompt</string>
-    <plurals name="my_site_blogging_prompt_card_number_of_answers">
-        <item quantity="one">%d answer</item>
-        <item quantity="other">%d answers</item>
-    </plurals>
+    <string name="my_site_blogging_prompt_card_number_of_answers_one">1 answer</string>
+    <string name="my_site_blogging_prompt_card_number_of_answers_other">%d answers</string>
 
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingUiStateMapperTest.kt
@@ -19,7 +19,12 @@ class BloggingPromptsOnboardingUiStateMapperTest {
             AvatarItem(""),
             AvatarItem(""),
             TrailingLabelTextItem(
-                    UiStringPluralRes(R.plurals.my_site_blogging_prompt_card_number_of_answers, 3),
+                    UiStringPluralRes(
+                            0,
+                            R.string.my_site_blogging_prompt_card_number_of_answers_one,
+                            R.string.my_site_blogging_prompt_card_number_of_answers_other,
+                            3
+                    ),
                     R.attr.colorOnSurface
             )
     )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
@@ -6,8 +6,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
 import org.wordpress.android.R.attr
-import org.wordpress.android.R.plurals
 import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
 import org.wordpress.android.ui.avatars.TrainOfAvatarsItem.AvatarItem
 import org.wordpress.android.ui.avatars.TrainOfAvatarsItem.TrailingLabelTextItem
@@ -26,7 +26,9 @@ private val RESPONDENTS_IN_CARD = listOf(
         AvatarItem("http://avatar3.url"),
         TrailingLabelTextItem(
                 UiStringPluralRes(
-                        plurals.my_site_blogging_prompt_card_number_of_answers,
+                        0,
+                        R.string.my_site_blogging_prompt_card_number_of_answers_one,
+                        R.string.my_site_blogging_prompt_card_number_of_answers_other,
                         NUMBER_OF_RESPONDENTS
                 ), attr.colorOnSurface
         )


### PR DESCRIPTION
This issue was raised during 20.7 beta testing (internal reference `p5T066-3y6-p2#comment-13494`).

The `my_site_blogging_prompt_card_number_of_answers` string resource (used in blogging prompts card) was modeled as a <plurals> resource, but our internal localization scripting/process does not support this yet, resulting in that resource not being localized. The support for <plurals> resources will be possibly introduced at some point, for now replacing it with using single string resources.

![image](https://user-images.githubusercontent.com/47797566/191268998-56ef2a30-3f2c-4696-b2f1-03933d85c1ab.png)

cc @AliSoftware , @thehenrybyrd 


To test:

- open the JP app in English language
- place the smartphone date in the past to find a prompt without answers, notice that no avatar nor "# answer" is presented
- answer the same prompt and notice "1 answer" is reported near your avatar
- move the smartphone date to 20 Sep 2022 where multiple answers are present, notice "N answers" (plurals) is present near the 3 avatars

## Regression Notes
1. Potential unintended areas of impact
NA

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests

3. What automated tests I added (or what prevented me from doing so)
Updated existing unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
