### PR TITLE
Add more social media handles on About Screen in Jetpack app

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/about/UnifiedAboutViewModel.kt
@@ -49,13 +49,7 @@ class UnifiedAboutViewModel @Inject constructor(
             socialsConfig = SocialsConfig(
                     twitterUsername = if (buildConfig.isJetpackApp) JP_SOCIAL_HANDLE else WP_SOCIAL_HANDLE
             ),
-            customItems = listOf(
-                    ItemConfig(
-                            name = BLOG_ITEM_NAME,
-                            title = blogTitle(),
-                            onClick = ::onBlogClick
-                    )
-            ),
+            customItems = getCustomItems(),
             legalConfig = LegalConfig(
                     tosUrl = wpUrlUtils.buildTermsOfServiceUrl(contextProvider.getContext()),
                     privacyPolicyUrl = Constants.URL_PRIVACY_POLICY,
@@ -92,12 +86,54 @@ class UnifiedAboutViewModel @Inject constructor(
         )
     }
 
+    private fun getCustomItems(): List<ItemConfig> = if (buildConfig.isJetpackApp) {
+        listOf(
+                ItemConfig(
+                        name = JP_TUMBLR_ITEM_NAME,
+                        title = contextProvider.getContext().getString(R.string.about_automattic_tumblr),
+                        onClick = { onItemClick(JP_TUMBLR_URL) }
+                ),
+                ItemConfig(
+                        name = JP_YOUTUBE_ITEM_NAME,
+                        title = contextProvider.getContext().getString(R.string.about_automattic_youtube),
+                        onClick =  { onItemClick(JP_YOUTUBE_URL) }
+                ),
+                ItemConfig(
+                        name = JP_FACEBOOK_ITEM_NAME,
+                        title = contextProvider.getContext().getString(R.string.about_automattic_facebook),
+                        onClick =  { onItemClick(JP_FACEBOOK_URL) }
+                ),
+                ItemConfig(
+                        name = JP_LINKEDIN_ITEM_NAME,
+                        title = contextProvider.getContext().getString(R.string.about_automattic_linkedin),
+                        onClick =  { onItemClick(JP_LINKEDIN_URL) }
+                ),
+                ItemConfig(
+                        name = BLOG_ITEM_NAME,
+                        title = contextProvider.getContext().getString(R.string.about_blog),
+                        onClick = ::onBlogClick
+                )
+        )
+    } else {
+        listOf(
+                ItemConfig(
+                name = BLOG_ITEM_NAME,
+                title = blogTitle(),
+                onClick = ::onBlogClick
+                )
+        )
+    }
+
     private fun onDismiss() {
         _onNavigation.postValue(Event(Dismiss))
     }
 
     private fun onBlogClick() {
         _onNavigation.postValue(Event(OpenBlog(if (buildConfig.isJetpackApp) JP_BLOG_URL else WP_BLOG_URL)))
+    }
+
+    private fun onItemClick(socialMedialUrl: String) {
+        _onNavigation.postValue(Event(OpenBlog(socialMedialUrl)))
     }
 
     private fun blogTitle() = if (buildConfig.isJetpackApp) {
@@ -131,5 +167,15 @@ class UnifiedAboutViewModel @Inject constructor(
         private const val JP_APPS_URL = "https://jetpack.com/app"
         private const val JP_BLOG_URL = "https://jetpack.com/blog"
         private const val JP_WORK_WITH_US_URL = "https://automattic.com/work-with-us/"
+
+        private const val JP_TUMBLR_ITEM_NAME = "tumblr"
+        private const val JP_YOUTUBE_ITEM_NAME = "youtube"
+        private const val JP_FACEBOOK_ITEM_NAME = "facebook"
+        private const val JP_LINKEDIN_ITEM_NAME = "linkedin"
+
+        private const val JP_TUMBLR_URL = "https://www.tumblr.com/jetpack/"
+        private const val JP_YOUTUBE_URL = "https://www.youtube.com/JetpackOfficial/"
+        private const val JP_FACEBOOK_URL = "https://www.facebook.com/jetpackme/"
+        private const val JP_LINKEDIN_URL = "https://www.linkedin.com/company/jetpack-for-wordpress/"
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4081,6 +4081,9 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="about_automattic_pocketcasts" tools:ignore="UnusedResources" a8c-src-lib="about">Pocket Casts</string>
     <string name="about_automattic_simplenote" tools:ignore="UnusedResources" a8c-src-lib="about">Simplenote</string>
     <string name="about_automattic_tumblr" tools:ignore="UnusedResources" a8c-src-lib="about">Tumblr</string>
+    <string name="about_automattic_youtube" tools:ignore="UnusedResources" a8c-src-lib="about">YouTube</string>
+    <string name="about_automattic_facebook" tools:ignore="UnusedResources" a8c-src-lib="about">Facebook</string>
+    <string name="about_automattic_linkedin" tools:ignore="UnusedResources" a8c-src-lib="about">LinkedIn</string>
     <string name="about_automattic_woocommerce" tools:ignore="UnusedResources" a8c-src-lib="about">WooCommerce</string>
     <string name="about_automattic_wordpress" tools:ignore="UnusedResources" a8c-src-lib="about">WordPress</string>
     <string name="about_automattic_logo_description" tools:ignore="UnusedResources" a8c-src-lib="about">Automattic logo</string>


### PR DESCRIPTION
Adds Tumblr, YouTube, Facebook and LinkedIn handles on About screen in Jetpack app

<img width=320 src="https://user-images.githubusercontent.com/990349/196865229-cb78e456-f558-43bb-94be-11d535e2ba60.png" />


To test:

- Launch Jetpack app
- Navigate to Me (Tap on Avatar at the top right hand corner on Dashboard)
- Tap on About Jetpack
- Check that About Screen has the social media handles for Tumblr, YouTube, Facebook and LinkedIn below Twitter


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Existing tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
