### PR TITLE
[Revamp Landing Screen] Limit width of buttons and Jetpack prompts on Tablets

### DIFF
--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
@@ -31,7 +31,7 @@ import org.wordpress.android.ui.accounts.login.components.PrimaryButton
 import org.wordpress.android.ui.accounts.login.components.SecondaryButton
 import org.wordpress.android.ui.accounts.login.components.TopLinearGradient
 import org.wordpress.android.ui.compose.theme.AppTheme
-import org.wordpress.android.util.extensions.setTransparentSystemBars
+import org.wordpress.android.util.extensions.setEdgeToEdgeContentDisplay
 
 val LocalPosition = compositionLocalOf { 0f }
 
@@ -64,12 +64,12 @@ class LoginPrologueRevampedFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        requireActivity().window.setTransparentSystemBars(true)
+        requireActivity().window.setEdgeToEdgeContentDisplay(true)
     }
 
     override fun onPause() {
         super.onPause()
-        requireActivity().window.setTransparentSystemBars(false)
+        requireActivity().window.setEdgeToEdgeContentDisplay(true)
     }
 
     companion object {

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
@@ -10,11 +10,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppTheme
 
@@ -33,7 +33,7 @@ fun LoopingTextWithBackground(
         LoopingText(
                 modifier = Modifier
                         .fillMaxSize()
-                        .padding(horizontal = 20.dp)
+                        .padding(horizontal = dimensionResource(R.dimen.login_prologue_revamped_prompts_padding))
                         .then(textModifier)
         )
     }

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/PrimaryButton.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/PrimaryButton.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -31,7 +32,7 @@ fun PrimaryButton(
                     contentColor = colorResource(R.color.text_color_jetpack_login_splash_primary_button),
             ),
             modifier = modifier
-                    .padding(horizontal = 20.dp)
+                    .padding(horizontal = dimensionResource(R.dimen.login_prologue_revamped_buttons_padding))
                     .padding(top = Margin.ExtraLarge.value)
                     .fillMaxWidth(),
     ) {

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/SecondaryButton.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/SecondaryButton.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -31,7 +32,7 @@ fun SecondaryButton(
                     backgroundColor = Color.Transparent,
             ),
             modifier = modifier
-                    .padding(horizontal = 20.dp)
+                    .padding(horizontal = dimensionResource(R.dimen.login_prologue_revamped_buttons_padding))
                     .padding(bottom = 60.dp)
                     .fillMaxWidth(),
     ) {

--- a/WordPress/src/jetpack/res/values-w600dp/dimens.xml
+++ b/WordPress/src/jetpack/res/values-w600dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="login_prologue_revamped_prompts_padding">150dp</dimen>
+</resources>

--- a/WordPress/src/jetpack/res/values/dimens.xml
+++ b/WordPress/src/jetpack/res/values/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="login_prologue_tagline_start_end_padding">40dp</dimen>
+    <dimen name="login_prologue_revamped_prompts_padding">20dp</dimen>
 </resources>

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/WindowExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/WindowExtensions.kt
@@ -7,8 +7,8 @@ import android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE
 import android.view.View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
 import android.view.View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
 import android.view.Window
-import android.view.WindowManager.LayoutParams
 import androidx.core.content.ContextCompat
+import androidx.core.view.WindowCompat
 import org.wordpress.android.R
 
 @Suppress("DEPRECATION")
@@ -44,23 +44,9 @@ fun Window.setLightNavigationBar(showInLightMode: Boolean, applyDefaultColors: B
     }
 }
 
