### PR TITLE
Detekt - Resolve/Suppress All Baseline Warnings - Long methods warnings_ MediaPickerActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -173,7 +173,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         return super.onOptionsItemSelected(item)
     }
 
-    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION", "LongMethod", "NestedBlockDepth")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun onActivityResult(
         requestCode: Int,
         resultCode: Int,
@@ -192,31 +192,29 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
                 }
             }
             TAKE_PHOTO -> takeAPhoto()
-
-            IMAGE_EDITOR_EDIT_IMAGE -> {
-                data?.let {
-                    val intent = Intent()
-                    val uris = WPMediaUtils.retrieveImageEditorResult(data)
-                    if (mediaPickerSetup.queueResults) {
-                        intent.putQueuedUris(uris)
-                    } else {
-                        intent.putUris(uris)
-                    }
-                    intent.putExtra(
-                            EXTRA_MEDIA_SOURCE,
-                            APP_PICKER.name
-                    )
-                    intent
-                }
-            }
-            else -> {
-                data
-            }
+            IMAGE_EDITOR_EDIT_IMAGE -> data?.let { editImageIntent(it) }
+            else -> data
         }
+
         intent?.let {
             setResult(Activity.RESULT_OK, intent)
             finish()
         }
+    }
+
+    private fun editImageIntent(data: Intent?): Intent {
+        val intent = Intent()
+        val uris = WPMediaUtils.retrieveImageEditorResult(data)
+        if (mediaPickerSetup.queueResults) {
+            intent.putQueuedUris(uris)
+        } else {
+            intent.putUris(uris)
+        }
+        intent.putExtra(
+                EXTRA_MEDIA_SOURCE,
+                APP_PICKER.name
+        )
+        return intent
     }
 
     private fun takeAPhoto() = try {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -191,29 +191,8 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
                     return
                 }
             }
-            TAKE_PHOTO -> {
-                try {
-                    val intent = Intent()
-                    mediaCapturePath!!.let {
-                        WPMediaUtils.scanMediaFile(this, it)
-                        val f = File(it)
-                        val capturedImageUri = listOf(Uri.fromFile(f))
-                        if (mediaPickerSetup.queueResults) {
-                            intent.putQueuedUris(capturedImageUri)
-                        } else {
-                            intent.putUris(capturedImageUri)
-                        }
-                        intent.putExtra(
-                                EXTRA_MEDIA_SOURCE,
-                                ANDROID_CAMERA.name
-                        )
-                    }
-                    intent
-                } catch (e: RuntimeException) {
-                    AppLog.e(MEDIA, e)
-                    null
-                }
-            }
+            TAKE_PHOTO -> takeAPhoto()
+
             IMAGE_EDITOR_EDIT_IMAGE -> {
                 data?.let {
                     val intent = Intent()
@@ -238,6 +217,28 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
             setResult(Activity.RESULT_OK, intent)
             finish()
         }
+    }
+
+    private fun takeAPhoto() = try {
+        val intent = Intent()
+        mediaCapturePath!!.let {
+            WPMediaUtils.scanMediaFile(this, it)
+            val f = File(it)
+            val capturedImageUri = listOf(Uri.fromFile(f))
+            if (mediaPickerSetup.queueResults) {
+                intent.putQueuedUris(capturedImageUri)
+            } else {
+                intent.putUris(capturedImageUri)
+            }
+            intent.putExtra(
+                    EXTRA_MEDIA_SOURCE,
+                    ANDROID_CAMERA.name
+            )
+        }
+        intent
+    } catch (e: RuntimeException) {
+        AppLog.e(MEDIA, e)
+        null
     }
 
     private fun launchChooserWithContext(openSystemPicker: OpenSystemPicker, uiHelpers: UiHelpers) {


### PR DESCRIPTION
Parent: https://github.com/wordpress-mobile/WordPress-Android/issues/17010

This PR resolved/suppress all complexity related LongMethod warnings for the WordPress module (see docs [here](https://detekt.dev/docs/rules/complexity#longmethod)):

`1` x LongMethod (Resolve: https://github.com/wordpress-mobile/WordPress-Android/pull/17355/commits/8594712f9710898997127be06ed249acfb4fb645 + https://github.com/wordpress-mobile/WordPress-Android/pull/17355/commits/f5cbb2e674469ecbef05ca170a8a476b3426ae35)
To test:

- There is nothing much to test here.

- Verifying that all the CI checks are successful should be enough (especially the detekt check).

- However, if you really want to be thorough, you could smoke test the WordPress and/or Jetpack apps to verify that everything works as expected on every screen that relates to these changes.
    STEPS
- Go to the menu tab
- click on media option 
- click on the upload media button or the (+) button at the top right corner 
- select choose from device 
- select an image

## Regression Notes
1. Potential unintended areas of impact
     can't think of any 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)
     N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
