### PR TITLE
[Revamp Landing Screen] Jetpack App - Ignore background and animated text by screen readers

### DIFF
--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/ColumnWithFrostedGlassBackground.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/ColumnWithFrostedGlassBackground.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Outline.Rectangle
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.Density
@@ -41,7 +40,7 @@ private fun ColumnWithTopGlassBorder(
     content: @Composable ColumnScope.() -> Unit
 ) {
     Column(
-            modifier = Modifier.background(SolidColor(colorResource(R.color.bg_jetpack_login_splash_bottom_panel)))
+            modifier = Modifier.background(colorResource(R.color.bg_jetpack_login_splash_bottom_panel))
     ) {
         Divider(
                 thickness = 1.dp,

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.draw.paint
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,6 +34,7 @@ fun LoopingTextWithBackground(
     ) {
         LoopingText(
                 modifier = Modifier
+                        .clearAndSetSemantics { }
                         .fillMaxSize()
                         .padding(horizontal = 20.dp)
                         .then(textModifier)

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
@@ -34,7 +34,7 @@ fun LoopingTextWithBackground(
     ) {
         LoopingText(
                 modifier = Modifier
-                        .clearAndSetSemantics { }
+                        .clearAndSetSemantics {}
                         .fillMaxSize()
                         .padding(horizontal = 20.dp)
                         .then(textModifier)

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
@@ -1,17 +1,16 @@
 package org.wordpress.android.ui.accounts.login.components
 
 import android.content.res.Configuration
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.paint
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -23,13 +22,15 @@ fun LoopingTextWithBackground(
     modifier: Modifier = Modifier,
     textModifier: Modifier = Modifier,
 ) {
-    Box(modifier.background(colorResource(R.color.bg_jetpack_login_splash))) {
-        Image(
-                painter = painterResource(R.drawable.bg_jetpack_login_splash),
-                contentDescription = stringResource(R.string.login_prologue_revamped_content_description_bg),
-                contentScale = ContentScale.FillBounds,
-                modifier = Modifier.matchParentSize(),
-        )
+    Box(
+            modifier
+                    .background(colorResource(R.color.bg_jetpack_login_splash))
+                    .paint(
+                            painter = painterResource(R.drawable.bg_jetpack_login_splash),
+                            sizeToIntrinsics = true,
+                            contentScale = ContentScale.FillBounds,
+                    )
+    ) {
         LoopingText(
                 modifier = Modifier
                         .fillMaxSize()

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/RepeatingColumn.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/RepeatingColumn.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.Constraints
 
 /** This composable accepts a child composable, and repeats that composable `repeat` times (default 3). It places the
@@ -25,7 +24,7 @@ fun RepeatingColumn(
 ) {
     Layout(
             content = {
-                Column(modifier.clearAndSetSemantics {}) {
+                Column(modifier = modifier) {
                     repeat(repeat) {
                         content()
                     }

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/RepeatingColumn.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/RepeatingColumn.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.Constraints
 
 /** This composable accepts a child composable, and repeats that composable `repeat` times (default 3). It places the
@@ -24,7 +25,7 @@ fun RepeatingColumn(
 ) {
     Layout(
             content = {
-                Column(modifier = modifier) {
+                Column(modifier.clearAndSetSemantics {}) {
                     repeat(repeat) {
                         content()
                     }

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/TopLinearGradient.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/TopLinearGradient.kt
@@ -8,18 +8,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R.drawable
-import org.wordpress.android.R.string
 import org.wordpress.android.ui.compose.theme.AppTheme
 
 @Composable
 fun TopLinearGradient(modifier: Modifier = Modifier) {
     Image(
             painter = painterResource(drawable.bg_jetpack_login_splash_top_gradient),
-            contentDescription = stringResource(string.login_prologue_revamped_content_description_top_bg),
+            contentDescription = null,
             contentScale = ContentScale.FillBounds,
             modifier = modifier
                     .fillMaxWidth()

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -13,7 +13,6 @@
     <string name="app_tagline">Site security and performance from your pocket</string>
     <string name="continue_with_wpcom_no_signup">Continue with WordPress.com</string>
     <string name="login_prologue_revamped_content_description_jetpack_logo">Jetpack logo</string>
-    <string name="login_prologue_revamped_content_description_top_bg">Jetpack top background fade</string>
 
     <string name="login_prologue_revamped_jetpack_feature_text_1">Update a plugin</string>
     <string name="login_prologue_revamped_jetpack_feature_text_2">Build a site</string>

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -13,7 +13,6 @@
     <string name="app_tagline">Site security and performance from your pocket</string>
     <string name="continue_with_wpcom_no_signup">Continue with WordPress.com</string>
     <string name="login_prologue_revamped_content_description_jetpack_logo">Jetpack logo</string>
-    <string name="login_prologue_revamped_content_description_bg">Jetpack background</string>
     <string name="login_prologue_revamped_content_description_top_bg">Jetpack top background fade</string>
 
     <string name="login_prologue_revamped_jetpack_feature_text_1">Update a plugin</string>


### PR DESCRIPTION
Fixes #17313

To test:


<details>
<summary><b>Prerequisite</b> - Enable the <code>LandingScreenRevamp</code> feature flag</summary>

- Either `login` → `Me` → `App Settings` → `Debug Settings` → enable `LandingScreenRevamp` → `RESTART THE APP` → `logout` or
- Apply this hard-coded solution:

<details>
<summary>Patch to enable the <code>LANDING_SCREEN_REVAMP</code> build flag</summary>

```diff
diff --git a/WordPress/build.gradle b/WordPress/build.gradle
index 63260a4ca8..fe999fa92f 100644
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -112,7 +112,7 @@ android {
         buildConfigField "boolean", "READER_COMMENTS_MODERATION", "false"
         buildConfigField "boolean", "SITE_INTENT_QUESTION", "true"
         buildConfigField "boolean", "SITE_NAME", "false"
-        buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "false"
+        buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "true"
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
         buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"
```  
</details>

---

</details>

0. On your device go to `Settings` → `Accessibility` → enable `Voice Assistant`
1. Open the Jetpack app and make sure you're logged out
2. Slide right to read next item on the screen
3. **Expect** the screen reader to read the first button
4. Slide right again to read next item on the screen
5. **Expect** the screen reader to read the second button

## Regression Notes
1. Potential unintended areas of impact
  N/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  N/a

3. What automated tests I added (or what prevented me from doing so)
  N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
