### PR TITLE
[UI Tests] - Update click element on image library

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
@@ -142,7 +142,7 @@ public class BlockEditorPage {
         clickOn("WordPress Media Library");
         waitForElementToBeDisplayed(onView(withText("WordPress media")));
         waitForElementToBeDisplayed(onView(withIndex(withId(R.id.image_thumbnail), 0)));
-        onView(withIndex(withId(R.id.image_thumbnail), 0)).perform(click());
+        onView(withIndex(withId(R.id.text_selection_count), 0)).perform(click());
         clickOn(R.id.mnu_confirm_selection);
         return this;
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
@@ -75,6 +75,7 @@ public class BlockEditorPage {
     }
 
     public void openPostSetting() {
+        waitForElementToBeDisplayed(R.id.toolbar_main);
         openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
         clickOn(onView(withText(R.string.post_settings)));
     }
@@ -141,7 +142,7 @@ public class BlockEditorPage {
         clickOn("Image");
         clickOn("WordPress Media Library");
         waitForElementToBeDisplayed(onView(withText("WordPress media")));
-        waitForElementToBeDisplayed(onView(withIndex(withId(R.id.image_thumbnail), 0)));
+        waitForElementToBeDisplayed(onView(withIndex(withId(R.id.text_selection_count), 0)));
         onView(withIndex(withId(R.id.text_selection_count), 0)).perform(click());
         clickOn(R.id.mnu_confirm_selection);
         return this;


### PR DESCRIPTION
# What
The `e2ePublishFullPost` test is flaky, most recently, it failed twice [on this build](https://buildkite.com/automattic/wordpress-android/builds/6985#0183c6f6-c6f1-4806-9b21-0bcc4563869e) before passing without any change on the third try. This PR is an attempt to fix that flakiness.

# Why is the test failing
Looks like the test is failing because the supposed click _sometimes_ acted like a long press, changing the flow of the test and making it fail ([failing test video](https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.f7bbef01bccfafb8/matrices/8082371841826030126/executions/bs.cff0b3770130b947/videos)) From the video, it looks like the screen jumps from the image media gallery to a full-screen photo view:

From this:
![image](https://user-images.githubusercontent.com/17252150/195512168-de7a3393-f48c-48ac-9d07-d511b2960c0c.png)

To this:
![image](https://user-images.githubusercontent.com/17252150/195512279-aa079e29-6e05-4427-bccb-627ecb636edb.png)

The only way to get to that view is by long-pressing the image from the gallery.

# How can this (potentially) be fixed
There are two elements that we can choose to click from that view to select the image, the element used currently is `image_thumbnail`, and there is another element `text_selection_count`. The difference between the two is `image_thumbnail` has the attribute `longClickable` set to `true`. The same attribute for `text_selection_count` is `false`, by updating the element, the long-press _should_ no longer happen on this test.

![Screenshot 2022-10-13 at 1 36 27 PM](https://user-images.githubusercontent.com/17252150/195513102-870aa8f5-cfb2-48b5-bcdf-1b6c6ee54f92.png)

![Screenshot 2022-10-13 at 1 36 45 PM](https://user-images.githubusercontent.com/17252150/195513139-4ec2cb35-14da-41f8-918b-729c48d1a4c3.png)

# Testing
The test should work locally and in CI