### PR TITLE
[Blogging Reminders Sync] Implement blogging reminders local notification schedule

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/bloggingreminders/provider/BloggingRemindersProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/bloggingreminders/provider/BloggingRemindersProvider.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.util.publicdata.ClientVerification
 import org.wordpress.android.util.signature.SignatureNotFoundException
 import javax.inject.Inject
 
-typealias SiteIDBloggingReminderMap = Map<Long?, BloggingRemindersModel?>
+typealias RemoteSiteId = Long
 
 class BloggingRemindersProvider : QueryContentProvider() {
     @Inject lateinit var bloggingRemindersStore: BloggingRemindersStore
@@ -53,7 +53,9 @@ class BloggingRemindersProvider : QueryContentProvider() {
                         val filteredSiteIds = filteredBloggingReminders.map { bloggingReminder ->
                             siteStore.getSiteIdForLocalId(bloggingReminder.siteId)
                         }
-                        val result: SiteIDBloggingReminderMap = filteredSiteIds.zip(filteredBloggingReminders).toMap()
+                        val result: Map<RemoteSiteId?, BloggingRemindersModel?> = filteredSiteIds.zip(
+                                filteredBloggingReminders
+                        ).toMap()
                         queryResult.createCursor(result)
                     }
                 } else null

--- a/WordPress/src/main/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolver.kt
@@ -68,6 +68,7 @@ class BloggingRemindersResolver @Inject constructor(
                     object : TypeToken<Map<RemoteSiteId?, BloggingRemindersModel?>>() {}.type
             ) ?: emptyMap()
 
