### PR TITLE
[UITII] Fix flakiness in "e2ePublishFullPost" while opening menu.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
@@ -28,6 +28,7 @@ import static org.wordpress.android.support.WPSupportUtils.withIndex;
 
 public class BlockEditorPage {
     private static ViewInteraction titleField = onView(withHint("Add title"));
+    private static ViewInteraction postSettingButton = onView(withText(R.string.post_settings));
 
     private ViewInteraction mEditor;
 
@@ -74,10 +75,25 @@ public class BlockEditorPage {
         return this;
     }
 
-    public void openPostSetting() {
+    /**
+     * Taps the three vertical dots menu button located at the editor screen top right.
+     * Since the tap does not always succeed on FTL, one retry is used
+     */
+    public void openPostKebabMenu() {
         waitForElementToBeDisplayed(R.id.toolbar_main);
+
+        // First attempt to tap the kebab menu (three dots)
         openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
-        clickOn(onView(withText(R.string.post_settings)));
+
+        // Check if the attempt succeeded, retry once if not
+        if (!waitForElementToBeDisplayedWithoutFailure(postSettingButton)) {
+            openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
+        }
+    }
+
+    public void openPostSetting() {
+        openPostKebabMenu();
+        clickOn(postSettingButton);
     }
 
     public void addCategory(String category) {

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
@@ -25,6 +25,7 @@ import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDis
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 import static junit.framework.TestCase.assertTrue;
 import static org.wordpress.android.support.WPSupportUtils.withIndex;
+import static org.junit.Assert.fail;
 
 public class BlockEditorPage {
     private static ViewInteraction titleField = onView(withHint("Add title"));
@@ -88,6 +89,10 @@ public class BlockEditorPage {
         // Check if the attempt succeeded, retry once if not
         if (!waitForElementToBeDisplayedWithoutFailure(postSettingButton)) {
             openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
+        }
+
+        if (!waitForElementToBeDisplayedWithoutFailure(postSettingButton)) {
+            fail("Failed to open post menu.");
         }
     }
 


### PR DESCRIPTION
### What
#17323 from @jostnes solves flakiness in `e2ePublishFullPost` related to featured image selection. But it looks like another flaky point still remains:

https://user-images.githubusercontent.com/73365754/197992626-ab53be1a-9c36-4678-8028-8ece75f288a2.mov

This is when the test attempts to tap the 3-dots menu, but ends in something that looks like a long tap, resulting in no menu being opened. After that, the test can't continue.

### How
Since the 3-dot button is not discoverable by the Layout Inspector, [openActionBarOverflowOrOptionsMenu](https://developer.android.com/reference/androidx/test/espresso/Espresso#openActionBarOverflowOrOptionsMenu(android.content.Context)) from Espresso was used to tap the button, and it's not easy to control the way of tapping in that case. So, I went for checking if the menu was opened after the first tap, and going for one more try if it did not.

### Testing
I have no proof that the change fixes the flakiness, because it occurs not consistently. Theoretically, it should improve the situation, but time will show. 

- [ ] So, I can suggest no other way of testing except for seeing the Instrumented Tests being 🟢.