### PR TITLE
Integrate gutenberg-mobile release 1.83.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.19.0'
     aztecVersion = 'v1.6.0'
-    gutenbergMobileVersion = '5180-3f731e6770734ba5923fdc61dfe44d9c2e39d622'
+    gutenbergMobileVersion = 'v1.83.0'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.19.0'
     aztecVersion = 'v1.6.0'
-    gutenbergMobileVersion = 'v1.82.1'
+    gutenbergMobileVersion = '5180-3f731e6770734ba5923fdc61dfe44d9c2e39d622'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.83.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5180

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.