### PR TITLE
Title is Scrollable on My Site Dashboard with no sites #16226

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -10,11 +10,17 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.NonNull
 import androidx.appcompat.widget.TooltipCompat
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.appbar.AppBarLayout.LayoutParams
+import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
+import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED
+import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_SNAP
+import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_NO_SCROLL
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import org.wordpress.android.R
@@ -27,9 +33,9 @@ import org.wordpress.android.ui.main.utils.MeGravatarLoader
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.SiteInfoHeaderCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.SiteInfoHeaderCard.IconState
 import org.wordpress.android.ui.mysite.MySiteViewModel.SiteInfoToolbarViewParams
-import org.wordpress.android.ui.mysite.MySiteViewModel.State
-import org.wordpress.android.ui.mysite.MySiteViewModel.TabsUiState
 import org.wordpress.android.ui.mysite.MySiteViewModel.TabsUiState.TabUiState
+import org.wordpress.android.ui.mysite.MySiteViewModel.TabsUiState
+import org.wordpress.android.ui.mysite.MySiteViewModel.State
 import org.wordpress.android.ui.mysite.tabs.MySiteTabFragment
 import org.wordpress.android.ui.mysite.tabs.MySiteTabsAdapter
 import org.wordpress.android.ui.posts.QuickStartPromptDialogFragment.QuickStartPromptClickInterface
@@ -52,6 +58,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     private var binding: MySiteFragmentBinding? = null
     private var siteTitle: String? = null
+    private var globalOffset: Int = 1
 
     private val viewPagerCallback = object : ViewPager2.OnPageChangeCallback() {
         override fun onPageSelected(position: Int) {
@@ -107,7 +114,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             val currentOffset = maxOffset + verticalOffset
 
             val percentage = if (maxOffset == 0) {
-                updateCollapsibleToolbar(1)
+                updateCollapsibleToolbar(globalOffset)
                 MAX_PERCENT
             } else {
                 updateCollapsibleToolbar(currentOffset)
@@ -195,6 +202,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             }
 
     private fun MySiteFragmentBinding.loadData(state: State.SiteSelected) {
+        val collapsingToolbarParams = collapsingToolbar.layoutParams as LayoutParams
+        collapsingToolbarParams.scrollFlags = SCROLL_FLAG_SCROLL or SCROLL_FLAG_EXIT_UNTIL_COLLAPSED or SCROLL_FLAG_SNAP
         tabLayout.setVisible(state.tabsUiState.showTabs)
         updateTabs(state.tabsUiState)
         actionableEmptyView.setVisible(false)
@@ -233,7 +242,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         switchSite.setOnClickListener { siteInfoHeader.onSwitchSiteClick.click() }
     }
 
-    private fun MySiteFragmentBinding.updateSiteInfoToolbarView(siteInfoToolbarViewParams: SiteInfoToolbarViewParams) {
+    private fun MySiteFragmentBinding.updateSiteInfoToolbarView(
+            siteInfoToolbarViewParams: SiteInfoToolbarViewParams) {
         showHeader(siteInfoToolbarViewParams.headerVisible)
         val appBarHeight = resources.getDimension(siteInfoToolbarViewParams.appBarHeight).toInt()
         appbarMain.layoutParams.height = appBarHeight
@@ -251,15 +261,28 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     private fun MySiteFragmentBinding.loadEmptyView(state: State.NoSites) {
+        globalOffset = 0
         tabLayout.setVisible(state.tabsUiState.showTabs)
         viewModel.setActionableEmptyViewVisible(actionableEmptyView.isVisible) {
             actionableEmptyView.setVisible(true)
             actionableEmptyView.image.setVisible(state.shouldShowImage)
         }
+        if (!state.tabsUiState.showTabs) {
+            val collapsingToolbarParams = collapsingToolbar.layoutParams as LayoutParams
+            collapsingToolbarParams.scrollFlags = SCROLL_FLAG_NO_SCROLL
+        }
         actionableEmptyView.image.setVisible(state.shouldShowImage)
         siteTitle = getString(R.string.my_site_section_screen_title)
         updateSiteInfoToolbarView(state.siteInfoToolbarViewParams)
         appbarMain.setExpanded(false, true)
+        val params: CoordinatorLayout.LayoutParams = appbarMain.layoutParams as CoordinatorLayout.LayoutParams
+        params.behavior = AppBarLayout.Behavior()
+        val behavior: AppBarLayout.Behavior = params.behavior as AppBarLayout.Behavior
+        behavior.setDragCallback(object : AppBarLayout.Behavior.DragCallback() {
+            override fun canDrag(appBarLayout: AppBarLayout): Boolean {
+                return false
+            }
+        })
     }
 
     private fun MySiteFragmentBinding.showHeader(visibility: Boolean) {

--- a/WordPress/src/main/res/values/styles_toolbar.xml
+++ b/WordPress/src/main/res/values/styles_toolbar.xml
@@ -47,6 +47,7 @@
         <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="fontFamily">serif</item>
         <item name="android:textStyle">bold</item>
+        <item name="android:textSize">@dimen/text_sz_extra_large</item>
     </style>
 
     <style name="TextAppearance.App.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">


### PR DESCRIPTION
Fixes #16226
[Bug] Title is Scrollable on My Site Dashboard with no sites 

Solution: Set toolbar scroll flags to 0 when list is empty and disable canDrag behaviour on Appbar

To test:

- Launch app with an account having no sites
- Notice that "My Site" is shown on toolbar
- Scroll down

## Regression Notes
1. Potential unintended areas of impact: None


2. What I did to test those areas of impact (or what existing automated tests I relied on): Tested visually.


3. What automated tests I added (or what prevented me from doing so): None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Before fix: https://www.loom.com/share/c4c3641c29d14fbd934bb5d8d28bc8ed

After fix: https://www.loom.com/share/f2503491a0ba4bfa89f32cd83eba07ed