### PR TITLE
Fix success message text color in QR code login flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 21.0
 -----
 * [*] Updates splash screen for Android 12+ [https://github.com/wordpress-mobile/WordPress-Android/pull/17273]
+* [*] Fix text color of success messages in the QR code login flow [https://github.com/wordpress-mobile/WordPress-Android/pull/17286]
 
 20.9
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthUiState.kt
@@ -31,24 +31,17 @@ const val BLURRED_ALPHA = 0.75f
 
 sealed class QRCodeAuthUiState {
     open val type: QRCodeAuthUiStateType? = null
-    open val scanningVisibility = false
-    open val loadingVisibility = false
-    open val errorVisibility = false
-    open val contentVisibility = false
 
     object Scanning : QRCodeAuthUiState() {
         override val type = SCANNING
-        override val scanningVisibility = true
     }
 
     object Loading : QRCodeAuthUiState() {
         override val type = LOADING
-        override val loadingVisibility = true
     }
 
     sealed class Error : QRCodeAuthUiState() {
         override val type = ERROR
-        override val errorVisibility = true
         abstract val title: UiString
         abstract val subtitle: UiString
         abstract val image: Int
@@ -98,7 +91,6 @@ sealed class QRCodeAuthUiState {
 
     sealed class Content : QRCodeAuthUiState() {
         override val type = CONTENT
-        override val contentVisibility: Boolean = true
         open val title: UiString? = null
         open val subtitle: UiString? = null
         @DrawableRes open val image: Int? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/components/Subtitle.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/components/Subtitle.kt
@@ -2,10 +2,10 @@ package org.wordpress.android.ui.qrcodeauth.compose.components
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.unit.Margin
@@ -13,13 +13,14 @@ import org.wordpress.android.ui.compose.unit.Margin
 @Composable
 fun Subtitle(
     text: String,
+    color: Color,
     modifier: Modifier = Modifier
 ) {
     Text(
             text = text,
             textAlign = TextAlign.Center,
             fontSize = FontSize.Large.value,
-            color = MaterialTheme.colors.error,
+            color = color,
             modifier = modifier
                     .wrapContentSize()
                     .padding(

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ContentState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ContentState.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,7 +53,7 @@ fun ContentState(uiState: QRCodeAuthUiState.Content) = with(uiState) {
             Title(text = uiStringText(it))
         }
         subtitle?.let {
-            Subtitle(text = uiStringText(it))
+            Subtitle(text = uiStringText(it), color = MaterialTheme.colors.onBackground)
         }
         primaryActionButton?.let { actionButton ->
             if (actionButton.isVisible) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
@@ -42,8 +42,8 @@ fun ErrorState(uiState: QRCodeAuthUiState.Error) = with(uiState) {
                         .padding(vertical = Margin.ExtraLarge.value)
                         .wrapContentSize()
         )
-        Title(text = uiStringText(title), modifier = Modifier)
-        Subtitle(text = uiStringText(subtitle), modifier = Modifier)
+        Title(text = uiStringText(title))
+        Subtitle(text = uiStringText(subtitle))
         primaryActionButton?.let { actionButton ->
             if (actionButton.isVisible) {
                 PrimaryButton(

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,7 +44,7 @@ fun ErrorState(uiState: QRCodeAuthUiState.Error) = with(uiState) {
                         .wrapContentSize()
         )
         Title(text = uiStringText(title))
-        Subtitle(text = uiStringText(subtitle))
+        Subtitle(text = uiStringText(subtitle), color = MaterialTheme.colors.error)
         primaryActionButton?.let { actionButton ->
             if (actionButton.isVisible) {
                 PrimaryButton(

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
@@ -102,7 +102,6 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         runBlockingTestWithData(uiStates) {
             viewModel.start()
 
-            assert(uiStates.first().loadingVisibility)
             assertThat(uiStates.last()).isInstanceOf(QRCodeAuthUiState.Scanning::class.java)
         }
     }
@@ -113,7 +112,6 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         runBlockingTestWithData(uiStates) {
             initAndStartVMForState(NO_INTERNET)
 
-            assert(uiStates.first().loadingVisibility)
             assertThat(uiStates.last().type).isEqualTo(NO_INTERNET)
         }
     }


### PR DESCRIPTION
Fixes #17276

The fix I went with is coloring the subtitle in red only for the error screens.
Another approach could have been to avoid red color only for the (last) success screen.

I also cleaned up a bit the `uiState` code to remove unused data and did a small cleanup related to default modifiers when calling the `Title` and `Subtitle` composables in `ErrorState`.

To test:

#### 1️⃣ Test Case 1: Happy Flow

1. Visit https://wordpress.com/log-in.
2. Tap Login via the mobile app.
3. Follow the instructions provided to successfully log in.
4. **Expect** The color of the subtitle text to **not be** red.

#### 2️⃣ Test Case 2: Error Flow
1. Visit https://wordpress.com/log-in.
2. Tap Login via the mobile app.
3. Follow the instructions provided excluding step 5, and scan instead the QR code from:
   https://apps.wordpress.com/mobile/#qr-code-login?token=asdfadsfa&data=asdfasdf
5. **Expect** The color of the subtitle text to **be** red.
6. Additionally you can test with the internet connection disabled on the device to scan a valid QR code (see step 1) **expecting** an error screen where the subtitle should **be** red.

## Previews

| Happy Flow Authenticating | Happy Flow Success | Error |
| - | - | - |
| <img width="250" src="https://user-images.githubusercontent.com/4588074/194539953-1332db85-23f8-438a-bc59-da11b204fa98.png"> | <img width="250" src="https://user-images.githubusercontent.com/4588074/194539950-9a59b218-dd16-444b-a6fa-f0bf0cfcbbbe.png"> | <img width="250" src="https://user-images.githubusercontent.com/4588074/194539948-cd9cf64e-431d-42e5-b14e-0418ba18ecdb.png"> |

## Regression Notes
1. Potential unintended areas of impact
   None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

3. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
