### PR TITLE
Detekt - Resolve/Suppress All Baseline Warnings - Long methods warnings_ MediaPickerFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -28,6 +28,7 @@ import androidx.recyclerview.widget.GridLayoutManager.SpanSizeLookup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.MediaPickerFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
@@ -261,42 +262,9 @@ class MediaPickerFragment : Fragment() {
                 }
             })
 
-            viewModel.onNavigate.observeEvent(viewLifecycleOwner,
-                    { navigationEvent ->
-                        when (navigationEvent) {
-                            is PreviewUrl -> {
-                                MediaPreviewActivity.showPreview(
-                                        requireContext(),
-                                        null,
-                                        navigationEvent.url
-                                )
-                                AccessibilityUtils.setActionModeDoneButtonContentDescription(
-                                        activity,
-                                        getString(R.string.cancel)
-                                )
-                            }
-                            is PreviewMedia -> MediaPreviewActivity.showPreview(
-                                    requireContext(),
-                                    null,
-                                    navigationEvent.media,
-                                    null
-                            )
-                            is EditMedia -> {
-                                val inputData = WPMediaUtils.createListOfEditImageInputData(
-                                        requireContext(),
-                                        navigationEvent.uris.map { wrapper -> wrapper.uri }
-                                )
-                                ActivityLauncher.openImageEditor(activity, inputData)
-                            }
-                            is InsertMedia -> listener?.onItemsChosen(navigationEvent.identifiers)
-                            is IconClickEvent -> listener?.onIconClicked(navigationEvent.action)
-                            Exit -> {
-                                val activity = requireActivity()
-                                activity.setResult(Activity.RESULT_CANCELED)
-                                activity.finish()
-                            }
-                        }
-                    })
+            viewModel.onNavigate.observeEvent(viewLifecycleOwner) { navigationEvent ->
+                navigateEvent(navigationEvent)
+            }
 
             viewModel.onPermissionsRequested.observeEvent(viewLifecycleOwner, {
                 when (it) {
@@ -311,6 +279,42 @@ class MediaPickerFragment : Fragment() {
             setupProgressDialog()
 
             viewModel.start(selectedIds, mediaPickerSetup, lastTappedIcon, site)
+        }
+    }
+
+    private fun navigateEvent(navigationEvent: MediaNavigationEvent) {
+        when (navigationEvent) {
+            is PreviewUrl -> {
+                MediaPreviewActivity.showPreview(
+                        requireContext(),
+                        null,
+                        navigationEvent.url
+                )
+                AccessibilityUtils.setActionModeDoneButtonContentDescription(
+                        activity,
+                        getString(string.cancel)
+                )
+            }
+            is PreviewMedia -> MediaPreviewActivity.showPreview(
+                    requireContext(),
+                    null,
+                    navigationEvent.media,
+                    null
+            )
+            is EditMedia -> {
+                val inputData = WPMediaUtils.createListOfEditImageInputData(
+                        requireContext(),
+                        navigationEvent.uris.map { wrapper -> wrapper.uri }
+                )
+                ActivityLauncher.openImageEditor(activity, inputData)
+            }
+            is InsertMedia -> listener?.onItemsChosen(navigationEvent.identifiers)
+            is IconClickEvent -> listener?.onIconClicked(navigationEvent.action)
+            Exit -> {
+                val activity = requireActivity()
+                activity.setResult(Activity.RESULT_CANCELED)
+                activity.finish()
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -235,10 +235,7 @@ class MediaPickerFragment : Fragment() {
             layoutManager.onRestoreInstanceState(it)
         }
         with(MediaPickerFragmentBinding.bind(view)) {
-            binding = this
-            recycler.layoutManager = layoutManager
-            recycler.setEmptyView(actionableEmptyView)
-            recycler.setHasFixedSize(true)
+            setUpRecyclerView(layoutManager)
 
             val swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
                 viewModel.onPullToRefresh()
@@ -315,6 +312,15 @@ class MediaPickerFragment : Fragment() {
 
             viewModel.start(selectedIds, mediaPickerSetup, lastTappedIcon, site)
         }
+    }
+
+    private fun MediaPickerFragmentBinding.setUpRecyclerView(
+        layoutManager: GridLayoutManager
+    ) {
+        binding = this
+        recycler.layoutManager = layoutManager
+        recycler.setEmptyView(actionableEmptyView)
+        recycler.setHasFixedSize(true)
     }
 
     override fun onDestroyView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -28,7 +28,6 @@ import androidx.recyclerview.widget.GridLayoutManager.SpanSizeLookup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.MediaPickerFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
@@ -292,7 +291,7 @@ class MediaPickerFragment : Fragment() {
                 )
                 AccessibilityUtils.setActionModeDoneButtonContentDescription(
                         activity,
-                        getString(string.cancel)
+                        getString(R.string.cancel)
                 )
             }
             is PreviewMedia -> MediaPreviewActivity.showPreview(

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -72,7 +72,6 @@
     <ID>LongMethod:BarChartViewHolder.kt$BarChartViewHolder$private fun BarChart.draw( item: BarChartItem, labelStart: TextView, labelEnd: TextView ): BarCount</ID>
     <ID>LongMethod:ClicksUseCase.kt$ClicksUseCase$override fun buildUiModel(domainModel: ClicksModel, uiState: SelectedClicksGroup): List&lt;BlockListItem></ID>
     <ID>LongMethod:HomepageSettingsDialog.kt$HomepageSettingsDialog$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
-    <ID>LongMethod:MediaPickerFragment.kt$MediaPickerFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:MediaPickerViewModel.kt$MediaPickerViewModel$private fun buildUiModel( domainModel: DomainModel?, selectedIds: List&lt;Identifier>?, softAskRequest: SoftAskRequest?, isSearching: Boolean? ): PhotoListUiModel</ID>
     <ID>LongMethod:PrepublishingHomeViewModel.kt$PrepublishingHomeViewModel$private fun setupHomeUiState( editPostRepository: EditPostRepository, site: SiteModel, isStoryPost: Boolean )</ID>
     <ID>LongMethod:PublishSettingsFragment.kt$PublishSettingsFragment$override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -18,7 +18,6 @@
     <ID>ComplexMethod:HomepageSettingsDialog.kt$HomepageSettingsDialog$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
     <ID>ComplexMethod:ImagePlaceholderManager.kt$ImagePlaceholderManager$fun getErrorResource(imgType: ImageType): Int?</ID>
     <ID>ComplexMethod:ImagePlaceholderManager.kt$ImagePlaceholderManager$fun getPlaceholderResource(imgType: ImageType): Int?</ID>
-    <ID>ComplexMethod:MediaPickerFragment.kt$MediaPickerFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>ComplexMethod:MediaPickerViewModel.kt$MediaPickerViewModel$private fun buildUiModel( domainModel: DomainModel?, selectedIds: List&lt;Identifier>?, softAskRequest: SoftAskRequest?, isSearching: Boolean? ): PhotoListUiModel</ID>
     <ID>ComplexMethod:NoticonUtils.kt$NoticonUtils$fun noticonToGridicon(noticon: String): Int</ID>
     <ID>ComplexMethod:PostActionHandler.kt$PostActionHandler$fun handlePostButton(buttonType: PostListButtonType, post: PostModel, hasAutoSave: Boolean)</ID>


### PR DESCRIPTION
Parent: https://github.com/wordpress-mobile/WordPress-Android/issues/17010

This PR resolves/suppresses all complexity related LongMethod warnings for the MediaPickerFragment class (see docs [here](https://detekt.dev/docs/rules/complexity#longmethod)):

`1` x LongMethod  and `1` x ComplexMethod (Resolve: 9bbd91e8b7668915952ba5618c94bbdef1cd7f55 + 37c9fa5279d8d8560db8d77d8f958c2fb6dbdc6c + eed436edc9dc09be03b3551593ed813184a4c4eb)

-----

To test:

- There is nothing much to test here.

- Verifying that all the CI checks are successful should be enough (especially the detekt check).

- However, if you really want to be thorough, you could smoke test the WordPress and/or Jetpack apps to verify that everything works as expected on every screen that relates to these changes. Specifically, you could follow the below steps:
   
    - Go to the menu tab
    - click on media option 
    - click on the upload media button or the (+) button at the top right corner 
    - select choose from device 
    - select an image

## Regression Notes
1. Potential unintended areas of impact
     can't think of any 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)
     N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
