### PR TITLE
[Tooling] Improve the Installable Build comment

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,7 +18,11 @@ APP_SPECIFIC_VALUES = {
 }.freeze
 
 UPLOAD_TO_PLAY_STORE_JSON_KEY = File.join(Dir.home, '.configure', 'wordpress-android', 'secrets', 'google-upload-credentials.json')
+
+INSTALLABLE_BUILD_FLAVOR = 'Jalapeno'.freeze
+INSTALLABLE_BUILD_TYPE = 'Debug'.freeze
 INSTALLABLE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
+
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 
 ########################################################################

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -259,10 +259,10 @@ platform :android do
 
     install_url = "#{INSTALLABLE_BUILD_DOMAIN}/#{upload_path}"
     qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
-    icon = "<img alt='#{product}' src='https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64/#{product.downcase}.png' width='20px' />"
+    icon = "<img alt='#{product}' align='top' src='https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64/#{product.downcase}.png' width='20px' />"
     comment_body = <<~PR_COMMENT
       <details>
-      <summary>📲 You can test these changes on #{icon} #{product} by <a href='#{install_url}'>downloading <tt>#{filename}</tt></a></summary>
+      <summary>#{icon}📲 You can test these changes on #{product} by <a href='#{install_url}'>downloading <tt>#{filename}</tt></a></summary>
       <table><tr>
         <td width="250"><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a></td>
         <td>Tip: You can also scan this QR code with your Android phone to download and install the APK directly on it.</td>

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -262,11 +262,16 @@ platform :android do
     icon = "<img alt='#{product}' align='top' src='https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64/#{product.downcase}.png' width='20px' />"
     comment_body = <<~PR_COMMENT
       <details>
-      <summary>#{icon}📲 You can test these changes on #{product} by <a href='#{install_url}'>downloading <tt>#{filename}</tt></a></summary>
-      <table><tr>
-        <td width="250"><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a></td>
-        <td>Tip: You can also scan this QR code with your Android phone to download and install the APK directly on it.</td>
-      </tr></table>
+        <summary>#{icon}📲 You can test these changes on #{product} by <a href='#{install_url}'>downloading <tt>#{filename}</tt></a></summary>
+        <table><tr>
+          <td width='250' rowspan='5'><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a></td>
+          <td colspan='2'>💡 Tip: You can also scan this QR code with your Android phone to download and install the APK directly on it.</td>
+        </tr>
+        <tr><td width='150px'><b>Product</b></td><td><tt>#{product}</tt></td></tr>
+        <tr><td><b>Flavor</b></td><td><tt>#{INSTALLABLE_BUILD_FLAVOR}</tt></td></tr>
+        <tr><td><b>Build Type</b></td><td><tt>#{INSTALLABLE_BUILD_TYPE}</tt></td></tr>
+        <tr><td><b>Commit</b></td><td>#{ENV['BUILDKITE_COMMIT']}</td></tr>
+        </table>
       </details>
       <em>Note: This installable build uses the <tt>#{INSTALLABLE_BUILD_FLAVOR}#{INSTALLABLE_BUILD_TYPE}</tt> flavor, and does not support Google Login.</em>
     PR_COMMENT

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -265,15 +265,15 @@ platform :android do
         <summary>#{icon}📲 You can test these changes on #{product} by <a href='#{install_url}'>downloading <tt>#{filename}</tt></a></summary>
         <table><tr>
           <td width='250' rowspan='5'><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a></td>
-          <td colspan='2'>💡 Tip: You can also scan this QR code with your Android phone to download and install the APK directly on it.</td>
+          <td colspan='2'>💡 Scan this QR code with your Android phone to download and install the APK directly on it.</td>
         </tr>
-        <tr><td width='150px'><b>Product</b></td><td><tt>#{product}</tt></td></tr>
-        <tr><td><b>Flavor</b></td><td><tt>#{INSTALLABLE_BUILD_FLAVOR}</tt></td></tr>
+        <tr><td width='150px'><b>App</b></td><td><tt>#{product}</tt></td></tr>
+        <tr><td><b>Build Flavor</b></td><td><tt>#{INSTALLABLE_BUILD_FLAVOR}</tt></td></tr>
         <tr><td><b>Build Type</b></td><td><tt>#{INSTALLABLE_BUILD_TYPE}</tt></td></tr>
         <tr><td><b>Commit</b></td><td>#{ENV['BUILDKITE_COMMIT']}</td></tr>
         </table>
       </details>