-fun Window.setTransparentSystemBars(isTransparent: Boolean) {
-    when (isTransparent) {
-        true -> {
-            if (VERSION.SDK_INT >= VERSION_CODES.R) {
-                setDecorFitsSystemWindows(false)
-            } else {
-                addFlags(LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-            }
-        }
-        false -> {
-            if (VERSION.SDK_INT >= VERSION_CODES.R) {
-                setDecorFitsSystemWindows(true)
-            } else {
-                clearFlags(LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-            }
-        }
-    }
+fun Window.setEdgeToEdgeContentDisplay(isEnabled: Boolean) {
+    val decorFitsSystemWindows = !isEnabled
+    WindowCompat.setDecorFitsSystemWindows(this, decorFitsSystemWindows)
 }
 
 @Suppress("DEPRECATION")

--- a/WordPress/src/main/res/values-v29/styles_login.xml
+++ b/WordPress/src/main/res/values-v29/styles_login.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="LoginTheme.TransparentSystemBars" parent="LoginTheme.BaseTransparentSystemBars">
+        <item name="android:enforceNavigationBarContrast">false</item>
+    </style>
+
+</resources>

--- a/WordPress/src/main/res/values-w600dp/dimens.xml
+++ b/WordPress/src/main/res/values-w600dp/dimens.xml
@@ -13,5 +13,5 @@
     <dimen name="interests_content_margin">@dimen/margin_extra_extra_large</dimen>
 
     <!-- Login Prologue -->
-    <dimen name="login_prologue_revamped_buttons_padding">@dimen/login_prologue_revamped_buttons_padding_tablet</dimen>
+    <dimen name="login_prologue_revamped_buttons_padding">250dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w600dp/dimens.xml
+++ b/WordPress/src/main/res/values-w600dp/dimens.xml
@@ -12,4 +12,6 @@
     <dimen name="post_list_content_margin_standard">@dimen/content_margin_tablet</dimen>
     <dimen name="interests_content_margin">@dimen/margin_extra_extra_large</dimen>
 
+    <!-- Login Prologue -->
+    <dimen name="login_prologue_revamped_buttons_padding">@dimen/login_prologue_revamped_buttons_padding_tablet</dimen>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -678,7 +678,6 @@
     <dimen name="login_prologue_background_circle_size">140dp</dimen>
     <dimen name="login_prologue_background_circle_size_large">160dp</dimen>
     <dimen name="login_prologue_revamped_buttons_padding">32dp</dimen>
-    <dimen name="login_prologue_revamped_buttons_padding_tablet">250dp</dimen>
 
     <!-- edit text with chips view -->
     <dimen name="edit_text_with_chips_margin_top">5dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -677,6 +677,8 @@
     <dimen name="login_prologue_content_area">320dp</dimen>
     <dimen name="login_prologue_background_circle_size">140dp</dimen>
     <dimen name="login_prologue_background_circle_size_large">160dp</dimen>
+    <dimen name="login_prologue_revamped_buttons_padding">32dp</dimen>
+    <dimen name="login_prologue_revamped_buttons_padding_tablet">250dp</dimen>
 
     <!-- edit text with chips view -->
     <dimen name="edit_text_with_chips_margin_top">5dp</dimen>

--- a/WordPress/src/main/res/values/styles_login.xml
+++ b/WordPress/src/main/res/values/styles_login.xml
@@ -8,10 +8,12 @@
         <item name="colorSecondaryVariant">@color/colorSecondaryVariant</item>
     </style>
 
-    <style name="LoginTheme.TransparentSystemBars" parent="LoginTheme">
+    <style name="LoginTheme.BaseTransparentSystemBars" parent="LoginTheme">
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
+
+    <style name="LoginTheme.TransparentSystemBars" parent="LoginTheme.BaseTransparentSystemBars" />
 
     <style name="Login.EmptyView.TextView.Username" parent="android:Widget.TextView">
         <item name="android:textSize">@null</item>

--- a/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
@@ -33,7 +33,7 @@ import org.wordpress.android.ui.accounts.login.compose.components.PrimaryButton
 import org.wordpress.android.ui.accounts.login.compose.components.SecondaryButton
 import org.wordpress.android.ui.accounts.login.compose.components.Tagline
 import org.wordpress.android.ui.compose.theme.AppTheme
-import org.wordpress.android.util.extensions.setTransparentSystemBars
+import org.wordpress.android.util.extensions.setEdgeToEdgeContentDisplay
 
 class LoginPrologueRevampedFragment : Fragment() {
     private lateinit var loginPrologueListener: LoginPrologueListener
@@ -61,12 +61,12 @@ class LoginPrologueRevampedFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        requireActivity().window.setTransparentSystemBars(true)
+        requireActivity().window.setEdgeToEdgeContentDisplay(true)
     }
 
     override fun onPause() {
         super.onPause()
-        requireActivity().window.setTransparentSystemBars(false)
+        requireActivity().window.setEdgeToEdgeContentDisplay(false)
     }
 
     companion object {

--- a/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/compose/components/PrimaryButton.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/compose/components/PrimaryButton.kt
@@ -12,13 +12,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.font.FontWeight.Companion
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R.color
+import org.wordpress.android.R.dimen
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 
@@ -46,7 +47,7 @@ fun PrimaryButton(
                     .fillMaxWidth()
                     .padding(
                             vertical = Margin.Small.value,
-                            horizontal = Margin.ExtraExtraMediumLarge.value,
+                            horizontal = dimensionResource(dimen.login_prologue_revamped_buttons_padding),
                     )
     ) {
         Text(
@@ -58,6 +59,7 @@ fun PrimaryButton(
         )
     }
 }
+
 @Preview(showBackground = true)
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable

--- a/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/compose/components/SecondaryButton.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/compose/components/SecondaryButton.kt
@@ -10,10 +10,12 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.wordpress.android.R.dimen
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 
@@ -39,7 +41,7 @@ fun SecondaryButton(
                     .fillMaxWidth()
                     .padding(
                             vertical = Margin.Small.value,
-                            horizontal = Margin.ExtraExtraMediumLarge.value,
+                            horizontal = dimensionResource(dimen.login_prologue_revamped_buttons_padding),
                     )
     ) {
         Text(


### PR DESCRIPTION
Fixes #17319

This PR updates the new landing screen on both WordPress and Jetpack apps by limiting the width of the buttons in both apps and the container of the scrolling prompts in the Jetpack App.

The approach I took was to use resource dimensions based on device width for the horizontal padding.
Another option would have been to set the max width of the components, but I felt that would add additional complexity specific only to tablets.

➕ I also refactored the logic to make the new landing screens render behind the system bars and <ins>added a fix to make sure on devices running Android 10+ (API 29+) the background of the navigation bar is fully transparent</ins>. I applied this fix after noticing it was not transparent while testing on a tablet emulator with Android 12.

To test:

<details>
<summary><b>Prerequisite</b> - Enable the <code>LandingScreenRevamp</code> feature flag</summary>

- Either `login` → `Me` → `App Settings` → `Debug Settings` → enable `LandingScreenRevamp` → `RESTART THE APP` → `logout` or
- Apply this hard-coded solution:

<details>
<summary>Patch to enable the <code>LANDING_SCREEN_REVAMP</code> build flag</summary>

```diff
diff --git a/WordPress/build.gradle b/WordPress/build.gradle
index 63260a4ca8..fe999fa92f 100644
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -112,7 +112,7 @@ android {
         buildConfigField "boolean", "READER_COMMENTS_MODERATION", "false"
         buildConfigField "boolean", "SITE_INTENT_QUESTION", "true"
         buildConfigField "boolean", "SITE_NAME", "false"
-        buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "false"
+        buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "true"
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
         buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"
```  
</details>

---

</details>

##### 1️⃣ Test Case 1: WordPress app
1. Open the WordPress app **on a tablet** and make sure you're logged out
2. **Expect** the width of the buttons to not stretch to the edges of the screen.

##### 2️⃣ Test Case 2: Jetpack app
1. Open the Jetpack app **on a tablet** and make sure you're logged out
2. **Expect** the width of the animated prompts and buttons to not stretch to the edges of the screen.
   - The width of the animated prompts should be wider than the width of the button.
3. **Expect** the system navigation bar to be transparent (it wasn't before on Android 12+)

## Previews

| WordPress App | Jetpack App |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/195630026-4e21c58f-fb85-4e32-bd0e-76bdf9a86f68.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/195630011-09895db0-f114-4878-9f67-55023ce60114.png"> |

## Regression Notes
1. Potential unintended areas of impact
   UI of revamped landing screen on phones.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

3. What automated tests I added (or what prevented me from doing so)
   N/a - PR tweaks UI for tablets.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
