### PR TITLE
Fix flaky verifyOnAppComesFromBackgroundCalled test

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.support.BaseTest
 class AppInitializerTest : BaseTest() {
     @Test
     fun verifyOnAppComesFromBackgroundCalled() {
-        Thread.sleep(100)
+        Thread.sleep(200)
         assertFalse(WordPress.appIsInTheBackground)
     }
 }


### PR DESCRIPTION
This increases sleep time in `verifyOnAppComesFromBackgroundCalled` test case.

`verifyOnAppComesFromBackgroundCalled` fails rarely on Firebase Test Lab environment. 
I ran the application multiple times on emulator and debugged the order of related functions. It's like this:

1. App is launched,
1. Application's `onCreate` runs,
2. `AppInitializer`'s [onAppComesFromBackground](https://github.com/wordpress-mobile/WordPress-Android/blob/25721585531635064d14f734df409f0e5a8569e4/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt#L772) runs,
3. `WordPress.appIsInTheBackground` is set to false.
4. If we run [verifyOnAppComesFromBackgroundCalled](https://github.com/wordpress-mobile/WordPress-Android/blob/81120a0d696e1bfe44e165ddf62cd97aee9596e3/WordPress/src/androidTest/java/org/wordpress/android/AppInitializerTest.kt#L19) test case, the test runs in this step.

But in FTL environment, step 4 works before 2 sometimes. That causes the test to fail. We don't use `WordPress.appIsInTheBackground` for instant checks after app launch, so it's totally safe to increase sleep time for `verifyOnAppComesFromBackgroundCalled`. The time was set to 200, but it can be increased if it still fails.

To test:
Run `verifyOnAppComesFromBackgroundCalled` test case on FTL a couple times.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Updated current test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
