### PR TITLE
Detekt - Resolve/Suppress All Baseline Warnings - Long methods warnings_ MediaPickerActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -173,7 +173,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         return super.onOptionsItemSelected(item)
     }
 
-    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION", "LongMethod", "NestedBlockDepth")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION",)
     override fun onActivityResult(
         requestCode: Int,
         resultCode: Int,
@@ -191,29 +191,8 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
                     return
                 }
             }
-            TAKE_PHOTO -> {
-                try {
-                    val intent = Intent()
-                    mediaCapturePath!!.let {
-                        WPMediaUtils.scanMediaFile(this, it)
-                        val f = File(it)
-                        val capturedImageUri = listOf(Uri.fromFile(f))
-                        if (mediaPickerSetup.queueResults) {
-                            intent.putQueuedUris(capturedImageUri)
-                        } else {
-                            intent.putUris(capturedImageUri)
-                        }
-                        intent.putExtra(
-                                EXTRA_MEDIA_SOURCE,
-                                ANDROID_CAMERA.name
-                        )
-                    }
-                    intent
-                } catch (e: RuntimeException) {
-                    AppLog.e(MEDIA, e)
-                    null
-                }
-            }
+            TAKE_PHOTO -> takeAPhoto()
+
             IMAGE_EDITOR_EDIT_IMAGE -> {
                 data?.let {
                     val intent = Intent()
@@ -238,6 +217,28 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
             setResult(Activity.RESULT_OK, intent)
             finish()
         }
+    }
+
+    private fun takeAPhoto() = try {
+        val intent = Intent()
+        mediaCapturePath!!.let {
+            WPMediaUtils.scanMediaFile(this, it)
+            val f = File(it)
+            val capturedImageUri = listOf(Uri.fromFile(f))
+            if (mediaPickerSetup.queueResults) {
+                intent.putQueuedUris(capturedImageUri)
+            } else {
+                intent.putUris(capturedImageUri)
+            }
+            intent.putExtra(
+                    EXTRA_MEDIA_SOURCE,
+                    ANDROID_CAMERA.name
+            )
+        }
+        intent
+    } catch (e: RuntimeException) {
+        AppLog.e(MEDIA, e)
+        null
     }
 
     private fun launchChooserWithContext(openSystemPicker: OpenSystemPicker, uiHelpers: UiHelpers) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -173,7 +173,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         return super.onOptionsItemSelected(item)
     }
 
-    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION",)
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun onActivityResult(
         requestCode: Int,
         resultCode: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -192,31 +192,29 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
                 }
             }
             TAKE_PHOTO -> takeAPhoto()
-
-            IMAGE_EDITOR_EDIT_IMAGE -> {
-                data?.let {
-                    val intent = Intent()
-                    val uris = WPMediaUtils.retrieveImageEditorResult(data)
-                    if (mediaPickerSetup.queueResults) {
-                        intent.putQueuedUris(uris)
-                    } else {
-                        intent.putUris(uris)
-                    }
-                    intent.putExtra(
-                            EXTRA_MEDIA_SOURCE,
-                            APP_PICKER.name
-                    )
-                    intent
-                }
-            }
-            else -> {
-                data
-            }
+            IMAGE_EDITOR_EDIT_IMAGE -> data?.let { editImageIntent(data) }
+            else -> data
         }
+
         intent?.let {
             setResult(Activity.RESULT_OK, intent)
             finish()
         }
+    }
+
+    private fun editImageIntent(data: Intent?): Intent {
+        val intent = Intent()
+        val uris = WPMediaUtils.retrieveImageEditorResult(data)
+        if (mediaPickerSetup.queueResults) {
+            intent.putQueuedUris(uris)
+        } else {
+            intent.putUris(uris)
+        }
+        intent.putExtra(
+                EXTRA_MEDIA_SOURCE,
+                APP_PICKER.name
+        )
+        return intent
     }
 
     private fun takeAPhoto() = try {


### PR DESCRIPTION
Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
