### PR TITLE
Make all stats card titles multiline

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/TitleWithMoreViewHolder.kt
@@ -17,21 +17,12 @@ class TitleWithMoreViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     private val viewMore = itemView.findViewById<MaterialButton>(id.view_more_button)
 
     fun bind(item: TitleWithMore) {
-        title.multiLineText(item)
-        title.setTextOrHide(item.textResource,item.text)
+        title.setTextOrHide(item.textResource, item.text)
         if (item.navigationAction != null) {
             viewMore.isVisible = true
             viewMore.setOnClickListener { item.navigationAction.click() }
         } else {
             viewMore.visibility = View.GONE
-        }
-    }
-
-    fun TextView.multiLineText(item: TitleWithMore) {
-        this.visibility = View.VISIBLE
-        if(item.navigationAction == null){
-            this.ellipsize = null
-            this.maxLines = Int.MAX_VALUE
         }
     }
 }

--- a/WordPress/src/main/res/layout/stats_block_title_with_more_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_title_with_more_item.xml
@@ -10,12 +10,12 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text"
-        android:layout_width="0dp"
         style="@style/StatsBlockTitle"
-        android:layout_marginEnd="@dimen/margin_medium"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="@string/unknown"
+        android:layout_marginEnd="@dimen/margin_medium"
         android:layout_weight="1"
+        android:text="@string/unknown"
         tools:text="@string/stats_insights_views_and_visitors" />
 
     <com.google.android.material.button.MaterialButton

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -46,10 +46,7 @@
         <item name="android:paddingStart">@dimen/margin_extra_large</item>
     </style>
 
-    <style name="StatsBlockTitle" parent="TextAppearance.MaterialComponents.Headline6">
-        <item name="android:maxLines">1</item>
-        <item name="android:ellipsize">end</item>
-    </style>
+    <style name="StatsBlockTitle" parent="TextAppearance.MaterialComponents.Headline6"/>
 
     <style name="StatsDateSelectorTitle" parent="TextAppearance.MaterialComponents.Subtitle1">
         <item name="android:textStyle">bold</item>


### PR DESCRIPTION
This adds a multi-line feature to stats card titles. 
Before, only cards with "VIEW MORE" button had 2 lines title, and there was an issue it was sometimes changing to single line when the screen was refreshed. Now, every stats card has a multi-line title. This is the same as the iOS version now.

|before|after|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/198656709-01da6ad5-d858-4c42-a2b6-6ea3fb832b9a.png" height=640>|<img src="https://user-images.githubusercontent.com/2471769/198656950-91f4d7d5-4791-4650-84ef-1385967a8f47.png" height=640>|

To test:
1. Change the device language to German or Turkish which have longer titles on stats titles.
1. Launch the JP app.
3. Open Stats from "My Site → HOME → Stats" or "My Site → MENU → Stats".
4. Ensure cards with long titles (Views & Visitors, Total Comments, Total Followers) are on the screen. If not, add them by tapping the ⚙ icon at the top end of the screen.
5. Ensure the title on Views & Visitors card isn't truncated and it's multiple lines. If it fits the single line without being truncated, use a device with a smaller screen to test.
6. Refresh the screen by pulling the list down multiple times. Ensure the title looks correct on every refresh.

## Regression Notes
1. Potential unintended areas of impact
Layout issues on stats cards.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

8. What automated tests I added (or what prevented me from doing so)
This is a small UI change. No test is added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
