### PR TITLE
[Compile Warnings As Errors] Editor Module - Resolve Warnings & Enable All Warnings as Errors

### DIFF
--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -42,6 +42,10 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
     }
 
+    kotlinOptions {
+        allWarningsAsErrors = true
+    }
+
     // Avoid 'duplicate files during packaging of APK' errors
     packagingOptions {
         exclude 'LICENSE.txt'

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergDialogFragment.kt
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergDialogFragment.kt
@@ -11,7 +11,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 class GutenbergDialogFragment : AppCompatDialogFragment() {
     private lateinit var mTag: String
     private lateinit var mMessage: CharSequence
-    private lateinit var mPositiveButtonLabel: CharSequence
+    private var mPositiveButtonLabel: CharSequence? = null
     private var mTitle: CharSequence? = null
     private var mNegativeButtonLabel: CharSequence? = null
     private var mId: Int = 0
@@ -56,7 +56,7 @@ class GutenbergDialogFragment : AppCompatDialogFragment() {
             mTag = requireNotNull(savedInstanceState.getString(STATE_KEY_TAG))
             mTitle = savedInstanceState.getCharSequence(STATE_KEY_TITLE)
             mMessage = requireNotNull(savedInstanceState.getCharSequence(STATE_KEY_MESSAGE))
-            mPositiveButtonLabel = requireNotNull(savedInstanceState.getCharSequence(STATE_KEY_POSITIVE_BUTTON_LABEL))
+            mPositiveButtonLabel = savedInstanceState.getCharSequence(STATE_KEY_POSITIVE_BUTTON_LABEL)
             mNegativeButtonLabel = savedInstanceState.getCharSequence(STATE_KEY_NEGATIVE_BUTTON_LABEL)
             mId = savedInstanceState.getInt(STATE_KEY_ID)
         }


### PR DESCRIPTION
Parent: #17173
Closes: #17180

This PR resolves/suppresses a couple of warnings for the `editor` module and then enables all warnings as errors on it as well.

Warnings Resolution List:

1) [Resolve unnecessary safe call type warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/e053210b84090971d63fbd11db89860afe00d4e0)

The `allWarningsAsErrors` configuration is currently applied on the module level in order to make sure that, as the overall [Compiler Warnings as Errors](https://github.com/wordpress-mobile/WordPress-Android/issues/17173) work is progressing, no new warnings are added to this module, which is already free of warnings.

When the overall [Compiler Warnings as Errors](https://github.com/wordpress-mobile/WordPress-Android/issues/17173) work is complete on all modules, then this module level `allWarningsAsErrors` configuration will be replaced by a root level such configuration that will be applied by default to all modules (see [here](https://github.com/wordpress-mobile/WordPress-Android/issues/17182)).

-----

PS.1: @SiobhyB I added you as the main reviewer, that is, in addition to @wordpress-mobile/apps-infrastructure team itself, but randomly, since I want someone from the `WordPress Android` team to primarily sign-off on that change. 🥇
PS.2 @SiobhyB I actually didn't add you here too randomly as I want you to verify this e053210b84090971d63fbd11db89860afe00d4e0 change I did, which reverts your such 24a053275df69f69924ab7dbf9ff60787ce30f8d change (as part of [this](https://github.com/wordpress-mobile/WordPress-Android/pull/14503) PR). I am actually not sure why you did this change, thus please do let me know if my change isn't breaking anything that you tried to fix with your change.

FYI: I am going to randomly add more of you in those PRs that will follow, just so you become more aware of this change and how close we are on enabling `allWarningsAsErrors` by default everywhere. 🎉

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could test any editor related functionality, since this `editor` module is responsible for that. For example, you could try replacing the featured image on a post, from a post image (not the settings page), and see if that works as expected.

-----

## Regression Notes
1. Potential unintended areas of impact

The editor functionality is not working as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
