### PR TITLE
[UITTI] Renamed UI tests to make them appear in group in FTL tests list.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.java
@@ -39,7 +39,7 @@ public class BlockEditorTests extends BaseTest {
                        + "<!-- /wp:image --></div>\n";
 
     @Test
-    public void publishSimplePost() {
+    public void e2ePublishSimplePost() {
         String title = "publishSimplePost";
 
         new MySitesPage()
@@ -55,7 +55,7 @@ public class BlockEditorTests extends BaseTest {
     }
 
     @Test
-    public void publishFullPost() {
+    public void e2ePublishFullPost() {
         String title = "publishFullPost";
 
         new MySitesPage()
@@ -75,7 +75,7 @@ public class BlockEditorTests extends BaseTest {
     }
 
     @Test
-    public void blockEditorCanDisplayElementAddedInHtmlMode() {
+    public void e2eBlockEditorCanDisplayElementAddedInHtmlMode() {
         String title = "blockEditorCanDisplayElementAddedInHtmlMode";
 
         new MySitesPage()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -20,7 +20,7 @@ public class ContactUsTests extends BaseTest {
 
     @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
     @Test
-    public void sendButtonEnabledWhenTextIsEntered() {
+    public void e2eSendButtonEnabledWhenTextIsEntered() {
         try {
             new LoginFlow()
                 .chooseContinueWithWpCom()
@@ -40,7 +40,7 @@ public class ContactUsTests extends BaseTest {
 
     @Ignore("As long as CI does not use gradle.properties from MobileSecrets")
     @Test
-    public void messageCanBeSent() {
+    public void e2eMessageCanBeSent() {
         String userMessageText = "Please ignore, this is an automated test.";
         String automatedReplyText = "Mobile support will respond as soon as possible, "
                                     + "generally within 48-96 hours. "
@@ -62,7 +62,7 @@ public class ContactUsTests extends BaseTest {
     }
 
     @Test
-    public void helpCanBeOpenedWhileEnteringEmail() {
+    public void e2eHelpCanBeOpenedWhileEnteringEmail() {
         new LoginFlow()
                 .chooseContinueWithWpCom()
                 .tapHelp()
@@ -70,7 +70,7 @@ public class ContactUsTests extends BaseTest {
     }
 
     @Test
-    public void helpCanBeOpenedWhileEnteringPassword() {
+    public void e2eHelpCanBeOpenedWhileEnteringPassword() {
         new LoginFlow()
                 .chooseContinueWithWpCom()
                 .enterEmailAddress(E2E_WP_COM_USER_EMAIL)

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/EditorTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/EditorTests.java
@@ -56,7 +56,7 @@ public class EditorTests extends BaseTest {
     // For more info see Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/14389
     @Ignore("Classic Editor being deprecated for new posts, test should be adjusted to editing existing classic post")
     @Test
-    public void testPublishSimplePost() {
+    public void e2ePublishSimplePostClassic() {
         String title = "Hello Espresso!";
         String content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
 
@@ -70,7 +70,7 @@ public class EditorTests extends BaseTest {
     // For more info see Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/14389
     @Ignore("Classic Editor being deprecated for new posts, test should be adjusted to editing existing classic post")
     @Test
-    public void testPublishFullPost() {
+    public void e2ePublishFullPostClassic() {
         String title = "Hello Espresso!";
         String content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
                          + "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud "

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -26,7 +26,7 @@ public class LoginTests extends BaseTest {
 
     @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
     @Test
-    public void loginWithEmailPassword() {
+    public void e2eLoginWithEmailPassword() {
         new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword(E2E_WP_COM_USER_PASSWORD)
@@ -35,7 +35,7 @@ public class LoginTests extends BaseTest {
 
     @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
     @Test
-    public void loginWithPasswordlessAccount() {
+    public void e2eLoginWithPasswordlessAccount() {
         new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress(E2E_WP_COM_PASSWORDLESS_USER_EMAIL)
                        .openMagicLink()
@@ -43,7 +43,7 @@ public class LoginTests extends BaseTest {
     }
 
     @Test
-    public void loginWithSiteAddress() {
+    public void e2eLoginWithSiteAddress() {
         new LoginFlow().chooseEnterYourSiteAddress()
                        .enterSiteAddress(E2E_WP_COM_USER_SITE_ADDRESS)
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
@@ -53,7 +53,7 @@ public class LoginTests extends BaseTest {
 
     @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
     @Test
-    public void loginWithMagicLink() {
+    public void e2eLoginWithMagicLink() {
         new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .chooseMagicLink()
@@ -62,7 +62,7 @@ public class LoginTests extends BaseTest {
     }
 
     @Test
-    public void loginWithSelfHostedAccount() {
+    public void e2eLoginWithSelfHostedAccount() {
         new LoginFlow().chooseEnterYourSiteAddress()
                        .enterSiteAddress(E2E_SELF_HOSTED_USER_SITE_ADDRESS)
                        .enterUsernameAndPassword(E2E_SELF_HOSTED_USER_USERNAME, E2E_SELF_HOSTED_USER_PASSWORD)

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ReaderTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ReaderTests.java
@@ -5,7 +5,9 @@ import android.Manifest.permission;
 import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.Test;
 import org.wordpress.android.e2e.pages.ReaderPage;
 import org.wordpress.android.support.BaseTest;
 
@@ -26,8 +28,9 @@ public class ReaderTests extends BaseTest {
     String mCoachingPostTitle = "Let's check out the coaching team!";
     String mCompetitionPostTitle = "Let's focus on the competition.";
 
-//    @Test
-    public void navigateThroughPosts() {
+    @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
+    @Test
+    public void e2eNavigateThroughPosts() {
         new ReaderPage()
                 .tapFollowingTab()
                 .openPost(mCoachingPostTitle)
@@ -39,8 +42,9 @@ public class ReaderTests extends BaseTest {
                 .goBackToReader();
     }
 
-//    @Test
-    public void likePost() {
+    @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
+    @Test
+    public void e2eLikePost() {
         new ReaderPage()
                 .tapFollowingTab()
                 .openPost(mCoachingPostTitle)

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -26,7 +26,7 @@ public class SignUpTests extends BaseTest {
     }
 
     @Test
-    public void signUpWithMagicLink() {
+    public void e2eSignUpWithMagicLink() {
         new SignupFlow().chooseContinueWithWpCom()
                         .enterEmail(E2E_SIGNUP_EMAIL)
                         .openMagicLink()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.java
@@ -38,7 +38,7 @@ public class StatsTests extends BaseTest {
     }
 
     @Test
-    public void allDayStatsLoad() {
+    public void e2eAllDayStatsLoad() {
         StatsVisitsData todayVisits = new StatsVisitsData("97", "28", "14", "11");
         List<StatsKeyValueData> postsList = new StatsMocksReader().readDayTopPostsToList();
         List<StatsKeyValueData> referrersList = new StatsMocksReader().readDayTopReferrersToList();


### PR DESCRIPTION
### Why
Both Unit Tests and UI Tests run as a part of `Instrumented Tests` task on FTL. Generally, Unit Tests start with `test` prefix (but not _always_), and also two old UI tests started with `test`. In result, the list of executed tests on FTL was mixed:

![SCR-20221005-gh4](https://user-images.githubusercontent.com/73365754/194021441-1aab9d75-7580-4669-aecd-9cd09a678c3e.png)

Since UI tests have a higher tendency for failures than Unit Tests, seeing the UI tests in the list first is the goal of this PR.

### How
By adding a prefix. Ideally, something like `ui` would be perfect, but unfortunately `u` comes after a `t` in the alphabet, which would mean scrolling through dozens of Unit Tests to see the UI tests. So, **I went for `e2e` prefix, about which I'm not sure**, because our UI tests are not E2E tests (they are not using real API). Any suggestions are welcomed.

### Testing instructions
- Check that [related FTL execution](https://console.firebase.google.com/u/1/project/api-project-108380595987/testlab/histories/bh.b3d1e88d8b09c8be/matrices/5518398317396088298/details?stepId=bs.42f8d3183ecd7dfd&testCaseId=29) has UI tests grouped, and now they can be filtered by using the `e2e` keyword.