### PR TITLE
Integrate gutenberg-mobile release 1.84.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     wordPressUtilsVersion = '3.0.0'
     wordPressLoginVersion = '1.0.0'
     aztecVersion = 'v1.6.2'
-    gutenbergMobileVersion = '5223-16130b31389066fbbb06afa116b5b3ab5591fa38'
+    gutenbergMobileVersion = 'v1.84.1'
     storiesVersion = '2.0.0'
     aboutAutomatticVersion = '1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     wordPressUtilsVersion = '3.0.0'
     wordPressLoginVersion = '1.0.0'
     aztecVersion = 'v1.6.2'
-    gutenbergMobileVersion = '5223-b1e30ba86c18c36b3534c88559c70902cf4514fb'
+    gutenbergMobileVersion = '5223-16130b31389066fbbb06afa116b5b3ab5591fa38'
     storiesVersion = '2.0.0'
     aboutAutomatticVersion = '1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     wordPressUtilsVersion = '3.0.0'
     wordPressLoginVersion = '1.0.0'
     aztecVersion = 'v1.6.2'
-    gutenbergMobileVersion = 'v1.84.0'
+    gutenbergMobileVersion = '5223-b1e30ba86c18c36b3534c88559c70902cf4514fb'
     storiesVersion = '2.0.0'
     aboutAutomatticVersion = '1.0.0'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.84.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5223

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.