### PR TITLE
Enable the Revamped Landing Screen in the Jetpack app

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 21.1
 -----
-
+* [***] Jetpack App: Redesigned the landing screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17351]
 
 21.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 21.1
 -----
-* [***] Jetpack App: Redesigned the landing screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17351]
+* [***] [Jetpack-only] Redesigned the landing screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17351]
 
 21.0
 -----

--- a/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
@@ -9,4 +9,8 @@ import javax.inject.Inject
  */
 @FeatureInDevelopment
 class LandingScreenRevampFeatureConfig
-@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.LANDING_SCREEN_REVAMP)
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.LANDING_SCREEN_REVAMP) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() || BuildConfig.IS_JETPACK_APP
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
@@ -11,6 +11,6 @@ import javax.inject.Inject
 class LandingScreenRevampFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.LANDING_SCREEN_REVAMP) {
     override fun isEnabled(): Boolean {
-        return super.isEnabled() || BuildConfig.IS_JETPACK_APP
+        return BuildConfig.IS_JETPACK_APP || super.isEnabled()
     }
 }


### PR DESCRIPTION
Fixes #17350

This PR enables the new Landing screen in the Jetpack app by making.

Checking if we are in the Jetpack app proved to be the simpler implementation since the code for deciding which version of the Landing Screen to show is shared for both apps (LoginActivity):
https://github.com/wordpress-mobile/WordPress-Android/blob/7496e01381d4ec48cfcd2df4800202d524851288/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java#L229-L234

To test:
#### 1️⃣ Test Case 1 - Jetpack Revamped Landing Screen
1. Open the Jetpack app and make sure you are logged out.
2. **Expect** The new landing screen to be shown (identifiable by the scrolling prompts).

#### 2️⃣ Test Case 2 - Wordpress Landing Screen - feature flag off
0. **Prerequisite** the `LandingScreenRevamp` feature flag should be disabled
  (if enabled see step **2** from Test Case 3 on how to change it)
2. Open the WordPress app and make sure you are logged out
3. **Expect** The old landing screen to be shown (identifiable by the horizontal carousel).

#### 3️⃣ Test Case 3 - Wordpress Landing Screen - feature flag on
1. Open the WordPress app and make sure you are logged out
2. Enable the `LandingScreenRevamp` feature flag
   1. Log in
   2. Go to `Me` → `App Settings` → `Debug Settings`
   3. Enable `LandingScreenRevampFeatureConfig`(scroll down if necessary)
   4. Tap `RESTART THE APP`
   5. Log out
3. **Expect** The new landing screen to be shown (identifiable by the lack of a horizontal carousel).

## Regression Notes
1. Potential unintended areas of impact
  WordPress App Landing Screen (old vs new) based on the `LandingScreenRevamp` feature flag.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

8. What automated tests I added (or what prevented me from doing so)
   N/a - uses build flags that are rather irrelevant to unit test.

| Before | After |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/196500239-404d34a0-5b55-4b37-a7b2-3becfb8dd03f.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/196500196-f89e6947-4d6d-4c61-9b67-c7d49f2139d3.png"> |

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
