### PR TITLE
Hilt migration of login screens

### DIFF
--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.kt
@@ -4,19 +4,18 @@ import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import com.google.android.material.button.MaterialButton
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.JetpackLoginPrologueScreenBinding
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowEmailLoginScreen
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowLoginViaSiteAddressScreen
 import org.wordpress.android.util.WPActivityUtils
-import javax.inject.Inject
 
+@AndroidEntryPoint
 class LoginPrologueFragment : Fragment(R.layout.jetpack_login_prologue_screen) {
-    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
-    private lateinit var viewModel: LoginPrologueViewModel
+    private val viewModel: LoginPrologueViewModel by viewModels()
     private lateinit var loginPrologueListener: LoginPrologueListener
 
     @Suppress("TooGenericExceptionThrown")
@@ -30,7 +29,6 @@ class LoginPrologueFragment : Fragment(R.layout.jetpack_login_prologue_screen) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initDagger()
 
         // setting up a full screen flags for the decor view of this fragment,
         // that will work with transparent status bar
@@ -41,14 +39,7 @@ class LoginPrologueFragment : Fragment(R.layout.jetpack_login_prologue_screen) {
         with(JetpackLoginPrologueScreenBinding.bind(view)) { initViewModel() }
     }
 
-    private fun initDagger() {
-        (requireActivity().application as WordPress).component().inject(this)
-    }
-
     private fun JetpackLoginPrologueScreenBinding.initViewModel() {
-        viewModel = ViewModelProvider(this@LoginPrologueFragment, viewModelFactory).get(
-                LoginPrologueViewModel::class.java
-        )
         initObservers()
         viewModel.start()
     }

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueViewModel.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueViewModel.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.accounts.login
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -24,6 +25,7 @@ import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
+@HiltViewModel
 class LoginPrologueViewModel @Inject constructor(
     private val unifiedLoginTracker: UnifiedLoginTracker,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -20,7 +20,6 @@ import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 import org.wordpress.android.ui.accounts.PostSignupInterstitialActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
-import org.wordpress.android.ui.accounts.login.LoginPrologueFragment;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesFragment;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginSiteCheckErrorFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
@@ -565,8 +564,6 @@ public interface AppComponent {
     void inject(AztecVideoLoader object);
 
     void inject(PhotoPickerFragment object);
-
-    void inject(LoginPrologueFragment object);
 
     void inject(ReaderDiscoverLogic object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -15,7 +15,6 @@ import org.wordpress.android.ui.ShareIntentReceiverFragment;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.about.UnifiedAboutActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
-import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 import org.wordpress.android.ui.accounts.PostSignupInterstitialActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesFragment;
@@ -234,8 +233,6 @@ public interface AppComponent {
     void inject(MediaUploadHandler object);
 
     void inject(PostUploadHandler object);
-
-    void inject(LoginMagicLinkInterceptActivity object);
 
     void inject(SignupEpilogueActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -15,7 +15,6 @@ import org.wordpress.android.ui.ShareIntentReceiverFragment;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.about.UnifiedAboutActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
-import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
 import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 import org.wordpress.android.ui.accounts.PostSignupInterstitialActivity;
@@ -238,8 +237,6 @@ public interface AppComponent {
     void inject(MediaUploadHandler object);
 
     void inject(PostUploadHandler object);
-
-    void inject(LoginActivity object);
 
     void inject(LoginEpilogueActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -17,7 +17,6 @@ import org.wordpress.android.ui.about.UnifiedAboutActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.PostSignupInterstitialActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
-import org.wordpress.android.ui.accounts.login.jetpack.LoginSiteCheckErrorFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailFragment;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListFragment;
@@ -594,8 +593,6 @@ public interface AppComponent {
     void inject(EngagedPeopleListFragment object);
 
     void inject(SiteSettingsTimezoneBottomSheet object);
-
-    void inject(LoginSiteCheckErrorFragment object);
 
     void inject(UserProfileBottomSheetFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -17,7 +17,6 @@ import org.wordpress.android.ui.about.UnifiedAboutActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.PostSignupInterstitialActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
-import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesFragment;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginSiteCheckErrorFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailFragment;
@@ -597,8 +596,6 @@ public interface AppComponent {
     void inject(SiteSettingsTimezoneBottomSheet object);
 
     void inject(LoginSiteCheckErrorFragment object);
-
-    void inject(LoginNoSitesFragment object);
 
     void inject(UserProfileBottomSheetFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -15,11 +15,9 @@ import org.wordpress.android.ui.ShareIntentReceiverFragment;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.about.UnifiedAboutActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
-import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
 import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 import org.wordpress.android.ui.accounts.PostSignupInterstitialActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
-import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesFragment;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginSiteCheckErrorFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
@@ -236,10 +234,6 @@ public interface AppComponent {
     void inject(MediaUploadHandler object);
 
     void inject(PostUploadHandler object);
-
-    void inject(LoginEpilogueActivity object);
-
-    void inject(LoginEpilogueFragment object);
 
     void inject(LoginMagicLinkInterceptActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel;
-import org.wordpress.android.ui.accounts.LoginEpilogueViewModel;
 import org.wordpress.android.ui.accounts.LoginViewModel;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginSiteCheckErrorViewModel;
@@ -488,11 +487,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(LoginNoSitesViewModel.class)
     abstract ViewModel loginNoSitesErrorViewModel(LoginNoSitesViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(LoginEpilogueViewModel.class)
-    abstract ViewModel loginEpilogueViewModel(LoginEpilogueViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel;
+import org.wordpress.android.ui.accounts.LoginEpilogueViewModel;
 import org.wordpress.android.ui.accounts.LoginViewModel;
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel;
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingViewModel;
@@ -480,6 +481,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(SiteSettingsTimezoneViewModel.class)
     abstract ViewModel siteSettingsTimezoneViewModel(SiteSettingsTimezoneViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(LoginEpilogueViewModel.class)
+    abstract ViewModel loginEpilogueViewModel(LoginEpilogueViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModelProvider;
 
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel;
 import org.wordpress.android.ui.accounts.LoginViewModel;
-import org.wordpress.android.ui.accounts.login.jetpack.LoginSiteCheckErrorViewModel;
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel;
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingViewModel;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
@@ -491,11 +490,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(DeepLinkingIntentReceiverViewModel.class)
     abstract ViewModel deepLinkingIntentReceiverViewModel(DeepLinkingIntentReceiverViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(LoginSiteCheckErrorViewModel.class)
-    abstract ViewModel loginSiteCheckErrorViewModel(LoginSiteCheckErrorViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModelProvider;
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel;
 import org.wordpress.android.ui.accounts.LoginEpilogueViewModel;
 import org.wordpress.android.ui.accounts.LoginViewModel;
-import org.wordpress.android.ui.accounts.login.LoginPrologueViewModel;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginSiteCheckErrorViewModel;
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel;
@@ -494,11 +493,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(LoginEpilogueViewModel.class)
     abstract ViewModel loginEpilogueViewModel(LoginEpilogueViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(LoginPrologueViewModel.class)
-    abstract ViewModel loginPrologueViewModel(LoginPrologueViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModelProvider;
 
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel;
 import org.wordpress.android.ui.accounts.LoginViewModel;
-import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginSiteCheckErrorViewModel;
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel;
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingViewModel;
@@ -482,11 +481,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(SiteSettingsTimezoneViewModel.class)
     abstract ViewModel siteSettingsTimezoneViewModel(SiteSettingsTimezoneViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(LoginNoSitesViewModel.class)
-    abstract ViewModel loginNoSitesErrorViewModel(LoginNoSitesViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -20,7 +20,6 @@ import com.google.android.material.snackbar.Snackbar;
 
 import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
@@ -90,7 +89,9 @@ import static org.wordpress.android.util.ActivityUtils.hideKeyboard;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasAndroidInjector;
+import dagger.hilt.android.AndroidEntryPoint;
 
+@AndroidEntryPoint
 public class LoginActivity extends LocaleAwareActivity implements ConnectionCallbacks, OnConnectionFailedListener,
         Callback, LoginListener, GoogleListener, LoginPrologueListener,
         HasAndroidInjector, BasicDialogPositiveClickInterface {
@@ -137,7 +138,6 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        ((WordPress) getApplication()).component().inject(this);
         super.onCreate(savedInstanceState);
 
         LoginFlowThemeHelper.injectMissingCustomAttributes(getTheme());

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -8,7 +8,6 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.ActivityLauncher;
@@ -30,6 +29,9 @@ import java.util.ArrayList;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginEpilogueListener {
     public static final String EXTRA_DO_LOGIN_UPDATE = "EXTRA_DO_LOGIN_UPDATE";
     public static final String EXTRA_SHOW_AND_RETURN = "EXTRA_SHOW_AND_RETURN";
@@ -44,7 +46,6 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        ((WordPress) getApplication()).component().inject(this);
 
         LoginFlowThemeHelper.injectMissingCustomAttributes(getTheme());
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMagicLinkInterceptActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMagicLinkInterceptActivity.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 
-import org.wordpress.android.WordPress;
 import org.wordpress.android.login.LoginAnalyticsListener;
 import org.wordpress.android.ui.JetpackConnectionSource;
 import org.wordpress.android.ui.LocaleAwareActivity;
@@ -12,10 +11,13 @@ import org.wordpress.android.ui.main.WPMainActivity;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
 /**
  * Deep link receiver for magic links. Starts {@link WPMainActivity} where flow is routed to login
  * or signup based on deep link scheme, host, and parameters.
  */
+@AndroidEntryPoint
 public class LoginMagicLinkInterceptActivity extends LocaleAwareActivity {
     private static final String PARAMETER_FLOW = "flow";
     private static final String PARAMETER_FLOW_JETPACK = "jetpack";
@@ -29,7 +31,6 @@ public class LoginMagicLinkInterceptActivity extends LocaleAwareActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        ((WordPress) getApplication()).component().inject(this);
 
         mAction = getIntent().getAction();
         mUri = getIntent().getData();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -19,7 +19,6 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.model.AccountModel;
@@ -45,6 +44,9 @@ import java.util.ArrayList;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueListener> {
     public static final String TAG = "login_epilogue_fragment_tag";
 
@@ -154,7 +156,6 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        ((WordPress) requireActivity().getApplication()).component().inject(this);
 
         mDoLoginUpdate = requireArguments().getBoolean(ARG_DO_LOGIN_UPDATE, false);
         mShowAndReturn = requireArguments().getBoolean(ARG_SHOW_AND_RETURN, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesFragment.kt
@@ -5,7 +5,8 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.JetpackLoginEmptyViewBinding
@@ -21,6 +22,7 @@ import org.wordpress.android.ui.main.utils.MeGravatarLoader
 import org.wordpress.android.ui.utils.UiHelpers
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class LoginNoSitesFragment : Fragment(R.layout.jetpack_login_empty_view) {
     companion object {
         const val TAG = "LoginNoSitesFragment"
@@ -30,25 +32,19 @@ class LoginNoSitesFragment : Fragment(R.layout.jetpack_login_empty_view) {
         }
     }
 
-    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var meGravatarLoader: MeGravatarLoader
     @Inject lateinit var uiHelpers: UiHelpers
     private var loginListener: LoginListener? = null
-    private lateinit var viewModel: LoginNoSitesViewModel
+    private val viewModel: LoginNoSitesViewModel by viewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initDagger()
         initBackPressHandler()
         with(JetpackLoginEmptyViewBinding.bind(view)) {
             initContentViews()
             initClickListeners()
             initViewModel(savedInstanceState)
         }
-    }
-
-    private fun initDagger() {
-        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun JetpackLoginEmptyViewBinding.initContentViews() {
@@ -62,9 +58,6 @@ class LoginNoSitesFragment : Fragment(R.layout.jetpack_login_empty_view) {
     }
 
     private fun JetpackLoginEmptyViewBinding.initViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(this@LoginNoSitesFragment, viewModelFactory)
-                .get(LoginNoSitesViewModel::class.java)
-
         initObservers()
 
         viewModel.start(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModel.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.accounts.login.jetpack
 import android.os.Bundle
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.wordpress.android.WordPress
@@ -24,6 +25,7 @@ import javax.inject.Named
 
 const val KEY_STATE = "key_state"
 
+@HiltViewModel
 class LoginNoSitesViewModel @Inject constructor(
     private val unifiedLoginTracker: UnifiedLoginTracker,
     private val accountStore: AccountStore,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorFragment.kt
@@ -5,9 +5,9 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.JetpackLoginEmptyViewBinding
 import org.wordpress.android.login.LoginListener
 import org.wordpress.android.ui.ActivityLauncher
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class LoginSiteCheckErrorFragment : Fragment(R.layout.jetpack_login_empty_view) {
     companion object {
         const val TAG = "LoginSiteCheckErrorFragment"
@@ -33,12 +34,11 @@ class LoginSiteCheckErrorFragment : Fragment(R.layout.jetpack_login_empty_view) 
         }
     }
 
-    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var unifiedLoginTracker: UnifiedLoginTracker
     @Inject lateinit var htmlMessageUtils: HtmlMessageUtils
     private var loginListener: LoginListener? = null
     private var siteAddress: String? = null
-    private lateinit var viewModel: LoginSiteCheckErrorViewModel
+    private val viewModel: LoginSiteCheckErrorViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,24 +51,13 @@ class LoginSiteCheckErrorFragment : Fragment(R.layout.jetpack_login_empty_view) 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initDagger()
         initBackPressHandler()
-        initViewModel()
         with(JetpackLoginEmptyViewBinding.bind(view)) {
             ActivityUtils.hideKeyboardForced(view)
             initErrorMessageView()
             initClickListeners()
         }
         initObservers()
-    }
-
-    private fun initDagger() {
-        (requireActivity().application as WordPress).component().inject(this)
-    }
-
-    private fun initViewModel() {
-        viewModel = ViewModelProvider(this@LoginSiteCheckErrorFragment, viewModelFactory)
-                .get(LoginSiteCheckErrorViewModel::class.java)
     }
 
     private fun JetpackLoginEmptyViewBinding.initErrorMessageView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.accounts.login.jetpack
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.accounts.LoginNavigationEvents
@@ -12,6 +13,7 @@ import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
+@HiltViewModel
 class LoginSiteCheckErrorViewModel @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {

--- a/WordPress/src/wordpress/java/org.wordpress.android.ui.accounts.login/LoginPrologueFragment.kt
+++ b/WordPress/src/wordpress/java/org.wordpress.android.ui.accounts.login/LoginPrologueFragment.kt
@@ -7,8 +7,8 @@ import androidx.annotation.FloatRange
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayoutMediator
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.LOGIN_PROLOGUE_VIEWED
 import org.wordpress.android.databinding.LoginSignupScreenBinding
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step.PROLOGUE
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class LoginPrologueFragment : Fragment(R.layout.login_signup_screen) {
     private lateinit var loginPrologueListener: LoginPrologueListener
 
@@ -39,8 +40,6 @@ class LoginPrologueFragment : Fragment(R.layout.login_signup_screen) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        (requireActivity().application as WordPress).component().inject(this)
 
         // setting up a full screen flags for the decor view of this fragment,
         // that will work with transparent status bar


### PR DESCRIPTION
This migrates login screens to Hilt. This is a part of the full Hilt migration. The purpose is to migrate all `inject` functions in [AppComponent](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java).

There are 2 possible drawbacks of migrating to Hilt.
- The screen could crash on opening. Just opening the screen is enough to test this.
- The ViewModel scope can change by using `viewModels()` or `activityViewModels`, and this could cause issues. This is hard to test because its effect could be different on each screen. Checking the code is more convenient for testing the scope of the view model.

To test:
**Test LoginActivity, LoginPrologueFragment:**
1. Launch the WordPress app. Log out if you're logged in.
2. The first screen is LoginActivity and LoginPrologueFragment. Ensure it doesn't crash.
3. Repeat 1-2 for the Jetpack app.

**Test LoginPrologueFragment:**
1. Launch the WordPress app. Log out if you're logged in.
2. Log in.
3. The site list will appear after the login. This is LoginEpilogueActivity and LoginEpilogueFragment.
4. Ensure the app doesn't crash.

**Test LoginMagicLinkInterceptActivity:**
1. Launch the WordPress app. Log out if you're logged in.
2. Tap "Log in or sign up  with WordPress.com" button.
3. Enter your email and tap "Continue".
4. Tap  "Get a login link bu email" button.
5. Open your email account on device and tap the link in the login email.
6. Ensure the WordPress app is launched and doesn't crash.
7. Repeat 1-6 for Jetpack app.

`LoginNoSitesFragment` and `LoginSiteCheckErrorFragment` don't run for any case currently.

## Regression Notes
1. Potential unintended areas of impact
The login screen and other screens related to login.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
No new feature was added. Relied on current tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
