### PR TITLE
Fix NullPointerException in SharedLoginResolver

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolver.kt
@@ -30,10 +30,13 @@ class SharedLoginResolver @Inject constructor(
     private val sharedLoginAnalyticsTracker: SharedLoginAnalyticsTracker
 ) {
     fun tryJetpackLogin() {
-        val isAlreadyLoggedIn = accountStore.accessToken.isNotEmpty()
-        val isFirstTry = appPrefsWrapper.getIsFirstTrySharedLoginJetpack()
         val isFeatureFlagEnabled = jetpackSharedLoginFlag.isEnabled()
-        if (isAlreadyLoggedIn || !isFirstTry || !isFeatureFlagEnabled) {
+        if (!isFeatureFlagEnabled) {
+            return
+        }
+        val isAlreadyLoggedIn = accountStore.hasAccessToken()
+        val isFirstTry = appPrefsWrapper.getIsFirstTrySharedLoginJetpack()
+        if (isAlreadyLoggedIn || !isFirstTry) {
             return
         }
         sharedLoginAnalyticsTracker.trackLoginStart()

--- a/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
@@ -71,7 +71,7 @@ class SharedLoginResolverTest {
     @Test
     fun `Should NOT query ContentResolver if feature flag is DISABLED`() {
         whenever(appPrefsWrapper.getIsFirstTrySharedLoginJetpack()).thenReturn(true)
-        whenever(accountStore.accessToken).thenReturn(notLoggedInToken)
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
         whenever(jetpackSharedLoginFlag.isEnabled()).thenReturn(false)
         classToTest.tryJetpackLogin()
         verify(contentResolverWrapper, never()).queryUri(contentResolver, uriValue)
@@ -80,7 +80,7 @@ class SharedLoginResolverTest {
     @Test
     fun `Should NOT query ContentResolver if IS already logged in`() {
         whenever(appPrefsWrapper.getIsFirstTrySharedLoginJetpack()).thenReturn(true)
-        whenever(accountStore.accessToken).thenReturn(loggedInToken)
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackSharedLoginFlag.isEnabled()).thenReturn(true)
         classToTest.tryJetpackLogin()
         verify(contentResolverWrapper, never()).queryUri(contentResolver, uriValue)
@@ -89,7 +89,7 @@ class SharedLoginResolverTest {
     @Test
     fun `Should NOT query ContentResolver if IS NOT the first try`() {
         whenever(appPrefsWrapper.getIsFirstTrySharedLoginJetpack()).thenReturn(false)
-        whenever(accountStore.accessToken).thenReturn(notLoggedInToken)
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
         whenever(jetpackSharedLoginFlag.isEnabled()).thenReturn(true)
         classToTest.tryJetpackLogin()
         verify(contentResolverWrapper, never()).queryUri(contentResolver, uriValue)
@@ -128,7 +128,7 @@ class SharedLoginResolverTest {
     @Test
     fun `Should NOT track login start if IS already logged in`() {
         whenever(appPrefsWrapper.getIsFirstTrySharedLoginJetpack()).thenReturn(true)
-        whenever(accountStore.accessToken).thenReturn(loggedInToken)
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackSharedLoginFlag.isEnabled()).thenReturn(true)
         classToTest.tryJetpackLogin()
         verify(sharedLoginAnalyticsTracker, never()).trackLoginStart()
@@ -137,7 +137,7 @@ class SharedLoginResolverTest {
     @Test
     fun `Should NOT track login start if feature flag is DISABLED`() {
         whenever(appPrefsWrapper.getIsFirstTrySharedLoginJetpack()).thenReturn(true)
-        whenever(accountStore.accessToken).thenReturn(notLoggedInToken)
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
         whenever(jetpackSharedLoginFlag.isEnabled()).thenReturn(false)
         classToTest.tryJetpackLogin()
         verify(sharedLoginAnalyticsTracker, never()).trackLoginStart()
@@ -146,7 +146,7 @@ class SharedLoginResolverTest {
     @Test
     fun `Should NOT track login start if IS NOT the first try`() {
         whenever(appPrefsWrapper.getIsFirstTrySharedLoginJetpack()).thenReturn(false)
-        whenever(accountStore.accessToken).thenReturn(notLoggedInToken)
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
         whenever(jetpackSharedLoginFlag.isEnabled()).thenReturn(true)
         classToTest.tryJetpackLogin()
         verify(sharedLoginAnalyticsTracker, never()).trackLoginStart()
@@ -181,7 +181,7 @@ class SharedLoginResolverTest {
 
     private fun featureEnabled() {
         whenever(appPrefsWrapper.getIsFirstTrySharedLoginJetpack()).thenReturn(true)
-        whenever(accountStore.accessToken).thenReturn(notLoggedInToken)
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
         whenever(jetpackSharedLoginFlag.isEnabled()).thenReturn(true)
     }
 }


### PR DESCRIPTION
This PR cherry pick changes from #17262 to be merged in the 20.9 release branch. Reporting below instructions from that original PR for convenience.

Fixes this line:
```
val isAlreadyLoggedIn = accountStore.accessToken.isNotEmpty()
```
There's at least one scenario where `accountStore.accessToken` returns `null`, which was causing the line above to crash. I've replaced that call with `accountStore.hasAccessToken()`, which uses the safe call `!TextUtils.isEmpty(mToken)` and also moved the feature flag check to be the first thing in the method, so we have more control over this feature.

To test:
The testing steps are the same as #17059:

### 1 - To test WordPress installed and logged in
1 - Install WordPress and login
2 - [Set the flag `isFeatureFlagEnabled`](https://github.com/wordpress-mobile/WordPress-Android/pull/17059/files#diff-90a223fc6cd4e93f8b73c9f73663fcd96d804b4acbc420af6be322bac2388948R32) to `true` (this cannot be done using the `Debug settings` screen because that is only available when the user is already logged in)
2 - Install Jetpack using the same variant (e.g. if installed WordPress version was `jalapenoDebug`, install Jetpack `jalapenoDebug`)
3 - Jetpack should login automatically after launching, and home screen should be shown. Actions only available to logged in users should be working (e.g. liking a comment, creating a new post, etc.)
4 - Log out of Jetpack. Close the app and open it again: login screen should be shown and it should NOT login automatically.

### 2 - To test WordPress installed and NOT logged in
1 - Install WordPress and don't login
2 - Install Jetpack using the same variant (e.g. if installed WordPress version was `jalapenoDebug`, install Jetpack `jalapenoDebug`)
3 - The login screen for Jetpack should be shown but it should NOT login automatically.

### 3 - To test WordPress NOT installed
1 - Make sure WordPress is not installed
2 - Install Jetpack (any variant)
3 - The login screen for Jetpack should be shown but it should NOT login automatically.

### 4 - To test Shared Login flag turned off
1 - Revert the change made in the feature flag (see step 1) so it is off (it's off by default).
2 - Install WP and log in. The login should work as it is in production right now (show site list and main screen after that).
3 - Install JP and log in.  The login should work as it is in production right now (show site list and main screen after that).

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit testing.

3. What automated tests I added (or what prevented me from doing so)
Updated `SharedLoginResolverTest.kt`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
