### PR TITLE
Add some missing Release Notes entries

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,9 @@
 -----
 * [***] [internal] Redesigned the landing screen of the WordPress and Jetpack apps, behind a feature flag. [https://github.com/wordpress-mobile/WordPress-Android/pull/17203]
 * [**] [internal] Added sensor feedback to influence the speed of the scrolling large text on the redesigned Jetpack landing screen based on the vertical rotation of the device. [https://github.com/wordpress-mobile/WordPress-Android/pull/17207]
+* [*] Quick Start: Retain Quick Start focus point after device rotation [https://github.com/wordpress-mobile/WordPress-Android/pull/17187]
+* [*] Stats: Fix Long title problem on stats cards [https://github.com/wordpress-mobile/WordPress-Android/pull/17084]
+* [*] Support "Enter" key for Excerpt editing in Post settings [https://github.com/wordpress-mobile/WordPress-Android/pull/17078]
 
 20.8
 -----

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,3 +1,5 @@
 * [***] [internal] Redesigned the landing screen of the WordPress and Jetpack apps, behind a feature flag. [https://github.com/wordpress-mobile/WordPress-Android/pull/17203]
 * [**] [internal] Added sensor feedback to influence the speed of the scrolling large text on the redesigned Jetpack landing screen based on the vertical rotation of the device. [https://github.com/wordpress-mobile/WordPress-Android/pull/17207]
-
+* [*] Quick Start: Retain Quick Start focus point after device rotation [https://github.com/wordpress-mobile/WordPress-Android/pull/17187]
+* [*] Stats: Fix Long title problem on stats cards [https://github.com/wordpress-mobile/WordPress-Android/pull/17084]
+* [*] Support "Enter" key for Excerpt editing in Post settings [https://github.com/wordpress-mobile/WordPress-Android/pull/17078]

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,2 +1,4 @@
 * [***] [internal] Redesigned the landing screen of the WordPress and Jetpack apps, behind a feature flag. [https://github.com/wordpress-mobile/WordPress-Android/pull/17203]
-
+* [*] Quick Start: Retain Quick Start focus point after device rotation [https://github.com/wordpress-mobile/WordPress-Android/pull/17187]
+* [*] Stats: Fix Long title problem on stats cards [https://github.com/wordpress-mobile/WordPress-Android/pull/17084]
+* [*] Support "Enter" key for Excerpt editing in Post settings [https://github.com/wordpress-mobile/WordPress-Android/pull/17078]


### PR DESCRIPTION
This release, we got some PRs made by external contributors from @gitstart 🎉 … but we completely forgot to tell them at the time to add entries for their changes to the `RELEASE-NOTES.txt` file as part of their PR. So this PR adds the relevant entries:

 - Not only to the `RELEASE-NOTES.txt` file (the one we expect contributors to update when they do a new PR to describe the changes, assuming those changes are interesting enough to end users to make it to the release notes)
 - But also to the `WordPress/{jetpack_,}metadata/release_notes.txt` files that are usually auto-generated by our release tooling when it extracts the entries from `RELEASE-NOTES.txt`. Since I already ran that tooling earlier today when I did the code freeze before adding those missing entries, I had to update those manually to simulate them being extracted from the `RELEASE-NOTES.txt` file during code-freeze.

---

PS: We need this PR to land ASAP so that our freelance writer can use those files (from `trunk` once they will have landed) to write nice editorialized copies for those entries, so we can then send that editorialized copy for release notes to translation this week.

cc @vanessamaartinstt FYI as you might want to include those additional entries in the upcoming Call for Testing you'll likely be drafting today 🙂 