### PR TITLE
Increase reader menu line height for long texts

### DIFF
--- a/WordPress/src/main/res/layout/reader_popup_menu_item.xml
+++ b/WordPress/src/main/res/layout/reader_popup_menu_item.xml
@@ -2,19 +2,19 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/reader_popup_menu_item_container"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/menu_item_height"
+    android:layout_height="wrap_content"
     android:gravity="start|center_vertical"
     android:orientation="horizontal"
-    android:paddingStart="@dimen/menu_item_margin"
-    android:paddingEnd="@dimen/menu_item_margin" >
+    android:paddingEnd="@dimen/menu_item_margin"
+    android:paddingStart="@dimen/menu_item_margin">
 
     <ImageView
         android:id="@+id/image"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_large"
         android:contentDescription="@null"
         android:tintMode="multiply"
-        android:layout_marginEnd="@dimen/margin_large"
         tools:src="@drawable/ic_reader_follow_white_24dp"
         tools:tint="@color/primary" />
 
@@ -22,8 +22,9 @@
         android:id="@+id/text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:minHeight="@dimen/menu_item_height"
         android:textAppearance="?textAppearanceSmallPopupMenu"
         tools:text="@string/reader_btn_follow"
         tools:textColor="@color/primary" />
-
 </LinearLayout>


### PR DESCRIPTION
Fixes #17324 
This fixes cut-off text on the reader popup menu. 
It's solved by increasing the line height if the text is longer than a single line.

|before EN|after EN (same)|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/198895732-f34ec612-32b3-4b5f-bc71-e364e140e297.png" height=640>|<img src="https://user-images.githubusercontent.com/2471769/198895773-c1f57174-6714-43b7-a090-63b31390a92b.png" height=640>|
|before DE|after DE|
|<img src="https://user-images.githubusercontent.com/2471769/198895821-71812d39-ffdd-49b5-8d24-14c85f2276f8.png" height=640>|<img src="https://user-images.githubusercontent.com/2471769/198895880-e62fc612-d0f1-4f27-b38a-dbce3d7d723a.png" height=640>|

To test:
1. Using Device language settings, change the language to German.
2. Restart the app.
3. Head to Reader > Following
4. Tap the "..." at the top-right of a post card.
5. Verify the text "Website-Benachrichtigungen aktivieren" is not cut off.

## Regression Notes
1. Potential unintended areas of impact
Reader popup menu in other languages.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested other languages.

3. What automated tests I added (or what prevented me from doing so)
None, since this is a small UI change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
