### PR TITLE
Integrate gutenberg-mobile release 1.85.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     wordPressUtilsVersion = '3.0.0'
     wordPressLoginVersion = '1.0.0'
     aztecVersion = 'v1.6.2'
-    gutenbergMobileVersion = '5240-825de827050becf012ff45603ff0609390b9880a'
+    gutenbergMobileVersion = '5240-5057ba40b78eb3deaf3bf99ebaa3f9ecb2f0acdd'
     storiesVersion = '2.0.0'
     aboutAutomatticVersion = '1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     wordPressUtilsVersion = '3.0.0'
     wordPressLoginVersion = '1.0.0'
     aztecVersion = 'v1.6.2'
-    gutenbergMobileVersion = 'v1.84.1'
+    gutenbergMobileVersion = '5240-825de827050becf012ff45603ff0609390b9880a'
     storiesVersion = '2.0.0'
     aboutAutomatticVersion = '1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     wordPressUtilsVersion = '3.0.0'
     wordPressLoginVersion = '1.0.0'
     aztecVersion = 'v1.6.2'
-    gutenbergMobileVersion = '5240-5057ba40b78eb3deaf3bf99ebaa3f9ecb2f0acdd'
+    gutenbergMobileVersion = 'v1.85.0'
     storiesVersion = '2.0.0'
     aboutAutomatticVersion = '1.0.0'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.85.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5240

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.