### PR TITLE
Fix editor role publish issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -43,7 +43,9 @@ class EditPostPublishSettingsViewModel @Inject constructor(
 
         postRepository?.let {
             val site = siteStore.getSiteByLocalId(it.localSiteId) ?: return@let
-            fetchAuthors(site)
+            if (site.hasCapabilityListUsers) {
+                fetchAuthors(site)
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -111,6 +111,8 @@ public class EditPostSettingsFragment extends Fragment {
     private TextView mStatusTextView;
     private TextView mPostFormatTextView;
     private TextView mPasswordTextView;
+    private View mPostAuthorDivider;
+    private LinearLayout mPostAuthorContainer;
     private TextView mAuthorTextView;
     private TextView mPublishDateTextView;
     private TextView mPublishDateTitleTextView;
@@ -261,6 +263,8 @@ public class EditPostSettingsFragment extends Fragment {
         mStatusTextView = rootView.findViewById(R.id.post_status);
         mPostFormatTextView = rootView.findViewById(R.id.post_format);
         mPasswordTextView = rootView.findViewById(R.id.post_password);
+        mPostAuthorDivider = rootView.findViewById(R.id.post_author_divider);
+        mPostAuthorContainer = rootView.findViewById(R.id.post_author_container);
         mAuthorTextView = rootView.findViewById(R.id.post_author);
         mPublishDateTextView = rootView.findViewById(R.id.publish_date);
         mPublishDateTitleTextView = rootView.findViewById(R.id.publish_date_title);
@@ -367,8 +371,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        final LinearLayout authorContainer = rootView.findViewById(R.id.post_author_container);
-        authorContainer.setOnClickListener(view -> showAuthorDialog());
+        mPostAuthorContainer.setOnClickListener(view -> showAuthorDialog());
 
         mStickySwitch.setOnCheckedChangeListener(mOnStickySwitchChangeListener);
 
@@ -948,19 +951,24 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     private void updateAuthorTextView(String authorDisplayName) {
-        if (authorDisplayName == null) {
-            // If the authorDisplayName is null, that means this is a new unpublished post.
-            // Set author to the current user name.
-            EditPostRepository editPostRepository = getEditPostRepository();
-            if (editPostRepository == null) {
-                return;
+        if (getSite() != null && getSite().getHasCapabilityListUsers()) {
+            mPostAuthorDivider.setVisibility(View.VISIBLE);
+            mPostAuthorContainer.setVisibility(View.VISIBLE);
+
+            if (authorDisplayName == null) {
+                // If the authorDisplayName is null, that means this is a new unpublished post.
+                // Set author to the current user name.
+                EditPostRepository editPostRepository = getEditPostRepository();
+                if (editPostRepository == null) {
+                    return;
+                }
+                PostImmutableModel postModel = editPostRepository.getPost();
+                if (postModel != null && postModel.getAuthorDisplayName() == null) {
+                    updateAuthorTextView(mAccountStore.getAccount().getDisplayName());
+                }
+            } else {
+                mAuthorTextView.setText(authorDisplayName);
             }
-            PostImmutableModel postModel = editPostRepository.getPost();
-            if (postModel != null && postModel.getAuthorDisplayName() == null) {
-                updateAuthorTextView(mAccountStore.getAccount().getDisplayName());
-            }
-        } else {
-            mAuthorTextView.setText(authorDisplayName);
         }
     }
 

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/settings_fragment_root"
     android:theme="@style/PostSettingsTheme"
     android:layout_width="match_parent"
@@ -65,11 +66,17 @@
                     android:hint="@string/post_settings_not_set" />
             </LinearLayout>
 
-            <View style="@style/PostSettingsDivider" />
+            <View
+                android:id="@+id/post_author_divider"
+                style="@style/PostSettingsDivider"
+                android:visibility="gone"
+                tools:visibility="visible" />
 
             <LinearLayout
                 android:id="@+id/post_author_container"
-                style="@style/PostSettingsContainer" >
+                style="@style/PostSettingsContainer"
+                android:visibility="gone"
+                tools:visibility="visible" >
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/PostSettingsTitle"

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PublishSettingsViewModelTest.kt
@@ -122,6 +122,7 @@ class PublishSettingsViewModelTest : BaseUnitTest() {
         val site = SiteModel()
         val siteTitle = "Site title"
         site.name = siteTitle
+        site.hasCapabilityListUsers = true
         whenever(siteStore.getSiteByLocalId(localSiteId)).thenReturn(site)
 
         val peopleList = listOf(Person(1, 1), Person(2, 1))


### PR DESCRIPTION
This fixes "Couldn’t retrieve authors" error message on post settings screen. The error appears for users who are not admins. https://github.com/wordpress-mobile/WordPress-Android/pull/17120 introduced the bug.

To test:
1. Launch the app.
2. Tap the blue button at the bottom right of the screen, then "Blog Post" or "Site page" to open the new post screen.
3. Tap the options button at the top right of the screen, then "Post settings".
4. Ensure no error message appears.

## Regression Notes
1. Potential unintended areas of impact
Author selection button for admin roles.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Updated `PublishSettingsViewModelTest.kt`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
