### PR TITLE
Make LoadingItem assertion an optional type

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
@@ -95,7 +95,7 @@ class PostListAdapter(
         }
         if (holder is LoadingViewHolder) {
             val item = getItem(position)
-            assert(item is LoadingItem) {
+            assert(item is LoadingItem?) {
                 "If we are presenting LoadingViewHolder, the item has to be of type LoadingItem " +
                         "for position: $position"
             }


### PR DESCRIPTION
# Description

This PR fixes a crash in debug mode. The post list item placeholder can be null (e.g. when scrolling the post list very quickly), and the assertion will crash unless the asserted type is optional. This crash will not happen in production, since we already guard with a `?.let`.

Fixes #17310

To test:

Prerequisite: Run the app from a development environment (one of the debug flavors, e.g. jalepeno debug from Android Studio).

1. Select a site with many posts
2. Navigate to the post list
3. Scroll down very quickly (so that placeholder views are encountered)
4. The app should not crash


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
