### PR TITLE
Refactor Frosted Glass Component to be Reusable

### DIFF
--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -24,6 +25,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.isActive
+import org.wordpress.android.R
 import org.wordpress.android.ui.accounts.login.components.JetpackLogo
 import org.wordpress.android.ui.accounts.login.components.LoopingTextWithBackground
 import org.wordpress.android.ui.accounts.login.components.PrimaryButton
@@ -121,7 +123,10 @@ private fun LoginScreenRevamped(
                         .align(Alignment.TopCenter)
         )
         ColumnWithFrostedGlassBackground(
-                background = { modifier, textModifier -> LoopingTextWithBackground(modifier, textModifier) }
+                blurRadius = 30.dp,
+                backgroundColor = colorResource(R.color.bg_jetpack_login_splash_bottom_panel),
+                borderColor = colorResource(R.color.border_top_jetpack_login_splash_bottom_panel),
+                background = { clipModifier, blurModifier -> LoopingTextWithBackground(clipModifier, blurModifier) }
         ) {
             PrimaryButton(onClick = onWpComLoginClicked)
             SecondaryButton(onClick = onSiteAddressLoginClicked)

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
@@ -24,12 +24,12 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.isActive
-import org.wordpress.android.ui.accounts.login.components.ColumnWithFrostedGlassBackground
 import org.wordpress.android.ui.accounts.login.components.JetpackLogo
 import org.wordpress.android.ui.accounts.login.components.LoopingTextWithBackground
 import org.wordpress.android.ui.accounts.login.components.PrimaryButton
 import org.wordpress.android.ui.accounts.login.components.SecondaryButton
 import org.wordpress.android.ui.accounts.login.components.TopLinearGradient
+import org.wordpress.android.ui.compose.components.ColumnWithFrostedGlassBackground
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.util.extensions.setEdgeToEdgeContentDisplay
 

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.ui.compose.theme.AppTheme
 @Composable
 fun LoopingTextWithBackground(
     modifier: Modifier = Modifier,
-    textModifier: Modifier = Modifier,
+    blurModifier: Modifier = Modifier,
 ) {
     Box(
             modifier
@@ -31,13 +31,13 @@ fun LoopingTextWithBackground(
                             sizeToIntrinsics = true,
                             contentScale = ContentScale.FillBounds,
                     )
+                    .then(blurModifier)
     ) {
         LoopingText(
                 modifier = Modifier
                         .clearAndSetSemantics {}
                         .fillMaxSize()
                         .padding(horizontal = dimensionResource(R.dimen.login_prologue_revamped_prompts_padding))
-                        .then(textModifier)
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ColumnWithFrostedGlassBackground.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ColumnWithFrostedGlassBackground.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.accounts.login.components
+package org.wordpress.android.ui.compose.components
 
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
@@ -23,8 +23,8 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.accounts.login.components.SlotsEnum.Buttons
-import org.wordpress.android.ui.accounts.login.components.SlotsEnum.ClippedBackground
+import org.wordpress.android.ui.compose.components.SlotsEnum.Buttons
+import org.wordpress.android.ui.compose.components.SlotsEnum.ClippedBackground
 
 private val blurRadius = 30.dp
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ColumnWithFrostedGlassBackground.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ColumnWithFrostedGlassBackground.kt
@@ -15,18 +15,15 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Outline.Rectangle
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.SubcomposeLayout
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
-import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.SlotsEnum.Buttons
 import org.wordpress.android.ui.compose.components.SlotsEnum.ClippedBackground
-
-private val blurRadius = 30.dp
 
 /**
  * These slots are utilized below in a subcompose layout in order to measure the size of the buttons composable. The
@@ -37,27 +34,32 @@ private enum class SlotsEnum { Buttons, ClippedBackground }
 
 @Composable
 private fun ColumnWithTopGlassBorder(
+    backgroundColor: Color,
+    borderColor: Color,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Column(
-            modifier = Modifier.background(colorResource(R.color.bg_jetpack_login_splash_bottom_panel))
+            modifier = Modifier.background(backgroundColor)
     ) {
-        Divider(
-                thickness = 1.dp,
-                color = colorResource(R.color.border_top_jetpack_login_splash_bottom_panel),
-        )
+        Divider(color = borderColor)
         content()
     }
 }
 
 @Composable
 fun ColumnWithFrostedGlassBackground(
-    background: @Composable (modifier: Modifier, textModifier: Modifier) -> Unit,
+    blurRadius: Dp,
+    backgroundColor: Color,
+    borderColor: Color,
+    background: @Composable (clipModifier: Modifier, blurModifier: Modifier) -> Unit,
     content: @Composable () -> Unit,
 ) {
     SubcomposeLayout { constraints ->
         val buttonsPlaceables = subcompose(Buttons) {
-            ColumnWithTopGlassBorder {
+            ColumnWithTopGlassBorder(
+                    backgroundColor = backgroundColor,
+                    borderColor = borderColor,
+            ) {
                 content()
             }
         }.map { it.measure(constraints) }
@@ -78,8 +80,8 @@ fun ColumnWithFrostedGlassBackground(
 
         val clippedBackgroundPlaceables = subcompose(ClippedBackground) {
             background(
-                    modifier = Modifier.clip(buttonsClipShape),
-                    textModifier = Modifier.composed {
+                    clipModifier = Modifier.clip(buttonsClipShape),
+                    blurModifier = Modifier.composed {
                         if (VERSION.SDK_INT >= VERSION_CODES.S) {
                             blur(blurRadius, BlurredEdgeTreatment.Unbounded)
                         } else {


### PR DESCRIPTION
Part 1 of splitting PR #17384

🔔 This PR contains only refactoring as preliminary work to use the component on the Welcome to Jetpack Screen.

Extracted the `ColumnWithFrostedGlassBackground` composable to the upper scope and and made it reusable by adding more parameters to allow configuring it from the outside.

To test:
1. Open the Jetpack App
2. **Verify** There is no regression on the design of the buttons container vs the `trunk` version.

<details>
<summary>📱 Previews</summary>

| Before | After |
| - | - |
| <img width="250" src="https://user-images.githubusercontent.com/4588074/198737515-edfc640d-5598-4a76-979a-81bf9e73d0e0.png"> | <img width="250" src="https://user-images.githubusercontent.com/4588074/198737749-d05ed390-919f-44c1-a361-f40a17333be2.png"> |
| <img width="250" src="https://user-images.githubusercontent.com/4588074/198737498-6671fb4a-ee0e-445c-a10a-ee0eea020469.png"> | <img width="250" src="https://user-images.githubusercontent.com/4588074/198737736-ee34577e-e614-4d58-ae23-ada8c491cd70.png"> |

</details>

## Regression Notes
1. Potential unintended areas of impact
   Jetpack app landing screen.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

4. What automated tests I added (or what prevented me from doing so)
   N/a - UI component refactoring.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
