### PR TITLE
[Compile Warnings As Errors] Annotations Module - Enable All Warnings as Errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id "com.automattic.android.fetchstyle"
     id "io.gitlab.arturbosch.detekt"
@@ -103,7 +105,7 @@ allprojects {
         debug = false
     }
 
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    tasks.withType(KotlinCompile).all {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_1_8
         }

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ allprojects {
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions {
-            jvmTarget = "1.8"
+            jvmTarget = JavaVersion.VERSION_1_8
         }
     }
 }

--- a/libs/annotations/build.gradle
+++ b/libs/annotations/build.gradle
@@ -1,3 +1,9 @@
 plugins {
     id "org.jetbrains.kotlin.jvm"
 }
+
+compileKotlin {
+    kotlinOptions {
+        allWarningsAsErrors = true
+    }
+}

--- a/libs/annotations/build.gradle
+++ b/libs/annotations/build.gradle
@@ -13,8 +13,3 @@ compileKotlin {
         jvmTarget = "1.8"
     }
 }
-compileTestKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}

--- a/libs/annotations/build.gradle
+++ b/libs/annotations/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }

--- a/libs/annotations/build.gradle
+++ b/libs/annotations/build.gradle
@@ -5,8 +5,3 @@ plugins {
 repositories {
     mavenCentral()
 }
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
-    }
-}

--- a/libs/annotations/build.gradle
+++ b/libs/annotations/build.gradle
@@ -1,7 +1,3 @@
 plugins {
     id "org.jetbrains.kotlin.jvm"
 }
-
-repositories {
-    mavenCentral()
-}

--- a/libs/annotations/build.gradle
+++ b/libs/annotations/build.gradle
@@ -2,9 +2,6 @@ plugins {
     id "org.jetbrains.kotlin.jvm"
 }
 
-sourceCompatibility = "7"
-targetCompatibility = "7"
-
 repositories {
     mavenCentral()
 }

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -41,10 +41,6 @@ android {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 
     // Avoid 'duplicate files during packaging of APK' errors
     packagingOptions {

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -42,8 +42,8 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
     }
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     // Avoid 'duplicate files during packaging of APK' errors

--- a/libs/image-editor/build.gradle
+++ b/libs/image-editor/build.gradle
@@ -18,10 +18,6 @@ android {
         vectorDrawables.useSupportLibrary = true
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         test.java.srcDirs += 'src/test/kotlin'

--- a/libs/processors/build.gradle
+++ b/libs/processors/build.gradle
@@ -17,7 +17,3 @@ dependencies {
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$nhaarmanMockitoVersion"
     testImplementation "org.assertj:assertj-core:$assertJVersion"
 }
-
-sourceCompatibility = "7"
-targetCompatibility = "7"
-


### PR DESCRIPTION
Parent: #17173
Closes: #17174
Associated To: #17197

This PR enables all warnings as errors for the `annotations` module.

This `allWarningsAsErrors` configuration is currently applied on the module level in order to make sure that, as the overall [Compiler Warnings as Errors](https://github.com/wordpress-mobile/WordPress-Android/issues/17173) work is progressing, no new warnings are added to this module, which is already free of warnings.

When the overall [Compiler Warnings as Errors](https://github.com/wordpress-mobile/WordPress-Android/issues/17173) work is complete on all modules, then this module level `allWarningsAsErrors` configuration will be replaced by a root level such configuration that will be applied by default to all modules (see [here](https://github.com/wordpress-mobile/WordPress-Android/issues/17182)).

-----

Note that, in addition to enabling the `allWarningsAsErrors` configuration on the `annotations` module, I took this opportunity to improve on other aspects of `java` and `build` related configurations. As such, this PR also improves on the following in order to mainstream this (kind of related) group of configurations, for this and all other lib module:
- `java`
    - `java 7`
        - [Remove unnecessary source/target compatibility for java 7.](https://github.com/wordpress-mobile/WordPress-Android/commit/653c99bebf4b85f760587714d8dfa7ffd192b664)
    - `source/targetCompatibility`
        - [Replace source/target compatibility 1.8 with java version const.](https://github.com/wordpress-mobile/WordPress-Android/commit/ae6d8758557484244850d9143056e71a93b180a8)
- `configuration`
    - `compileTestKotlin`
        - [Remove unnecessary compile test kotlin configuration block.](https://github.com/wordpress-mobile/WordPress-Android/commit/bf532f56a1fadc56f8fe7c0d43768de2f80ffae7)
    - `kotlinOptions`
        - [Replace kotlin options jvm target 1.8 with java version const.](https://github.com/wordpress-mobile/WordPress-Android/commit/2cb515d9c84208131bf6ad93267354e378839b3f)
        - [Remove unnecessary kotlin options jvm target config from all mods.](https://github.com/wordpress-mobile/WordPress-Android/commit/f8bc7e9736ddc738882eb46dfde44719091ee869)
    - `compileOptions`
        - [Remove compile options configuration from editor libs module.](https://github.com/wordpress-mobile/WordPress-Android/commit/388d6cd806b0ca46550e366073abefd0f55f88ef)
- `repos`
    - `repositories`
        - [Remove maven central repositories config from annotatios module.](https://github.com/wordpress-mobile/WordPress-Android/commit/65eff20ce838c310e4dc1589c689c4b1c4dc9ce5)

-----

PS: @ovitrif I added you as the main reviewer, that is, in addition to @wordpress-mobile/apps-infrastructure team itself, but randomly, since I want someone from the `WordPress Android` team to primarily sign-off on that change. 🥇

FYI: I am going to randomly add more of you in those PRs that will follow, just so you become more aware of this change and how close we are on enabling `allWarningsAsErrors` by default everywhere. 🎉

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could test the feature flag functionality, since this `annotations` module, along with the `processors` module is responsible for that. For example, you could try switching the `jetpack_powered_bottom_sheet_remote_field` feature flag, on and off, and see if that works as expected.

## Regression Notes
1. Potential unintended areas of impact

The feature flag functionality is not workings as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
