### PR TITLE
[Compile Warnings As Errors] WordPress Module - Resolve Deprecated Warnings - Part.1

### DIFF
--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.kt
@@ -79,6 +79,7 @@ class LoginPrologueFragment : Fragment(R.layout.jetpack_login_prologue_screen) {
         viewModel.onFragmentResume()
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         // important for accessibility - talkback

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPostDiscoverData.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPostDiscoverData.java
@@ -1,11 +1,11 @@
 package org.wordpress.android.models;
 
 import android.content.Context;
-import android.text.Html;
 import android.text.Spanned;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.core.text.HtmlCompat;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -183,7 +183,7 @@ public class ReaderPostDiscoverData {
                     html = "";
             }
 
-            mAttributionHtml = Html.fromHtml(html);
+            mAttributionHtml = HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_LEGACY);
         }
         return mAttributionHtml;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -5,7 +5,6 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -18,6 +17,7 @@ import android.widget.TextView;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.text.HtmlCompat;
 
 import org.wordpress.android.R;
 import org.wordpress.android.util.AppLog;
@@ -96,7 +96,7 @@ public class AppLogViewerActivity extends LocaleAwareActivity {
                 holder.mTxtLineNumber.setVisibility(View.GONE);
             }
 
-            holder.mTxtLogEntry.setText(Html.fromHtml(mEntries.get(position)));
+            holder.mTxtLogEntry.setText(HtmlCompat.fromHtml(mEntries.get(position), HtmlCompat.FROM_HTML_MODE_LEGACY));
 
             return convertView;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
@@ -14,6 +15,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.JetpackRemoteInstallFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.login.LoginMode
+import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActionData
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActionData.Action.CONNECT
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActionData.Action.LOGIN
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActionData.Action.MANUAL_INSTALL
@@ -54,34 +56,51 @@ class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fr
             viewModel.liveActionOnResult.observe(viewLifecycleOwner, Observer { result ->
                 if (result != null) {
                     when (result.action) {
-                        MANUAL_INSTALL -> {
-                            JetpackConnectionWebViewActivity.startManualFlow(
-                                    activity,
-                                    source,
-                                    result.site,
-                                    result.loggedIn
-                            )
-                            activity.finish()
-                        }
-                        LOGIN -> {
-                            val loginIntent = Intent(activity, LoginActivity::class.java)
-                            LoginMode.JETPACK_STATS.putInto(loginIntent)
-                            loginIntent.putExtra(LoginActivity.ARG_JETPACK_CONNECT_SOURCE, source)
-                            startActivityForResult(loginIntent, JETPACK_LOGIN)
-                        }
-                        CONNECT -> {
-                            JetpackConnectionWebViewActivity.startJetpackConnectionFlow(
-                                    activity,
-                                    source,
-                                    result.site,
-                                    result.loggedIn
-                            )
-                            activity.finish()
-                        }
+                        MANUAL_INSTALL -> onManualInstallResultAction(activity, source, result)
+                        LOGIN -> onLoginResultAction(activity, source)
+                        CONNECT -> onConnectResultAction(activity, source, result)
                     }
                 }
             })
         }
+    }
+
+    private fun onManualInstallResultAction(
+        activity: FragmentActivity,
+        source: JetpackConnectionSource,
+        result: JetpackResultActionData
+    ) {
+        JetpackConnectionWebViewActivity.startManualFlow(
+                activity,
+                source,
+                result.site,
+                result.loggedIn
+        )
+        activity.finish()
+    }
+
+    private fun onLoginResultAction(
+        activity: FragmentActivity,
+        source: JetpackConnectionSource
+    ) {
+        val loginIntent = Intent(activity, LoginActivity::class.java)
+        LoginMode.JETPACK_STATS.putInto(loginIntent)
+        loginIntent.putExtra(LoginActivity.ARG_JETPACK_CONNECT_SOURCE, source)
+        startActivityForResult(loginIntent, JETPACK_LOGIN)
+    }
+
+    private fun onConnectResultAction(
+        activity: FragmentActivity,
+        source: JetpackConnectionSource,
+        result: JetpackResultActionData
+    ) {
+        JetpackConnectionWebViewActivity.startJetpackConnectionFlow(
+                activity,
+                source,
+                result.site,
+                result.loggedIn
+        )
+        activity.finish()
     }
 
     private fun JetpackRemoteInstallFragmentBinding.initLiveViewStateObserver() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -79,6 +79,7 @@ class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fr
         activity.finish()
     }
 
+    @Suppress("DEPRECATION")
     private fun onLoginResultAction(
         activity: FragmentActivity,
         source: JetpackConnectionSource
@@ -130,6 +131,7 @@ class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fr
         })
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == JETPACK_LOGIN && resultCode == Activity.RESULT_OK) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/PrivateAtCookieRefreshProgressDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/PrivateAtCookieRefreshProgressDialog.kt
@@ -25,6 +25,7 @@ class PrivateAtCookieRefreshProgressDialog : DialogFragment() {
         return dialog != null && dialog!!.isShowing
     }
 
