### PR TITLE
Merge Editorialized Release Notes for 21.0

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -11,20 +11,21 @@ msgstr ""
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_210"
+msgid ""
+"21.0:\n"
+"- Added correct links to Automattic Family app marbles on the About screen\n"
+"- Updated the launch screen for Android versions 12+\n"
+"- Changed success message text from red to black for QR code logins\n"
+"- Fixed the Stats screen to include Western Arabic numerals for Arabic language users\n"
+msgstr ""
+
 msgctxt "release_note_209"
 msgid ""
 "20.9:\n"
 "- “Get to know your app” flows now stay on screen after rotating your device.\n"
 "- Long titles display properly on Stats cards without being cut off.\n"
 "- We added the Enter key to Post excerpts to allow for easy line breaks.\n"
-msgstr ""
-
-msgctxt "release_note_208"
-msgid ""
-"20.8:\n"
-"We added dynamic widgets to show at-a-glance, all-time, and daily stats on user devices’ home screens.\n"
-"Users on multi-author sites can change content authors in post and page settings.\n"
-"Arabic language users will see numerals on Stats screens exclusively in Western Arabic numbers.\n"
 msgstr ""
 
 #. translators: Title to be displayed in the Play Store. Limit to 30 characters including spaces and commas!

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,6 +1,4 @@
-* [***] [internal] Updates the target sdk to 31 - Android 12 [https://github.com/wordpress-mobile/WordPress-Android/pull/17153]
-* [*] Updated About screen to use correct urls. [https://github.com/wordpress-mobile/WordPress-Android/pull/17282]
-* [*] Updates splash screen for Android 12+ [https://github.com/wordpress-mobile/WordPress-Android/pull/17273]
-* [*] Fix text color of success messages in the QR code login flow [https://github.com/wordpress-mobile/WordPress-Android/pull/17286]
-* [*] Stats: Fix Western Arabic Numerals not being shown on every text of the stats screens in Arabic languages [https://github.com/wordpress-mobile/WordPress-Android/pull/17217]
-
+- Added correct links to Automattic Family app marbles on the About screen
+- Updated the launch screen for Android versions 12+
+- Changed success message text from red to black for QR code logins
+- Fixed the Stats screen to include Western Arabic numerals for Arabic language users

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -11,19 +11,21 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_210"
+msgid ""
+"21.0:\n"
+"- Removed the Automattic Family app marbles from the About page\n"
+"- Updated the launch screen for Android versions 12+\n"
+"- Changed success message text from red to black for QR code logins\n"
+"- Fixed the Stats screen to include Western Arabic numerals for Arabic language users\n"
+msgstr ""
+
 msgctxt "release_note_209"
 msgid ""
 "20.9:\n"
 "- “Get to know your app” flows now stay on screen after rotating your device.\n"
 "- Long titles display properly on Stats cards without being cut off.\n"
 "- We added the Enter key to Post excerpts to allow for easy line breaks.\n"
-msgstr ""
-
-msgctxt "release_note_208"
-msgid ""
-"20.8:\n"
-"Users on multi-author sites can change content authors in post and page settings.\n"
-"Arabic language users will now see numerals on Stats screens exclusively in Western Arabic numbers—no more mix and match with Eastern Arabic numbers.\n"
 msgstr ""
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,6 +1,4 @@
-* [***] [internal] Updates the target sdk to 31 - Android 12 [https://github.com/wordpress-mobile/WordPress-Android/pull/17153]
-* [*] Updated About screen to move the Automattic apps marbles to the Jetpack app only. [https://github.com/wordpress-mobile/WordPress-Android/pull/17282]
-* [*] Updates splash screen for Android 12+ [https://github.com/wordpress-mobile/WordPress-Android/pull/17273]
-* [*] Fix text color of success messages in the QR code login flow [https://github.com/wordpress-mobile/WordPress-Android/pull/17286]
-* [*] Stats: Fix Western Arabic Numerals not being shown on every text of the stats screens in Arabic languages [https://github.com/wordpress-mobile/WordPress-Android/pull/17217]
-
+- Removed the Automattic Family app marbles from the About page
+- Updated the launch screen for Android versions 12+
+- Changed success message text from red to black for QR code logins
+- Fixed the Stats screen to include Western Arabic numerals for Arabic language users


### PR DESCRIPTION
What it says on the tin:
 - Updates WordPress and Jetpack `release_notes.txt` file used as source of truth for the translations
 - Updates the `PlayStoreStrings.po` files that will get imported to GlotPress (and allow polyglots to start translating) as soon as this PR lands in `trunk`

[Internal Ref for the editorialization of the release notes copy: p1666143609847819-slack-C02S5P5MBGA]