### PR TITLE
[Compile Warnings As Errors] WordPress Module - Resolve Test Warnings

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/util/StatsMocksReader.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/StatsMocksReader.kt
@@ -5,11 +5,10 @@ import org.json.JSONObject
 import java.util.ArrayList
 
 class StatsMocksReader {
-    fun readDayStatsGenericFile(fileName: String, lastObjectName: String, keyName: String, valueName: String):
+    private fun readDayStatsGenericFile(fileName: String, lastObjectName: String, keyName: String, valueName: String):
             MutableList<StatsKeyValueData> {
-        val fileName = "mocks/mappings/wpcom/stats/$fileName.json"
         val todayMarker = "{{now format='yyyy-MM-dd'}}"
-        val readString = this.readAssetsFile(fileName)
+        val readString = this.readAssetsFile("mocks/mappings/wpcom/stats/$fileName.json")
         val wireMockJSON = JSONObject(readString)
         val arrayRaw = wireMockJSON
                 .getJSONObject("response")
@@ -58,7 +57,7 @@ class StatsMocksReader {
     }
 
     fun readDayCountriesToList(): MutableList<StatsKeyValueData> {
-        var countriesList = readDayStatsGenericFile(
+        val countriesList = readDayStatsGenericFile(
                 "stats_country-views-day", "views", "country_code", "views"
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -172,7 +172,7 @@ class StatsUtils @Inject constructor(
         entries: List<Line>
     ): List<String> {
         val contentDescriptions = mutableListOf<String>()
-        entries.forEachIndexed { _, bar ->
+        entries.forEach { bar ->
             val contentDescription = resourceProvider.getString(
                     R.string.stats_bar_chart_accessibility_entry,
                     bar.label,

--- a/WordPress/src/test/java/org/wordpress/android/BaseUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/BaseUnitTest.kt
@@ -8,5 +8,6 @@ import org.mockito.junit.MockitoJUnitRunner
 @Suppress("UnnecessaryAbstractClass")
 @RunWith(MockitoJUnitRunner::class)
 abstract class BaseUnitTest {
-    @Rule @JvmField val rule = InstantTaskExecutorRule()
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
 }

--- a/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListStateTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListStateTest.kt
@@ -1,8 +1,6 @@
 package org.wordpress.android.models.networkresource
 
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.CoreMatchers.equalTo
-import org.junit.Assert.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ListStateTest {
@@ -10,12 +8,12 @@ class ListStateTest {
     fun testInitState() {
         val initState: ListState<String> = ListState.Init()
 
-        assertThat(initState.data, `is`(emptyList()))
+        assertThat(initState.data).isEqualTo(emptyList<ListState<String>>())
 
-        assertThat(initState.isFetchingFirstPage(), `is`(false))
-        assertThat(initState.isLoadingMore(), `is`(false))
-        assertThat(initState.shouldFetch(true), `is`(false))
-        assertThat(initState.shouldFetch(false), `is`(false))
+        assertThat(initState.isFetchingFirstPage()).isEqualTo(false)
+        assertThat(initState.isLoadingMore()).isEqualTo(false)
+        assertThat(initState.shouldFetch(true)).isEqualTo(false)
+        assertThat(initState.shouldFetch(false)).isEqualTo(false)
     }
 
     @Test
@@ -23,12 +21,12 @@ class ListStateTest {
         val testData = listOf("item1", "item2")
         val readyState: ListState<String> = ListState.Ready(testData)
 
-        assertThat(readyState.data, `is`(equalTo(testData)))
+        assertThat(readyState.data).isEqualTo(testData)
 
-        assertThat(readyState.isFetchingFirstPage(), `is`(false))
-        assertThat(readyState.isLoadingMore(), `is`(false))
-        assertThat(readyState.shouldFetch(true), `is`(false))
-        assertThat(readyState.shouldFetch(false), `is`(true))
+        assertThat(readyState.isFetchingFirstPage()).isEqualTo(false)
+        assertThat(readyState.isLoadingMore()).isEqualTo(false)
+        assertThat(readyState.shouldFetch(true)).isEqualTo(false)
+        assertThat(readyState.shouldFetch(false)).isEqualTo(true)
     }
 
     @Test
@@ -37,12 +35,12 @@ class ListStateTest {
         val readyState: ListState<String> = ListState.Ready(testData)
         val loadingState: ListState<String> = ListState.Loading(readyState)
 
-        assertThat(loadingState.data, `is`(equalTo(testData)))
+        assertThat(loadingState.data).isEqualTo(testData)
 
-        assertThat(loadingState.isFetchingFirstPage(), `is`(true))
-        assertThat(loadingState.isLoadingMore(), `is`(false))
-        assertThat(loadingState.shouldFetch(true), `is`(false))
-        assertThat(loadingState.shouldFetch(false), `is`(false))
+        assertThat(loadingState.isFetchingFirstPage()).isEqualTo(true)
+        assertThat(loadingState.isLoadingMore()).isEqualTo(false)
+        assertThat(loadingState.shouldFetch(true)).isEqualTo(false)
+        assertThat(loadingState.shouldFetch(false)).isEqualTo(false)
     }
 
     @Test
@@ -51,12 +49,12 @@ class ListStateTest {
         val readyState: ListState<String> = ListState.Ready(testData)
         val loadingState: ListState<String> = ListState.Loading(readyState, true)
 
-        assertThat(loadingState.data, `is`(equalTo(testData)))
+        assertThat(loadingState.data).isEqualTo(testData)
 
-        assertThat(loadingState.isFetchingFirstPage(), `is`(false))
-        assertThat(loadingState.isLoadingMore(), `is`(true))
-        assertThat(loadingState.shouldFetch(true), `is`(false))
-        assertThat(loadingState.shouldFetch(false), `is`(false))
+        assertThat(loadingState.isFetchingFirstPage()).isEqualTo(false)
+        assertThat(loadingState.isLoadingMore()).isEqualTo(true)
+        assertThat(loadingState.shouldFetch(true)).isEqualTo(false)
+        assertThat(loadingState.shouldFetch(false)).isEqualTo(false)
     }
 
     @Test
@@ -64,8 +62,8 @@ class ListStateTest {
         val testData = listOf("item7")
 
         val successState = ListState.Success(testData)
-        assertThat(successState.data, `is`(equalTo(testData)))
-        assertThat(successState.canLoadMore, `is`(false))
+        assertThat(successState.data).isEqualTo(testData)
+        assertThat(successState.canLoadMore).isEqualTo(false)
     }
 
     @Test
@@ -73,8 +71,8 @@ class ListStateTest {
         val testData = listOf("item8")
 
         val successState2 = ListState.Success(testData, true)
-        assertThat(successState2.data, `is`(equalTo(testData)))
-        assertThat(successState2.canLoadMore, `is`(true))
+        assertThat(successState2.data).isEqualTo(testData)
+        assertThat(successState2.canLoadMore).isEqualTo(true)
     }
 
     @Test
@@ -85,8 +83,8 @@ class ListStateTest {
 
         val errorMessage = "Some error message"
         val errorState = ListState.Error(loadingState, errorMessage)
-        assertThat(errorState.errorMessage, `is`(equalTo(errorMessage)))
-        assertThat(errorState.data, `is`(testDataReady))
+        assertThat(errorState.errorMessage).isEqualTo(errorMessage)
+        assertThat(errorState.data).isEqualTo(testDataReady)
     }
 
     @Test
@@ -97,9 +95,9 @@ class ListStateTest {
             list.map { it.toUpperCase() }
         }
         val transformedReadyState = readyState.transform(toUpperCase)
-        assertThat(transformedReadyState.data, `is`(equalTo(toUpperCase(testData))))
-        assertThat(transformedReadyState.data.size, `is`(3))
-        assertThat(transformedReadyState is ListState.Ready, `is`(true))
+        assertThat(transformedReadyState.data).isEqualTo(toUpperCase(testData))
+        assertThat(transformedReadyState.data.size).isEqualTo(3)
+        assertThat(transformedReadyState is ListState.Ready).isEqualTo(true)
     }
 
     @Test
@@ -111,8 +109,8 @@ class ListStateTest {
             list.filter { it != "not-item" }
         }
         val transformedLoadingState = loadingState.transform(filterNotItem)
-        assertThat(transformedLoadingState.data, `is`(equalTo(filterNotItem(testData))))
-        assertThat(transformedLoadingState.data.size, `is`(2))
-        assertThat(transformedLoadingState is ListState.Loading, `is`(true))
+        assertThat(transformedLoadingState.data).isEqualTo(filterNotItem(testData))
+        assertThat(transformedLoadingState.data.size).isEqualTo(2)
+        assertThat(transformedLoadingState is ListState.Loading).isEqualTo(true)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/JetpackRemoteInstallViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/JetpackRemoteInstallViewModelTest.kt
@@ -6,9 +6,7 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertNull
-import junit.framework.Assert.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -18,19 +16,16 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.JetpackAction
-import org.wordpress.android.fluxc.action.JetpackAction.INSTALL_JETPACK
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.JetpackStore
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallError
-import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType
 import org.wordpress.android.fluxc.store.JetpackStore.OnJetpackInstalled
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.test
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActionData
-import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActionData.Action.CONNECT
-import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActionData.Action.MANUAL_INSTALL
 import org.wordpress.android.ui.JetpackRemoteInstallViewState.Error
 import org.wordpress.android.ui.JetpackRemoteInstallViewState.Installed
 import org.wordpress.android.ui.JetpackRemoteInstallViewState.Installing
@@ -78,8 +73,8 @@ class JetpackRemoteInstallViewModelTest {
         assertInstallingState(installingState)
 
         verify(dispatcher).dispatch(actionCaptor.capture())
-        assertEquals(actionCaptor.lastValue.type, JetpackAction.INSTALL_JETPACK)
-        assertEquals(actionCaptor.lastValue.payload, site)
+        assertThat(actionCaptor.lastValue.type).isEqualTo(JetpackAction.INSTALL_JETPACK)
+        assertThat(actionCaptor.lastValue.payload).isEqualTo(site)
     }
 
     @Test
@@ -92,7 +87,7 @@ class JetpackRemoteInstallViewModelTest {
         val startState = viewStates[0]
         assertStartState(startState)
 
-        viewModel.onEventsUpdated(OnJetpackInstalled(true, INSTALL_JETPACK))
+        viewModel.onEventsUpdated(OnJetpackInstalled(true, JetpackAction.INSTALL_JETPACK))
         val installedState = viewStates[1]
         assertInstalledState(installedState)
 
@@ -100,20 +95,20 @@ class JetpackRemoteInstallViewModelTest {
         installedState.onClick()
 
         val connectionData = jetpackResultActionData!!
-        assertTrue(connectionData.loggedIn)
-        assertTrue(connectionData.site == updatedSite)
-        assertTrue(connectionData.action == CONNECT)
+        assertThat(connectionData.loggedIn).isTrue
+        assertThat(connectionData.site == updatedSite).isTrue
+        assertThat(connectionData.action == JetpackResultActionData.Action.CONNECT).isTrue
     }
 
     @Test
     fun `on error result shows failure`() = test {
-        val installError = JetpackInstallError(GENERIC_ERROR, "error")
+        val installError = JetpackInstallError(JetpackInstallErrorType.GENERIC_ERROR, "error")
         viewModel.start(site, null)
 
         val startState = viewStates[0]
         assertStartState(startState)
 
-        viewModel.onEventsUpdated(OnJetpackInstalled(installError, INSTALL_JETPACK))
+        viewModel.onEventsUpdated(OnJetpackInstalled(installError, JetpackAction.INSTALL_JETPACK))
 
         val errorState = viewStates[1]
         assertErrorState(errorState)
@@ -121,28 +116,32 @@ class JetpackRemoteInstallViewModelTest {
         errorState.onClick()
 
         verify(dispatcher).dispatch(actionCaptor.capture())
-        assertEquals(actionCaptor.lastValue.type, JetpackAction.INSTALL_JETPACK)
-        assertEquals(actionCaptor.lastValue.payload, site)
+        assertThat(actionCaptor.lastValue.type).isEqualTo(JetpackAction.INSTALL_JETPACK)
+        assertThat(actionCaptor.lastValue.payload).isEqualTo(site)
     }
 
     @Test
     fun `on invalid credentials triggers manual install`() = test {
-        val installError = JetpackInstallError(GENERIC_ERROR, "INVALID_CREDENTIALS", message = "msg")
+        val installError = JetpackInstallError(
+                JetpackInstallErrorType.GENERIC_ERROR,
+                "INVALID_CREDENTIALS",
+                message = "msg"
+        )
         viewModel.start(site, null)
 
         val startState = viewStates[0]
         assertStartState(startState)
 
-        viewModel.onEventsUpdated(OnJetpackInstalled(installError, INSTALL_JETPACK))
+        viewModel.onEventsUpdated(OnJetpackInstalled(installError, JetpackAction.INSTALL_JETPACK))
 
         val connectionData = jetpackResultActionData!!
-        assertTrue(connectionData.action == MANUAL_INSTALL)
-        assertTrue(connectionData.site == site)
+        assertThat(connectionData.action == JetpackResultActionData.Action.MANUAL_INSTALL).isTrue
+        assertThat(connectionData.site == site).isTrue
     }
 
     @Test
     fun `on login retries jetpack connect with access token`() = test {
-        assertNull(jetpackResultActionData)
+        assertThat(jetpackResultActionData).isNull()
 
         val updatedSite = mock<SiteModel>()
         whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(updatedSite)
@@ -151,47 +150,47 @@ class JetpackRemoteInstallViewModelTest {
         viewModel.onLogin(siteId)
 
         val connectionData = jetpackResultActionData!!
-        assertTrue(connectionData.loggedIn)
-        assertTrue(connectionData.site == updatedSite)
+        assertThat(connectionData.loggedIn).isTrue
+        assertThat(connectionData.site == updatedSite).isTrue
     }
 
     private fun assertStartState(state: JetpackRemoteInstallViewState) {
-        assertTrue(state is Start)
-        assertEquals(state.type, JetpackRemoteInstallViewState.Type.START)
-        assertEquals(state.titleResource, R.string.install_jetpack)
-        assertEquals(state.messageResource, R.string.install_jetpack_message)
-        assertEquals(state.icon, R.drawable.ic_plans_white_24dp)
-        assertEquals(state.buttonResource, R.string.install_jetpack_continue)
-        assertEquals(state.progressBarVisible, false)
+        assertThat(state).isInstanceOf(Start::class.java)
+        assertThat(state.type).isEqualTo(JetpackRemoteInstallViewState.Type.START)
+        assertThat(state.titleResource).isEqualTo(R.string.install_jetpack)
+        assertThat(state.messageResource).isEqualTo(R.string.install_jetpack_message)
+        assertThat(state.icon).isEqualTo(R.drawable.ic_plans_white_24dp)
+        assertThat(state.buttonResource).isEqualTo(R.string.install_jetpack_continue)
+        assertThat(state.progressBarVisible).isEqualTo(false)
     }
 
     private fun assertInstallingState(state: JetpackRemoteInstallViewState) {
-        assertTrue(state is Installing)
-        assertEquals(state.type, JetpackRemoteInstallViewState.Type.INSTALLING)
-        assertEquals(state.titleResource, R.string.installing_jetpack)
-        assertEquals(state.messageResource, R.string.installing_jetpack_message)
-        assertEquals(state.icon, R.drawable.ic_plans_white_24dp)
-        assertNull(state.buttonResource)
-        assertEquals(state.progressBarVisible, true)
+        assertThat(state).isInstanceOf(Installing::class.java)
+        assertThat(state.type).isEqualTo(JetpackRemoteInstallViewState.Type.INSTALLING)
+        assertThat(state.titleResource).isEqualTo(R.string.installing_jetpack)
+        assertThat(state.messageResource).isEqualTo(R.string.installing_jetpack_message)
+        assertThat(state.icon).isEqualTo(R.drawable.ic_plans_white_24dp)
+        assertThat(state.buttonResource).isNull()
+        assertThat(state.progressBarVisible).isEqualTo(true)
     }
 
     private fun assertInstalledState(state: JetpackRemoteInstallViewState) {
-        assertTrue(state is Installed)
-        assertEquals(state.type, JetpackRemoteInstallViewState.Type.INSTALLED)
-        assertEquals(state.titleResource, R.string.jetpack_installed)
-        assertEquals(state.messageResource, R.string.jetpack_installed_message)
-        assertEquals(state.icon, R.drawable.ic_plans_white_24dp)
-        assertEquals(state.buttonResource, R.string.install_jetpack_continue)
-        assertEquals(state.progressBarVisible, false)
+        assertThat(state).isInstanceOf(Installed::class.java)
+        assertThat(state.type).isEqualTo(JetpackRemoteInstallViewState.Type.INSTALLED)
+        assertThat(state.titleResource).isEqualTo(R.string.jetpack_installed)
+        assertThat(state.messageResource).isEqualTo(R.string.jetpack_installed_message)
+        assertThat(state.icon).isEqualTo(R.drawable.ic_plans_white_24dp)
+        assertThat(state.buttonResource).isEqualTo(R.string.install_jetpack_continue)
+        assertThat(state.progressBarVisible).isEqualTo(false)
     }
 
     private fun assertErrorState(state: JetpackRemoteInstallViewState) {
-        assertTrue(state is Error)
-        assertEquals(state.type, JetpackRemoteInstallViewState.Type.ERROR)
-        assertEquals(state.titleResource, R.string.jetpack_installation_problem)
-        assertEquals(state.messageResource, R.string.jetpack_installation_problem_message)
-        assertEquals(state.icon, R.drawable.img_illustration_info_outline_88dp)
-        assertEquals(state.buttonResource, R.string.install_jetpack_retry)
-        assertEquals(state.progressBarVisible, false)
+        assertThat(state).isInstanceOf(Error::class.java)
+        assertThat(state.type).isEqualTo(JetpackRemoteInstallViewState.Type.ERROR)
+        assertThat(state.titleResource).isEqualTo(R.string.jetpack_installation_problem)
+        assertThat(state.messageResource).isEqualTo(R.string.jetpack_installation_problem_message)
+        assertThat(state.icon).isEqualTo(R.drawable.img_illustration_info_outline_88dp)
+        assertThat(state.buttonResource).isEqualTo(R.string.install_jetpack_retry)
+        assertThat(state.progressBarVisible).isEqualTo(false)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/JetpackRemoteInstallViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/JetpackRemoteInstallViewModelTest.kt
@@ -9,7 +9,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import junit.framework.Assert.assertEquals
 import junit.framework.Assert.assertNull
 import junit.framework.Assert.assertTrue
-import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -28,6 +27,7 @@ import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallError
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.JetpackStore.OnJetpackInstalled
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.test
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActionData
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActionData.Action.CONNECT
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActionData.Action.MANUAL_INSTALL
@@ -65,7 +65,7 @@ class JetpackRemoteInstallViewModelTest {
     }
 
     @Test
-    fun `on click starts jetpack install`() = runBlocking {
+    fun `on click starts jetpack install`() = test {
         viewModel.start(site, null)
 
         val startState = viewStates[0]
@@ -83,7 +83,7 @@ class JetpackRemoteInstallViewModelTest {
     }
 
     @Test
-    fun `on successful result finishes jetpack install`() = runBlocking {
+    fun `on successful result finishes jetpack install`() = test {
         val updatedSite = mock<SiteModel>()
         whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(updatedSite)
         whenever(accountStore.hasAccessToken()).thenReturn(true)
@@ -106,7 +106,7 @@ class JetpackRemoteInstallViewModelTest {
     }
 
     @Test
-    fun `on error result shows failure`() = runBlocking {
+    fun `on error result shows failure`() = test {
         val installError = JetpackInstallError(GENERIC_ERROR, "error")
         viewModel.start(site, null)
 
@@ -126,7 +126,7 @@ class JetpackRemoteInstallViewModelTest {
     }
 
     @Test
-    fun `on invalid credentials triggers manual install`() = runBlocking {
+    fun `on invalid credentials triggers manual install`() = test {
         val installError = JetpackInstallError(GENERIC_ERROR, "INVALID_CREDENTIALS", message = "msg")
         viewModel.start(site, null)
 
@@ -141,7 +141,7 @@ class JetpackRemoteInstallViewModelTest {
     }
 
     @Test
-    fun `on login retries jetpack connect with access token`() = runBlocking {
+    fun `on login retries jetpack connect with access token`() = test {
         assertNull(jetpackResultActionData)
 
         val updatedSite = mock<SiteModel>()

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
@@ -10,7 +10,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -24,6 +23,7 @@ import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore.BloggingPromptsResult
+import org.wordpress.android.test
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingAction.DismissDialog
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingAction.DoNothing
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingAction.OpenEditor
@@ -88,7 +88,7 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should provide a Ready UI state when start is called`() = runBlocking {
+    fun `Should provide a Ready UI state when start is called`() = test {
         classToTest.start(ONBOARDING)
         val startState = viewStates[0]
         assertNotNull(startState)
@@ -98,7 +98,7 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
     // ONBOARDING dialog type actions
 
     @Test
-    fun `Should trigger OpenEditor action when primary button is tapped`() = runBlocking {
+    fun `Should trigger OpenEditor action when primary button is tapped`() = test {
         val selectedSiteModel = SiteModel()
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(selectedSiteModel)
         classToTest.start(ONBOARDING)
@@ -111,22 +111,21 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should trigger OpenSitePicker if Remind Me is clicked, user has more than 1 site and is first onboarding`() {
-        runBlocking {
-            val selectedSiteModel = SiteModel()
-            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(selectedSiteModel)
-            whenever(siteStore.sitesCount).thenReturn(2)
-            whenever(getIsFirstBloggingPromptsOnboardingUseCase.execute()).thenReturn(true)
-            classToTest.start(ONBOARDING)
-            val startState = viewStates[0]
-            (startState as Ready).onPrimaryButtonClick()
-            startState.onSecondaryButtonClick()
-            verify(actionObserver).onChanged(OpenSitePicker(selectedSiteModel))
-        }
-    }
+    fun `Should trigger OpenSitePicker if Remind Me is clicked, user has more than 1 site and is first onboarding`() =
+            test {
+                val selectedSiteModel = SiteModel()
+                whenever(selectedSiteRepository.getSelectedSite()).thenReturn(selectedSiteModel)
+                whenever(siteStore.sitesCount).thenReturn(2)
+                whenever(getIsFirstBloggingPromptsOnboardingUseCase.execute()).thenReturn(true)
+                classToTest.start(ONBOARDING)
+                val startState = viewStates[0]
+                (startState as Ready).onPrimaryButtonClick()
+                startState.onSecondaryButtonClick()
+                verify(actionObserver).onChanged(OpenSitePicker(selectedSiteModel))
+            }
 
     @Test
-    fun `Should trigger OpenRemindersIntro if Remind Me is clicked and user has only 1 site`() = runBlocking {
+    fun `Should trigger OpenRemindersIntro if Remind Me is clicked and user has only 1 site`() = test {
         classToTest.start(ONBOARDING)
         val siteModel = SiteModel().apply { id = 123 }
         whenever(siteStore.sitesCount).thenReturn(1)
@@ -139,7 +138,7 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should trigger OpenRemindersIntro if Remind Me is clicked and is NOT first onboarding`() = runBlocking {
+    fun `Should trigger OpenRemindersIntro if Remind Me is clicked and is NOT first onboarding`() = test {
         val siteModel = SiteModel().apply { id = 123 }
         whenever(siteStore.sitesCount).thenReturn(1)
         whenever(siteStore.sites).thenReturn(listOf(siteModel))
@@ -181,31 +180,30 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
     // INFORMATION dialog type actions
 
     @Test
-    fun `Should trigger DismissDialog action when primary button is tapped and dialog type is INFORMATION`() =
-            runBlocking {
-                classToTest.start(INFORMATION)
+    fun `Should trigger DismissDialog action when primary button is tapped and dialog type is INFORMATION`() = test {
+        classToTest.start(INFORMATION)
 
-                val startState = viewStates[0]
-                (startState as Ready).onPrimaryButtonClick()
-                verify(actionObserver).onChanged(DismissDialog)
-            }
+        val startState = viewStates[0]
+        (startState as Ready).onPrimaryButtonClick()
+        verify(actionObserver).onChanged(DismissDialog)
+    }
 
     @Test
-    fun `Should track screen shown only the first time start is called with ONBOARDING`() = runBlocking {
+    fun `Should track screen shown only the first time start is called with ONBOARDING`() = test {
         classToTest.start(ONBOARDING)
         classToTest.start(ONBOARDING)
         verify(analyticsTracker).trackScreenShown()
     }
 
     @Test
-    fun `Should track screen shown only the first time start is called with INFORMATION`() = runBlocking {
+    fun `Should track screen shown only the first time start is called with INFORMATION`() = test {
         classToTest.start(INFORMATION)
         classToTest.start(INFORMATION)
         verify(analyticsTracker).trackScreenShown()
     }
 
     @Test
-    fun `Should track try it now clicked when onPrimaryButtonClick is called with ONBOARDING`() = runBlocking {
+    fun `Should track try it now clicked when onPrimaryButtonClick is called with ONBOARDING`() = test {
         classToTest.start(ONBOARDING)
         val startState = viewStates[0]
         (startState as Ready).onPrimaryButtonClick()
@@ -213,7 +211,7 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should track got it clicked when onPrimaryButtonClick is called with INFORMATION`() = runBlocking {
+    fun `Should track got it clicked when onPrimaryButtonClick is called with INFORMATION`() = test {
         classToTest.start(INFORMATION)
         val startState = viewStates[0]
         (startState as Ready).onPrimaryButtonClick()
@@ -221,7 +219,7 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should track remind me clicked when onSecondaryButtonClick is called`() = runBlocking {
+    fun `Should track remind me clicked when onSecondaryButtonClick is called`() = test {
         classToTest.start(INFORMATION)
         val startState = viewStates[0]
         (startState as Ready).onSecondaryButtonClick()

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/BatchModerateCommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/BatchModerateCommentsUseCaseTest.kt
@@ -15,7 +15,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.notification.Failure
 import org.mockito.Mock
-import org.mockito.Mockito.*
+import org.mockito.Mockito.`when`
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
 import org.wordpress.android.fluxc.model.CommentStatus.DELETED
@@ -273,7 +273,7 @@ class BatchModerateCommentsUseCaseTest : BaseUnitTest() {
                         )
                 )
 
-                assertThat(result.any { it is Failure }).isFalse() // no errors
+                result.forEach { assertThat(it).isNotInstanceOf(Failure::class.java) }
 
                 verify(commentStore, times(1)).getCommentByLocalSiteAndRemoteId(site.id, 1)
                 verify(commentStore, times(1)).getCommentByLocalSiteAndRemoteId(site.id, 3)
@@ -347,7 +347,7 @@ class BatchModerateCommentsUseCaseTest : BaseUnitTest() {
                 )
         )
 
-        assertThat(result.any { it is Failure }).isFalse() // no errors
+        result.forEach { assertThat(it).isNotInstanceOf(Failure::class.java) }
 
         verify(commentStore, times(1)).getCommentByLocalSiteAndRemoteId(site.id, 1)
         verify(commentStore, times(1)).getCommentByLocalSiteAndRemoteId(site.id, 3)
@@ -429,7 +429,9 @@ class BatchModerateCommentsUseCaseTest : BaseUnitTest() {
                 )
 
                 assertThat(result.size).isEqualTo(2)
-                assertThat(result.filter { it is UseCaseResult.Failure }.size).isEqualTo(2)
+                result.filterIsInstance<UseCaseResult.Failure<CommentsUseCaseType, CommentError, DoNotCare>>().let {
+                    assertThat(it.size).isEqualTo(2)
+                }
 
                 // getting a backup from DB
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/BatchModerateCommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/BatchModerateCommentsUseCaseTest.kt
@@ -9,17 +9,14 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.notification.Failure
 import org.mockito.Mock
-import org.mockito.Mockito
+import org.mockito.Mockito.*
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.MainCoroutineScopeRule
 import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
 import org.wordpress.android.fluxc.model.CommentStatus.DELETED
 import org.wordpress.android.fluxc.model.CommentStatus.TRASH
@@ -39,6 +36,7 @@ import org.wordpress.android.models.usecases.CommentsUseCaseType
 import org.wordpress.android.models.usecases.CommentsUseCaseType.BATCH_MODERATE_USE_CASE
 import org.wordpress.android.models.usecases.LocalCommentCacheUpdateHandler
 import org.wordpress.android.models.usecases.ModerateCommentsResourceProvider
+import org.wordpress.android.test
 import org.wordpress.android.ui.comments.utils.approvedComment
 import org.wordpress.android.ui.comments.utils.pendingComment
 import org.wordpress.android.ui.comments.utils.trashedComment
@@ -48,8 +46,6 @@ import org.wordpress.android.util.NoDelayCoroutineDispatcher
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 class BatchModerateCommentsUseCaseTest : BaseUnitTest() {
-    @Rule @JvmField val coroutineScopeRule = MainCoroutineScopeRule()
-
     @Mock private lateinit var commentStore: CommentsStore
     @Mock private lateinit var localCommentCacheUpdateHandler: LocalCommentCacheUpdateHandler
 
@@ -60,24 +56,19 @@ class BatchModerateCommentsUseCaseTest : BaseUnitTest() {
     val site = SiteModel().also { it.id = 5 }.also { it.name = "Test Site" }
 
     @Before
-    fun setup() {
+    fun setup() = test {
         whenever(moderateCommentsResourceProvider.commentsStore).thenReturn(commentStore)
         whenever(moderateCommentsResourceProvider.localCommentCacheUpdateHandler).thenReturn(
                 localCommentCacheUpdateHandler
         )
         whenever(moderateCommentsResourceProvider.bgDispatcher).thenReturn(NoDelayCoroutineDispatcher())
 
-        runBlocking {
-            Mockito.`when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(1)))
-        }.thenReturn(listOf(approvedComment))
-
-        runBlocking {
-            Mockito.`when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(2)))
-        }.thenReturn(listOf(pendingComment))
-
-        runBlocking {
-            Mockito.`when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(3)))
-        }.thenReturn(listOf(trashedComment))
+        `when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(1)))
+                .thenReturn(listOf(approvedComment))
+        `when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(2)))
+                .thenReturn(listOf(pendingComment))
+        `when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(3)))
+                .thenReturn(listOf(trashedComment))
 
         batchModerateCommentsUseCase = BatchModerateCommentsUseCase(moderateCommentsResourceProvider)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/ModerateCommentsWithUndoUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/ModerateCommentsWithUndoUseCaseTest.kt
@@ -10,16 +10,13 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito
+import org.mockito.Mockito.*
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.MainCoroutineScopeRule
 import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
 import org.wordpress.android.fluxc.model.CommentStatus.DELETED
 import org.wordpress.android.fluxc.model.CommentStatus.TRASH
@@ -42,14 +39,13 @@ import org.wordpress.android.models.usecases.ModerateCommentWithUndoUseCase.Para
 import org.wordpress.android.models.usecases.ModerateCommentWithUndoUseCase.Parameters.ModerateWithFallbackParameters
 import org.wordpress.android.models.usecases.ModerateCommentWithUndoUseCase.SingleCommentModerationResult
 import org.wordpress.android.models.usecases.ModerateCommentsResourceProvider
+import org.wordpress.android.test
 import org.wordpress.android.ui.comments.utils.approvedComment
 import org.wordpress.android.ui.comments.utils.trashedComment
 import org.wordpress.android.usecase.UseCaseResult
 
 @ExperimentalCoroutinesApi
 class ModerateCommentsWithUndoUseCaseTest : BaseUnitTest() {
-    @Rule @JvmField val coroutineScopeRule = MainCoroutineScopeRule()
-
     @Mock private lateinit var commentStore: CommentsStore
     @Mock private lateinit var localCommentCacheUpdateHandler: LocalCommentCacheUpdateHandler
 
@@ -60,15 +56,14 @@ class ModerateCommentsWithUndoUseCaseTest : BaseUnitTest() {
     val site = SiteModel().also { it.id = 5 }.also { it.name = "Test Site" }
 
     @Before
-    fun setup() {
+    fun setup() = test {
         whenever(moderateCommentsResourceProvider.commentsStore).thenReturn(commentStore)
         whenever(moderateCommentsResourceProvider.localCommentCacheUpdateHandler).thenReturn(
                 localCommentCacheUpdateHandler
         )
 
-        runBlocking {
-            Mockito.`when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(1)))
-        }.thenReturn(listOf(approvedComment))
+        `when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(1)))
+                .thenReturn(listOf(approvedComment))
 
         moderateCommentWithUndoUseCase = ModerateCommentWithUndoUseCase(moderateCommentsResourceProvider)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/ModerateCommentsWithUndoUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/ModerateCommentsWithUndoUseCaseTest.kt
@@ -15,7 +15,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.*
+import org.mockito.Mockito.`when`
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
 import org.wordpress.android.fluxc.model.CommentStatus.DELETED

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/PaginateCommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/PaginateCommentsUseCaseTest.kt
@@ -13,7 +13,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.*
+import org.mockito.Mockito.`when`
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.CommentStore.CommentError
@@ -127,7 +127,7 @@ class PaginateCommentsUseCaseTest : BaseUnitTest() {
 
         val commentsPayload = dataResult.data
 
-        assertThat(commentsPayload.hasMore).isTrue()
+        assertThat(commentsPayload.hasMore).isTrue
         assertThat(commentsPayload.comments).isEqualTo(testComments.take(30))
         job.cancel()
     }
@@ -152,7 +152,7 @@ class PaginateCommentsUseCaseTest : BaseUnitTest() {
 
         val commentsPayload = dataResult.data
 
-        assertThat(commentsPayload.hasMore).isTrue()
+        assertThat(commentsPayload.hasMore).isTrue
         assertThat(commentsPayload.comments).isEqualTo(testComments.take(60))
         job.cancel()
     }
@@ -177,7 +177,7 @@ class PaginateCommentsUseCaseTest : BaseUnitTest() {
 
         val commentsPayload = dataResult.data
 
-        assertThat(commentsPayload.hasMore).isFalse()
+        assertThat(commentsPayload.hasMore).isFalse
         assertThat(commentsPayload.comments).isEqualTo(testComments.take(90))
         job.cancel()
     }
@@ -214,7 +214,7 @@ class PaginateCommentsUseCaseTest : BaseUnitTest() {
 
         paginateCommentsUseCase.manageAction(OnGetPage(GetPageParameters(site, 30, 30, ALL)))
 
-        assertThat(result.any { it is UseCaseResult.Loading }).isFalse()
+        assertThat(result.any { it is UseCaseResult.Loading }).isFalse
         job.cancel()
     }
 
@@ -362,7 +362,7 @@ class PaginateCommentsUseCaseTest : BaseUnitTest() {
                 )
         )
 
-        assertThat(result.any { it is UseCaseResult.Loading }).isFalse()
+        assertThat(result.any { it is UseCaseResult.Loading }).isFalse
 
         job.cancel()
     }
@@ -399,7 +399,7 @@ class PaginateCommentsUseCaseTest : BaseUnitTest() {
 
                 val commentsPayload = dataResult.data
 
-                assertThat(commentsPayload.hasMore).isTrue()
+                assertThat(commentsPayload.hasMore).isTrue
                 assertThat(commentsPayload.comments).isEqualTo(testComments.take(60))
                 job.cancel()
             }

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/PaginateCommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/PaginateCommentsUseCaseTest.kt
@@ -8,16 +8,13 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito
+import org.mockito.Mockito.*
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.MainCoroutineScopeRule
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.CommentStore.CommentError
 import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.GENERIC_ERROR
@@ -32,6 +29,7 @@ import org.wordpress.android.models.usecases.PaginateCommentsUseCase.PaginateCom
 import org.wordpress.android.models.usecases.PaginateCommentsUseCase.PaginateCommentsAction.OnReloadFromCache
 import org.wordpress.android.models.usecases.PaginateCommentsUseCase.Parameters.GetPageParameters
 import org.wordpress.android.models.usecases.PaginateCommentsUseCase.Parameters.ReloadFromCacheParameters
+import org.wordpress.android.test
 import org.wordpress.android.ui.comments.unified.CommentFilter.ALL
 import org.wordpress.android.ui.comments.unified.CommentFilter.PENDING
 import org.wordpress.android.ui.comments.unified.CommentFilter.UNREPLIED
@@ -45,8 +43,6 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 
 @ExperimentalCoroutinesApi
 class PaginateCommentsUseCaseTest : BaseUnitTest() {
-    @Rule @JvmField val coroutineScopeRule = MainCoroutineScopeRule()
-
     @Mock private lateinit var commentStore: CommentsStore
     @Mock private lateinit var paginateCommentsResourceProvider: PaginateCommentsResourceProvider
     @Mock private lateinit var unrepliedCommentsUtils: UnrepliedCommentsUtils
@@ -57,27 +53,20 @@ class PaginateCommentsUseCaseTest : BaseUnitTest() {
     val site = SiteModel().also { it.id = 5 }.also { it.name = "Test Site" }
 
     @Before
-    fun setup() {
+    fun setup() = test {
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
         whenever(paginateCommentsResourceProvider.commentsStore).thenReturn(commentStore)
         whenever(paginateCommentsResourceProvider.unrepliedCommentsUtils).thenReturn(unrepliedCommentsUtils)
         whenever(paginateCommentsResourceProvider.networkUtilsWrapper).thenReturn(networkUtilsWrapper)
 
-        runBlocking {
-            Mockito.`when`(commentStore.fetchCommentsPage(eq(site), any(), eq(0), any(), any()))
-        }.thenReturn(testCommentsPayload30)
-
-        runBlocking {
-            Mockito.`when`(commentStore.fetchCommentsPage(eq(site), any(), eq(30), any(), any()))
-        }.thenReturn(testCommentsPayload60)
-
-        runBlocking {
-            Mockito.`when`(commentStore.fetchCommentsPage(eq(site), any(), eq(60), any(), any()))
-        }.thenReturn(testCommentsPayloadLastPage)
-
-        runBlocking {
-            Mockito.`when`(commentStore.getCachedComments(eq(site), any(), any()))
-        }.thenReturn(testCommentsPayload60)
+        `when`(commentStore.fetchCommentsPage(eq(site), any(), eq(0), any(), any()))
+                .thenReturn(testCommentsPayload30)
+        `when`(commentStore.fetchCommentsPage(eq(site), any(), eq(30), any(), any()))
+                .thenReturn(testCommentsPayload60)
+        `when`(commentStore.fetchCommentsPage(eq(site), any(), eq(60), any(), any()))
+                .thenReturn(testCommentsPayloadLastPage)
+        `when`(commentStore.getCachedComments(eq(site), any(), any()))
+                .thenReturn(testCommentsPayload60)
 
         paginateCommentsUseCase = PaginateCommentsUseCase(paginateCommentsResourceProvider)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/utils/GetLikesTestUtils.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/utils/GetLikesTestUtils.kt
@@ -119,6 +119,7 @@ fun getGetLikesState(testConfig: GetLikesTestConfig): GetLikesState {
     }
 }
 
+@Suppress("UNCHECKED_CAST")
 fun List<LikeModel>.isEqualTo(engageItemList: List<EngageItem>): Boolean {
     val sameSize = this.size == engageItemList.size
     val likersList = engageItemList as? List<Liker>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCaseTest.kt
@@ -87,7 +87,7 @@ class JetpackCapabilitiesUseCaseTest {
 
         useCase.getJetpackPurchasedProducts(SITE_ID).toList(mutableListOf())
 
-        verify(appPrefsWrapper).setSiteJetpackCapabilities(SITE_ID, event.capabilities!!)
+        verify(appPrefsWrapper).setSiteJetpackCapabilities(SITE_ID, event.capabilities)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -261,17 +260,16 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given no network error ui state, when retry is clicked, then fetch scan state is triggered`() =
-            coroutineScope.runBlockingTest {
-                whenever(scanStore.getScanStateForSite(site)).thenReturn(null)
-                whenever(fetchScanStateUseCase.fetchScanState(site)).thenReturn(flowOf(Failure.NetworkUnavailable))
-                val uiStates = init().uiStates
+    fun `given no network error ui state, when retry is clicked, then fetch scan state is triggered`() = test {
+        whenever(scanStore.getScanStateForSite(site)).thenReturn(null)
+        whenever(fetchScanStateUseCase.fetchScanState(site)).thenReturn(flowOf(Failure.NetworkUnavailable))
+        val uiStates = init().uiStates
 
-                (uiStates.last() as ErrorUiState).action?.invoke()
-                advanceTimeBy(RETRY_DELAY)
+        (uiStates.last() as ErrorUiState).action?.invoke()
+        coroutineScope.advanceTimeBy(RETRY_DELAY)
 
-                verify(fetchScanStateUseCase, times(2)).fetchScanState(site)
-            }
+        verify(fetchScanStateUseCase, times(2)).fetchScanState(site)
+    }
 
     @Test
     fun `given request failed error ui state, when contact support is clicked, then contact support screen is shown`() =

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilderTest.kt
@@ -104,7 +104,7 @@ class ThreatDetailsListItemsBuilderTest : BaseUnitTest() {
         whenever(dateFormatWrapper.getLongDateFormat()).thenReturn(dateFormat)
         whenever(dateFormat.format(ThreatTestData.genericThreatModel.baseThreatModel.firstDetected))
                 .thenReturn(TEST_FOUND_ON_DATE)
-        whenever(dateFormat.format(ThreatTestData.genericThreatModel.baseThreatModel.fixedOn))
+        whenever(dateFormat.format(ThreatTestData.genericThreatModel.baseThreatModel.fixedOn!!))
                 .thenReturn(TEST_FIXED_ON_DATE)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
@@ -7,7 +7,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -72,24 +71,23 @@ class FetchFixThreatsStatusUseCaseTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when in progress threats fix status is fetched, then polling occurs until in progress status changes`() =
-            coroutineScope.runBlockingTest {
-                whenever(scanStore.fetchFixThreatsStatus(any()))
-                        .thenReturn(storeResultWithInProgressFixStatusModel)
-                        .thenReturn(storeResultWithInProgressFixStatusModel)
-                        .thenReturn(storeResultWithFixedFixStatusModel)
+    fun `when in progress threats fix status fetched, then polling occurs until in progress status changes`() = test {
+        whenever(scanStore.fetchFixThreatsStatus(any()))
+                .thenReturn(storeResultWithInProgressFixStatusModel)
+                .thenReturn(storeResultWithInProgressFixStatusModel)
+                .thenReturn(storeResultWithFixedFixStatusModel)
 
-                val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(fakeThreatId))
-                        .toList(mutableListOf())
-                advanceTimeBy(FETCH_FIX_THREATS_STATUS_DELAY_MILLIS)
+        val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(fakeThreatId))
+                .toList(mutableListOf())
+        coroutineScope.advanceTimeBy(FETCH_FIX_THREATS_STATUS_DELAY_MILLIS)
 
-                verify(scanStore, times(3)).fetchFixThreatsStatus(any())
-                assertThat(useCaseResult).containsSequence(
-                        InProgress(listOf(fakeThreatId)),
-                        InProgress(listOf(fakeThreatId)),
-                        Complete(fixedThreatsCount = 1)
-                )
-            }
+        verify(scanStore, times(3)).fetchFixThreatsStatus(any())
+        assertThat(useCaseResult).containsSequence(
+                InProgress(listOf(fakeThreatId)),
+                InProgress(listOf(fakeThreatId)),
+                Complete(fixedThreatsCount = 1)
+        )
+    }
 
     @Test
     fun `given threats fixed successfully, when threats fix status is fetched, then Complete is returned`() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
@@ -286,7 +286,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
         viewModel.refreshData(false)
 
         assertThat(navigateEvents).isEmpty()
-        clickItem(0)
+        clickItem()
         assertThat(navigateEvents).isNotEmpty
         verify(mediaPickerTracker).trackPreview(
                 firstItem.type == VIDEO,
@@ -724,11 +724,12 @@ class MediaPickerViewModelTest : BaseUnitTest() {
             is PhotoItem -> item.toggleAction.toggle()
             is VideoItem -> item.toggleAction.toggle()
             is FileItem -> item.toggleAction.toggle()
+            is NextPageLoader -> Unit // Do nothing
         }
     }
 
-    private fun clickItem(position: Int) {
-        when (val item = itemOnPosition(position)) {
+    private fun clickItem() {
+        when (val item = itemOnPosition(0)) {
             is PhotoItem -> item.clickAction.click()
             is VideoItem -> item.clickAction.click()
             is FileItem -> item.clickAction.click()

--- a/WordPress/src/test/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModelTest.kt
@@ -18,16 +18,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.MEDIA_PICKER_PREVIE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.test
 import org.wordpress.android.ui.media.MediaBrowserType
-import org.wordpress.android.ui.media.MediaBrowserType.EDITOR_PICKER
-import org.wordpress.android.ui.media.MediaBrowserType.GUTENBERG_IMAGE_PICKER
-import org.wordpress.android.ui.media.MediaBrowserType.GUTENBERG_MEDIA_PICKER
-import org.wordpress.android.ui.media.MediaBrowserType.GUTENBERG_SINGLE_IMAGE_PICKER
-import org.wordpress.android.ui.media.MediaBrowserType.GUTENBERG_SINGLE_VIDEO_PICKER
-import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.ActionModeUiModel
-import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.BottomBarUiModel.BottomBar
-import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PhotoListUiModel
-import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PhotoPickerUiState
-import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.SoftAskViewUiModel
 import org.wordpress.android.ui.posts.editor.media.CopyMediaToAppStorageUseCase
 import org.wordpress.android.ui.posts.editor.media.GetMediaModelUseCase
 import org.wordpress.android.ui.utils.UiString
@@ -40,6 +30,7 @@ import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 
 class PhotoPickerViewModelTest : BaseUnitTest() {
+    @Suppress("DEPRECATION")
     @Mock lateinit var deviceMediaListBuilder: DeviceMediaListBuilder
     @Mock lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
@@ -50,17 +41,18 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var copyMediaToAppStorageUseCase: CopyMediaToAppStorageUseCase
     @Mock lateinit var getMediaModelUseCase: GetMediaModelUseCase
-    private lateinit var viewModel: PhotoPickerViewModel
-    private var uiStates = mutableListOf<PhotoPickerUiState>()
+    @Suppress("DEPRECATION") private lateinit var viewModel: PhotoPickerViewModel
+    @Suppress("DEPRECATION") private var uiStates = mutableListOf<PhotoPickerViewModel.PhotoPickerUiState>()
     private var navigateEvents = mutableListOf<Event<UriWrapper>>()
-    private val singleSelectBrowserType = GUTENBERG_SINGLE_IMAGE_PICKER
+    private val singleSelectBrowserType = MediaBrowserType.GUTENBERG_SINGLE_IMAGE_PICKER
     private val multiSelectBrowserType = MediaBrowserType.GUTENBERG_IMAGE_PICKER
     private val site = SiteModel()
-    private lateinit var firstItem: PhotoPickerItem
-    private lateinit var secondItem: PhotoPickerItem
+    @Suppress("DEPRECATION") private lateinit var firstItem: PhotoPickerItem
+    @Suppress("DEPRECATION") private lateinit var secondItem: PhotoPickerItem
 
-    @InternalCoroutinesApi
     @Before
+    @InternalCoroutinesApi
+    @Suppress("DEPRECATION")
     fun setUp() {
         viewModel = PhotoPickerViewModel(
                 TEST_DISPATCHER,
@@ -222,7 +214,7 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
         viewModel.refreshData(false)
 
         assertThat(navigateEvents).isEmpty()
-        clickItem(0)
+        clickItem()
         assertThat(navigateEvents).isNotEmpty
         verify(analyticsTrackerWrapper).track(eq(MEDIA_PICKER_PREVIEW_OPENED), any<MutableMap<String, Any>>())
     }
@@ -243,7 +235,7 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `action mode title is Use Photo when photo browser type`() = test {
-        setupViewModel(listOf(firstItem, secondItem), GUTENBERG_SINGLE_IMAGE_PICKER)
+        setupViewModel(listOf(firstItem, secondItem), MediaBrowserType.GUTENBERG_SINGLE_IMAGE_PICKER)
 
         viewModel.refreshData(false)
 
@@ -254,7 +246,7 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `action mode title is Use Video when video browser type`() = test {
-        setupViewModel(listOf(firstItem, secondItem), GUTENBERG_SINGLE_VIDEO_PICKER)
+        setupViewModel(listOf(firstItem, secondItem), MediaBrowserType.GUTENBERG_SINGLE_VIDEO_PICKER)
 
         viewModel.refreshData(false)
 
@@ -265,7 +257,7 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `action mode title is Use Media when image and video browser type`() = test {
-        setupViewModel(listOf(firstItem, secondItem), GUTENBERG_MEDIA_PICKER)
+        setupViewModel(listOf(firstItem, secondItem), MediaBrowserType.GUTENBERG_MEDIA_PICKER)
 
         viewModel.refreshData(false)
 
@@ -277,7 +269,7 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
     @Test
     fun `action mode title is Select N items when multi selection available`() = test {
         whenever(resourceProvider.getString(R.string.cab_selected)).thenReturn("%d selected")
-        setupViewModel(listOf(firstItem, secondItem), GUTENBERG_IMAGE_PICKER)
+        setupViewModel(listOf(firstItem, secondItem), MediaBrowserType.GUTENBERG_IMAGE_PICKER)
 
         viewModel.refreshData(false)
 
@@ -290,7 +282,7 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
     @Test
     fun `action mode shows confirmation action in EDITOR PICKER`() = test {
         whenever(resourceProvider.getString(R.string.cab_selected)).thenReturn("%d selected")
-        setupViewModel(listOf(firstItem, secondItem), EDITOR_PICKER)
+        setupViewModel(listOf(firstItem, secondItem), MediaBrowserType.EDITOR_PICKER)
 
         viewModel.refreshData(false)
 
@@ -299,22 +291,31 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
         assertActionModeVisible(UiStringText("1 selected"), showConfirmationAction = true)
     }
 
+    @Suppress("DEPRECATION")
     private fun selectItem(position: Int) {
-        (uiStates.last().photoListUiModel as PhotoListUiModel.Data).items[position].toggleAction.toggle()
+        (uiStates.last().photoListUiModel as PhotoPickerViewModel.PhotoListUiModel.Data)
+                .items[position]
+                .toggleAction
+                .toggle()
     }
 
-    private fun clickItem(position: Int) {
-        (uiStates.last().photoListUiModel as PhotoListUiModel.Data).items[position].clickAction.click()
+    @Suppress("DEPRECATION")
+    private fun clickItem() {
+        (uiStates.last().photoListUiModel as PhotoPickerViewModel.PhotoListUiModel.Data)
+                .items[0]
+                .clickAction
+                .click()
     }
 
+    @Suppress("DEPRECATION")
     private fun assertDataList(
         browserType: MediaBrowserType,
         selectedItems: List<PhotoPickerItem>,
         domainItems: List<PhotoPickerItem>
     ) {
         uiStates.last().apply {
-            assertThat(this.photoListUiModel).isNotNull()
-            (uiStates.last().photoListUiModel as PhotoListUiModel.Data).apply {
+            assertThat(this.photoListUiModel).isNotNull
+            (uiStates.last().photoListUiModel as PhotoPickerViewModel.PhotoListUiModel.Data).apply {
                 assertThat(this.items).hasSize(domainItems.size)
                 domainItems.forEachIndexed { index, photoPickerItem ->
                     val isSelected = selectedItems.any { it.id == photoPickerItem.id }
@@ -333,21 +334,24 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
         assertSoftAskUiModelHidden()
     }
 
+    @Suppress("DEPRECATION")
     private fun assertSoftAskUiModelVisible() {
         uiStates.last().softAskViewUiModel.let {
-            val model = it as SoftAskViewUiModel.Visible
+            val model = it as PhotoPickerViewModel.SoftAskViewUiModel.Visible
             assertThat(model.allowId).isEqualTo(UiStringRes(R.string.photo_picker_soft_ask_allow))
             assertThat(model.isAlwaysDenied).isEqualTo(false)
             assertThat(model.label).isEqualTo("Soft ask label")
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun assertSoftAskUiModelHidden() {
         uiStates.last().softAskViewUiModel.let {
-            assertThat(it is SoftAskViewUiModel.Hidden).isTrue()
+            assertThat(it is PhotoPickerViewModel.SoftAskViewUiModel.Hidden).isTrue
         }
     }
 
+    @Suppress("DEPRECATION")
     private suspend fun setupViewModel(
         domainModel: List<PhotoPickerItem>,
         browserType: MediaBrowserType,
@@ -369,7 +373,8 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
         assertThat(uiStates).hasSize(1)
     }
 
-    private fun PhotoListUiModel.Data.assertSelection(
+    @Suppress("DEPRECATION")
+    private fun PhotoPickerViewModel.PhotoListUiModel.Data.assertSelection(
         position: Int,
         isSelected: Boolean,
         isMultiSelection: Boolean = false,
@@ -388,6 +393,7 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun PhotoPickerUiItem.assertEqualToDomainItem(domainItem: PhotoPickerItem) {
         assertThat(this.id).isEqualTo(domainItem.id)
         if (domainItem.isVideo) {
@@ -399,41 +405,46 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
         assertThat(this.uri).isEqualTo(domainItem.uri)
     }
 
+    @Suppress("DEPRECATION")
     private fun assertBottomBarHidden() {
         uiStates.last().apply {
-            assertThat(bottomBarUiModel.type).isEqualTo(BottomBar.NONE)
+            assertThat(bottomBarUiModel.type).isEqualTo(PhotoPickerViewModel.BottomBarUiModel.BottomBar.NONE)
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun assertSingleIconMediaBottomBarVisible() {
         uiStates.last().apply {
-            assertThat(bottomBarUiModel.type).isEqualTo(BottomBar.MEDIA_SOURCE)
-            assertThat(bottomBarUiModel.canShowInsertEditBottomBar).isTrue()
-            assertThat(bottomBarUiModel.hideMediaBottomBarInPortrait).isFalse()
-            assertThat(bottomBarUiModel.showCameraButton).isFalse()
+            assertThat(bottomBarUiModel.type).isEqualTo(PhotoPickerViewModel.BottomBarUiModel.BottomBar.MEDIA_SOURCE)
+            assertThat(bottomBarUiModel.canShowInsertEditBottomBar).isTrue
+            assertThat(bottomBarUiModel.hideMediaBottomBarInPortrait).isFalse
+            assertThat(bottomBarUiModel.showCameraButton).isFalse
             assertThat(bottomBarUiModel.showWPMediaIcon).isFalse()
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun assertInsertEditBottomBarVisible() {
         uiStates.last().apply {
-            assertThat(bottomBarUiModel.type).isEqualTo(BottomBar.INSERT_EDIT)
-            assertThat(bottomBarUiModel.canShowInsertEditBottomBar).isTrue()
-            assertThat(bottomBarUiModel.hideMediaBottomBarInPortrait).isFalse()
-            assertThat(bottomBarUiModel.showCameraButton).isFalse()
+            assertThat(bottomBarUiModel.type).isEqualTo(PhotoPickerViewModel.BottomBarUiModel.BottomBar.INSERT_EDIT)
+            assertThat(bottomBarUiModel.canShowInsertEditBottomBar).isTrue
+            assertThat(bottomBarUiModel.hideMediaBottomBarInPortrait).isFalse
+            assertThat(bottomBarUiModel.showCameraButton).isFalse
             assertThat(bottomBarUiModel.showWPMediaIcon).isFalse()
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun assertActionModeHidden() {
         uiStates.last().actionModeUiModel.let { model ->
-            assertThat(model is ActionModeUiModel.Hidden).isTrue()
+            assertThat(model is PhotoPickerViewModel.ActionModeUiModel.Hidden).isTrue
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun assertActionModeVisible(title: UiString, showConfirmationAction: Boolean = false) {
         uiStates.last().actionModeUiModel.let {
-            val model = it as ActionModeUiModel.Visible
+            val model = it as PhotoPickerViewModel.ActionModeUiModel.Visible
             assertThat(model.actionModeTitle).isEqualTo(title)
             assertThat(model.showConfirmAction).isEqualTo(showConfirmationAction)
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
@@ -71,7 +71,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "scheduled for" for scheduled post`() {
+    fun `returns 'scheduled for' for scheduled post`() {
         postModel.setStatus(PostStatus.SCHEDULED.toString())
         postModel.setDateCreated(dateCreated)
 
@@ -81,7 +81,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "published on" for published post`() {
+    fun `returns 'published on' for published post`() {
         postModel.setStatus(PostStatus.PUBLISHED.toString())
         postModel.setDateCreated(dateCreated)
 
@@ -91,7 +91,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "published on" for private post`() {
+    fun `returns 'published on' for private post`() {
         postModel.setStatus(PostStatus.PRIVATE.toString())
         postModel.setDateCreated(dateCreated)
 
@@ -101,7 +101,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "scheduled for" for private post that is local and scheduled`() {
+    fun `returns 'scheduled for' for private post that is local and scheduled`() {
         postModel.setStatus(PostStatus.PRIVATE.toString())
         postModel.setIsLocalDraft(true)
 
@@ -115,7 +115,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "backdated for" for local draft when publish date in the past`() {
+    fun `returns 'backdated for' for local draft when publish date in the past`() {
         postModel.setIsLocalDraft(true)
         postModel.setDateCreated(dateCreated)
 
@@ -125,7 +125,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "immediately" for local draft when should publish immediately`() {
+    fun `returns 'immediately' for local draft when should publish immediately`() {
         postModel.setIsLocalDraft(true)
         postModel.setStatus(PostStatus.DRAFT.toString())
         postModel.setDateCreated(currentDate)
@@ -136,7 +136,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "immediately" for local private post that should publish immediately`() {
+    fun `returns 'immediately' for local private post that should publish immediately`() {
         postModel.setIsLocalDraft(true)
         postModel.setStatus(PostStatus.PRIVATE.toString())
         postModel.setDateCreated(currentDate)
@@ -147,7 +147,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "publish on" for local draft when date within the next 30 minutes`() {
+    fun `returns 'publish on' for local draft when date within the next 30 minutes`() {
         postModel.setIsLocalDraft(true)
 
         // This date is 5 minutes before the currentDate
@@ -161,7 +161,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "schedule for" when post published in future`() {
+    fun `returns 'schedule for' when post published in future`() {
         // two hours ahead of the currentDate
         val futureDate = "2019-05-05T22:28:20+0200"
 
@@ -173,7 +173,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "immediately" when post does not have the date and is draft`() {
+    fun `returns 'immediately' when post does not have the date and is draft`() {
         postModel.setStatus(PostStatus.DRAFT.toString())
         postModel.setDateCreated("")
 
@@ -183,7 +183,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "immediately" in other cases`() {
+    fun `returns 'immediately' in other cases`() {
         postModel.setDateCreated("")
 
         val publishedDate = postSettingsUtils.getPublishDateLabel(postModel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
@@ -42,8 +42,9 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
     @Mock lateinit var getCategoriesUseCase: GetCategoriesUseCase
     @Mock lateinit var site: SiteModel
 
-    @InternalCoroutinesApi
     @Before
+    @InternalCoroutinesApi
+    @Suppress("UNCHECKED_CAST")
     fun setUp() {
         viewModel = PrepublishingHomeViewModel(
                 getPostTagsUseCase,

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModelTest.kt
@@ -3,10 +3,8 @@ package org.wordpress.android.ui.prefs.categories.detail
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertTrue
 import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.BaseUnitTest
@@ -76,15 +74,15 @@ class CategoryDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `when vm starts, then default parent category is selected`() {
         viewModel.start()
-        assertEquals(topLevelCategory, uiStates.first().categories[0].name)
+        assertThat(topLevelCategory).isEqualTo(uiStates.first().categories[0].name)
     }
 
     @Test
     fun `when vm starts, then submit button is shown and disabled`() {
         viewModel.start()
 
-        assertFalse(uiStates.first().submitButtonUiState.enabled)
-        assertTrue(uiStates.first().submitButtonUiState.visibility)
+        assertThat(uiStates.first().submitButtonUiState.enabled).isFalse
+        assertThat(uiStates.first().submitButtonUiState.visibility).isTrue
     }
 
     @Test
@@ -92,7 +90,7 @@ class CategoryDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
         viewModel.onCategoryNameUpdated("category name")
 
-        assertTrue(uiStates.last().submitButtonUiState.enabled)
+        assertThat(uiStates.last().submitButtonUiState.enabled).isTrue
     }
 
     @Test
@@ -104,7 +102,7 @@ class CategoryDetailViewModelTest : BaseUnitTest() {
         val selectedCategoryParent = 2
         viewModel.onParentCategorySelected(selectedCategoryParent)
 
-        assertEquals(selectedCategoryParent, uiStates.last().selectedParentCategoryPosition)
+        assertThat(selectedCategoryParent).isEqualTo(uiStates.last().selectedParentCategoryPosition)
     }
 
     @Test
@@ -115,10 +113,8 @@ class CategoryDetailViewModelTest : BaseUnitTest() {
         viewModel.onCategoryNameUpdated(categoryName)
         viewModel.onSubmitButtonClick()
 
-        assertEquals(
-                Failure(UiStringRes(R.string.no_network_message)),
-                (onCategoryPushStates[0].peekContent() as Failure)
-        )
+        assertThat(Failure(UiStringRes(R.string.no_network_message)))
+                .isEqualTo(onCategoryPushStates[0].peekContent() as Failure)
     }
 
     @Test
@@ -130,7 +126,7 @@ class CategoryDetailViewModelTest : BaseUnitTest() {
         viewModel.onCategoryNameUpdated(categoryName)
         viewModel.onSubmitButtonClick()
 
-        assertEquals(InProgress, onCategoryPushStates[0].peekContent())
+        assertThat(InProgress).isEqualTo(onCategoryPushStates[0].peekContent())
         verify(addCategoryUseCase).addCategory(categoryName, 0, siteModel)
     }
 
@@ -139,10 +135,8 @@ class CategoryDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
         viewModel.onTermUploaded(getTermUploadSuccess())
 
-        assertEquals(
-                Success(UiStringRes(R.string.adding_cat_success)),
-                (onCategoryPushStates[0].peekContent() as Success)
-        )
+        assertThat(Success(UiStringRes(R.string.adding_cat_success)))
+                .isEqualTo(onCategoryPushStates[0].peekContent() as Success)
     }
 
     @Test
@@ -150,10 +144,8 @@ class CategoryDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
         viewModel.onTermUploaded(getTermUploadError())
 
-        assertEquals(
-                Failure(UiStringRes(R.string.adding_cat_failed)),
-                (onCategoryPushStates[0].peekContent() as Failure)
-        )
+        assertThat(Failure(UiStringRes(R.string.adding_cat_failed)))
+                .isEqualTo(onCategoryPushStates[0].peekContent() as Failure)
     }
 
     private fun getTermUploadSuccess() = OnTermUploaded(TermModel())

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/notifications/FollowedBlogsProviderTest.kt
@@ -231,9 +231,7 @@ class FollowedBlogsProviderTest {
         subscriptionModel.emailPostsFrequency = emailFrequency
         subscriptionModel.shouldEmailComments = shouldEmailComments
         subscriptionModel.url = subscriptionUrl
-        feedId?.let {
-            subscriptionModel.feedId = it
-        }
+        subscriptionModel.feedId = feedId
         whenever(urlUtils.getHost(subscriptionUrl)).thenReturn(subscriptionUrlHost)
         return subscriptionModel
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
@@ -97,9 +97,9 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given empty instance state, when vm started, then loading is followed by scanning`() = runBlockingTest {
+    fun `given empty instance state, when vm started, then loading is followed by scanning`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             viewModel.start()
 
             assertThat(uiStates.last()).isInstanceOf(QRCodeAuthUiState.Scanning::class.java)
@@ -109,7 +109,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given non empty instance state, when vm started, then state is restored`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initAndStartVMForState(NO_INTERNET)
 
             assertThat(uiStates.last().type).isEqualTo(NO_INTERNET)
@@ -128,7 +128,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given validate state, when primary action is clicked, then state is authenticating`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initAndStartVMForState(VALIDATED)
 
             (uiStates.last() as Validated).primaryActionButton.clickAction()
@@ -141,7 +141,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     fun `given validate state, when secondary action is clicked, then activity finished event`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
         val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
-        runBlockingTestWithData(uiStates, actionEvents) {
+        testWithData(uiStates, actionEvents) {
             initAndStartVMForState(VALIDATED)
 
             (uiStates.last() as Validated).secondaryActionButton.clickAction()
@@ -153,7 +153,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given valid qr code, when scanned qrcode, then validated is shown`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initValidate()
 
             viewModel.start()
@@ -168,7 +168,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         whenever(validator.isValidUri(SCANNED_VALUE)).thenReturn(false)
 
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             viewModel.start()
             viewModel.onScanSuccess(SCANNED_VALUE)
 
@@ -181,7 +181,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         whenever(validator.isValidUri(SCANNED_VALUE)).thenReturn(false)
 
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             viewModel.start()
             viewModel.onScanSuccess(SCANNED_VALUE)
 
@@ -195,7 +195,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         whenever(validator.extractQueryParams(SCANNED_VALUE)).thenReturn(invalidQueryParams)
 
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             viewModel.start()
             viewModel.onScanSuccess(SCANNED_VALUE)
 
@@ -209,7 +209,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         whenever(validator.extractQueryParams(SCANNED_VALUE)).thenReturn(invalidQueryParams)
 
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             viewModel.start()
             viewModel.onScanSuccess(SCANNED_VALUE)
 
@@ -220,7 +220,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given not authorized error, when validate failure, then auth failed is shown`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initValidate(false, NOT_AUTHORIZED)
 
             viewModel.start()
@@ -233,7 +233,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given not authorized error, when validate failure, then auth failed error is tracked`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initValidate(false, NOT_AUTHORIZED)
 
             viewModel.start()
@@ -246,7 +246,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given error, when validate failure, then invalid data is shown`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initValidate(false, GENERIC_ERROR)
 
             viewModel.start()
@@ -259,7 +259,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given error, when validate failure, then invalid data is tracked`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initValidate(false, GENERIC_ERROR)
 
             viewModel.start()
@@ -272,7 +272,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given authorization required with valid error message, when validate failure, then expired is shown`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initValidate(false, AUTHORIZATION_REQUIRED, VALID_EXPIRED_MESSAGE)
 
             viewModel.start()
@@ -285,7 +285,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given authorization required with valid error message, when validate failure, then expired is tracked`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initValidate(false, AUTHORIZATION_REQUIRED, VALID_EXPIRED_MESSAGE)
 
             viewModel.start()
@@ -298,7 +298,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given authorization required with invalid error message, when validate failure, then auth failed is shown`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initValidate(false, AUTHORIZATION_REQUIRED, INVALID_EXPIRED_MESSAGE)
 
             viewModel.start()
@@ -309,9 +309,9 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given authorization required with invalid error message, when validate failure, then authfailed is tracked`() {
+    fun `given authorization required with invalid error message, when validate failure, then failed is tracked`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initValidate(false, AUTHORIZATION_REQUIRED, INVALID_EXPIRED_MESSAGE)
 
             viewModel.start()
@@ -324,7 +324,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given validated state, when authenticate invoked, then authenticating followed by done`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initAuthenticate()
             initAndStartVMForState(VALIDATED)
 
@@ -340,7 +340,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given not authorized error, when authenticate failure, then auth failed is shown`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initAuthenticate(false, NOT_AUTHORIZED)
             initAndStartVMForState(VALIDATED)
 
@@ -353,7 +353,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given not authorized error, when authenticate failure, then auth failed is tracked`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initAuthenticate(false, NOT_AUTHORIZED)
             initAndStartVMForState(VALIDATED)
 
@@ -366,7 +366,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given error, when authenticate failure, then invalid data is shown`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initAuthenticate(false, GENERIC_ERROR)
             initAndStartVMForState(VALIDATED)
 
@@ -379,7 +379,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given error, when authenticate failure, then invalid data is tracked`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initAuthenticate(false, GENERIC_ERROR)
             initAndStartVMForState(VALIDATED)
 
@@ -393,7 +393,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given authorization required with valid message, when authenticate failure, then expired is shown`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initAuthenticate(false, AUTHORIZATION_REQUIRED, VALID_EXPIRED_MESSAGE)
             initAndStartVMForState(VALIDATED)
 
@@ -406,7 +406,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given authorization required with valid message, when authenticate failure, then expired is tracked`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initAuthenticate(false, AUTHORIZATION_REQUIRED, VALID_EXPIRED_MESSAGE)
             initAndStartVMForState(VALIDATED)
 
@@ -420,7 +420,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given authorization required with invalid message, when authenticate failure, then auth failed is shown`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initAuthenticate(false, AUTHORIZATION_REQUIRED, INVALID_EXPIRED_MESSAGE)
             initAndStartVMForState(VALIDATED)
 
@@ -433,7 +433,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given authorization required with invalid message, when authenticate failure, then auth failed is tracked`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             initAuthenticate(false, AUTHORIZATION_REQUIRED, INVALID_EXPIRED_MESSAGE)
             initAndStartVMForState(VALIDATED)
 
@@ -448,7 +448,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     fun `given done, when primary action is clicked, then finish activity is raised`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
         val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
-        runBlockingTestWithData(uiStates, actionEvents) {
+        testWithData(uiStates, actionEvents) {
             initAndStartVMForState(DONE)
 
             (uiStates.last() as Done).primaryActionButton.clickAction()
@@ -461,7 +461,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     fun `given error, when primary action clicked, then launch scanner is raised`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
         val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
-        runBlockingTestWithData(uiStates, actionEvents) {
+        testWithData(uiStates, actionEvents) {
             initAndStartVMForState(INVALID_DATA)
 
             (uiStates.last() as InvalidData).primaryActionButton.clickAction()
@@ -474,7 +474,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     fun `given error, when secondary action clicked, then finish activity is raised`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
         val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
-        runBlockingTestWithData(uiStates, actionEvents) {
+        testWithData(uiStates, actionEvents) {
             initAndStartVMForState(INVALID_DATA)
 
             (uiStates.last() as InvalidData).secondaryActionButton.clickAction()
@@ -486,7 +486,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given any state, when back is pressed, then dismiss dialog event is raised`() {
         val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
-        runBlockingTestWithData(actionEvents = actionEvents) {
+        testWithData(actionEvents = actionEvents) {
             viewModel.onBackPressed()
 
             assertThat(actionEvents.last()).isInstanceOf(QRCodeAuthActionEvent.LaunchDismissDialog::class.java)
@@ -496,7 +496,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `when scan fails, then finish activity event is raised`() {
         val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
-        runBlockingTestWithData(actionEvents = actionEvents) {
+        testWithData(actionEvents = actionEvents) {
             viewModel.onScanFailure()
 
             assertThat(actionEvents.last()).isInstanceOf(QRCodeAuthActionEvent.FinishActivity::class.java)
@@ -506,7 +506,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given valid scan, when no network connection, then no internet error is shown`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
             startViewModel()
             viewModel.onScanSuccess(SCANNED_VALUE)
@@ -518,7 +518,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given authenticating, when no network connection, then error view is shown`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
-        runBlockingTestWithData(uiStates) {
+        testWithData(uiStates) {
             whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
             initAndStartVMForState(VALIDATED)
 
@@ -531,7 +531,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given dismiss dialog showing, when ok clicked, then finish activity event is raised`() {
         val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
-        runBlockingTestWithData(actionEvents = actionEvents) {
+        testWithData(actionEvents = actionEvents) {
             viewModel.onDialogInteraction(DialogInteraction.Positive("positive"))
 
             assertThat(actionEvents.last()).isInstanceOf(QRCodeAuthActionEvent.FinishActivity::class.java)
@@ -541,7 +541,7 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     @Test
     fun `given dismiss dialog showing, when cancel clicked, then no event is raised`() {
         val actionEvents = mutableListOf<QRCodeAuthActionEvent>()
-        runBlockingTestWithData(actionEvents = actionEvents) {
+        testWithData(actionEvents = actionEvents) {
             viewModel.onDialogInteraction(DialogInteraction.Negative("negative"))
 
             assertThat(actionEvents.isEmpty())
@@ -609,17 +609,15 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
         )
     }
 
-    private fun runBlockingTestWithData(
+    private fun testWithData(
         uiStates: MutableList<QRCodeAuthUiState> = mutableListOf(),
         actionEvents: MutableList<QRCodeAuthActionEvent> = mutableListOf(),
         testBody: suspend TestCoroutineScope.() -> Unit
-    ) {
-        runBlockingTest {
+    ) = runBlockingTest {
             val uiStatesJob = launch { viewModel.uiState.toList(uiStates) }
             val actionEventsJob = launch { viewModel.actionEvents.toList(actionEvents) }
             testBody()
             uiStatesJob.cancel()
             actionEventsJob.cancel()
-        }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFileDownloadManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFileDownloadManagerTest.kt
@@ -35,6 +35,7 @@ class ReaderFileDownloadManagerTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `enqueues file for download`() {
         val url = "http://wordpress.com/file_name.pdf"
         val header = "Authentication"

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -9,7 +9,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -22,6 +21,7 @@ import org.wordpress.android.R
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.models.ReaderTagType
+import org.wordpress.android.test
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsFragment.EntryPoint
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.DoneButtonUiState.DoneButtonDisabledUiState
@@ -618,21 +618,21 @@ class ReaderInterestsViewModelTest {
     )
 
     private fun <T> testWithEmptyUserTags(block: suspend CoroutineScope.() -> T) {
-        coroutineScope.runBlockingTest {
+        test {
             whenever(readerTagRepository.getUserTags()).thenReturn(SuccessWithData(ReaderTagList()))
             block()
         }
     }
 
     private fun <T> testWithFailedUserTags(block: suspend CoroutineScope.() -> T) {
-        coroutineScope.runBlockingTest {
+        test {
             whenever(readerTagRepository.getUserTags()).thenReturn(NetworkUnavailable)
             block()
         }
     }
 
     private fun <T> testWithNonEmptyUserTags(block: suspend CoroutineScope.() -> T) {
-        coroutineScope.runBlockingTest {
+        test {
             val nonEmptyUserTags = ReaderTagList().apply {
                 this.add(mock())
                 this.add(mock())

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItemMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItemMapperTest.kt
@@ -5,12 +5,9 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
-import org.hamcrest.core.StringContains
 import org.json.JSONObject
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
@@ -28,13 +25,11 @@ class SubfilterListItemMapperTest {
     @Mock lateinit var readerUtilsWrapper: ReaderUtilsWrapper
     @Mock lateinit var readerBlogTableWrapper: ReaderBlogTableWrapper
 
-    @Rule @JvmField var thrown: ExpectedException = ExpectedException.none()
-
     private lateinit var listItemMapper: SubfilterListItemMapper
     private val jsonTester = JsonParser()
 
-    val blog = ReaderBlog.fromJson(JSONObject(SITE_JSON_WITH_BLOGID))
-    val feed = ReaderBlog.fromJson(JSONObject(SITE_JSON_WITH_FEEDID))
+    private val blog: ReaderBlog = ReaderBlog.fromJson(JSONObject(SITE_JSON_WITH_BLOG_ID))
+    private val feed: ReaderBlog = ReaderBlog.fromJson(JSONObject(SITE_JSON_WITH_FEED_ID))
 
     private val tag = ReaderTag(
             "news",
@@ -66,15 +61,13 @@ class SubfilterListItemMapperTest {
         )
 
         // Then
-        assertThat(item is SiteAll).isTrue()
+        assertThat(item is SiteAll).isTrue
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException::class)
     fun `fromJson returns exception on unknown type`() {
         // Given
         val json = WRONG_TYPE_JSON
-        thrown.expect(IllegalArgumentException::class.java)
-        thrown.expectMessage(StringContains("fromJson > Unexpected Subfilter type"))
 
         // When
         listItemMapper.fromJson(
@@ -100,13 +93,13 @@ class SubfilterListItemMapperTest {
         )
 
         // Then
-        assertThat(item is SiteAll).isTrue()
+        assertThat(item is SiteAll).isTrue
     }
 
     @Test
     fun `fromJson returns blog when valid blogId`() {
         // Given
-        val json = SITE_JSON_WITH_BLOGID
+        val json = SITE_JSON_WITH_BLOG_ID
 
         // When
         val item = listItemMapper.fromJson(
@@ -116,13 +109,13 @@ class SubfilterListItemMapperTest {
         )
 
         // Then
-        assertThat(item is Site && item.blog == blog).isTrue()
+        assertThat(item is Site && item.blog == blog).isTrue
     }
 
     @Test
     fun `fromJson returns feed when valid feedId`() {
         // Given
-        val json = SITE_JSON_WITH_FEEDID
+        val json = SITE_JSON_WITH_FEED_ID
 
         // When
         val item = listItemMapper.fromJson(
@@ -132,7 +125,7 @@ class SubfilterListItemMapperTest {
         )
 
         // Then
-        assertThat(item is Site && item.blog == feed).isTrue()
+        assertThat(item is Site && item.blog == feed).isTrue
     }
 
     @Test
@@ -148,7 +141,7 @@ class SubfilterListItemMapperTest {
         )
 
         // Then
-        assertThat(item is Tag && item.tag == tag).isTrue()
+        assertThat(item is Tag && item.tag == tag).isTrue
     }
 
     @Test
@@ -164,7 +157,7 @@ class SubfilterListItemMapperTest {
         )
 
         // Then
-        assertThat(item is SiteAll).isTrue()
+        assertThat(item is SiteAll).isTrue
     }
 
     @Test
@@ -222,9 +215,9 @@ class SubfilterListItemMapperTest {
     private companion object Fixtures {
         private const val SITE_ALL_JSON = "{\"blogId\":0,\"feedId\":0,\"tagSlug\":\"\",\"tagType\":0,\"type\":1}"
         private const val SITE_JSON = "{\"blogId\":0,\"feedId\":0,\"tagSlug\":\"\",\"tagType\":0,\"type\":2}"
-        private const val SITE_JSON_WITH_BLOGID =
+        private const val SITE_JSON_WITH_BLOG_ID =
                 "{\"blogId\":1234,\"feedId\":0,\"tagSlug\":\"\",\"tagType\":0,\"type\":2}"
-        private const val SITE_JSON_WITH_FEEDID =
+        private const val SITE_JSON_WITH_FEED_ID =
                 "{\"blogId\":0,\"feedId\":1234,\"tagSlug\":\"\",\"tagType\":0,\"type\":2}"
         private const val TAG_JSON = "{\"blogId\":0,\"feedId\":0,\"tagSlug\":\"news\",\"tagType\":1,\"type\":4}"
         private const val TAG_JSON_EMPTY_SLUG = "{\"blogId\":0,\"feedId\":0,\"tagSlug\":\"\",\"tagType\":1,\"type\":4}"

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderFetchRelatedPostsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderFetchRelatedPostsUseCaseTest.kt
@@ -13,7 +13,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.MainCoroutineScopeRule
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.test
 import org.wordpress.android.ui.reader.ReaderEvents.RelatedPostsUpdated
@@ -28,9 +27,6 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 class ReaderFetchRelatedPostsUseCaseTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
-
-    @Rule
-    @JvmField val coroutineScope = MainCoroutineScopeRule()
 
     lateinit var useCase: ReaderFetchRelatedPostsUseCase
     @Mock lateinit var readerPostActionsWrapper: ReaderPostActionsWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModelTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -188,7 +187,7 @@ class ConversationNotificationsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `followCommentsHandler is not called for external posts`() = runBlocking {
+    fun `followCommentsHandler is not called for external posts`() = test {
         whenever(readerPostTableWrapper.getBlogPost(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(externalPost)
         setupObserversAndStart()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainSanitizerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainSanitizerTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.sitecreation.domains
 
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertFalse
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class SiteCreationDomainSanitizerTest {
@@ -10,42 +9,42 @@ class SiteCreationDomainSanitizerTest {
     @Test
     fun `Verify everything after the first period is removed`() {
         val result = domainSanitizer.sanitizeDomainQuery("test.wordpress.com")
-        assertFalse(result.contains("wordpress.com"))
+        assertThat(result.contains("wordpress.com")).isFalse
     }
 
     @Test
     fun `Verify that a word doesn't break the sanitizer and its value is returned`() {
         val result = domainSanitizer.sanitizeDomainQuery("test")
-        assertEquals(result, "test")
+        assertThat(result).isEqualTo("test")
     }
 
     @Test
     fun `Remove https if its present`() {
         val result = domainSanitizer.sanitizeDomainQuery("https://test.wordpress.com")
-        assertFalse(result.contains("https://"))
+        assertThat(result.contains("https://")).isFalse
     }
 
     @Test
     fun `Remove http if its present`() {
         val result = domainSanitizer.sanitizeDomainQuery("http://test.wordpress.com")
-        assertFalse(result.contains("http://"))
+        assertThat(result.contains("http://")).isFalse
     }
 
     @Test
     fun `Remove all characters that are not alphanumeric`() {
         val result = domainSanitizer.sanitizeDomainQuery("test_this-site.wordpress.com")
-        assertEquals(result, "testthissite")
+        assertThat(result).isEqualTo("testthissite")
     }
 
     @Test
     fun `Get first domain part`() {
         val result = domainSanitizer.getName("https://test_this-site.wordpress.com")
-        assertEquals(result, "test_this-site")
+        assertThat(result).isEqualTo("test_this-site")
     }
 
     @Test
     fun `Get second domain part`() {
         val result = domainSanitizer.getDomain("https://test_this-site.wordpress.com")
-        assertEquals(result, ".wordpress.com")
+        assertThat(result).isEqualTo(".wordpress.com")
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -14,8 +14,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.InternalCoroutinesApi
-import org.hamcrest.CoreMatchers.instanceOf
-import org.hamcrest.MatcherAssert.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -39,7 +38,6 @@ import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.usecases.FetchDomainsUseCase
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
-import org.hamcrest.CoreMatchers.`is` as Is
 
 private const val MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE = 20
 private val MULTI_RESULT_DOMAIN_FETCH_QUERY = "multi_result_query" to MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE
@@ -201,10 +199,8 @@ class SiteCreationDomainsViewModelTest {
                 showClearButton = true,
                 numberOfItems = 1
         )
-        assertThat(
-                captor.thirdValue.contentState.items[0],
-                instanceOf(DomainsFetchSuggestionsErrorUiState::class.java)
-        )
+        assertThat(captor.thirdValue.contentState.items[0])
+                .isInstanceOf(DomainsFetchSuggestionsErrorUiState::class.java)
     }
 
     /**
@@ -279,7 +275,7 @@ class SiteCreationDomainsViewModelTest {
         viewModel.createSiteBtnClicked()
         val captor = ArgumentCaptor.forClass(String::class.java)
         verify(createSiteBtnObserver, times(1)).onChanged(captor.capture())
-        assertThat(captor.firstValue, Is(domainName))
+        assertThat(captor.firstValue).isEqualTo(domainName)
     }
 
     /**
@@ -290,10 +286,10 @@ class SiteCreationDomainsViewModelTest {
         showProgress: Boolean = false,
         showClearButton: Boolean = false
     ) {
-        assertThat(uiState.searchInputUiState.showProgress, Is(showProgress))
-        assertThat(uiState.searchInputUiState.showClearButton, Is(showClearButton))
-        assertThat(uiState.contentState, instanceOf(DomainsUiContentState.Initial::class.java))
-        assertThat(uiState.createSiteButtonContainerVisibility, Is(false))
+        assertThat(uiState.searchInputUiState.showProgress).isEqualTo(showProgress)
+        assertThat(uiState.searchInputUiState.showClearButton).isEqualTo(showClearButton)
+        assertThat(uiState.contentState).isInstanceOf(DomainsUiContentState.Initial::class.java)
+        assertThat(uiState.createSiteButtonContainerVisibility).isEqualTo(false)
     }
 
     /**
@@ -304,10 +300,10 @@ class SiteCreationDomainsViewModelTest {
         showClearButton: Boolean = false,
         numberOfItems: Int = MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE
     ) {
-        assertThat(uiState.searchInputUiState.showProgress, Is(false))
-        assertThat(uiState.searchInputUiState.showClearButton, Is(showClearButton))
-        assertThat(uiState.contentState, instanceOf(DomainsUiContentState.VisibleItems::class.java))
-        assertThat(uiState.contentState.items.size, Is(numberOfItems))
+        assertThat(uiState.searchInputUiState.showProgress).isEqualTo(false)
+        assertThat(uiState.searchInputUiState.showClearButton).isEqualTo(showClearButton)
+        assertThat(uiState.contentState).isInstanceOf(DomainsUiContentState.VisibleItems::class.java)
+        assertThat(uiState.contentState.items.size).isEqualTo(numberOfItems)
     }
 
     /**
@@ -316,10 +312,8 @@ class SiteCreationDomainsViewModelTest {
     private fun verifyContentAndDomainValidityUiStatesAreVisible(
         uiState: DomainsUiState
     ) {
-        assertThat(
-                uiState.contentState.items.first(),
-                instanceOf(DomainsModelUnavailabilityUiState::class.java)
-        )
+        assertThat(uiState.contentState.items.first())
+                .isInstanceOf(DomainsModelUnavailabilityUiState::class.java)
     }
 
     /**
@@ -330,18 +324,18 @@ class SiteCreationDomainsViewModelTest {
         showClearButton: Boolean = false,
         isInvalidQuery: Boolean = false
     ) {
-        assertThat(uiState.searchInputUiState.showProgress, Is(false))
-        assertThat(uiState.searchInputUiState.showClearButton, Is(showClearButton))
-        assertThat(uiState.contentState, instanceOf(DomainsUiContentState.Empty::class.java))
+        assertThat(uiState.searchInputUiState.showProgress).isEqualTo(false)
+        assertThat(uiState.searchInputUiState.showClearButton).isEqualTo(showClearButton)
+        assertThat(uiState.contentState).isInstanceOf(DomainsUiContentState.Empty::class.java)
         val contentStateAsEmpty = uiState.contentState as DomainsUiContentState.Empty
-        assertThat(contentStateAsEmpty.message, instanceOf(UiStringRes::class.java))
+        assertThat(contentStateAsEmpty.message).isInstanceOf(UiStringRes::class.java)
         val expectedEmptyListTextMessage = if (isInvalidQuery) {
             R.string.new_site_creation_empty_domain_list_message_invalid_query
         } else {
             R.string.new_site_creation_empty_domain_list_message
         }
-        assertThat((contentStateAsEmpty.message as UiStringRes).stringRes, Is(expectedEmptyListTextMessage))
-        assertThat(uiState.contentState.items.size, Is(0))
+        assertThat((contentStateAsEmpty.message as UiStringRes).stringRes).isEqualTo(expectedEmptyListTextMessage)
+        assertThat(uiState.contentState.items.size).isEqualTo(0)
     }
 
     /**

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/FetchHomePageLayoutsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/FetchHomePageLayoutsUseCaseTest.kt
@@ -54,6 +54,7 @@ class FetchHomePageLayoutsUseCaseTest {
     }
 
     @Test
+    @Suppress("CAST_NEVER_SUCCEEDS")
     fun `when beta site designs are enabled the stable and beta groups are passed to the call`() = test {
         whenever(dispatcher.dispatch(any())).then { useCase.onStarterDesignsFetched(event) }
         whenever(betaSiteDesigns.isEnabled()).thenReturn(true)
@@ -68,6 +69,7 @@ class FetchHomePageLayoutsUseCaseTest {
     }
 
     @Test
+    @Suppress("CAST_NEVER_SUCCEEDS")
     fun `when beta site designs are disabled no groups are passed to the call`() = test {
         whenever(dispatcher.dispatch(any())).then { useCase.onStarterDesignsFetched(event) }
         whenever(betaSiteDesigns.isEnabled()).thenReturn(false)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/SearchTermsUseCaseTest.kt
@@ -140,9 +140,9 @@ class SearchTermsUseCaseTest : BaseUnitTest() {
         assertThat(result.type).isEqualTo(TimeStatsType.SEARCH_TERMS)
         assertThat(result.state).isEqualTo(UseCaseState.SUCCESS)
         result.data!!.apply {
-            assertThat(this!!).hasSize(4)
-            assertTitle(this!![0])
-            assertLink(this!![3])
+            assertThat(this).hasSize(4)
+            assertTitle(this[0])
+            assertLink(this[3])
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/StoriesIntroViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/StoriesIntroViewModelTest.kt
@@ -8,12 +8,12 @@ import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.test
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stories.intro.StoriesIntroViewModel
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
@@ -30,7 +30,7 @@ class StoriesIntroViewModelTest : BaseUnitTest() {
     @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
 
     @Before
-    fun setUp() = runBlockingTest {
+    fun setUp() = test {
         viewModel = StoriesIntroViewModel(
                 analyticsTrackerWrapper,
                 appPrefsWrapper,

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/LoadStoryFromStoriesPrefsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/LoadStoryFromStoriesPrefsUseCaseTest.kt
@@ -36,6 +36,7 @@ class LoadStoryFromStoriesPrefsUseCaseTest {
     }
 
     @Test
+    @Suppress("UNCHECKED_CAST")
     fun `obtain empty media ids list from empty mediaFiles array`() {
         // Given
         val mediaFiles: ArrayList<HashMap<String, Any>> = setupMediaFiles(emptyList = true)
@@ -50,6 +51,7 @@ class LoadStoryFromStoriesPrefsUseCaseTest {
     }
 
     @Test
+    @Suppress("UNCHECKED_CAST")
     fun `obtain media ids list from non empty mediaFiles array`() {
         // Given
         val mediaFiles: ArrayList<HashMap<String, Any>> = setupMediaFiles(emptyList = false)

--- a/WordPress/src/test/java/org/wordpress/android/ui/suggestion/SuggestionSourceProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/suggestion/SuggestionSourceProviderTest.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.suggestion
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import junit.framework.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,7 +33,7 @@ class SuggestionSourceProviderTest {
         whenever(mockSuggestionSourceSubcomponent.xPostSuggestionSource())
                 .thenReturn(expected)
         val actual = provider.get(XPosts, mockSite)
-        assertEquals(expected, actual)
+        assertThat(expected).isEqualTo(actual)
     }
 
     @Test
@@ -42,6 +42,6 @@ class SuggestionSourceProviderTest {
         whenever(mockSuggestionSourceSubcomponent.userSuggestionSource())
                 .thenReturn(expected)
         val actual = provider.get(Users, mockSite)
-        assertEquals(expected, actual)
+        assertThat(expected).isEqualTo(actual)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/suggestion/SuggestionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/suggestion/SuggestionViewModelTest.kt
@@ -6,9 +6,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -58,18 +56,18 @@ class SuggestionViewModelTest {
     fun `init when suggestions not supported`() {
         setSuggestionsSupported(false)
         val anySuggestionType = XPosts
-        assertFalse(viewModel.init(anySuggestionType, mockSite))
+        assertThat(viewModel.init(anySuggestionType, mockSite)).isFalse
     }
 
     @Test
     fun `init with xpost suggestions`() {
-        assertTrue(initViewModel(XPosts))
+        assertThat(initViewModel(XPosts)).isTrue
         verifyViewModelSuggestionType(XPosts)
     }
 
     @Test
     fun `init with user suggestions`() {
-        assertTrue(initViewModel(Users))
+        assertThat(initViewModel(Users)).isTrue
         verifyViewModelSuggestionType(Users)
     }
 
@@ -94,7 +92,7 @@ class SuggestionViewModelTest {
 
         val nonEmptyList = listOf(mock<Suggestion>())
         val actual = viewModel.getEmptyViewState(nonEmptyList)
-        assertEquals(View.GONE, actual.visibility)
+        assertThat(View.GONE).isEqualTo(actual.visibility)
     }
 
     @Test
@@ -103,7 +101,7 @@ class SuggestionViewModelTest {
         stubEmptyViewStateText()
 
         val actual = viewModel.getEmptyViewState(emptyList())
-        assertEquals(View.VISIBLE, actual.visibility)
+        assertThat(View.VISIBLE).isEqualTo(actual.visibility)
     }
 
     private fun stubEmptyViewStateText() {
@@ -121,7 +119,7 @@ class SuggestionViewModelTest {
                 .thenReturn(expectedText)
 
         val actual = viewModel.getEmptyViewState(emptyList())
-        assertEquals(expectedText, actual.string)
+        assertThat(expectedText).isEqualTo(actual.string)
     }
 
     @Test
@@ -133,7 +131,7 @@ class SuggestionViewModelTest {
         whenever(mockResourceProvider.getString(R.string.suggestion_problem)).thenReturn(expectedText)
 
         val actual = viewModel.getEmptyViewState(emptyList())
-        assertEquals(expectedText, actual.string)
+        assertThat(expectedText).isEqualTo(actual.string)
     }
 
     @Test
@@ -146,7 +144,7 @@ class SuggestionViewModelTest {
                 .thenReturn(expectedText)
 
         val actual = viewModel.getEmptyViewState(emptyList())
-        assertEquals(expectedText, actual.string)
+        assertThat(expectedText).isEqualTo(actual.string)
     }
 
     @Test
@@ -159,7 +157,7 @@ class SuggestionViewModelTest {
                 .thenReturn(expectedText)
 
         val actual = viewModel.getEmptyViewState(emptyList())
-        assertEquals(expectedText, actual.string)
+        assertThat(expectedText).isEqualTo(actual.string)
     }
 
     @Test
@@ -172,7 +170,7 @@ class SuggestionViewModelTest {
                 .thenReturn(expectedText)
 
         val actual = viewModel.getEmptyViewState(emptyList())
-        assertEquals(expectedText, actual.string)
+        assertThat(expectedText).isEqualTo(actual.string)
     }
 
     @Test
@@ -191,7 +189,7 @@ class SuggestionViewModelTest {
         val actual = viewModel.onAttemptToFinish(emptyList(), userInput)
 
         val expected = NotExactlyOneAvailable(expectedMesage)
-        assertEquals(expected, actual)
+        assertThat(expected).isEqualTo(actual)
     }
 
     @Test
@@ -206,7 +204,7 @@ class SuggestionViewModelTest {
         val actual = viewModel.onAttemptToFinish(listWithMoreThanOne, emptyUserInput)
 
         val expected = NotExactlyOneAvailable(expectedMesage)
-        assertEquals(expected, actual)
+        assertThat(expected).isEqualTo(actual)
     }
 
     @Test
@@ -226,7 +224,7 @@ class SuggestionViewModelTest {
         val actual = viewModel.onAttemptToFinish(listWithMoreThanOne, userInput)
 
         val expected = NotExactlyOneAvailable(expectedMesage)
-        assertEquals(expected, actual)
+        assertThat(expected).isEqualTo(actual)
     }
 
     @Test
@@ -234,11 +232,11 @@ class SuggestionViewModelTest {
         initViewModel()
 
         val mockSuggestion = Suggestion("", "expected_value", "")
-        val listWithExactlyOne = listOf<Suggestion>(mockSuggestion)
+        val listWithExactlyOne = listOf(mockSuggestion)
         val actual = viewModel.onAttemptToFinish(listWithExactlyOne, "")
 
         val expected = OnlyOneAvailable(mockSuggestion.value)
-        assertEquals(expected, actual)
+        assertThat(expected).isEqualTo(actual)
     }
 
     @Test
@@ -313,7 +311,7 @@ class SuggestionViewModelTest {
             Users -> '@'
         }
         val actualPrefix = viewModel.suggestionPrefix
-        assertEquals(expectedPrefix, actualPrefix)
+        assertThat(expectedPrefix).isEqualTo(actualPrefix)
     }
 
     private fun verifySuggestionTypeString(type: SuggestionType) {
@@ -322,7 +320,7 @@ class SuggestionViewModelTest {
             Users -> userSuggestionTypeString
         }
         val actualTypeString = viewModel.suggestionTypeString
-        assertEquals(expectedTypeString, actualTypeString)
+        assertThat(expectedTypeString).isEqualTo(actualTypeString)
     }
 
     private fun setSuggestionsSupported(areSupported: Boolean) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,6 +17,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.test
 import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
@@ -51,16 +51,14 @@ class UploadStarterConcurrentTest {
     }
 
     @Test
-    fun `it uploads local drafts concurrently`() {
+    fun `it uploads local drafts concurrently`() = test {
         // Given
         val uploadServiceFacade = createMockedUploadServiceFacade()
 
         val starter = createUploadStarter(uploadServiceFacade)
 
         // When
-        runBlocking {
-            starter.queueUploadFromSite(site).join()
-        }
+        starter.queueUploadFromSite(site).join()
 
         // Then
         verify(uploadServiceFacade, times(draftPosts.size)).uploadPost(

--- a/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
@@ -107,8 +107,8 @@ class ReaderHtmlUtilsTest {
         var lastMatchUrl = ""
         while (matcher.find()) {
             count++
-            lastMatchUrl = matcher.group(1)
-            lastMatchWidth = matcher.group(2)
+            lastMatchUrl = matcher.group(1) ?: ""
+            lastMatchWidth = matcher.group(2) ?: ""
         }
         assertEquals("1050", lastMatchWidth)
         assertEquals("https://i1.wp.com/image-scaled.jpg?w=1050", lastMatchUrl)

--- a/WordPress/src/test/java/org/wordpress/android/util/SnackbarSequencerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SnackbarSequencerTest.kt
@@ -32,7 +32,8 @@ private const val TEST_MESSAGE = "This is a test message"
 @InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class SnackbarSequencerTest {
-    @Rule @JvmField val rule = InstantTaskExecutorRule()
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
 
     @Mock lateinit var wpSnackbarWrapper: WPSnackbarWrapper
     @Mock lateinit var wpSnackbar: Snackbar

--- a/WordPress/src/test/java/org/wordpress/android/util/SnackbarSequencerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SnackbarSequencerTest.kt
@@ -17,7 +17,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
@@ -34,7 +33,6 @@ private const val TEST_MESSAGE = "This is a test message"
 @RunWith(MockitoJUnitRunner::class)
 class SnackbarSequencerTest {
     @Rule @JvmField val rule = InstantTaskExecutorRule()
-    @Rule @JvmField var thrown2: ExpectedException = ExpectedException.none()
 
     @Mock lateinit var wpSnackbarWrapper: WPSnackbarWrapper
     @Mock lateinit var wpSnackbar: Snackbar

--- a/WordPress/src/test/java/org/wordpress/android/util/ValidationUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/ValidationUtilsTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.util
 
-import org.hamcrest.CoreMatchers
-import org.junit.Assert.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ValidationUtilsTest {
@@ -12,15 +11,11 @@ class ValidationUtilsTest {
 
     @Test
     fun testValidIPv4Addresses() {
-        validIpV4Addresses.forEach { ip ->
-            assertThat("$ip is a valid ipv4 address", validateIPv4(ip), CoreMatchers.`is`(true))
-        }
+        validIpV4Addresses.forEach { assertThat(validateIPv4(it)).isEqualTo(true) }
     }
 
     @Test
     fun testInvalidIPv4Addresses() {
-        invalidIpV4Addresses.forEach { ip ->
-            assertThat("$ip is not a valid ipv4 address", validateIPv4(ip), CoreMatchers.`is`(false))
-        }
+        invalidIpV4Addresses.forEach { assertThat(validateIPv4(it)).isEqualTo(false) }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/accounts/PostSignupInterstitialViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/accounts/PostSignupInterstitialViewModelTest.kt
@@ -23,7 +23,8 @@ import org.wordpress.android.viewmodel.accounts.PostSignupInterstitialViewModel.
 
 @RunWith(MockitoJUnitRunner::class)
 class PostSignupInterstitialViewModelTest {
-    @Rule @JvmField val rule = InstantTaskExecutorRule()
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
 
     private val appPrefs: AppPrefsWrapper = mock()
     private val unifiedLoginTracker: UnifiedLoginTracker = mock()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -33,7 +33,8 @@ import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
 class ActivityLogDetailViewModelTest {
-    @Rule @JvmField val rule = InstantTaskExecutorRule()
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
 
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var activityLogStore: ActivityLogStore

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -100,7 +100,8 @@ private val DOWNLOAD_VALID_UNTIL = Date()
 @Suppress("LargeClass")
 @RunWith(MockitoJUnitRunner::class)
 class ActivityLogViewModelTest {
-    @Rule @JvmField val rule = InstantTaskExecutorRule()
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
 
     @Mock private lateinit var store: ActivityLogStore
     @Mock private lateinit var site: SiteModel

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/comments/UnifiedCommentListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/comments/UnifiedCommentListViewModelTest.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -35,6 +34,7 @@ import org.wordpress.android.models.usecases.ModerateCommentsResourceProvider
 import org.wordpress.android.models.usecases.PaginateCommentsResourceProvider
 import org.wordpress.android.models.usecases.PaginateCommentsUseCase
 import org.wordpress.android.models.usecases.UnifiedCommentsListHandler
+import org.wordpress.android.test
 import org.wordpress.android.ui.comments.unified.CommentFilter.ALL
 import org.wordpress.android.ui.comments.unified.CommentListUiModelHelper
 import org.wordpress.android.ui.comments.unified.CommentListUiModelHelper.CommentList
@@ -57,7 +57,8 @@ import org.wordpress.android.viewmodel.ResourceProvider
 
 @ExperimentalCoroutinesApi
 class UnifiedCommentListViewModelTest : BaseUnitTest() {
-    @Rule @JvmField val coroutineScopeRule = MainCoroutineScopeRule()
+    @Rule
+    @JvmField val coroutineScope = MainCoroutineScopeRule()
 
     private lateinit var viewModel: UnifiedCommentListViewModel
     private lateinit var unifiedCommentsListHandler: UnifiedCommentsListHandler
@@ -83,7 +84,7 @@ class UnifiedCommentListViewModelTest : BaseUnitTest() {
 
     @InternalCoroutinesApi
     @Before
-    fun setUp() {
+    fun setUp() = test {
         whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(anyOrNull())).thenReturn("Apr 19")
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
         whenever(paginateCommentsResourceProvider.commentsStore).thenReturn(commentStore)
@@ -104,13 +105,10 @@ class UnifiedCommentListViewModelTest : BaseUnitTest() {
         localCommentCacheUpdateUseCase = LocalCommentCacheUpdateUseCase()
         localCommentCacheUpdateHandler = LocalCommentCacheUpdateHandler(localCommentCacheUpdateUseCase)
 
-        runBlocking {
-            `when`(commentStore.fetchCommentsPage(any(), any(), eq(0), any(), any()))
-        }.thenReturn(testCommentsPayload30)
-
-        runBlocking {
-            `when`(commentStore.fetchCommentsPage(any(), any(), eq(30), any(), any()))
-        }.thenReturn(testCommentsPayload60)
+        `when`(commentStore.fetchCommentsPage(any(), any(), eq(0), any(), any()))
+                .thenReturn(testCommentsPayload30)
+        `when`(commentStore.fetchCommentsPage(any(), any(), eq(30), any(), any()))
+                .thenReturn(testCommentsPayload60)
 
         commentListUiModelHelper = CommentListUiModelHelper(resourceProvider, dateTimeUtilsWrapper, networkUtilsWrapper)
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveDataTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveDataTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.viewmodel.helpers
 
 import android.content.BroadcastReceiver
@@ -14,8 +16,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.wordpress.android.viewmodel.helpers.ConnectionStatus.AVAILABLE
-import org.wordpress.android.viewmodel.helpers.ConnectionStatus.UNAVAILABLE
 
 class ConnectionStatusLiveDataTest {
     @get:Rule val rule = InstantTaskExecutorRule()
@@ -43,20 +43,20 @@ class ConnectionStatusLiveDataTest {
 
         broadcastReceiver.onReceive(mockedBroadcastReceiverContext(connectedNetwork = false), mock())
 
-        assertThat(connectionStatusLiveData.value).isEqualTo(UNAVAILABLE)
+        assertThat(connectionStatusLiveData.value).isEqualTo(ConnectionStatus.UNAVAILABLE)
     }
 
     @Test
     fun `it emits a value when the network availability changes`() {
         // Arrange
         broadcastReceiver.onReceive(mockedBroadcastReceiverContext(connectedNetwork = true), mock())
-        assertThat(connectionStatusLiveData.value).isEqualTo(AVAILABLE)
+        assertThat(connectionStatusLiveData.value).isEqualTo(ConnectionStatus.AVAILABLE)
 
         // Act
         broadcastReceiver.onReceive(mockedBroadcastReceiverContext(connectedNetwork = false), mock())
 
         // Assert
-        assertThat(connectionStatusLiveData.value).isEqualTo(UNAVAILABLE)
+        assertThat(connectionStatusLiveData.value).isEqualTo(ConnectionStatus.UNAVAILABLE)
     }
 
     @Test
@@ -77,9 +77,10 @@ class ConnectionStatusLiveDataTest {
 
         // Assert
         assertThat(emitCount).isEqualTo(1)
-        assertThat(connectionStatusLiveData.value).isEqualTo(AVAILABLE)
+        assertThat(connectionStatusLiveData.value).isEqualTo(ConnectionStatus.AVAILABLE)
     }
 
+    @Suppress("DEPRECATION")
     private fun mockedBroadcastReceiverContext(connectedNetwork: Boolean): Context {
         val networkInfo = mock<NetworkInfo> {
             on { isConnected } doReturn connectedNetwork

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -13,7 +13,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -409,7 +408,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `bottom sheet does show prompt card when FF is ON`() = runBlockingTest {
+    fun `bottom sheet does show prompt card when FF is ON`() = test {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
         startViewModelWithDefaultParameters()
         val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMPT }
@@ -425,7 +424,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `bottom sheet action is ANSWER_BLOGGING_PROMPT when the BP answer button is clicked`() = runBlockingTest {
+    fun `bottom sheet action is ANSWER_BLOGGING_PROMPT when the BP answer button is clicked`() = test {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
         startViewModelWithDefaultParameters()
         val action = viewModel.mainActions.value?.firstOrNull {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -17,7 +16,6 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.MainCoroutineScopeRule
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.annotations.action.Action
@@ -28,6 +26,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnBlockLayoutsFetched
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.GENERIC_ERROR
+import org.wordpress.android.test
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Content
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Error
 import org.wordpress.android.ui.mlp.ModalLayoutPickerDimensionProvider
@@ -48,9 +47,6 @@ import org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel.PageReques
 class ModalLayoutPickerViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
-
-    @Rule
-    @JvmField val coroutineScope = MainCoroutineScopeRule()
 
     private lateinit var viewModel: ModalLayoutPickerViewModel
 
@@ -108,8 +104,7 @@ class ModalLayoutPickerViewModelTest {
         isError: Boolean = false,
         isSiteUnavailable: Boolean = false,
         block: suspend CoroutineScope.() -> T
-    ) {
-        coroutineScope.runBlockingTest {
+    ) = test {
             val site = SiteModel().apply {
                 id = 1
                 mobileEditor = GB_EDITOR_NAME
@@ -127,7 +122,6 @@ class ModalLayoutPickerViewModelTest {
             whenever(networkUtils.isNetworkAvailable()).thenReturn(true)
             setupFetchLayoutsDispatcher(isError)
             block()
-        }
     }
 
     private fun setupFetchLayoutsDispatcher(isError: Boolean) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCaseTest.kt
@@ -308,7 +308,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `when a page is locally changed and is local draft only "Local draft" label is displayed`() {
+    fun `when a page is locally changed and is local draft only 'Local draft' label is displayed`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply {
                     setIsLocallyChanged(true)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import junit.framework.Assert.assertNull
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -443,7 +442,7 @@ class PageListViewModelTest : BaseUnitTest() {
 
         val pageItems = pagesResult[1].first
         val pageItem = pageItems[0] as PublishedPage
-        assertNull(pageItem.author)
+        assertThat(pageItem.author).isNull()
     }
 
     private fun buildPageModel(
@@ -468,7 +467,7 @@ class PageListViewModelTest : BaseUnitTest() {
     }
 
     private fun assertDivider(pageItem: PageItem) {
-        assertThat(pageItem is Divider).isTrue()
+        assertThat(pageItem is Divider).isTrue
     }
 
     private fun assertPublishedPage(pageItem: PageItem, pageModel: PageModel, indent: Int = 0) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -11,7 +11,6 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -188,7 +187,7 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun `when searching and the Store is empty, it returns an empty list`() = runBlocking {
+    fun `when searching and the Store is empty, it returns an empty list`() = test {
         // Arrange
         setUpPageStoreWithEmptyPages()
         viewModel.start(site)
@@ -204,7 +203,7 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun `when searching with an empty query, it clears the search results`() = runBlocking {
+    fun `when searching with an empty query, it clears the search results`() = test {
         // Arrange
         setUpPageStoreWithEmptyPages()
         viewModel.start(site)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -13,20 +13,12 @@ import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.post.PostStatus
-import org.wordpress.android.fluxc.model.post.PostStatus.DRAFT
-import org.wordpress.android.fluxc.model.post.PostStatus.PENDING
-import org.wordpress.android.fluxc.model.post.PostStatus.PRIVATE
-import org.wordpress.android.fluxc.model.post.PostStatus.PUBLISHED
-import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
 import org.wordpress.android.fluxc.store.MediaStore.MediaError
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
-import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.AUTHORIZATION_REQUIRED
 import org.wordpress.android.fluxc.store.PostStore.PostError
-import org.wordpress.android.fluxc.store.PostStore.PostErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.PostStore.PostErrorType
 import org.wordpress.android.fluxc.store.UploadStore.UploadError
 import org.wordpress.android.ui.posts.AuthorFilterSelection
-import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
-import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.ui.posts.PostModelUploadStatusTracker
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -45,11 +37,11 @@ import org.wordpress.android.widgets.PostListButtonType
 
 private const val FORMATTER_DATE = "January 1st, 1:35pm"
 
-private val POST_STATE_PUBLISH = PUBLISHED.toString()
-private val POST_STATE_SCHEDULED = SCHEDULED.toString()
-private val POST_STATE_PRIVATE = PRIVATE.toString()
-private val POST_STATE_PENDING = PENDING.toString()
-private val POST_STATE_DRAFT = DRAFT.toString()
+private val POST_STATE_PUBLISH = PostStatus.PUBLISHED.toString()
+private val POST_STATE_SCHEDULED = PostStatus.SCHEDULED.toString()
+private val POST_STATE_PRIVATE = PostStatus.PRIVATE.toString()
+private val POST_STATE_PENDING = PostStatus.PENDING.toString()
+private val POST_STATE_DRAFT = PostStatus.DRAFT.toString()
 private val POST_STATE_TRASHED = PostStatus.TRASHED.toString()
 
 @Suppress("LargeClass")
@@ -498,7 +490,7 @@ class PostListItemUiStateHelperTest {
                 )
         ).thenReturn(
                 createFailedUploadUiState(
-                        UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        UploadError(MediaError(MediaErrorType.AUTHORIZATION_REQUIRED)),
                         isEligibleForAutoUpload = true
                 )
         )
@@ -606,7 +598,7 @@ class PostListItemUiStateHelperTest {
     @Test
     fun `error uploading media label shown when the media upload fails`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                createFailedUploadUiState(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
+                createFailedUploadUiState(uploadError = UploadError(MediaError(MediaErrorType.AUTHORIZATION_REQUIRED)))
         )
         val state = createPostListItemUiState()
         assertThat(state.data.statuses).contains(UiStringRes(R.string.error_media_recover_post))
@@ -616,7 +608,7 @@ class PostListItemUiStateHelperTest {
     fun `generic error message shown when upload fails from unknown reason`() {
         val errorMsg = "testing error message"
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                createFailedUploadUiState(uploadError = UploadError(PostError(GENERIC_ERROR, errorMsg)))
+                createFailedUploadUiState(uploadError = UploadError(PostError(PostErrorType.GENERIC_ERROR, errorMsg)))
         )
         val state = createPostListItemUiState()
         assertThat(state.data.statuses).contains(UiStringRes(R.string.error_generic_error))
@@ -625,7 +617,7 @@ class PostListItemUiStateHelperTest {
     @Test
     fun `given a mix of info and error statuses, only the error status is shown`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                createFailedUploadUiState(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
+                createFailedUploadUiState(uploadError = UploadError(MediaError(MediaErrorType.AUTHORIZATION_REQUIRED)))
         )
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PRIVATE)
@@ -643,11 +635,8 @@ class PostListItemUiStateHelperTest {
                 )
         ).thenReturn(
                 createFailedUploadUiState(
-                        uploadError = UploadError(
-                                MediaError(
-                                        AUTHORIZATION_REQUIRED
-                                )
-                        ), isEligibleForAutoUpload = true
+                        uploadError = UploadError(MediaError(MediaErrorType.AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = true
                 )
         )
         val state = createPostListItemUiState(
@@ -661,7 +650,7 @@ class PostListItemUiStateHelperTest {
     fun `media upload error shown with specific message for pending post not eligible for auto-upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
                 createFailedUploadUiState(
-                        uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        uploadError = UploadError(MediaError(MediaErrorType.AUTHORIZATION_REQUIRED)),
                         isEligibleForAutoUpload = false,
                         retryWillPushChanges = true
                 )
@@ -676,7 +665,7 @@ class PostListItemUiStateHelperTest {
     fun `media upload error shown with specific message for scheduled post eligible for auto-upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
                 createFailedUploadUiState(
-                        uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        uploadError = UploadError(MediaError(MediaErrorType.AUTHORIZATION_REQUIRED)),
                         isEligibleForAutoUpload = true
                 )
         )
@@ -691,7 +680,7 @@ class PostListItemUiStateHelperTest {
     fun `media upload error shown with specific message for scheduled post not eligible for auto-upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
                 createFailedUploadUiState(
-                        uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        uploadError = UploadError(MediaError(MediaErrorType.AUTHORIZATION_REQUIRED)),
                         isEligibleForAutoUpload = false,
                         retryWillPushChanges = true
                 )
@@ -706,7 +695,7 @@ class PostListItemUiStateHelperTest {
     fun `retrying media upload shown for draft eligible for auto-upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
                 createFailedUploadUiState(
-                        uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        uploadError = UploadError(MediaError(MediaErrorType.AUTHORIZATION_REQUIRED)),
                         isEligibleForAutoUpload = true
                 )
         )
@@ -720,7 +709,7 @@ class PostListItemUiStateHelperTest {
     fun `base media upload error shown for draft not eligible for auto-upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
                 createFailedUploadUiState(
-                        uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        uploadError = UploadError(MediaError(MediaErrorType.AUTHORIZATION_REQUIRED)),
                         isEligibleForAutoUpload = false,
                         retryWillPushChanges = false
                 )
@@ -735,7 +724,7 @@ class PostListItemUiStateHelperTest {
     fun `base upload error shown on GENERIC ERROR and not eligible for auto upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
                 createFailedUploadUiState(
-                        uploadError = UploadError(PostError(GENERIC_ERROR)),
+                        uploadError = UploadError(PostError(PostErrorType.GENERIC_ERROR)),
                         isEligibleForAutoUpload = false,
                         retryWillPushChanges = false
                 )
@@ -750,7 +739,7 @@ class PostListItemUiStateHelperTest {
     fun `retrying upload shown for draft eligible for auto-upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
                 createFailedUploadUiState(
-                        uploadError = UploadError(PostError(GENERIC_ERROR)),
+                        uploadError = UploadError(PostError(PostErrorType.GENERIC_ERROR)),
                         isEligibleForAutoUpload = true,
                         retryWillPushChanges = true
                 )
@@ -823,7 +812,7 @@ class PostListItemUiStateHelperTest {
     @Test
     fun `show overlay when performing critical action`() {
         val state = createPostListItemUiState(performingCriticalAction = true)
-        assertThat(state.data.showOverlay).isTrue()
+        assertThat(state.data.showOverlay).isTrue
     }
 
     @Test
@@ -832,7 +821,7 @@ class PostListItemUiStateHelperTest {
                 UploadingPost(false)
         )
         val state = createPostListItemUiState()
-        assertThat(state.data.showOverlay).isTrue()
+        assertThat(state.data.showOverlay).isTrue
     }
 
     @Test
@@ -866,7 +855,7 @@ class PostListItemUiStateHelperTest {
     @Test
     fun `pending publish post label shown when post eligible for auto-upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                UploadWaitingForConnection(PUBLISHED)
+                UploadWaitingForConnection(PostStatus.PUBLISHED)
         )
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PUBLISH)
@@ -878,7 +867,7 @@ class PostListItemUiStateHelperTest {
     @Test
     fun `pending schedule label shown when post eligible for auto-upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                UploadWaitingForConnection(SCHEDULED)
+                UploadWaitingForConnection(PostStatus.SCHEDULED)
         )
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_SCHEDULED)
@@ -891,7 +880,7 @@ class PostListItemUiStateHelperTest {
     @Test
     fun `pending publish private post label shown when post eligible for auto-upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                UploadWaitingForConnection(PRIVATE)
+                UploadWaitingForConnection(PostStatus.PRIVATE)
         )
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PRIVATE)
@@ -904,7 +893,7 @@ class PostListItemUiStateHelperTest {
     @Test
     fun `pending submit post label shown when post eligible for auto-upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                UploadWaitingForConnection(PENDING)
+                UploadWaitingForConnection(PostStatus.PENDING)
         )
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PENDING)
@@ -917,7 +906,7 @@ class PostListItemUiStateHelperTest {
     @Test
     fun `local changes post label shown when draft eligible for auto-upload`() {
         whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                UploadWaitingForConnection(DRAFT)
+                UploadWaitingForConnection(PostStatus.DRAFT)
         )
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_DRAFT)
@@ -976,7 +965,7 @@ class PostListItemUiStateHelperTest {
         // Arrange
         val authorDisplayName = "John Novak"
         val state = createPostListItemUiState(
-                authorFilterSelection = EVERYONE,
+                authorFilterSelection = AuthorFilterSelection.EVERYONE,
                 post = createPostModel(
                         authorDisplayName = authorDisplayName
                 ), formattedDate = FORMATTER_DATE
@@ -993,7 +982,7 @@ class PostListItemUiStateHelperTest {
         // Arrange
         val authorDisplayName = "John Novak"
         val state = createPostListItemUiState(
-                authorFilterSelection = ME,
+                authorFilterSelection = AuthorFilterSelection.ME,
                 post = createPostModel(
                         authorDisplayName = authorDisplayName
                 ), formattedDate = FORMATTER_DATE
@@ -1020,7 +1009,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `when a post is locally changed and is local draft only "Local draft" label is displayed`() {
+    fun `when a post is locally changed and is local draft only 'Local draft' label is displayed`() {
         // Arrange
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, isLocalDraft = true)
@@ -1031,7 +1020,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `when a post is sticky and no errors ocurred, the "Sticky" label is displayed`() {
+    fun `when a post is sticky and no errors occurred, the 'Sticky' label is displayed`() {
         // Arrange
         val state = createPostListItemUiState(
                 post = createPostModel(sticky = true)
@@ -1042,7 +1031,7 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `when a post is sticky and private, the labels "Private" and "Sticky" are displayed`() {
+    fun `when a post is sticky and private, the labels 'Private' and 'Sticky' are displayed`() {
         // Arrange
         val state = createPostListItemUiState(
                 post = createPostModel(status = POST_STATE_PRIVATE, sticky = true)
@@ -1070,7 +1059,7 @@ class PostListItemUiStateHelperTest {
     }
 
     private fun createPostListItemUiState(
-        authorFilterSelection: AuthorFilterSelection = EVERYONE,
+        authorFilterSelection: AuthorFilterSelection = AuthorFilterSelection.EVERYONE,
         post: PostModel = PostModel(),
         site: SiteModel = SiteModel(),
         unhandledConflicts: Boolean = false,
@@ -1110,5 +1099,5 @@ class PostListItemUiStateHelperTest {
         )
     }
 
-    private fun createGenericError(): UploadError = UploadError(PostError(GENERIC_ERROR))
+    private fun createGenericError(): UploadError = UploadError(PostError(PostErrorType.GENERIC_ERROR))
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/quickstart/QuickStartViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/quickstart/QuickStartViewModelTest.kt
@@ -20,7 +20,8 @@ import org.wordpress.android.ui.quickstart.QuickStartTaskState
 
 @RunWith(MockitoJUnitRunner::class)
 class QuickStartViewModelTest {
-    @Rule @JvmField val rule = InstantTaskExecutorRule()
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
 
     @Mock private lateinit var store: QuickStartStore
     private val siteId = 1L

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -73,7 +72,7 @@ class FeatureAnnouncementViewModelTest : BaseUnitTest() {
     )
 
     @Before
-    fun setUp() = runBlockingTest {
+    fun setUp() = test {
         uiModelResults.clear()
 
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement(any())).thenReturn(featureAnnouncement)

--- a/WordPress/src/test/java/org/wordpress/android/workers/reminder/PromptReminderNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/reminder/PromptReminderNotifierTest.kt
@@ -4,7 +4,6 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -15,6 +14,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
+import org.wordpress.android.test
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker
 import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
@@ -54,26 +54,26 @@ class PromptReminderNotifierTest {
     }
 
     @Test
-    fun `Should NOT notify if hasAccessToken returns FALSE`() = runBlocking {
+    fun `Should NOT notify if hasAccessToken returns FALSE`() = test {
         whenever(accountStore.hasAccessToken()).thenReturn(false)
         assertFalse(classToTest.shouldNotify(123))
     }
 
     @Test
-    fun `Should NOT notify if blogging prompts notification flag isEnabled returns FALSE`() = runBlocking {
+    fun `Should NOT notify if blogging prompts notification flag isEnabled returns FALSE`() = test {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
         assertFalse(classToTest.shouldNotify(123))
     }
 
     @Test
-    fun `Should NOT notify if getSiteByLocalId returns NULL`() = runBlocking {
+    fun `Should NOT notify if getSiteByLocalId returns NULL`() = test {
         val siteId = 123
         whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(null)
         assertFalse(classToTest.shouldNotify(siteId))
     }
 
     @Test
-    fun `Should NOT notify if user did NOT opt in to include prompts in the reminders`() = runBlocking {
+    fun `Should NOT notify if user did NOT opt in to include prompts in the reminders`() = test {
         val siteId = 123
         val siteModel: SiteModel = mock()
         val disabledPromptBloggingReminderModel = BloggingRemindersModel(
@@ -89,20 +89,19 @@ class PromptReminderNotifierTest {
     }
 
     @Test
-    fun `Should notify if has access token, flag is enabled and user opted in to include prompts in the reminders`() =
-            runBlocking {
-                val siteId = 123
-                val siteModel: SiteModel = mock()
-                val enabledPromptBloggingReminderModel = BloggingRemindersModel(
-                        siteId = siteId,
-                        isPromptIncluded = true
-                )
-                whenever(bloggingRemindersStore.bloggingRemindersModel(siteId)).thenReturn(
-                        flowOf(enabledPromptBloggingReminderModel)
-                )
-                whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
-                whenever(accountStore.hasAccessToken()).thenReturn(true)
-                whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(siteModel)
-                assertTrue(classToTest.shouldNotify(siteId))
-            }
+    fun `Should notify if has access token, flag enabled and user opted in to include prompts in reminders`() = test {
+        val siteId = 123
+        val siteModel: SiteModel = mock()
+        val enabledPromptBloggingReminderModel = BloggingRemindersModel(
+                siteId = siteId,
+                isPromptIncluded = true
+        )
+        whenever(bloggingRemindersStore.bloggingRemindersModel(siteId)).thenReturn(
+                flowOf(enabledPromptBloggingReminderModel)
+        )
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(siteModel)
+        assertTrue(classToTest.shouldNotify(siteId))
+    }
 }


### PR DESCRIPTION
Parent: #17173
Partially Closes: #17181

This PR resolves one part of all `Test` related warnings for the `WordPress` module:

Deprecated Related (`80`)
- `58` x `'XYX' is deprecated. Deprecated in Java`
- `2` x `'xyz' is deprecated. Use xyz instead.`
- `20` x `'Xyz' is deprecated. This class is being refactored, if you implement any change, please also update xyz`

Type Related (`8`)
- `3` x `Type mismatch: inferred type is Xyz? but Xyz was expected`
- `4` x `Unnecessary non-null assertion (!!) on a non-null receiver of type Xyz`
- `1` x `Unnecessary safe call on a non-null receiver of type Xyz. This expression will have nullable type in future releases`

Cast Related (`6`)
- `4` x `Unchecked cast: Xyz to Xyz`
- `2` x `This cast can never succeed`

When Related (`1`)
- `1` x `Non exhaustive 'when' statements on xyz will be prohibited in 1.7, add 'Xyz', 'Xyz' branch(es) or 'else' branch instead`

Other Related (`23`)
- `5` x `Parameter 'xyz' is never used`
- `2` x `Check for instance is always 'xyz'`
- `15` x `Name contains characters which can cause problems on Windows: "`
- `1` x `Name shadowed: fileName`

-----

Warnings Resolution List:

- `deprecated`
    1. [Resolve junit assert that test deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/13d5146e77a040fa2d54902d9e7948ada531d4ef)
    2. [Resolve junit assert test deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/58eaace5c035b1b4f6b87fa648cea0bcaa409b18)
    3. [Resolve none expected exception test deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/a1c9e1e6fb1325657adbd42e986d489bb0b2f180)
- `type`
    1. [Resolve type mismatch test type warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/667610503dc10c66f232137b564b42270db405a9)
    2. [Resolve unnecessary non-null assertion test type warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/2e09cbd6b7d65f5a81de7cf4c36631556fd58113)
    3. [Resolve unnecessary safe call test type warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/632adcc23d1aa6ff1d006cbd78a8fc531fd5ca77)
- `when`
    1. [Resolve non exhaustive when statements test when warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/7b69170c7f295927319025e431a8a861c6777316)
- `other`
    1. [Resolve check for instance test warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/4666d5d44928a6bd2f4f2260ba1a42686a3aa126)
    2. [Resolve test function name characters test warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/f36f0639e7ada6665d3ba4f13e8f00633c1a99ee)
    3. [Resolve name shadowed ui test warning.](https://github.com/wordpress-mobile/WordPress-Android/commit/6cc1d058e38c8c0d771a041659b838d6ca730882)

Warnings Suppression List:

- `deprecated`
    1. [Suppress allow scanning by media scanner test deprecated warns.](https://github.com/wordpress-mobile/WordPress-Android/commit/3008099e5c7dd1c1311c3b8ceed5a40b08585e50)
    4. [Suppress network info test deprecated warns.](https://github.com/wordpress-mobile/WordPress-Android/commit/fb3a1eb9cb6eabf43723e3fb6f17999a843430c1)
    5. [Suppress all photo picker related test deprecated warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/cccbe49257960421203939f205ed0b7c54fb64a6)
- `cast`
    1. [Suppress unchecked cast test cast warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/1b0a22b0e42b43fb4abe73e2e1e5bec068b30226)
    3. [Suppress cast can never succeed test cast warnings.](https://github.com/wordpress-mobile/WordPress-Android/commit/82209f52dc16684cf339e643ad0802e970cfb9a2)

Refactor List:

- `deprecated`
    1. [Replace hamcrest matchers with assertj assertions for test.](https://github.com/wordpress-mobile/WordPress-Android/commit/f24421a56231bb020aeb64914ff031fd66150bec)
    2. [Replace run blocking test block with coroutines utils test.](https://github.com/wordpress-mobile/WordPress-Android/commit/cd3483eb026e31dad043509940573730b5c999ae)
    4. [Split rule and jvm field lines for instant task executor rule.](https://github.com/wordpress-mobile/WordPress-Android/commit/d01fccdb1c1ae7ff6b18fd9fd8c9ef66547e34b7)
- `other`
    1. [Replace for each indexed with for each for stats utils.](https://github.com/wordpress-mobile/WordPress-Android/commit/c740332a6d9927449e1e5da018c10c1639ebb4a5)

-----

PS: @AjeshRPai I added you as the main reviewer, that is, in addition to @wordpress-mobile/apps-infrastructure team itself, but randomly, since I want someone from the WordPress Android team to primarily sign-off on that change. 🥇

FYI: I am going to randomly add more of you in those PRs that will follow, just so you become more aware of this change and how close we are on enabling allWarningsAsErrors by default everywhere. 🎉

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.

-----

## Regression Notes

1. Potential unintended areas of impact

N/A

10. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

11. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
