### PR TITLE
[Compile Warnings As Errors] WordPress Module - Resolve Type/Cast/When Warnings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.kt
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.kt
@@ -1,16 +1,11 @@
 package org.wordpress.android
 
-import android.app.Activity
-import android.app.Application
-import android.text.TextUtils
 import androidx.multidex.MultiDexApplication
 import com.android.volley.RequestQueue
 import dagger.hilt.EntryPoints
 import org.wordpress.android.AppInitializer.StoryNotificationTrackerProvider
 import org.wordpress.android.fluxc.tools.FluxCImageLoader
 import org.wordpress.android.modules.AppComponent
-import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.AppLog.T.NUX
 
 /**
  * An abstract class to be extended by {@link WordPressApp} for real application and WordPressTest for UI test
@@ -28,6 +23,7 @@ abstract class WordPress : MultiDexApplication() {
         initializer().wordPressComSignOut()
     }
 
+    @Suppress("TooManyFunctions")
     companion object {
         const val SITE = "SITE"
         const val LOCAL_SITE_ID = "LOCAL_SITE_ID"
@@ -79,57 +75,5 @@ abstract class WordPress : MultiDexApplication() {
 
         @JvmStatic
         fun getUserAgent() = AppInitializer.userAgent
-
-        /**
-         * Gets a field from the project's BuildConfig using reflection. This is useful when flavors are used at the
-         * project level to set custom fields.
-         * based on: https://code.google.com/p/android/issues/detail?id=52962#c38
-         *
-         * @param application Used to find the correct file
-         * @param fieldName The name of the field-to-access
-         * @return The value of the field, or `null` if the field is not found.
-         */
-        @Suppress("TooGenericExceptionCaught", "SwallowedException")
-        fun getBuildConfigValue(application: Application, fieldName: String?): Any? {
-            return try {
-                val packageName = application.javaClass.getPackage().name
-                val clazz = Class.forName("$packageName.BuildConfig")
-                val field = clazz.getField(fieldName)
-                field[null]
-            } catch (e: LinkageError) {
-                null
-            } catch (e: ExceptionInInitializerError) {
-                null
-            } catch (e: ClassNotFoundException) {
-                null
-            } catch (e: NoSuchFieldException) {
-                null
-            } catch (e: NullPointerException) {
-                null
-            }
-        }
-
-        /**
-         * Gets a field from the project's BuildConfig using reflection. This is useful when flavors are used at the
-         * project level to set custom fields.
-         * based on: https://code.google.com/p/android/issues/detail?id=52962#c38
-         *
-         * @param activity Used to get the Application instance
-         * @param configValueName The name of the field-to-access
-         * @return The string value of the field, or empty string if the field is not found.
-         */
-        fun getBuildConfigString(activity: Activity, configValueName: String): String? {
-            return if (!BuildConfig.DEBUG) {
-                ""
-            } else {
-                val value = getBuildConfigValue(activity.application, configValueName) as String?
-                if (!TextUtils.isEmpty(value)) {
-                    AppLog.d(NUX, "Auto-filled from build config: $configValueName")
-                    value
-                } else {
-                    ""
-                }
-            }
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/InvitePeopleUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/InvitePeopleUtils.kt
@@ -81,7 +81,7 @@ class InvitePeopleUtils @Inject constructor(
                         expiryDate = formatter.format(dateTimeUtilsWrapper.dateFromTimestamp(linksData.expiry))
                 )
             }
