### PR TITLE
Revamp Jetpack Landing Screen - Use orientation angle approach for text scrolling speed

### DIFF
--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedViewModel.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedViewModel.kt
@@ -28,7 +28,6 @@ class LoginPrologueRevampedViewModel @Inject constructor(
     private val magnetometerData = FloatArray(3)
     private val rotationMatrix = FloatArray(9)
     private val orientationAngles = floatArrayOf(0f, DEFAULT_PITCH, 0f)
-    private var velocity = 0f
     private var position = 0f
 
     /**
@@ -43,12 +42,13 @@ class LoginPrologueRevampedViewModel @Inject constructor(
      */
     fun updateForFrame(elapsed: Float) {
         orientationAngles.let { (_, pitch) ->
-            velocity = pitch * VELOCITY_FACTOR
-        }
-        // Update the position, modulo 1 (ensuring a value greater or equal to 0, and less than 1)
-        position = ((position + elapsed * velocity) % 1 + 1) % 1
+            val velocity = pitch * VELOCITY_FACTOR
 
-        _positionData.postValue(position)
+            // Update the position, modulo 1 (ensuring a value greater or equal to 0, and less than 1)
+            position = ((position + elapsed * velocity) % 1 + 1) % 1
+
+            _positionData.postValue(position)
+        }
     }
 
     /** This LiveData responds to accelerometer data from the y-axis of the device and emits updated position data. */

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedViewModel.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedViewModel.kt
@@ -17,9 +17,6 @@ import kotlin.math.PI
 // composables.
 private const val VELOCITY_FACTOR = (0.2 / (PI / 2)).toFloat()
 
-// An additional velocity applied to make the text scroll when the device is flat on a table
-private const val DRIFT = -0.01f
-
 // Default pitch provided for devices lacking support for the sensors used
 private const val DEFAULT_PITCH = (-30 * PI / 180).toFloat()
 