+    @Suppress("ReturnCount")
     private fun shouldTrySyncBloggingReminders(): Boolean {
         val isFeatureFlagEnabled = jetpackBloggingRemindersSyncFlag.isEnabled()
         if (!isFeatureFlagEnabled) {

--- a/WordPress/src/main/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolver.kt
@@ -9,17 +9,23 @@ import org.wordpress.android.bloggingreminders.BloggingRemindersSyncAnalyticsTra
 import org.wordpress.android.bloggingreminders.BloggingRemindersSyncAnalyticsTracker.ErrorType
 import org.wordpress.android.bloggingreminders.JetpackBloggingRemindersSyncFlag
 import org.wordpress.android.bloggingreminders.provider.BloggingRemindersProvider
-import org.wordpress.android.bloggingreminders.provider.SiteIDBloggingReminderMap
+import org.wordpress.android.bloggingreminders.provider.RemoteSiteId
+import org.wordpress.android.fluxc.model.BloggingRemindersModel
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.APPLICATION_SCOPE
 import org.wordpress.android.provider.query.QueryResult
 import org.wordpress.android.resolver.ContentResolverWrapper
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersModelMapper
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.extensions.filterNull
 import org.wordpress.android.util.publicdata.WordPressPublicData
 import org.wordpress.android.viewmodel.ContextProvider
+import org.wordpress.android.workers.reminder.ReminderScheduler
 import javax.inject.Inject
 import javax.inject.Named
+
+typealias RemoteSiteIdBloggingRemindersMap = Map<RemoteSiteId, BloggingRemindersModel>
 
 class BloggingRemindersResolver @Inject constructor(
     private val jetpackBloggingRemindersSyncFlag: JetpackBloggingRemindersSyncFlag,
@@ -31,28 +37,20 @@ class BloggingRemindersResolver @Inject constructor(
     private val bloggingRemindersSyncAnalyticsTracker: BloggingRemindersSyncAnalyticsTracker,
     private val siteStore: SiteStore,
     private val bloggingRemindersStore: BloggingRemindersStore,
-    @Named(APPLICATION_SCOPE) private val coroutineScope: CoroutineScope
+    @Named(APPLICATION_SCOPE) private val coroutineScope: CoroutineScope,
+    private val reminderScheduler: ReminderScheduler,
+    private val bloggingRemindersModelMapper: BloggingRemindersModelMapper
 ) {
     fun trySyncBloggingReminders(onSuccess: () -> Unit, onFailure: () -> Unit) {
-        val isFeatureFlagEnabled = jetpackBloggingRemindersSyncFlag.isEnabled()
-        if (!isFeatureFlagEnabled) {
+        if (!shouldTrySyncBloggingReminders()) {
             onFailure()
             return
         }
-        val isFirstTry = appPrefsWrapper.getIsFirstTryBloggingRemindersSyncJetpack()
-        if (!isFirstTry) {
-            onFailure()
-            return
-        }
-        bloggingRemindersSyncAnalyticsTracker.trackStart()
-        appPrefsWrapper.saveIsFirstTryBloggingRemindersSyncJetpack(false)
         val bloggingRemindersResultCursor = getBloggingRemindersSyncResultCursor()
         if (bloggingRemindersResultCursor != null) {
-            val siteModelBloggingReminderMap = queryResult.getValue<SiteIDBloggingReminderMap>(
-                        bloggingRemindersResultCursor, object : TypeToken<SiteIDBloggingReminderMap?>() {}.type
-            ) ?: emptyMap()
-            if (siteModelBloggingReminderMap.isNotEmpty()) {
-                val success = syncBloggingReminders(siteModelBloggingReminderMap)
+            val remindersMap = mapBloggingRemindersResultCursor(bloggingRemindersResultCursor).filterNull()
+            if (remindersMap.isNotEmpty()) {
+                val success = setBloggingReminders(remindersMap)
                 if (success) onSuccess() else onFailure()
             } else {
                 bloggingRemindersSyncAnalyticsTracker.trackSuccess(0)
@@ -62,6 +60,26 @@ class BloggingRemindersResolver @Inject constructor(
             bloggingRemindersSyncAnalyticsTracker.trackFailed(ErrorType.QueryBloggingRemindersError)
             onFailure()
         }
+    }
+
+    private fun mapBloggingRemindersResultCursor(bloggingRemindersResultCursor: Cursor) =
+            queryResult.getValue<Map<RemoteSiteId?, BloggingRemindersModel?>>(
+                    bloggingRemindersResultCursor,
+                    object : TypeToken<Map<RemoteSiteId?, BloggingRemindersModel?>>() {}.type
+            ) ?: emptyMap()
+
+    private fun shouldTrySyncBloggingReminders(): Boolean {
+        val isFeatureFlagEnabled = jetpackBloggingRemindersSyncFlag.isEnabled()
+        if (!isFeatureFlagEnabled) {
+            return false
+        }
+        val isFirstTry = appPrefsWrapper.getIsFirstTryBloggingRemindersSyncJetpack()
+        if (!isFirstTry) {
+            return false
+        }
+        bloggingRemindersSyncAnalyticsTracker.trackStart()
+        appPrefsWrapper.saveIsFirstTryBloggingRemindersSyncJetpack(false)
+        return true
     }
 
     private fun getBloggingRemindersSyncResultCursor(): Cursor? {
@@ -74,28 +92,38 @@ class BloggingRemindersResolver @Inject constructor(
     }
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    private fun syncBloggingReminders(siteIdBloggingReminderMap: SiteIDBloggingReminderMap): Boolean {
+    private fun setBloggingReminders(remindersMap: RemoteSiteIdBloggingRemindersMap): Boolean {
         try {
             coroutineScope.launch {
-                var remindersSyncedCount = 0
-                for ((siteId, bloggingReminder) in siteIdBloggingReminderMap) {
-                    if (siteId == null || bloggingReminder == null) {
-                        continue
-                    }
+                var syncCount = 0
+                for ((siteId, bloggingReminder) in remindersMap) {
                     val siteLocalId = siteStore.getLocalIdForRemoteSiteId(siteId)
-                    val isBloggingReminderAlreadySet = bloggingRemindersStore.bloggingRemindersModel(siteLocalId)
-                            .first().enabledDays.isNotEmpty()
-                    if (siteLocalId != 0 && !isBloggingReminderAlreadySet) {
-                        remindersSyncedCount = remindersSyncedCount.inc()
-                        bloggingRemindersStore.updateBloggingReminders(bloggingReminder.copy(siteId = siteLocalId))
+                    if (siteLocalId != 0 && !isBloggingReminderAlreadySet(siteLocalId)) {
+                        val bloggingReminderWithLocalId = bloggingReminder.copy(siteId = siteLocalId)
+                        bloggingRemindersStore.updateBloggingReminders(bloggingReminderWithLocalId)
+                        setLocalReminderNotification(bloggingReminderWithLocalId)
+                        syncCount = syncCount.inc()
                     }
                 }
-                bloggingRemindersSyncAnalyticsTracker.trackSuccess(remindersSyncedCount)
+                bloggingRemindersSyncAnalyticsTracker.trackSuccess(syncCount)
             }
             return true
         } catch (exception: Exception) {
             bloggingRemindersSyncAnalyticsTracker.trackFailed(ErrorType.UpdateBloggingRemindersError)
             return false
         }
+    }
+
+    private suspend fun isBloggingReminderAlreadySet(siteLocalId: Int) =
+            bloggingRemindersStore.bloggingRemindersModel(siteLocalId).first().enabledDays.isNotEmpty()
+
+    private fun setLocalReminderNotification(bloggingRemindersModel: BloggingRemindersModel) {
+        val bloggingRemindersUiModel = bloggingRemindersModelMapper.toUiModel(bloggingRemindersModel)
+        reminderScheduler.schedule(
+                bloggingRemindersUiModel.siteId,
+                bloggingRemindersUiModel.hour,
+                bloggingRemindersUiModel.minute,
+                bloggingRemindersUiModel.toReminderConfig()
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolver.kt
@@ -45,7 +45,7 @@ class SharedLoginResolver @Inject constructor(
         appPrefsWrapper.saveIsFirstTrySharedLoginJetpack(false)
         val accessTokenCursor = getAccessTokenCursor()
         if (accessTokenCursor != null) {
-            val accessToken = queryResult.getValue<String>(accessTokenCursor) ?: ""
+            val accessToken = queryResult.getValue(accessTokenCursor) ?: ""
             if (accessToken.isNotEmpty()) {
                 sharedLoginAnalyticsTracker.trackLoginSuccess()
                 dispatchUpdateAccessToken(accessToken)

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.bloggingreminders
 
+import org.wordpress.android.workers.reminder.ReminderConfig.WeeklyReminder
 import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
@@ -18,4 +19,6 @@ data class BloggingRemindersUiModel(
 
     fun getNotificationTime24hour(): CharSequence =
             LocalTime.of(hour, minute).format(DateTimeFormatter.ofPattern("HH:mm", Locale.ROOT))
+
+    fun toReminderConfig() = WeeklyReminder(this.enabledDays)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.util.merge
 import org.wordpress.android.util.perform
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
-import org.wordpress.android.workers.reminder.ReminderConfig.WeeklyReminder
 import org.wordpress.android.workers.reminder.ReminderScheduler
 import java.time.DayOfWeek
 import javax.inject.Inject
@@ -279,9 +278,6 @@ class BloggingRemindersViewModel @Inject constructor(
             null -> Unit // Do nothing
         }
     }
-
-    private fun BloggingRemindersUiModel.toReminderConfig() =
-            WeeklyReminder(this.enabledDays)
 
     enum class Screen(val trackingName: String) {
         PROLOGUE("main"), // displayed after post is published

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/MapExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/MapExtensions.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.util.extensions
+
+@Suppress("UNCHECKED_CAST")
+fun <K, V> Map<K?, V?>.filterNull(): Map<K, V> =
+        (filterValues { it != null } as Map<K?, V>)
+                .filterKeys { it != null } as Map<K, V>

--- a/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolverTest.kt
@@ -26,9 +26,13 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.provider.query.QueryResult
 import org.wordpress.android.resolver.ContentResolverWrapper
 import org.wordpress.android.test
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersModelMapper
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersUiModel
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.publicdata.WordPressPublicData
 import org.wordpress.android.viewmodel.ContextProvider
+import org.wordpress.android.workers.reminder.ReminderScheduler
+import java.time.DayOfWeek
 
 @ExperimentalCoroutinesApi
 class BloggingRemindersResolverTest {
@@ -44,6 +48,8 @@ class BloggingRemindersResolverTest {
     private val bloggingRemindersSyncAnalyticsTracker: BloggingRemindersSyncAnalyticsTracker = mock()
     private val siteStore: SiteStore = mock()
     private val bloggingRemindersStore: BloggingRemindersStore = mock()
+    private val reminderScheduler: ReminderScheduler = mock()
+    private val bloggingRemindersModelMapper: BloggingRemindersModelMapper = mock()
     private val classToTest = BloggingRemindersResolver(
             jetpackBloggingRemindersSyncFlag,
             contextProvider,
@@ -54,7 +60,9 @@ class BloggingRemindersResolverTest {
             bloggingRemindersSyncAnalyticsTracker,
             siteStore,
             bloggingRemindersStore,
-            coroutineScope
+            coroutineScope,
+            reminderScheduler,
+            bloggingRemindersModelMapper
     )
 
     private val context: Context = mock()
@@ -63,8 +71,11 @@ class BloggingRemindersResolverTest {
     private val wordPressCurrentPackageId = "packageId"
     private val uriValue = "content://$wordPressCurrentPackageId.${BloggingRemindersProvider::class.simpleName}"
     private val validLocalId = 123
-    private val userSetBloggingRemindersModel = BloggingRemindersModel(validLocalId, setOf(MONDAY))
+    private val userSetBloggingRemindersModel = BloggingRemindersModel(validLocalId, setOf(MONDAY), 5, 43, false)
     private val defaultBloggingRemindersModel = BloggingRemindersModel(validLocalId)
+    private val bloggingRemindersUiModel = BloggingRemindersUiModel(
+            validLocalId, setOf(DayOfWeek.MONDAY), 5, 43, false
+    )
 
     @Before
     fun setup() {
@@ -164,12 +175,15 @@ class BloggingRemindersResolverTest {
 
     @Test
     fun `Should track success if result map has entries`() = test {
+        whenever(bloggingRemindersModelMapper.toUiModel(any())).thenReturn(bloggingRemindersUiModel)
         whenever(siteStore.getLocalIdForRemoteSiteId(123L)).thenReturn(validLocalId)
         whenever(bloggingRemindersStore.bloggingRemindersModel(validLocalId))
                 .thenReturn(flowOf(defaultBloggingRemindersModel))
         featureEnabled()
-        whenever(mockCursor.getString(0)).thenReturn("{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
-                ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}")
+        whenever(mockCursor.getString(0)).thenReturn(
+                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+        )
         classToTest.trySyncBloggingReminders({}, {})
         verify(bloggingRemindersSyncAnalyticsTracker).trackSuccess(1)
     }
@@ -180,8 +194,10 @@ class BloggingRemindersResolverTest {
                 .thenReturn(flowOf(userSetBloggingRemindersModel))
         whenever(siteStore.getLocalIdForRemoteSiteId(123L)).thenReturn(validLocalId)
         featureEnabled()
-        whenever(mockCursor.getString(0)).thenReturn("{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
-                ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}")
+        whenever(mockCursor.getString(0)).thenReturn(
+                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+        )
         val onSuccess: () -> Unit = mock()
         classToTest.trySyncBloggingReminders(onSuccess) {}
         verify(onSuccess).invoke()
@@ -189,12 +205,15 @@ class BloggingRemindersResolverTest {
 
     @Test
     fun `Should update blogging reminder if site local ID is valid AND store returns default reminder`() = test {
+        whenever(bloggingRemindersModelMapper.toUiModel(any())).thenReturn(bloggingRemindersUiModel)
         whenever(siteStore.getLocalIdForRemoteSiteId(123)).thenReturn(validLocalId)
         whenever(bloggingRemindersStore.bloggingRemindersModel(validLocalId))
                 .thenReturn(flowOf(defaultBloggingRemindersModel))
         featureEnabled()
-        whenever(mockCursor.getString(0)).thenReturn("{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
-                ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}")
+        whenever(mockCursor.getString(0)).thenReturn(
+                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+        )
         classToTest.trySyncBloggingReminders({}, {})
         verify(bloggingRemindersStore, times(1)).updateBloggingReminders(
                 BloggingRemindersModel(
@@ -208,14 +227,51 @@ class BloggingRemindersResolverTest {
     }
 
     @Test
+    fun `Should map blogging reminder when setting local notification`() = test {
+        whenever(bloggingRemindersModelMapper.toUiModel(any())).thenReturn(bloggingRemindersUiModel)
+        whenever(siteStore.getLocalIdForRemoteSiteId(123)).thenReturn(validLocalId)
+        whenever(bloggingRemindersStore.bloggingRemindersModel(validLocalId))
+                .thenReturn(flowOf(defaultBloggingRemindersModel))
+        featureEnabled()
+        whenever(mockCursor.getString(0)).thenReturn(
+                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+        )
+        classToTest.trySyncBloggingReminders({}, {})
+        verify(bloggingRemindersModelMapper).toUiModel(userSetBloggingRemindersModel)
+    }
+
+    @Test
+    fun `Should schedule blogging reminder local notification`() = test {
+        whenever(bloggingRemindersModelMapper.toUiModel(any())).thenReturn(bloggingRemindersUiModel)
+        whenever(siteStore.getLocalIdForRemoteSiteId(123)).thenReturn(validLocalId)
+        whenever(bloggingRemindersStore.bloggingRemindersModel(validLocalId))
+                .thenReturn(flowOf(defaultBloggingRemindersModel))
+        featureEnabled()
+        whenever(mockCursor.getString(0)).thenReturn(
+                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+        )
+        classToTest.trySyncBloggingReminders({}, {})
+        verify(reminderScheduler).schedule(
+                validLocalId,
+                bloggingRemindersUiModel.hour,
+                bloggingRemindersUiModel.minute,
+                bloggingRemindersUiModel.toReminderConfig()
+        )
+    }
+
+    @Test
     fun `Should NOT update blogging reminder if site local ID is invalid`() = test {
         val invalidLocalId = 0
         whenever(bloggingRemindersStore.bloggingRemindersModel(invalidLocalId))
                 .thenReturn(flowOf(defaultBloggingRemindersModel))
         whenever(siteStore.getLocalIdForRemoteSiteId(123)).thenReturn(invalidLocalId)
         featureEnabled()
-        whenever(mockCursor.getString(0)).thenReturn("{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
-                ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}")
+        whenever(mockCursor.getString(0)).thenReturn(
+                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+        )
         classToTest.trySyncBloggingReminders({}, {})
         verify(bloggingRemindersStore, times(0)).updateBloggingReminders(any())
     }
@@ -226,8 +282,10 @@ class BloggingRemindersResolverTest {
                 .thenReturn(flowOf(userSetBloggingRemindersModel))
         whenever(siteStore.getLocalIdForRemoteSiteId(123)).thenReturn(validLocalId)
         featureEnabled()
-        whenever(mockCursor.getString(0)).thenReturn("{\"123\":{\"enabledDays\":[],\"hour\":5" +
-                ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}")
+        whenever(mockCursor.getString(0)).thenReturn(
+                "{\"123\":{\"enabledDays\":[],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+        )
         classToTest.trySyncBloggingReminders({}, {})
         verify(bloggingRemindersStore, times(0)).updateBloggingReminders(any())
     }

--- a/WordPress/src/test/java/org/wordpress/android/util/extensions/MapExtensionsKtTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/extensions/MapExtensionsKtTest.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.util.extensions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class MapExtensionsKtTest {
+    @Test
+    fun `Should filter null keys and values in filterNull`() {
+        mapOf(0 to "0", null to "1", 2 to null, 3 to "3", null to null)
+                .filterNull().forEach { (key, value) ->
+                    assertThat(key).isNotNull
+                    assertThat(value).isNotNull
+                }
+    }
+}


### PR DESCRIPTION
Fixes #17328 

To test:
1 - Install WordPress and log in;
2 - Add blogging prompts to a couple of different sites;
3 - Set the flag `isFeatureFlagEnabled` to `true` on `SharedLoginResolver.kt`, `UserFlagsResolver.kt` **and** `BloggingRemindersResolver.kt` (this cannot be done using the `Debug settings` screen because that is only available when the user is already logged in);
4 - Replace `jetpackProviderSyncFeatureConfig.isEnabled()` with `true` on `SharedLoginProvider.kt`, `UserFlagsProvider.kt` **and** `BloggingRemindersProvider.kt`.
5 - Install Jetpack using the same variant (e.g. if installed WordPress version was `jalapenoDebug`, install Jetpack `jalapenoDebug`);
6 - Jetpack should login automatically after launching, and home screen should be shown;
7 - Check if the blogging prompts set on step 2 were set correctly in the site settings.
8 - Change the device date/time ahead of the scheduled time of the reminder. A local notification should be triggered, and tapping on it should open the Editor.

## Regression Notes
1. Potential unintended areas of impact
None since this is behind a feature flag, but we have to take care of the place the blogging resolver is called (right now it's called in the fetch sites callback).

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests.

3. What automated tests I added (or what prevented me from doing so)
Updated existing unit tests and added new.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