-        } ?: listOf()
+        }
     }
 
     fun getInviteLinksRoleDisplayNames(

--- a/WordPress/src/main/java/org/wordpress/android/models/usecases/ModerateCommentWithUndoUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/usecases/ModerateCommentWithUndoUseCase.kt
@@ -34,12 +34,12 @@ class ModerateCommentWithUndoUseCase @Inject constructor(
             CommentError> {
         object Idle : ModerateCommentsState() {
             override suspend fun runAction(
-                resourceProvider: ModerateCommentsResourceProvider,
+                utilsProvider: ModerateCommentsResourceProvider,
                 action: ModerateCommentsAction,
                 flowChannel: MutableSharedFlow<UseCaseResult<CommentsUseCaseType, CommentError, Any>>
             ): StateInterface<ModerateCommentsResourceProvider, ModerateCommentsAction, Any, CommentsUseCaseType,
                     CommentError> {
-                val commentsStore = resourceProvider.commentsStore
+                val commentsStore = utilsProvider.commentsStore
                 return when (action) {
                     is OnModerateComment -> {
                         val parameters = action.parameters
@@ -78,7 +78,7 @@ class ModerateCommentWithUndoUseCase @Inject constructor(
                                             )
                                     )
                             )
-                            resourceProvider.localCommentCacheUpdateHandler.requestCommentsUpdate()
+                            utilsProvider.localCommentCacheUpdateHandler.requestCommentsUpdate()
                         }
                         Idle
                     }
@@ -92,7 +92,7 @@ class ModerateCommentWithUndoUseCase @Inject constructor(
                                 remoteCommentId = parameters.remoteCommentId,
                                 newStatus = parameters.newStatus
                         )
-                        resourceProvider.localCommentCacheUpdateHandler.requestCommentsUpdate()
+                        utilsProvider.localCommentCacheUpdateHandler.requestCommentsUpdate()
 
                         val result = if (parameters.newStatus == DELETED) {
                             commentsStore.deleteComment(
@@ -118,7 +118,7 @@ class ModerateCommentWithUndoUseCase @Inject constructor(
                         } else {
                             flowChannel.emit(Success(MODERATE_USE_CASE, DoNotCare))
                         }
-                        resourceProvider.localCommentCacheUpdateHandler.requestCommentsUpdate()
+                        utilsProvider.localCommentCacheUpdateHandler.requestCommentsUpdate()
                         Idle
                     }
                     is OnUndoModerateComment -> {
@@ -129,7 +129,7 @@ class ModerateCommentWithUndoUseCase @Inject constructor(
                                 newStatus = parameters.fallbackStatus
                         )
                         flowChannel.emit(Success(MODERATE_USE_CASE, DoNotCare))
-                        resourceProvider.localCommentCacheUpdateHandler.requestCommentsUpdate()
+                        utilsProvider.localCommentCacheUpdateHandler.requestCommentsUpdate()
                         Idle
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -37,7 +37,7 @@ class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fr
     }
 
     private fun initDagger() {
-        (requireActivity().application as WordPress).component()!!.inject(this)
+        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun JetpackRemoteInstallFragmentBinding.initViewModel(savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -128,11 +128,10 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun restoreDateRangePickerListeners() {
         (childFragmentManager.findFragmentByTag(DATE_PICKER_TAG) as? MaterialDatePicker<Pair<Long, Long>>)
-                ?.let { picker ->
-                    initDateRangePickerButtonClickListener(picker)
-                }
+                ?.let { initDateRangePickerButtonClickListener(it) }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -66,7 +66,7 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
         super.onViewCreated(view, savedInstanceState)
 
         val nonNullActivity = requireActivity()
-        (nonNullActivity.application as WordPress).component()?.inject(this@ActivityLogListFragment)
+        (nonNullActivity.application as WordPress).component().inject(this@ActivityLogListFragment)
         viewModel = ViewModelProvider(
                 this@ActivityLogListFragment,
                 viewModelFactory

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -17,10 +17,6 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTrac
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source.BLOG_SETTINGS
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source.NOTIFICATION_SETTINGS
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source.PUBLISH_FLOW
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Screen.EPILOGUE
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Screen.PROLOGUE
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Screen.PROLOGUE_SETTINGS
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Screen.SELECTION
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.merge
@@ -68,28 +64,28 @@ class BloggingRemindersViewModel @Inject constructor(
     ) { screen, bloggingRemindersModel, isFirstTimeFlow ->
         if (screen != null) {
             val uiItems = when (screen) {
-                PROLOGUE -> prologueBuilder.buildUiItems()
-                PROLOGUE_SETTINGS -> prologueBuilder.buildUiItemsForSettings()
-                SELECTION -> daySelectionBuilder.buildSelection(
+                Screen.PROLOGUE -> prologueBuilder.buildUiItems()
+                Screen.PROLOGUE_SETTINGS -> prologueBuilder.buildUiItemsForSettings()
+                Screen.SELECTION -> daySelectionBuilder.buildSelection(
                         bloggingRemindersModel,
                         this::selectDay,
                         this::selectTime,
                         this::togglePromptSwitch,
                         this::showBloggingPromptDialog
                 )
-                EPILOGUE -> epilogueBuilder.buildUiItems(bloggingRemindersModel)
+                Screen.EPILOGUE -> epilogueBuilder.buildUiItems(bloggingRemindersModel)
             }
             val primaryButton = when (screen) {
-                PROLOGUE, PROLOGUE_SETTINGS -> prologueBuilder.buildPrimaryButton(
+                Screen.PROLOGUE, Screen.PROLOGUE_SETTINGS -> prologueBuilder.buildPrimaryButton(
                         isFirstTimeFlow == true,
                         startDaySelection
                 )
-                SELECTION -> daySelectionBuilder.buildPrimaryButton(
+                Screen.SELECTION -> daySelectionBuilder.buildPrimaryButton(
                         bloggingRemindersModel,
                         isFirstTimeFlow == true,
                         this::showEpilogue
                 )
-                EPILOGUE -> epilogueBuilder.buildPrimaryButton(finish)
+                Screen.EPILOGUE -> epilogueBuilder.buildPrimaryButton(finish)
             }
             UiState(uiItems, primaryButton)
         } else {
@@ -98,13 +94,13 @@ class BloggingRemindersViewModel @Inject constructor(
     }.distinctUntilChanged()
 
     private val startDaySelection: (isFirstTimeFlow: Boolean) -> Unit = { isFirstTimeFlow ->
-        analyticsTracker.trackPrimaryButtonPressed(PROLOGUE)
+        analyticsTracker.trackPrimaryButtonPressed(Screen.PROLOGUE)
         _isFirstTimeFlow.value = isFirstTimeFlow
-        _selectedScreen.value = SELECTION
+        _selectedScreen.value = Screen.SELECTION
     }
 
     private val finish: () -> Unit = {
-        analyticsTracker.trackPrimaryButtonPressed(EPILOGUE)
+        analyticsTracker.trackPrimaryButtonPressed(Screen.EPILOGUE)
         _isBottomSheetShowing.value = Event(false)
     }
 
@@ -126,7 +122,7 @@ class BloggingRemindersViewModel @Inject constructor(
     private fun showBottomSheet(siteId: Int, screen: Screen, source: Source) {
         analyticsTracker.setSite(siteId)
         analyticsTracker.trackFlowStart(source)
-        val isPrologueScreen = screen == PROLOGUE || screen == PROLOGUE_SETTINGS
+        val isPrologueScreen = screen == Screen.PROLOGUE || screen == Screen.PROLOGUE_SETTINGS
         if (isPrologueScreen) {
             bloggingRemindersManager.bloggingRemindersShown(siteId)
         }
@@ -180,7 +176,7 @@ class BloggingRemindersViewModel @Inject constructor(
     }
 
     private fun showEpilogue(bloggingRemindersModel: BloggingRemindersUiModel?) {
-        analyticsTracker.trackPrimaryButtonPressed(SELECTION)
+        analyticsTracker.trackPrimaryButtonPressed(Screen.SELECTION)
         if (bloggingRemindersModel != null) {
             launch {
                 bloggingRemindersStore.updateBloggingReminders(
@@ -203,7 +199,7 @@ class BloggingRemindersViewModel @Inject constructor(
                     reminderScheduler.cancelBySiteId(bloggingRemindersModel.siteId)
                     analyticsTracker.trackRemindersCancelled()
                 }
-                _selectedScreen.value = EPILOGUE
+                _selectedScreen.value = Screen.EPILOGUE
             }
         }
     }
@@ -247,7 +243,7 @@ class BloggingRemindersViewModel @Inject constructor(
 
     fun onPublishingPost(siteId: Int, isFirstTimePublishing: Boolean?) {
         if (isFirstTimePublishing == true && bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)) {
-            showBottomSheet(siteId, PROLOGUE, PUBLISH_FLOW)
+            showBottomSheet(siteId, Screen.PROLOGUE, PUBLISH_FLOW)
         }
     }
 
@@ -260,15 +256,15 @@ class BloggingRemindersViewModel @Inject constructor(
     }
 
     fun onBloggingPromptSchedulingRequested(siteId: Int) {
-        showBottomSheet(siteId, PROLOGUE, BLOGGING_PROMPTS_ONBOARDING)
+        showBottomSheet(siteId, Screen.PROLOGUE, BLOGGING_PROMPTS_ONBOARDING)
     }
 
     private fun onSettingsItemClicked(siteId: Int, source: Source) {
         launch {
             val screen = if (bloggingRemindersStore.hasModifiedBloggingReminders(siteId)) {
-                SELECTION
+                Screen.SELECTION
             } else {
-                PROLOGUE_SETTINGS
+                Screen.PROLOGUE_SETTINGS
             }
             showBottomSheet(siteId, screen, source)
         }
@@ -276,10 +272,11 @@ class BloggingRemindersViewModel @Inject constructor(
 
     fun onBottomSheetDismissed() {
         when (val screen = selectedScreen.value) {
-            PROLOGUE,
-            PROLOGUE_SETTINGS,
-            SELECTION -> analyticsTracker.trackFlowDismissed(screen)
-            EPILOGUE -> analyticsTracker.trackFlowCompleted()
+            Screen.PROLOGUE,
+            Screen.PROLOGUE_SETTINGS,
+            Screen.SELECTION -> analyticsTracker.trackFlowDismissed(screen)
+            Screen.EPILOGUE -> analyticsTracker.trackFlowCompleted()
+            null -> Unit // Do nothing
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -73,7 +73,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val nonNullActivity = requireActivity()
-        (nonNullActivity.application as WordPress).component()?.inject(this)
+        (nonNullActivity.application as WordPress).component().inject(this)
     }
 
     override fun onCreateView(

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
@@ -91,20 +91,18 @@ class EngagedPeopleListFragment : Fragment() {
         recycler.layoutManager = layoutManager
 
         userProfileViewModel.onBottomSheetAction.observeEvent(viewLifecycleOwner, { state ->
-            val fragmentManager = childFragmentManager
-            fragmentManager?.let {
-                var bottomSheet = it.findFragmentByTag(USER_PROFILE_BOTTOM_SHEET_TAG) as? UserProfileBottomSheetFragment
+            var bottomSheet = childFragmentManager.findFragmentByTag(USER_PROFILE_BOTTOM_SHEET_TAG)
+                    as? UserProfileBottomSheetFragment
 
-                when (state) {
-                    ShowBottomSheet -> {
-                        if (bottomSheet == null) {
-                            bottomSheet = UserProfileBottomSheetFragment.newInstance(USER_PROFILE_VM_KEY)
-                            bottomSheet.show(fragmentManager, USER_PROFILE_BOTTOM_SHEET_TAG)
-                        }
+            when (state) {
+                ShowBottomSheet -> {
+                    if (bottomSheet == null) {
+                        bottomSheet = UserProfileBottomSheetFragment.newInstance(USER_PROFILE_VM_KEY)
+                        bottomSheet.show(childFragmentManager, USER_PROFILE_BOTTOM_SHEET_TAG)
                     }
-                    HideBottomSheet -> {
-                        bottomSheet?.apply { this.dismiss() }
-                    }
+                }
+                HideBottomSheet -> {
+                    bottomSheet?.apply { this.dismiss() }
                 }
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModel.kt
@@ -213,7 +213,7 @@ class EngagedPeopleListViewModel @Inject constructor(
         var emptyStateAction: (() -> Unit)? = null
 
         if (updateLikesState is Failure) {
-            updateLikesState.emptyStateData?.let {
+            updateLikesState.emptyStateData.let {
                 showEmptyState = it.showEmptyState
                 emptyStateTitle = it.title
                 emptyStateAction = ::onRefreshData

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCase.kt
@@ -69,7 +69,7 @@ class JetpackCapabilitiesUseCase @Inject constructor(
             dispatcher.dispatch(SiteActionBuilder.newFetchJetpackCapabilitiesAction(payload))
         }
 
-        val capabilities: List<JetpackCapability> = response.capabilities ?: listOf()
+        val capabilities: List<JetpackCapability> = response.capabilities
         if (!response.isError) {
             updateCache(remoteSiteId, capabilities)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -49,7 +49,7 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
     }
 
     private fun initDagger() {
-        (requireActivity().application as WordPress).component()?.inject(this)
+        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun ScanFragmentBinding.initRecyclerView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -44,7 +44,7 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
     }
 
     private fun initDagger() {
-        (requireActivity().application as WordPress).component()?.inject(this)
+        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun ThreatDetailsFragmentBinding.initAdapter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -140,7 +140,7 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
         override fun createFragment(position: Int): Fragment = ScanHistoryListFragment.newInstance(items[position].type)
     }
 
-    override fun onScrollableViewInitialized(viewId: Int) {
-        binding?.appbarMain?.liftOnScrollTargetViewId = viewId
+    override fun onScrollableViewInitialized(containerId: Int) {
+        binding?.appbarMain?.liftOnScrollTargetViewId = containerId
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -57,7 +57,7 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
     }
 
     private fun initDagger() {
-        (requireActivity().application as WordPress).component()?.inject(this)
+        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun ScanHistoryFragmentBinding.initViewModel(site: SiteModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -45,7 +45,7 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
     }
 
     private fun initDagger() {
-        (requireActivity().application as WordPress).component()?.inject(this)
+        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun ScanHistoryListFragmentBinding.initRecyclerView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -140,6 +140,8 @@ class MediaPickerFragment : Fragment() {
                 is SwitchSource -> {
                     bundle.putInt(KEY_LAST_TAPPED_ICON_DATA_SOURCE, this.dataSource.ordinal)
                 }
+                is CapturePhoto -> Unit // Do nothing
+                is WpStoriesCapture -> Unit // Do nothing
             }
         }
 
@@ -487,6 +489,8 @@ class MediaPickerFragment : Fragment() {
                     }
                 }
             }
+            PhotoListUiModel.Hidden -> Unit // Do nothing
+            PhotoListUiModel.Loading -> Unit // Do nothing
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerTracker.kt
@@ -22,9 +22,6 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mediapicker.MediaItem.Identifier
 import org.wordpress.android.ui.mediapicker.MediaItem.Identifier.LocalUri
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerIcon
-import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerIcon.ChooseFromAndroidDevice
-import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerIcon.SwitchSource
-import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerIcon.WpStoriesCapture
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.DEVICE
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.GIF_LIBRARY
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.STOCK_LIBRARY
@@ -83,15 +80,15 @@ class MediaPickerTracker
 
     fun trackIconClick(icon: MediaPickerIcon, mediaPickerSetup: MediaPickerSetup) {
         when (icon) {
-            is WpStoriesCapture -> analyticsTrackerWrapper.track(
+            is MediaPickerIcon.WpStoriesCapture -> analyticsTrackerWrapper.track(
                     MEDIA_PICKER_OPEN_WP_STORIES_CAPTURE,
                     mediaPickerSetup.toProperties()
             )
-            is ChooseFromAndroidDevice -> analyticsTrackerWrapper.track(
+            is MediaPickerIcon.ChooseFromAndroidDevice -> analyticsTrackerWrapper.track(
                     MEDIA_PICKER_OPEN_DEVICE_LIBRARY,
                     mediaPickerSetup.toProperties()
             )
-            is SwitchSource -> {
+            is MediaPickerIcon.SwitchSource -> {
                 val event = when (icon.dataSource) {
                     DEVICE -> MEDIA_PICKER_OPEN_DEVICE_LIBRARY
                     WP_LIBRARY -> MEDIA_PICKER_OPEN_WP_MEDIA
@@ -100,6 +97,7 @@ class MediaPickerTracker
                 }
                 analyticsTrackerWrapper.track(event, mediaPickerSetup.toProperties())
             }
+            is MediaPickerIcon.CapturePhoto -> Unit // Do nothing
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -18,10 +18,6 @@ import org.wordpress.android.fluxc.utils.MimeTypes
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.mediapicker.MediaItem.Identifier
-import org.wordpress.android.ui.mediapicker.MediaItem.Identifier.GifMediaIdentifier
-import org.wordpress.android.ui.mediapicker.MediaItem.Identifier.LocalUri
-import org.wordpress.android.ui.mediapicker.MediaItem.Identifier.RemoteId
-import org.wordpress.android.ui.mediapicker.MediaItem.Identifier.StockMediaIdentifier
 import org.wordpress.android.ui.mediapicker.MediaNavigationEvent.EditMedia
 import org.wordpress.android.ui.mediapicker.MediaNavigationEvent.Exit
 import org.wordpress.android.ui.mediapicker.MediaNavigationEvent.IconClickEvent
@@ -51,7 +47,6 @@ import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.PhotoItem
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.ToggleAction
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.VideoItem
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.BrowseMenuUiModel.BrowseAction
-import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.BrowseMenuUiModel.BrowseAction.SYSTEM_PICKER
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel.Hidden
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel.Visible
 import org.wordpress.android.ui.mediapicker.MediaType.AUDIO
@@ -150,7 +145,7 @@ class MediaPickerViewModel @Inject constructor(
         return if (showActions && (showSystemPicker || mediaPickerSetup.availableDataSources.isNotEmpty())) {
             val actions = mutableSetOf<BrowseAction>()
             if (showSystemPicker) {
-                actions.add(SYSTEM_PICKER)
+                actions.add(BrowseAction.SYSTEM_PICKER)
             }
             actions.addAll(mediaPickerSetup.availableDataSources.map {
                 when (it) {
@@ -404,17 +399,17 @@ class MediaPickerViewModel @Inject constructor(
             mediaPickerTracker.trackPreview(isVideo, identifier, mediaPickerSetup)
         }
         when (identifier) {
-            is LocalUri -> {
+            is Identifier.LocalUri -> {
                 mediaUtilsWrapper.getRealPathFromURI(identifier.value.uri)?.let { path ->
                     _onNavigate.postValue(Event(PreviewUrl(path)))
                 }
             }
-            is StockMediaIdentifier -> {
+            is Identifier.StockMediaIdentifier -> {
                 if (identifier.url != null) {
                     _onNavigate.postValue(Event(PreviewUrl(identifier.url)))
                 }
             }
-            is RemoteId -> {
+            is Identifier.RemoteId -> {
                 site?.let {
                     launch {
                         val media: MediaModel = mediaStore.getSiteMediaWithId(it, identifier.value)
@@ -422,9 +417,10 @@ class MediaPickerViewModel @Inject constructor(
                     }
                 }
             }
-            is GifMediaIdentifier -> {
+            is Identifier.GifMediaIdentifier -> {
                 _onNavigate.postValue(Event(PreviewUrl(identifier.largeImageUri.toString())))
             }
+            is Identifier.LocalId -> Unit // Do nothing
         }
     }
 
@@ -665,7 +661,7 @@ class MediaPickerViewModel @Inject constructor(
     fun urisSelectedFromSystemPicker(uris: List<UriWrapper>) {
         launch {
             delay(100)
-            insertIdentifiers(uris.map { LocalUri(it) })
+            insertIdentifiers(uris.map { Identifier.LocalUri(it) })
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceMediaLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceMediaLoader.kt
@@ -123,9 +123,9 @@ class DeviceMediaLoader
     fun loadDocuments(filter: String?, pageSize: Int, limitDate: Long? = null): DeviceMediaList {
         val storagePublicDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
         val nextPage = (storagePublicDirectory?.listFiles() ?: arrayOf()).filter {
-            (limitDate == null || it.lastModifiedInSecs() <= limitDate) && (filter == null || it.name?.toLowerCase(
+            (limitDate == null || it.lastModifiedInSecs() <= limitDate) && (filter == null || it.name.toLowerCase(
                     localeManagerWrapper.getLocale()
-            )?.contains(filter) == true)
+            ).contains(filter))
         }.sortedByDescending { it.lastModified() }.take(pageSize + 1)
 
         val nextItem = if (nextPage.size > pageSize) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
@@ -7,20 +7,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.fluxc.tools.FormattableRangeType
-import org.wordpress.android.fluxc.tools.FormattableRangeType.BLOCKQUOTE
-import org.wordpress.android.fluxc.tools.FormattableRangeType.COMMENT
-import org.wordpress.android.fluxc.tools.FormattableRangeType.FOLLOW
-import org.wordpress.android.fluxc.tools.FormattableRangeType.LIKE
-import org.wordpress.android.fluxc.tools.FormattableRangeType.MATCH
-import org.wordpress.android.fluxc.tools.FormattableRangeType.MEDIA
-import org.wordpress.android.fluxc.tools.FormattableRangeType.NOTICON
-import org.wordpress.android.fluxc.tools.FormattableRangeType.PAGE
-import org.wordpress.android.fluxc.tools.FormattableRangeType.POST
-import org.wordpress.android.fluxc.tools.FormattableRangeType.REWIND_DOWNLOAD_READY
-import org.wordpress.android.fluxc.tools.FormattableRangeType.SITE
-import org.wordpress.android.fluxc.tools.FormattableRangeType.STAT
-import org.wordpress.android.fluxc.tools.FormattableRangeType.UNKNOWN
-import org.wordpress.android.fluxc.tools.FormattableRangeType.USER
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPWebViewActivity
@@ -53,16 +39,16 @@ class FormattableContentClickHandler @Inject constructor(
         val siteId = clickedSpan.siteId ?: 0
         val postId = clickedSpan.postId ?: 0
         when (val rangeType = clickedSpan.rangeType()) {
-            SITE ->
+            FormattableRangeType.SITE ->
                 // Show blog preview
                 showBlogPreviewActivity(activity, id, postId, source)
-            USER ->
+            FormattableRangeType.USER ->
                 // Show blog preview
                 showBlogPreviewActivity(activity, siteId, postId, source)
-            PAGE, POST ->
+            FormattableRangeType.PAGE, FormattableRangeType.POST ->
                 // Show post detail
                 showPostActivity(activity, siteId, id)
-            COMMENT -> {
+            FormattableRangeType.COMMENT -> {
                 // Load the comment in the reader list if it exists, otherwise show a webview
                 val postId = clickedSpan.postId ?: clickedSpan.rootId ?: 0
                 if (ReaderUtils.postAndCommentExists(siteId, postId, id)) {
@@ -71,22 +57,24 @@ class FormattableContentClickHandler @Inject constructor(
                     showWebViewActivityForUrl(activity, clickedSpan.url, rangeType)
                 }
             }
-            STAT, FOLLOW ->
+            FormattableRangeType.STAT, FormattableRangeType.FOLLOW ->
                 // We can open native stats if the site is a wpcom or Jetpack sites
                 showStatsActivityForSite(activity, siteId, rangeType)
-            LIKE -> if (ReaderPostTable.postExists(siteId, id)) {
+            FormattableRangeType.LIKE -> if (ReaderPostTable.postExists(siteId, id)) {
                 showReaderPostLikeUsers(activity, siteId, id)
             } else {
                 showPostActivity(activity, siteId, id)
             }
-            REWIND_DOWNLOAD_READY -> showBackup(activity, siteId)
-            BLOCKQUOTE,
-            NOTICON,
-            MATCH,
-            MEDIA,
-            UNKNOWN -> {
+            FormattableRangeType.REWIND_DOWNLOAD_READY -> showBackup(activity, siteId)
+            FormattableRangeType.BLOCKQUOTE,
+            FormattableRangeType.NOTICON,
+            FormattableRangeType.MATCH,
+            FormattableRangeType.MEDIA,
+            FormattableRangeType.UNKNOWN -> {
                 showWebViewActivityForUrl(activity, clickedSpan.url, rangeType)
             }
+            FormattableRangeType.SCAN -> Unit // Do nothing
+            FormattableRangeType.B -> Unit // Do nothing
         }
     }
 
@@ -126,7 +114,7 @@ class FormattableContentClickHandler @Inject constructor(
         site: SiteModel,
         rangeType: FormattableRangeType
     ) {
-        if (rangeType == FOLLOW) {
+        if (rangeType == FormattableRangeType.FOLLOW) {
             ActivityLauncher.viewAllTabbedInsightsStats(activity, FOLLOWERS, 0, site.id)
         } else {
             ActivityLauncher.viewBlogStats(activity, site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtilsWrapper.kt
@@ -19,6 +19,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class NotificationsUtilsWrapper @Inject constructor(private val formattableContentMapper: FormattableContentMapper) {
+    @Suppress("CAST_NEVER_SUCCEEDS")
     fun getSpannableContentForRanges(subject: FormattableContent?): SpannableStringBuilder = NotificationsUtils
             .getSpannableContentForRanges(subject, null, null as? NoteBlock.OnNoteBlockTextClickListener, false)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -34,8 +34,6 @@ import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType
 import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
-import org.wordpress.android.viewmodel.uistate.ProgressBarUiState.Determinate
-import org.wordpress.android.viewmodel.uistate.ProgressBarUiState.Indeterminate
 import java.util.Date
 import java.util.Locale
 
@@ -134,11 +132,12 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
         private fun updateProgressBarState(progressBarUiState: ProgressBarUiState) {
             uiHelper.updateVisibility(uploadProgressBar, progressBarUiState.visibility)
             when (progressBarUiState) {
-                Indeterminate -> uploadProgressBar.isIndeterminate = true
-                is Determinate -> {
+                is ProgressBarUiState.Indeterminate -> uploadProgressBar.isIndeterminate = true
+                is ProgressBarUiState.Determinate -> {
                     uploadProgressBar.isIndeterminate = false
                     uploadProgressBar.progress = progressBarUiState.progress
                 }
+                is ProgressBarUiState.Hidden -> Unit // Do nothing
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansListFragment.kt
@@ -55,7 +55,7 @@ class PlansListFragment : Fragment() {
                 }
             }
 
-            (nonNullActivity.application as WordPress).component()?.inject(this@PlansListFragment)
+            (nonNullActivity.application as WordPress).component().inject(this@PlansListFragment)
 
             viewModel = ViewModelProvider(this@PlansListFragment, viewModelFactory).get(PlansViewModel::class.java)
             setObservers()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -52,7 +52,7 @@ class HistoryListFragment : Fragment(R.layout.history_list_fragment) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        (requireActivity().application as WordPress).component()?.inject(this)
+        (requireActivity().application as WordPress).component().inject(this)
 
         viewModel = ViewModelProvider(this, viewModelFactory).get(HistoryViewModel::class.java)
     }
@@ -80,7 +80,7 @@ class HistoryListFragment : Fragment(R.layout.history_list_fragment) {
                 viewModel.onPullToRefresh()
             }
 
-            (nonNullActivity.application as WordPress).component()?.inject(this@HistoryListFragment)
+            (nonNullActivity.application as WordPress).component().inject(this@HistoryListFragment)
 
             viewModel = ViewModelProvider(this@HistoryListFragment, viewModelFactory).get(HistoryViewModel::class.java)
             viewModel.create(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
@@ -9,8 +9,6 @@ import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.ui.posts.PublishSettingsFragmentType.EDIT_POST
-import org.wordpress.android.ui.posts.PublishSettingsFragmentType.PREPUBLISHING_NUDGES
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsViewModel
 import javax.inject.Inject
 
@@ -23,11 +21,12 @@ class PostDatePickerDialogFragment : DialogFragment() {
                 ARG_PUBLISH_SETTINGS_FRAGMENT_TYPE
         )
 
-        when (publishSettingsFragmentType) {
-            EDIT_POST -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-                    .get(EditPostPublishSettingsViewModel::class.java)
-            PREPUBLISHING_NUDGES -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-                    .get(PrepublishingPublishSettingsViewModel::class.java)
+        viewModel = when (publishSettingsFragmentType) {
+            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(requireActivity(), viewModelFactory)
+                        .get(EditPostPublishSettingsViewModel::class.java)
+            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(requireActivity(), viewModelFactory)
+                        .get(PrepublishingPublishSettingsViewModel::class.java)
+            null -> error("PublishSettingsViewModel not initialized")
         }
 
         val datePickerDialog = DatePickerDialog(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -28,8 +28,6 @@ import org.wordpress.android.viewmodel.posts.PostListItemAction
 import org.wordpress.android.viewmodel.posts.PostListItemAction.MoreItem
 import org.wordpress.android.viewmodel.posts.PostListItemAction.SingleItem
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
-import org.wordpress.android.viewmodel.uistate.ProgressBarUiState.Determinate
-import org.wordpress.android.viewmodel.uistate.ProgressBarUiState.Indeterminate
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 import org.wordpress.android.viewmodel.posts.PostListItemUiStateData
 import org.wordpress.android.widgets.PostListButton
@@ -185,11 +183,12 @@ sealed class PostListItemViewHolder(
     private fun updateProgressBarState(progressBarUiState: ProgressBarUiState) {
         uiHelpers.updateVisibility(uploadProgressBar, progressBarUiState.visibility)
         when (progressBarUiState) {
-            Indeterminate -> uploadProgressBar.isIndeterminate = true
-            is Determinate -> {
+            is ProgressBarUiState.Indeterminate -> uploadProgressBar.isIndeterminate = true
+            is ProgressBarUiState.Determinate -> {
                 uploadProgressBar.isIndeterminate = false
                 uploadProgressBar.progress = progressBarUiState.progress
             }
+            is ProgressBarUiState.Hidden -> Unit // Do nothing
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
@@ -14,8 +14,6 @@ import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.Schedul
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.ONE_HOUR
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.TEN_MINUTES
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.WHEN_PUBLISHED
-import org.wordpress.android.ui.posts.PublishSettingsFragmentType.EDIT_POST
-import org.wordpress.android.ui.posts.PublishSettingsFragmentType.PREPUBLISHING_NUDGES
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsViewModel
 import javax.inject.Inject
 
@@ -28,11 +26,12 @@ class PostNotificationScheduleTimeDialogFragment : DialogFragment() {
                 ARG_PUBLISH_SETTINGS_FRAGMENT_TYPE
         )
 
-        when (publishSettingsFragmentType) {
-            EDIT_POST -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-                    .get(EditPostPublishSettingsViewModel::class.java)
-            PREPUBLISHING_NUDGES -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-                    .get(PrepublishingPublishSettingsViewModel::class.java)
+        viewModel = when (publishSettingsFragmentType) {
+            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(requireActivity(), viewModelFactory)
+                        .get(EditPostPublishSettingsViewModel::class.java)
+            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(requireActivity(), viewModelFactory)
+                        .get(PrepublishingPublishSettingsViewModel::class.java)
+            null -> error("PublishSettingsViewModel not initialized")
         }
 
         val alertDialogBuilder = MaterialAlertDialogBuilder(requireActivity())

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
@@ -11,8 +11,6 @@ import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R.style
 import org.wordpress.android.WordPress
-import org.wordpress.android.ui.posts.PublishSettingsFragmentType.EDIT_POST
-import org.wordpress.android.ui.posts.PublishSettingsFragmentType.PREPUBLISHING_NUDGES
 
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsViewModel
 import javax.inject.Inject
@@ -26,11 +24,12 @@ class PostTimePickerDialogFragment : DialogFragment() {
                 ARG_PUBLISH_SETTINGS_FRAGMENT_TYPE
         )
 
-        when (publishSettingsFragmentType) {
-            EDIT_POST -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-                    .get(EditPostPublishSettingsViewModel::class.java)
-            PREPUBLISHING_NUDGES -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-                    .get(PrepublishingPublishSettingsViewModel::class.java)
+        viewModel = when (publishSettingsFragmentType) {
+            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(requireActivity(), viewModelFactory)
+                        .get(EditPostPublishSettingsViewModel::class.java)
+            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(requireActivity(), viewModelFactory)
+                        .get(PrepublishingPublishSettingsViewModel::class.java)
+            null -> error("PublishSettingsViewModel not initialized")
         }
 
         val is24HrFormat = DateFormat.is24HourFormat(activity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -261,9 +261,10 @@ class PostsListActivity : LocaleAwareActivity(),
             when (createAction) {
                 ActionType.CREATE_NEW_POST -> viewModel.newPost()
                 ActionType.CREATE_NEW_STORY -> viewModel.newStoryPost()
-                ActionType.CREATE_NEW_PAGE -> Unit
-                ActionType.NO_ACTION -> Unit
-                null -> Unit
+                ActionType.CREATE_NEW_PAGE -> Unit // Do nothing
+                ActionType.NO_ACTION -> Unit // Do nothing
+                ActionType.ANSWER_BLOGGING_PROMPT -> Unit // Do nothing
+                null -> Unit // Do nothing
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -512,21 +512,19 @@ class PostsListActivity : LocaleAwareActivity(),
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         super.onCreateOptionsMenu(menu)
-        menu?.let {
-            menuInflater.inflate(R.menu.posts_list_toggle_view_layout, it)
-            toggleViewLayoutMenuItem = it.findItem(R.id.toggle_post_list_item_layout)
-            viewModel.viewLayoutTypeMenuUiState.observe(this, { menuUiState ->
-                menuUiState?.let {
-                    updateMenuIcon(menuUiState.iconRes, toggleViewLayoutMenuItem)
-                    updateMenuTitle(menuUiState.title, toggleViewLayoutMenuItem)
-                }
-            })
+        menuInflater.inflate(R.menu.posts_list_toggle_view_layout, menu)
+        toggleViewLayoutMenuItem = menu.findItem(R.id.toggle_post_list_item_layout)
+        viewModel.viewLayoutTypeMenuUiState.observe(this, { menuUiState ->
+            menuUiState?.let {
+                updateMenuIcon(menuUiState.iconRes, toggleViewLayoutMenuItem)
+                updateMenuTitle(menuUiState.title, toggleViewLayoutMenuItem)
+            }
+        })
 
-            searchActionButton = it.findItem(R.id.toggle_post_search)
+        searchActionButton = menu.findItem(R.id.toggle_post_search)
 
-            initSearchFragment()
-            binding.initSearchView()
-        }
+        initSearchFragment()
+        binding.initSearchView()
         return true
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -314,6 +314,7 @@ class StoriesEventListener @Inject constructor(
         return reCreateStoryResult.noSlidesLoaded
     }
 
+    @Suppress("UNCHECKED_CAST")
     fun onCancelUploadForMediaCollection(mediaFiles: ArrayList<Any>) {
         // just cancel upload for each media
         for (mediaFile in mediaFiles) {
@@ -326,6 +327,7 @@ class StoriesEventListener @Inject constructor(
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
     fun onRetryUploadForMediaCollection(
         activity: Activity,
         mediaFiles: ArrayList<Any>,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailFragment.kt
@@ -50,7 +50,7 @@ class CategoryDetailFragment : Fragment(R.layout.category_detail_fragment) {
     }
 
     private fun initDagger() {
-        (requireActivity().application as WordPress).component()?.inject(this)
+        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun CategoryDetailFragmentBinding.initAdapter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListFragment.kt
@@ -37,7 +37,7 @@ class CategoriesListFragment : Fragment(R.layout.site_settings_categories_list_f
     }
 
     private fun initDagger() {
-        (requireActivity().application as WordPress).component()?.inject(this)
+        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun SiteSettingsCategoriesListFragmentBinding.initViewModel(site: SiteModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFollowCommentsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFollowCommentsHandler.kt
@@ -14,11 +14,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
 import org.wordpress.android.R
 import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource
-import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.Failure
-import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FollowCommentsNotAllowed
-import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FollowStateChanged
-import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.Loading
-import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.UserNotAuthenticated
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 
 class ReaderFollowCommentsHandler @Inject constructor(
@@ -31,8 +26,8 @@ class ReaderFollowCommentsHandler @Inject constructor(
     private val _followStatusUpdate = MediatorLiveData<FollowCommentsState>()
     val followStatusUpdate: LiveData<FollowCommentsState> = _followStatusUpdate
 
-    private val _pushNotificationsStatusUpdate = MediatorLiveData<FollowStateChanged>()
-    val pushNotificationsStatusUpdate: LiveData<FollowStateChanged> = _pushNotificationsStatusUpdate
+    private val _pushNotificationsStatusUpdate = MediatorLiveData<FollowCommentsState.FollowStateChanged>()
+    val pushNotificationsStatusUpdate: LiveData<FollowCommentsState.FollowStateChanged> = _pushNotificationsStatusUpdate
 
     suspend fun handleFollowCommentsClicked(
         blogId: Long,
@@ -69,7 +64,7 @@ class ReaderFollowCommentsHandler @Inject constructor(
 
     private fun manageState(state: FollowCommentsState, onSuccessSnackbarAction: (() -> Unit)? = null) {
         when (state) {
-            is FollowStateChanged -> {
+            is FollowCommentsState.FollowStateChanged -> {
                 _followStatusUpdate.postValue(state)
                 if (state.forcePushNotificationsUpdate) {
                     _pushNotificationsStatusUpdate.postValue(state)
@@ -88,19 +83,20 @@ class ReaderFollowCommentsHandler @Inject constructor(
                     )))
                 }
             }
-            is Failure -> {
+            is FollowCommentsState.Failure -> {
                 _followStatusUpdate.postValue(state)
                 _snackbarEvents.postValue(Event(SnackbarMessageHolder(state.error)))
             }
-            Loading -> {
+            is FollowCommentsState.Loading -> {
                 _followStatusUpdate.postValue(state)
             }
-            FollowCommentsNotAllowed -> {
+            is FollowCommentsState.FollowCommentsNotAllowed -> {
                 _followStatusUpdate.postValue(state)
             }
-            UserNotAuthenticated -> {
+            is FollowCommentsState.UserNotAuthenticated -> {
                 _followStatusUpdate.postValue(state)
             }
+            is FollowCommentsState.FlagsMappedState -> Unit // Do nothing
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1436,29 +1436,23 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         renderer?.beginRender()
     }
 
-    private fun handleDirectOperation(): Boolean {
-        if (directOperation != null) {
-            when (directOperation) {
-                DirectOperation.COMMENT_JUMP, DirectOperation.COMMENT_REPLY, DirectOperation.COMMENT_LIKE -> {
-                    viewModel.post?.let {
-                        ReaderActivityLauncher.showReaderComments(
-                                activity, it.blogId, it.postId,
-                                directOperation, commentId.toLong(), viewModel.interceptedUri,
-                                DIRECT_OPERATION.sourceDescription
-                        )
-                    }
-
-                    activity?.finish()
-                    activity?.overridePendingTransition(0, 0)
-                    return true
-                }
-                DirectOperation.POST_LIKE -> {
-                }
+    private fun handleDirectOperation() = when (directOperation) {
+        DirectOperation.COMMENT_JUMP, DirectOperation.COMMENT_REPLY, DirectOperation.COMMENT_LIKE -> {
+            viewModel.post?.let {
+                ReaderActivityLauncher.showReaderComments(
+                        activity, it.blogId, it.postId,
+                        directOperation, commentId.toLong(), viewModel.interceptedUri,
+                        DIRECT_OPERATION.sourceDescription
+                )
             }
-            // Liking needs to be handled "later" after the post has been updated from the server so,
-            // nothing special to do here
+
+            activity?.finish()
+            activity?.overridePendingTransition(0, 0)
+            true
         }
-        return false
+        // Like needs to be handled "later" after the post has been updated from the server, nothing special to do here.
+        DirectOperation.POST_LIKE -> false
+        null -> false
     }
 
     @Suppress("DEPRECATION")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1026,7 +1026,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         }
 
         if (commentsSnippetFeatureConfig.isEnabled()) {
-            commentSnippetRecycler?.layoutManager?.let {
+            commentSnippetRecycler.layoutManager?.let {
                 outState.putParcelable(KEY_COMMENTS_SNIPPET_LIST_STATE, it.onSaveInstanceState())
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -24,8 +24,7 @@ import org.wordpress.android.ui.reader.ReaderActivityLauncher
 import org.wordpress.android.ui.reader.ReaderActivityLauncher.OpenUrlType
 import org.wordpress.android.ui.reader.ReaderPostWebViewCachingFragment
 import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.READER_POST_CARD
-import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
-import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.EmptyUiState
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEditorForReblog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.SharePost
@@ -92,19 +91,20 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
 
         viewModel.uiState.observe(viewLifecycleOwner, {
             when (it) {
-                is ContentUiState -> {
+                is DiscoverUiState.ContentUiState -> {
                     (recyclerView.adapter as ReaderDiscoverAdapter).update(it.cards)
                     if (it.scrollToTop) {
                         recyclerView.scrollToPosition(0)
                     }
                 }
-                is EmptyUiState -> {
+                is DiscoverUiState.EmptyUiState -> {
                     uiHelpers.setTextOrHide(actionableEmptyView.title, it.titleResId)
                     uiHelpers.setTextOrHide(actionableEmptyView.subtitle, it.subTitleRes)
                     uiHelpers.setImageOrHide(actionableEmptyView.image, it.illustrationResId)
                     uiHelpers.setTextOrHide(actionableEmptyView.button, it.buttonResId)
                     actionableEmptyView.button.setOnClickListener { _ -> it.action.invoke() }
                 }
+                is DiscoverUiState.LoadingUiState -> Unit // Do nothing
             }
 
             uiHelpers.updateVisibility(recyclerView, it.contentVisiblity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -201,6 +201,7 @@ class ReaderDiscoverLogic(
      * It for example copies only ids from post object as we don't need to store the gigantic post in the json
      * as it's already stored in the db.
      */
+    @Suppress("NestedBlockDepth")
     private fun createSimplifiedJson(cardsJsonArray: JSONArray): JSONArray {
         var index = 0
         val simplifiedJson = JSONArray()
@@ -208,9 +209,10 @@ class ReaderDiscoverLogic(
             val cardJson = cardsJsonArray.getJSONObject(i)
             when (cardJson.getString(JSON_CARD_TYPE)) {
                 JSON_CARD_RECOMMENDED_BLOGS -> {
-                    val recommendedBlogsCardJson = cardJson.optJSONArray(JSON_CARD_DATA)
-                    if (recommendedBlogsCardJson.length() > 0) {
-                        simplifiedJson.put(index++, createSimplifiedRecommendedBlogsCardJson(cardJson))
+                    cardJson.optJSONArray(JSON_CARD_DATA)?.let { recommendedBlogsCardJson ->
+                        if (recommendedBlogsCardJson.length() > 0) {
+                            simplifiedJson.put(index++, createSimplifiedRecommendedBlogsCardJson(cardJson))
+                        }
                     }
                 }
                 JSON_CARD_INTERESTS_YOU_MAY_LIKE -> {
@@ -242,6 +244,7 @@ class ReaderDiscoverLogic(
         return simplifiedCardJson
     }
 
+    @Suppress("NestedBlockDepth")
     private fun createSimplifiedRecommendedBlogsCardJson(originalCardJson: JSONObject): JSONObject {
         return JSONObject().apply {
             JSONArray().apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItemMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItemMapper.kt
@@ -4,12 +4,6 @@ import com.google.gson.Gson
 import org.wordpress.android.datasets.ReaderBlogTableWrapper
 import org.wordpress.android.models.ReaderBlog
 import org.wordpress.android.models.ReaderTagType
-import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SITE
-import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SITE_ALL
-import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.TAG
-import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Site
-import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.SiteAll
-import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import javax.inject.Inject
 
@@ -32,14 +26,14 @@ class SubfilterListItemMapper @Inject constructor(
         isSelected: Boolean
     ): SubfilterListItem {
         val mappedItem = if (json.isEmpty()) {
-            MappedSubfilterListItem(type = SITE_ALL.value)
+            MappedSubfilterListItem(type = SubfilterListItem.ItemType.SITE_ALL.value)
         } else {
             val gson = Gson()
             gson.fromJson(json, MappedSubfilterListItem::class.java)
         }
 
         return when (mappedItem.type) {
-            SITE.value -> {
+            SubfilterListItem.ItemType.SITE.value -> {
                 val blogInfo: ReaderBlog? = if (mappedItem.blogId != 0L) {
                     readerBlogTableWrapper.getBlogInfo(mappedItem.blogId)
                 } else if (mappedItem.feedId != 0L) {
@@ -47,29 +41,32 @@ class SubfilterListItemMapper @Inject constructor(
                 } else null
 
                 blogInfo?.let {
-                    Site(
+                    SubfilterListItem.Site(
                         blog = blogInfo,
                         onClickAction = onClickAction,
                         isSelected = isSelected
                     )
-                } ?: SiteAll(onClickAction = onClickAction, isSelected = isSelected)
+                } ?: SubfilterListItem.SiteAll(onClickAction = onClickAction, isSelected = isSelected)
             }
-            TAG.value -> {
+            SubfilterListItem.ItemType.TAG.value -> {
                 if (mappedItem.tagSlug.isNotEmpty()) {
                     val tag = readerUtilsWrapper.getTagFromTagName(
                             mappedItem.tagSlug,
                             ReaderTagType.fromInt(mappedItem.tagType)
                     )
-                    Tag(
+                    SubfilterListItem.Tag(
                         tag = tag,
                         onClickAction = onClickAction,
                         isSelected = isSelected
                     )
                 } else {
-                    SiteAll(onClickAction = onClickAction, isSelected = isSelected)
+                    SubfilterListItem.SiteAll(onClickAction = onClickAction, isSelected = isSelected)
                 }
             }
-            SITE_ALL.value -> SiteAll(onClickAction = onClickAction, isSelected = isSelected)
+            SubfilterListItem.ItemType.SITE_ALL.value -> SubfilterListItem.SiteAll(
+                    onClickAction = onClickAction,
+                    isSelected = isSelected
+            )
             else -> throw IllegalArgumentException("fromJson > Unexpected Subfilter type $mappedItem.type")
         }
     }
@@ -80,14 +77,17 @@ class SubfilterListItemMapper @Inject constructor(
         val mappedItem = MappedSubfilterListItem(type = item.type.value)
 
         when (item) {
-            is Site -> {
+            is SubfilterListItem.Site -> {
                 mappedItem.feedId = item.blog.feedId
                 mappedItem.blogId = item.blog.blogId
             }
-            is Tag -> {
+            is SubfilterListItem.Tag -> {
                 mappedItem.tagSlug = item.tag.tagSlug
                 mappedItem.tagType = item.tag.tagType.toInt()
             }
+            is SubfilterListItem.Divider -> Unit // Do nothing
+            is SubfilterListItem.SectionTitle -> Unit // Do nothing
+            is SubfilterListItem.SiteAll -> Unit // Do nothing
         }
 
         return gson.toJson(mappedItem)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -679,7 +679,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         var emptyStateTitle: UiString? = null
 
         if (updateLikesState is Failure && !showLoading) {
-            updateLikesState.emptyStateData?.let {
+            updateLikesState.emptyStateData.let {
                 showEmptyState = it.showEmptyState
                 emptyStateTitle = it.title
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -20,9 +20,6 @@ import org.wordpress.android.networking.MShot
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_DESIGNS
-import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState
@@ -198,11 +195,13 @@ class SiteCreationMainVM @Inject constructor(
 
     private fun clearOldSiteCreationState(wizardStep: SiteCreationStep) {
         when (wizardStep) {
-            SITE_DESIGNS -> { }
-            DOMAINS -> siteCreationState.domain?.let {
+            SiteCreationStep.SITE_DESIGNS -> Unit // Do nothing
+            SiteCreationStep.DOMAINS -> siteCreationState.domain?.let {
                 siteCreationState = siteCreationState.copy(domain = null)
             }
-            SITE_PREVIEW -> {} // intentionally left empty
+            SiteCreationStep.SITE_PREVIEW -> Unit // Do nothing
+            SiteCreationStep.INTENTS -> Unit // Do nothing
+            SiteCreationStep.SITE_NAME -> Unit // Do nothing
         }
     }
 
@@ -216,7 +215,7 @@ class SiteCreationMainVM @Inject constructor(
         val stepCount = wizardManager.stepsCount
         val firstStep = stepPosition == 1
         val lastStep = stepPosition == stepCount
-        val singleInBetweenStepDomains = step.name == DOMAINS.name
+        val singleInBetweenStepDomains = step.name == SiteCreationStep.DOMAINS.name
 
         return when {
             firstStep -> ScreenTitleGeneral(R.string.new_site_creation_screen_title_general)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -162,7 +162,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
         if (event.isError && event.error.type != SuggestDomainErrorType.INVALID_QUERY) {
             tracker.trackErrorShown(
                     ERROR_CONTEXT,
-                    event.error.type?.toString() ?: SiteCreationErrorType.UNKNOWN.toString(),
+                    event.error.type.toString(),
                     event.error.message
             )
             updateUiStateToContent(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/LineChartMarkerView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/LineChartMarkerView.kt
@@ -61,7 +61,7 @@ class LineChartMarkerView @Inject constructor(
                     prevWeekCount = y.toLong()
                 }
             }
-            val positive = thisWeekCount >= (prevWeekCount ?: 0)
+            val positive = thisWeekCount >= prevWeekCount
             val change = statsUtils.buildChange(prevWeekCount, thisWeekCount, positive, isFormattedNumber = false)
             changeView.text = change.toString()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -40,13 +40,6 @@ import org.wordpress.android.ui.stats.refresh.StatsModuleActivateRequestState.Fa
 import org.wordpress.android.ui.stats.refresh.StatsModuleActivateRequestState.Success
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.ANNUAL_STATS
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DAYS
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DETAIL
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.utils.NewsCardHandler
 import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
@@ -98,7 +91,9 @@ class StatsViewModel
 
     val siteChanged = statsSiteProvider.siteChanged
 
-    val toolbarHasShadow: LiveData<Boolean> = statsSectionManager.liveSelectedSection.mapNullable { it == INSIGHTS }
+    val toolbarHasShadow: LiveData<Boolean> = statsSectionManager.liveSelectedSection.mapNullable {
+        it == StatsSection.INSIGHTS
+    }
 
     val hideToolbar = newsCardHandler.hideToolbar
 
@@ -138,11 +133,11 @@ class StatsViewModel
 
     private fun getInitialTimeFrame(intent: Intent): StatsSection? {
         return when (intent.getSerializableExtra(StatsActivity.ARG_DESIRED_TIMEFRAME)) {
-            StatsTimeframe.INSIGHTS -> INSIGHTS
-            DAY -> DAYS
-            WEEK -> WEEKS
-            MONTH -> MONTHS
-            YEAR -> YEARS
+            StatsTimeframe.INSIGHTS -> StatsSection.INSIGHTS
+            DAY -> StatsSection.DAYS
+            WEEK -> StatsSection.WEEKS
+            MONTH -> StatsSection.MONTHS
+            YEAR -> StatsSection.YEARS
             else -> null
         }
     }
@@ -171,7 +166,7 @@ class StatsViewModel
             )
 
             initialSection?.let { statsSectionManager.setSelectedSection(it) }
-            trackSectionSelected(initialSection ?: INSIGHTS)
+            trackSectionSelected(initialSection ?: StatsSection.INSIGHTS)
 
             val initialGranularity = initialSection?.toStatsGranularity()
             if (initialGranularity != null && initialSelectedPeriod != null) {
@@ -203,7 +198,7 @@ class StatsViewModel
             }
         }
 
-        if (statsSectionManager.getSelectedSection() == INSIGHTS) showInsightsUpdateAlert()
+        if (statsSectionManager.getSelectedSection() == StatsSection.INSIGHTS) showInsightsUpdateAlert()
 
         if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) showJetpackPoweredBottomSheet()
     }
@@ -225,7 +220,7 @@ class StatsViewModel
     }
 
     private fun updateRevampedInsights() {
-        val insightsUseCase = listUseCases[INSIGHTS]
+        val insightsUseCase = listUseCases[StatsSection.INSIGHTS]
         insightsUseCase?.launch(defaultDispatcher) {
             val insightTypes = statsStore.getAddedInsights(statsSiteProvider.siteModel)
 
@@ -284,20 +279,24 @@ class StatsViewModel
 
         listUseCases[statsSection]?.onListSelected()
 
-        if (statsSection == INSIGHTS) showInsightsUpdateAlert()
+        if (statsSection == StatsSection.INSIGHTS) showInsightsUpdateAlert()
 
         trackSectionSelected(statsSection)
     }
 
     private fun trackSectionSelected(statsSection: StatsSection) {
         when (statsSection) {
-            INSIGHTS -> analyticsTracker.track(STATS_INSIGHTS_ACCESSED)
-            DAYS -> analyticsTracker.trackGranular(STATS_PERIOD_DAYS_ACCESSED, StatsGranularity.DAYS)
-            WEEKS -> analyticsTracker.trackGranular(STATS_PERIOD_WEEKS_ACCESSED, StatsGranularity.WEEKS)
-            MONTHS -> analyticsTracker.trackGranular(STATS_PERIOD_MONTHS_ACCESSED, StatsGranularity.MONTHS)
-            YEARS -> analyticsTracker.trackGranular(STATS_PERIOD_YEARS_ACCESSED, StatsGranularity.YEARS)
-            ANNUAL_STATS, DETAIL -> {
-            }
+            StatsSection.INSIGHTS -> analyticsTracker.track(STATS_INSIGHTS_ACCESSED)
+            StatsSection.DAYS -> analyticsTracker.trackGranular(STATS_PERIOD_DAYS_ACCESSED, StatsGranularity.DAYS)
+            StatsSection.WEEKS -> analyticsTracker.trackGranular(STATS_PERIOD_WEEKS_ACCESSED, StatsGranularity.WEEKS)
+            StatsSection.MONTHS -> analyticsTracker.trackGranular(STATS_PERIOD_MONTHS_ACCESSED, StatsGranularity.MONTHS)
+            StatsSection.YEARS -> analyticsTracker.trackGranular(STATS_PERIOD_YEARS_ACCESSED, StatsGranularity.YEARS)
+            StatsSection.ANNUAL_STATS -> Unit // Do nothing
+            StatsSection.DETAIL -> Unit // Do nothing
+            StatsSection.INSIGHT_DETAIL -> Unit // Do nothing
+            StatsSection.TOTAL_LIKES_DETAIL -> Unit // Do nothing
+            StatsSection.TOTAL_COMMENTS_DETAIL -> Unit // Do nothing
+            StatsSection.TOTAL_FOLLOWERS_DETAIL -> Unit // Do nothing
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualSiteStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/AnnualSiteStatsUseCase.kt
@@ -11,8 +11,6 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.NavigationTarget
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.ANNUAL_STATS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.StatelessUseCase
-import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
-import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.utils.ListItemInteraction
@@ -72,7 +70,7 @@ class AnnualSiteStatsUseCase(
         val items = mutableListOf<BlockListItem>()
 
         when (useCaseMode) {
-            BLOCK -> {
+            UseCaseMode.BLOCK -> {
                 items.add(buildTitle())
                 items.addAll(annualStatsMapper.mapYearInBlock(domainModel.years.last()))
                 if (domainModel.years.size > VISIBLE_ITEMS) {
@@ -84,13 +82,14 @@ class AnnualSiteStatsUseCase(
                     )
                 }
             }
-            VIEW_ALL -> {
+            UseCaseMode.VIEW_ALL -> {
                 items.addAll(
                         annualStatsMapper.mapYearInViewAll(
                                 domainModel.years.getOrNull(index) ?: domainModel.years.last()
                         )
                 )
             }
+            UseCaseMode.BLOCK_DETAIL -> Unit // Do nothing
         }
         return items
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/CommentsUseCase.kt
@@ -66,10 +66,10 @@ class CommentsUseCase
         return listOf(buildTitle(), Empty())
     }
 
-    override fun buildUiModel(model: CommentsModel, uiState: Int): List<BlockListItem> {
+    override fun buildUiModel(domainModel: CommentsModel, uiState: Int): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
         items.add(buildTitle())
-        if (model.authors.isNotEmpty() || model.posts.isNotEmpty()) {
+        if (domainModel.authors.isNotEmpty() || domainModel.posts.isNotEmpty()) {
             items.add(
                     TabsItem(
                             listOf(R.string.stats_comments_authors, R.string.stats_comments_posts_and_pages),
@@ -78,9 +78,9 @@ class CommentsUseCase
             )
 
             if (uiState == 0) {
-                items.addAll(buildAuthorsTab(model.authors))
+                items.addAll(buildAuthorsTab(domainModel.authors))
             } else {
-                items.addAll(buildPostsTab(model.posts))
+                items.addAll(buildPostsTab(domainModel.posts))
             }
         } else {
             items.add(Empty())

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/PostingActivityMapper.kt
@@ -61,14 +61,14 @@ class PostingActivityMapper
                 boxes.add(box)
                 boxDaysForAccessibility.add(Pair(box, day.key))
             }
-            val monthDisplayName = getMonthDisplayName(Calendar.LONG)
+            val monthDisplayName = getMonthDisplayName(Calendar.LONG) ?: ""
             val labelContentDescription = resourceProvider.getString(
                     R.string.stats_posting_activity_label_content_description,
                     monthDisplayName
             )
             blocks.add(
                     Block(
-                            getMonthDisplayName(Calendar.SHORT),
+                            getMonthDisplayName(Calendar.SHORT) ?: "",
                             boxes,
                             labelContentDescription,
                             addBlockContentDescriptions(boxDaysForAccessibility, monthDisplayName)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatter.kt
@@ -57,8 +57,14 @@ class StatsDateFormatter
      * @param period in this format yyyy-MM-dd
      * @return localized date in the medium format, in English - Jan 5, 2019
      */
+    @Suppress("TooGenericExceptionThrown")
     fun printDate(period: String): String {
-        return printDate(inputFormat.parse(period))
+        try {
+            return inputFormat.parse(period)?.let { outputFormat.format(it) }
+                    ?: throw RuntimeException("Unexpected date format")
+        } catch (e: ParseException) {
+            throw RuntimeException("Unexpected date format")
+        }
     }
 
     /**
@@ -68,14 +74,6 @@ class StatsDateFormatter
      */
     fun printStatsDate(date: Date): String {
         return inputFormat.format(date)
-    }
-
-    private fun printDate(date: Date): String {
-        try {
-            return outputFormat.format(date)
-        } catch (e: ParseException) {
-            throw RuntimeException("Unexpected date format")
-        }
     }
 
     /**
@@ -175,12 +173,13 @@ class StatsDateFormatter
      * @param date string date coming from the endpoints
      * @return parsed Date
      */
+    @Suppress("TooGenericExceptionThrown", "ThrowsCount")
     fun parseStatsDate(
         granularity: StatsGranularity,
         date: String
     ): Date {
         return when (granularity) {
-            DAYS -> inputFormat.parse(date)
+            DAYS -> inputFormat.parse(date) ?: throw RuntimeException("Unexpected date format")
             WEEKS -> {
                 // first four digits are the year
                 // followed by Wxx where xx is the month
@@ -188,13 +187,13 @@ class StatsDateFormatter
                 // ex: 2013W07W22 = July 22, 2013
                 val sdf = SimpleDateFormat("yyyy'W'MM'W'dd", Locale.ROOT)
                 // Calculate the end of the week
-                val parsedDate = sdf.parse(date)
+                val parsedDate = sdf.parse(date) ?: throw RuntimeException("Unexpected date format")
                 dateToWeekDate(parsedDate)
             }
             MONTHS -> {
                 val sdf = SimpleDateFormat("yyyy-MM", Locale.ROOT)
                 // Calculate the end of the month
-                val parsedDate = sdf.parse(date)
+                val parsedDate = sdf.parse(date) ?: throw RuntimeException("Unexpected date format")
                 val calendar: Calendar = Calendar.getInstance()
                 calendar.time = parsedDate
                 // last day of this month
@@ -206,7 +205,7 @@ class StatsDateFormatter
             YEARS -> {
                 val sdf = SimpleDateFormat(STATS_INPUT_FORMAT, Locale.ROOT)
                 // Calculate the end of the week
-                val parsedDate = sdf.parse(date)
+                val parsedDate = sdf.parse(date) ?: throw RuntimeException("Unexpected date format")
                 val calendar: Calendar = Calendar.getInstance()
                 calendar.time = parsedDate
                 calendar.set(Calendar.MONTH, Calendar.DECEMBER)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import androidx.fragment.app.FragmentActivity
 import org.wordpress.android.R
@@ -24,33 +25,6 @@ import org.wordpress.android.ui.stats.StatsViewType.TAGS_AND_CATEGORIES
 import org.wordpress.android.ui.stats.StatsViewType.TOP_POSTS_AND_PAGES
 import org.wordpress.android.ui.stats.StatsViewType.VIDEO_PLAYS
 import org.wordpress.android.ui.stats.refresh.NavigationTarget
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.AddNewPost
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.CheckCourse
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.SchedulePost
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.SetBloggingReminders
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.SharePost
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewAnnualStats
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewAttachment
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewAuthors
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewClicks
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewCommentsStats
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewCountries
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewFileDownloads
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewFollowersStats
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewInsightDetails
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewInsightsManagement
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewMonthsAndYearsStats
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPost
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPostDetailStats
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPostsAndPages
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewPublicizeStats
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewRecentWeeksStats
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewReferrers
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewSearchTerms
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTag
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewTagsAndCategoriesStats
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewUrl
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewVideoPlays
 import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.util.ToastUtils
@@ -66,10 +40,10 @@ class StatsNavigator @Inject constructor(
     @Suppress("LongMethod", "ComplexMethod", "SwallowedException")
     fun navigate(activity: FragmentActivity, target: NavigationTarget) {
         when (target) {
-            is AddNewPost -> {
+            is NavigationTarget.AddNewPost -> {
                 ActivityLauncher.addNewPostForResult(activity, siteProvider.siteModel, false, POST_FROM_STATS, -1, null)
             }
-            is ViewPost -> {
+            is NavigationTarget.ViewPost -> {
                 StatsNavigatorHelper.openPostInReaderOrInAppWebView(
                         activity,
                         siteProvider.siteModel.siteId,
@@ -79,18 +53,18 @@ class StatsNavigator @Inject constructor(
                         readerTracker
                 )
             }
-            is SharePost -> {
+            is NavigationTarget.SharePost -> {
                 val intent = Intent(Intent.ACTION_SEND)
                 intent.type = "text/plain"
                 intent.putExtra(Intent.EXTRA_TEXT, target.url)
                 intent.putExtra(Intent.EXTRA_SUBJECT, target.title)
                 try {
                     activity.startActivity(Intent.createChooser(intent, activity.getString(R.string.share_link)))
-                } catch (ex: android.content.ActivityNotFoundException) {
+                } catch (ex: ActivityNotFoundException) {
                     ToastUtils.showToast(activity, R.string.reader_toast_err_share_intent)
                 }
             }
-            is ViewPostDetailStats -> {
+            is NavigationTarget.ViewPostDetailStats -> {
                 StatsDetailActivity.start(
                         activity,
                         siteProvider.siteModel,
@@ -100,7 +74,7 @@ class StatsNavigator @Inject constructor(
                         postUrl = target.postUrl
                 )
             }
-            is ViewFollowersStats -> {
+            is NavigationTarget.ViewFollowersStats -> {
                 ActivityLauncher.viewAllTabbedInsightsStats(
                         activity,
                         FOLLOWERS,
@@ -108,7 +82,7 @@ class StatsNavigator @Inject constructor(
                         siteProvider.siteModel.id
                 )
             }
-            is ViewCommentsStats -> {
+            is NavigationTarget.ViewCommentsStats -> {
                 ActivityLauncher.viewAllTabbedInsightsStats(
                         activity,
                         COMMENTS,
@@ -116,22 +90,22 @@ class StatsNavigator @Inject constructor(
                         siteProvider.siteModel.id
                 )
             }
-            is ViewTagsAndCategoriesStats -> {
+            is NavigationTarget.ViewTagsAndCategoriesStats -> {
                 ActivityLauncher.viewAllInsightsStats(activity, TAGS_AND_CATEGORIES, siteProvider.siteModel.id)
             }
-            is ViewMonthsAndYearsStats -> {
+            is NavigationTarget.ViewMonthsAndYearsStats -> {
                 ActivityLauncher.viewAllInsightsStats(activity, DETAIL_MONTHS_AND_YEARS, siteProvider.siteModel.id)
             }
-            is ViewRecentWeeksStats -> {
+            is NavigationTarget.ViewRecentWeeksStats -> {
                 ActivityLauncher.viewAllInsightsStats(activity, DETAIL_RECENT_WEEKS, siteProvider.siteModel.id)
             }
-            is ViewTag -> {
+            is NavigationTarget.ViewTag -> {
                 ActivityLauncher.openStatsUrl(activity, target.link)
             }
-            is ViewPublicizeStats -> {
+            is NavigationTarget.ViewPublicizeStats -> {
                 ActivityLauncher.viewAllInsightsStats(activity, PUBLICIZE, siteProvider.siteModel.id)
             }
-            is ViewPostsAndPages -> {
+            is NavigationTarget.ViewPostsAndPages -> {
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
@@ -140,7 +114,7 @@ class StatsNavigator @Inject constructor(
                         siteProvider.siteModel.id
                 )
             }
-            is ViewReferrers -> {
+            is NavigationTarget.ViewReferrers -> {
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
@@ -149,7 +123,7 @@ class StatsNavigator @Inject constructor(
                         siteProvider.siteModel.id
                 )
             }
-            is ViewClicks -> {
+            is NavigationTarget.ViewClicks -> {
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
@@ -158,7 +132,7 @@ class StatsNavigator @Inject constructor(
                         siteProvider.siteModel.id
                 )
             }
-            is ViewCountries -> {
+            is NavigationTarget.ViewCountries -> {
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
@@ -167,7 +141,7 @@ class StatsNavigator @Inject constructor(
                         siteProvider.siteModel.id
                 )
             }
-            is ViewVideoPlays -> {
+            is NavigationTarget.ViewVideoPlays -> {
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
@@ -176,7 +150,7 @@ class StatsNavigator @Inject constructor(
                         siteProvider.siteModel.id
                 )
             }
-            is ViewSearchTerms -> {
+            is NavigationTarget.ViewSearchTerms -> {
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
@@ -185,7 +159,7 @@ class StatsNavigator @Inject constructor(
                         siteProvider.siteModel.id
                 )
             }
-            is ViewAuthors -> {
+            is NavigationTarget.ViewAuthors -> {
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
@@ -194,7 +168,7 @@ class StatsNavigator @Inject constructor(
                         siteProvider.siteModel.id
                 )
             }
-            is ViewFileDownloads -> {
+            is NavigationTarget.ViewFileDownloads -> {
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         target.statsGranularity,
@@ -203,7 +177,7 @@ class StatsNavigator @Inject constructor(
                         siteProvider.siteModel.id
                 )
             }
-            is ViewAnnualStats -> {
+            is NavigationTarget.ViewAnnualStats -> {
                 ActivityLauncher.viewAllGranularStats(
                         activity,
                         YEARS,
@@ -212,13 +186,13 @@ class StatsNavigator @Inject constructor(
                         siteProvider.siteModel.id
                 )
             }
-            is ViewUrl -> {
+            is NavigationTarget.ViewUrl -> {
                 WPWebViewActivity.openURL(activity, target.url)
             }
-            is ViewInsightsManagement -> {
+            is NavigationTarget.ViewInsightsManagement -> {
                 ActivityLauncher.viewInsightsManagement(activity, siteProvider.siteModel.id)
             }
-            is ViewAttachment -> {
+            is NavigationTarget.ViewAttachment -> {
                 StatsNavigatorHelper.openPostInReaderOrInAppWebView(
                         activity,
                         siteProvider.siteModel.siteId,
@@ -228,7 +202,7 @@ class StatsNavigator @Inject constructor(
                         readerTracker
                 )
             }
-            is ViewInsightDetails -> {
+            is NavigationTarget.ViewInsightDetails -> {
                 ActivityLauncher.viewInsightsDetail(
                         activity,
                         target.statsSection,
@@ -241,18 +215,19 @@ class StatsNavigator @Inject constructor(
                 )
             }
 
-            is SetBloggingReminders -> {
+            is NavigationTarget.SetBloggingReminders -> {
                 ActivityLauncher.showSetBloggingReminders(activity, siteProvider.siteModel)
             }
-            is CheckCourse -> {
+            is NavigationTarget.CheckCourse -> {
                 ActivityLauncher.openStatsUrl(
                         activity,
                         "https://wpcourses.com/course/intro-to-blogging/"
                 )
             }
-            is SchedulePost -> {
+            is NavigationTarget.SchedulePost -> {
                 ActivityLauncher.showSchedulingPost(activity, siteProvider.siteModel)
             }
+            NavigationTarget.ViewDayAverageStats -> Unit // Do nothing
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -17,8 +17,7 @@ const val TEN_THOUSAND = 10000
 const val HUNDRED_THOUSAND = 100000
 const val MILLION = 1000000
 
-class StatsUtils
-@Inject constructor(
+class StatsUtils @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val localeManager: LocaleManagerWrapper,
     private val percentFormatter: PercentFormatter
@@ -92,8 +91,8 @@ class StatsUtils
         }
 
         val e = suffixes.floorEntry(safeNumber)
-        val divideBy = e.key
-        val suffix = e.value
+        val divideBy = e?.key
+        val suffix = e?.value
 
         val truncated = safeNumber / (divideBy!! / 10)
         val hasDecimal = truncated < 100 && truncated / 10.0 != (truncated / 10).toDouble()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/LoadStoryFromStoriesPrefsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/LoadStoryFromStoriesPrefsUseCase.kt
@@ -25,6 +25,7 @@ class LoadStoryFromStoriesPrefsUseCase @Inject constructor(
     private val storiesPrefs: StoriesPrefs,
     private val mediaStore: MediaStore
 ) {
+    @Suppress("UNCHECKED_CAST")
     fun getMediaIdsFromStoryBlockBridgeMediaFiles(mediaFiles: ArrayList<Any>): ArrayList<String> {
         val mediaIds = ArrayList<String>()
         for (mediaFile in mediaFiles) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/XPostsSuggestionSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/XPostsSuggestionSource.kt
@@ -37,6 +37,7 @@ class XPostsSuggestionSource @Inject constructor(
                         _suggestions.postValue(SuggestionResult(xPostSuggestions, false))
                     }
                 }
+                is XPostsResult.Unknown -> Unit // Do nothing
             }
         }
         refreshSuggestions()

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
@@ -45,12 +45,14 @@ class DownloadManagerWrapper
     private fun toPublicUri(fileUrl: String): Uri {
         val fileUri = Uri.parse(fileUrl)
         return if (ContentResolver.SCHEME_FILE == fileUri.scheme) {
-            val file = File(fileUri.path)
-            FileProvider.getUriForFile(
-                    context,
-                    "${BuildConfig.APPLICATION_ID}.provider",
-                    file
-            )
+            fileUri.path?.let { path ->
+                val file = File(path)
+                FileProvider.getUriForFile(
+                        context,
+                        "${BuildConfig.APPLICATION_ID}.provider",
+                        file
+                )
+            } ?: fileUri
         } else {
             fileUri
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/SnackbarSequencer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SnackbarSequencer.kt
@@ -66,7 +66,7 @@ class SnackbarSequencer @Inject constructor(
             } as? Activity
 
             if (context != null && isContextAlive(context)) {
-                prepareSnackBar(context, item)?.show()
+                item?.let { prepareSnackBar(context, it)?.show() }
                 AppLog.d(T.UTILS, "SnackbarSequencer > before delay")
                 /**
                  * Delay showing the next snackbar only if the current snack bar is important.

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
@@ -8,8 +8,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.BACKGROUND
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.RemoteAutoSavePost
-import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.UpdatePost
+import org.wordpress.android.fluxc.model.CauseOfOnPostChanged
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
@@ -77,7 +76,7 @@ class PageListEventListener(
         launch {
             when (event.causeOfChange) {
                 // Fetched post list event will be handled by OnListChanged
-                is RemoteAutoSavePost -> {
+                is CauseOfOnPostChanged.RemoteAutoSavePost -> {
                     if (event.isError) {
                         AppLog.d(
                                 T.POSTS, "REMOTE_AUTO_SAVE_POST failed: " +
@@ -85,14 +84,16 @@ class PageListEventListener(
                         )
                     }
 
-                    uploadStatusChanged(LocalId((event.causeOfChange as RemoteAutoSavePost).localPostId))
+                    uploadStatusChanged(
+                            LocalId((event.causeOfChange as CauseOfOnPostChanged.RemoteAutoSavePost).localPostId)
+                    )
                     handleRemoteAutoSave.invoke(
-                            LocalId((event.causeOfChange as RemoteAutoSavePost).localPostId),
+                            LocalId((event.causeOfChange as CauseOfOnPostChanged.RemoteAutoSavePost).localPostId),
                             event.isError
                     )
                 }
 
-                is UpdatePost -> {
+                is CauseOfOnPostChanged.UpdatePost -> {
                     if (event.isError) {
                         AppLog.e(
                                 T.POSTS,
@@ -100,8 +101,15 @@ class PageListEventListener(
                                         " message: ${event.error.message}"
                         )
                     }
-                    uploadStatusChanged(LocalId((event.causeOfChange as UpdatePost).localPostId))
+                    uploadStatusChanged(LocalId((event.causeOfChange as CauseOfOnPostChanged.UpdatePost).localPostId))
                 }
+                is CauseOfOnPostChanged.DeletePost -> Unit // Do nothing
+                is CauseOfOnPostChanged.RestorePost -> Unit // Do nothing
+                is CauseOfOnPostChanged.FetchPages -> Unit // Do nothing
+                is CauseOfOnPostChanged.FetchPosts -> Unit // Do nothing
+                is CauseOfOnPostChanged.RemoveAllPosts -> Unit // Do nothing
+                is CauseOfOnPostChanged.RemovePost -> Unit // Do nothing
+                is CauseOfOnPostChanged.FetchPostLikes -> Unit // Do nothing
             }
         }
     }

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -177,7 +177,6 @@
     <ID>NestedBlockDepth:LoadStoryFromStoriesPrefsUseCase.kt$LoadStoryFromStoriesPrefsUseCase$private fun loadOrReCreateStoryFromStoriesPrefs(site: SiteModel, mediaIds: ArrayList&lt;String>): ReCreateStoryResult</ID>
     <ID>NestedBlockDepth:PublicizeErrorDialogFragment.kt$PublicizeErrorDialogFragment$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
     <ID>NestedBlockDepth:PublishNotificationReceiverViewModel.kt$PublishNotificationReceiverViewModel$fun loadNotification(notificationId: Int): NotificationUiModel?</ID>
-    <ID>NestedBlockDepth:ReaderDiscoverLogic.kt$ReaderDiscoverLogic$private fun createSimplifiedRecommendedBlogsCardJson(originalCardJson: JSONObject): JSONObject</ID>
     <ID>NestedBlockDepth:StoriesPrefs.kt$StoriesPrefs$private fun checkSlideOriginalBackgroundMediaExists(storyFrameItem: StoryFrameItem?): Boolean</ID>
     <ID>NestedBlockDepth:StoryComposerActivity.kt$StoryComposerActivity$override fun onStorySaveButtonPressed()</ID>
     <ID>NestedBlockDepth:StoryComposerActivity.kt$StoryComposerActivity$private fun buildStoryMediaFileDataListFromStoryFrameIndexes( storyIndex: StoryIndex ): ArrayList&lt;StoryMediaFileData></ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -250,7 +250,6 @@
     <ID>TooGenericExceptionThrown:ReaderTracker.kt$ReaderTab.Companion$throw RuntimeException("Unexpected ReaderTab id")</ID>
     <ID>TooGenericExceptionThrown:RestoreFragment.kt$RestoreFragment$throw Throwable("Couldn't initialize ${this.javaClass.simpleName} view model")</ID>
     <ID>TooGenericExceptionThrown:RestoreViewModel.kt$RestoreViewModel$throw Throwable("Unexpected restoreRequestResult ${this.javaClass.simpleName}")</ID>
-    <ID>TooGenericExceptionThrown:StatsDateFormatter.kt$StatsDateFormatter$throw RuntimeException("Unexpected date format")</ID>
     <ID>TooGenericExceptionThrown:ThreatDetailsFragment.kt$ThreatDetailsFragment$throw RuntimeException("ThreatDetailsFragment - missing siteModel extras.")</ID>
     <ID>TopLevelPropertyNaming:ActivityLogTypeFilterAdapter.kt$private const val activityViewType: Int = 2</ID>
     <ID>TopLevelPropertyNaming:ActivityLogTypeFilterAdapter.kt$private const val headerViewType: Int = 1</ID>


### PR DESCRIPTION
Parent: #17173
Partially Closes: #17181

This PR resolves one part of all `Type/Cast/When` related warnings for the `WordPress` module, and in this part, specific to the main source:

Type Related (`44`):
- `4` x `Unsafe use of a nullable receiver of type Xyz?`
- `13` x `Type mismatch: inferred type is Xyz? but Xyz was expected`
- `4` x `Elvis operator (?:) always returns the left operand of non-nullable type Xyz`
- `4` x `The corresponding parameter in the supertype 'Xyz' is named 'xyz'. This may cause problems when calling this function with named arguments.`
- `11` x `ents. (4)
Unnecessary non-null assertion (!!) on a non-null receiver of type Xyz`
- `18` x `Unnecessary safe call on a non-null receiver of type Xyz. This expression will have nullable type in future releases`

Cast Related (`5`):
- `4` x `Unchecked cast: Xyz to Xyz`
- `1` x `This cast can never succeed`

When Related (`26`):
- `26` x `Non exhaustive 'when' statements on xyz will be prohibited in 1.7, add 'Xyz', 'Xyz' branch(es) or 'else' branch instead`

-----

Warnings Resolution List:

- `type`
    1. [Resolve unsafe use of a nullable receiver type warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/ca26213804edba0819e5f6ea422fbcc80994d68c)
    2. [Resolve type mismatch type warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/2e5a0d36cceabbf9f609f62bc767d7c451bf85fb)
    3. [Resolve elvis operator type warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/d16beb7f65989c8ab6689409f4c2712fe43948ee)
    4. [Resolve parameter supertype naming type warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/c703718378273f60ec3eb431ce5e9e12ed4102e0)
    5. [Resolve non-null assertion type warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/3473b4b08b8853b9c40f0585c5ad5e5bf8c1116a)
    6. [Resolve unnecessary safe call type warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/9aad20cbbd1f6260009e10a873377bab29d758c3)
- `when`
    1. [Resolve non exhaustive when statements when warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/f15bfc915999af84c3bdcb02095ee3a778f0a327)

Warnings Suppression List:

- `cast`
    1. [Suppress unchecked cast cast warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/df2808c6b779eb1e736a7d11c7c971ddbaae10c4)
    2. [Suppress cast can never succeed cast warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/b4dc49b2e5c8b0dcb8f3fd119593fd3979505b3a)

Refactor List:

- `type`
    1. [Remove unused get build config string/value functions.](https://github.com/wordpress-mobile/WordPress-Android/commit/76cf29fa4dc6cb78f358ba477525dd0edaec2111)

-----

PS: @ovitrif I added you as the main reviewer, that is, in addition to @wordpress-mobile/apps-infrastructure team itself, but randomly, since I want someone from the WordPress Android team to primarily sign-off on that change. 🥇

FYI: I am going to randomly add more of you in those PRs that will follow, just so you become more aware of this change and how close we are on enabling allWarningsAsErrors by default everywhere. 🎉

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could quickly smoke test both, the `WordPress` and `Jetpack` apps, and see if they are both working as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
