### PR TITLE
Merge Editorialized Release Notes for 20.8

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -11,6 +11,14 @@ msgstr ""
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_208"
+msgid ""
+"20.8:\n"
+"We added dynamic widgets to show at-a-glance, all-time, and daily stats on user devices’ home screens.\n"
+"Users on multi-author sites can change content authors in post and page settings.\n"
+"Arabic language users will see numerals on Stats screens exclusively in Western Arabic numbers.\n"
+msgstr ""
+
 msgctxt "release_note_207"
 msgid ""
 "20.7:\n"
@@ -18,13 +26,6 @@ msgid ""
 "- Media preview controls are visible in both light and dark mode\n"
 "- Compose theme’s Login Code screen has better color contrast\n"
 "- Certain elements of the editor and post settings are now WordPress blue\n"
-msgstr ""
-
-msgctxt "release_note_206"
-msgid ""
-"20.6:\n"
-"- You can now log in to the app using an email address that contains a special character.\n"
-"- Preloading themes no longer crash the app during Site Creation. Whew.\n"
 msgstr ""
 
 #. translators: Title to be displayed in the Play Store. Limit to 30 characters including spaces and commas!

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,3 +1,3 @@
-* [**] Stats: Always use Western Arabic numerals in Arabic languages (previously there was a mix of Eastern and Western Arabic numerals) [https://github.com/wordpress-mobile/WordPress-Android/pull/17160]
-* [*] Add more widgets: "At a glance", "All-time" and "Today" widgets, with dynamic previews [https://github.com/wordpress-mobile/WordPress-Android/pull/17140]
-* [**] Added author button to the post settings and the author of the post can be changed with it. [https://github.com/wordpress-mobile/WordPress-Android/pull/17120]
+We added dynamic widgets to show at-a-glance, all-time, and daily stats on user devices’ home screens.
+Users on multi-author sites can change content authors in post and page settings.
+Arabic language users will see numerals on Stats screens exclusively in Western Arabic numbers.

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -11,20 +11,19 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_208"
+msgid ""
+"20.8:\n"
+"Users on multi-author sites can change content authors in post and page settings.\n"
+"Arabic language users will now see numerals on Stats screens exclusively in Western Arabic numbers—no more mix and match with Eastern Arabic numbers.\n"
+msgstr ""
+
 msgctxt "release_note_207"
 msgid ""
 "20.7:\n"
 "We can see clearly now—media preview controls (like the back button) are now visible in both light and dark mode.\n"
 "\n"
 "The Login Code screen in the Compose theme also has better color contrast for more readable text. Shiny.\n"
-msgstr ""
-
-msgctxt "release_note_206"
-msgid ""
-"20.6:\n"
-"- You can now log in to the app using an email address that contains a special character.\n"
-"- Preloading themes no longer crash the app during Site Creation. Whew.\n"
-"- Power up—the Jetpack Powered banner is shown in lists of search results.\n"
 msgstr ""
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,2 +1,2 @@
-* [**] Stats: Always use Western Arabic numerals in Arabic languages (previously there was a mix of Eastern and Western Arabic numerals) [https://github.com/wordpress-mobile/WordPress-Android/pull/17160]
-* [**] Added author button to the post settings and the author of the post can be changed with it. [https://github.com/wordpress-mobile/WordPress-Android/pull/17120]
+Users on multi-author sites can change content authors in post and page settings.
+Arabic language users will now see numerals on Stats screens exclusively in Western Arabic numbers—no more mix and match with Eastern Arabic numbers.


### PR DESCRIPTION
- Update Release Notes with Editorial copy
- Update WordPress `PlayStoreStrings.po` for version 20.8
- Update Jetpack `PlayStoreStrings.po` for version 20.8

[Internal ref: p1663812771623849-slack-C02S5P5MBGA]