### PR TITLE
Media Quick start: Snackbar Flickering #16572

### DIFF
--- a/WordPress/src/main/res/layout/media_browser_activity.xml
+++ b/WordPress/src/main/res/layout/media_browser_activity.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:id="@+id/coordinator_layout"
-    android:animateLayoutChanges="true">
+    android:animateLayoutChanges="false">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"


### PR DESCRIPTION
Fixes #[16572](https://github.com/wordpress-mobile/WordPress-Android/issues/16572)
Snackbar flickering when shown during media quick start

**Solution**
Set `android:animateLayoutChanges` to false in `media_browser_activity.xml`

To test:
1. Go to a site with a quick start in progress
2. Start Media quick start
3. Notice that there is no flickering when selecting plus icon to upload media

## Regression Notes
1. Potential unintended areas of impact
    None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    manual testing

4. What automated tests I added (or what prevented me from doing so)
   None, visual testing was enough

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Bug -> https://www.loom.com/share/d70c328a8e0545c597a44b2d82a3b3e5
Fix-> https://www.loom.com/share/9e4ea140398447f5a0b591c15c5794a2