### PR TITLE
Merge editorialized release notes for 20.9

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -11,21 +11,20 @@ msgstr ""
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_209"
+msgid ""
+"20.9:\n"
+"- “Get to know your app” flows now stay on screen after rotating your device.\n"
+"- Long titles display properly on Stats cards without being cut off.\n"
+"- We added the Enter key to Post excerpts to allow for easy line breaks.\n"
+msgstr ""
+
 msgctxt "release_note_208"
 msgid ""
 "20.8:\n"
 "We added dynamic widgets to show at-a-glance, all-time, and daily stats on user devices’ home screens.\n"
 "Users on multi-author sites can change content authors in post and page settings.\n"
 "Arabic language users will see numerals on Stats screens exclusively in Western Arabic numbers.\n"
-msgstr ""
-
-msgctxt "release_note_207"
-msgid ""
-"20.7:\n"
-"- Jetpack widgets are now available on your device’s home screen\n"
-"- Media preview controls are visible in both light and dark mode\n"
-"- Compose theme’s Login Code screen has better color contrast\n"
-"- Certain elements of the editor and post settings are now WordPress blue\n"
 msgstr ""
 
 #. translators: Title to be displayed in the Play Store. Limit to 30 characters including spaces and commas!

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,5 +1,3 @@
-* [***] [internal] Redesigned the landing screen of the WordPress and Jetpack apps, behind a feature flag. [https://github.com/wordpress-mobile/WordPress-Android/pull/17203]
-* [**] [internal] Added sensor feedback to influence the speed of the scrolling large text on the redesigned Jetpack landing screen based on the vertical rotation of the device. [https://github.com/wordpress-mobile/WordPress-Android/pull/17207]
-* [*] Quick Start: Retain Quick Start focus point after device rotation [https://github.com/wordpress-mobile/WordPress-Android/pull/17187]
-* [*] Stats: Fix Long title problem on stats cards [https://github.com/wordpress-mobile/WordPress-Android/pull/17084]
-* [*] Support "Enter" key for Excerpt editing in Post settings [https://github.com/wordpress-mobile/WordPress-Android/pull/17078]
+- “Get to know your app” flows now stay on screen after rotating your device.
+- Long titles display properly on Stats cards without being cut off.
+- We added the Enter key to Post excerpts to allow for easy line breaks.

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -11,19 +11,19 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_209"
+msgid ""
+"20.9:\n"
+"- “Get to know your app” flows now stay on screen after rotating your device.\n"
+"- Long titles display properly on Stats cards without being cut off.\n"
+"- We added the Enter key to Post excerpts to allow for easy line breaks.\n"
+msgstr ""
+
 msgctxt "release_note_208"
 msgid ""
 "20.8:\n"
 "Users on multi-author sites can change content authors in post and page settings.\n"
 "Arabic language users will now see numerals on Stats screens exclusively in Western Arabic numbers—no more mix and match with Eastern Arabic numbers.\n"
-msgstr ""
-
-msgctxt "release_note_207"
-msgid ""
-"20.7:\n"
-"We can see clearly now—media preview controls (like the back button) are now visible in both light and dark mode.\n"
-"\n"
-"The Login Code screen in the Compose theme also has better color contrast for more readable text. Shiny.\n"
 msgstr ""
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,4 +1,3 @@
-* [***] [internal] Redesigned the landing screen of the WordPress and Jetpack apps, behind a feature flag. [https://github.com/wordpress-mobile/WordPress-Android/pull/17203]
-* [*] Quick Start: Retain Quick Start focus point after device rotation [https://github.com/wordpress-mobile/WordPress-Android/pull/17187]
-* [*] Stats: Fix Long title problem on stats cards [https://github.com/wordpress-mobile/WordPress-Android/pull/17084]
-* [*] Support "Enter" key for Excerpt editing in Post settings [https://github.com/wordpress-mobile/WordPress-Android/pull/17078]
+- “Get to know your app” flows now stay on screen after rotating your device.
+- Long titles display properly on Stats cards without being cut off.
+- We added the Enter key to Post excerpts to allow for easy line breaks.


### PR DESCRIPTION
- [x] `PlayStoreStrings.po` changed with editorialized release notes