### PR TITLE
Update FluxC version to 1.54.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = '1.54.0'
+    fluxCVersion = '1.54.1'
 
     appCompatVersion = '1.0.2'
     androidxCoreVersion = '1.3.2'


### PR DESCRIPTION
This updates FluxC version to 1.54.1 to fix publish issue. The new FluxC version contains only this PR  → https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2527

To test:
The feature is already tested in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2527 but you can test it again if you want to be sure.
1. Launch the app.
2. Select a site which you're not an admin.
3. Tap the blue button at the bottom right of the screen, then "Blog Post" or "Site page" to open the new post screen.
4. Type something in the post.
5. Tap PUBLISH button.
6. Ensure the post is published without any error message.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