@@ -46,7 +43,7 @@ class LoginPrologueRevampedViewModel @Inject constructor(
      */
     fun updateForFrame(elapsed: Float) {
         orientationAngles.let { (_, pitch) ->
-            velocity = pitch * VELOCITY_FACTOR + DRIFT
+            velocity = pitch * VELOCITY_FACTOR
         }
         // Update the position, modulo 1 (ensuring a value greater or equal to 0, and less than 1)
         position = ((position + elapsed * velocity) % 1 + 1) % 1

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedViewModel.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedViewModel.kt
@@ -13,11 +13,22 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.math.PI
 
-// This factor is used to convert the raw values emitted from device sensor to an appropriate scale for the consuming
-// composables.
+/**
+ * This factor is used to convert the raw values emitted from device sensor to an appropriate scale for the consuming
+ * composables. The range for pitch values is -π/2 to π/2, representing an upright pose and an upside-down pose,
+ * respectively. E.g. Setting this factor to 0.2 / (π/2) will scale this output range to -0.2 to 0.2. The resulting
+ * product is interpreted in units proportional to the repeating child composable's height per second, i.e. at a
+ * velocity of 0.1, it will take 10 seconds for the looping animation to repeat. When applied, the product can also be
+ * thought of as a frequency value in Hz.
+ */
 private const val VELOCITY_FACTOR = (0.2 / (PI / 2)).toFloat()
 
-// Default pitch provided for devices lacking support for the sensors used
+/**
+ * This is the default pitch provided for devices lacking support for the sensors used. This is consumed by the model
+ * as a value in radians, but is specified here as -30 degrees for convenience. This represents a device pose that is
+ * slightly upright from flat, approximating a typical usage pattern, and will ensure that the text is animated at
+ * an appropriate velocity when sensors are unavailable.
+ */
 private const val DEFAULT_PITCH = (-30 * PI / 180).toFloat()
 
 @HiltViewModel
@@ -51,7 +62,10 @@ class LoginPrologueRevampedViewModel @Inject constructor(
         }
     }
 
-    /** This LiveData responds to accelerometer data from the y-axis of the device and emits updated position data. */
+    /**
+     * This LiveData responds to orientation data to calculate the pitch of the device. This is then used to update the
+     * velocity and position for each frame.
+     */
     private val _positionData = object : MutableLiveData<Float>(), SensorEventListener {
         private val sensorManager
             get() = appContext.getSystemService(Context.SENSOR_SERVICE) as SensorManager


### PR DESCRIPTION
This PR improves the physics model for the scrolling text animation on the new Jetpack Landing Screen in terms of responsiveness.

The main concern we're addressing here is the translation of device pose into the scrolling speed of the large text, which on the previous model got us close to a "dead end" considering we wanted to get a slower baseline speed (I.e. the speed of the animation in the normal device rotation that is somewhere between `-30°` and `-60°`).

We felt the previous model was constraining us in terms of freedom over the range of rotation that influences the scrolling speed (see Internal reference: p1664942369291519-slack-C03TPENB2BB).

To test:

<details>
<summary><b>Prerequisite</b> - Enable the <code>LandingScreenRevamp</code> feature flag</summary>

- Either `login` → `Me` → `App Settings` → `Debug Settings` → enable `LandingScreenRevamp` → `RESTART THE APP` → `logout` or
- Apply this hard-coded solution:

<details>
<summary>Patch to enable the <code>LANDING_SCREEN_REVAMP</code> build flag</summary>

```diff
diff --git a/WordPress/build.gradle b/WordPress/build.gradle
index 63260a4ca8..fe999fa92f 100644
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -112,7 +112,7 @@ android {
         buildConfigField "boolean", "READER_COMMENTS_MODERATION", "false"
         buildConfigField "boolean", "SITE_INTENT_QUESTION", "true"
         buildConfigField "boolean", "SITE_NAME", "false"
-        buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "false"
+        buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "true"
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
         buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"
```  
</details>

---

</details>

##### 1️⃣ Test Case 1: Happy Flow

1. Open the JP app and make sure you're logged out
2. Make sure you're holding the device in your hand slightly rotated vertically, as illustrated:
   <img width="100" src="https://user-images.githubusercontent.com/4588074/191999204-611285aa-9bc0-4cdc-8384-bed2ef6f07ff.png">
3. **Expect** the large text on the new login screen to scroll down by default at an speed that makes the text readable
4. Lay the device flat on your office table
5. **Expect** The text to **not** scroll
6. Pick up the device and rotate it vertically inverse than in the illustration (top of the phone should be below its bottom)
7. **Expect** The text to scroll **up**

##### 2️⃣ Test Case 2: Sensors disabled

1. Enable developer mode:
   `Settings` → `About phone / emulated device` → tap `Build number` 7 times
2. Enable `Sensors Off quick setting:
   `Go to `Settings` → `System` → `Developer options` → `Quick settings developer tiles` tap `Sensors Off`
3. Toggle Sensors off:
   Swipe down from the top of the screen and tap `Sensors Off`
4. Open the JP app and make sure you're logged out
5. **Expect** the large text to scroll down at a speed similar to the normal position speed when sensors are enabled
   (Test Case 1️⃣: Step 3)

##### 3️⃣ Test Case 3: No sensors

1. Apply this patch to simulate missing sensors on the device:

```diff
diff --git a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedViewModel.kt b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedViewModel.kt
index e7dc8e9b37..74d857e632 100644
--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedViewModel.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedViewModel.kt
@@ -59,10 +59,10 @@ class LoginPrologueRevampedViewModel @Inject constructor(
         override fun onActive() {
             super.onActive()
             sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)?.also {
-                sensorManager.registerListener( this, it, SensorManager.SENSOR_DELAY_GAME)
+//                sensorManager.registerListener( this, it, SensorManager.SENSOR_DELAY_GAME)
             }
             sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)?.also {
-                sensorManager.registerListener( this, it, SensorManager.SENSOR_DELAY_GAME)
+//                sensorManager.registerListener( this, it, SensorManager.SENSOR_DELAY_GAME)
             }
         }
```

2. Open the JP app and make sure you're logged out
3. **Expect** the large text to scroll down at a speed similar to the normal position speed when sensors  are enabled 
   (Test Case 1️⃣: Step 3)

<details>
<summary><h4>🎬 Video Preview</h4></summary>

https://user-images.githubusercontent.com/4588074/194008692-9e66cd6b-f150-45f6-b126-18f1f44edaa5.mp4

- Initially the device is rotated to `-45°` (reflecting a normal use position)
- At second `6` the device is rotated to `-90°` (reflecting flat on table position)
- At second `13` the device is rotated to `0°` fully vertical position)
- At second `22` the device is rotated to `-135°` (inverted rotation that triggers reverse scrolling)
---

</details>

## Regression Notes
1. Potential unintended areas of impact
   The New Jetpack Landing Screen when sensors are not available.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Tested manually different configs: sensors disabled & missing.
   Added test cases for disabled / missing sensors.

3. What automated tests I added (or what prevented me from doing so)
   N/a.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.