### PR TITLE
Removes: click on before every input event in login flow

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -38,7 +38,6 @@ public class LoginFlow {
     public LoginFlow enterEmailAddress(String emailAddress) {
         // Email Address Screen – Fill it in and click "Continue"
         // See LoginEmailFragment
-        clickOn(R.id.input);
         populateTextField(R.id.input, emailAddress);
         clickOn(R.id.login_continue_button);
         return this;
@@ -47,7 +46,6 @@ public class LoginFlow {
     public LoginFlow enterPassword(String password) {
         // Password Screen – Fill it in and click "Continue"
         // See LoginEmailPasswordFragment
-        clickOn(R.id.input);
         populateTextField(R.id.input, password);
         clickOn(R.id.bottom_button);
         return this;
@@ -106,9 +104,7 @@ public class LoginFlow {
                 Matchers.instanceOf(EditText.class)));
         ViewInteraction passwordElement = onView(allOf(isDescendantOfA(withId(R.id.login_password_row)),
                 Matchers.instanceOf(EditText.class)));
-        clickOn(usernameElement);
         populateTextField(usernameElement, username + "\n");
-        clickOn(passwordElement);
         populateTextField(passwordElement, password + "\n");
         clickOn(R.id.bottom_button);
         return this;
@@ -124,7 +120,6 @@ public class LoginFlow {
     public LoginFlow enterSiteAddress(String siteAddress) {
         // Site Address Screen – Fill it in and click "Continue"
         // See LoginSiteAddressFragment
-        clickOn(R.id.input);
         populateTextField(R.id.input, siteAddress);
         clickOn(R.id.bottom_button);
         return this;


### PR DESCRIPTION
While doing some work for screenshot testing, I found that the google autofill manager popup is not dismissed on devices with google Accounts and hence the screenshot tests are failing.  

The google autofill manager pop up shown during screenshot testing

<img src="https://user-images.githubusercontent.com/17463767/191485054-0469fbe8-65e3-45f9-a61b-483e84610ef3.jpg" width="250" height="580">

### Some info about the two pop-ups shown in the Login flow 

The behaviour of the Google authentication pop-up is that when the email address field has the focus/clicks on the email field, then the pop-up is shown. The pop-up visibility is handled by the code base and not google. This popup and the popup which is shown when clicking on the `continue with google` are different. The pop shown on clicking the email field is shown by the autofill manager present in the android os whereas the popup which is shown when clicking on `continue with google` button is through API integration(it shows only the google accounts signed in the device). 

| Pop up shown when clicking on continue with google | Pop shown by Android OS Autofill manager| 
|---|---|
| ![Screenshot_20220916-180635_Google Play services](https://user-images.githubusercontent.com/17463767/191488380-a6ee2124-b2ed-4449-b212-3578a530e9c3.jpg)|![Screenshot_20220916-165334_Google Play services](https://user-images.githubusercontent.com/17463767/191488427-0338318a-b260-49c5-bfbe-bd20ef2370b1.jpg)|  


### Issue 
The `click-on` added before the populate text field committed on this [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16993) triggers the autofill manager popup. This popup can't be dismissed in tests as the app doesn't have the reference of the view provided by Android OS. This causes the failure of the screenshot tests. So I re-ran the tests by removing the line `click-on` and found that the tests are getting succeeded. 

I also found that the following code doesn’t trigger the email pop-up.

```
 populateTextField(R.id.input, password);
 clickOn(R.id.bottom_button);
 return this;
```

```
public static void populateTextField(Integer elementID, String text) {
        waitForElementToBeDisplayed(elementID);
        onView(withId(elementID))
                .perform(replaceText(text))
                .perform(closeSoftKeyboard());
    }
```

As such I have reverted the changes made in this commit [Test: Added `clickOn()` before every input event in `LoginFlow`. · wordpress-mobile/WordPress-Android@3886e91 · GitHub](https://github.com/wordpress-mobile/WordPress-Android/commit/3886e917ccfb109921c4f9b09711b3d2bfe78095) , which was added for fixing this login issue. I believe all the `clickOn()` was added for fixing this issue, if not I will revert the ones that are not needed. 

Am adding everyone involved in this [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16993) as Reviewers. 

cc: @AliSoftware for visibility 

## To test:

Test 1 
- Run jPScreenshotTest/WpScreenshotTest on a device with google accounts 
- Verify that the autofill manager is not shown and the test passes 

Test 2
-  Run jPScreenshotTest/WpScreenshotTest on a device without google accounts(tested this on an emulator)
- Verify that the autofill manager is not shown and the test passes 

## Regression Notes
1. Potential unintended areas of impact
Screenshots tests failing 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ran screenshot tests 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
