### PR TITLE
[Jetpack Focus] Make Landing Screen Revamp Feature Flag Configurable Remotely

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
@@ -1,12 +1,21 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
 /**
  * Configuration for the landing screen revamp work
  */
-@FeatureInDevelopment
-class LandingScreenRevampFeatureConfig
-@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.LANDING_SCREEN_REVAMP)
+@Feature(LandingScreenRevampFeatureConfig.LANDING_SCREEN_REVAMP_REMOTE_FIELD, false)
+class LandingScreenRevampFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.LANDING_SCREEN_REVAMP,
+        LANDING_SCREEN_REVAMP_REMOTE_FIELD,
+) {
+    companion object {
+        const val LANDING_SCREEN_REVAMP_REMOTE_FIELD = "landing_screen_revamp_remote_field"
+    }
+}


### PR DESCRIPTION
Fixes #17236

This PR makes the feature flag to toggle the Revamped Landing Screen for both WordPress and Jetpack apps configurable remotely.

📣 **Important** Please run both test cases to leave the feature flag **disabled**.

To test:

#### 1️⃣ Test Case 1: Remote feature flag `enabled`

1. Go to Firebase Remote Config, set the default value of the `landing_screen_revamp_remote_field` feature flag to `true` and publish your changes.
2. Launch the WordPress / Jetpack App and make sure you're logged out.
3. **Verify** that the **new** landing screen is displayed.

#### 2️⃣ Test Case 2 - Remote feature flag `disabled`

1. Go to Firebase Remote Config, set the default value of the `landing_screen_revamp_remote_field` feature flag to `false` and publish your changes.
2. Launch the WordPress / Jetpack App and make sure you're logged out.


#### 3️⃣ Test Case 3: Local feature flag override

1. Launch the WordPress / Jetpack app.
3. **Verify** that the **old** landing screen is displayed.
4. Login.
5. Go `Me` → `App Settings` → `Debug settings` → check `landing_screen_revamp_remote_field` `on` and tap `RESTART THE APP` at the bottom.
6. Logout of the app.
7. **Verify** that the **new** landing screen is displayed.


## Regression Notes
1. Potential unintended areas of impact
   N/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

4. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
