### PR TITLE
Merge release/21.1 after Code Freeze (21.1-rc-1)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+21.2
+-----
+
+
 21.1
 -----
 * [**] Added functionality to set the parent of a page from page settings in the editor. [https://github.com/wordpress-mobile/WordPress-Android/pull/17329]

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,3 +1,2 @@
 * [**] Added functionality to set the parent of a page from page settings in the editor. [https://github.com/wordpress-mobile/WordPress-Android/pull/17329]
-* [***] [Jetpack-only] Redesigned the landing screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17351]
-
+* [***] Redesigned the landing screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17351]

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,4 +1,3 @@
-- Added correct links to Automattic Family app marbles on the About screen
-- Updated the launch screen for Android versions 12+
-- Changed success message text from red to black for QR code logins
-- Fixed the Stats screen to include Western Arabic numerals for Arabic language users
+* [**] Added functionality to set the parent of a page from page settings in the editor. [https://github.com/wordpress-mobile/WordPress-Android/pull/17329]
+* [***] [Jetpack-only] Redesigned the landing screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17351]
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,4 +1,3 @@
-- Removed the Automattic Family app marbles from the About page
-- Updated the launch screen for Android versions 12+
-- Changed success message text from red to black for QR code logins
-- Fixed the Stats screen to include Western Arabic numerals for Arabic language users
+* [**] Added functionality to set the parent of a page from page settings in the editor. [https://github.com/wordpress-mobile/WordPress-Android/pull/17329]
+* [***] [Jetpack-only] Redesigned the landing screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17351]
+

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,3 +1,1 @@
 * [**] Added functionality to set the parent of a page from page settings in the editor. [https://github.com/wordpress-mobile/WordPress-Android/pull/17329]
-* [***] [Jetpack-only] Redesigned the landing screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17351]
-

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1667,8 +1667,10 @@
     <string name="post_settings_publish">Publish</string>
     <string name="post_settings_mark_as_sticky_options_header">Mark as sticky</string>
     <string name="post_settings_more_options">More Options</string>
+    <string name="post_settings_page_attributes">Page Attributes</string>
     <string name="post_settings_not_set">Not Set</string>
     <string name="post_settings_excerpt">Excerpt</string>
+    <string name="post_settings_parent">Parent Page</string>
     <string name="post_settings_slug">Slug</string>
     <string name="post_settings_tags">Tags</string>
     <string name="post_settings_post_format">Post Format</string>
@@ -4216,7 +4218,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="wp_jetpack_powered_stats_powered_by_jetpack_caption">Watch your traffic grow and learn about your audience with redesigned Stats and Insights, now available in the new Jetpack app.</string>
     <string name="wp_jetpack_powered_notifications_powered_by_jetpack">Notifications are powered by Jetpack</string>
     <string name="wp_jetpack_powered_notifications_powered_by_jetpack_caption">Stay informed with realtime updates for new comments, site traffic, security reports and more.</string>
-    <string name="wp_jetpack_get_new_jetpack_app">Get the new Jetpack app</string>
+    <string name="wp_jetpack_get_new_jetpack_app">Try the new Jetpack app</string>
     <string name="wp_jetpack_continue_to_reader">Continue to Reader</string>
     <string name="wp_jetpack_continue_to_stats">Continue to Stats</string>
     <string name="wp_jetpack_continue_to_notifications">Continue to Notifications</string>

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Mon, 30 Aug 2021 11:48:28 +0200
 
-versionName=21.0
-versionCode=1285
+versionName=21.1-rc-1
+versionCode=1286


### PR DESCRIPTION
- [x] New empty entry created in `RELEASE-NOTES.txt` for next iteration.
- [x] `{jetpack_}metadata/release_notes.txt` extracted for WordPress and Jetpack.
- [x] `WordPress/jetpack_metadata/release_notes.txt` audited to remove any item not applicable for Jetpack.
- [x] ~Internal dependencies (FluxC, Login. Stories. About…) bumped to a new stable version in `build.gradle` if necessary.~
    - N/A: Everything was already on a tag.
- [x] ~`WordPress/src/main/res/values/strings.xml` updated with strings from binary dependencies.~
    - N/A: No lib update, so no new strings from libs either.
- [x] New strings frozen/copied into `fastlane/resources/values/strings.xml`.
- [x] Version bumped in `version.properties`