### PR TITLE
Merge release/21.0 after code freeze and 21.0-rc-1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+21.1
+-----
+
+
 21.0
 -----
 * [***] [internal] Updates the target sdk to 31 - Android 12 [https://github.com/wordpress-mobile/WordPress-Android/pull/17153]

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,3 +1,6 @@
-- “Get to know your app” flows now stay on screen after rotating your device.
-- Long titles display properly on Stats cards without being cut off.
-- We added the Enter key to Post excerpts to allow for easy line breaks.
+* [***] [internal] Updates the target sdk to 31 - Android 12 [https://github.com/wordpress-mobile/WordPress-Android/pull/17153]
+* [***] Updated About screen for WordPress and Jetpack apps to their respective urls. [https://github.com/wordpress-mobile/WordPress-Android/pull/17282]
+* [*] Updates splash screen for Android 12+ [https://github.com/wordpress-mobile/WordPress-Android/pull/17273]
+* [*] Fix text color of success messages in the QR code login flow [https://github.com/wordpress-mobile/WordPress-Android/pull/17286]
+* [*] Stats: Fix Western Arabic Numerals not being shown on every text of the stats screens in Arabic languages [https://github.com/wordpress-mobile/WordPress-Android/pull/17217]
+

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,5 +1,5 @@
 * [***] [internal] Updates the target sdk to 31 - Android 12 [https://github.com/wordpress-mobile/WordPress-Android/pull/17153]
-* [***] Updated About screen for WordPress and Jetpack apps to their respective urls. [https://github.com/wordpress-mobile/WordPress-Android/pull/17282]
+* [*] Updated About screen to use correct urls. [https://github.com/wordpress-mobile/WordPress-Android/pull/17282]
 * [*] Updates splash screen for Android 12+ [https://github.com/wordpress-mobile/WordPress-Android/pull/17273]
 * [*] Fix text color of success messages in the QR code login flow [https://github.com/wordpress-mobile/WordPress-Android/pull/17286]
 * [*] Stats: Fix Western Arabic Numerals not being shown on every text of the stats screens in Arabic languages [https://github.com/wordpress-mobile/WordPress-Android/pull/17217]

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,3 +1,6 @@
-- “Get to know your app” flows now stay on screen after rotating your device.
-- Long titles display properly on Stats cards without being cut off.
-- We added the Enter key to Post excerpts to allow for easy line breaks.
+* [***] [internal] Updates the target sdk to 31 - Android 12 [https://github.com/wordpress-mobile/WordPress-Android/pull/17153]
+* [***] Updated About screen for WordPress and Jetpack apps to their respective urls. [https://github.com/wordpress-mobile/WordPress-Android/pull/17282]
+* [*] Updates splash screen for Android 12+ [https://github.com/wordpress-mobile/WordPress-Android/pull/17273]
+* [*] Fix text color of success messages in the QR code login flow [https://github.com/wordpress-mobile/WordPress-Android/pull/17286]
+* [*] Stats: Fix Western Arabic Numerals not being shown on every text of the stats screens in Arabic languages [https://github.com/wordpress-mobile/WordPress-Android/pull/17217]
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,5 +1,5 @@
 * [***] [internal] Updates the target sdk to 31 - Android 12 [https://github.com/wordpress-mobile/WordPress-Android/pull/17153]
-* [***] Updated About screen for WordPress and Jetpack apps to their respective urls. [https://github.com/wordpress-mobile/WordPress-Android/pull/17282]
+* [*] Updated About screen to remove mentions of Automattic apps. [https://github.com/wordpress-mobile/WordPress-Android/pull/17282]
 * [*] Updates splash screen for Android 12+ [https://github.com/wordpress-mobile/WordPress-Android/pull/17273]
 * [*] Fix text color of success messages in the QR code login flow [https://github.com/wordpress-mobile/WordPress-Android/pull/17286]
 * [*] Stats: Fix Western Arabic Numerals not being shown on every text of the stats screens in Arabic languages [https://github.com/wordpress-mobile/WordPress-Android/pull/17217]

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,5 +1,5 @@
 * [***] [internal] Updates the target sdk to 31 - Android 12 [https://github.com/wordpress-mobile/WordPress-Android/pull/17153]
-* [*] Updated About screen to remove mentions of Automattic apps. [https://github.com/wordpress-mobile/WordPress-Android/pull/17282]
+* [*] Updated About screen to move the Automattic apps marbles to the Jetpack app only. [https://github.com/wordpress-mobile/WordPress-Android/pull/17282]
 * [*] Updates splash screen for Android 12+ [https://github.com/wordpress-mobile/WordPress-Android/pull/17273]
 * [*] Fix text color of success messages in the QR code login flow [https://github.com/wordpress-mobile/WordPress-Android/pull/17286]
 * [*] Stats: Fix Western Arabic Numerals not being shown on every text of the stats screens in Arabic languages [https://github.com/wordpress-mobile/WordPress-Android/pull/17217]

--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,12 @@ plugins {
 }
 
 ext {
-    wordPressUtilsVersion = 'trunk-bc2b41b8adbd28462209bdd654cde074a36a4c0a'
-    wordPressLoginVersion = 'trunk-86258aa940fe32e0d4bfd0a91fe147c80845c19b'
+    wordPressUtilsVersion = '3.0.0'
+    wordPressLoginVersion = '1.0.0'
     aztecVersion = 'v1.6.2'
     gutenbergMobileVersion = 'v1.84.0'
-    storiesVersion = 'trunk-4926f0d5d34adf6a63bd67586a7e56420caa43da'
-    aboutAutomatticVersion = 'trunk-6f46a8aa2abbfa28aa2c65f6b66969abdcf3e8c2'
+    storiesVersion = '2.0.0'
+    aboutAutomatticVersion = '1.0.0'
 
     minSdkVersion = 24
     compileSdkVersion = 31
@@ -24,7 +24,7 @@ ext {
     coroutinesVersion = '1.5.2'
     androidxWorkVersion = "2.7.0"
 
-    fluxCVersion = 'trunk-065315b4d0a57112dfe8a37d379431735063bc82'
+    fluxCVersion = '2.0.0'
 
     appCompatVersion = '1.0.2'
     androidxCoreVersion = '1.3.2'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,7 @@ UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Hel
 
 APP_SPECIFIC_VALUES = {
   wordpress: {
+    display_name: 'WordPress',
     metadata_dir: 'metadata',
     glotpress_appstrings_project: 'https://translate.wordpress.org/projects/apps/android/dev/',
     glotpress_metadata_project: 'https://translate.wordpress.org/projects/apps/android/release-notes/',
@@ -9,6 +10,7 @@ APP_SPECIFIC_VALUES = {
     bundle_name_prefix: 'wpandroid'
   },
   jetpack: {
+    display_name: 'Jetpack',
     metadata_dir: 'jetpack_metadata',
     glotpress_appstrings_project: 'https://translate.wordpress.com/projects/jetpack/apps/android/',
     glotpress_metadata_project: 'https://translate.wordpress.com/projects/jetpack/apps/android/release-notes/',

--- a/fastlane/jetpack_resources/values/strings.xml
+++ b/fastlane/jetpack_resources/values/strings.xml
@@ -13,8 +13,6 @@
     <string name="app_tagline">Site security and performance from your pocket</string>
     <string name="continue_with_wpcom_no_signup">Continue with WordPress.com</string>
     <string name="login_prologue_revamped_content_description_jetpack_logo">Jetpack logo</string>
-    <string name="login_prologue_revamped_content_description_bg">Jetpack background</string>
-    <string name="login_prologue_revamped_content_description_top_bg">Jetpack top background fade</string>
 
     <string name="login_prologue_revamped_jetpack_feature_text_1">Update a plugin</string>
     <string name="login_prologue_revamped_jetpack_feature_text_2">Build a site</string>

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -11,7 +11,6 @@ ALL_LOCALES = [
   # First are the locales which are used for *both* downloading the `strings.xml` files from GlotPress *and* for generating the release notes XML files.
   { glotpress: 'ar', android: 'ar',    google_play: 'ar',     promo_config: {} },
   { glotpress: 'de', android: 'de',    google_play: 'de-DE',  promo_config: {} },
-  { glotpress: 'en-gb', android: 'en-rGB', google_play: 'en-US', promo_config: {} },
   { glotpress: 'es', android: 'es', google_play: 'es-ES', promo_config: {} },
   { glotpress: 'fr', android: 'fr-rCA', google_play: 'fr-CA', promo_config: false },
   { glotpress: 'fr', android: 'fr',    google_play: 'fr-FR',  promo_config: {} },
@@ -209,70 +208,47 @@ platform :android do
   #####################################################################################
   desc 'Downloads translated metadata from GlotPress'
   lane :download_metadata_strings do |options|
-    download_wordpress_metadata_strings(options)
-    download_jetpack_metadata_strings(options)
-  end
+    version = options.fetch(:version, android_get_app_version)
+    build_number = options.fetch(:build_number, android_get_release_version['code'])
 
-  desc "Downloads WordPress's translated metadata from GlotPress"
-  lane :download_wordpress_metadata_strings do |options|
-    app_values = APP_SPECIFIC_VALUES[:wordpress]
-    values = options[:version].split('.')
-    files = {
-      "release_note_#{values[0]}#{values[1]}" => { desc: "changelogs/#{options[:build_number]}.txt", max_size: 500, alternate_key: "release_note_short_#{values[0]}#{values[1]}" },
-      play_store_app_title: { desc: 'title.txt', max_size: 30 },
-      play_store_promo: { desc: 'short_description.txt', max_size: 80 },
-      play_store_desc: { desc: 'full_description.txt', max_size: 4000 }
-    }
+    # If no `app:` is specified, call this for both WordPress and Jetpack
+    apps = options[:app].nil? ? %i[wordpress jetpack] : Array(options[:app]&.downcase&.to_sym)
 
-    delete_old_changelogs(app: 'wordpress', build: options[:build_number])
-    download_path = File.join(Dir.pwd, app_values[:metadata_dir], 'android')
-    # The case for the source locale (en-US) is pulled in a hacky way, by having an {en-gb => en-US} mapping as part of the WP_RELEASE_NOTES_LOCALES,
-    # which is then treated in a special way by gp_downloadmetadata by specifying a `source_locale: 'en-US'` to process it differently from the rest.
-    gp_downloadmetadata(
-      project_url: app_values[:glotpress_metadata_project],
-      target_files: files,
-      locales: WP_RELEASE_NOTES_LOCALES,
-      source_locale: 'en-US',
-      download_path: download_path
-    )
+    apps.each do |app|
+      app_values = APP_SPECIFIC_VALUES[app]
 
-    git_add(path: download_path)
-    git_commit(path: download_path, message: "Update WordPress metadata translations for #{options[:version]}", allow_nothing_to_commit: true)
-    push_to_git_remote
-  end
+      version_suffix = version.split('.').join
+      files = {
+        "release_note_#{version_suffix}" => { desc: "changelogs/#{build_number}.txt", max_size: 500, alternate_key: "release_note_short_#{version_suffix}" },
+        play_store_app_title: { desc: 'title.txt', max_size: 30 },
+        play_store_promo: { desc: 'short_description.txt', max_size: 80 },
+        play_store_desc: { desc: 'full_description.txt', max_size: 4000 }
+      }
 
-  desc "Downloads Jetpack's translated metadata from GlotPress"
-  lane :download_jetpack_metadata_strings do |options|
-    UI.message('Hey')
-    app_values = APP_SPECIFIC_VALUES[:jetpack]
-    values = options[:version].split('.')
-    files = {
-      "release_note_#{values[0]}#{values[1]}" => { desc: "changelogs/#{options[:build_number]}.txt", max_size: 500, alternate_key: "release_note_short_#{values[0]}#{values[1]}" },
-      play_store_app_title: { desc: 'title.txt', max_size: 30 },
-      play_store_promo: { desc: 'short_description.txt', max_size: 80 },
-      play_store_desc: { desc: 'full_description.txt', max_size: 4000 }
-    }
+      delete_old_changelogs(app: app, build: build_number)
 
-    delete_old_changelogs(app: 'jetpack', build: options[:build_number])
-    download_path = File.join(Dir.pwd, app_values[:metadata_dir], 'android')
-    gp_downloadmetadata(
-      project_url: app_values[:glotpress_metadata_project],
-      target_files: files,
-      locales: JP_RELEASE_NOTES_LOCALES,
-      download_path: download_path
-    )
+      download_path = File.join(Dir.pwd, app_values[:metadata_dir], 'android')
+      locales = { wordpress: WP_RELEASE_NOTES_LOCALES, jetpack: JP_RELEASE_NOTES_LOCALES }[app]
+      UI.header("Downloading metadata translations for #{app_values[:display_name]}")
+      gp_downloadmetadata(
+        project_url: app_values[:glotpress_metadata_project],
+        target_files: files,
+        locales: locales,
+        download_path: download_path
+      )
 
-    # For WordPress, the en-US release notes come from using the source keys (instead of translations) downloaded from GlotPress' en-gb locale (which is unused otherwise).
-    # But for Jetpack, we don't have an unused locale like en-gb in the GP release notes project, so copy from source instead as a fallback
-    metadata_source_dir = File.join(Dir.pwd, '..', 'WordPress', 'jetpack_metadata')
-    FileUtils.cp(File.join(metadata_source_dir, 'release_notes.txt'), File.join(download_path, 'en-US', 'changelogs', "#{options[:build_number]}.txt"))
-    FileUtils.cp(
-      ['title.txt', 'short_description.txt', 'full_description.txt'].map { |f| File.join(metadata_source_dir, f) },
-      File.join(download_path, 'en-US')
-    )
-
-    git_add(path: download_path)
-    git_commit(path: download_path, message: "Update Jetpack metadata translations for #{options[:version]}", allow_nothing_to_commit: true)
+      # Copy the source `.txt` files (used as source of truth when we generated the `.po`) to the `fastlane/*metadata/android/en-US` dir,
+      # as `en-US` is the source language, and isn't exported from GlotPress during `gp_downloadmetadata`
+      metadata_source_dir = File.join(PROJECT_ROOT_FOLDER, 'WordPress', app_values[:metadata_dir])
+      FileUtils.cp(File.join(metadata_source_dir, 'release_notes.txt'), File.join(download_path, 'en-US', 'changelogs', "#{build_number}.txt"))
+      FileUtils.cp(
+        ['title.txt', 'short_description.txt', 'full_description.txt'].map { |f| File.join(metadata_source_dir, f) },
+        File.join(download_path, 'en-US')
+      )
+    
+      git_add(path: download_path)
+      git_commit(path: download_path, message: "Update #{app_values[:display_name]} metadata translations for #{version}", allow_nothing_to_commit: true)
+    end
     push_to_git_remote
   end
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -314,7 +314,7 @@ platform :android do
   def get_app_name_option!(options)
     app = options[:app]&.downcase
     UI.user_error!("Missing 'app' parameter. Expected 'app:wordpress' or 'app:jetpack'") if app.nil?
-    unless ['wordpress', 'jetpack'].include?(app)
+    unless %i[wordpress jetpack].include?(app.to_sym)
       UI.user_error!("Invalid 'app' parameter #{app.inspect}. Expected 'wordpress' or 'jetpack'")
     end
     return app

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -4057,6 +4057,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- About -->
     <string name="about_blog">Blog</string>
+    <string name="about_news">News</string>
     <string name="about_automattic_main_page_title" tools:ignore="UnusedResources" a8c-src-lib="about">About %1$s</string>
     <string name="about_automattic_legal_page_title" tools:ignore="UnusedResources" a8c-src-lib="about">Legal and More</string>
     <string name="about_automattic_acknowledgements_page_title" tools:ignore="UnusedResources" a8c-src-lib="about">Acknowledgements</string>
@@ -4068,6 +4069,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="about_automattic_legal_and_more_item_title" tools:ignore="UnusedResources" a8c-src-lib="about">Legal and More</string>
     <string name="about_automattic_family_item_title" tools:ignore="UnusedResources" a8c-src-lib="about">Automattic Family</string>
     <string name="about_automattic_work_with_us_item_title" tools:ignore="UnusedResources" a8c-src-lib="about">Work With Us</string>
+    <string name="about_automattic_contribute_item_title" tools:ignore="UnusedResources" a8c-src-lib="about">Contribute</string>
     <string name="about_automattic_work_with_us_item_subtitle" tools:ignore="UnusedResources" a8c-src-lib="about">Work from Anywhere</string>
     <string name="about_automattic_terms_of_service_item_title" tools:ignore="UnusedResources" a8c-src-lib="about">Terms of Service</string>
     <string name="about_automattic_privacy_policy_item_title" tools:ignore="UnusedResources" a8c-src-lib="about">Privacy Policy</string>

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
-versionName=20.9
-versionCode=1281
+versionName=21.0-rc-1
+versionCode=1282


### PR DESCRIPTION
- [x] New empty entry created in `RELEASE-NOTES.txt` for next iteration.
- [x] `{jetpack_}metadata/release_notes.txt` extracted for WordPress and Jetpack.
- [x] `WordPress/jetpack_metadata/release_notes.txt` audited to remove any item not applicable for Jetpack.
    - See open question for the entry on the About screen update
- [x] Internal dependencies (FluxC, Login. Stories. About…) bumped to a new stable version in `build.gradle` if necessary.
    - _All_ libs have been updated this time around, because all had gone thru the Android 12 / SDK 31 update.
    - I've considered that updating the `targetSdk` to `31` was a breaking change for all the libs, so I took the occasion to bump each of them to next _major_ version.
- [x] `WordPress/src/main/res/values/strings.xml` updated with strings from binary dependencies.
    - At first I was surprised that the logs in my Terminal said `:updated` for many entries, but then ended up with "nothing to commit" and an empty change for the strings, especially given all the lib that had been updated.
    - But then I added some `UI.verbose` logs and re-ran `fastlane --verbose localize_libraries` to check, and indeed the `release-toolkit` says `:updated` even if the update consists of updating the `<string>` node's content… with the exact same copy before/after — which is what obviously happened here, because even if the versions of all the libs were bumped, most of them were only having a new version because of the migration to Android 12, which didn't change any of the strings in the libs, so I'm not sure why I expected any new string in the first place anyway 😄 ☕ 
- [x] New strings frozen/copied into `fastlane/resources/values/strings.xml`.
- [x] Version bumped in `version.properties`