### PR TITLE
[Compile Warnings As Errors] WordPress Module - Resolve Coroutines Warnings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/usecases/LocalCommentCacheUpdateHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/usecases/LocalCommentCacheUpdateHandler.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.models.usecases
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.merge
 import org.wordpress.android.models.usecases.LocalCommentCacheUpdateUseCase.PropagateCommentsUpdateAction.UpdatedComments
 import javax.inject.Inject
@@ -11,6 +12,7 @@ class LocalCommentCacheUpdateHandler @Inject constructor(
 ) {
     private val useCases = listOf(localCommentCacheUpdateUseCase)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun subscribe() = useCases.map { it.subscribe() }.merge()
 
     suspend fun requestCommentsUpdate() = localCommentCacheUpdateUseCase.manageAction(

--- a/WordPress/src/main/java/org/wordpress/android/models/usecases/UnifiedCommentsListHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/usecases/UnifiedCommentsListHandler.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.models.usecases
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.merge
 import org.wordpress.android.models.usecases.BatchModerateCommentsUseCase.ModerateCommentsAction.OnModerateComments
 import org.wordpress.android.models.usecases.BatchModerateCommentsUseCase.Parameters.ModerateCommentsParameters
@@ -21,6 +22,7 @@ class UnifiedCommentsListHandler @Inject constructor(
 ) {
     private val useCases = listOf(paginateCommentsUseCase, batchModerationUseCase, moderationWithUndoUseCase)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun subscribe() = useCases.map { it.subscribe() }.merge()
 
     suspend fun requestPage(parameters: GetPageParameters) = paginateCommentsUseCase.manageAction(

--- a/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
@@ -10,10 +10,6 @@ import kotlinx.coroutines.Dispatchers
 import org.wordpress.android.util.helpers.Debouncer
 import javax.inject.Named
 
-@Deprecated(message = "Implement CoroutineScope interface and cancel all child coroutines in onCleared/onDestroy/..")
-const val UI_SCOPE = "UI_SCOPE"
-@Deprecated(message = "Implement CoroutineScope interface and cancel all child coroutines in onCleared/onDestroy/..")
-const val DEFAULT_SCOPE = "DEFAULT_SCOPE"
 const val APPLICATION_SCOPE = "APPLICATION_SCOPE"
 const val UI_THREAD = "UI_THREAD"
 const val BG_THREAD = "BG_THREAD"
@@ -23,25 +19,9 @@ const val IO_THREAD = "IO_THREAD"
 @Module
 class ThreadModule {
     @Provides
-    @Named(UI_SCOPE)
-    fun provideUiScope(): CoroutineScope {
-        return CoroutineScope(Dispatchers.Main)
-    }
-
-    @Provides
     @Named(UI_THREAD)
     fun provideUiDispatcher(): CoroutineDispatcher {
         return Dispatchers.Main
-    }
-
-    @Provides
-    @Named(DEFAULT_SCOPE)
-    @Deprecated(
-            message = "CoroutineScope should be provided by an object which implements CoroutineScope",
-            replaceWith = ReplaceWith("Inject dispatcher and implement CoroutineScope interface")
-    )
-    fun provideBackgroundScope(): CoroutineScope {
-        return CoroutineScope(Dispatchers.Default)
     }
 
     @Provides

--- a/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.util.helpers.Debouncer
 import javax.inject.Named
 
 const val APPLICATION_SCOPE = "APPLICATION_SCOPE"
+
 const val UI_THREAD = "UI_THREAD"
 const val BG_THREAD = "BG_THREAD"
 const val IO_THREAD = "IO_THREAD"
@@ -19,15 +20,15 @@ const val IO_THREAD = "IO_THREAD"
 @Module
 class ThreadModule {
     @Provides
-    @Named(UI_THREAD)
-    fun provideUiDispatcher(): CoroutineDispatcher {
-        return Dispatchers.Main
-    }
-
-    @Provides
     @Named(APPLICATION_SCOPE)
     fun provideApplicationScope(): CoroutineScope {
         return CoroutineScope(Dispatchers.Default)
+    }
+
+    @Provides
+    @Named(UI_THREAD)
+    fun provideUiDispatcher(): CoroutineDispatcher {
+        return Dispatchers.Main
     }
 
     @Provides

--- a/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
@@ -37,7 +37,7 @@ class ThreadModule {
 
     @Provides
     @Named(BG_THREAD)
-    fun provideBackgroundDispatcher(): CoroutineDispatcher {
+    fun provideBgDispatcher(): CoroutineDispatcher {
         return Dispatchers.Default
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
@@ -19,11 +19,15 @@ const val IO_THREAD = "IO_THREAD"
 @InstallIn(SingletonComponent::class)
 @Module
 class ThreadModule {
+    /* SCOPE */
+
     @Provides
     @Named(APPLICATION_SCOPE)
     fun provideApplicationScope(): CoroutineScope {
         return CoroutineScope(Dispatchers.Default)
     }
+
+    /* DISPATCHER */
 
     @Provides
     @Named(UI_THREAD)
@@ -42,6 +46,8 @@ class ThreadModule {
     fun provideIoDispatcher(): CoroutineDispatcher {
         return Dispatchers.IO
     }
+
+    /* OTHER */
 
     @Provides
     fun provideDebouncer(): Debouncer {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.UploadActionBuilder
@@ -64,6 +65,13 @@ class UploadStarter @Inject constructor(
     private val connectionStatus: LiveData<ConnectionStatus>
 ) : CoroutineScope {
     private val job = Job()
+
+    /**
+     * When the app comes to foreground both `queueUploadFromAllSites` and `queueUploadFromSite` are invoked.
+     * The problem is that they can run in parallel and `uploadServiceFacade.isPostUploadingOrQueued(it)` might return
+     * out-of-date result and a same post is added twice.
+     */
+    private val mutex = Mutex()
 
     override val coroutineContext: CoroutineContext get() = job + bgDispatcher
 
@@ -136,45 +144,44 @@ class UploadStarter @Inject constructor(
 
     /**
      * This is meant to be used by [checkConnectionAndUpload] only.
-     *
-     * The method needs to be synchronized from the following reasons. When the app comes to foreground both
-     * `queueUploadFromAllSites` and `queueUploadFromSite` are invoked. The problem is that they can run in parallel
-     * and `uploadServiceFacade.isPostUploadingOrQueued(it)` might return out-of-date result and a same post is added
-     * twice.
      */
-    @Suppress("SYNCHRONIZED_ON_SUSPEND")
-    @Synchronized
     private suspend fun upload(site: SiteModel) = coroutineScope {
-        val posts = async { postStore.getPostsWithLocalChanges(site) }
-        val pages = async { pageStore.getPagesWithLocalChanges(site) }
-        val list = posts.await() + pages.await()
+        try {
+            mutex.lock()
 
-        list.asSequence()
-                .map { post ->
-                    val action = uploadActionUseCase.getAutoUploadAction(post, site)
-                    Pair(post, action)
-                }
-                .filter { (_, action) ->
-                    action != DO_NOTHING
-                }
-                .toList()
-                .forEach { (post, action) ->
-                    trackAutoUploadAction(action, post.status, post.isPage)
-                    AppLog.d(
-                            AppLog.T.POSTS,
-                            "UploadStarter for post (isPage: ${post.isPage}) title: ${post.title}, action: $action"
-                    )
-                    dispatcher.dispatch(
-                            UploadActionBuilder.newIncrementNumberOfAutoUploadAttemptsAction(
-                                    post
-                            )
-                    )
-                    uploadServiceFacade.uploadPost(
-                            context = context,
-                            post = post,
-                            trackAnalytics = false
-                    )
-                }
+            val posts = async { postStore.getPostsWithLocalChanges(site) }
+            val pages = async { pageStore.getPagesWithLocalChanges(site) }
+            val list = posts.await() + pages.await()
+
+            list.asSequence()
+                    .map { post ->
+                        val action = uploadActionUseCase.getAutoUploadAction(post, site)
+                        Pair(post, action)
+                    }
+                    .filter { (_, action) ->
+                        action != DO_NOTHING
+                    }
+                    .toList()
+                    .forEach { (post, action) ->
+                        trackAutoUploadAction(action, post.status, post.isPage)
+                        AppLog.d(
+                                AppLog.T.POSTS,
+                                "UploadStarter for post (isPage: ${post.isPage}) title: ${post.title}, action: $action"
+                        )
+                        dispatcher.dispatch(
+                                UploadActionBuilder.newIncrementNumberOfAutoUploadAttemptsAction(
+                                        post
+                                )
+                        )
+                        uploadServiceFacade.uploadPost(
+                                context = context,
+                                post = post,
+                                trackAnalytics = false
+                        )
+                    }
+        } finally {
+            mutex.unlock()
+        }
     }
 
     private fun trackAutoUploadAction(

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -142,6 +142,7 @@ class UploadStarter @Inject constructor(
      * and `uploadServiceFacade.isPostUploadingOrQueued(it)` might return out-of-date result and a same post is added
      * twice.
      */
+    @Suppress("SYNCHRONIZED_ON_SUSPEND")
     @Synchronized
     private suspend fun upload(site: SiteModel) = coroutineScope {
         val posts = async { postStore.getPostsWithLocalChanges(site) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/ConcurrentContinuationWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/ConcurrentContinuationWrapper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.utils
 
 import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
 
 class ConcurrentContinuationWrapper<T> : ContinuationWrapper<T> {
@@ -18,6 +19,7 @@ class ConcurrentContinuationWrapper<T> : ContinuationWrapper<T> {
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun continueWith(t: T) {
         continuationList.removeFirstOrNull()?.let {
             if (it.isActive) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/usecases/GetBackupDownloadStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/usecases/GetBackupDownloadStatusUseCaseTest.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.jetpack.backup.download.usecases
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import org.assertj.core.api.Assertions.assertThat
@@ -30,7 +29,6 @@ import java.util.Calendar
 import java.util.Date
 
 @InternalCoroutinesApi
-@ExperimentalCoroutinesApi
 class GetBackupDownloadStatusUseCaseTest : BaseUnitTest() {
     private lateinit var useCase: GetBackupDownloadStatusUseCase
     @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.jetpack.restore.usecases
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import org.assertj.core.api.Assertions.assertThat
@@ -41,7 +40,6 @@ private const val CURRENT_ENTRY = "current entry"
 private val PUBLISHED = Date()
 
 @InternalCoroutinesApi
-@ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class GetRestoreStatusUseCaseTest {
     private lateinit var useCase: GetRestoreStatusUseCase

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -64,9 +64,9 @@ private const val ON_ENTER_SERVER_CREDS_MESSAGE_CLICKED_PARAM_POSITION = 7
 private const val TEST_SITE_ID = 1L
 private const val SERVER_CREDS_LINK = "${Constants.URL_JETPACK_SETTINGS}/$TEST_SITE_ID}"
 
-@ExperimentalCoroutinesApi
-@InternalCoroutinesApi
 @Suppress("LargeClass")
+@InternalCoroutinesApi
+@ExperimentalCoroutinesApi
 class ScanViewModelTest : BaseUnitTest() {
     @Rule
     @JvmField val coroutineScope = MainCoroutineScopeRule()

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
@@ -30,8 +30,8 @@ import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCa
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.NotStarted
 import org.wordpress.android.util.NetworkUtilsWrapper
 
-@ExperimentalCoroutinesApi
 @InternalCoroutinesApi
+@ExperimentalCoroutinesApi
 class FetchFixThreatsStatusUseCaseTest : BaseUnitTest() {
     @Rule
     @JvmField val coroutineScope = MainCoroutineScopeRule()

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCaseTest.kt
@@ -27,8 +27,8 @@ import org.wordpress.android.ui.jetpack.scan.usecases.FetchScanStateUseCase.Fetc
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchScanStateUseCase.FetchScanState.Success
 import org.wordpress.android.util.NetworkUtilsWrapper
 
-@ExperimentalCoroutinesApi
 @InternalCoroutinesApi
+@ExperimentalCoroutinesApi
 class FetchScanStateUseCaseTest : BaseUnitTest() {
     private lateinit var useCase: FetchScanStateUseCase
     @Mock private lateinit var site: SiteModel

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCaseTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import org.assertj.core.api.Assertions.assertThat
@@ -28,7 +27,6 @@ import org.wordpress.android.ui.jetpack.scan.usecases.FetchScanStateUseCase.Fetc
 import org.wordpress.android.util.NetworkUtilsWrapper
 
 @InternalCoroutinesApi
-@ExperimentalCoroutinesApi
 class FetchScanStateUseCaseTest : BaseUnitTest() {
     private lateinit var useCase: FetchScanStateUseCase
     @Mock private lateinit var site: SiteModel

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
@@ -694,7 +694,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
                 hasStoragePermissions = false
         )
 
-        assertThat(actions.poll()).isNull()
+        assertThat(actions.tryReceive().getOrNull()).isNull()
     }
 
     @Test
@@ -705,7 +705,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
                 hasStoragePermissions = true
         )
 
-        assertThat(actions.poll()).isEqualTo(LoadAction.Start(null))
+        assertThat(actions.tryReceive().getOrNull()).isEqualTo(LoadAction.Start(null))
     }
 
     @Test
@@ -716,7 +716,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
                 hasStoragePermissions = false
         )
 
-        assertThat(actions.poll()).isEqualTo(LoadAction.Start(null))
+        assertThat(actions.tryReceive().getOrNull()).isEqualTo(LoadAction.Start(null))
     }
 
     private fun selectItem(position: Int) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.MediatorLiveData
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -33,7 +32,6 @@ import org.wordpress.android.ui.quickstart.QuickStartTracker
 
 const val SITE_LOCAL_ID = 1
 
-@ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class MySiteSourceManagerTest : BaseUnitTest() {
     @Mock lateinit var quickStartTracker: QuickStartTracker

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -150,8 +150,8 @@ import java.util.Date
 
 private const val DYNAMIC_CARDS_BUILDER_MORE_CLICK_PARAM_POSITION = 3
 
-@ExperimentalCoroutinesApi
 @Suppress("LargeClass")
+@ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var siteItemsBuilder: SiteItemsBuilder

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -17,7 +17,6 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -151,7 +150,6 @@ import java.util.Date
 private const val DYNAMIC_CARDS_BUILDER_MORE_CLICK_PARAM_POSITION = 3
 
 @Suppress("LargeClass")
-@ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var siteItemsBuilder: SiteItemsBuilder

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
@@ -62,9 +62,9 @@ const val SCANNED_VALUE =
 const val VALID_EXPIRED_MESSAGE = "qr code data expired"
 const val INVALID_EXPIRED_MESSAGE = "invalid qr code data expired"
 
+@Suppress("LargeClass")
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
-@Suppress("LargeClass")
 class QRCodeAuthViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: QRCodeAuthViewModel
     @Mock lateinit var store: QRCodeAuthStore

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProviderTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions
 import org.junit.Before
@@ -38,6 +39,7 @@ import org.wordpress.android.util.EventBusWrapper
 private const val NUMBER_OF_ITEMS = 10L
 
 @InternalCoroutinesApi
+@ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class ReaderDiscoverDataProviderTest {
     @Rule

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderFetchRelatedPostsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderFetchRelatedPostsUseCaseTest.kt
@@ -23,12 +23,12 @@ import org.wordpress.android.ui.reader.usecases.ReaderFetchRelatedPostsUseCase.F
 import org.wordpress.android.util.NetworkUtilsWrapper
 
 @InternalCoroutinesApi
+@ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class ReaderFetchRelatedPostsUseCaseTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 
-    @ExperimentalCoroutinesApi
     @Rule
     @JvmField val coroutineScope = MainCoroutineScopeRule()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/StoriesIntroViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/StoriesIntroViewModelTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.util.NoDelayCoroutineDispatcher
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
 @InternalCoroutinesApi
+@ExperimentalCoroutinesApi
 class StoriesIntroViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: StoriesIntroViewModel
     @Mock lateinit var onDialogClosedObserver: Observer<Unit>
@@ -28,7 +29,6 @@ class StoriesIntroViewModelTest : BaseUnitTest() {
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
     @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
 
-    @ExperimentalCoroutinesApi
     @Before
     fun setUp() = runBlockingTest {
         viewModel = StoriesIntroViewModel(

--- a/WordPress/src/test/java/org/wordpress/android/util/SnackbarSequencerConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SnackbarSequencerConcurrentTest.kt
@@ -28,8 +28,8 @@ import org.wordpress.android.widgets.WPSnackbarWrapper
 private const val TEST_MESSAGE_TEMPLATE = "This is test message number "
 private const val SNACKBAR_DURATION_MS = 500L
 
-@ExperimentalCoroutinesApi
 @InternalCoroutinesApi
+@ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class SnackbarSequencerConcurrentTest {
     @get:Rule val rule = InstantTaskExecutorRule()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -10,6 +10,7 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runBlockingTest
@@ -60,8 +61,9 @@ import org.wordpress.android.viewmodel.main.WPMainActivityViewModel.FocusPointIn
 import java.util.Date
 
 @Suppress("LargeClass")
-@RunWith(MockitoJUnitRunner::class)
 @InternalCoroutinesApi
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
 class WPMainActivityViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: WPMainActivityViewModel
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
@@ -42,13 +42,13 @@ import org.wordpress.android.util.SiteUtils.GB_EDITOR_NAME
 import org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel.PageRequest.Blank
 import org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel.PageRequest.Create
 
-@RunWith(MockitoJUnitRunner::class)
 @InternalCoroutinesApi
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
 class ModalLayoutPickerViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 
-    @ExperimentalCoroutinesApi
     @Rule
     @JvmField val coroutineScope = MainCoroutineScopeRule()
 
@@ -104,7 +104,6 @@ class ModalLayoutPickerViewModelTest {
         )
     }
 
-    @ExperimentalCoroutinesApi
     private fun <T> mockFetchingSelectedSite(
         isError: Boolean = false,
         isSiteUnavailable: Boolean = false,
@@ -144,7 +143,6 @@ class ModalLayoutPickerViewModelTest {
         }
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when the user scroll beyond a threshold the title becomes visible`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -152,7 +150,6 @@ class ModalLayoutPickerViewModelTest {
         assertThat(requireNotNull(viewModel.uiState.value as Content).isHeaderVisible).isEqualTo(true)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when the user scroll bellow a threshold the title remains hidden`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -160,28 +157,24 @@ class ModalLayoutPickerViewModelTest {
         assertThat(requireNotNull(viewModel.uiState.value as Content).isHeaderVisible).isEqualTo(false)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when modal layout picker starts the categories are loaded`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
         assertThat(requireNotNull(viewModel.uiState.value as Content).categories.size).isGreaterThan(0)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when modal layout picker starts the layouts are loaded`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
         assertThat(requireNotNull(viewModel.uiState.value as Content).layoutCategories.size).isGreaterThan(0)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when modal layout picker starts fetch errors are handled`() = mockFetchingSelectedSite(true) {
         viewModel.createPageFlowTriggered()
         assertThat(viewModel.uiState.value is Error).isEqualTo(true)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when modal layout picker starts and the site is unavailable errors are handled`() =
             mockFetchingSelectedSite(isSiteUnavailable = true) {
@@ -189,14 +182,12 @@ class ModalLayoutPickerViewModelTest {
                 assertThat(viewModel.uiState.value is Error).isEqualTo(true)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `modal layout picker is shown when triggered`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
         assertThat(viewModel.isModalLayoutPickerShowing.value!!.peekContent()).isEqualTo(true)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `modal layout picker is dismissed when the user hits the back button`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -204,7 +195,6 @@ class ModalLayoutPickerViewModelTest {
         assertThat(viewModel.isModalLayoutPickerShowing.value!!.peekContent()).isEqualTo(false)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when no layout is selected and the create page is triggered the blank page creation flow starts`() =
             mockFetchingSelectedSite {
@@ -215,7 +205,6 @@ class ModalLayoutPickerViewModelTest {
                 assertThat(captor.value).isEqualTo(Blank)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when a layout is selected and the create page is triggered the page creation flow starts with a template`() =
             mockFetchingSelectedSite {
@@ -228,14 +217,12 @@ class ModalLayoutPickerViewModelTest {
                 assertThat(captor.value.template).isEqualTo("about")
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when modal layout picker starts no layout is selected`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
         assertThat(requireNotNull(viewModel.uiState.value as Content).selectedLayoutSlug).isNull()
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when the user taps on a layout the layout is selected if the thumbnail has loaded`() =
             mockFetchingSelectedSite {
@@ -246,7 +233,6 @@ class ModalLayoutPickerViewModelTest {
                         .isEqualTo("about-1")
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when the user taps on a layout the layout is selected if the thumbnail has not loaded`() =
             mockFetchingSelectedSite {
@@ -256,7 +242,6 @@ class ModalLayoutPickerViewModelTest {
                         .isNotEqualTo("about-1")
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when the user taps on a selected layout the layout is deselected`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -265,7 +250,6 @@ class ModalLayoutPickerViewModelTest {
         assertThat(requireNotNull(viewModel.uiState.value as Content).selectedLayoutSlug).isNull()
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when the modal layout picker is dismissed the layout is deselected`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -274,14 +258,12 @@ class ModalLayoutPickerViewModelTest {
         assertThat(requireNotNull(viewModel.uiState.value as Content).selectedLayoutSlug).isNull()
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when modal layout picker starts no category is selected`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
         assertThat(requireNotNull(viewModel.uiState.value as Content).selectedCategoriesSlugs).isEmpty()
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when the user taps on a category the category is selected`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -290,7 +272,6 @@ class ModalLayoutPickerViewModelTest {
                 .contains("about")
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when the user taps on a selected category the category is deselected`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -300,7 +281,6 @@ class ModalLayoutPickerViewModelTest {
                 .doesNotContain("about")
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when the modal layout picker is dismissed the category is deselected`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -309,7 +289,6 @@ class ModalLayoutPickerViewModelTest {
         assertThat(requireNotNull(viewModel.uiState.value as Content).selectedCategoriesSlugs).isEmpty()
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when no layout is selected the create blank page button is visible`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -317,7 +296,6 @@ class ModalLayoutPickerViewModelTest {
                 .isEqualTo(true)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when a layout is selected the create blank page button is not visible`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -327,7 +305,6 @@ class ModalLayoutPickerViewModelTest {
                 .isEqualTo(false)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when no layout is selected the create page button is not visible`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -335,7 +312,6 @@ class ModalLayoutPickerViewModelTest {
                 .isEqualTo(false)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when a layout is selected the create page button is visible`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -345,7 +321,6 @@ class ModalLayoutPickerViewModelTest {
                 .isEqualTo(true)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when no layout is selected the preview button is not visible`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()
@@ -353,7 +328,6 @@ class ModalLayoutPickerViewModelTest {
                 .isEqualTo(false)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `when a layout is selected the preview button is visible`() = mockFetchingSelectedSite {
         viewModel.createPageFlowTriggered()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
@@ -26,6 +27,7 @@ import org.wordpress.android.util.NoDelayCoroutineDispatcher
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
 @InternalCoroutinesApi
+@ExperimentalCoroutinesApi
 class FeatureAnnouncementViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: FeatureAnnouncementViewModel
     @Mock lateinit var onDialogClosedObserver: Observer<Unit>

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,9 @@ allprojects {
     tasks.withType(KotlinCompile).all {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_1_8
+            freeCompilerArgs += [
+                    "-Xopt-in=kotlin.RequiresOptIn"
+            ]
         }
     }
 }


### PR DESCRIPTION
Parent: #17173
Partially Closes: #17181

This PR resolves all `Coroutines` related warnings for the `WordPress` module:

- Main Source:
    - 3 warnings x `This declaration is experimental and its usage should be marked with '@kotlinx.coroutines.ExperimentalCoroutinesApi' or '@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)'`
    - 2 warnings x `'XYZ' is deprecated. Implement CoroutineScope interface and cancel all child coroutines in xyz`
    - 1 warning x `@Synchronized annotation is not applicable to suspend functions and lambdas` + Question [❓]: [see comment](https://github.com/wordpress-mobile/WordPress-Android/pull/10878#issuecomment-1258130096) @malinajirka
- Test Source:
    - 8 warnings x `This declaration is experimental and its usage should be marked with '@kotlinx.coroutines.ExperimentalCoroutinesApi' or '@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)'`
    - 3 warnings x `'Xyz' is deprecated. Deprecated in the favour of 'xyz'. Please note that the provided replacement does not rethrow channel's close cause as 'poll' did, for the precise replacement please refer to the 'poll' documentation`

-----

Warnings Resolution List:

1. [Resolve opt-in experimental coroutines api warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/0ab8933e765fdc567f82912f8fd55f63eeab2b93)
2. [Resolve deprecated coroutines thread module scope warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/ea825920691bfdd973deb192375d421055280766)
3. [Resolve opt-in experimental coroutines api warnings for tests.](https://github.com/wordpress-mobile/WordPress-Android/commit/e6471d4cf17c5763aa15f606f71270589705c031)
4. [Resolve deprecated coroutines channel poll warnings for tests.](https://github.com/wordpress-mobile/WordPress-Android/commit/fc6e457377bd4bb79a8b8fe429563accd421c944)

Warnings Suppression List:

1. [Suppress synchronized on suspend coroutines warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/175f0e364cf4b923a64c7cf036ae75a244924c9e)

Refactor List:

1. [Move ui dispatcher down to group scope and dispatcher funs.](https://github.com/wordpress-mobile/WordPress-Android/commit/d1f74fdd436d65e41fab3a77bebc298c3503536d)
2. [Rename provide background to bg dispatcher.](https://github.com/wordpress-mobile/WordPress-Android/commit/e03d208247c7487a7497f873d91f6b0e52a3622e)
3. [Reorder and add experimental coroutines api on top of test suites.](https://github.com/wordpress-mobile/WordPress-Android/commit/d2f4ca2e317c6b033383aa1aa82d297f93127451)
4. [Remove unnecessary experimental coroutines api annotation.](https://github.com/wordpress-mobile/WordPress-Android/commit/2fd0fc8fc1c1a71c01b0256d0618d187dcbd8916)

Documentation List:

1. [Add scope, dispatcher and other group sections to thread module.](https://github.com/wordpress-mobile/WordPress-Android/commit/e3242a543ba60786a01ec9bd1ac885b4e9cfc72c)

-----

PS: @AjeshRPai I added you as the main reviewer, that is, in addition to @wordpress-mobile/apps-infrastructure team itself, but randomly, since I want someone from the `WordPress Android` team to primarily sign-off on that change. 🥇

FYI: I am going to randomly add more of you in those PRs that will follow, just so you become more aware of this change and how close we are on enabling `allWarningsAsErrors` by default everywhere. 🎉

-----

To test:


- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could quickly smoke test both, the `WordPress` and `Jetpack` apps, and see if they are both working as expected.

PS: Also note the additional testing instructions as specified in this comment [here](https://github.com/wordpress-mobile/WordPress-Android/pull/17210#issuecomment-1259265799).

-----

## Regression Notes

1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
