### PR TITLE
Quick Start: Retain Quick Start focus point after device rotation #16656

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -47,6 +47,7 @@ import org.wordpress.android.util.merge
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
+import java.io.Serializable
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
@@ -389,5 +390,9 @@ class WPMainActivityViewModel @Inject constructor(
     data class FocusPointInfo(
         val task: QuickStartTask,
         val isVisible: Boolean
-    )
+    ) : Serializable {
+        companion object {
+            const val serialVersionUID = 1L
+        }
+    }
 }


### PR DESCRIPTION
Fixes #16656
Quick Start: Retain Quick Start focus point after device rotation

Add the current active QuickStartFocus point to the `savedInstanceState` when the device is rotated and retrieve it when it is recreated

To test:

1. Launch the app.
2. Logout and log in.
3. Select an existing site from the Login Epilogue screen.
4. Select `Show me around` on the onboarding Quick Start dialogue.
5. Go to `My Site tab`.
6. Notice that the `Quick Start` card is shown for the existing site with the title `Get to know your app`.
7. Tap on the `Quick Start` card then tap on Check your notifications in the tasks modal.
8. Notice that the Quick Start focus point is shown on the notifications tab.
9. Rotate the device
10. Notice that the Quick Start focus point is still shown on the notifications tab.

## Regression Notes
1. Potential unintended areas of impact
NONE

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Virtual testing

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Bug loom 
https://www.loom.com/share/d8ae5978f2534b9dbdd08ab78c031156

Fix loom video
https://www.loom.com/share/1ffba7f5d8034a13b823ca7166d1ebbf

**NB On how to setup see the Bug loom video**