### PR TITLE
[Compile Warnings As Errors] WordPress Module - Resolve `LifecycleEvent` Deprecated Warnings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -28,9 +28,8 @@ import androidx.core.provider.FontRequest
 import androidx.emoji.text.EmojiCompat
 import androidx.emoji.text.EmojiCompat.InitCallback
 import androidx.emoji.text.FontRequestEmojiCompatConfig
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.WorkManager
 import com.android.volley.RequestQueue
@@ -128,7 +127,7 @@ import javax.inject.Singleton
 class AppInitializer @Inject constructor(
     wellSqlInitializer: WellSqlInitializer,
     private val application: Application
-) : LifecycleObserver {
+) : DefaultLifecycleObserver {
     @Inject lateinit var dispatcher: Dispatcher
     @Inject lateinit var accountStore: AccountStore
     @Inject lateinit var siteStore: SiteStore
@@ -678,16 +677,12 @@ class AppInitializer @Inject constructor(
         EmojiCompat.init(config)
     }
 
-    @Suppress("unused")
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    fun onAppComesFromBackground() {
+    override fun onStart(owner: LifecycleOwner) {
         applicationLifecycleMonitor.onAppComesFromBackground()
         appConfig.refresh()
     }
 
-    @Suppress("unused")
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    fun onAppGoesToBackground() {
+    override fun onStop(owner: LifecycleOwner) {
         applicationLifecycleMonitor.onAppGoesToBackground()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListEventListener.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.posts
 
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -59,7 +59,7 @@ class PostListEventListener(
     private val triggerPreviewStateUpdate: (PostListRemotePreviewState, PostInfoType) -> Unit,
     private val isRemotePreviewingFromPostsList: () -> Boolean,
     private val hasRemoteAutoSavePreviewError: () -> Boolean
-) : LifecycleObserver, CoroutineScope {
+) : DefaultLifecycleObserver, CoroutineScope {
     init {
         dispatcher.register(this)
         EventBus.getDefault().register(this)
@@ -94,9 +94,7 @@ class PostListEventListener(
      * Handles the [Lifecycle.Event.ON_DESTROY] event to cleanup the registration for dispatcher and removing the
      * observer for lifecycle.
      */
-    @Suppress("unused")
-    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-    private fun onDestroy() {
+    override fun onDestroy(owner: LifecycleOwner) {
         job.cancel()
         lifecycle.removeObserver(this)
         dispatcher.unregister(this)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -3,10 +3,10 @@ package org.wordpress.android.ui.posts.editor
 import android.app.Activity
 import android.net.Uri
 import androidx.appcompat.app.AlertDialog.Builder
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.State.CREATED
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.LifecycleOwner
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.wordpress.stories.compose.frame.StorySaveEvents.FrameSaveCompleted
 import com.wordpress.stories.compose.frame.StorySaveEvents.FrameSaveFailed
@@ -56,7 +56,7 @@ class StoriesEventListener @Inject constructor(
     private val loadStoryFromStoriesPrefsUseCase: LoadStoryFromStoriesPrefsUseCase,
     private val storiesPrefs: StoriesPrefs,
     private val storyRepositoryWrapper: StoryRepositoryWrapper
-) : LifecycleObserver {
+) : DefaultLifecycleObserver {
     private lateinit var lifecycle: Lifecycle
     private lateinit var site: SiteModel
     private lateinit var editPostRepository: EditPostRepository
@@ -89,9 +89,7 @@ class StoriesEventListener @Inject constructor(
      * Handles the [Lifecycle.Event.ON_DESTROY] event to cleanup the registration for dispatcher and removing the
      * observer for lifecycle   .
      */
-    @Suppress("unused")
-    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-    private fun onDestroy() {
+    override fun onDestroy(owner: LifecycleOwner) {
         lifecycle.removeObserver(this)
         pauseListening()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
@@ -2,11 +2,8 @@ package org.wordpress.android.ui.stories.media
 
 import android.content.Context
 import android.net.Uri
-import androidx.lifecycle.Lifecycle.Event.ON_CREATE
-import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
-import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.OnLifecycleEvent
 import com.wordpress.stories.compose.frame.StorySaveEvents.StorySaveResult
 import com.wordpress.stories.compose.story.StoryFrameItem
 import kotlinx.coroutines.CoroutineDispatcher
@@ -62,7 +59,7 @@ class StoryMediaSaveUploadBridge @Inject constructor(
     private val eventBusWrapper: EventBusWrapper,
     private val storyRepositoryWrapper: StoryRepositoryWrapper,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
-) : CoroutineScope, LifecycleObserver {
+) : CoroutineScope, DefaultLifecycleObserver {
     // region Fields
     private var job: Job = Job()
     private lateinit var appContext: Context
@@ -74,15 +71,11 @@ class StoryMediaSaveUploadBridge @Inject constructor(
     @Inject lateinit var storiesTrackerHelper: StoriesTrackerHelper
     @Inject lateinit var saveStoryGutenbergBlockUseCase: SaveStoryGutenbergBlockUseCase
 
-    @Suppress("unused")
-    @OnLifecycleEvent(ON_CREATE)
-    fun onCreate(source: LifecycleOwner) {
+    override fun onCreate(owner: LifecycleOwner) {
         eventBusWrapper.register(this)
     }
 
-    @Suppress("unused")
-    @OnLifecycleEvent(ON_DESTROY)
-    fun onDestroy(source: LifecycleOwner) {
+    override fun onDestroy(owner: LifecycleOwner) {
         // note: not sure whether this is ever going to get called if we attach it to the lifecycle of the Application
         // class, but leaving it here prepared for the case when this class is attached to some other LifeCycleOwner
         // other than the Application.

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -1,11 +1,10 @@
 package org.wordpress.android.ui.uploads
 
 import android.content.Context
-import androidx.lifecycle.Lifecycle.Event
-import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -70,9 +69,8 @@ class UploadStarter @Inject constructor(
     /**
      * The hook for making this class automatically launch uploads whenever the app is placed in the foreground.
      */
-    private val processLifecycleObserver = object : LifecycleObserver {
-        @OnLifecycleEvent(Event.ON_START)
-        fun onAppComesFromBackground() {
+    private val processLifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onStart(owner: LifecycleOwner) {
             queueUploadFromAllSites()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostFetcher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostFetcher.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.viewmodel.posts
 
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.LifecycleOwner
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -20,7 +20,7 @@ import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
 class PostFetcher constructor(
     private val lifecycle: Lifecycle,
     private val dispatcher: Dispatcher
-) : LifecycleObserver {
+) : DefaultLifecycleObserver {
     private val ongoingRequests = HashSet<RemoteId>()
 
     init {
@@ -32,9 +32,7 @@ class PostFetcher constructor(
      * Handles the [Lifecycle.Event.ON_DESTROY] event to cleanup the registration for dispatcher and removing the
      * observer for lifecycle.
      */
-    @Suppress("unused")
-    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-    private fun onDestroy() {
+    override fun onDestroy(owner: LifecycleOwner) {
         lifecycle.removeObserver(this)
         dispatcher.unregister(this)
     }


### PR DESCRIPTION
Parent: #17173
Partially Closes: #17181

This PR resolves all `LifecycleEvent` related `Deprecated` warnings for the `WordPress` module:

Classes:
- Init
    - AppInitializer: [Resolve on lifecycle event deprecated warnings for app init.](https://github.com/wordpress-mobile/WordPress-Android/commit/fdc10e639ab6b533642a46fa1cafb3b14a7d7f81)
    - UploadStarter: [Resolve on lifecycle event deprecated warns for upload starter.](https://github.com/wordpress-mobile/WordPress-Android/commit/a48d2742fb299b3849b979fd7327a6ec0a6d6b3e)
- Posts
    - PostFetcher: [Resolve on lifecycle event deprecated warns for post fetcher.](https://github.com/wordpress-mobile/WordPress-Android/commit/52ffd38829f6e03781954dfe7fdbf30d24c118ee)
    - PostListEventListener: [Resolve on lifecycle event deprecated warns for post list.](https://github.com/wordpress-mobile/WordPress-Android/commit/a91ac89684f0ab2a695bae2348b1d06ab5df9154)
- Stories
    - StoriesEventListener: [Resolve on lifecycle event deprecated warns for stories event.](https://github.com/wordpress-mobile/WordPress-Android/commit/7f44f25a2f98c57e7d1ce0b00cdb09456f73d17f)
    - StoryMediaSaveUploadBridge: [Resolve on lifecycle event deprecated warns for story media.](https://github.com/wordpress-mobile/WordPress-Android/commit/b60be53732a8ac30dfb38bac7fe2973fe7768c3c)

-----

PS: @zwarm I added you as the main reviewer, that is, in addition to @wordpress-mobile/apps-infrastructure team itself, but randomly, since I want someone from the `WordPress Android` team to primarily sign-off on that change. 🥇

FYI: I am going to randomly add more of you in those PRs that will follow, just so you become more aware of this change and how close we are on enabling `allWarningsAsErrors` by default everywhere. 🎉

-----

To test:

- Smoke test both, the `WordPress` and `Jetpack` apps, and see if their lifecycle observer related functionalities are working as expected. In more details, and per class, you could test the following (using the debugger or adding extra logs):
    - Init
        - AppInitializer:
            - `[onStop]`: Put the app in background and verify that the `onStop(...)` function is called.
            - `[onStart]`Pull the app from background and verify that the `onStart(...)` function is called.
        - UploadStarter `[onStart]`: Pull the app from background and verify that the `onStart(...)` function is called.
    - Posts
        - PostFetcher `[onDestroy]`: Enter the `Posts` screen, then exit the `Posts` screen and verify that the `onDestroy(...)` function is called.
        - PostListEventListener `[onDestroy]`: Enter the `Posts` screen, then exit the `Posts` screen and verify that the `onDestroy(...)` function is called.
    - Stories
        - StoriesEventListener `[onDestroy]`: Trigger a new `Post` creation, then go back and verify that the `onDestroy(...)` function is called.
        - StoryMediaSaveUploadBridge:
            -  `[onCreate]`: Swipe-off the app and kill it, then open the app and verify the `onCreate(...)` function is called.
            -  `[onDestroy]`: I am not sure how to verify that the `onDestroy(...)` function is also called, but verifying the `onCreate(...)` should be enough anyway. PS: From the comment within this function you will notice that the author wasn't sure about that too.

-----

## Regression Notes
1. Potential unintended areas of impact

The lifecycle observer related functionalities are not working as expected, thus causing problems with various background related functionalities of the app (see the `To test` section above to understand more about that via testing).

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