-      <em>Note: This installable build uses the <tt>#{INSTALLABLE_BUILD_FLAVOR}#{INSTALLABLE_BUILD_TYPE}</tt> flavor, and does not support Google Login.</em>
+      <em>Note: This installable build uses the <tt>#{INSTALLABLE_BUILD_FLAVOR}#{INSTALLABLE_BUILD_TYPE}</tt> build flavor, and does not support Google Login.</em>
     PR_COMMENT
 
     comment_on_pr(

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -148,8 +148,8 @@ platform :android do
 
     gradle(
       task: 'assemble',
-      flavor: 'WordPressJalapeno',
-      build_type: 'Debug',
+      flavor: "WordPress#{INSTALLABLE_BUILD_FLAVOR}",
+      build_type: INSTALLABLE_BUILD_TYPE,
       properties: { installableBuildVersionName: generate_installable_build_number }
     )
 
@@ -170,8 +170,8 @@ platform :android do
 
     gradle(
       task: 'assemble',
-      flavor: 'JetpackJalapeno',
-      build_type: 'Debug',
+      flavor: "Jetpack#{INSTALLABLE_BUILD_FLAVOR}",
+      build_type: INSTALLABLE_BUILD_TYPE,
       properties: { installableBuildVersionName: generate_installable_build_number }
     )
 
@@ -259,7 +259,16 @@ platform :android do
 
     install_url = "#{INSTALLABLE_BUILD_DOMAIN}/#{upload_path}"
     qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
-    comment_body = "You can test the #{product} changes on this Pull Request by <a href='#{install_url}'>downloading an installable build (#{filename})</a>, or scanning this QR code:<br><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a>"
+    comment_body = <<~PR_COMMENT
+      <details>
+      <summary>📲 You can test the #{product} changes on this Pull Request by <a href='#{install_url}'>downloading an installable build (#{filename})</a></summary>
+      <table><tr>
+        <td><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a></td>
+        <td>You can also scan this QR code with your Android phone to download and install the APK directly on it.</td>
+      </tr></table>
+      </details>
+      _Note: This installable build uses the `#{INSTALLABLE_BUILD_FLAVOR}#{INSTALLABLE_BUILD_TYPE}` flavor, and does not support Google Login._
+    PR_COMMENT
 
     comment_on_pr(
       project: GHHELPER_REPO,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -261,13 +261,13 @@ platform :android do
     qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
     comment_body = <<~PR_COMMENT
       <details>
-      <summary>📲 You can test the #{product} changes on this Pull Request by <a href='#{install_url}'>downloading an installable build (#{filename})</a></summary>
+      <summary>📲 You can test these changes on #{product} by <a href='#{install_url}'>downloading <tt>#{filename}</tt></a></summary>
       <table><tr>
-        <td><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a></td>
-        <td>You can also scan this QR code with your Android phone to download and install the APK directly on it.</td>
+        <td width="250"><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a></td>
+        <td>Tip: You can also scan this QR code with your Android phone to download and install the APK directly on it.</td>
       </tr></table>
       </details>
-      _Note: This installable build uses the `#{INSTALLABLE_BUILD_FLAVOR}#{INSTALLABLE_BUILD_TYPE}` flavor, and does not support Google Login._
+      <em>Note: This installable build uses the <tt>#{INSTALLABLE_BUILD_FLAVOR}#{INSTALLABLE_BUILD_TYPE}</tt> flavor, and does not support Google Login.</em>
     PR_COMMENT
 
     comment_on_pr(

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -259,9 +259,10 @@ platform :android do
 
     install_url = "#{INSTALLABLE_BUILD_DOMAIN}/#{upload_path}"
     qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
+    icon = "<img alt='#{product}' src='https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64/#{product.downcase}.png' width='20px' />"
     comment_body = <<~PR_COMMENT
       <details>
-      <summary>📲 You can test these changes on #{product} by <a href='#{install_url}'>downloading <tt>#{filename}</tt></a></summary>
+      <summary>📲 You can test these changes on #{icon} #{product} by <a href='#{install_url}'>downloading <tt>#{filename}</tt></a></summary>
       <table><tr>
         <td width="250"><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a></td>
         <td>Tip: You can also scan this QR code with your Android phone to download and install the APK directly on it.</td>


### PR DESCRIPTION
## Why

[There were some confusion about Google Login not working on Installable Builds recently](https://github.com/wordpress-mobile/WordPress-Android/issues/17147), so we want to better communicate those limitations (and other info) about Installable Builds

## What

This improves the Installable Build PR comment done by CI on our PRs to:
 - Hide the QR code under a collapsible section, to reduce noise on the PR
 - Use the collapsible section and the fact that we have some room at the right of the QR code to add some more metadata there, including product flavor, and commit to build it (especially useful when you push new commits after a first installable build has been done, to check if the comment is about the old or new commit)
 - Add information about the limitations of those installable builds around Google Login (because the appID used by `JalapanoDebug` builds isn't whitelisted in our Firebase config at the moment — and we don't have much slots left in there to add it anyway)

[Internal ref: pdnsEh-BN-p2]


## To test

Just check the look of the Installable Build comment posted by CI on this very PR.

This is how it should look like (for WordPress), collapsed by default:
<img width="919" alt="image" src="https://user-images.githubusercontent.com/216089/191827707-87d9ab38-6c67-477e-abdc-6c09c062354f.png">

And how it should look like (for Jetpack) once you manually expand the triangle:
<img width="921" alt="image" src="https://user-images.githubusercontent.com/216089/191837788-d2553090-de04-417a-8cd8-e1ba6a02ae4c.png">
