### PR TITLE
[Gutenberg] Upgrade compile and target sdk version to Android API 31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 ext {
     wordPressUtilsVersion = '2.7.0'
     wordPressLoginVersion = '0.19.0'
-    gutenbergMobileVersion = 'v1.82.1'
+    gutenbergMobileVersion = '5184-a21b6e7d1e945a8bfb64f47515402dfd7bdd7e15'
     storiesVersion = '1.4.0'
     aboutAutomatticVersion = '0.0.6'
 


### PR DESCRIPTION
**Parent issue:** https://github.com/wordpress-mobile/WordPress-Android/issues/16062

Related PRs:
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5184
- https://github.com/WordPress/gutenberg/pull/44610

Upgrade Gutenberg library to Android 12 (API 31).

**To test:**
This change doesn't affect a specific area, hence to test it we should basically smoke test the editor and check that works as expected.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
