### PR TITLE
[Fix] [Shared login] Add feature flag to SharedLoginProvider

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -122,6 +122,7 @@ android {
         buildConfigField "boolean", "JETPACK_POWERED_BOTTOM_SHEET", "false"
         buildConfigField "boolean", "JETPACK_SHARED_LOGIN", "false"
         buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "false"
+        buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/provider/SharedLoginProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/provider/SharedLoginProvider.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.provider.query.QueryContentProvider
 import org.wordpress.android.provider.query.QueryResult
 import org.wordpress.android.sharedlogin.data.JetpackPublicData
+import org.wordpress.android.util.config.JetpackProviderSyncFeatureConfig
 import org.wordpress.android.util.signature.SignatureNotFoundException
 import org.wordpress.android.util.signature.SignatureUtils
 import javax.inject.Inject
@@ -16,6 +17,7 @@ class SharedLoginProvider : QueryContentProvider() {
     @Inject lateinit var signatureUtils: SignatureUtils
     @Inject lateinit var queryResult: QueryResult
     @Inject lateinit var jetpackPublicData: JetpackPublicData
+    @Inject lateinit var jetpackProviderSyncFeatureConfig: JetpackProviderSyncFeatureConfig
 
     override fun onCreate(): Boolean {
         return true
@@ -30,6 +32,9 @@ class SharedLoginProvider : QueryContentProvider() {
         sortOrder: String?
     ): Cursor? {
         inject()
+        if (!jetpackProviderSyncFeatureConfig.isEnabled()) {
+            return null
+        }
         return context?.let {
             try {
                 val callerPackageId = callingPackage

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackProviderSyncFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackProviderSyncFeatureConfig.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.JetpackProviderSyncFeatureConfig.Companion.JETPACK_PROVIDER_SYNC_REMOTE_FIELD
+import javax.inject.Inject
+
+@Feature(JETPACK_PROVIDER_SYNC_REMOTE_FIELD, false)
+class JetpackProviderSyncFeatureConfig
+@Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.JETPACK_PROVIDER_SYNC,
+        JETPACK_PROVIDER_SYNC_REMOTE_FIELD
+) {
+    companion object {
+        const val JETPACK_PROVIDER_SYNC_REMOTE_FIELD = "provider_sync_remote_field"
+    }
+}
+


### PR DESCRIPTION
Adds a feature flag to `SharedLoginProvider`.

To test:

1 - Install WordPress and login
2 - [Set the flag `isFeatureFlagEnabled`](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolver.kt#L35) to `true` (this cannot be done using the `Debug settings` screen because that is only available when the user is already logged in)
2 - Install Jetpack using the same variant (e.g. if installed WordPress version was `jalapenoDebug`, install Jetpack `jalapenoDebug`)
3 - Jetpack should NOT login automatically after launching.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
There is no straightforward way to test the provider with our current testing tools.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
