### PR TITLE
Jetpack focus: Jetpack feature removal - adds Phase helper, Remote fields and test class 

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -125,6 +125,11 @@ android {
         buildConfigField "boolean", "JETPACK_BLOGGING_REMINDERS_SYNC", "false"
         buildConfigField "boolean", "JETPACK_READER_SAVED_POSTS", "false"
         buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "false"
+        buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_ONE", "false"
+        buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_TWO", "false"
+        buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_THREE", "false"
+        buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_FOUR", "false"
+        buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_NEW_USERS", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -2,11 +2,11 @@ package org.wordpress.android.ui.jetpackoverlay
 
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_ONE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO
-import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseFour
-import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseNewUsers
-import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseOne
-import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseThree
-import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseTwo
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseFour
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseNewUsers
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.config.JetpackFeatureRemovalNewUsersConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseFourConfig
@@ -34,7 +34,7 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
     private val jetpackFeatureRemovalPhaseFourConfig: JetpackFeatureRemovalPhaseFourConfig,
     private val jetpackFeatureRemovalNewUsersConfig: JetpackFeatureRemovalNewUsersConfig
 ) {
-    fun getTheCurrentPhase(): JetpackPoweredCurrentPhase? {
+    fun getTheCurrentPhase(): JetpackFeatureRemovalPhase? {
         return if (buildConfigWrapper.isJetpackApp) null
         else if (jetpackFeatureRemovalNewUsersConfig.isEnabled()) PhaseNewUsers
         else if (jetpackFeatureRemovalPhaseFourConfig.isEnabled()) PhaseFour
@@ -57,27 +57,27 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
 
 // Feature specific overlay frequency is the frequency at which the overlay is shown for a specific feature
 
-sealed class JetpackPoweredCurrentPhase(
+sealed class JetpackFeatureRemovalPhase(
     val globalOverlayFrequency: Int = 0,
     val featureSpecificOverlayFrequency: Int = 0
 ) {
-    object PhaseOne : JetpackPoweredCurrentPhase(
+    object PhaseOne : JetpackFeatureRemovalPhase(
             PHASE_ONE_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS,
             PHASE_ONE_FEATURE_OVERLAY_FREQUENCY_IN_DAYS
     )
 
-    object PhaseTwo : JetpackPoweredCurrentPhase(
+    object PhaseTwo : JetpackFeatureRemovalPhase(
             PHASE_TWO_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS,
             PHASE_TWO_FEATURE_OVERLAY_FREQUENCY_IN_DAYS
     )
 
-    object PhaseThree : JetpackPoweredCurrentPhase(
+    object PhaseThree : JetpackFeatureRemovalPhase(
             PHASE_THREE_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS,
             PHASE_THREE_FEATURE_OVERLAY_FREQUENCY_IN_DAYS
     )
 
-    object PhaseFour : JetpackPoweredCurrentPhase()
-    object PhaseNewUsers : JetpackPoweredCurrentPhase()
+    object PhaseFour : JetpackFeatureRemovalPhase()
+    object PhaseNewUsers : JetpackFeatureRemovalPhase()
 }
 
 enum class JetpackFeatureRemovalSiteCreationPhase {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -34,7 +34,7 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
     private val jetpackFeatureRemovalPhaseFourConfig: JetpackFeatureRemovalPhaseFourConfig,
     private val jetpackFeatureRemovalNewUsersConfig: JetpackFeatureRemovalNewUsersConfig
 ) {
-    fun getTheCurrentPhase(): JetpackFeatureRemovalPhase? {
+    fun getCurrentPhase(): JetpackFeatureRemovalPhase? {
         return if (buildConfigWrapper.isJetpackApp) null
         else if (jetpackFeatureRemovalNewUsersConfig.isEnabled()) PhaseNewUsers
         else if (jetpackFeatureRemovalPhaseFourConfig.isEnabled()) PhaseFour
@@ -45,7 +45,7 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
     }
 
     fun getSiteCreationPhase(): JetpackFeatureRemovalSiteCreationPhase? {
-        val currentPhase = getTheCurrentPhase() ?: return null
+        val currentPhase = getCurrentPhase() ?: return null
         return when (currentPhase) {
             is PhaseOne, PhaseTwo, PhaseThree -> PHASE_ONE
             is PhaseFour, PhaseNewUsers -> PHASE_TWO

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -1,0 +1,85 @@
+package org.wordpress.android.ui.jetpackoverlay
+
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_ONE
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO
+import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseFour
+import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseNewUsers
+import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseOne
+import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseThree
+import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseTwo
+import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.config.JetpackFeatureRemovalNewUsersConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseFourConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseOneConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseThreeConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseTwoConfig
+import javax.inject.Inject
+
+private const val PHASE_ONE_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS = 2
+private const val PHASE_ONE_FEATURE_OVERLAY_FREQUENCY_IN_DAYS = 7
+
+private const val PHASE_TWO_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS = 2
+private const val PHASE_TWO_FEATURE_OVERLAY_FREQUENCY_IN_DAYS = 7
+
+private const val PHASE_THREE_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS = 2
+private const val PHASE_THREE_FEATURE_OVERLAY_FREQUENCY_IN_DAYS = 4
+
+// Class used to find the current phase
+// of the Jetpack powered migration
+class JetpackFeatureRemovalPhaseHelper @Inject constructor(
+    private val buildConfigWrapper: BuildConfigWrapper,
+    private val jetpackFeatureRemovalPhaseOneConfig: JetpackFeatureRemovalPhaseOneConfig,
+    private val jetpackFeatureRemovalPhaseTwoConfig: JetpackFeatureRemovalPhaseTwoConfig,
+    private val jetpackFeatureRemovalPhaseThreeConfig: JetpackFeatureRemovalPhaseThreeConfig,
+    private val jetpackFeatureRemovalPhaseFourConfig: JetpackFeatureRemovalPhaseFourConfig,
+    private val jetpackFeatureRemovalNewUsersConfig: JetpackFeatureRemovalNewUsersConfig
+) {
+    fun getTheCurrentPhase(): JetpackPoweredCurrentPhase? {
+        return if (buildConfigWrapper.isJetpackApp) null
+        else if (jetpackFeatureRemovalNewUsersConfig.isEnabled()) PhaseNewUsers
+        else if (jetpackFeatureRemovalPhaseFourConfig.isEnabled()) PhaseFour
+        else if (jetpackFeatureRemovalPhaseThreeConfig.isEnabled()) PhaseThree
+        else if (jetpackFeatureRemovalPhaseTwoConfig.isEnabled()) PhaseTwo
+        else if (jetpackFeatureRemovalPhaseOneConfig.isEnabled()) PhaseOne
+        else null
+    }
+
+    fun getSiteCreationPhase(): JetpackFeatureRemovalSiteCreationPhase? {
+        val currentPhase = getTheCurrentPhase() ?: return null
+        return when (currentPhase) {
+            is PhaseOne, PhaseTwo, PhaseThree -> PHASE_ONE
+            is PhaseFour, PhaseNewUsers -> PHASE_TWO
+        }
+    }
+}
+// Global overlay frequency is the frequency at which the overlay is shown across the features
+// no matter which feature was accessed last time
+
+// Feature specific overlay frequency is the frequency at which the overlay is shown for a specific feature
+
+sealed class JetpackPoweredCurrentPhase(
+    val globalOverlayFrequency: Int = 0,
+    val featureSpecificOverlayFrequency: Int = 0
+) {
+    object PhaseOne : JetpackPoweredCurrentPhase(
+            PHASE_ONE_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS,
+            PHASE_ONE_FEATURE_OVERLAY_FREQUENCY_IN_DAYS
+    )
+
+    object PhaseTwo : JetpackPoweredCurrentPhase(
+            PHASE_TWO_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS,
+            PHASE_TWO_FEATURE_OVERLAY_FREQUENCY_IN_DAYS
+    )
+
+    object PhaseThree : JetpackPoweredCurrentPhase(
+            PHASE_THREE_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS,
+            PHASE_THREE_FEATURE_OVERLAY_FREQUENCY_IN_DAYS
+    )
+
+    object PhaseFour : JetpackPoweredCurrentPhase()
+    object PhaseNewUsers : JetpackPoweredCurrentPhase()
+}
+
+enum class JetpackFeatureRemovalSiteCreationPhase {
+    PHASE_ONE, PHASE_TWO
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalNewUsersConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalNewUsersConfig.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.JetpackFeatureRemovalNewUsersConfig.Companion.JETPACK_FEATURE_REMOVAL_NEW_USERS_REMOTE_FIELD
+import javax.inject.Inject
+
+/**
+ * Configuration for Jetpack feature removal phase new users
+ */
+@Feature(JETPACK_FEATURE_REMOVAL_NEW_USERS_REMOTE_FIELD, false)
+class JetpackFeatureRemovalNewUsersConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.JETPACK_FEATURE_REMOVAL_NEW_USERS,
+        JETPACK_FEATURE_REMOVAL_NEW_USERS_REMOTE_FIELD
+) {
+    companion object {
+        const val JETPACK_FEATURE_REMOVAL_NEW_USERS_REMOTE_FIELD = "jp_removal_new_users"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalPhaseFourConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalPhaseFourConfig.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseFourConfig.Companion.JETPACK__FEATURE_REMOVAL_PHASE_FOUR_REMOTE_FIELD
+import javax.inject.Inject
+
+@Feature(JETPACK__FEATURE_REMOVAL_PHASE_FOUR_REMOTE_FIELD, false)
+class JetpackFeatureRemovalPhaseFourConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.JETPACK_FEATURE_REMOVAL_PHASE_FOUR,
+        JETPACK__FEATURE_REMOVAL_PHASE_FOUR_REMOTE_FIELD
+) {
+    companion object {
+        const val JETPACK__FEATURE_REMOVAL_PHASE_FOUR_REMOTE_FIELD = "jp_removal_four"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalPhaseOneConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalPhaseOneConfig.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseOneConfig.Companion.JETPACK_FEATURE_REMOVAL_PHASE_ONE_REMOTE_FIELD
+import javax.inject.Inject
+
+@Feature(JETPACK_FEATURE_REMOVAL_PHASE_ONE_REMOTE_FIELD, false)
+class JetpackFeatureRemovalPhaseOneConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.JETPACK_FEATURE_REMOVAL_PHASE_ONE,
+        JETPACK_FEATURE_REMOVAL_PHASE_ONE_REMOTE_FIELD
+) {
+    companion object {
+        const val JETPACK_FEATURE_REMOVAL_PHASE_ONE_REMOTE_FIELD = "jp_removal_one"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalPhaseThreeConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalPhaseThreeConfig.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseThreeConfig.Companion.JETPACK_FEATURE_REMOVAL_PHASE_THREE_REMOTE_FIELD
+import javax.inject.Inject
+
+@Feature(JETPACK_FEATURE_REMOVAL_PHASE_THREE_REMOTE_FIELD, false)
+class JetpackFeatureRemovalPhaseThreeConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.JETPACK_FEATURE_REMOVAL_PHASE_THREE,
+        JETPACK_FEATURE_REMOVAL_PHASE_THREE_REMOTE_FIELD
+) {
+    companion object {
+        const val JETPACK_FEATURE_REMOVAL_PHASE_THREE_REMOTE_FIELD = "jp_removal_three"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalPhaseTwoConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalPhaseTwoConfig.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseTwoConfig.Companion.JETPACK_FEATURE_REMOVAL_PHASE_TWO_REMOTE_FIELD
+import javax.inject.Inject
+
+@Feature(JETPACK_FEATURE_REMOVAL_PHASE_TWO_REMOTE_FIELD, false)
+class JetpackFeatureRemovalPhaseTwoConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.JETPACK_FEATURE_REMOVAL_PHASE_TWO,
+        JETPACK_FEATURE_REMOVAL_PHASE_TWO_REMOTE_FIELD
+) {
+    companion object {
+        const val JETPACK_FEATURE_REMOVAL_PHASE_TWO_REMOTE_FIELD = "jp_removal_two"
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
@@ -12,11 +12,11 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_ONE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO
-import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseFour
-import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseNewUsers
-import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseOne
-import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseThree
-import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseTwo
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseFour
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseNewUsers
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.config.JetpackFeatureRemovalNewUsersConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseFourConfig

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
@@ -55,7 +55,7 @@ class JetpackFeatureRemovalPhaseHelperTest {
     fun `given jetpack app, when current phase is fetched, then return null`() {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
 
-        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase()
 
         assertNull(currentPhase)
     }
@@ -64,7 +64,7 @@ class JetpackFeatureRemovalPhaseHelperTest {
     fun `given phase one config true, when current phase is fetched, then return phase one`() {
         whenever(jetpackFeatureRemovalPhaseOneConfig.isEnabled()).thenReturn(true)
 
-        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase()
 
         assertEquals(currentPhase, PhaseOne)
     }
@@ -73,7 +73,7 @@ class JetpackFeatureRemovalPhaseHelperTest {
     fun `given phase two config true, when current phase is fetched, then return phase two`() {
         whenever(jetpackFeatureRemovalPhaseTwoConfig.isEnabled()).thenReturn(true)
 
-        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase()
 
         assertEquals(currentPhase, PhaseTwo)
     }
@@ -82,7 +82,7 @@ class JetpackFeatureRemovalPhaseHelperTest {
     fun `given phase three config true, when current phase is fetched, then return phase three`() {
         whenever(jetpackFeatureRemovalPhaseThreeConfig.isEnabled()).thenReturn(true)
 
-        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase()
 
         assertEquals(currentPhase, PhaseThree)
     }
@@ -91,7 +91,7 @@ class JetpackFeatureRemovalPhaseHelperTest {
     fun `given phase four config true, when current phase is fetched, then return phase four`() {
         whenever(jetpackFeatureRemovalPhaseFourConfig.isEnabled()).thenReturn(true)
 
-        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase()
 
         assertEquals(currentPhase, PhaseFour)
     }
@@ -100,7 +100,7 @@ class JetpackFeatureRemovalPhaseHelperTest {
     fun `given phase new users config true, when current phase is fetched, then return phase new users`() {
         whenever(jetpackFeatureRemovalNewUsersConfig.isEnabled()).thenReturn(true)
 
-        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase()
 
         assertEquals(currentPhase, PhaseNewUsers)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
@@ -1,0 +1,135 @@
+package org.wordpress.android.ui.jetpackoverlay
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_ONE
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO
+import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseFour
+import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseNewUsers
+import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseOne
+import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseThree
+import org.wordpress.android.ui.jetpackoverlay.JetpackPoweredCurrentPhase.PhaseTwo
+import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.config.JetpackFeatureRemovalNewUsersConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseFourConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseOneConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseThreeConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseTwoConfig
+
+@RunWith(MockitoJUnitRunner::class)
+class JetpackFeatureRemovalPhaseHelperTest {
+    @Mock private lateinit var buildConfigWrapper: BuildConfigWrapper
+    @Mock private lateinit var jetpackFeatureRemovalPhaseOneConfig: JetpackFeatureRemovalPhaseOneConfig
+    @Mock private lateinit var jetpackFeatureRemovalPhaseTwoConfig: JetpackFeatureRemovalPhaseTwoConfig
+    @Mock private lateinit var jetpackFeatureRemovalPhaseThreeConfig: JetpackFeatureRemovalPhaseThreeConfig
+    @Mock private lateinit var jetpackFeatureRemovalPhaseFourConfig: JetpackFeatureRemovalPhaseFourConfig
+    @Mock private lateinit var jetpackFeatureRemovalNewUsersConfig: JetpackFeatureRemovalNewUsersConfig
+
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
+    @Before
+    fun setup() {
+        jetpackFeatureRemovalPhaseHelper = JetpackFeatureRemovalPhaseHelper(
+                buildConfigWrapper,
+                jetpackFeatureRemovalPhaseOneConfig,
+                jetpackFeatureRemovalPhaseTwoConfig,
+                jetpackFeatureRemovalPhaseThreeConfig,
+                jetpackFeatureRemovalPhaseFourConfig,
+                jetpackFeatureRemovalNewUsersConfig
+        )
+    }
+
+    // general phase tests
+    @Test
+    fun `given jetpack app, when current phase is fetched, then return null`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+
+        assertNull(currentPhase)
+    }
+
+    @Test
+    fun `given phase one config true, when current phase is fetched, then return phase one`() {
+        whenever(jetpackFeatureRemovalPhaseOneConfig.isEnabled()).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+
+        assertEquals(currentPhase, PhaseOne)
+    }
+
+    @Test
+    fun `given phase two config true, when current phase is fetched, then return phase two`() {
+        whenever(jetpackFeatureRemovalPhaseTwoConfig.isEnabled()).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+
+        assertEquals(currentPhase, PhaseTwo)
+    }
+
+    @Test
+    fun `given phase three config true, when current phase is fetched, then return phase three`() {
+        whenever(jetpackFeatureRemovalPhaseThreeConfig.isEnabled()).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+
+        assertEquals(currentPhase, PhaseThree)
+    }
+
+    @Test
+    fun `given phase four config true, when current phase is fetched, then return phase four`() {
+        whenever(jetpackFeatureRemovalPhaseFourConfig.isEnabled()).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+
+        assertEquals(currentPhase, PhaseFour)
+    }
+
+    @Test
+    fun `given phase new users config true, when current phase is fetched, then return phase new users`() {
+        whenever(jetpackFeatureRemovalNewUsersConfig.isEnabled()).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getTheCurrentPhase()
+
+        assertEquals(currentPhase, PhaseNewUsers)
+    }
+
+    // site creation phase tests
+    @Test
+    fun `given jetpack app, when current site creation phase is fetched, then return null`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()
+
+        assertNull(currentPhase)
+    }
+
+    @Test
+    fun `given phase one config true, when current site creation phase is fetched, then return phase one`() {
+        whenever(jetpackFeatureRemovalPhaseOneConfig.isEnabled()).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()
+
+        assertEquals(currentPhase, PHASE_ONE)
+    }
+
+    @Test
+    fun `given phase four config true, when current site creation phase is fetched, then return phase two`() {
+        whenever(jetpackFeatureRemovalNewUsersConfig.isEnabled()).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()
+
+        assertEquals(currentPhase, PHASE_TWO)
+    }
+}


### PR DESCRIPTION
Closes #17332 

Project spec: pe7hp4-4k-p2

## Changes 
This PR
1. adds the remote config fields for the Jetpack feature removal phases. 
2. adds a phase helper class for getting the current general phase and site creation phase  in Jetpack feature removal 

## To test:
### Verify that the remote config fields are present 
1. Go to me -> app settings -> debug settings 
2. Make sure that the following remote config fields are present and are disabled
```
    jp_removal_one
    jp_removal_two
    jp_removal_three
    jp_removal_four
    jp_removal_new_users
```
### Verify that the Unit tests pass 
1. Verify that the logic for getting the current phase and site creation phase in `JetpackFeatureRemovalPhaseHelper` is as per the Project spec - pe7hp4-4k-p2
2. Verify that the unit tests pass present in `JetpackFeatureRemovalPhaseHelperTest` 



## Regression Notes
1. Potential unintended areas of impact
- Remote feature flags are present for the Jetpack feature removal 
- `JetpackFeatureRemovalPhaseHelper` has incorrect logic 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and Unit testing fro `JetpackFeatureRemovalPhaseHelper`

3. What automated tests I added (or what prevented me from doing so)
Unit tests for `JetpackFeatureRemovalPhaseHelper`

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.