### PR TITLE
Add Progress Bar to Reader content

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -173,6 +173,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private lateinit var scrollView: WPScrollView
     private lateinit var layoutFooter: ViewGroup
     private lateinit var readerWebView: ReaderWebView
+    private lateinit var readerProgressBar: ProgressBar
 
     private lateinit var likeFacesTrain: View
     private lateinit var likeProgressBar: ProgressBar
@@ -382,6 +383,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         readerWebView.setCustomViewListener(this)
         readerWebView.setUrlClickListener(this)
         readerWebView.setPageFinishedListener(this)
+
+        readerProgressBar = view.findViewById(R.id.reader_progress_bar)
     }
 
     private fun initLikeFacesTrain(view: View) {
@@ -1459,6 +1462,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private fun ReaderPostDetailFragment.showPostInWebView(post: ReaderPost) {
         readerWebView.setIsPrivatePost(post.isPrivate)
         readerWebView.setBlogSchemeIsHttps(UrlUtils.isHttps(post.blogUrl))
+        readerProgressBar.visibility = View.VISIBLE
         renderer = ReaderPostRenderer(readerWebView, viewModel.post, readerCssProvider)
 
         // if the post is from private atomic site postpone render until we have a special access cookie
@@ -1492,6 +1496,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         if (!isAdded) {
             return
         }
+
+        readerProgressBar.visibility = View.GONE
 
         if (url != null && url == "about:blank") {
             // brief delay before showing related posts to give page time to render

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -11,12 +11,27 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <org.wordpress.android.ui.reader.views.ReaderWebView
-        android:id="@+id/reader_webview"
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_extra_large"
-        android:scrollbars="none" />
+        android:layout_height="wrap_content">
+
+        <org.wordpress.android.ui.reader.views.ReaderWebView
+            android:id="@+id/reader_webview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:scrollbars="none" />
+
+        <ProgressBar
+            android:id="@+id/reader_progress_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="@dimen/margin_extra_large"
+            android:layout_gravity="center"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+    </FrameLayout>
 
     <RelativeLayout
         android:id="@+id/excerpt_footer"


### PR DESCRIPTION
Fixes #14840

Show a circular Progress Bar on top of the reader post detail content while the content is being loaded / rendered, and hides it when the content is completed loading in the WebView.

The approach is simple:
- When the `ReaderPostDetailFragment` receives the `ShowPostInWebView` Event and calls `showPostInWebView`, it also shows the new progress bar (in `reader_include_post_detail_content.xml`) when setting up the Renderer and content `WebView`.
- On the Reader `WebView` callback for `onPageFinished`, which is called when the content has finished loading, hide that content progress bar.

To test:
Pre requisite (optional): it is preferred that you are in a slow connection so the progress bar shows up for longer.

0. Open the WordPress app
1. Tap the `Reader` item in the bottom bar menu
   - **Verify** a list of posts show up
2. Tap any post in the list (preferably one with a lot of content)
   - **Check** the loading progress bar shows up while the content is being loaded

## Regression Notes
1. Potential unintended areas of impact
N/A, the change is very specific to that flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
None, this is purely UI in a screen not covered by UI tests and I couldn't find a good way to test this intermediary state.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
