### PR TITLE
[UI Tests] - Update emulator version

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.support.BaseTest
 class AppInitializerTest : BaseTest() {
     @Test
     fun verifyOnAppComesFromBackgroundCalled() {
+        Thread.sleep(500)
         assertFalse(WordPress.appIsInTheBackground)
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.support.BaseTest
 class AppInitializerTest : BaseTest() {
     @Test
     fun verifyOnAppComesFromBackgroundCalled() {
-        Thread.sleep(500)
+        Thread.sleep(100)
         assertFalse(WordPress.appIsInTheBackground)
     }
 }

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -25,7 +25,7 @@ platform :android do
      project_id: firebase_secret(name: 'project_id'),
      key_file: GOOGLE_FIREBASE_SECRETS_PATH,
      model: 'Pixel2.arm',
-     version: 32,
+     version: 30,
      test_apk_path: File.join(apk_dir, 'androidTest', 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug-androidTest.apk'),
      apk_path: File.join(apk_dir, 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug.apk'),
      test_targets: 'notPackage org.wordpress.android.ui.screenshots',

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -24,8 +24,8 @@ platform :android do
    android_firebase_test(
      project_id: firebase_secret(name: 'project_id'),
      key_file: GOOGLE_FIREBASE_SECRETS_PATH,
-     model: 'Pixel2',
-     version: 28,
+     model: 'Pixel2.arm',
+     version: 32,
      test_apk_path: File.join(apk_dir, 'androidTest', 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug-androidTest.apk'),
      apk_path: File.join(apk_dir, 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug.apk'),
      test_targets: 'notPackage org.wordpress.android.ui.screenshots',


### PR DESCRIPTION
### What does this do
This PR updates the emulator version that is being used to run instrumented tests on FTL from API 28 (Android 9) to API 30 (Android 11). 

### Testing
UI tests should pass locally and in CI