### PR TITLE
[DO NOT MERGE]: Add Swipe-able tabbed layout to Prompts List Screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1754,6 +1754,6 @@ public class ActivityLauncher {
     }
 
     public static void viewMorePrompts(@NonNull Context context, SiteModel site) {
-        BloggingPromptsActivity.start(context, site);
+        BloggingPromptsActivity.start(context, site.getSiteId());
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
@@ -5,27 +5,14 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import org.wordpress.android.WordPress
-import org.wordpress.android.databinding.BloggingPromptsListActivityBinding
-import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.databinding.BloggingPromptsActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
-import org.wordpress.android.util.AppLog
 
 class BloggingPromptsActivity : LocaleAwareActivity() {
-
-    private lateinit var site: SiteModel
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        setContentView(BloggingPromptsListActivityBinding.inflate(layoutInflater).root)
-
-        site = if (savedInstanceState == null) {
-            checkNotNull(intent.getSerializableExtra(WordPress.SITE) as? SiteModel) {
-                "SiteModel cannot be null, check the PendingIntent starting BloggingPromptsActivity"
-            }
-        } else {
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
-        }
+        val binding = BloggingPromptsActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -36,41 +23,21 @@ class BloggingPromptsActivity : LocaleAwareActivity() {
         return super.onOptionsItemSelected(item)
     }
 
-    override fun onNewIntent(intent: Intent) {
-        if (!intent.hasExtra(WordPress.SITE)) {
-            AppLog.e(AppLog.T.MY_SITE_DASHBOARD, "BloggingPromptsActivity started without a site.")
-            finish()
-            return
-        }
-        restartWhenSiteHasChanged(intent)
-        super.onNewIntent(intent)
-    }
-
-    private fun restartWhenSiteHasChanged(intent: Intent) {
-        val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-        if (site.id != this.site.id) {
-            finish()
-            startActivity(intent)
-            return
-        }
-    }
-
     companion object {
-
         @JvmStatic
         @JvmOverloads
         fun start(
             context: Context,
-            site: SiteModel,
-        ) = context.startActivity(buildIntent(context, site))
+            siteId: Long,
+        ) = context.startActivity(buildIntent(context, siteId))
 
         @JvmStatic
         @JvmOverloads
         fun buildIntent(
             context: Context,
-            site: SiteModel,
+            siteId: Long,
         ) = Intent(context, BloggingPromptsActivity::class.java).apply {
-            putExtra(WordPress.SITE, site)
+            putExtra(WordPress.LOCAL_SITE_ID, siteId)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListFragment.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import org.wordpress.android.databinding.BloggingPromptsListFragmentBinding
+import org.wordpress.android.ui.ViewPagerFragment
+
+class BloggingPromptsListFragment : ViewPagerFragment() {
+    private lateinit var binding: BloggingPromptsListFragmentBinding
+
+    override fun getScrollableViewForUniqueIdProvision(): View? = null
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        binding = BloggingPromptsListFragmentBinding.inflate(inflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val section = arguments?.getSerializable(LIST_TYPE) as? PromptSection
+                ?: PromptSection.ALL
+        binding.tempText.text = section.name
+    }
+
+    companion object {
+        const val LIST_TYPE = "type_key"
+
+        fun newInstance(section: PromptSection): BloggingPromptsListFragment {
+            val fragment = BloggingPromptsListFragment()
+            val bundle = Bundle()
+            bundle.putSerializable(LIST_TYPE, section)
+            fragment.arguments = bundle
+            return fragment
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsParentFragment.kt
@@ -1,0 +1,107 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
+import com.google.android.material.tabs.TabLayout.Tab
+import com.google.android.material.tabs.TabLayoutMediator
+import org.wordpress.android.R
+import org.wordpress.android.databinding.BloggingPromptsParentFragmentBinding
+import org.wordpress.android.ui.bloggingprompts.PromptSection.ALL
+import org.wordpress.android.ui.bloggingprompts.PromptSection.ANSWERED
+import org.wordpress.android.ui.bloggingprompts.PromptSection.NOT_ANSWERED
+
+class BloggingPromptsParentFragment : Fragment() {
+    private lateinit var binding: BloggingPromptsParentFragmentBinding
+
+    private val viewModel: BloggingPromptsParentViewModel by activityViewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        binding = BloggingPromptsParentFragmentBinding.inflate(inflater)
+        setupToolbar(binding)
+        setupTabLayout(binding)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.onOpen()
+    }
+
+    private fun setupToolbar(binding: BloggingPromptsParentFragmentBinding) {
+        with(binding) {
+            with(activity as AppCompatActivity) {
+                setSupportActionBar(toolbar)
+
+                title = getString(R.string.blogging_prompts_title)
+                supportActionBar?.setDisplayShowTitleEnabled(true)
+                supportActionBar?.setDisplayHomeAsUpEnabled(true)
+            }
+        }
+    }
+
+    private fun setupTabLayout(binding: BloggingPromptsParentFragmentBinding) {
+        with(binding) {
+            val adapter = BloggingPromptsPagerAdapter(this@BloggingPromptsParentFragment)
+            promptPager.adapter = adapter
+            TabLayoutMediator(tabLayout, promptPager) { tab, position ->
+                tab.text = adapter.getTabTitle(position)
+            }.attach()
+            tabLayout.addOnTabSelectedListener(SelectedTabListener(viewModel))
+        }
+    }
+
+    companion object {
+        const val LIST_TYPE = "type_key"
+
+        fun newInstance(section: PromptSection): BloggingPromptsParentFragment {
+            val fragment = BloggingPromptsParentFragment()
+            val bundle = Bundle()
+            bundle.putSerializable(LIST_TYPE, section)
+            fragment.arguments = bundle
+            return fragment
+        }
+    }
+}
+
+private val promptsSections = listOf(ALL, ANSWERED, NOT_ANSWERED)
+
+enum class PromptSection(@StringRes val titleRes: Int) {
+    ALL(R.string.blogging_prompts_tab_all),
+    ANSWERED(R.string.blogging_prompts_tab_answered),
+    NOT_ANSWERED(R.string.blogging_prompts_tab_not_answered)
+}
+
+class BloggingPromptsPagerAdapter(private val parent: BloggingPromptsParentFragment) : FragmentStateAdapter(parent) {
+    override fun getItemCount(): Int = promptsSections.size
+
+    override fun createFragment(position: Int): Fragment {
+        return BloggingPromptsListFragment.newInstance(promptsSections[position])
+    }
+
+    fun getTabTitle(position: Int): CharSequence {
+        return parent.context?.getString(promptsSections[position].titleRes).orEmpty()
+    }
+}
+
+private class SelectedTabListener(val viewModel: BloggingPromptsParentViewModel) : OnTabSelectedListener {
+    override fun onTabReselected(tab: Tab?) = Unit
+
+    override fun onTabUnselected(tab: Tab?) = Unit
+
+    override fun onTabSelected(tab: Tab) {
+        viewModel.onSectionSelected(promptsSections[tab.position])
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsParentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsParentViewModel.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import androidx.lifecycle.ViewModel
+
+class BloggingPromptsParentViewModel : ViewModel() {
+    fun onOpen() {
+        // TODO: Track page accessed
+    }
+
+    fun onSectionSelected(promptSection: PromptSection) {
+        // TODO: Track tab selection
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -222,7 +222,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val attribution: BloggingPromptAttribution,
                         val onShareClick: (String) -> Unit,
                         val onAnswerClick: (PromptID) -> Unit,
-                        val onSkipClick: () -> Unit
+                        val onSkipClick: () -> Unit,
+                        val onViewMorePrompts: () -> Unit
                     ) : BloggingPromptCard(dashboardCardType = DashboardCardType.BLOGGING_PROMPT_CARD)
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -95,6 +95,7 @@ sealed class MySiteCardAndItemBuilderParams {
         val bloggingPrompt: BloggingPromptModel?,
         val onShareClick: (message: String) -> Unit,
         val onAnswerClick: (promptId: Int) -> Unit,
-        val onSkipClick: () -> Unit
+        val onSkipClick: () -> Unit,
+        val onViewMorePrompts: () -> Unit
     ) : MySiteCardAndItemBuilderParams()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -461,7 +461,8 @@ class MySiteViewModel @Inject constructor(
                                 } else null,
                                 onShareClick = this::onBloggingPromptShareClick,
                                 onAnswerClick = this::onBloggingPromptAnswerClick,
-                                onSkipClick = this::onBloggingPromptSkipClicked
+                                onSkipClick = this::onBloggingPromptSkipClicked,
+                                onViewMorePrompts = this::onBloggingPromptViewMorePrompts
                         )
                 ),
                 QuickLinkRibbonBuilderParams(
@@ -1234,6 +1235,12 @@ class MySiteViewModel @Inject constructor(
             )
 
             _onSnackbarMessage.postValue(Event(snackbar))
+        }
+    }
+
+    private fun onBloggingPromptViewMorePrompts() {
+        selectedSiteRepository.getSelectedSite()?.let { site ->
+            _onNavigation.postValue(Event(SiteNavigationAction.ViewMorePrompts(site)))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
@@ -32,7 +32,8 @@ class BloggingPromptCardBuilder @Inject constructor() {
                 attribution = BloggingPromptAttribution.fromString(params.bloggingPrompt.attribution),
                 onShareClick = params.onShareClick,
                 onAnswerClick = params.onAnswerClick,
-                onSkipClick = params.onSkipClick
+                onSkipClick = params.onSkipClick,
+                onViewMorePrompts = params.onViewMorePrompts
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
@@ -92,7 +92,10 @@ class BloggingPromptCardViewHolder(
         val quickStartPopupMenu = PopupMenu(bloggingPromptCardMenu.context, bloggingPromptCardMenu)
         quickStartPopupMenu.setOnMenuItemClickListener {
             when (it.itemId) {
-                R.id.view_more -> bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuViewMorePromptsClicked()
+                R.id.view_more -> {
+                    bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuViewMorePromptsClicked()
+                    card.onViewMorePrompts.invoke()
+                }
                 R.id.skip -> {
                     bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuSkipThisPromptClicked()
                     card.onSkipClick.invoke()

--- a/WordPress/src/main/res/layout/blogging_prompts_activity.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_activity.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.fragment.app.FragmentContainerView
+    <fragment
         android:id="@+id/fragment_container"
+        android:name="org.wordpress.android.ui.bloggingprompts.BloggingPromptsParentFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-    <!-- TODO: android:name -->
+
 </FrameLayout>

--- a/WordPress/src/main/res/layout/blogging_prompts_list_fragment.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_list_fragment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/temp_text"
+        android:layout_width="wrap_content"
+        android:layout_gravity="center"
+        android:layout_height="wrap_content"
+        android:text="PROMPTS LIST PAGE" />
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/blogging_prompts_parent_fragment.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_parent_fragment.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/promptPager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        android:fitsSystemWindows="true">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:theme="@style/WordPress.ActionBar" />
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:layout_marginBottom="0dp"
+            android:background="@null"
+            android:clipToPadding="false"
+            app:tabGravity="fill"
+            app:tabMode="scrollable" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/menu/blogging_prompt_card_menu.xml
+++ b/WordPress/src/main/res/menu/blogging_prompt_card_menu.xml
@@ -4,7 +4,7 @@
         <item
             android:id="@+id/view_more"
             android:title="@string/my_site_blogging_prompt_card_menu_view_more"
-            android:visible="false" />
+            android:visible="true" />
         <item
             android:id="@+id/skip"
             android:title="@string/my_site_blogging_prompt_card_menu_skip" />

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4103,6 +4103,9 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_prompts_answer_prompt_notification_answer_action">Answer</string>
     <string name="blogging_prompts_notification_dismiss">Dismiss</string>
     <string name="blogging_prompts_title">Prompts</string>
+    <string name="blogging_prompts_tab_all">All</string>
+    <string name="blogging_prompts_tab_answered">Answered</string>
+    <string name="blogging_prompts_tab_not_answered">Not Answered</string>
 
     <!-- Editor module -->
     <string name="post_content" tools:ignore="UnusedResources" a8c-src-lib="module:editor">Content</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -251,6 +251,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private var onBloggingPromptShareClicked: ((message: String) -> Unit)? = null
     private var onBloggingPromptAnswerClicked: ((promptId: Int) -> Unit)? = null
     private var onBloggingPromptSkipClicked: (() -> Unit)? = null
+    private var onBloggingPromptViewMoreClicked: (() -> Unit)? = null
     private val quickStartCategory: QuickStartCategory
         get() = QuickStartCategory(
                 taskType = QuickStartTaskType.CUSTOMIZE,
@@ -1655,6 +1656,17 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given blogging prompt card, when view more prompts button is clicked, open prompt list page`() {
+        initSelectedSite()
+
+        requireNotNull(onBloggingPromptViewMoreClicked).invoke()
+
+        assertThat(navigationActions).containsOnly(
+                SiteNavigationAction.ViewMorePrompts(site)
+        )
+    }
+
+    @Test
     fun `given blogging prompt card, when skip button is clicked, prompt is skipped and undo snackbar displayed`() =
             test {
                 initSelectedSite()
@@ -2956,6 +2968,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         onBloggingPromptShareClicked = params.bloggingPromptCardBuilderParams.onShareClick
         onBloggingPromptAnswerClicked = params.bloggingPromptCardBuilderParams.onAnswerClick
         onBloggingPromptSkipClicked = params.bloggingPromptCardBuilderParams.onSkipClick
+        onBloggingPromptViewMoreClicked = params.bloggingPromptCardBuilderParams.onViewMorePrompts
         return BloggingPromptCardWithData(
                 prompt = UiStringText("Test prompt"),
                 respondents = emptyList(),
@@ -2965,7 +2978,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 attribution = BloggingPromptAttribution.DAY_ONE,
                 onShareClick = onBloggingPromptShareClicked as ((message: String) -> Unit),
                 onAnswerClick = onBloggingPromptAnswerClicked as ((promptId: Int) -> Unit),
-                onSkipClick = onBloggingPromptSkipClicked as (() -> Unit)
+                onSkipClick = onBloggingPromptSkipClicked as (() -> Unit),
+                onViewMorePrompts = onBloggingPromptViewMoreClicked as (() -> Unit)
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -188,7 +188,7 @@ class CardsBuilderTest {
                         todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                         postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                         bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
-                                mock(), mock(), mock(), mock()
+                                mock(), mock(), mock(), mock(), mock()
                         )
                 ),
                 quickLinkRibbonBuilderParams = QuickLinkRibbonBuilderParams(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -200,7 +200,7 @@ class CardsBuilderTest : BaseUnitTest() {
                         todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                         postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                         bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
-                                mock(), mock(), mock(), mock()
+                                mock(), mock(), mock(), mock(), mock()
                         )
                 )
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
@@ -84,12 +84,13 @@ class BloggingPromptCardBuilderTest : BaseUnitTest() {
     }
 
     private fun buildBloggingPromptCard(bloggingPrompt: BloggingPromptModel?) = builder.build(
-            BloggingPromptCardBuilderParams(bloggingPrompt, onShareClick, onAnswerClick, onSkipClick)
+            BloggingPromptCardBuilderParams(bloggingPrompt, onShareClick, onAnswerClick, onSkipClick, onViewMorePrompts)
     )
 
     private val onShareClick: (message: String) -> Unit = { }
     private val onAnswerClick: (promptId: Int) -> Unit = { }
     private val onSkipClick: () -> Unit = { }
+    private val onViewMorePrompts: () -> Unit = { }
 
     private val bloggingPromptCard = BloggingPromptCardWithData(
             prompt = UiStringText(PROMPT_TITLE),
@@ -100,6 +101,7 @@ class BloggingPromptCardBuilderTest : BaseUnitTest() {
             onShareClick = onShareClick,
             onAnswerClick = onAnswerClick,
             attribution = BloggingPromptAttribution.DAY_ONE,
-            onSkipClick = onSkipClick
+            onSkipClick = onSkipClick,
+            onViewMorePrompts = onViewMorePrompts
     )
 }


### PR DESCRIPTION
Fixes #17125 

**WARNING: DO NOT MERGE.** 
- This PR is still a work in progress.
- This PR should only be merged after #17241 is reviewed and approved. 

**To test:**
- Click on a tab to move to the correct fragment
- Swipe left and right to switch tabs
- Click back button on toolbar to close page
- Ensure the screen is retained on screen rotation

| Screenshot 1 | Screenshot 2 |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/2140539/193653570-91f7c804-0835-4ce6-bf0e-9fe50ac9260a.png)|  ![image](https://user-images.githubusercontent.com/2140539/193653882-ca8b3bcc-f12f-46a2-b286-2101f6b8b938.png)|

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.



