### PR TITLE
[Compile Warnings As Errors] Image Editor Module - Resolve Warnings & Enable All Warnings as Errors

### DIFF
--- a/libs/image-editor/build.gradle
+++ b/libs/image-editor/build.gradle
@@ -18,6 +18,10 @@ android {
         vectorDrawables.useSupportLibrary = true
     }
 
+    kotlinOptions {
+        allWarningsAsErrors = true
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         test.java.srcDirs += 'src/test/kotlin'

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
@@ -44,6 +44,7 @@ class CropViewModel : ViewModel() {
     private var shouldReturnToPreviewScreen: Boolean = false
     private var isStarted = false
 
+    @Suppress("DEPRECATION")
     private val cropOptions by lazy {
         Options().apply {
             setShowCropGrid(true)

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -316,7 +316,7 @@ class PreviewImageViewModel : ViewModel() {
     private fun getOutputData() = (uiState.value?.viewPagerItemsStates?.map { OutputData(it.data.highResImageUrl) }
         ?: emptyList())
 
-    private fun isFileUrl(url: String): Boolean = url.toLowerCase(Locale.ROOT).startsWith(FILE_BASE)
+    private fun isFileUrl(url: String): Boolean = url.lowercase(Locale.ROOT).startsWith(FILE_BASE)
 
     data class ImageData(
         val id: Long = UUID.randomUUID().hashCode().toLong(),


### PR DESCRIPTION
Parent: #17173
Closes: #17179

This PR resolves/suppresses a couple of warnings for the `image-editor` module and then enables all warnings as errors on it as well.

Warnings Resolution List:

1) [Resolve to lower case deprecated warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/ed8ae3dff5822597f60448351bab734290570287)

Warnings Suppression List:

1) [Suppress bitmap's compress format webp deprecated warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/6b733bcf2ed72040fc4893aca30dbd3570ac6e18)

The `allWarningsAsErrors` configuration is currently applied on the module level in order to make sure that, as the overall [Compiler Warnings as Errors](https://github.com/wordpress-mobile/WordPress-Android/issues/17173) work is progressing, no new warnings are added to this module, which is already free of warnings.

When the overall [Compiler Warnings as Errors](https://github.com/wordpress-mobile/WordPress-Android/issues/17173) work is complete on all modules, then this module level `allWarningsAsErrors` configuration will be replaced by a root level such configuration that will be applied by default to all modules (see [here](https://github.com/wordpress-mobile/WordPress-Android/issues/17182)).

-----

PS: ~~@ravishanker~~ @zwarm I added you as the main reviewer, that is, in addition to @wordpress-mobile/apps-infrastructure team itself, but randomly, since I want someone from the `WordPress Android` team to primarily sign-off on that change. 🥇

FYI: I am going to randomly add more of you in those PRs that will follow, just so you become more aware of this change and how close we are on enabling `allWarningsAsErrors` by default everywhere. 🎉

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could test any image editor related functionality, since this `image-editor` module is responsible for that. For example, you could try cropping an image on a post and see if that works as expected.

-----

## Regression Notes
1. Potential unintended areas of impact

The image editor functionality is not workings as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
