### PR TITLE
[Tooling] Fix issue with en-US release notes not generated if en-GB was not translated

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,7 @@ UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Hel
 
 APP_SPECIFIC_VALUES = {
   wordpress: {
+    display_name: 'WordPress',
     metadata_dir: 'metadata',
     glotpress_appstrings_project: 'https://translate.wordpress.org/projects/apps/android/dev/',
     glotpress_metadata_project: 'https://translate.wordpress.org/projects/apps/android/release-notes/',
@@ -9,6 +10,7 @@ APP_SPECIFIC_VALUES = {
     bundle_name_prefix: 'wpandroid'
   },
   jetpack: {
+    display_name: 'Jetpack',
     metadata_dir: 'jetpack_metadata',
     glotpress_appstrings_project: 'https://translate.wordpress.com/projects/jetpack/apps/android/',
     glotpress_metadata_project: 'https://translate.wordpress.com/projects/jetpack/apps/android/release-notes/',

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -11,7 +11,6 @@ ALL_LOCALES = [
   # First are the locales which are used for *both* downloading the `strings.xml` files from GlotPress *and* for generating the release notes XML files.
   { glotpress: 'ar', android: 'ar',    google_play: 'ar',     promo_config: {} },
   { glotpress: 'de', android: 'de',    google_play: 'de-DE',  promo_config: {} },
-  { glotpress: 'en-gb', android: 'en-rGB', google_play: 'en-US', promo_config: {} },
   { glotpress: 'es', android: 'es', google_play: 'es-ES', promo_config: {} },
   { glotpress: 'fr', android: 'fr-rCA', google_play: 'fr-CA', promo_config: false },
   { glotpress: 'fr', android: 'fr',    google_play: 'fr-FR',  promo_config: {} },
@@ -209,70 +208,47 @@ platform :android do
   #####################################################################################
   desc 'Downloads translated metadata from GlotPress'
   lane :download_metadata_strings do |options|
-    download_wordpress_metadata_strings(options)
-    download_jetpack_metadata_strings(options)
-  end
+    version = options.fetch(:version, android_get_app_version)
+    build_number = options.fetch(:build_number, android_get_release_version['code'])
 
-  desc "Downloads WordPress's translated metadata from GlotPress"
-  lane :download_wordpress_metadata_strings do |options|
-    app_values = APP_SPECIFIC_VALUES[:wordpress]
-    values = options[:version].split('.')
-    files = {
-      "release_note_#{values[0]}#{values[1]}" => { desc: "changelogs/#{options[:build_number]}.txt", max_size: 500, alternate_key: "release_note_short_#{values[0]}#{values[1]}" },
-      play_store_app_title: { desc: 'title.txt', max_size: 30 },
-      play_store_promo: { desc: 'short_description.txt', max_size: 80 },
-      play_store_desc: { desc: 'full_description.txt', max_size: 4000 }
-    }
+    # If no `app:` is specified, call this for both WordPress and Jetpack
+    apps = options[:app].nil? ? %i[wordpress jetpack] : Array(options[:app]&.downcase&.to_sym)
 
-    delete_old_changelogs(app: 'wordpress', build: options[:build_number])
-    download_path = File.join(Dir.pwd, app_values[:metadata_dir], 'android')
-    # The case for the source locale (en-US) is pulled in a hacky way, by having an {en-gb => en-US} mapping as part of the WP_RELEASE_NOTES_LOCALES,
-    # which is then treated in a special way by gp_downloadmetadata by specifying a `source_locale: 'en-US'` to process it differently from the rest.
-    gp_downloadmetadata(
-      project_url: app_values[:glotpress_metadata_project],
-      target_files: files,
-      locales: WP_RELEASE_NOTES_LOCALES,
-      source_locale: 'en-US',
-      download_path: download_path
-    )
+    apps.each do |app|
+      app_values = APP_SPECIFIC_VALUES[app]
 
-    git_add(path: download_path)
-    git_commit(path: download_path, message: "Update WordPress metadata translations for #{options[:version]}", allow_nothing_to_commit: true)
-    push_to_git_remote
-  end
+      version_suffix = version.split('.').join
+      files = {
+        "release_note_#{version_suffix}" => { desc: "changelogs/#{build_number}.txt", max_size: 500, alternate_key: "release_note_short_#{version_suffix}" },
+        play_store_app_title: { desc: 'title.txt', max_size: 30 },
+        play_store_promo: { desc: 'short_description.txt', max_size: 80 },
+        play_store_desc: { desc: 'full_description.txt', max_size: 4000 }
+      }
 
-  desc "Downloads Jetpack's translated metadata from GlotPress"
-  lane :download_jetpack_metadata_strings do |options|
-    UI.message('Hey')
-    app_values = APP_SPECIFIC_VALUES[:jetpack]
-    values = options[:version].split('.')
-    files = {
-      "release_note_#{values[0]}#{values[1]}" => { desc: "changelogs/#{options[:build_number]}.txt", max_size: 500, alternate_key: "release_note_short_#{values[0]}#{values[1]}" },
-      play_store_app_title: { desc: 'title.txt', max_size: 30 },
-      play_store_promo: { desc: 'short_description.txt', max_size: 80 },
-      play_store_desc: { desc: 'full_description.txt', max_size: 4000 }
-    }
+      delete_old_changelogs(app: app, build: build_number)
 
-    delete_old_changelogs(app: 'jetpack', build: options[:build_number])
-    download_path = File.join(Dir.pwd, app_values[:metadata_dir], 'android')
-    gp_downloadmetadata(
-      project_url: app_values[:glotpress_metadata_project],
-      target_files: files,
-      locales: JP_RELEASE_NOTES_LOCALES,
-      download_path: download_path
-    )
+      download_path = File.join(Dir.pwd, app_values[:metadata_dir], 'android')
+      locales = { wordpress: WP_RELEASE_NOTES_LOCALES, jetpack: JP_RELEASE_NOTES_LOCALES }[app]
+      UI.header("Downloading metadata translations for #{app_values[:display_name]}")
+      gp_downloadmetadata(
+        project_url: app_values[:glotpress_metadata_project],
+        target_files: files,
+        locales: locales,
+        download_path: download_path
+      )
 
-    # For WordPress, the en-US release notes come from using the source keys (instead of translations) downloaded from GlotPress' en-gb locale (which is unused otherwise).
-    # But for Jetpack, we don't have an unused locale like en-gb in the GP release notes project, so copy from source instead as a fallback
-    metadata_source_dir = File.join(Dir.pwd, '..', 'WordPress', 'jetpack_metadata')
-    FileUtils.cp(File.join(metadata_source_dir, 'release_notes.txt'), File.join(download_path, 'en-US', 'changelogs', "#{options[:build_number]}.txt"))
-    FileUtils.cp(
-      ['title.txt', 'short_description.txt', 'full_description.txt'].map { |f| File.join(metadata_source_dir, f) },
-      File.join(download_path, 'en-US')
-    )
-
-    git_add(path: download_path)
-    git_commit(path: download_path, message: "Update Jetpack metadata translations for #{options[:version]}", allow_nothing_to_commit: true)
+      # Copy the source `.txt` files (used as source of truth when we generated the `.po`) to the `fastlane/*metadata/android/en-US` dir,
+      # as `en-US` is the source language, and isn't exported from GlotPress during `gp_downloadmetadata`
+      metadata_source_dir = File.join(PROJECT_ROOT_FOLDER, 'WordPress', app_values[:metadata_dir])
+      FileUtils.cp(File.join(metadata_source_dir, 'release_notes.txt'), File.join(download_path, 'en-US', 'changelogs', "#{build_number}.txt"))
+      FileUtils.cp(
+        ['title.txt', 'short_description.txt', 'full_description.txt'].map { |f| File.join(metadata_source_dir, f) },
+        File.join(download_path, 'en-US')
+      )
+    
+      git_add(path: download_path)
+      git_commit(path: download_path, message: "Update #{app_values[:display_name]} metadata translations for #{version}", allow_nothing_to_commit: true)
+    end
     push_to_git_remote
   end
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -314,7 +314,7 @@ platform :android do
   def get_app_name_option!(options)
     app = options[:app]&.downcase
     UI.user_error!("Missing 'app' parameter. Expected 'app:wordpress' or 'app:jetpack'") if app.nil?
-    unless ['wordpress', 'jetpack'].include?(app)
+    unless %i[wordpress jetpack].include?(app.to_sym)
       UI.user_error!("Invalid 'app' parameter #{app.inspect}. Expected 'wordpress' or 'jetpack'")
     end
     return app


### PR DESCRIPTION
## What is this fixing?

This fixes an issue we've been randomly having  in the past couple of releases, where if the release notes didn't have any translation for `en-GB` in GlotPress, then the `en-US` release notes would not be generated in `fastlane/metadata/android/en-US/changelogs/*.txt`, leading to missing `en-US` release notes in Play Store (and Play Store falling back to use the Arabic release notes as default language 😱 !)

The latest occurrences of this happening to us was [during the `20.6` submission here](https://github.com/wordpress-mobile/WordPress-Android/pull/17118#pullrequestreview-1095119566), and [today with the `20.9` submission to the Play Store](https://github.com/wordpress-mobile/WordPress-Android/pull/17340#issuecomment-1279104503) — where we almost shipped to end users with those `en-US` release notes missing and that `ar` fallback… if it hadn't has been for a careful PR review by Petros catching the missing `en-US` ones amongst the noise and flood of other `changelogs/*.txt` in the PR diff.

[See also: internal ref pdnsEh-jJ-p2#comment-1233]

## Why did it happen?

The main reason for this issue to have happened was that we relied on a ugly hack when calling `gp_downloadmetadata` by providing a `en-GB => en-US` mapping as part of its `locales` parameter, then setting its `source_locale: 'en-US'`, which had the effect of `gp_downloadmetadata` to download the GlotPress export for the `en-GB` translations, and then extract the source copy (en-US) from that translation entry.
This didn't work when the release notes don't have an `en-GB` translation in GlotPress for the current release notes, as in those cases the export would be empty (and thus not even export the source en-US copy alongside it)

## How does this PR fix it?

- Removes the `en-gb => en-US` hack for WP metadata, to instead use the same solution we've been using for the case of Jetpack (whose lanes never relied on such hack, unlike WordPress' ones), i.e. doing a `FileUtils.cp` of the source files to `fastlane/metadata/android/en-US` explicitly for the `en-US` case
- DRY the `download_metadata_strings` lanes (into a single one, that can take `app:` if necessary, defaulting to act on both apps), now that the two implementations were the same after removing the hack
- DRY the `update_appstore_strings` lanes together (into a single one, that can take `app:` if necessary, defaulting to act on both apps) while we were at it, inspired by the previous DRY-ing

> **Note**: The diff end up looking a bit long, but in practice it's mostly replacing the duplicated code from `download_wordpress_metadata_strings` and `download_jetpack_metadata_strings` with only one instance of that same code, which ends up being indented one extra level due to the `apps.each do |app|` loop, and have slight tweaks compared to each original code to make the code generic over said `app`. This means that it might be easier to review this PR with "Ignore Whitespaces" option turned on to make the diff clearer to understand and compare.

## To test

I've tested this change by:
 - Cutting a test branch from this one ➡️  [`tooling/test-pr-17341`](https://github.com/wordpress-mobile/WordPress-Android/compare/tooling/fix-enUS-enGB-hack...tooling/test-pr-17341)
 - Removing all the `*.txt` files from `fastlane/metadata/android` and `fastlane/jetpack_metadata/android`, and doing some dummy modifications to the `WordPress/metadata/*.txt` and `WordPress/jetpack_metadata/*.txt` source files ➡️  2d75cde
 - Running `bundle exec fastlane update_appstore_strings` to re-generate the `.po` file, and checking that the dummy modifications I made were taken into account in the new `.po` files ➡️ 7220fe0 & 04cb6f2
 - Running `bundle exec fastlane download_metadata_strings` to re-generate the `fastlane/*metadata/android/**/*.txt` files from GlotPress, and checking that not only they were all regenerated with the current GlotPress content, but especially that the `fastlane/{jetpack_}metadata/android/en-US/changelogs/1281.txt` file was properly created with the content of the `WordPress/{jetpack_}metadata/release_notes.txt` files. ➡️  dcb1326 & a73cbf8