### PR TITLE
[UI Tests] - Remove e2eMessageCanBeSent test from test suite

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -38,29 +38,6 @@ public class ContactUsTests extends BaseTest {
         }
     }
 
-    @Ignore("As long as CI does not use gradle.properties from MobileSecrets")
-    @Test
-    public void e2eMessageCanBeSent() {
-        String userMessageText = "Please ignore, this is an automated test.";
-        String automatedReplyText = "Mobile support will respond as soon as possible, "
-                                    + "generally within 48-96 hours. "
-                                    + "Please reply with your site address (URL) "
-                                    + "and any additional details we should know.";
-
-        try {
-            new LoginFlow()
-                .chooseContinueWithWpCom()
-                .tapHelp()
-                .openContactUs()
-                .setMessageText(userMessageText)
-                .tapSendButton()
-                .assertUserMessageDelivered(userMessageText)
-                .assertSystemMessageReceived(automatedReplyText);
-        } finally {
-            new ContactSupportScreen().goBackAndDeleteUnsentMessageIfNeeded();
-        }
-    }
-
     @Test
     public void e2eHelpCanBeOpenedWhileEnteringEmail() {
         new LoginFlow()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
@@ -8,7 +8,6 @@ import org.wordpress.android.R;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -18,7 +17,6 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.not;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.sleep;
-import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 
 public class ContactSupportScreen {
@@ -42,11 +40,6 @@ public class ContactSupportScreen {
     ));
 
     // Actions:
-    public ContactSupportScreen tapSendButton() {
-        sendButton.perform(ViewActions.click());
-        return this;
-    }
-
     public ContactSupportScreen setMessageText(String text) {
         populateTextField(textInput, text);
         // This sleep serves only one purpose: allowing human to notice
@@ -86,34 +79,6 @@ public class ContactSupportScreen {
 
     public ContactSupportScreen assertSendButtonEnabled() {
         sendButton.check(matches(isEnabled()));
-        return this;
-    }
-
-    public ContactSupportScreen assertUserMessageDelivered(String messageText) {
-        ViewInteraction userMessageContainer = onView(allOf(
-                withId(R.id.request_user_message_container),
-                hasDescendant(allOf(
-                        withId(R.id.request_user_message_text),
-                        withText(messageText)
-                )),
-                hasDescendant(allOf(
-                        withId(R.id.request_user_message_status),
-                        withText("Delivered")
-                ))
-        ));
-
-        waitForElementToBeDisplayed(userMessageContainer);
-        userMessageContainer.check(matches(isCompletelyDisplayed()));
-        return this;
-    }
-
-    public ContactSupportScreen assertSystemMessageReceived(String messageText) {
-        ViewInteraction systemResponseBubble = onView(allOf(
-                withId(R.id.request_system_message_text),
-                withText(messageText)));
-
-        waitForElementToBeDisplayed(systemResponseBubble);
-        systemResponseBubble.check(matches(isCompletelyDisplayed()));
         return this;
     }
 }


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-Android/issues/17281

### What
This PR does not add anything new, it removes a currently disabled test `e2eMessageCanBeSent` from the UI Tests test suite

### Why
After [discussing this test case](https://github.com/wordpress-mobile/WordPress-Android/issues/17281#issuecomment-1269552812), we don't think this has much value in a disabled state and the cost to re-enable it doesn't match the value it adds.

### Testing
Other existing tests in the test suite should still work as expected
