### PR TITLE
[Compile Warnings As Errors] Processors Module - Resolve Warnings & Enable All Warnings as Errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ ext {
 
     composeVersion = '1.1.1'
 
+    // annotations/processors
+    kotlinPoetVersion = '1.6.0'
+    autoServiceVersion = '1.0'
+
     // testing
     jUnitVersion = '4.13'
     jUnitExtVersion = '1.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.19.0'
+    aztecVersion = 'v1.6.0'
     gutenbergMobileVersion = 'v1.82.1'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -4,8 +4,6 @@ plugins {
     id "org.jetbrains.kotlin.plugin.parcelize"
 }
 
-ext.aztecVersion = 'v1.6.0'
-
 repositories {
     maven {
         url "https://a8c-libs.s3.amazonaws.com/android"

--- a/libs/processors/build.gradle
+++ b/libs/processors/build.gradle
@@ -3,6 +3,12 @@ plugins {
     id "org.jetbrains.kotlin.kapt"
 }
 
+compileKotlin {
+    kotlinOptions {
+        allWarningsAsErrors = true
+    }
+}
+
 dependencies {
     implementation project(':libs:annotations')
     implementation "com.google.auto.service:auto-service:$autoServiceVersion"

--- a/libs/processors/build.gradle
+++ b/libs/processors/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id "org.jetbrains.kotlin.kapt"
 }
 
-ext.kotlinPoetVersion = '1.6.0'
-ext.autoServiceVersion = '1.0'
-
 dependencies {
     implementation project(':libs:annotations')
     implementation "com.google.auto.service:auto-service:$autoServiceVersion"

--- a/libs/processors/src/main/java/org/wordpress/android/processor/RemoteConfigCheckBuilder.kt
+++ b/libs/processors/src/main/java/org/wordpress/android/processor/RemoteConfigCheckBuilder.kt
@@ -50,10 +50,10 @@ class RemoteConfigCheckBuilder(private val remoteFeatures: List<TypeName>) {
     private fun buildCheckFunction(remoteFeatures: List<Pair<String, TypeName>>): CodeBlock {
         val stringBuilder = StringBuilder()
         remoteFeatures.forEach { feature ->
-            stringBuilder.appendln("if (${feature.first}.remoteField == null) {")
+            stringBuilder.appendLine("if (${feature.first}.remoteField == null) {")
             val error = "    throw IllegalArgumentException(\"\"\"${feature.second} needs to define remoteField\"\"\")"
-            stringBuilder.appendln(error)
-            stringBuilder.appendln("}")
+            stringBuilder.appendLine(error)
+            stringBuilder.appendLine("}")
         }
         return CodeBlock.of(stringBuilder.toString().trimIndent())
     }

--- a/libs/processors/src/main/java/org/wordpress/android/processor/RemoteConfigCheckBuilder.kt
+++ b/libs/processors/src/main/java/org/wordpress/android/processor/RemoteConfigCheckBuilder.kt
@@ -11,6 +11,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import java.util.Locale
 
 class RemoteConfigCheckBuilder(private val remoteFeatures: List<TypeName>) {
+    @Suppress("DEPRECATION")
     fun getContent(): FileSpec {
         val remoteFeaturesWithNames = remoteFeatures.map {
             it.toString()

--- a/libs/processors/src/main/java/org/wordpress/android/processor/RemoteConfigProcessor.kt
+++ b/libs/processors/src/main/java/org/wordpress/android/processor/RemoteConfigProcessor.kt
@@ -24,6 +24,7 @@ import javax.tools.Diagnostic.Kind
         "org.wordpress.android.annotation.FeatureInDevelopment"
 )
 class RemoteConfigProcessor : AbstractProcessor() {
+    @Suppress("DEPRECATION")
     override fun process(p0: MutableSet<out TypeElement>?, roundEnvironment: RoundEnvironment?): Boolean {
         val experiments = roundEnvironment?.getElementsAnnotatedWith(Experiment::class.java)?.map { element ->
             val annotation = element.getAnnotation(Experiment::class.java)


### PR DESCRIPTION
Parent: #17173
Closes: #17175
Associated To: #17195

This PR resolves/suppresses a couple of warnings for the `processors` module and then enables all warnings as errors on it as well.

Warnings Resolution List:

1) [Analysis: Resolve append in deprecated warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/31019f9dd37ca1a2ed2521feab783c16db772eb5)

Warnings Suppression List:

1) [Suppress kotlin stdlib's decapitalize deprecated warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/b8d4e45365a1cc2f22b42c4855209ecc975e2bb1)
2) [Suppress kotlin poet's as type name deprecated warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/476a7c4822878c7d497e5179465d150b36e08723)

The `allWarningsAsErrors` configuration is currently applied on the module level in order to make sure that, as the overall [Compiler Warnings as Errors](https://github.com/wordpress-mobile/WordPress-Android/issues/17173) work is progressing, no new warnings are added to this module, which is already free of warnings.

When the overall [Compiler Warnings as Errors](https://github.com/wordpress-mobile/WordPress-Android/issues/17173) work is complete on all modules, then this module level `allWarningsAsErrors` configuration will be replaced by a root level such configuration that will be applied by default to all modules (see [here](https://github.com/wordpress-mobile/WordPress-Android/issues/17182)).

----- 

Note that, in addition to enabling the `allWarningsAsErrors` configuration on the `processors` module, I took this opportunity to improve on other aspects of `version` related configurations. As such, this PR also improves on the following in order to mainstream this (kind of related) group of configurations, for this and all other lib module:

- `version`
    - [Move annotations/processors related version definitions to root.](https://github.com/wordpress-mobile/WordPress-Android/commit/81066991cb25a6b2e6549898e16e7173b513c642)
    - [Move editor related aztec version definition to root.](https://github.com/wordpress-mobile/WordPress-Android/commit/cbef4e0b3fed9fb02e3ae052decbc1737fbb3c35)

-----

PS: @irfano I added you as the main reviewer, that is, in addition to @wordpress-mobile/apps-infrastructure team itself, but randomly, since I want someone from the `WordPress Android` team to primarily sign-off on that change. 🥇

FYI: I am going to randomly add more of you in those PRs that will follow, just so you become more aware of this change and how close we are on enabling `allWarningsAsErrors` by default everywhere. 🎉

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could test the feature flag functionality, since this `processors` module, along with the `annotations` module is responsible for that. For example, you could try switching the `jetpack_powered_bottom_sheet_remote_field` feature flag, on and off, and see if that works as expected.

-----

## Regression Notes
1. Potential unintended areas of impact

The feature flag functionality is not workings as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
