### PR TITLE
Fix rounding issues on stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapper.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.math.RoundingMode.HALF_UP
 import javax.inject.Inject
 
 class PostDayViewsMapper
@@ -67,7 +68,7 @@ class PostDayViewsMapper
                 0 -> "∞"
                 else -> {
                     val percentageValue = difference.toFloat() / previousValue
-                    percentFormatter.format(percentageValue)
+                    percentFormatter.format(value = percentageValue, rounding = HALF_UP)
                 }
             }
             val formattedDifference = mapIntToString(difference, isFormattedNumber)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCase.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.math.RoundingMode
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.math.roundToInt
@@ -75,11 +76,17 @@ class MostPopularInsightsUseCase
         } else {
             val highestDayPercent = resourceProvider.getString(
                     R.string.stats_most_popular_percent_views,
-                    percentFormatter.format(domainModel.highestDayPercent.roundToInt())
+                    percentFormatter.format(
+                            value = domainModel.highestDayPercent.roundToInt(),
+                            rounding = RoundingMode.HALF_UP
+                    )
             )
             val highestHourPercent = resourceProvider.getString(
                     R.string.stats_most_popular_percent_views,
-                    percentFormatter.format(domainModel.highestHourPercent.roundToInt())
+                    percentFormatter.format(
+                            value = domainModel.highestHourPercent.roundToInt(),
+                            rounding = RoundingMode.HALF_UP
+                    )
             )
             items.add(
                     QuickScanItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.LineC
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.math.RoundingMode.HALF_UP
 import java.text.DecimalFormat
 import java.util.TreeMap
 import javax.inject.Inject
@@ -197,7 +198,7 @@ class StatsUtils @Inject constructor(
                 0L -> "∞"
                 else -> {
                     val percentageValue = difference.toFloat() / previousValue
-                    percentFormatter.format(percentageValue)
+                    percentFormatter.format(value = percentageValue, rounding = HALF_UP)
                 }
             }
             val formattedDifference = mapLongToString(difference, isFormattedNumber)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsMapperTest.kt
@@ -17,6 +17,8 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.math.RoundingMode
+import java.math.RoundingMode.HALF_UP
 
 class PostDayViewsMapperTest : BaseUnitTest() {
     @Mock lateinit var statsDateFormatter: StatsDateFormatter
@@ -57,7 +59,7 @@ class PostDayViewsMapperTest : BaseUnitTest() {
 
     @Test
     fun `builds title with positive difference`() {
-        whenever(percentFormatter.format(3.0F)).thenReturn("300")
+        whenever(percentFormatter.format(value = 3.0F, rounding = RoundingMode.HALF_UP)).thenReturn("300")
         val previousCount = 5
         val previousItem = selectedItem.copy(count = previousCount)
         val positiveLabel = "+15 (300%)"
@@ -92,7 +94,7 @@ class PostDayViewsMapperTest : BaseUnitTest() {
 
     @Test
     fun `builds title with negative difference`() {
-        whenever(percentFormatter.format(-0.33333334F)).thenReturn("-33")
+        whenever(percentFormatter.format(value = -0.33333334F, rounding = HALF_UP)).thenReturn("-33")
         val previousCount = 30
         val previousItem = selectedItem.copy(count = previousCount)
         val negativeLabel = "-10 (-33%)"
@@ -109,7 +111,7 @@ class PostDayViewsMapperTest : BaseUnitTest() {
 
     @Test
     fun `builds title with max negative difference`() {
-        whenever(percentFormatter.format(-1F)).thenReturn("-100")
+        whenever(percentFormatter.format(value = -1F, rounding = HALF_UP)).thenReturn("-100")
         val newCount = 0
         val newItem = selectedItem.copy(count = newCount)
         val negativeLabel = "-20 (-100%)"
@@ -150,7 +152,7 @@ class PostDayViewsMapperTest : BaseUnitTest() {
 
     @Test
     fun `builds title with negative difference for the last item`() {
-        whenever(percentFormatter.format(-0.33333334F)).thenReturn("-33")
+        whenever(percentFormatter.format(value = -0.33333334F, rounding = HALF_UP)).thenReturn("-33")
         val previousCount = 30
         val previousItem = selectedItem.copy(count = previousCount)
         val negativeLabel = "-10 (-33%)"
@@ -167,12 +169,12 @@ class PostDayViewsMapperTest : BaseUnitTest() {
 
     @Test
     fun `should call PercentFormatter when builds title`() {
-        whenever(percentFormatter.format(3.0F)).thenReturn("3%")
+        whenever(percentFormatter.format(value = 3.0F, rounding = HALF_UP)).thenReturn("3%")
         val previousCount = 5
         val previousItem = selectedItem.copy(count = previousCount)
         mapper.buildTitle(selectedItem, previousItem, false)
 
         // buildChange is called twice: for change and unformattedChange
-        verify(percentFormatter, times(2)).format(3.0F)
+        verify(percentFormatter, times(2)).format(value = 3.0F, rounding = HALF_UP)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/MostPopularInsightsUseCaseTest.kt
@@ -32,6 +32,8 @@ import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.math.RoundingMode
+import java.math.RoundingMode.HALF_UP
 import kotlin.math.roundToInt
 
 class MostPopularInsightsUseCaseTest : BaseUnitTest() {
@@ -66,8 +68,18 @@ class MostPopularInsightsUseCaseTest : BaseUnitTest() {
                 actionCardHandler,
                 percentFormatter
         )
-        whenever(percentFormatter.format(highestDayPercent.roundToInt())).thenReturn("10%")
-        whenever(percentFormatter.format(highestHourPercent.roundToInt())).thenReturn("20%")
+        whenever(
+                percentFormatter.format(
+                        value = highestDayPercent.roundToInt(),
+                        rounding = RoundingMode.HALF_UP
+                )
+        ).thenReturn("10%")
+        whenever(
+                percentFormatter.format(
+                        value = highestHourPercent.roundToInt(),
+                        rounding = RoundingMode.HALF_UP
+                )
+        ).thenReturn("20%")
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(dateUtils.getWeekDay(day)).thenReturn(dayString)
 
@@ -127,8 +139,14 @@ class MostPopularInsightsUseCaseTest : BaseUnitTest() {
     @Test
     fun `when buildUiModel is called, should call PercentFormatter`() = test {
         useCase.buildUiModel(InsightsMostPopularModel(0, day, hour, highestDayPercent, highestHourPercent))
-        verify(percentFormatter).format(highestDayPercent.roundToInt())
-        verify(percentFormatter).format(highestHourPercent.roundToInt())
+        verify(percentFormatter).format(
+                value = highestDayPercent.roundToInt(),
+                rounding = HALF_UP
+        )
+        verify(percentFormatter).format(
+                value = highestHourPercent.roundToInt(),
+                rounding = HALF_UP
+        )
     }
 
     private fun assertTitle(item: BlockListItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.R.string
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.math.RoundingMode.HALF_UP
 import java.util.Locale
 
 @RunWith(MockitoJUnitRunner::class)
@@ -258,7 +259,7 @@ class StatsUtilsTest {
 
     @Test
     fun `build change with positive difference`() {
-        whenever(percentFormatter.format(3.0F)).thenReturn("300")
+        whenever(percentFormatter.format(value = 3.0F, rounding = HALF_UP)).thenReturn("300")
         val previousValue = 5L
         val value = 20L
         val positive = true
@@ -273,7 +274,7 @@ class StatsUtilsTest {
 
     @Test
     fun `build change with infinite positive difference`() {
-        whenever(percentFormatter.format(3.0F)).thenReturn("∞")
+        whenever(percentFormatter.format(value = 3.0F, rounding = HALF_UP)).thenReturn("∞")
         val previousValue = 0L
         val value = 20L
         val positive = true
@@ -288,7 +289,7 @@ class StatsUtilsTest {
 
     @Test
     fun `build change with negative difference`() {
-        whenever(percentFormatter.format(-0.33333334F)).thenReturn("-33")
+        whenever(percentFormatter.format(value = -0.33333334F, rounding = HALF_UP)).thenReturn("-33")
         val previousValue = 30L
         val value = 20L
         val positive = false
@@ -304,7 +305,7 @@ class StatsUtilsTest {
     @Test
     fun `build change with max negative difference`() {
         val previousValue = 20L
-        whenever(percentFormatter.format(-1F)).thenReturn("-100")
+        whenever(percentFormatter.format(value = -1F, rounding = HALF_UP)).thenReturn("-100")
         val value = 0L
         val positive = false
         val expectedChange = "-20 (-100%)"
@@ -332,8 +333,8 @@ class StatsUtilsTest {
 
     @Test
     fun `when buildChange, should call PercentFormatter`() {
-        whenever(percentFormatter.format(3.0F)).thenReturn("3%")
+        whenever(percentFormatter.format(value = 3.0F, rounding = HALF_UP)).thenReturn("3%")
         statsUtils.buildChange(5L, 20L, true, isFormattedNumber = true)
-        verify(percentFormatter).format(3.0F)
+        verify(percentFormatter).format(value = 3.0F, rounding = HALF_UP)
     }
 }


### PR DESCRIPTION
This fixes rounding issues on stats cards. The problem is introduced in #16947. 

It was showing `16.6%` as `16%`. This PR will show it as `17%`.
These are the cards having the issues:
- Most Popular Time card
- Views & Visitors card
- Total Likes card
- Total Comments card
- The bar chart on DAYS, WEEKS, MONTHS, YEARS tabs
- The bar chart on Posts and Pages detail screen

To test:
1. Launch the Jetpack app.
2. Open Stats from "My Site → HOME → Stats" or "My Site → MENU → Stats".
3. If **Most Popular Time** card is not added to the screen, add it by using ⚙️ button at the top end of the screen.
4. Verify percentage numbers are the same with the iOS version and web. (You can navigate the same screen on the iOS app by using the same steps here)
5. If **Views & Visitors** card is not added to the screen, add it by using ⚙️ button at the top end of the screen.
6. Verify percentage number on the Views & Visitors card is correct.
7. Tap **Views & Visitors** and navigate to the **detail** screen.
8. Verify percentage number on the Views & Visitors card is correct.
9. Navigate back.
10. If **Total Likes** and **Total Comments** cards are not added to the screen, add them by using ⚙️ button at the top end of the screen.
11. Verify percentage numbers on the Total Likes, and Total Comments cards are correct.
12. Navigate to DAYS, WEEKS, MONTHS, or YEARS tab.
13. Verify percentage number on the **bar chart** card is correct. 
14. Change the tab on the bar chart card and repeat 13.
15. Tap an item on the **Posts and Pages** card.
16. Verify percentage number on the bar chart card is correct. 
17. Repeat 2-16 for a different site.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Updated current unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
