### PR TITLE
Jetpack Badge not read by TalkBack #17092

### DIFF
--- a/WordPress/src/main/res/layout/jetpack_badge.xml
+++ b/WordPress/src/main/res/layout/jetpack_badge.xml
@@ -13,7 +13,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:importantForAccessibility="no"
+        android:importantForAccessibility="yes"
         android:paddingEnd="15dp"
         android:paddingStart="5dp"
         android:paddingVertical="5dp"


### PR DESCRIPTION
Fixes #17092

Jetpack Badge not read by TalkBack

**Solution**
Enable accessibility on Jetpack badge by setting `importantForAccessibility` attribute to `yes`

To test:
- Ensure TalkBack is installed on the device. If not, install Android Accessibility Suite from the Play Store
- Enable TalkBack from the Settings
- Open the WordPress app to a screen with the Jetpack badge (not the banner).
- Turn on TalkBack (press and hold the + and - volume buttons for 3 seconds).
- Using TalkBack, navigate through the items on the screen.
- Now, the Jetpack badge will not be skipped. 

## Regression Notes
1. Potential unintended areas of impact: None

2. What I did to test those areas of impact (or what existing automated tests I relied on): Tested manually

3. What automated tests I added (or what prevented me from doing so): None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Before fix: https://www.loom.com/share/efb67616f1704cdb8fd04daa73730ec9
After Fix:  https://www.loom.com/share/ae3a21740d784b03863c1a475095279d