+    @Suppress("DEPRECATION")
     override fun onCancel(dialog: DialogInterface) {
         super.onCancel(dialog)
         if (targetFragment is PrivateAtCookieProgressDialogOnDismissListener) {
@@ -41,6 +42,7 @@ class PrivateAtCookieRefreshProgressDialog : DialogFragment() {
             showIfNecessary(fragmentManager, null)
         }
 
+        @Suppress("DEPRECATION")
         fun showIfNecessary(fragmentManager: FragmentManager?, targetFragment: Fragment?) {
             fragmentManager?.let {
                 val thisFragment = fragmentManager.findFragmentByTag(TAG)

--- a/WordPress/src/main/java/org/wordpress/android/ui/PrivateAtCookieRefreshProgressDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/PrivateAtCookieRefreshProgressDialog.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui
 
 import android.app.Dialog
@@ -10,6 +12,7 @@ import androidx.fragment.app.FragmentManager
 import org.wordpress.android.R
 
 class PrivateAtCookieRefreshProgressDialog : DialogFragment() {
+    @Suppress("DEPRECATION")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialogMessage = activity?.getString(R.string.media_accessing_progress)
         return ProgressDialog.show(

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
@@ -66,7 +66,9 @@ public class ShareIntentReceiverFragment extends Fragment {
         }
     }
 
-    @Override public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+    @Override
+    @SuppressWarnings("deprecation")
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         // important for accessibility - talkback
         getActivity().setTitle(R.string.share_intent_screen_title);

--- a/WordPress/src/main/java/org/wordpress/android/ui/TextInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/TextInputDialogFragment.java
@@ -52,6 +52,7 @@ public class TextInputDialogFragment extends DialogFragment {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         LayoutInflater layoutInflater = LayoutInflater.from(getActivity());
         //noinspection InflateParams
@@ -112,7 +113,9 @@ public class TextInputDialogFragment extends DialogFragment {
         return alertDialog;
     }
 
-    @Override public void onDismiss(@NonNull DialogInterface dialog) {
+    @Override
+    @SuppressWarnings("deprecation")
+    public void onDismiss(@NonNull DialogInterface dialog) {
         super.onDismiss(dialog);
         if (getTargetFragment() instanceof Callback) {
             ((Callback) getTargetFragment()).onTextInputDialogDismissed(callbackId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginProloguePageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginProloguePageFragment.kt
@@ -1,13 +1,13 @@
 package org.wordpress.android.ui.accounts.login
 
 import android.os.Bundle
-import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.EditText
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
+import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import org.wordpress.android.R
 import org.wordpress.android.databinding.LoginIntroTemplateViewBinding
@@ -83,12 +83,18 @@ class LoginProloguePageFragment : Fragment(R.layout.login_intro_template_view) {
 
                 // format text from HTML to show bold on third prologue screen
                 if (promoLayoutId == R.layout.login_prologue_third) {
-                    view.findViewById<TextView>(R.id.text_one).text = Html.fromHtml(getString(
-                            R.string.login_prologue_third_subtitle_one))
-                    view.findViewById<TextView>(R.id.text_two).text = Html.fromHtml(getString(
-                            R.string.login_prologue_third_subtitle_two))
-                    view.findViewById<TextView>(R.id.text_three).text = Html.fromHtml(getString(
-                            R.string.login_prologue_third_subtitle_three))
+                    view.findViewById<TextView>(R.id.text_one).text = HtmlCompat.fromHtml(
+                            getString(R.string.login_prologue_third_subtitle_one),
+                            HtmlCompat.FROM_HTML_MODE_LEGACY
+                    )
+                    view.findViewById<TextView>(R.id.text_two).text = HtmlCompat.fromHtml(
+                            getString(R.string.login_prologue_third_subtitle_two),
+                            HtmlCompat.FROM_HTML_MODE_LEGACY
+                    )
+                    view.findViewById<TextView>(R.id.text_three).text = HtmlCompat.fromHtml(
+                            getString(R.string.login_prologue_third_subtitle_three),
+                            HtmlCompat.FROM_HTML_MODE_LEGACY
+                    )
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.accounts.signup;
 import android.os.Bundle;
 import android.os.Handler;
 import android.text.Editable;
-import android.text.Html;
 import android.text.Spanned;
 import android.text.SpannedString;
 import android.text.TextUtils;
@@ -17,6 +16,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.text.HtmlCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.SimpleItemAnimator;
@@ -381,9 +381,7 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
                     mUsernameSuggestionInput,
                     "</b>"
             );
-            mUsernameView.setError(Html.fromHtml(
-                    error
-            ));
+            mUsernameView.setError(HtmlCompat.fromHtml(error, HtmlCompat.FROM_HTML_MODE_LEGACY));
         } else {
             populateUsernameSuggestions(event.suggestions);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SettingsUsernameChangerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SettingsUsernameChangerFragment.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.accounts.signup
 
 import android.app.ProgressDialog
@@ -33,7 +35,7 @@ import org.wordpress.android.widgets.WPDialogSnackbar
  */
 class SettingsUsernameChangerFragment : BaseUsernameChangerFullScreenDialogFragment() {
     private lateinit var dialogController: FullScreenDialogController
-    private var progressDialog: ProgressDialog? = null
+    @Suppress("DEPRECATION") private var progressDialog: ProgressDialog? = null
 
     override fun getSuggestionsFailedStat() = ACCOUNT_SETTINGS_CHANGE_USERNAME_SUGGESTIONS_FAILED
     override fun canHeaderTextLiveUpdate() = false
@@ -154,6 +156,7 @@ class SettingsUsernameChangerFragment : BaseUsernameChangerFullScreenDialogFragm
         }
     }
 
+    @Suppress("DEPRECATION")
     fun showProgress() {
         if (progressDialog == null || progressDialog?.window == null || progressDialog?.isShowing == false) {
             progressDialog = ProgressDialog(context).apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -65,7 +65,6 @@ import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step;
 import org.wordpress.android.ui.photopicker.MediaPickerConstants;
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
-import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource;
 import org.wordpress.android.ui.prefs.AppPrefsWrapper;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
@@ -365,6 +364,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
@@ -378,8 +378,10 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                                         data.getStringArrayExtra(MediaPickerConstants.EXTRA_MEDIA_URIS);
 
                                 if (mediaUriStringsArray != null && mediaUriStringsArray.length > 0) {
-                                    PhotoPickerMediaSource source = PhotoPickerMediaSource.fromString(
-                                            data.getStringExtra(MediaPickerConstants.EXTRA_MEDIA_SOURCE));
+                                    PhotoPickerActivity.PhotoPickerMediaSource source =
+                                            PhotoPickerActivity.PhotoPickerMediaSource.fromString(
+                                                    data.getStringExtra(MediaPickerConstants.EXTRA_MEDIA_SOURCE)
+                                            );
                                     AnalyticsTracker.Stat stat =
                                             source == PhotoPickerActivity.PhotoPickerMediaSource.ANDROID_CAMERA
                                                     ? SIGNUP_EMAIL_EPILOGUE_GRAVATAR_SHOT_NEW

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragment.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.accounts.signup
 
 import android.os.Bundle
-import android.text.Html
 import android.text.Spanned
+import androidx.core.text.HtmlCompat
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.SIGNUP_SOCIAL_EPILOGUE_USERNAME_SUGGESTIONS_FAILED
 import org.wordpress.android.ui.FullScreenDialogFragment.FullScreenDialogController
@@ -13,7 +13,7 @@ import org.wordpress.android.ui.FullScreenDialogFragment.FullScreenDialogControl
 class UsernameChangerFullScreenDialogFragment : BaseUsernameChangerFullScreenDialogFragment() {
     override fun getSuggestionsFailedStat() = SIGNUP_SOCIAL_EPILOGUE_USERNAME_SUGGESTIONS_FAILED
     override fun canHeaderTextLiveUpdate() = true
-    override fun getHeaderText(username: String?, display: String?): Spanned = Html.fromHtml(
+    override fun getHeaderText(username: String?, display: String?): Spanned = HtmlCompat.fromHtml(
             String.format(
                     getString(R.string.username_changer_header),
                     "<b>",
@@ -22,7 +22,8 @@ class UsernameChangerFullScreenDialogFragment : BaseUsernameChangerFullScreenDia
                     "<b>",
                     display,
                     "</b>"
-            )
+            ),
+            HtmlCompat.FROM_HTML_MODE_LEGACY
     )
 
     override fun getTrackEventSource() = SOURCE

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
@@ -31,6 +31,7 @@ class ActivityLogDetailActivity : LocaleAwareActivity() {
         return super.onOptionsItemSelected(item)
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -95,6 +95,7 @@ class ActivityLogListActivity : LocaleAwareActivity(), ScrollableViewInitialized
         return super.onOptionsItemSelected(item)
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -107,6 +107,7 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
         }
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         with(requireActivity()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -8,7 +8,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
-import android.text.Html;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.HapticFeedbackConstants;
@@ -27,6 +26,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
@@ -825,7 +825,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
                           + ">"
                           + postTitle.trim()
                           + "</font>";
-            txtTitle.setText(Html.fromHtml(html));
+            txtTitle.setText(HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_LEGACY));
         } else {
             String text = getString(R.string.on) + " " + postTitle.trim();
             txtTitle.setText(text);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -198,6 +198,7 @@ public class CommentsDetailActivity extends LocaleAwareActivity
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void loadDataInViewPager() {
         if (mIsLoadingComments) {
             AppLog.w(AppLog.T.COMMENTS, "load comments task already active");

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -246,6 +246,7 @@ public class EditCommentActivity extends LocaleAwareActivity {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected Dialog onCreateDialog(int id) {
         if (id == ID_DIALOG_SAVING) {
             ProgressDialog savingDialog = new ProgressDialog(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentDetailsActivityContract.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentDetailsActivityContract.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.comments.unified
 
 import android.app.Activity
@@ -13,6 +15,7 @@ import org.wordpress.android.ui.comments.unified.CommentDetailsActivityContract.
 
 class CommentDetailsActivityContract : ActivityResultContract<CommentDetailsActivityRequest,
         CommentDetailsActivityResponse?>() {
+    @Suppress("DEPRECATION")
     override fun createIntent(context: Context, input: CommentDetailsActivityRequest): Intent {
         val detailIntent = Intent(context, CommentsDetailActivity::class.java)
         detailIntent.putExtra(CommentsDetailActivity.COMMENT_ID_EXTRA, input.commentId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -5,7 +5,6 @@ import android.app.ProgressDialog
 import android.content.Context
 import android.os.Bundle
 import android.text.Editable
-import android.text.Html
 import android.text.TextUtils
 import android.text.TextWatcher
 import android.text.method.LinkMovementMethod
@@ -13,6 +12,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
+import androidx.core.text.HtmlCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -164,12 +164,13 @@ class DomainRegistrationDetailsFragment : Fragment() {
 
     // make link to ToS clickable
     private fun DomainRegistrationDetailsFragmentBinding.setupTosLink() {
-        tosExplanation.text = Html.fromHtml(
+        tosExplanation.text = HtmlCompat.fromHtml(
                 String.format(
                         resources.getString(R.string.domain_registration_privacy_protection_tos),
                         "<u>",
                         "</u>"
-                )
+                ),
+                HtmlCompat.FROM_HTML_MODE_LEGACY
         )
         tosExplanation.movementMethod = LinkMovementMethod.getInstance()
         tosExplanation.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.domains
 
 import android.app.Dialog
@@ -65,7 +67,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
     private lateinit var viewModel: DomainRegistrationDetailsViewModel
     private lateinit var mainViewModel: DomainRegistrationMainViewModel
 
-    private var loadingProgressDialog: ProgressDialog? = null
+    @Suppress("DEPRECATION") private var loadingProgressDialog: ProgressDialog? = null
     private var binding: DomainRegistrationDetailsFragmentBinding? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -278,6 +280,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
                         } // Something else, will just show a Toast with an error message
                     }
                     affectedInputFields?.forEach {
+                        @Suppress("DEPRECATION")
                         showFieldError(it, StringEscapeUtils.unescapeHtml4(error?.message))
                     }
                     affectedInputFields?.firstOrNull { it.requestFocus() }
@@ -418,6 +421,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun showDomainRegistrationProgressDialog() {
         if (loadingProgressDialog == null) {
             loadingProgressDialog = ProgressDialog(context)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -373,12 +373,14 @@ class DomainRegistrationDetailsFragment : Fragment() {
         )
     }
 
+    @Suppress("DEPRECATION")
     private fun showStatePicker(states: List<SupportedStateResponse>) {
         val dialogFragment = StatePickerDialogFragment.newInstance(states.toCollection(ArrayList()))
         dialogFragment.setTargetFragment(this, 0)
         dialogFragment.show(requireFragmentManager(), StatePickerDialogFragment.TAG)
     }
 
+    @Suppress("DEPRECATION")
     private fun showCountryPicker(countries: List<SupportedDomainCountry>) {
         val dialogFragment = CountryPickerDialogFragment.newInstance(
                 countries.toCollection(
@@ -460,7 +462,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
                     as ArrayList<SupportedStateResponse>
         }
 
-        @Suppress("UseCheckOrError")
+        @Suppress("DEPRECATION", "UseCheckOrError")
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             if (targetFragment == null) {
                 throw IllegalStateException("StatePickerDialogFragment is missing a targetFragment ")
@@ -511,7 +513,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
                     as ArrayList<SupportedDomainCountry>
         }
 
-        @Suppress("UseCheckOrError")
+        @Suppress("DEPRECATION", "UseCheckOrError")
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             if (targetFragment == null) {
                 throw IllegalStateException("CountryPickerDialogFragment is missing a targetFragment ")

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
@@ -71,6 +71,7 @@ class DomainsDashboardFragment : Fragment(R.layout.domains_dashboard_fragment) {
         )
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (resultCode == RESULT_OK && requestCode == DOMAIN_REGISTRATION) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -207,6 +207,7 @@ public class HistoryDetailContainerFragment extends Fragment {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         showHistoryTimeStampInToolbar();

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -124,6 +124,7 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
         threatActionDialog?.show()
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (requireActivity().intent.extras?.containsKey(WordPress.SITE) != true) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
@@ -24,6 +24,7 @@ class MeActivity : LocaleAwareActivity() {
         return super.onOptionsItemSelected(item)
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.main
 
 import android.app.Activity
@@ -54,8 +56,7 @@ import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFra
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
-import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource
-import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource.ANDROID_CAMERA
+import org.wordpress.android.ui.photopicker.PhotoPickerActivity
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MAIN
@@ -82,7 +83,7 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
-    private var disconnectProgressDialog: ProgressDialog? = null
+    @Suppress("DEPRECATION") private var disconnectProgressDialog: ProgressDialog? = null
     private var isUpdatingGravatar = false
     private var binding: MeFragmentBinding? = null
 
@@ -433,6 +434,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         NotificationsUtils.cancelAllNotifications(requireActivity())
     }
 
+    @Suppress("DEPRECATION")
     private fun showDisconnectDialog() {
         disconnectProgressDialog = ProgressDialog.show(
                 requireContext(),
@@ -468,10 +470,14 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
                     )
                     return
                 }
-                val source = PhotoPickerMediaSource.fromString(
+                val source = PhotoPickerActivity.PhotoPickerMediaSource.fromString(
                         data.getStringExtra(MediaPickerConstants.EXTRA_MEDIA_SOURCE)
                 )
-                val stat = if (source == ANDROID_CAMERA) ME_GRAVATAR_SHOT_NEW else ME_GRAVATAR_GALLERY_PICKED
+                val stat = if (source == PhotoPickerActivity.PhotoPickerMediaSource.ANDROID_CAMERA) {
+                    ME_GRAVATAR_SHOT_NEW
+                } else {
+                    ME_GRAVATAR_GALLERY_PICKED
+                }
                 AnalyticsTracker.track(stat)
                 val imageUri = Uri.parse(mediaUriStringsArray[0])
                 if (imageUri != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -449,6 +449,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         disconnectProgressDialog = null
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -451,7 +451,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         disconnectProgressDialog = null
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "LongMethod", "NestedBlockDepth")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -654,6 +654,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         return changeSet;
     }
 
+    @SuppressWarnings("deprecation")
     void loadSites() {
         new LoadSitesTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
@@ -710,6 +711,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     /*
      * AsyncTask which loads sites from database and populates the adapter
      */
+    @SuppressWarnings("deprecation")
     @SuppressLint("StaticFieldLeak")
     private class LoadSitesTask extends AsyncTask<Void, Void, SiteList[]> {
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.main
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -17,9 +16,9 @@ import androidx.fragment.app.FragmentManager
 import com.google.android.material.bottomnavigation.BottomNavigationItemView
 import com.google.android.material.bottomnavigation.BottomNavigationMenuView
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import com.google.android.material.bottomnavigation.BottomNavigationView.OnNavigationItemReselectedListener
-import com.google.android.material.bottomnavigation.BottomNavigationView.OnNavigationItemSelectedListener
-import com.google.android.material.bottomnavigation.LabelVisibilityMode
+import com.google.android.material.navigation.NavigationBarView
+import com.google.android.material.navigation.NavigationBarView.OnItemReselectedListener
+import com.google.android.material.navigation.NavigationBarView.OnItemSelectedListener
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.main.WPMainActivity.OnScrollToTopListener
@@ -45,7 +44,7 @@ class WPMainNavigationView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : BottomNavigationView(context, attrs, defStyleAttr),
-        OnNavigationItemSelectedListener, OnNavigationItemReselectedListener {
+        OnItemSelectedListener, OnItemReselectedListener {
     private lateinit var navAdapter: NavAdapter
     private lateinit var fragmentManager: FragmentManager
     private lateinit var pageListener: OnPageListener
@@ -110,14 +109,13 @@ class WPMainNavigationView @JvmOverloads constructor(
         menu.removeItem(R.id.nav_reader)
     }
 
-    @SuppressLint("WrongConstant")
     private fun disableShiftMode() {
-        labelVisibilityMode = LabelVisibilityMode.LABEL_VISIBILITY_LABELED
+        labelVisibilityMode = NavigationBarView.LABEL_VISIBILITY_LABELED
     }
 
     private fun assignNavigationListeners(assign: Boolean) {
-        setOnNavigationItemSelectedListener(if (assign) this else null)
-        setOnNavigationItemReselectedListener(if (assign) this else null)
+        setOnItemSelectedListener(if (assign) this else null)
+        setOnItemReselectedListener(if (assign) this else null)
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/ExoPlayerUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/ExoPlayerUtils.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.media
 
 import android.content.Context
@@ -22,8 +24,8 @@ import org.wordpress.android.ui.utils.AuthenticationUtils
 import javax.inject.Inject
 
 @Reusable
-class ExoPlayerUtils
-@Inject constructor(
+@Suppress("DEPRECATION")
+class ExoPlayerUtils @Inject constructor(
     private val authenticationUtils: AuthenticationUtils,
     private val appContext: Context
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -173,7 +173,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         return super.onOptionsItemSelected(item)
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "LongMethod", "NestedBlockDepth")
     override fun onActivityResult(
         requestCode: Int,
         resultCode: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -173,6 +173,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         return super.onOptionsItemSelected(item)
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(
         requestCode: Int,
         resultCode: Int,
@@ -307,6 +308,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         finish()
     }
 
+    @Suppress("DEPRECATION")
     override fun onIconClicked(action: MediaPickerAction) {
         when (action) {
             is OpenSystemPicker -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -7,7 +7,6 @@ import android.content.Intent.ACTION_OPEN_DOCUMENT
 import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
-import android.text.Html
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -19,6 +18,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AlertDialog.Builder
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
+import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -426,7 +426,7 @@ class MediaPickerFragment : Fragment() {
     private fun MediaPickerFragmentBinding.setupSoftAskView(uiModel: SoftAskViewUiModel) {
         when (uiModel) {
             is SoftAskViewUiModel.Visible -> {
-                softAskView.title.text = Html.fromHtml(uiModel.label)
+                softAskView.title.text = HtmlCompat.fromHtml(uiModel.label, HtmlCompat.FROM_HTML_MODE_LEGACY)
                 softAskView.button.setText(uiModel.allowId.stringRes)
                 softAskView.button.setOnClickListener {
                     if (uiModel.isAlwaysDenied) {
@@ -460,11 +460,12 @@ class MediaPickerFragment : Fragment() {
                 actionableEmptyView.title.text = uiHelpers.getTextOfUiString(requireContext(), uiModel.title)
 
                 actionableEmptyView.subtitle.applyOrHide(uiModel.htmlSubtitle) { htmlSubtitle ->
-                    actionableEmptyView.subtitle.text = Html.fromHtml(
+                    actionableEmptyView.subtitle.text = HtmlCompat.fromHtml(
                             uiHelpers.getTextOfUiString(
                                     requireContext(),
                                     htmlSubtitle
-                            ).toString()
+                            ).toString(),
+                            HtmlCompat.FROM_HTML_MODE_LEGACY
                     )
                     actionableEmptyView.subtitle.movementMethod = WPLinkMovementMethod.getInstance()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -618,6 +618,7 @@ class MediaPickerFragment : Fragment() {
         viewModel.checkStoragePermission(isStoragePermissionAlwaysDenied)
     }
 
+    @Suppress("DEPRECATION")
     private fun requestStoragePermission() {
         val permissions = arrayOf(permission.WRITE_EXTERNAL_STORAGE, permission.READ_EXTERNAL_STORAGE)
         requestPermissions(
@@ -625,6 +626,7 @@ class MediaPickerFragment : Fragment() {
         )
     }
 
+    @Suppress("DEPRECATION")
     private fun requestCameraPermission() {
         // in addition to CAMERA permission we also need a storage permission, to store media from the camera
         val permissions = arrayOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceMediaLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceMediaLoader.kt
@@ -119,6 +119,7 @@ class DeviceMediaLoader
         )
     }
 
+    @Suppress("DEPRECATION")
     fun loadDocuments(filter: String?, pageSize: Int, limitDate: Long? = null): DeviceMediaList {
         val storagePublicDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
         val nextPage = (storagePublicDirectory?.listFiles() ?: arrayOf()).filter {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -313,6 +313,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         binding?.viewPager?.getCurrentFragment()?.onNegativeClicked(instanceTag)
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         /* Add brief delay before passing result to nested (view pager) tab fragments to give them time to get created.

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1,4 +1,4 @@
-@file:Suppress("MaximumLineLength")
+@file:Suppress("DEPRECATION", "MaximumLineLength")
 
 package org.wordpress.android.ui.mysite
 
@@ -83,8 +83,7 @@ import org.wordpress.android.ui.mysite.items.SiteItemsTracker
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
-import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource
-import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource.ANDROID_CAMERA
+import org.wordpress.android.ui.photopicker.PhotoPickerActivity
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Dismissed
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Negative
@@ -963,8 +962,13 @@ class MySiteViewModel @Inject constructor(
         quickStartTracker.track(Stat.QUICK_START_REMOVE_DIALOG_NEGATIVE_TAPPED)
     }
 
-    fun handleTakenSiteIcon(iconUrl: String?, source: PhotoPickerMediaSource?) {
-        val stat = if (source == ANDROID_CAMERA) Stat.MY_SITE_ICON_SHOT_NEW else Stat.MY_SITE_ICON_GALLERY_PICKED
+    @Suppress("DEPRECATION")
+    fun handleTakenSiteIcon(iconUrl: String?, source: PhotoPickerActivity.PhotoPickerMediaSource?) {
+        val stat = if (source == PhotoPickerActivity.PhotoPickerMediaSource.ANDROID_CAMERA) {
+            Stat.MY_SITE_ICON_SHOT_NEW
+        } else {
+            Stat.MY_SITE_ICON_GALLERY_PICKED
+        }
         analyticsTrackerWrapper.track(stat)
         val imageUri = Uri.parse(iconUrl)?.let { UriWrapper(it) }
         if (imageUri != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -197,7 +197,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         }
     }
 
-    @Suppress("LongMethod")
+    @Suppress("DEPRECATION", "LongMethod")
     private fun MySiteTabFragmentBinding.setupObservers() {
         viewModel.uiModel.observe(viewLifecycleOwner, { uiModel ->
             hideRefreshIndicatorIfNeeded()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.mysite.tabs
 
 import android.app.Activity
@@ -48,7 +50,7 @@ import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFra
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
-import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource
+import org.wordpress.android.ui.photopicker.PhotoPickerActivity
 import org.wordpress.android.ui.posts.BasicDialogViewModel
 import org.wordpress.android.ui.posts.BasicDialogViewModel.BasicDialogModel
 import org.wordpress.android.ui.posts.EditPostActivity.EXTRA_IS_LANDING_EDITOR_OPENED_FOR_NEW_SITE
@@ -472,7 +474,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
                                 MediaPickerConstants.EXTRA_MEDIA_URIS
                         ) ?: return
 
-                        val source = PhotoPickerMediaSource.fromString(
+                        val source = PhotoPickerActivity.PhotoPickerMediaSource.fromString(
                                 data.getStringExtra(MediaPickerConstants.EXTRA_MEDIA_SOURCE)
                         )
                         val iconUrl = mediaUriStringsArray.getOrNull(0) ?: return

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -448,7 +448,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         binding = null
     }
 
-    @Suppress("ReturnCount", "LongMethod", "ComplexMethod")
+    @Suppress("DEPRECATION", "ReturnCount", "LongMethod", "ComplexMethod")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (data == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -100,6 +100,7 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
         return view
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityCreated(bundle: Bundle?) {
         super.onActivityCreated(bundle)
         val listView = listView

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 /**
  * One fragment to rule them all (Notes, that is)
  */
@@ -186,6 +188,7 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
         super.onSaveInstanceState(outState)
     }
 
+    @Suppress("DEPRECATION")
     private fun reloadNoteBlocks() {
         LoadNoteBlocksTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR)
     }
@@ -314,6 +317,7 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
 
     // Loop through the 'body' items in this note, and create blocks for each.
     // TODO replace this inner async task with a coroutine
+    @Suppress("DEPRECATION")
     @SuppressLint("StaticFieldLeak")
     private inner class LoadNoteBlocksTask : AsyncTask<Void, Void, List<NoteBlock>?>() {
         private var mIsBadgeView = false
@@ -495,6 +499,7 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
             return hasRangeOfTypePost && hasRangeOfTypeSite
         }
 
+        @Suppress("DEPRECATION")
         private fun buildGeneratedLinkBlock(
             onNoteBlockTextClickListener: OnNoteBlockTextClickListener,
             pingbackUrl: String?,

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -4,13 +4,13 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
-import android.text.Html
 import android.text.TextUtils
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
@@ -108,8 +108,9 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
             viewPager.pageMargin = resources.getDimensionPixelSize(R.dimen.margin_extra_large)
             tabLayout.setupWithViewPager(viewPager)
 
-            jetpackTermsAndConditions.text = Html.fromHtml(
-                    String.format(resources.getString(R.string.jetpack_connection_terms_and_conditions), "<u>", "</u>")
+            jetpackTermsAndConditions.text = HtmlCompat.fromHtml(
+                    String.format(resources.getString(R.string.jetpack_connection_terms_and_conditions), "<u>", "</u>"),
+                    HtmlCompat.FROM_HTML_MODE_LEGACY
             )
             jetpackTermsAndConditions.setOnClickListener {
                 WPWebViewActivity.openURL(requireContext(), WPUrlUtils.buildTermsOfServiceUrl(context))

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.notifications
 
 import android.app.Activity
@@ -201,6 +203,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         }
     }
 
+    @Suppress("DEPRECATION")
     private class NotificationsFragmentAdapter(
         fragmentManager: FragmentManager,
         private val titles: List<String>

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -67,6 +67,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
     private var lastTabPosition = 0
     private var binding: NotificationsListFragmentBinding? = null
 
+    @Suppress("DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -80,6 +80,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         fun onClickNote(noteId: String?)
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         val adapter = createOrGetNotesAdapter()

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -97,6 +97,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         }
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == RequestCodes.NOTE_DETAIL) {
             shouldRefreshNotifications = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -253,7 +253,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
         // Subject is stored in db as html to preserve text formatting
         Spanned noteSubjectSpanned = note.getFormattedSubject(mNotificationsUtilsWrapper);
-        // Trim the '\n\n' added by Html.fromHtml()
+        // Trim the '\n\n' added by HtmlCompat.fromHtml(...)
         noteSubjectSpanned =
                 (Spanned) noteSubjectSpanned.subSequence(0, TextUtils.getTrimmedLength(noteSubjectSpanned));
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -349,12 +349,14 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         }
     }
 
+    @SuppressWarnings("deprecation")
     public void reloadNotesFromDBAsync() {
         cancelReloadNotesTask();
         mReloadNotesFromDBTask = new ReloadNotesFromDBTask();
         mReloadNotesFromDBTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
+    @SuppressWarnings("deprecation")
     @SuppressLint("StaticFieldLeak")
     private class ReloadNotesFromDBTask extends AsyncTask<Void, Void, ArrayList<Note>> {
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.notifications.blocks;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.text.Html;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -11,6 +10,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.text.HtmlCompat;
 import androidx.core.view.ViewCompat;
 
 import org.wordpress.android.R;
@@ -85,7 +85,10 @@ public class CommentUserNoteBlock extends UserNoteBlock {
 
     private void setUserName() {
         mNoteBlockHolder.mNameTextView.setText(
-                Html.fromHtml("<strong>" + getNoteText().toString() + "</strong>")
+                HtmlCompat.fromHtml(
+                        "<strong>" + getNoteText().toString() + "</strong>",
+                        HtmlCompat.FROM_HTML_MODE_LEGACY
+                )
         );
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -577,6 +577,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
     }
 }
 
+@Suppress("DEPRECATION")
 class PagesPagerAdapter(val context: Context, val fm: FragmentManager) : FragmentPagerAdapter(
         fm,
         BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -137,6 +137,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         binding = null
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == RequestCodes.EDIT_POST && resultCode == Activity.RESULT_OK && data != null) {
             if (EditPostActivity.checkToRestart(data)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.pages
 
 import android.annotation.SuppressLint
@@ -91,7 +93,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
     @Inject lateinit var uploadActionUseCase: UploadActionUseCase
     @Inject lateinit var uploadUtilsWrapper: UploadUtilsWrapper
 
-    private var progressDialog: ProgressDialog? = null
+    @Suppress("DEPRECATION") private var progressDialog: ProgressDialog? = null
 
     private var restorePreviousSearch = false
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteDialogFragment.kt
@@ -36,6 +36,7 @@ class PeopleInviteDialogFragment : DialogFragment() {
         (requireActivity().applicationContext as WordPress).component().inject(this)
     }
 
+    @Suppress("DEPRECATION")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         viewModel = ViewModelProvider(
                 targetFragment as ViewModelStoreOwner, viewModelFactory
@@ -78,6 +79,7 @@ class PeopleInviteDialogFragment : DialogFragment() {
 
         @JvmStatic
         @JvmOverloads
+        @Suppress("DEPRECATION")
         fun newInstance(
             fragment: Fragment,
             dialogMode: DialogMode,

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
@@ -34,6 +34,7 @@ public class RoleSelectDialogFragment extends DialogFragment {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         SiteModel site = (SiteModel) getArguments().getSerializable(WordPress.SITE);
         final List<RoleModel> inviteRoles = RoleUtils.getInviteRoles(mSiteStore, site, mContextProvider.getContext());
@@ -59,6 +60,7 @@ public class RoleSelectDialogFragment extends DialogFragment {
         return builder.create();
     }
 
+    @SuppressWarnings("deprecation")
     public static <T extends Fragment & OnRoleSelectListener> void show(T parentFragment, int requestCode,
                                                                         @NonNull SiteModel site) {
         RoleSelectDialogFragment roleChangeDialogFragment = new RoleSelectDialogFragment();

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
@@ -73,6 +73,7 @@ class MediaPickerLauncher @Inject constructor(
         activity.startActivityForResult(intent, RequestCodes.PHOTO_PICKER)
     }
 
+    @Suppress("DEPRECATION")
     fun showSiteIconPicker(
         fragment: Fragment,
         site: SiteModel?
@@ -127,6 +128,7 @@ class MediaPickerLauncher @Inject constructor(
         showStoriesPhotoPickerForResult(activity, site)
     }
 
+    @Suppress("DEPRECATION")
     fun showStoriesPhotoPickerForResult(
         activity: Activity,
         site: SiteModel?
@@ -134,6 +136,7 @@ class MediaPickerLauncher @Inject constructor(
         ActivityLauncher.showPhotoPickerForResult(activity, WP_STORIES_MEDIA_PICKER, site, null)
     }
 
+    @Suppress("DEPRECATION")
     fun showGravatarPicker(fragment: Fragment) {
         val mediaPickerSetup = MediaPickerSetup(
                 primaryDataSource = DEVICE,

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -4,12 +4,12 @@ import android.Manifest.permission
 import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
-import android.text.Html
 import android.view.View
 import android.widget.PopupMenu
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AlertDialog.Builder
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -194,7 +194,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
     private fun PhotoPickerFragmentBinding.setupSoftAskView(uiModel: SoftAskViewUiModel) {
         when (uiModel) {
             is SoftAskViewUiModel.Visible -> {
-                softAskView.title.text = Html.fromHtml(uiModel.label)
+                softAskView.title.text = HtmlCompat.fromHtml(uiModel.label, HtmlCompat.FROM_HTML_MODE_LEGACY)
                 softAskView.button.setText(uiModel.allowId.stringRes)
                 softAskView.button.setOnClickListener {
                     if (uiModel.isAlwaysDenied) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -408,6 +408,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
         viewModel.checkStoragePermission(isStoragePermissionAlwaysDenied)
     }
 
+    @Suppress("DEPRECATION")
     private fun requestStoragePermission() {
         val permissions = arrayOf(permission.WRITE_EXTERNAL_STORAGE)
         requestPermissions(
@@ -415,6 +416,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
         )
     }
 
+    @Suppress("DEPRECATION")
     private fun requestCameraPermission() {
         // in addition to CAMERA permission we also need a storage permission, to store media from the camera
         val permissions = arrayOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -7,7 +7,6 @@ import android.app.ProgressDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
-import android.text.Html;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -30,6 +29,7 @@ import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.appcompat.widget.Toolbar;
 import androidx.cardview.widget.CardView;
+import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentTransaction;
 
@@ -572,7 +572,8 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
         }
         mByLineTextView.setMovementMethod(WPLinkMovementMethod.getInstance());
         if (!TextUtils.isEmpty(mPlugin.getAuthorAsHtml())) {
-            mByLineTextView.setText(Html.fromHtml(mPlugin.getAuthorAsHtml()));
+            //noinspection ConstantConditions
+            mByLineTextView.setText(HtmlCompat.fromHtml(mPlugin.getAuthorAsHtml(), HtmlCompat.FROM_HTML_MODE_LEGACY));
         } else {
             String authorName = mPlugin.getAuthorName();
             String authorUrl = mPlugin.getAuthorUrl();
@@ -582,7 +583,7 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
                 String authorLink = "<a href='" + authorUrl + "'>" + authorName + "</a>";
                 String byline = String.format(getString(R.string.plugin_byline), authorLink);
                 mByLineTextView.setMovementMethod(WPLinkMovementMethod.getInstance());
-                mByLineTextView.setText(Html.fromHtml(byline));
+                mByLineTextView.setText(HtmlCompat.fromHtml(byline, HtmlCompat.FROM_HTML_MODE_LEGACY));
             }
         }
 
@@ -603,7 +604,8 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
         if (!TextUtils.isEmpty(htmlText)) {
             textView.setTextColor(ContextExtensionsKt.getColorFromAttribute(this, R.attr.colorOnSurface));
             textView.setMovementMethod(WPLinkMovementMethod.getInstance());
-            textView.setText(Html.fromHtml(htmlText));
+            //noinspection ConstantConditions
+            textView.setText(HtmlCompat.fromHtml(htmlText, HtmlCompat.FROM_HTML_MODE_LEGACY));
         } else {
             textView.setTextColor(
                     ContextExtensionsKt.getColorStateListFromAttribute(this, R.attr.wpColorOnSurfaceMedium));

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -80,6 +80,7 @@ public class PluginListFragment extends Fragment {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         // this enables us to clear the search icon in onCreateOptionsMenu when the list isn't showing search results

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -179,6 +179,7 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -456,6 +456,7 @@ class PostsListActivity : LocaleAwareActivity(),
         postListCreateMenuViewModel.onResume()
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.posts
 
 import android.app.Activity
@@ -105,7 +107,7 @@ class PostsListActivity : LocaleAwareActivity(),
 
     private var restorePreviousSearch = false
 
-    private var progressDialog: ProgressDialog? = null
+    @Suppress("DEPRECATION") private var progressDialog: ProgressDialog? = null
 
     private var onPageChangeListener: OnPageChangeListener = object : OnPageChangeListener {
         override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsPagerAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsPagerAdapter.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.posts
 
 import android.view.ViewGroup
@@ -7,6 +9,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import java.lang.ref.WeakReference
 
+@Suppress("DEPRECATION")
 class PostsPagerAdapter(
     private val pages: List<PostListType>,
     private val site: SiteModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/ProgressDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/ProgressDialogHelper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.posts
 
 import android.app.ProgressDialog
@@ -22,6 +24,7 @@ class ProgressDialogHelper @Inject constructor() {
      *
      * @return The resulting dialog with its (eventually) modified state. Can be {@code null}
      */
+    @Suppress("DEPRECATION")
     fun updateProgressDialogState(
         context: Context,
         dialog: ProgressDialog?,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.posts.services
 
 import android.content.Context
@@ -33,7 +35,7 @@ class AztecImageLoader(
     private val imageManager: ImageManager,
     private val loadingInProgress: Drawable
 ) : Html.ImageGetter {
-    private val targets = ArrayList<WeakReference<BaseTarget<Bitmap>>>()
+    @Suppress("DEPRECATION") private val targets = ArrayList<WeakReference<BaseTarget<Bitmap>>>()
     private val mRequestsInProgress = ArrayList<String>()
 
     override fun loadImage(url: String, callbacks: Html.ImageGetter.Callbacks, maxWidth: Int) {
@@ -43,7 +45,7 @@ class AztecImageLoader(
     override fun loadImage(url: String, callbacks: Html.ImageGetter.Callbacks, maxSize: Int, minWidth: Int) {
         mRequestsInProgress.add(url)
 
-        val target = object : BaseTarget<Bitmap>() {
+        @Suppress("DEPRECATION") val target = object : BaseTarget<Bitmap>() {
             override fun onLoadStarted(placeholder: Drawable?) {
                 callbacks.onImageLoading(loadingInProgress)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
@@ -47,6 +47,7 @@ public class AztecVideoLoader implements Html.VideoThumbnailGetter {
         new LoadAztecVideoTask(mContext, mAuthenticationUtils, url, maxWidth, callbacks).execute();
     }
 
+    @SuppressWarnings("deprecation")
     private static class LoadAztecVideoTask extends AsyncTask<Void, Void, Bitmap> {
         final String mUrl;
         final int mMaxWidth;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileFragment.java
@@ -139,6 +139,7 @@ public class MyProfileFragment extends Fragment implements TextInputDialogFragme
     }
 
     // helper method to create onClickListener to avoid code duplication
+    @SuppressWarnings("deprecation")
     private View.OnClickListener createOnClickListener(final String dialogTitle,
                                                        final String hint,
                                                        final WPTextView textView,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.prefs
 
 import android.os.Bundle
@@ -21,7 +23,7 @@ import androidx.lifecycle.coroutineScope
  * which supports the use of lifecycleCoroutineScope for observing Live data or Flows.
  * https://developer.android.com/topic/libraries/architecture/lifecycle#implementing-lco
  */
-@SuppressWarnings("deprecation")
+@Suppress("DEPRECATION")
 open class PreferenceFragmentLifeCycleOwner : PreferenceFragment(), LifecycleOwner {
     private lateinit var lifecycleRegistry: LifecycleRegistry
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -3,12 +3,12 @@ package org.wordpress.android.ui.prefs;
 import android.content.Context;
 import android.database.Cursor;
 import android.os.Handler;
-import android.text.Html;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.collection.SparseArrayCompat;
+import androidx.core.text.HtmlCompat;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -285,7 +285,10 @@ public abstract class SiteSettingsInterface {
         SparseArrayCompat<String> categoryNames = new SparseArrayCompat<>();
         if (mSettings.categories != null && mSettings.categories.length > 0) {
             for (CategoryModel model : mSettings.categories) {
-                categoryNames.put(model.id, Html.fromHtml(model.name).toString());
+                categoryNames.put(
+                        model.id,
+                        HtmlCompat.fromHtml(model.name, HtmlCompat.FROM_HTML_MODE_LEGACY).toString()
+                );
             }
         }
 
@@ -299,7 +302,7 @@ public abstract class SiteSettingsInterface {
     public @NonNull String getDefaultCategoryForDisplay() {
         for (CategoryModel model : getCategories()) {
             if (model != null && model.id == getDefaultCategory()) {
-                return Html.fromHtml(model.name).toString();
+                return HtmlCompat.fromHtml(model.name, HtmlCompat.FROM_HTML_MODE_LEGACY).toString();
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.prefs.accountsettings
 
 import android.app.ProgressDialog
@@ -67,7 +69,7 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
     private lateinit var primarySitePreference: DetailListPreference
     private lateinit var webAddressPreference: EditTextPreferenceWithValidation
     private lateinit var changePasswordPreference: EditTextPreferenceWithValidation
-    private var changePasswordProgressDialog: ProgressDialog? = null
+    @Suppress("DEPRECATION") private var changePasswordProgressDialog: ProgressDialog? = null
     private var emailSnackbar: Snackbar? = null
 
     @Deprecated("Deprecated")
@@ -318,6 +320,7 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
         changePasswordProgressDialog?.show()
     }
 
+    @Suppress("DEPRECATION")
     private fun createChangePasswordDialogIfNull() {
         if (changePasswordProgressDialog == null) {
             changePasswordProgressDialog = ProgressDialog(activity).apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailFragment.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.prefs.categories.detail
 
 import android.app.ProgressDialog
@@ -32,7 +34,7 @@ class CategoryDetailFragment : Fragment(R.layout.category_detail_fragment) {
     private lateinit var categoryAdapter: ParentCategorySpinnerAdapter
 
     private var spinnerTouched: Boolean = false
-    private var progressDialog: ProgressDialog? = null
+    @Suppress("DEPRECATION") private var progressDialog: ProgressDialog? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -146,6 +148,7 @@ class CategoryDetailFragment : Fragment(R.layout.category_detail_fragment) {
         categoryAdapter.replaceItems(categoryLevels)
     }
 
+    @Suppress("DEPRECATION")
     private fun showProgressDialog(@StringRes messageId: Int) {
         progressDialog = ProgressDialog(requireContext())
         progressDialog?.apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
@@ -110,6 +110,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -72,6 +72,7 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
         mServiceClickListener = listener;
     }
 
+    @SuppressWarnings("deprecation")
     public void refresh() {
         if (!mIsTaskRunning) {
             new LoadServicesTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
@@ -173,6 +174,7 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
         }
     }
 
+    @SuppressWarnings("deprecation")
     @SuppressLint("StaticFieldLeak")
     private class LoadServicesTask extends AsyncTask<Void, Void, Boolean> {
         private final PublicizeServiceList mTmpServices = new PublicizeServiceList();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -138,6 +138,7 @@ public class ReaderBlogFragment extends Fragment
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         mRecyclerView.setAdapter(getBlogAdapter());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFileDownloadManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFileDownloadManager.kt
@@ -23,6 +23,7 @@ class ReaderFileDownloadManager
         }
     }
 
+    @Suppress("DEPRECATION")
     fun downloadFile(fileUrl: String) {
         val request = downloadManager.buildRequest(fileUrl)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1257,6 +1257,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         }
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -339,6 +339,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun initAppBar(view: View) {
         appBar = view.findViewById(R.id.appbar_with_collapsing_toolbar_layout)
         toolBar = appBar.findViewById(R.id.toolbar_main)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1399,7 +1399,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         viewModel.onShowPost(blogId = blogId, postId = postId)
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "DEPRECATION")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onPrivateAtomicCookieFetched(event: OnPrivateAtomicCookieFetched) {
         if (!isAdded) {
@@ -1461,6 +1461,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         return false
     }
 
+    @Suppress("DEPRECATION")
     private fun ReaderPostDetailFragment.showPostInWebView(post: ReaderPost) {
         readerWebView.setIsPrivatePost(post.isPrivate)
         readerWebView.setBlogSchemeIsHttps(UrlUtils.isHttps(post.blogUrl))

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -419,7 +419,9 @@ public class ReaderPostListFragment extends ViewPagerFragment
         }
     }
 
-    @Override public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+    @Override
+    @SuppressWarnings("deprecation")
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         mViewModel = new ViewModelProvider(this, mViewModelFactory)
                 .get(ReaderPostListViewModel.class);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.text.Html;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -26,6 +25,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
+import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.RecyclerView;
@@ -1793,7 +1793,9 @@ public class ReaderPostListFragment extends ViewPagerFragment
             mActionableEmptyView.subtitle.setVisibility(View.VISIBLE);
 
             if (description.contains("<") && description.contains(">")) {
-                mActionableEmptyView.subtitle.setText(Html.fromHtml(description));
+                mActionableEmptyView.subtitle.setText(
+                        HtmlCompat.fromHtml(description, HtmlCompat.FROM_HTML_MODE_LEGACY)
+                );
             } else {
                 mActionableEmptyView.subtitle.setText(description);
             }
@@ -2666,9 +2668,13 @@ public class ReaderPostListFragment extends ViewPagerFragment
                 : blogName;
 
         if (blogId > 0) {
-            WPSnackbar.make(getSnackbarParent(), Html.fromHtml(getString(R.string.reader_followed_blog_notifications,
-                              "<b>", blog, "</b>")), Snackbar.LENGTH_LONG)
-                      .setAction(getString(R.string.reader_followed_blog_notifications_action),
+            WPSnackbar.make(getSnackbarParent(),
+                              HtmlCompat.fromHtml(
+                                      getString(R.string.reader_followed_blog_notifications, "<b>", blog, "</b>"),
+                                      HtmlCompat.FROM_HTML_MODE_LEGACY
+                              ),
+                              Snackbar.LENGTH_LONG
+                      ).setAction(getString(R.string.reader_followed_blog_notifications_action),
                               new View.OnClickListener() {
                                   @Override public void onClick(View view) {
                                       mReaderTracker.trackBlog(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -56,6 +56,7 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagD
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         mRecyclerView.setAdapter(getTagAdapter());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -90,6 +90,7 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mClickListener = listener;
     }
 
+    @SuppressWarnings("deprecation")
     public void refresh() {
         if (mIsTaskRunning) {
             AppLog.w(T.READER, "load blogs task is already running");
@@ -263,6 +264,7 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
     }
 
+    @SuppressWarnings("deprecation")
     @SuppressLint("StaticFieldLeak")
     private class LoadBlogsTask extends AsyncTask<Void, Void, Boolean> {
         private ReaderBlogList mTmpFollowedBlogs;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -232,6 +232,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         return position == 0 ? VIEW_TYPE_HEADER : VIEW_TYPE_COMMENT;
     }
 
+    @SuppressWarnings("deprecation")
     public void refreshComments() {
         if (mIsTaskRunning) {
             AppLog.w(T.READER, "reader comment adapter > Load comments task already running");
@@ -658,6 +659,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
      */
     private boolean mIsTaskRunning = false;
 
+    @SuppressWarnings("deprecation")
     @SuppressLint("StaticFieldLeak")
     private class LoadCommentsTask extends AsyncTask<Void, Void, Boolean> {
         private ReaderCommentList mTmpComments;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -633,6 +633,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         loadPosts();
     }
 
+    @SuppressWarnings("deprecation")
     private void loadPosts() {
         if (mIsTaskRunning) {
             AppLog.w(AppLog.T.READER, "reader posts task already running");
@@ -748,6 +749,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
      */
     private boolean mIsTaskRunning = false;
 
+    @SuppressWarnings("deprecation")
     @SuppressLint("StaticFieldLeak")
     private class LoadPostsTask extends AsyncTask<Void, Void, Boolean> {
         private ReaderPostList mAllPosts;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -66,6 +66,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
         return mWeakContext.get();
     }
 
+    @SuppressWarnings("deprecation")
     public void refresh() {
         if (mIsTaskRunning) {
             AppLog.w(T.READER, "tag task is already running");
@@ -153,6 +154,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
      */
     private boolean mIsTaskRunning = false;
 
+    @SuppressWarnings("deprecation")
     @SuppressLint("StaticFieldLeak")
     private class LoadTagsTask extends AsyncTask<Void, Void, ReaderTagList> {
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -221,6 +221,7 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
         return binding?.recyclerView
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == RequestCodes.SITE_PICKER && resultCode == Activity.RESULT_OK && data != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.reader.subfilter
 
 import android.content.Context
@@ -133,6 +135,7 @@ class SubfilterPageFragment : DaggerFragment() {
     }
 }
 
+@Suppress("DEPRECATION")
 class SubfilterPagerAdapter(
     val context: Context,
     val fm: FragmentManager,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderXPostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderXPostUtils.java
@@ -1,10 +1,10 @@
 package org.wordpress.android.ui.reader.utils;
 
 import android.net.Uri;
-import android.text.Html;
 import android.text.Spanned;
 
 import androidx.annotation.NonNull;
+import androidx.core.text.HtmlCompat;
 
 import org.wordpress.android.models.ReaderPost;
 
@@ -45,7 +45,7 @@ public class ReaderXPostUtils {
                 "<strong>" + getFromSiteName(post) + "</strong>",
                 "<strong>" + getToSiteName(post) + "</strong>");
 
-        return Html.fromHtml(subtitle);
+        return HtmlCompat.fromHtml(subtitle, HtmlCompat.FROM_HTML_MODE_LEGACY);
     }
 
     // origin site name can be extracted from the excerpt,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
@@ -109,6 +109,7 @@ public class ReaderLikingUsersView extends LinearLayout {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private static class LoadAvatarsTask extends AsyncTask<ReaderPost, Void, ArrayList<String>> {
         private final WeakReference<ReaderLikingUsersView> mViewReference;
         private final long mCurrentUserId;

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SearchInputWithHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SearchInputWithHeader.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.sitecreation.misc
 
 import android.content.Context
 import android.os.Handler
+import android.os.Looper
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
@@ -20,7 +21,7 @@ class SearchInputWithHeader(private val uiHelpers: UiHelpers, rootView: View, on
     private val progressBar = rootView.findViewById<View>(R.id.progress_bar)
     private val clearAllLayout = rootView.findViewById<View>(R.id.clear_all_layout)
     private val divider = rootView.findViewById<View>(R.id.divider)
-    private val showKeyboardHandler = Handler()
+    private val showKeyboardHandler = Handler(Looper.getMainLooper())
 
     var onTextChanged: ((String) -> Unit)? = null
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -83,6 +83,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
         }
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.stats
 
 import android.os.Bundle
-import android.text.Html
 import android.text.TextUtils
 import android.view.MenuItem
+import androidx.core.text.HtmlCompat
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.R.string
@@ -80,8 +80,9 @@ class StatsConnectJetpackActivity : LocaleAwareActivity() {
         jetpackFaq.setOnClickListener {
             WPWebViewActivity.openURL(this@StatsConnectJetpackActivity, FAQ_URL)
         }
-        jetpackTermsAndConditions.text = Html.fromHtml(
-                String.format(resources.getString(string.jetpack_connection_terms_and_conditions), "<u>", "</u>")
+        jetpackTermsAndConditions.text = HtmlCompat.fromHtml(
+                String.format(resources.getString(string.jetpack_connection_terms_and_conditions), "<u>", "</u>"),
+                HtmlCompat.FROM_HTML_MODE_LEGACY
         )
         jetpackTermsAndConditions.setOnClickListener {
             WPWebViewActivity.openURL(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -132,6 +132,7 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
         binding = null
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -71,7 +71,7 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
         return inflater.inflate(R.layout.stats_widget_configure_fragment, container, false)
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val nonNullActivity = requireActivity()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -71,6 +71,7 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
         return inflater.inflate(R.layout.stats_widget_configure_fragment, container, false)
     }
 
+    @Suppress("DEPRECATION")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val nonNullActivity = requireActivity()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -39,7 +39,7 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment(R.layout.stats_widge
     private lateinit var colorSelectionViewModel: StatsColorSelectionViewModel
     private lateinit var dataTypeSelectionViewModel: StatsDataTypeSelectionViewModel
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val nonNullActivity = requireActivity()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -39,6 +39,7 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment(R.layout.stats_widge
     private lateinit var colorSelectionViewModel: StatsColorSelectionViewModel
     private lateinit var dataTypeSelectionViewModel: StatsDataTypeSelectionViewModel
 
+    @Suppress("DEPRECATION")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val nonNullActivity = requireActivity()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -59,6 +59,7 @@ class BarChartAccessibilityHelper(
         return false
     }
 
+    @Suppress("DEPRECATION")
     override fun onPopulateNodeForVirtualView(
         virtualViewId: Int,
         node: AccessibilityNodeInfoCompat

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LineChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LineChartAccessibilityHelper.kt
@@ -61,6 +61,7 @@ class LineChartAccessibilityHelper(
         return false
     }
 
+    @Suppress("DEPRECATION")
     override fun onPopulateNodeForVirtualView(
         virtualViewId: Int,
         node: AccessibilityNodeInfoCompat

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -4,7 +4,6 @@ import android.app.ProgressDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
-import android.text.Html;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.view.MenuItem;
@@ -20,6 +19,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -318,7 +318,10 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
                 if (isEmpty) {
                     actionableEmptyView.title.setText(R.string.stock_media_picker_initial_empty_text);
                     String link = "<a href='https://pexels.com/'>Pexels</a>";
-                    Spanned html = Html.fromHtml(getString(R.string.stock_media_picker_initial_empty_subtext, link));
+                    Spanned html = HtmlCompat.fromHtml(
+                            getString(R.string.stock_media_picker_initial_empty_subtext, link),
+                            HtmlCompat.FROM_HTML_MODE_LEGACY
+                    );
                     actionableEmptyView.subtitle.setText(html);
                     actionableEmptyView.getSubtitle().setMovementMethod(WPLinkMovementMethod.getInstance());
                     actionableEmptyView.subtitle.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -297,7 +297,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         viewModel.writeToBundle(outState)
     }
 
-    @Suppress("NestedBlockDepth")
+    @Suppress("DEPRECATION", "NestedBlockDepth")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         viewModel.onStoryComposerAnalyticsSessionStartTimeReset()
         super.onActivityResult(requestCode, resultCode, data)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.stories
 
 import android.app.Activity
@@ -123,7 +125,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
 
     private lateinit var viewModel: StoryComposerViewModel
 
-    private var addingMediaToEditorProgressDialog: ProgressDialog? = null
+    @Suppress("DEPRECATION") private var addingMediaToEditorProgressDialog: ProgressDialog? = null
     private val frameIdsToRemove = ArrayList<String>()
 
     override fun getSite() = site

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -179,6 +179,7 @@ public class ThemeBrowserFragment extends Fragment
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -168,6 +168,7 @@ public class PostUploadHandler implements UploadHandler<PostModel>, OnAutoSavePo
         return sCurrentUploadingPost != null || !sQueuedPostsList.isEmpty();
     }
 
+    @SuppressWarnings("deprecation")
     private void uploadNextPost() {
         synchronized (sQueuedPostsList) {
             if (mCurrentTask == null) { // make sure nothing is running
@@ -197,6 +198,7 @@ public class PostUploadHandler implements UploadHandler<PostModel>, OnAutoSavePo
         PUSH_POST_DISPATCHED, ERROR, NOTHING_TO_UPLOAD, AUTO_SAVE_OR_UPDATE_DRAFT
     }
 
+    @SuppressWarnings("deprecation")
     @SuppressLint("StaticFieldLeak")
     private class UploadPostTask extends AsyncTask<PostModel, Boolean, UploadPostTaskResult> {
         private Context mContext;

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -98,6 +98,7 @@ class UiHelpers @Inject constructor() {
     }
 
     companion object {
+        @Suppress("DEPRECATION")
         fun adjustDialogSize(dialog: Dialog) {
             val window = requireNotNull(dialog.window)
             val size = Point()

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -389,6 +389,7 @@ public class WPMediaUtils {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private static Intent getLaunchCameraIntent(Context context, String applicationId, LaunchCameraCallback callback)
             throws IOException {
         File externalStoragePublicDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
@@ -8,12 +8,12 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.provider.Settings;
-import android.text.Html;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
+import androidx.core.text.HtmlCompat;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
@@ -199,7 +199,7 @@ public class WPPermissionUtils {
 
         AlertDialog.Builder builder = new MaterialAlertDialogBuilder(activity)
                 .setTitle(activity.getString(R.string.permissions_denied_title))
-                .setMessage(Html.fromHtml(message))
+                .setMessage(HtmlCompat.fromHtml(message, HtmlCompat.FROM_HTML_MODE_LEGACY))
                 .setPositiveButton(R.string.button_edit_permissions, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -5,13 +5,13 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.preference.PreferenceManager;
-import android.text.Html;
 import android.text.TextUtils;
 import android.webkit.MimeTypeMap;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.text.HtmlCompat;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -220,7 +220,10 @@ public class AnalyticsUtils {
     }
 
     public static int getWordCount(String content) {
-        String text = Html.fromHtml(content.replaceAll("<img[^>]*>", "")).toString();
+        String text = HtmlCompat.fromHtml(
+                content.replaceAll("<img[^>]*>", ""),
+                HtmlCompat.FROM_HTML_MODE_LEGACY
+        ).toString();
         return text.split("\\s+").length;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/DialogExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/DialogExtensions.kt
@@ -16,6 +16,7 @@ fun Dialog.getPreferenceDialogContainerView(): View? {
     return view
 }
 
+@Suppress("DEPRECATION")
 fun Dialog.setStatusBarAsSurfaceColor() {
     window?.apply {
         statusBarColor = context.getColorFromAttribute(attr.colorSurface)

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/WindowExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/WindowExtensions.kt
@@ -10,6 +10,7 @@ import android.view.Window
 import androidx.core.content.ContextCompat
 import org.wordpress.android.R
 
+@Suppress("DEPRECATION")
 fun Window.setLightStatusBar(showInLightMode: Boolean) {
     if (isLightTheme()) {
         decorView.systemUiVisibility = decorView.systemUiVisibility.let {
@@ -22,6 +23,7 @@ fun Window.setLightStatusBar(showInLightMode: Boolean) {
     }
 }
 
+@Suppress("DEPRECATION")
 fun Window.setLightNavigationBar(showInLightMode: Boolean, applyDefaultColors: Boolean = false) {
     if (isLightTheme() && VERSION.SDK_INT >= VERSION_CODES.O) {
         decorView.systemUiVisibility = decorView.systemUiVisibility.let {
@@ -41,6 +43,7 @@ fun Window.setLightNavigationBar(showInLightMode: Boolean, applyDefaultColors: B
     }
 }
 
+@Suppress("DEPRECATION")
 fun Window.showFullScreen() {
     decorView.systemUiVisibility = decorView.systemUiVisibility.let {
         it or SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or SYSTEM_UI_FLAG_LAYOUT_STABLE

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.util.image
 
 import android.app.Activity
@@ -438,6 +440,7 @@ class ImageManager @Inject constructor(
      * Use this method with caution and only when you necessarily need it(in other words, don't use it
      * when you need to load an image into an ImageView).
      */
+    @Suppress("DEPRECATION")
     fun loadIntoCustomTarget(viewTarget: ViewTarget<TextView, Drawable>, imageType: ImageType, imgUrl: String) {
         val context = WordPress.getContext()
         if (!context.isAvailable()) return
@@ -455,6 +458,7 @@ class ImageManager @Inject constructor(
      * Use this method with caution and only when you necessarily need it(in other words, don't use it
      * when you need to load an image into an ImageView).
      */
+    @Suppress("DEPRECATION")
     fun loadAsBitmapIntoCustomTarget(
         context: Context,
         target: BaseTarget<Bitmap>,
@@ -485,6 +489,7 @@ class ImageManager @Inject constructor(
      * Cancel any pending requests and free any resources that may have been
      * loaded for the view.
      */
+    @Suppress("DEPRECATION")
     fun <T : Any> cancelRequest(context: Context, target: BaseTarget<T>?) {
         GlideApp.with(context).clear(target)
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPCustomImageGetter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPCustomImageGetter.kt
@@ -15,7 +15,7 @@ import java.lang.ref.WeakReference
 import javax.inject.Inject
 
 /**
- * ImageGetter for Html.fromHtml(). Retrieves images for HTML img tags using Glide library.
+ * ImageGetter for HtmlCompat.fromHtml(...). Retrieves images for HTML img tags using Glide library.
  *
  *
  * See {@link android.text.Html} for more details.

--- a/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPRemoteResourceViewTarget.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/getters/WPRemoteResourceViewTarget.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.util.image.getters
 
 import android.annotation.SuppressLint
@@ -25,6 +27,7 @@ import org.wordpress.android.util.ImageUtils
  * It clears the View's Request when the View is detached from its Window and restarts the Request when the View is
  * re-attached from its Window.
  */
+@Suppress("DEPRECATION")
 internal class WPRemoteResourceViewTarget(
     view: TextView,
     private val maxSize: Int
@@ -114,6 +117,7 @@ internal class WPRemoteResourceViewTarget(
             drawable?.colorFilter = colorFilter
         }
 
+        @Suppress("DEPRECATION")
         override fun getOpacity(): Int {
             return drawable?.opacity ?: PixelFormat.UNKNOWN
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/signature/SignatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/signature/SignatureUtils.kt
@@ -9,7 +9,7 @@ import java.security.MessageDigest
 import javax.inject.Inject
 
 class SignatureUtils @Inject constructor() {
-    @Suppress("SwallowedException")
+    @Suppress("DEPRECATION", "SwallowedException")
     fun getSignatureHash(ctxt: Context, packageName: String): String {
         val md: MessageDigest = MessageDigest.getInstance("SHA-256")
         val sig: Signature = try {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.viewmodel.plugins
 
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -57,7 +58,7 @@ class PluginBrowserViewModel @Inject constructor(
 
     private var isStarted = false
 
-    private val handler = Handler()
+    private val handler = Handler(Looper.getMainLooper())
 
     private val _featuredPluginsLiveData = MutableLiveData<PluginListState>()
     private val _popularPluginsLiveData = MutableLiveData<PluginListState>()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -267,7 +267,7 @@ class PostListViewModel @Inject constructor(
         connectionStatus.observe(lifecycleOwner, Observer {
             retryOnConnectionAvailableAfterRefreshError()
         })
-        lifecycleOwner.lifecycleRegistry.markState(Lifecycle.State.CREATED)
+        lifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.CREATED
     }
 
     fun search(query: String?, delay: Long = SEARCH_DELAY_MS) {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialog.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.widgets
 
 import android.app.Dialog
@@ -70,6 +72,7 @@ object AppRatingDialog {
      * Show the rate dialog if the criteria is satisfied.
      * @return true if shown, false otherwise.
      */
+    @Suppress("DEPRECATION")
     fun showRateDialogIfNeeded(fragmentManger: FragmentManager): Boolean {
         return if (shouldShowRateDialog()) {
             showRateDialog(fragmentManger)
@@ -104,6 +107,7 @@ object AppRatingDialog {
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun showRateDialog(fragmentManger: FragmentManager) {
         var dialog = fragmentManger.findFragmentByTag(AppRatingDialog.TAG_APP_RATING_PROMPT_DIALOG)
         if (dialog == null) {
@@ -113,6 +117,7 @@ object AppRatingDialog {
         }
     }
 
+    @Suppress("DEPRECATION")
     class AppRatingDialog : DialogFragment() {
         companion object {
             internal const val TAG_APP_RATING_PROMPT_DIALOG = "TAG_APP_RATING_PROMPT_DIALOG"

--- a/WordPress/src/main/java/org/wordpress/android/widgets/NestedWebView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/NestedWebView.kt
@@ -5,7 +5,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.MotionEvent
-import androidx.core.view.MotionEventCompat
 import androidx.core.view.NestedScrollingChild3
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat
@@ -35,13 +34,12 @@ class NestedWebView @JvmOverloads constructor(
     override fun onTouchEvent(ev: MotionEvent): Boolean {
         var returnValue = false
         val event = MotionEvent.obtain(ev)
-        val action = MotionEventCompat.getActionMasked(event)
-        if (action == MotionEvent.ACTION_DOWN) {
+        if (event.actionMasked == MotionEvent.ACTION_DOWN) {
             nestedOffsetY = 0
         }
         val eventY = event.y.toInt()
         event.offsetLocation(0f, nestedOffsetY.toFloat())
-        when (action) {
+        when (event.actionMasked) {
             MotionEvent.ACTION_MOVE -> {
                 var totalScrollOffset = 0
                 var deltaY = lastY - eventY

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/services/AztecImageLoaderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/services/AztecImageLoaderTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.posts.services
 
 import android.content.Context
@@ -83,7 +85,7 @@ class AztecImageLoaderTest {
         whenever(imageManager.loadAsBitmapIntoCustomTarget(any(), any(), any(), any()))
                 .thenAnswer { invocation ->
                     run {
-                        @Suppress("UNCHECKED_CAST")
+                        @Suppress("DEPRECATION", "UNCHECKED_CAST")
                         (invocation.arguments[1] as BaseTarget<Bitmap>).onLoadFailed(mock(Drawable::class.java))
                     }
                 }
@@ -93,7 +95,7 @@ class AztecImageLoaderTest {
         whenever(imageManager.loadAsBitmapIntoCustomTarget(any(), any(), any(), any()))
                 .thenAnswer { invocation ->
                     run {
-                        @Suppress("UNCHECKED_CAST")
+                        @Suppress("DEPRECATION", "UNCHECKED_CAST")
                         (invocation.arguments[1] as BaseTarget<Bitmap>).onResourceReady(bitmap, null)
                     }
                 }
@@ -103,7 +105,7 @@ class AztecImageLoaderTest {
         whenever(imageManager.loadAsBitmapIntoCustomTarget(any(), any(), any(), any()))
                 .thenAnswer { invocation ->
                     run {
-                        @Suppress("UNCHECKED_CAST")
+                        @Suppress("DEPRECATION", "UNCHECKED_CAST")
                         (invocation.arguments[1] as BaseTarget<Bitmap>).onLoadStarted(mock(Drawable::class.java))
                     }
                 }

--- a/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.kt
@@ -125,6 +125,7 @@ class LoginPrologueFragment : Fragment(R.layout.login_signup_screen) {
         unifiedLoginTracker.setFlowAndStep(Flow.PROLOGUE, PROLOGUE)
     }
 
+    @Suppress("DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         // important for accessibility - talkback

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -72,7 +72,6 @@
     <ID>LongMethod:BarChartViewHolder.kt$BarChartViewHolder$private fun BarChart.draw( item: BarChartItem, labelStart: TextView, labelEnd: TextView ): BarCount</ID>
     <ID>LongMethod:ClicksUseCase.kt$ClicksUseCase$override fun buildUiModel(domainModel: ClicksModel, uiState: SelectedClicksGroup): List&lt;BlockListItem></ID>
     <ID>LongMethod:HomepageSettingsDialog.kt$HomepageSettingsDialog$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
-    <ID>LongMethod:MediaPickerActivity.kt$MediaPickerActivity$override fun onActivityResult( requestCode: Int, resultCode: Int, data: Intent? )</ID>
     <ID>LongMethod:MediaPickerFragment.kt$MediaPickerFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:MediaPickerViewModel.kt$MediaPickerViewModel$private fun buildUiModel( domainModel: DomainModel?, selectedIds: List&lt;Identifier>?, softAskRequest: SoftAskRequest?, isSearching: Boolean? ): PhotoListUiModel</ID>
     <ID>LongMethod:PhotoPickerFragment.kt$PhotoPickerFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
@@ -80,8 +79,6 @@
     <ID>LongMethod:PublishSettingsFragment.kt$PublishSettingsFragment$override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?</ID>
     <ID>LongMethod:ReferrersUseCase.kt$ReferrersUseCase$override fun buildUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List&lt;BlockListItem></ID>
     <ID>LongMethod:SearchListViewModel.kt$SearchListViewModel$private fun PageModel.toPageItem(areActionsEnabled: Boolean): PageItem</ID>
-    <ID>LongMethod:StatsMinifiedWidgetConfigureFragment.kt$StatsMinifiedWidgetConfigureFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
-    <ID>LongMethod:StatsWidgetConfigureFragment.kt$StatsWidgetConfigureFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:SuggestionActivity.kt$SuggestionActivity$private fun initializeActivity(siteModel: SiteModel, suggestionType: SuggestionType)</ID>
     <ID>LoopWithTooManyJumpStatements:RemoveMediaUseCase.kt$RemoveMediaUseCase$for (mediaId in mediaIds) { if (!TextUtils.isEmpty(mediaId)) { // make sure the MediaModel exists val mediaModel = try { mediaStore.getMediaWithLocalId(Integer.valueOf(mediaId)) ?: continue } catch (e: NumberFormatException) { AppLog.e(AppLog.T.MEDIA, "Invalid media id: $mediaId") continue } // also make sure it's not being uploaded anywhere else (maybe on some other Post, // simultaneously) if (mediaModel.uploadState != null &amp;&amp; mediaUtils.isLocalFile(mediaModel.uploadState.toLowerCase(Locale.ROOT)) &amp;&amp; !uploadService.isPendingOrInProgressMediaUpload(mediaModel)) { dispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(mediaModel)) } } }</ID>
     <ID>MagicNumber:ActivityViewHolder.kt$ActivityViewHolder$3</ID>
@@ -178,8 +175,6 @@
     <ID>NestedBlockDepth:AllTimeWidgetListViewModel.kt$AllTimeWidgetListViewModel$fun onDataSetChanged(onError: (appWidgetId: Int) -> Unit)</ID>
     <ID>NestedBlockDepth:CreatePageListItemActionsUseCase.kt$CreatePageListItemActionsUseCase$fun setupPageActions( listType: PageListType, uploadUiState: PostUploadUiState, siteModel: SiteModel, remoteId: Long ): Set&lt;Action></ID>
     <ID>NestedBlockDepth:LoadStoryFromStoriesPrefsUseCase.kt$LoadStoryFromStoriesPrefsUseCase$private fun loadOrReCreateStoryFromStoriesPrefs(site: SiteModel, mediaIds: ArrayList&lt;String>): ReCreateStoryResult</ID>
-    <ID>NestedBlockDepth:MeFragment.kt$MeFragment$override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?)</ID>
-    <ID>NestedBlockDepth:MediaPickerActivity.kt$MediaPickerActivity$override fun onActivityResult( requestCode: Int, resultCode: Int, data: Intent? )</ID>
     <ID>NestedBlockDepth:PublicizeErrorDialogFragment.kt$PublicizeErrorDialogFragment$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
     <ID>NestedBlockDepth:PublishNotificationReceiverViewModel.kt$PublishNotificationReceiverViewModel$fun loadNotification(notificationId: Int): NotificationUiModel?</ID>
     <ID>NestedBlockDepth:ReaderDiscoverLogic.kt$ReaderDiscoverLogic$private fun createSimplifiedRecommendedBlogsCardJson(originalCardJson: JSONObject): JSONObject</ID>


### PR DESCRIPTION
Parent: #17173
Partially Closes: #17181

This PR resolves one part of all `Deprecated` related warnings for the `WordPress` module, and in this part, the most generic ones and specific to the main source:

Main Source (About `247`)
- About `247` warnings x `'XYX' is deprecated. Deprecated in Java`

-----

Warnings Resolution List:

1. [Resolve from html deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/542ace1d56d3a6accb29c7fdf2ebe7c16cab46d3)
2. [Resolve on navigation (re) selected deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/11e6f278ab4326e627287cd0b65d32e95e2d1413)
3. [Resolve handler deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/7ee8cb30fdac64c7e098a6972bda3fe4e3932178)
4. [Resolve lifecycle registry mark state deprecated warning.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/a3be18f24ecf743800b54d106405ba62807fcfd9)
5. [Resolve nested web view get action masked deprecated warning.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/2f57fdc0c7e2acc2794fbb5e3d93bba5f15122ae)

Warnings Suppression List:

1. [Suppress on/start activity (for) result deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/103b90ccd3664c3295c772d2fcb4b119fc3750cd) (Associated Issue: #17249)
2. [Suppress set/get target fragment deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/7ddf2f631312ebf1043fa4dbba1c101f91c0d0b6) (Associated Issue: #17250)
6. [Suppress on activity created deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/6e32c33ccf1257205eff2df33f03838439438567) (Associated Issue: #17251)
7. [Suppress fragment pager adapter deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/623cf29516ed585831263f26c9493731121fac59) (Associated Issue: #17257)
8. [Suppress progress dialog deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/a1de9eb9aa55de319bc909432415e291ffcaa38d) (Associated Issue: #17258)
9. [Suppress comments detail activity deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/28bcef782d4541de127d0cfb1662669cc07cfb6e)
10. [Suppress exo player utils deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/567e63e0ad3d4487859eb0b9b339ce528384a70e) (Associated Issue: #17259)
11. [Suppress request permissions deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/4a037bef101a0e61d2bf69387285a0455a430aa6) (Associated Issue: #17249)
12. [Suppress get external storage public dir deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/f1e9bcd4ea0053bef7b21828c2d90df48d77d2f4) (Associated Issue: #17252)
13. [Suppress photo picker activity deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/7159db448c0ab5985353cffbb63cd0adbeac4215)
14. [Suppress async task deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/954bfaed48bf535db4825f90f9e73ff77ebac26f) (Associated Issue: #17260)
15. [Suppress glide deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/538e46c0a9586b9305f0eb920f473f41d317c4b2) (Associated Issue: #17261)
16. [Suppress allow scanning by media scanner deprecated warning.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/8c76d9e19118d6288256aab7f06598fa8dbe044a) (Associated Issue: #17252)
17. [Suppress window manager display/insets deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/a5b8e332aaa79f2bc99ad48e7d57abffab35e29e) (Associated Issue: #17256)
18. [Suppress fragment manager deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/75db65bced75dfbd53b0c34797eafa4e4024f6b9) (Associated Issue: #17253)
19. [Suppress set bound in parent deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/bff920f3e565a2860df1c95615d434c5132c5999) (Associated Issue: #17254)
20. [Suppress signature deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/3751b8fd5b676d97ddab3c02cd1e73d7cf265d2c) (Associated Issue: #17255)

Refactor List:

1. [Extract on result action functions for jetpack remote install.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/5970d09df0eb754399dd0a6b20942f8135c4ba66)
2. [Replace java with kotlin suppression for deprecation.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/897977a2dac84ffed576f789c58d02a4c95176fd)

In addition to the above warning resolution list, the below `Detekt` warnings got resolved as well, leaving Detekt's `baseline.xml` file 5 entries shorter:

1. [Resolve detekt warnings by manually updating the baseline.](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/7811dd138074056d0363c5644752d2b883cb6678)

-----

PS: @ovitrif  I added you as the main reviewer, that is, in addition to @wordpress-mobile/apps-infrastructure team itself, but randomly, since I want someone from the WordPress Android team to primarily sign-off on that change. 🥇

FYI: I am going to randomly add more of you in those PRs that will follow, just so you become more aware of this change and how close we are on enabling allWarningsAsErrors by default everywhere. 🎉

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could:
    - Quickly smoke test both, the `WordPress` and `Jetpack` apps, and see if they are both working as expected.
    - In addition to the above smoke testing, per the below class refactor, you could do some more targeted testing:
        - [WPMainNavigationView](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/11e6f278ab4326e627287cd0b65d32e95e2d1413):
            1. Make sure the `MySite`, `Reader` and `Notification` tab labels are shown on the selected navigation item.
            2. Add debugger and test the `MySite`, `Reader` and `Notification` tabs to make sure that when selecting a new tab, the `onNavigationItemSelected(...)` function is called, while when re-selecting the existing tab, the `onNavigationItemReselected(...)` function is called.
        - [PostListViewModel](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/a3be18f24ecf743800b54d106405ba62807fcfd9):
            1. Make sure the `Posts` screen works as expected.
        - [NestedWebView](https://github.com/wordpress-mobile/WordPress-Android/pull/17246/commits/2f57fdc0c7e2acc2794fbb5e3d93bba5f15122ae):
            1. Make sure the nested web view related screens and functionality is working as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

See the `targeted testing` part above, which is, within the `To test` section itself.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
