### PR TITLE
Site Creation: Domains picker difficult to scroll in landscape mode #17040

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -2,8 +2,12 @@ package org.wordpress.android.ui.sitecreation
 
 import android.app.Activity
 import android.content.Intent
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.MenuItem
+import android.view.MotionEvent
+import android.view.View
+import android.widget.EditText
 import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -146,6 +150,21 @@ class SiteCreationActivity : LocaleAwareActivity(),
         if (!siteNameFeatureConfig.isEnabled()) {
             ActivityUtils.hideKeyboard(this)
         }
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        if (event.action == MotionEvent.ACTION_DOWN) {
+            val view: View? = currentFocus
+            if (view is EditText) {
+                val rect = Rect()
+                view.getGlobalVisibleRect(rect)
+                if (!rect.contains(event.rawX.toInt(), event.rawY.toInt())) {
+                    ActivityUtils.hideKeyboard(this)
+                    view.clearFocus()
+                }
+            }
+        }
+        return super.dispatchTouchEvent(event)
     }
 
     override fun onSiteNameEntered(siteName: String) {


### PR DESCRIPTION
Fixes #17040

Site Creation: Domains picker difficult to scroll in landscape mode
**Solution**
Add code to `SiteCreationActivity.kt` to hide the keyboard when the user taps outside the search and scroll area

To test:

1. Go through the Site Creation flow in landscape mode, stopping when you arrive on the "Choose a domain" page.
2. Enter something in the search bar.
3. Tap outside the search and scroll area

## Regression Notes
1. Potential unintended areas of impact
  NONE
3. What I did to test those areas of impact (or what existing automated tests I relied on)

- Manual regression test where post list is displayed

4. What automated tests I added (or what prevented me from doing so)

- None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

### Demo
https://www.loom.com/share/bbf9dc0a46e345658ac47fc4d91c5a97
