### PR TITLE
Fix RTL rendering on Reader Post detail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -22,6 +22,7 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.StringUtils;
 
 import java.lang.ref.WeakReference;
+import java.text.Bidi;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -349,7 +350,14 @@ public class ReaderPostRenderer {
         final String galleryOnlyClass = "gallery-only-class" + new Random().nextInt(1000);
 
         @SuppressWarnings("StringBufferReplaceableByString")
-        StringBuilder sbHtml = new StringBuilder("<!DOCTYPE html><html><head><meta charset='UTF-8' />");
+        String str;
+        if (isRTL(content)) {
+            str = "<!DOCTYPE html><html dir='rtl' lang=''><head><meta charset='UTF-8' />";
+        } else {
+            str = "<!DOCTYPE html><html><head><meta charset='UTF-8' />";
+        }
+
+        StringBuilder sbHtml = new StringBuilder(str);
 
         // title isn't necessary, but it's invalid html5 without one
         sbHtml.append("<title>Reader Post</title>")
@@ -601,5 +609,10 @@ public class ReaderPostRenderer {
             return 0;
         }
         return DisplayUtils.pxToDp(WordPress.getContext(), px);
+    }
+
+    private boolean isRTL(String content) {
+        Bidi bidi = new Bidi(content, Bidi.DIRECTION_DEFAULT_LEFT_TO_RIGHT);
+        return bidi.isRightToLeft() || bidi.isMixed();
     }
 }


### PR DESCRIPTION
Added RTL detection and html directive to render RTL language in WebView properly

Fixes #17163 

| Before | After |
|---|---|
|![Screenshot_20220929_171458](https://user-images.githubusercontent.com/990349/192964968-8872563c-f6f6-4ac1-9e3d-049b24539a4b.png)|![Screenshot_20220929_171403](https://user-images.githubusercontent.com/990349/192965036-c2d4084a-00c2-4552-9756-636c8329a6ce.png)|


To test:

Test 1
- Use current WP or JP apps
- Publish an RTL post or search for an RTL post in Reader
- Click on the post in Reader to view its detail view
- The post title will be aligned right, but the **content will be aligned left** as show in before image above

Test 2
- Build and run either WP or JP variant
- Click on the post in Reader to view its detail
- The post title will be aligned right, the content **should be aligned right** as well as shown in after image above

NOTE:
_- This applies to only Post detail view and not the Post in List view on Reader_

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested with a RTL languages like Arabic

3. What automated tests I added (or what prevented me from doing so)
Existing tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
