### PR TITLE
[UI Tests] - Re-enable e2eSendButtonEnabledWhenTextIsEntered test

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.e2e;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wordpress.android.e2e.flows.LoginFlow;
 import org.wordpress.android.e2e.pages.ContactSupportScreen;
@@ -18,7 +17,6 @@ public class ContactUsTests extends BaseTest {
         logoutIfNecessary();
     }
 
-    @Ignore("Ignored temporarily. This sometimes fail on CI while running with whole test suite.")
     @Test
     public void e2eSendButtonEnabledWhenTextIsEntered() {
         try {

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.not;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.sleep;
+import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 
 public class ContactSupportScreen {
@@ -67,6 +68,7 @@ public class ContactSupportScreen {
 
     // Assertions:
     public ContactSupportScreen assertContactSupportScreenLoaded() {
+        waitForElementToBeDisplayed(R.id.message_composer_input_text);
         textInput.check(matches(isCompletelyDisplayed()));
         sendButton.check(matches(isCompletelyDisplayed()));
         return this;

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
@@ -40,8 +40,6 @@ public class ContactSupportScreen {
             )
     ));
 
-    static ViewInteraction inputTextField = onView(withId(R.id.message_composer_input_text));
-
     // Actions:
     public ContactSupportScreen setMessageText(String text) {
         populateTextField(textInput, text);
@@ -70,7 +68,7 @@ public class ContactSupportScreen {
 
     // Assertions:
     public ContactSupportScreen assertContactSupportScreenLoaded() {
-        waitForElementToBeDisplayed(inputTextField);
+        waitForElementToBeDisplayed(textInput);
         textInput.check(matches(isCompletelyDisplayed()));
         sendButton.check(matches(isCompletelyDisplayed()));
         return this;

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ContactSupportScreen.java
@@ -40,6 +40,8 @@ public class ContactSupportScreen {
             )
     ));
 
+    static ViewInteraction inputTextField = onView(withId(R.id.message_composer_input_text));
+
     // Actions:
     public ContactSupportScreen setMessageText(String text) {
         populateTextField(textInput, text);
@@ -68,7 +70,7 @@ public class ContactSupportScreen {
 
     // Assertions:
     public ContactSupportScreen assertContactSupportScreenLoaded() {
-        waitForElementToBeDisplayed(R.id.message_composer_input_text);
+        waitForElementToBeDisplayed(inputTextField);
         textInput.check(matches(isCompletelyDisplayed()));
         sendButton.check(matches(isCompletelyDisplayed()));
         return this;


### PR DESCRIPTION
Closes: https://github.com/wordpress-mobile/WordPress-Android/issues/17281

### What
Re-enable "e2eSendButtonEnabledWhenTextIsEntered" tests, this needed a new wait on the support screen to make this work in FTL. The test worked in the local emulator but was failing in FTL because of a loading issue, looks like the fix was to wait for an element on the support screen before continuing the test

### Testing
`e2eSendButtonEnabledWhenTextIsEntered` test should pass locally and in CI/FTL