### PR TITLE
Show Jetpack icon for JP app

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -183,6 +183,10 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         if (unifiedAboutFeatureConfig.isEnabled()) {
             aboutTheAppContainer.isVisible = true
 
+            if (BuildConfig.IS_JETPACK_APP) {
+                meAboutIcon.setImageResource(R.drawable.ic_jetpack_logo_white_24dp)
+            }
+
             rowAboutTheApp.setOnClickListener {
                 viewModel.showUnifiedAbout()
             }


### PR DESCRIPTION
Updates About Jetpack row on Me to show Jetpack icon when it is Jetpack app

| Before | After |
|---|---|
|![Screenshot_20221019_134713](https://user-images.githubusercontent.com/990349/196586700-b9fc63eb-0ed7-40eb-be1b-adf69919693a.png)|![Screenshot_20221019_132750](https://user-images.githubusercontent.com/990349/196586729-df93eedb-f232-416b-8e8a-e407392c15fb.png)|



To test:

Test 1:
- Launch Jetpack app
- Navigate to Me (Tap on Avatar at the top right hand corner on Dashboard)
- Check that icon for About Jetpack has Jetpack icon and not WordPress icon (see after above)

Test 2:
- Launch WordPress app
- Navigate to Me 
- Check that icon for About Wordpress has WordPress icon and not Jetpack icon (see before above)

## Regression Notes
1. Potential unintended areas of impact
None


3. What I did to test those areas of impact (or what existing automated tests I relied on)
Checked on both JP and WP variants

4. What automated tests I added (or what prevented me from doing so)
Existing tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
