### PR TITLE
[Compile Warnings As Errors] WordPress Module - Resolve Other Warnings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -533,7 +533,7 @@ class AppInitializer @Inject constructor(
         }
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAuthenticationChanged(event: OnAuthenticationChanged) {
         if (accountStore.hasAccessToken()) {

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -533,7 +533,7 @@ class AppInitializer @Inject constructor(
         }
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAuthenticationChanged(event: OnAuthenticationChanged) {
         if (accountStore.hasAccessToken()) {

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.kt
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.kt
@@ -58,15 +58,15 @@ abstract class WordPress : MultiDexApplication() {
         @JvmStatic
         fun getRestClientUtils() = AppInitializer.restClientUtils
 
-        @SuppressWarnings("FunctionNaming")
+        @Suppress("FunctionNaming")
         @JvmStatic
         fun getRestClientUtilsV1_1() = AppInitializer.restClientUtilsV1_1
 
-        @SuppressWarnings("FunctionNaming")
+        @Suppress("FunctionNaming")
         @JvmStatic
         fun getRestClientUtilsV1_2() = AppInitializer.restClientUtilsV1_2
 
-        @SuppressWarnings("FunctionNaming")
+        @Suppress("FunctionNaming")
         @JvmStatic
         fun getRestClientUtilsV1_3() = AppInitializer.restClientUtilsV1_3
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallViewModel.kt
@@ -147,8 +147,8 @@ class JetpackRemoteInstallViewModel
     }
 
     // Network Callbacks
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    @SuppressWarnings("unused")
     fun onEventsUpdated(event: OnJetpackInstalled) {
         val site = siteModel ?: return
         if (event.isError) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -224,7 +224,6 @@ class DomainsDashboardViewModel @Inject constructor(
                 TODO("Not yet implemented")
             }
         }
-        return true
     }
 
     fun onSuccessfulDomainRegistration() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/GetLikesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/GetLikesUseCase.kt
@@ -46,10 +46,8 @@ import kotlin.coroutines.suspendCoroutine
 class GetLikesUseCase @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val dispatcher: Dispatcher,
-    @SuppressWarnings("Unused")
-    val commentStore: CommentStore,
-    @SuppressWarnings("Unused")
-    val postStore: PostStore,
+    @Suppress("Unused") val commentStore: CommentStore,
+    @Suppress("Unused") val postStore: PostStore,
     val accountStore: AccountStore
 ) {
     private var getLikesContinuations = mutableMapOf<String, Continuation<OnChanged<*>>>()
@@ -76,7 +74,7 @@ class GetLikesUseCase @Inject constructor(
         getLikes(COMMENT_LIKE, this, fingerPrint, paginationParams)
     }
 
-    @SuppressWarnings("ComplexMethod", "NestedBlockDepth", "LoopWithTooManyJumpStatements")
+    @Suppress("ComplexMethod", "NestedBlockDepth", "LoopWithTooManyJumpStatements")
     private suspend fun getLikes(
         category: LikeCategory,
         flow: FlowCollector<GetLikesState>,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCase.kt
@@ -96,8 +96,8 @@ class JetpackCapabilitiesUseCase @Inject constructor(
         )
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onJetpackCapabilitiesFetched(event: OnJetpackCapabilitiesFetched) {
         continuation[event.remoteSiteId]?.let {
             continuation.remove(event.remoteSiteId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -586,7 +586,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         }
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAccountChanged(event: OnAccountChanged?) {
         binding?.refreshAccountDetails()

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -586,7 +586,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         }
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAccountChanged(event: OnAccountChanged?) {
         binding?.refreshAccountDetails()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceMediaLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceMediaLoader.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.mediapicker.loader
 
 import android.content.ContentResolver
 import android.content.Context
-import android.database.Cursor
 import android.net.Uri
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
@@ -42,7 +41,6 @@ class DeviceMediaLoader
         }
         val result = mutableListOf<DeviceMediaItem>()
         val projection = arrayOf(ID_COL, ID_DATE_MODIFIED, ID_TITLE)
-        var cursor: Cursor? = null
         val dateCondition = if (limitDate != null && limitDate != 0L) {
             "$ID_DATE_MODIFIED <= \'$limitDate\'"
         } else {
@@ -55,11 +53,8 @@ class DeviceMediaLoader
             dateCondition ?: filterCondition
         }
 
-        cursor = getCursor(condition, pageSize, baseUri, projection)
+        val cursor = getCursor(condition, pageSize, baseUri, projection) ?: return DeviceMediaList(listOf(), null)
 
-        if (cursor == null) {
-            return DeviceMediaList(listOf(), null)
-        }
         try {
             val idIndex = cursor.getColumnIndexOrThrow(ID_COL)
             val dateIndex = cursor.getColumnIndexOrThrow(ID_DATE_MODIFIED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -301,7 +301,7 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
             }
         }
     }
-    private val mOnGravatarClickedListener = OnGravatarClickedListener { siteId, userId, siteUrl ->
+    private val mOnGravatarClickedListener = OnGravatarClickedListener { siteId, _, siteUrl ->
         if (!isAdded || activity !is NotificationsDetailActivity) {
             return@OnGravatarClickedListener
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -443,7 +443,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         notesAdapter!!.addAll(event.notes, true)
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = MAIN)
     fun onEventMainThread(error: NotificationsRefreshError?) {
         if (isAdded) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -443,7 +443,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         notesAdapter!!.addAll(event.notes, true)
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = MAIN)
     fun onEventMainThread(error: NotificationsRefreshError?) {
         if (isAdded) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/FormattableContentClickHandler.kt
@@ -64,9 +64,9 @@ class FormattableContentClickHandler @Inject constructor(
                 showPostActivity(activity, siteId, id)
             COMMENT -> {
                 // Load the comment in the reader list if it exists, otherwise show a webview
-                val postId = clickedSpan.postId ?: clickedSpan.rootId ?: 0
-                if (ReaderUtils.postAndCommentExists(siteId, postId, id)) {
-                    showReaderCommentsList(activity, siteId, postId, id, ACTIVITY_LOG_DETAIL)
+                val rootId = clickedSpan.postId ?: clickedSpan.rootId ?: 0
+                if (ReaderUtils.postAndCommentExists(siteId, rootId, id)) {
+                    showReaderCommentsList(activity, siteId, rootId, id, ACTIVITY_LOG_DETAIL)
                 } else {
                     showWebViewActivityForUrl(activity, clickedSpan.url, rangeType)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/InviteLinksApiCallsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/InviteLinksApiCallsProvider.kt
@@ -50,7 +50,7 @@ class InviteLinksApiCallsProvider @Inject constructor(
     suspend fun generateLinks(blogId: Long): InviteLinksCallResult = suspendCoroutine { cont ->
         val endPointPath = "/sites/$blogId/invites/links/generate"
 
-        val listener = Listener { jsonObject ->
+        val listener = Listener {
             AppLog.d(
                     T.PEOPLE,
                     "generateLinks > Succeeded [blogId=$blogId]"
@@ -72,7 +72,7 @@ class InviteLinksApiCallsProvider @Inject constructor(
     suspend fun disableLinks(blogId: Long): InviteLinksCallResult = suspendCoroutine { cont ->
         val endPointPath = "/sites/$blogId/invites/links/disable"
 
-        val listener = Listener { jsonObject ->
+        val listener = Listener {
             AppLog.d(
                     T.PEOPLE,
                     "deleteLinks > Succeeded [blogId=$blogId]"

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/WPEditTextWithChipsOutlined.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/WPEditTextWithChipsOutlined.kt
@@ -276,7 +276,7 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
     }
 
     private fun setListeners() {
-        editor.setOnFocusChangeListener { v, hasFocus ->
+        editor.setOnFocusChangeListener { _, hasFocus ->
             val canAnimate = hint.width > 0 && label.width > 0 && hint.height > 0 && label.height > 0
             if (canAnimate) {
                 styleView(hasFocus, hasItemsOrText(), true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansViewModel.kt
@@ -89,8 +89,8 @@ class PlansViewModel @Inject constructor(
         _plans.value = _cachedPlans.value
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onPlanOffersFetched(event: OnPlanOffersFetched) {
         if (event.isError && event.planOffers?.isEmpty() == false) {
             _listStatus.value = PlansListStatus.ERROR_WITH_CACHE

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -205,13 +205,13 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
         }
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = MAIN)
     fun onTermUploaded(event: OnTermUploaded) {
         viewModel.onTermUploadedComplete(event)
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = MAIN)
     fun onTaxonomyChanged(event: OnTaxonomyChanged) {
         viewModel.onTaxonomyChanged(event)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -187,13 +187,13 @@ class StorePostViewModel
         _onFinish.postValue(Event(state))
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe
     fun onPostUploaded(event: OnPostUploaded) {
         hideSavingProgressDialog()
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe
     fun onPostChanged(event: OnPostChanged) {
         hideSavingProgressDialog()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -187,13 +187,13 @@ class StorePostViewModel
         _onFinish.postValue(Event(state))
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe
     fun onPostUploaded(event: OnPostUploaded) {
         hideSavingProgressDialog()
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe
     fun onPostChanged(event: OnPostChanged) {
         hideSavingProgressDialog()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -293,7 +293,7 @@ class StoriesEventListener @Inject constructor(
                 )
                 builder.setTitle(activity.getString(R.string.dialog_edit_story_unavailable_title))
                 builder.setMessage(activity.getString(R.string.dialog_edit_story_unavailable_message))
-                builder.setPositiveButton(R.string.dialog_button_ok) { dialog, id ->
+                builder.setPositiveButton(R.string.dialog_button_ok) { dialog, _ ->
                     dialog.dismiss()
                 }
                 val dialog = builder.create()
@@ -305,7 +305,7 @@ class StoriesEventListener @Inject constructor(
                 )
                 builder.setTitle(activity.getString(R.string.dialog_edit_story_unrecoverable_title))
                 builder.setMessage(activity.getString(R.string.dialog_edit_story_unrecoverable_message))
-                builder.setPositiveButton(R.string.dialog_button_ok) { dialog, id -> dialog.dismiss() }
+                builder.setPositiveButton(R.string.dialog_button_ok) { dialog, _ -> dialog.dismiss() }
                 val dialog = builder.create()
                 dialog.show()
             }
@@ -348,7 +348,7 @@ class StoriesEventListener @Inject constructor(
                             activity
                     )
                     builder.setTitle(activity.getString(R.string.cannot_retry_deleted_media_item_fatal))
-                    builder.setPositiveButton(R.string.ok) { dialog, id -> dialog.dismiss() }
+                    builder.setPositiveButton(R.string.ok) { dialog, _ -> dialog.dismiss() }
                     val dialog = builder.create()
                     dialog.show()
                     return

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -18,7 +18,6 @@ import com.wordpress.stories.compose.story.StoryIndex
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.EDITOR_UPLOAD_MEDIA_RETRIED
 import org.wordpress.android.editor.EditorMediaUploadListener
@@ -348,8 +347,8 @@ class StoriesEventListener @Inject constructor(
                     val builder: Builder = MaterialAlertDialogBuilder(
                             activity
                     )
-                    builder.setTitle(activity.getString(string.cannot_retry_deleted_media_item_fatal))
-                    builder.setPositiveButton(string.ok) { dialog, id -> dialog.dismiss() }
+                    builder.setTitle(activity.getString(R.string.cannot_retry_deleted_media_item_fatal))
+                    builder.setPositiveButton(R.string.ok) { dialog, id -> dialog.dismiss() }
                     val dialog = builder.create()
                     dialog.show()
                     return
@@ -380,7 +379,7 @@ class StoriesEventListener @Inject constructor(
         AnalyticsTracker.track(EDITOR_UPLOAD_MEDIA_RETRIED)
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     fun onCancelSaveForMediaCollection(mediaFiles: ArrayList<Any>) {
         // TODO implement cancelling save process for media collection
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/XPostsCapabilityChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/XPostsCapabilityChecker.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.posts.editor
 
 import androidx.core.util.Consumer
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -13,6 +14,7 @@ class XPostsCapabilityChecker @Inject constructor(
     private val xPostsStore: XPostsStore
 ) {
     @Suppress("GlobalCoroutineUsage")
+    @OptIn(DelicateCoroutinesApi::class)
     fun retrieveCapability(site: SiteModel, callback: Consumer<Boolean>) {
         GlobalScope.launch(Dispatchers.IO) {
             val capability = isCapable(site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsOptimisticUpdateHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsOptimisticUpdateHandler.kt
@@ -64,10 +64,10 @@ class AccountSettingsOptimisticUpdateHandler @Inject constructor() {
         ).plus(value)
     }
 
-    fun removeFirstChange(preferenceKey: String): () -> Unit = removeFirstChange@{
+    fun removeFirstChange(preferenceKey: String): () -> Unit = removeFirstChangeLambda@{
         val preferenceValue = optimisticallyChangedPreferenceMap
                 .getOrDefault(preferenceKey, listOf())
-        if (preferenceValue.isEmpty()) return@removeFirstChange
+        if (preferenceValue.isEmpty()) return@removeFirstChangeLambda
         if (preferenceValue.size == 1) {
             optimisticallyChangedPreferenceMap.remove(preferenceKey)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModel.kt
@@ -118,7 +118,7 @@ class CategoryDetailViewModel @Inject constructor(
         }
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = MAIN)
     fun onTermUploaded(event: OnTermUploaded) {
         if (event.isError) AppLog.e(

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListViewModel.kt
@@ -107,7 +107,7 @@ class CategoriesListViewModel @Inject constructor(
         _navigation.postValue(CreateCategory)
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     fun onCategoryClicked(categoryNode: CategoryNode) {
         // todo implement the logic of navigation to category detail page
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListViewModel.kt
@@ -86,7 +86,7 @@ class CategoriesListViewModel @Inject constructor(
         } else if (_uiState.value is Loading) _uiState.postValue(NoConnection(::onRetryClicked))
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = MAIN)
     fun onTaxonomyChanged(event: OnTaxonomyChanged) {
         if (event.isError) AppLog.e(
@@ -97,7 +97,7 @@ class CategoriesListViewModel @Inject constructor(
         if (event.causeOfChange == TaxonomyAction.FETCH_CATEGORIES) processFetchCategoriesCallback(event)
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = MAIN)
     fun onTermUploaded(event: OnTermUploaded) {
         if (!event.isError) getCategoriesFromDb()
@@ -107,7 +107,7 @@ class CategoriesListViewModel @Inject constructor(
         _navigation.postValue(CreateCategory)
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     fun onCategoryClicked(categoryNode: CategoryNode) {
         // todo implement the logic of navigation to category detail page
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/FollowConversationUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/FollowConversationUiState.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.ui.reader
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 const val FOLLOW_CONVERSATION_UI_STATE_FLAGS_KEY = "follow-conversation-ui-state-flags-key"
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -348,7 +348,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         appBar.addOnOffsetChangedListener(appBarLayoutOffsetChangedListener)
 
         // Fixes collapsing toolbar layout being obscured by the status bar when drawn behind it
-        ViewCompat.setOnApplyWindowInsetsListener(appBar) { v: View, insets: WindowInsetsCompat ->
+        ViewCompat.setOnApplyWindowInsetsListener(appBar) { _: View, insets: WindowInsetsCompat ->
             val insetTop = insets.systemWindowInsetTop
             if (insetTop > 0) {
                 toolBar.setPadding(0, insetTop, 0, 0)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -369,7 +369,7 @@ class ReaderDiscoverViewModel @Inject constructor(
         }
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     private fun onDiscoverClicked(postId: Long, blogId: Long) {
         // TODO malinjir: add on discover clicked listener
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProvider.kt
@@ -186,8 +186,8 @@ class ReaderDiscoverDataProvider @Inject constructor(
     }
 
     // Event bus events
+    @Suppress("unused")
     @Subscribe(threadMode = BACKGROUND)
-    @SuppressWarnings("unused")
     fun onReaderPostTableAction(event: ReaderPostTableActionEnded) {
         if (_discoverFeed.hasObservers()) {
             isDirty.compareAndSet(true, false)
@@ -208,7 +208,7 @@ class ReaderDiscoverDataProvider @Inject constructor(
         }
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = BACKGROUND)
     fun onFollowedTagsChanged(event: FollowedTagsChanged) {
         launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProvider.kt
@@ -186,7 +186,7 @@ class ReaderDiscoverDataProvider @Inject constructor(
     }
 
     // Event bus events
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = BACKGROUND)
     fun onReaderPostTableAction(event: ReaderPostTableActionEnded) {
         if (_discoverFeed.hasObservers()) {
@@ -208,7 +208,7 @@ class ReaderDiscoverDataProvider @Inject constructor(
         }
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = BACKGROUND)
     fun onFollowedTagsChanged(event: FollowedTagsChanged) {
         launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FetchFollowedTagsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FetchFollowedTagsUseCase.kt
@@ -46,8 +46,8 @@ class FetchFollowedTagsUseCase @Inject constructor(
         }
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    @SuppressWarnings("unused")
     fun onFollowedTagsChanged(event: FollowedTagsChanged) {
         val result = if (event.didSucceed()) {
             Success

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FetchInterestTagsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FetchInterestTagsUseCase.kt
@@ -45,8 +45,8 @@ class FetchInterestTagsUseCase @Inject constructor(
         }
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    @SuppressWarnings("unused")
     fun onInterestTagsFetchEnded(event: InterestTagsFetchEnded) {
         val result = if (event.didSucceed()) {
                 SuccessWithData(event.interestTags)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FollowInterestTagsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/tags/FollowInterestTagsUseCase.kt
@@ -41,8 +41,8 @@ class FollowInterestTagsUseCase @Inject constructor(
         }
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    @SuppressWarnings("unused")
     fun onFollowedTagsChanged(event: FollowedTagsChanged) {
         val result = if (event.didSucceed()) {
             Success

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -355,14 +355,14 @@ class SubFilterViewModel @Inject constructor(
         outState.putBoolean(ARG_IS_FIRST_LOAD, isFirstLoad)
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ReaderEvents.FollowedTagsChanged) {
         AppLog.d(T.READER, "Subfilter bottom sheet > followed tags changed")
         loadSubFilters()
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ReaderEvents.FollowedBlogsChanged) {
         AppLog.d(T.READER, "Subfilter bottom sheet > followed blogs changed")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -355,14 +355,14 @@ class SubFilterViewModel @Inject constructor(
         outState.putBoolean(ARG_IS_FIRST_LOAD, isFirstLoad)
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ReaderEvents.FollowedTagsChanged) {
         AppLog.d(T.READER, "Subfilter bottom sheet > followed tags changed")
         loadSubFilters()
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ReaderEvents.FollowedBlogsChanged) {
         AppLog.d(T.READER, "Subfilter bottom sheet > followed blogs changed")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderFetchRelatedPostsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderFetchRelatedPostsUseCase.kt
@@ -39,8 +39,8 @@ class ReaderFetchRelatedPostsUseCase @Inject constructor(
         }
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    @SuppressWarnings("unused")
     fun onRelatedPostUpdated(event: RelatedPostsUpdated) {
         val result = if (event.didSucceed()) {
             Success(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderSiteNotificationsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderSiteNotificationsUseCase.kt
@@ -92,8 +92,8 @@ class ReaderSiteNotificationsUseCase @Inject constructor(
         dispatcher.dispatch(AccountActionBuilder.newUpdateSubscriptionNotificationPostAction(payload))
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    @SuppressWarnings("unused")
     fun onSubscriptionUpdated(event: OnSubscriptionUpdated) {
         if (event.isError) {
             continuation?.resume(false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -895,7 +895,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         }
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = MAIN)
     fun onEventMainThread(event: UpdateCommentsStarted?) {
         if (!commentsSnippetFeatureConfig.isEnabled() || event == null || event.scenario != COMMENT_SNIPPET) return
@@ -904,7 +904,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         _commentSnippetState.value = CommentSnippetState.Loading
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = MAIN)
     fun onEventMainThread(event: UpdateCommentsEnded?) {
         if (!commentsSnippetFeatureConfig.isEnabled() || event == null || event.scenario != COMMENT_SNIPPET) return

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -239,7 +239,7 @@ class ReaderViewModel @Inject constructor(
 
     private fun ReaderTag.isDefaultSelectedTab(): Boolean = this.isDiscover
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = MAIN)
     fun onTagsUpdated(event: ReaderEvents.FollowedTagsChanged) {
         loadTabs()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -239,7 +239,7 @@ class ReaderViewModel @Inject constructor(
 
     private fun ReaderTag.isDefaultSelectedTab(): Boolean = this.isDiscover
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = MAIN)
     fun onTagsUpdated(event: ReaderEvents.FollowedTagsChanged) {
         loadTabs()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/SiteDesignRecommendationProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/SiteDesignRecommendationProvider.kt
@@ -19,7 +19,7 @@ class SiteDesignRecommendationProvider @Inject constructor(private val resourceP
     ) {
         val verticalSlug: String? = if (vertical.isNullOrEmpty()) null else getVerticalSlug(vertical)
         val hasRecommendations = !verticalSlug.isNullOrEmpty() &&
-                designs.any { it.group != null && it.group.contains(verticalSlug) }
+                designs.any { it.group.contains(verticalSlug) }
 
         if (hasRecommendations) {
             val recommendedTitle = resourceProvider.getString(R.string.hpp_recommended_title, vertical)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
@@ -67,8 +67,8 @@ class CreateSiteUseCase @Inject constructor(
         }
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    @SuppressWarnings("unused")
     fun onNewSiteCreated(event: OnNewSiteCreated) {
         continuation?.resume(event)
         continuation = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchSegmentsUseCase.kt
@@ -31,8 +31,8 @@ class FetchSegmentsUseCase @Inject constructor(
         }
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onSiteCategoriesFetched(event: OnSegmentsFetched) {
         continuation?.resume(event)
         continuation = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/VerticalsSearchResultsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/VerticalsSearchResultsProvider.kt
@@ -11,7 +11,7 @@ class VerticalsSearchResultsProvider @Inject constructor(localeManagerWrapper: L
 
     fun search(items: List<IntentListItemUiState>, query: String) = if (query.isEmpty()) items else items.filter {
         val text = it.verticalText.lowercase(locale)
-        val query = query.lowercase(locale)
-        text.contains(query)
+        val lowercasedQuery = query.lowercase(locale)
+        text.contains(lowercasedQuery)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -173,7 +173,7 @@ class StatsUtils
         entries: List<Line>
     ): List<String> {
         val contentDescriptions = mutableListOf<String>()
-        entries.forEachIndexed { index, bar ->
+        entries.forEachIndexed { _, bar ->
             val contentDescription = resourceProvider.getString(
                     R.string.stats_bar_chart_accessibility_entry,
                     bar.label,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -685,7 +685,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         }
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onStoryLoadEnd(event: StoryLoadEnd) {
         // once the Story has been loaded by the Composer, we should mark the composing session start as the

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -685,7 +685,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         }
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onStoryLoadEnd(event: StoryLoadEnd) {
         // once the Story has been loaded by the Composer, we should mark the composing session start as the

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ExampleExperimentConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ExampleExperimentConfig.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
  * An example of how to create and use an experiment.
  * The experiment defines a list of variants.
  */
-@SuppressWarnings("Unused")
+@Suppress("Unused")
 @Experiment(remoteField = EXAMPLE_EXPERIMENT_REMOTE_FIELD, defaultVariant = CONTROL_GROUP)
 class ExampleExperimentConfig
 @Inject constructor(appConfig: AppConfig) : ExperimentConfig(appConfig, EXAMPLE_EXPERIMENT_REMOTE_FIELD) {

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ExampleRemoteFeature.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ExampleRemoteFeature.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 /**
  * Configuration of an example remote feature
  */
-@SuppressWarnings("Unused")
+@Suppress("Unused")
 @Feature(remoteField = EXAMPLE_REMOTE_FEATURE_FIELD, defaultValue = false)
 class ExampleRemoteFeature
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -234,8 +234,8 @@ class HistoryViewModel @Inject constructor(
 
     data class ShowDialogEvent(val historyListItem: HistoryListItem, val revisionsList: List<Revision>)
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onRevisionsFetched(event: OnRevisionsFetched) {
         if (event.isError) {
             AppLog.e(T.API, "An error occurred while fetching History revisions")

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/ActionPerformer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/ActionPerformer.kt
@@ -57,8 +57,8 @@ class ActionPerformer
         }
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onPostUploaded(event: OnPostUploaded) {
         // negative local page ID used as a temp remote post ID for local-only pages (assigned by the PageStore)
         val continuation = continuations[event.post.remotePostId to UPLOAD]
@@ -66,8 +66,8 @@ class ActionPerformer
         continuation?.resume(!event.isError to event.post.remotePostId)
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onPostChange(event: OnPostChanged) {
         postCauseOfChangeToPostAction(event.causeOfChange)?.let { (remoteId, localId, eventType) ->
             // negative local page ID used as a temp remote post ID for local-only pages (assigned by the PageStore)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
@@ -171,7 +171,7 @@ class PageListEventListener(
         }
     }
 
-    @SuppressWarnings("unused")
+    @Suppress("unused")
     @Subscribe(threadMode = MAIN)
     fun onSiteChanged(event: OnSiteChanged) {
         if (!event.isError && siteStore.hasSiteWithLocalId(site.id)) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
@@ -156,7 +156,7 @@ class PageListEventListener(
     @Suppress("unused")
     @Subscribe(threadMode = BACKGROUND)
     fun onEventBackgroundThread(event: ProgressEvent) {
-        if (event.media != null && site.id == event.media.localSiteId) {
+        if (site.id == event.media.localSiteId) {
             uploadStatusChanged(LocalId(event.media.localPostId))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -450,8 +450,8 @@ class PageListViewModel @Inject constructor(
         pagesViewModel.onImagesChanged()
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    @SuppressWarnings("unused")
     fun onMediaChanged(event: OnMediaChanged) {
         if (!event.isError && event.mediaList != null) {
             invalidateFeaturedMedia(*event.mediaList.map { it.mediaId }.toLongArray())

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
@@ -251,8 +251,8 @@ class PluginBrowserViewModel @Inject constructor(
 
     // Network Callbacks
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onWPOrgPluginFetched(event: OnWPOrgPluginFetched) {
         if (event.isError) {
             AppLog.e(T.PLUGINS, "An error occurred while fetching the wporg plugin with type: " + event.error.type)
@@ -261,8 +261,8 @@ class PluginBrowserViewModel @Inject constructor(
         updateAllPluginListsForSlug(event.pluginSlug)
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onPluginDirectoryFetched(event: OnPluginDirectoryFetched) {
         if (event.isError) {
             AppLog.e(T.PLUGINS, "An error occurred while fetching the plugin directory " + event.type + ": " +
@@ -273,8 +273,8 @@ class PluginBrowserViewModel @Inject constructor(
         }
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onPluginDirectorySearched(event: OnPluginDirectorySearched) {
         if (searchQuery != event.searchTerm) {
             return
@@ -287,8 +287,8 @@ class PluginBrowserViewModel @Inject constructor(
         searchResults = ListState.Success(event.plugins, false) // Disable pagination for search
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onSitePluginConfigured(event: OnSitePluginConfigured) {
         if (event.isError) {
             // The error should be handled wherever the action has been triggered from (probably PluginDetailActivity)
@@ -297,8 +297,8 @@ class PluginBrowserViewModel @Inject constructor(
         updateAllPluginListsForSlug(event.slug)
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onSitePluginDeleted(event: OnSitePluginDeleted) {
         if (event.isError) {
             // The error should be handled wherever the action has been triggered from (probably PluginDetailActivity)
@@ -307,8 +307,8 @@ class PluginBrowserViewModel @Inject constructor(
         updateAllPluginListsForSlug(event.slug)
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onSitePluginInstalled(event: OnSitePluginInstalled) {
         if (event.isError) {
             // The error should be handled wherever the action has been triggered from (probably PluginDetailActivity)
@@ -317,8 +317,8 @@ class PluginBrowserViewModel @Inject constructor(
         updateAllPluginListsForSlug(event.slug)
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    @SuppressWarnings("unused")
     fun onSitePluginUpdated(event: OnSitePluginUpdated) {
         if (event.isError) {
             // The error should be handled wherever the action has been triggered from (probably PluginDetailActivity)
@@ -327,8 +327,8 @@ class PluginBrowserViewModel @Inject constructor(
         updateAllPluginListsForSlug(event.slug)
     }
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    @SuppressWarnings("unused")
     fun onSiteChanged(event: OnSiteChanged) {
         if (event.isError) {
             // The error should be safe to ignore since we are not triggering the action and there is nothing we need

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/EngagementUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/EngagementUtilsTest.kt
@@ -61,6 +61,6 @@ class EngagementUtilsTest {
         assertThat(engageItems.all { (it as Liker).source == source }).isTrue
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     private fun onClickDummy(userProfile: UserProfile, source: EngagementNavigationSource?) = Unit
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProviderTest.kt
@@ -125,7 +125,6 @@ class ReaderDiscoverDataProviderTest {
     fun `when new observer added and db is empty, does NOT post anything to discover feed`() = test {
         whenever(shouldAutoUpdateTagUseCase.get(dataProvider.readerTag)).thenReturn(false)
         whenever(getDiscoverCardsUseCase.get()).thenReturn(ReaderDiscoverCards(listOf()))
-        val event = FetchDiscoverCardsEnded(REQUEST_FIRST_PAGE, HAS_NEW)
 
         dataProvider.discoverFeed.observeForever { }
 
@@ -136,7 +135,6 @@ class ReaderDiscoverDataProviderTest {
     fun `when new observer added and db is NOT empty, the data gets posted to discover feed`() = test {
         whenever(shouldAutoUpdateTagUseCase.get(dataProvider.readerTag)).thenReturn(false)
         whenever(getDiscoverCardsUseCase.get()).thenReturn(createDummyReaderCardsList())
-        val event = FetchDiscoverCardsEnded(REQUEST_FIRST_PAGE, HAS_NEW)
 
         dataProvider.discoverFeed.observeForever { }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/utils/ListItemInteractionTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/utils/ListItemInteractionTest.kt
@@ -65,6 +65,6 @@ class ListItemInteractionTest {
 
     private fun emptyFunction() = Unit
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     private fun parametrizedEmptyFunction(param: String) = Unit
 }


### PR DESCRIPTION
Parent: #17173
Partially Closes: #17181

This PR resolves one part of all `Other` related warnings for the `WordPress` module, and in this part, (mainly) specific to the main source:

Main Source (`35`):
- `1` x `This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.`
- `17` x `Parameter 'xyz' is never used`
- `9` x `Parameter 'xyz' is never used, could be renamed to _`
- `2` x `Name shadowed: xyz`
- `1` x `Parcelize annotations from package 'kotlinx.android.parcel' are deprecated. Change package to 'kotlinx.parcelize'`
- `1` x `Variable 'xyz' initializer is redundant`
- `1` x `There is more than one label with such a name in this scope`
- `2` x `Condition 'xyz' is always 'xyz'`
- `1` x `Unreachable code`

Test Source (`5`)
- `3` x `Parameter 'xyz' is never used`
- `2` x `Variable 'xyz' is never used`

-----

Warnings Resolution List:

1. [Resolve global scope delicate coroutines api warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/d81c5ed16894b6013db5ec327e7acc603d26b25c)
2. [Resolve parameter is never and could be renamed to _ warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/528a9915f0bbc350593aabc7ff5729c4376397b2)
3. [Resolve variable is never used test warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/4a4f28014731434a65923608328a16e3528f2f0a)
4. [Resolve name shadowed warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/4eee7ad94afaebcd4638676a1d1555c2f5b37fd9)
5. [Resolve parcelize annotations deprecated package warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/53b180c90ede495c316fded460a93cd1bd64fdd9)
6. [Resolve variable initializer is redundant warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/bb6349c146c56d102767ae74c35f3bfb139f1f13)
7. [Resolve more than one label with such a name in scope warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/32b8d595812f59f4ad34d7c2bec7712694e171a3)
8. [Resolve condition is always true warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/d6bd9512801cbc1a10a1a3ed60bd1075096ccd57)
9. [Resolve unreachable code warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/306046922c1631fe3b97a8ea495147a98f73ee6e)

Warnings Suppression List:

1. [Suppress parameter is never used warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/ac8fbda82eeb7df50db619978baec1cb355d4fa9)

Refactor List:

1. [Use suppress in favor of suppress warnings for kotlin classes.](https://github.com/wordpress-mobile/WordPress-Android/commit/66688f456786581ee971ffcea8a5e6cca92f77fe)

-----

PS: @zwarm I added you as the main reviewer, that is, in addition to @wordpress-mobile/apps-infrastructure team itself, but randomly, since I want someone from the WordPress Android team to primarily sign-off on that change. 🥇

FYI: I am going to randomly add more of you in those PRs that will follow, just so you become more aware of this change and how close we are on enabling allWarningsAsErrors by default everywhere. 🎉

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could quickly smoke test both, the `WordPress` and `Jetpack` apps, and see if they are both working as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

N/A

10. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

11. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
