### PR TITLE
Fix Threats Found label repeating

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
@@ -92,10 +92,10 @@ class ScanStateListItemsBuilder @Inject constructor(
         items.add(scanHeader)
         items.add(scanDescription)
         items.add(scanProgress)
+        items.add(ThreatsHeaderItemState(threatsCount = fixingThreatIds.size))
 
         items.addAll(
                 fixingThreatIds.mapNotNull { threatId ->
-                    items.add(ThreatsHeaderItemState(threatsCount = fixingThreatIds.size))
                     scanStore.getThreatModelByThreatId(threatId)?.let { threatModel ->
                         val threatItem = threatItemBuilder.buildThreatItem(threatModel).copy(
                                 isFixing = true,


### PR DESCRIPTION
Moved Threats Header out of loop to stop it from repeating with threat items

Fixes #14790 

| Scan | Before | After |
|---|---|---|
|![Screenshot_20220930_154612](https://user-images.githubusercontent.com/990349/193202392-7514dcdc-0ead-4b30-a23d-c5e59fec9ea0.png)|![Screenshot_20220930_155400](https://user-images.githubusercontent.com/990349/193202475-63bfdd50-83b0-4c20-8056-d014824283d5.png)|![Screenshot_20220930_160052](https://user-images.githubusercontent.com/990349/193202529-ceb816f3-9497-4ddd-b002-b81b44a1fe89.png)


To test:

Setup

- Need a Jetpack enabled site with Scan plugin installed  (Follow the instructions on this P2: p1HpG7-9a5-p2) or Use the one I setup already critical-jambu.jurassic.ninja
- You'll need to launch admin and edit plugin files and add some text and save to report threats as shown in first image above.
 

Test 1

1. Login with a wp account having a scan capability and two or more threats.
2. Go to the My Site tab -> Tap the Scan item -> Wait till the scan completes on the Scan screen.
3. Once the threat is found, tap on the Fix All button.
4. A Fix all threats confirmation dialog will appear.
5. Tap OK and the threat fixing will start.
6. Notice that the label "Threats found" repeats as many times as there are threats as shown in **before** image above.

Test 2

- Build and run
- Repeat step 1- 5 from above.
- Notice that the label "Threats found" is shown only once as in **after** image above.



## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Existing threats

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
