### PR TITLE
feat: Add Home deep link intent

### DIFF
--- a/WordPress/src/jetpack/AndroidManifest.xml
+++ b/WordPress/src/jetpack/AndroidManifest.xml
@@ -37,6 +37,9 @@
                 <data
                     android:host="notifications"
                     android:scheme="jetpack" />
+                <data
+                    android:host="home"
+                    android:scheme="jetpack" />
             </intent-filter>
         </activity>
 

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -400,6 +400,9 @@
                 <data
                     android:host="notifications"
                     android:scheme="wordpress" />
+                <data
+                    android:host="home"
+                    android:scheme="wordpress" />
             </intent-filter>
 
             <intent-filter android:autoVerify="true">

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1751,4 +1751,13 @@ public class ActivityLauncher {
 
         taskStackBuilder.startActivities();
     }
+
+    public static void showHome(@NonNull Context context, @NonNull Boolean isLoggedIn) {
+        if (isLoggedIn) {
+            viewMySiteInNewStack(context);
+        } else {
+            Intent intent = new Intent(context, LoginActivity.class);
+            context.startActivity(intent);
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1752,12 +1752,8 @@ public class ActivityLauncher {
         taskStackBuilder.startActivities();
     }
 
-    public static void showHome(@NonNull Context context, @NonNull Boolean isLoggedIn) {
-        if (isLoggedIn) {
-            viewMySiteInNewStack(context);
-        } else {
-            Intent intent = new Intent(context, LoginActivity.class);
-            context.startActivity(intent);
-        }
+    public static void showLoginPrologue(@NonNull Context context) {
+        Intent intent = new Intent(context, LoginActivity.class);
+        context.startActivity(intent);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -8,9 +8,10 @@ import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.Login
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenEditor
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenEditorForPost
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenEditorForSite
-import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenHome
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenMySite
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInBrowser
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInReader
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenLoginPrologue
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenNotifications
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenPages
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenPagesForSite
@@ -75,7 +76,8 @@ class DeepLinkNavigator
             is OpenPagesForSite -> ActivityLauncher.viewPagesInNewStack(activity, navigateAction.site)
             OpenPages -> ActivityLauncher.viewPagesInNewStack(activity)
             is OpenQRCodeAuthFlow -> ActivityLauncher.startQRCodeAuthFlowInNewStack(activity, navigateAction.uri)
-            is OpenHome -> ActivityLauncher.showHome(activity, navigateAction.isLoggedIn)
+            OpenMySite -> ActivityLauncher.viewMySiteInNewStack(activity)
+            OpenLoginPrologue -> ActivityLauncher.showLoginPrologue(activity)
         }
         if (navigateAction != LoginForResult) {
             activity.finish()
@@ -103,6 +105,7 @@ class DeepLinkNavigator
         data class OpenPagesForSite(val site: SiteModel) : NavigateAction()
         object OpenPages : NavigateAction()
         data class OpenQRCodeAuthFlow(val uri: String) : NavigateAction()
-        data class OpenHome(val isLoggedIn: Boolean) : NavigateAction()
+        object OpenMySite : NavigateAction()
+        object OpenLoginPrologue : NavigateAction()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.Login
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenEditor
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenEditorForPost
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenEditorForSite
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenHome
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInBrowser
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInReader
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenNotifications
@@ -74,6 +75,7 @@ class DeepLinkNavigator
             is OpenPagesForSite -> ActivityLauncher.viewPagesInNewStack(activity, navigateAction.site)
             OpenPages -> ActivityLauncher.viewPagesInNewStack(activity)
             is OpenQRCodeAuthFlow -> ActivityLauncher.startQRCodeAuthFlowInNewStack(activity, navigateAction.uri)
+            OpenHome -> ActivityLauncher.viewMySiteInNewStack(activity)
         }
         if (navigateAction != LoginForResult) {
             activity.finish()
@@ -101,5 +103,6 @@ class DeepLinkNavigator
         data class OpenPagesForSite(val site: SiteModel) : NavigateAction()
         object OpenPages : NavigateAction()
         data class OpenQRCodeAuthFlow(val uri: String) : NavigateAction()
+        object OpenHome : NavigateAction()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -75,7 +75,7 @@ class DeepLinkNavigator
             is OpenPagesForSite -> ActivityLauncher.viewPagesInNewStack(activity, navigateAction.site)
             OpenPages -> ActivityLauncher.viewPagesInNewStack(activity)
             is OpenQRCodeAuthFlow -> ActivityLauncher.startQRCodeAuthFlowInNewStack(activity, navigateAction.uri)
-            OpenHome -> ActivityLauncher.viewMySiteInNewStack(activity)
+            is OpenHome -> ActivityLauncher.showHome(activity, navigateAction.isLoggedIn)
         }
         if (navigateAction != LoginForResult) {
             activity.finish()
@@ -103,6 +103,6 @@ class DeepLinkNavigator
         data class OpenPagesForSite(val site: SiteModel) : NavigateAction()
         object OpenPages : NavigateAction()
         data class OpenQRCodeAuthFlow(val uri: String) : NavigateAction()
-        object OpenHome : NavigateAction()
+        data class OpenHome(val isLoggedIn: Boolean) : NavigateAction()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -8,8 +8,8 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.LoginForResult
-import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenHome
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInBrowser
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenLoginPrologue
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.ShowSignInFlow
 import org.wordpress.android.ui.deeplinks.handlers.DeepLinkHandlers
 import org.wordpress.android.ui.deeplinks.handlers.ServerTrackingHandler
@@ -82,7 +82,7 @@ class DeepLinkingIntentReceiverViewModel
         return accountStore.hasAccessToken() ||
                 action is OpenInBrowser ||
                 action is ShowSignInFlow ||
-                action is OpenHome
+                action is OpenLoginPrologue
     }
 
     private fun buildNavigateAction(uri: UriWrapper, rootUri: UriWrapper = uri): NavigateAction? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -70,12 +70,19 @@ class DeepLinkingIntentReceiverViewModel
             if (action != null) {
                 deepLinkTrackingUtils.track(action, it, uriWrapper)
             }
-            if (accountStore.hasAccessToken() || it is OpenInBrowser || it is ShowSignInFlow || it is OpenHome) {
+            if (loginIsUnnecessary(it)) {
                 _navigateAction.value = Event(it)
             } else {
                 _navigateAction.value = Event(LoginForResult)
             }
         } != null
+    }
+
+    private fun loginIsUnnecessary(action: NavigateAction): Boolean {
+        return accountStore.hasAccessToken() ||
+                action is OpenInBrowser ||
+                action is ShowSignInFlow ||
+                action is OpenHome
     }
 
     private fun buildNavigateAction(uri: UriWrapper, rootUri: UriWrapper = uri): NavigateAction? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.LoginForResult
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenHome
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInBrowser
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.ShowSignInFlow
 import org.wordpress.android.ui.deeplinks.handlers.DeepLinkHandlers
@@ -69,7 +70,7 @@ class DeepLinkingIntentReceiverViewModel
             if (action != null) {
                 deepLinkTrackingUtils.track(action, it, uriWrapper)
             }
-            if (accountStore.hasAccessToken() || it is OpenInBrowser || it is ShowSignInFlow) {
+            if (accountStore.hasAccessToken() || it is OpenInBrowser || it is ShowSignInFlow || it is OpenHome) {
                 _navigateAction.value = Event(it)
             } else {
                 _navigateAction.value = Event(LoginForResult)

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
@@ -15,7 +15,8 @@ class DeepLinkHandlers
     readerLinkHandler: ReaderLinkHandler,
     pagesLinkHandler: PagesLinkHandler,
     notificationsLinkHandler: NotificationsLinkHandler,
-    qrCodeAuthLinkHandler: QRCodeAuthLinkHandler
+    qrCodeAuthLinkHandler: QRCodeAuthLinkHandler,
+    homeLinkHandler: HomeLinkHandler
 ) {
     private val handlers = listOf(
             editorLinkHandler,
@@ -24,7 +25,8 @@ class DeepLinkHandlers
             readerLinkHandler,
             pagesLinkHandler,
             notificationsLinkHandler,
-            qrCodeAuthLinkHandler
+            qrCodeAuthLinkHandler,
+            homeLinkHandler
     )
 
     private val _toast by lazy {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandler.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenMySite
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenLoginPrologue
+import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverViewModel
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
 
@@ -25,7 +26,12 @@ class HomeLinkHandler
     }
 
     override fun stripUrl(uri: UriWrapper): String {
-        return HOME_PATH;
+        return buildString {
+            if (uri.host == HOME_PATH) {
+                append(DeepLinkingIntentReceiverViewModel.APPLINK_SCHEME)
+            }
+            append(HOME_PATH)
+        }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandler.kt
@@ -2,7 +2,8 @@ package org.wordpress.android.ui.deeplinks.handlers
 
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
-import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenHome
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenMySite
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenLoginPrologue
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
 
@@ -16,13 +17,15 @@ class HomeLinkHandler
     }
 
     override fun buildNavigateAction(uri: UriWrapper): NavigateAction {
-        return OpenHome(accountStore.hasAccessToken())
+        return if (accountStore.hasAccessToken()) {
+            OpenMySite
+        } else {
+            OpenLoginPrologue
+        }
     }
 
     override fun stripUrl(uri: UriWrapper): String {
-        return buildString {
-            append(HOME_PATH)
-        }
+        return HOME_PATH;
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandler.kt
@@ -1,0 +1,30 @@
+package org.wordpress.android.ui.deeplinks.handlers
+
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenHome
+import org.wordpress.android.util.UriWrapper
+import javax.inject.Inject
+
+class HomeLinkHandler
+@Inject constructor() : DeepLinkHandler {
+    /**
+     * Returns true if the URI looks like `wordpress://home`
+     */
+    override fun shouldHandleUrl(uri: UriWrapper): Boolean {
+        return uri.host == HOME_PATH
+    }
+
+    override fun buildNavigateAction(uri: UriWrapper): NavigateAction {
+        return OpenHome
+    }
+
+    override fun stripUrl(uri: UriWrapper): String {
+        return buildString {
+            append(HOME_PATH)
+        }
+    }
+
+    companion object {
+        private const val HOME_PATH = "home"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandler.kt
@@ -1,12 +1,13 @@
 package org.wordpress.android.ui.deeplinks.handlers
 
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenHome
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
 
 class HomeLinkHandler
-@Inject constructor() : DeepLinkHandler {
+@Inject constructor(private val accountStore: AccountStore) : DeepLinkHandler {
     /**
      * Returns true if the URI looks like `wordpress://home`
      */
@@ -15,7 +16,7 @@ class HomeLinkHandler
     }
 
     override fun buildNavigateAction(uri: UriWrapper): NavigateAction {
-        return OpenHome
+        return OpenHome(accountStore.hasAccessToken())
     }
 
     override fun stripUrl(uri: UriWrapper): String {

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlersTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlersTest.kt
@@ -20,6 +20,7 @@ class DeepLinkHandlersTest : BaseUnitTest() {
     @Mock lateinit var pagesLinkHandler: PagesLinkHandler
     @Mock lateinit var notificationsLinkHandler: NotificationsLinkHandler
     @Mock lateinit var qrCodeAuthLinkHandler: QRCodeAuthLinkHandler
+    @Mock lateinit var homeLinkHandler: HomeLinkHandler
     @Mock lateinit var uri: UriWrapper
     private lateinit var deepLinkHandlers: DeepLinkHandlers
     private lateinit var handlers: List<DeepLinkHandler>
@@ -33,7 +34,8 @@ class DeepLinkHandlersTest : BaseUnitTest() {
                 readerLinkHandler,
                 pagesLinkHandler,
                 notificationsLinkHandler,
-                qrCodeAuthLinkHandler
+                qrCodeAuthLinkHandler,
+                homeLinkHandler
         )
         initDeepLinkHandlers()
     }
@@ -46,7 +48,8 @@ class DeepLinkHandlersTest : BaseUnitTest() {
                 readerLinkHandler,
                 pagesLinkHandler,
                 notificationsLinkHandler,
-                qrCodeAuthLinkHandler
+                qrCodeAuthLinkHandler,
+                homeLinkHandler
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandlerTest.kt
@@ -3,16 +3,10 @@ package org.wordpress.android.ui.deeplinks.handlers
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.deeplinks.buildUri
 
-@RunWith(MockitoJUnitRunner::class)
 class HomeLinkHandlerTest {
-    @Mock lateinit var site: SiteModel
     private lateinit var homeLinkHandler: HomeLinkHandler
 
     @Before

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandlerTest.kt
@@ -1,25 +1,52 @@
 package org.wordpress.android.ui.deeplinks.handlers
 
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenMySite
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenLoginPrologue
 import org.wordpress.android.ui.deeplinks.buildUri
 
+@RunWith(MockitoJUnitRunner::class)
 class HomeLinkHandlerTest {
+    @Mock lateinit var accountStore: AccountStore
     private lateinit var homeLinkHandler: HomeLinkHandler
 
     @Before
     fun setUp() {
-        homeLinkHandler = HomeLinkHandler()
+        homeLinkHandler = HomeLinkHandler(accountStore)
     }
 
     @Test
-    fun `opens home screen from app link`() {
-        val uri = buildUri(host = "home")
+    fun `returns login prologue action when user is logged out`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
 
-        val navigateAction = homeLinkHandler.buildNavigateAction(uri)
+        val navigateAction = homeLinkHandler.buildNavigateAction(mock())
 
-        assertThat(navigateAction).isEqualTo(NavigateAction.OpenHome)
+        assertThat(navigateAction).isEqualTo(OpenLoginPrologue)
+    }
+
+    @Test
+    fun `returns my site action when user is logged in`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+
+        val navigateAction = homeLinkHandler.buildNavigateAction(mock())
+
+        assertThat(navigateAction).isEqualTo(OpenMySite)
+    }
+
+    @Test
+    fun `builds URL for tracking`() {
+        val homeUri = buildUri("home")
+
+        val strippedUrl = homeLinkHandler.stripUrl(homeUri)
+
+        assertThat(strippedUrl).isEqualTo("home")
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandlerTest.kt
@@ -47,6 +47,6 @@ class HomeLinkHandlerTest {
 
         val strippedUrl = homeLinkHandler.stripUrl(homeUri)
 
-        assertThat(strippedUrl).isEqualTo("home")
+        assertThat(strippedUrl).isEqualTo("wordpress://home")
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/HomeLinkHandlerTest.kt
@@ -1,0 +1,31 @@
+package org.wordpress.android.ui.deeplinks.handlers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.deeplinks.buildUri
+
+@RunWith(MockitoJUnitRunner::class)
+class HomeLinkHandlerTest {
+    @Mock lateinit var site: SiteModel
+    private lateinit var homeLinkHandler: HomeLinkHandler
+
+    @Before
+    fun setUp() {
+        homeLinkHandler = HomeLinkHandler()
+    }
+
+    @Test
+    fun `opens home screen from app link`() {
+        val uri = buildUri(host = "home")
+
+        val navigateAction = homeLinkHandler.buildNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenHome)
+    }
+}


### PR DESCRIPTION
## Description

Support deep linking to the default tab of the application, which is useful for generic promotions found on web pages. This was added in support of https://github.com/Automattic/wp-calypso/pull/68062. Specifically, this intent is [needed for the new banner](https://github.com/Automattic/wp-calypso/pull/68062/files/6e160a2042cf4fbf6d30c68b66aff2958d685657#r976689110) displayed.

## Testing

With this branch checked out and the WordPress/Jetpack app running in an emulator, run the following command in Android Studio's terminal to confirm the custom scheme works to open the correct section: 

- **Jetpack:** `adb shell am start -a android.intent.action.VIEW -d "jetpack://home"`
- **WordPress:** `adb shell am start -a android.intent.action.VIEW -d "wordpress://home"`

For logged in users, the _My Site_ tab should display. For logged out users, the _Login Prologue_ should display. 

## Regression Notes
1. Potential unintended areas of impact
    Other deep links could stop working.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Verified automated tests pass. Manually tested existing deep links via `adb` commands similar to the above.
3. What automated tests I added (or what prevented me from doing so)
    Tests mirroring existing handler tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
