### PR TITLE
Document updateContextLocale contract to remove confusion about context non-null requirement

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -1019,9 +1019,17 @@ class AppInitializer @Inject constructor(
 
         /**
          * Update locale of the static context when language is changed.
+         *
+         * When calling this method the application context **must** be already initialized.
+         * This is already the case in `Activity`, `Fragment` or `View`.
+         *
+         * When called from other places (E.g. a `TestRule`) we should provide it in the [appContext] parameter.
          */
         fun updateContextLocale(appContext: Context? = null) {
-            val context = appContext ?: context!!
+            val context = appContext ?: run {
+                check (context != null) { "Context must be initialized before calling updateContextLocale" }
+                return@run context
+            }
             this.context = LocaleManager.setLocale(context)
         }
     }


### PR DESCRIPTION
Improves documentation and error handling for `AppInitializer.updateContextLocale` to remove confusion caused by the former usage of the not-null assertion operator.

See more details in this comment: https://github.com/wordpress-mobile/WordPress-Android/pull/17096#discussion_r975317076

To test:
⚠️ **Remark** Not mandatory — This PR suggests improvements to an [open PR with testing steps](https://github.com/wordpress-mobile/WordPress-Android/pull/17096).

1. Run `WPScreenshotTest` in Android Studio → The changes should not produce issues.
2. Run the WordPress app
3. Change the language via `Me` → `App Settings` → `Interface Language`
4. Expect no regression (no errors / crashes, this should work as good as before).

## Regression Notes
1. Potential unintended areas of impact
  Changing the language inside the app.

5. What I did to test those areas of impact (or what existing automated tests I relied on)
  Manual testing.

6. What automated tests I added (or what prevented me from doing so)
  N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
