### PR TITLE
[Jetpack overlay] Set overlay background to white and updates text

### DIFF
--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -47,7 +47,7 @@
     <color name="jetpack_banner_background">@color/jetpack_green_0</color>
     <color name="jetpack_banner_divider">@color/gray_5</color>
     <color name="jetpack_badge_background">@color/jetpack_green</color>
-    <color name="jetpack_powered_bottom_sheet_background">@color/jetpack_green_0</color>
+    <color name="jetpack_powered_bottom_sheet_background">@color/white</color>
 
     <!-- Reader -->
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4216,7 +4216,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="wp_jetpack_powered_stats_powered_by_jetpack_caption">Watch your traffic grow and learn about your audience with redesigned Stats and Insights, now available in the new Jetpack app.</string>
     <string name="wp_jetpack_powered_notifications_powered_by_jetpack">Notifications are powered by Jetpack</string>
     <string name="wp_jetpack_powered_notifications_powered_by_jetpack_caption">Stay informed with realtime updates for new comments, site traffic, security reports and more.</string>
-    <string name="wp_jetpack_get_new_jetpack_app">Get the new Jetpack app</string>
+    <string name="wp_jetpack_get_new_jetpack_app">Try the new Jetpack app</string>
     <string name="wp_jetpack_continue_to_reader">Continue to Reader</string>
     <string name="wp_jetpack_continue_to_stats">Continue to Stats</string>
     <string name="wp_jetpack_continue_to_notifications">Continue to Notifications</string>


### PR DESCRIPTION
## Description
Sets the Jetpack overlay color for light mode to white and updates the button text

# To test
1. Launch the WordPress app
2. Enable the Jetpack overlay
3. *Verify* that the overlay color is `white` in light mode and that the text reads `Try the new Jetpack app` in the following screens:
   1. **Badges**
      1. `Dashboard` → `Home` tab
      3. `Me`
      5. `Activity Log` → `Activity Item Detail`
      6. `Me` → `App Settings`
      7. `Notifications` → `Notifications Settings`
      8. `Sharing`
      9. `Reader` → `Reader Detail`
   2. **Banners**
      1. `Reader` list
      2. `Reader` → `Search` (both empty and with search suggestions that show after searching once)
      3. `Reader` → `Search` → `Search results` list
      5. `Notifications` list
      6. `Stats` page
      7. `Activity Log` list

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
