### PR TITLE
[Blogging Reminders Sync] Implement blogging reminders provider

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/bloggingreminders/provider/BloggingRemindersProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/bloggingreminders/provider/BloggingRemindersProvider.kt
@@ -1,0 +1,71 @@
+package org.wordpress.android.bloggingreminders.provider
+
+import android.database.Cursor
+import android.net.Uri
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.BloggingRemindersModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.BloggingRemindersStore
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.provider.query.QueryContentProvider
+import org.wordpress.android.provider.query.QueryResult
+import org.wordpress.android.util.publicdata.ClientVerification
+import org.wordpress.android.util.signature.SignatureNotFoundException
+import javax.inject.Inject
+
+typealias SiteModelBloggingReminderMap = Map<SiteModel, BloggingRemindersModel>
+
+class BloggingRemindersProvider : QueryContentProvider() {
+    @Inject lateinit var bloggingRemindersStore: BloggingRemindersStore
+    @Inject lateinit var siteStore: SiteStore
+    @Inject lateinit var queryResult: QueryResult
+    @Inject lateinit var clientVerification: ClientVerification
+
+    override fun onCreate(): Boolean {
+        return true
+    }
+
+    @Suppress("SwallowedException")
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?
+    ): Cursor? {
+        inject()
+        return context?.let {
+            try {
+                if (clientVerification.canTrust(callingPackage)) {
+                    runBlocking {
+                        val allSiteModels = siteStore.sites
+                        val filteredBloggingReminders = allSiteModels.map { siteModel ->
+                            bloggingRemindersStore.bloggingRemindersModel(siteModel.id).first()
+                        }.filter { bloggingRemindersModel ->
+                            bloggingRemindersModel.enabledDays.isNotEmpty()
+                        }
+                        val filteredSiteIds = filteredBloggingReminders.map { bloggingReminder ->
+                            bloggingReminder.siteId
+                        }
+                        val filteredSiteModels = allSiteModels.filter { siteModel ->
+                            filteredSiteIds.contains(siteModel.id)
+                        }
+                        val result: SiteModelBloggingReminderMap =
+                                filteredSiteModels.zip(filteredBloggingReminders).toMap()
+                        queryResult.createCursor(result)
+                    }
+                } else null
+            } catch (signatureNotFoundException: SignatureNotFoundException) {
+                null
+            }
+        }
+    }
+
+    private fun inject() {
+        if (!this::bloggingRemindersStore.isInitialized) {
+            (context?.applicationContext as WordPress).component().inject(this)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -2,6 +2,7 @@ package org.wordpress.android.modules;
 
 import com.automattic.android.tracks.crashlogging.CrashLogging;
 
+import org.wordpress.android.bloggingreminders.provider.BloggingRemindersProvider;
 import org.wordpress.android.push.GCMMessageService;
 import org.wordpress.android.push.GCMRegistrationIntentService;
 import org.wordpress.android.push.NotificationsProcessingService;
@@ -652,4 +653,6 @@ public interface AppComponent {
     void inject(WeekWidgetBlockListProviderFactory object);
 
     void inject(UserFlagsProvider object);
+
+    void inject(BloggingRemindersProvider object);
 }

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/provider/SharedLoginProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/provider/SharedLoginProvider.kt
@@ -6,16 +6,14 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.provider.query.QueryContentProvider
 import org.wordpress.android.provider.query.QueryResult
-import org.wordpress.android.util.publicdata.JetpackPublicData
+import org.wordpress.android.util.publicdata.ClientVerification
 import org.wordpress.android.util.signature.SignatureNotFoundException
-import org.wordpress.android.util.signature.SignatureUtils
 import javax.inject.Inject
 
 class SharedLoginProvider : QueryContentProvider() {
     @Inject lateinit var accountStore: AccountStore
-    @Inject lateinit var signatureUtils: SignatureUtils
     @Inject lateinit var queryResult: QueryResult
-    @Inject lateinit var jetpackPublicData: JetpackPublicData
+    @Inject lateinit var clientVerification: ClientVerification
 
     override fun onCreate(): Boolean {
         return true
@@ -32,11 +30,7 @@ class SharedLoginProvider : QueryContentProvider() {
         inject()
         return context?.let {
             try {
-                val callerPackageId = callingPackage
-                val callerExpectedPackageId = jetpackPublicData.currentPackageId()
-                val callerSignatureHash = signatureUtils.getSignatureHash(it, callerExpectedPackageId)
-                val callerExpectedSignatureHash = jetpackPublicData.currentPublicKeyHash()
-                if (callerPackageId == callerExpectedPackageId && callerSignatureHash == callerExpectedSignatureHash) {
+                if (clientVerification.canTrust(callingPackage)) {
                     queryResult.createCursor(accountStore.accessToken)
                 } else null
             } catch (signatureNotFoundException: SignatureNotFoundException) {

--- a/WordPress/src/main/java/org/wordpress/android/userflags/provider/UserFlagsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/userflags/provider/UserFlagsProvider.kt
@@ -9,17 +9,15 @@ import org.wordpress.android.provider.query.QueryResult
 import org.wordpress.android.ui.prefs.AppPrefs.DeletablePrefKey
 import org.wordpress.android.ui.prefs.AppPrefs.UndeletablePrefKey
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.util.publicdata.JetpackPublicData
+import org.wordpress.android.util.publicdata.ClientVerification
 import org.wordpress.android.util.signature.SignatureNotFoundException
-import org.wordpress.android.util.signature.SignatureUtils
 import javax.inject.Inject
 
 class UserFlagsProvider : QueryContentProvider() {
     @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
     @Inject lateinit var siteStore: SiteStore
-    @Inject lateinit var signatureUtils: SignatureUtils
     @Inject lateinit var queryResult: QueryResult
-    @Inject lateinit var jetpackPublicData: JetpackPublicData
+    @Inject lateinit var clientVerification: ClientVerification
 
     private val userFlagsKeysSet: Set<String> = setOf(
             DeletablePrefKey.MAIN_PAGE_INDEX.name,
@@ -70,11 +68,7 @@ class UserFlagsProvider : QueryContentProvider() {
         inject()
         return context?.let {
             try {
-                val callerPackageId = callingPackage
-                val callerExpectedPackageId = jetpackPublicData.currentPackageId()
-                val callerSignatureHash = signatureUtils.getSignatureHash(it, callerExpectedPackageId)
-                val callerExpectedSignatureHash = jetpackPublicData.currentPublicKeyHash()
-                if (callerPackageId == callerExpectedPackageId && callerSignatureHash == callerExpectedSignatureHash) {
+                if (clientVerification.canTrust(callingPackage)) {
                     val userFlagsMap = appPrefsWrapper.getAllPrefs()
                             .filter { entry ->
                                 userFlagsKeysSet.contains(entry.key)

--- a/WordPress/src/main/java/org/wordpress/android/util/publicdata/ClientVerification.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/publicdata/ClientVerification.kt
@@ -9,7 +9,6 @@ class ClientVerification @Inject constructor(
     private val signatureUtils: SignatureUtils,
     private val contextProvider: ContextProvider,
 ) {
-
     fun canTrust(callerPackage: String?): Boolean {
         if (callerPackage == null) {
             return false

--- a/WordPress/src/main/java/org/wordpress/android/util/publicdata/ClientVerification.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/publicdata/ClientVerification.kt
@@ -10,13 +10,13 @@ class ClientVerification @Inject constructor(
     private val contextProvider: ContextProvider,
 ) {
 
-    fun canTrust(callingPackage: String?): Boolean {
-        if (callingPackage == null) {
+    fun canTrust(callerPackage: String?): Boolean {
+        if (callerPackage == null) {
             return false
         }
         val callerExpectedPackageId = jetpackPublicData.currentPackageId()
         val callerSignatureHash = signatureUtils.getSignatureHash(contextProvider.getContext(), callerExpectedPackageId)
         val callerExpectedSignatureHash = jetpackPublicData.currentPublicKeyHash()
-        return callingPackage == callerExpectedPackageId && callerSignatureHash == callerExpectedSignatureHash
+        return callerPackage == callerExpectedPackageId && callerSignatureHash == callerExpectedSignatureHash
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/publicdata/ClientVerification.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/publicdata/ClientVerification.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.util.publicdata
+
+import org.wordpress.android.util.signature.SignatureUtils
+import org.wordpress.android.viewmodel.ContextProvider
+import javax.inject.Inject
+
+class ClientVerification @Inject constructor(
+    private val jetpackPublicData: JetpackPublicData,
+    private val signatureUtils: SignatureUtils,
+    private val contextProvider: ContextProvider,
+) {
+
+    fun canTrust(callingPackage: String?): Boolean {
+        if (callingPackage == null) {
+            return false
+        }
+        val callerExpectedPackageId = jetpackPublicData.currentPackageId()
+        val callerSignatureHash = signatureUtils.getSignatureHash(contextProvider.getContext(), callerExpectedPackageId)
+        val callerExpectedSignatureHash = jetpackPublicData.currentPublicKeyHash()
+        return callingPackage == callerExpectedPackageId && callerSignatureHash == callerExpectedSignatureHash
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/util/publicdata/ClientVerificationTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/publicdata/ClientVerificationTest.kt
@@ -1,0 +1,76 @@
+package org.wordpress.android.util.publicdata
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.util.signature.SignatureUtils
+import org.wordpress.android.viewmodel.ContextProvider
+
+class ClientVerificationTest {
+    private val jetpackPublicData: JetpackPublicData = mock()
+    private val signatureUtils: SignatureUtils = mock()
+    private val contextProvider: ContextProvider = mock()
+    private val classToTest = ClientVerification(jetpackPublicData, signatureUtils, contextProvider)
+
+    private val expectedPackage = "match"
+    private val expectedSignatureHash = "signatureHash"
+
+    @Before
+    fun setup() {
+        whenever(jetpackPublicData.currentPackageId()).thenReturn(expectedPackage)
+        whenever(jetpackPublicData.currentPublicKeyHash()).thenReturn(expectedSignatureHash)
+        whenever(signatureUtils.getSignatureHash(contextProvider.getContext(), expectedPackage))
+                .thenReturn(expectedSignatureHash)
+    }
+
+    @Test
+    fun `Should return false if calling package is null when canTrust is called`() {
+        val expected = false
+        val actual = classToTest.canTrust(null)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should return false if caller package does not match the expected when canTrust is called`() {
+        val expected = false
+        val actual = classToTest.canTrust("no_match")
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should return false if caller signature hash does not match the expected when canTrust is called`() {
+        whenever(signatureUtils.getSignatureHash(contextProvider.getContext(), expectedPackage))
+                .thenReturn("no_match")
+        val expected = false
+        val actual = classToTest.canTrust(expectedPackage)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should return true if caller package and signature hash match the expected when canTrust is called`() {
+        val expected = true
+        val actual = classToTest.canTrust(expectedPackage)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should call jetpackPublicData currentPackageId when canTrust is called`() {
+        classToTest.canTrust(expectedPackage)
+        verify(jetpackPublicData).currentPackageId()
+    }
+
+    @Test
+    fun `Should call signatureUtils getSignatureHash when canTrust is called`() {
+        classToTest.canTrust(expectedPackage)
+        verify(signatureUtils).getSignatureHash(contextProvider.getContext(), expectedPackage)
+    }
+
+    @Test
+    fun `Should call jetpackPublicData currentPublicKeyHash when canTrust is called`() {
+        classToTest.canTrust(expectedPackage)
+        verify(jetpackPublicData).currentPublicKeyHash()
+    }
+}

--- a/WordPress/src/wordpress/AndroidManifest.xml
+++ b/WordPress/src/wordpress/AndroidManifest.xml
@@ -11,5 +11,10 @@
             android:name=".userflags.provider.UserFlagsProvider"
             android:authorities="${applicationId}.UserFlagsProvider"
             android:exported="true" />
+
+        <provider
+            android:name=".bloggingreminders.provider.BloggingRemindersProvider"
+            android:authorities="${applicationId}.UserFlagsProvider"
+            android:exported="true" />
     </application>
 </manifest>

--- a/WordPress/src/wordpress/AndroidManifest.xml
+++ b/WordPress/src/wordpress/AndroidManifest.xml
@@ -14,7 +14,7 @@
 
         <provider
             android:name=".bloggingreminders.provider.BloggingRemindersProvider"
-            android:authorities="${applicationId}.UserFlagsProvider"
+            android:authorities="${applicationId}.BloggingRemindersProvider"
             android:exported="true" />
     </application>
 </manifest>


### PR DESCRIPTION
Fixes #17218 

To test:
Nothing to test until we have the resolver implemented.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Unit tests

3. What automated tests I added (or what prevented me from doing so)
Added `ClientVerificationTest.kt`. There is no straightforward way to test the provider with our current testing tools.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
