### PR TITLE
[Tooling] [Screenshots] Update API level of emulators used for screenshots

### DIFF
--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -9,12 +9,12 @@ SCREENSHOT_DEVICES = [
   {
     device_type: 'phone',
     device: 'pixel_3',
-    api: 28
+    api: 31
   },
   {
     device_type: 'tenInch',
     device: 'Nexus 9',
-    api: 28
+    api: 31
   }
 ].freeze
 


### PR DESCRIPTION
This updates the API level of the emulators used for the screenshot automation, from API 28 to API 31.

Those are the emulators created and launched dynamically when we run `bundle exec fastlane screenshots app:<wordpress|jetpack>` to generate the raw screenshots based on the `WPScreenshotTest`/`JPScreenshotTest` UI tests.

Updating the API Level of those emulators to API 31 should fix #17191

### To Test

 - Run `bundle exec fastlane screenshots app:wordpress` (if you want to limit your test to only one locale and/or one device type, you can add arguments `locale:fr-FR` and `device:phone` to that command, respectively — though it would be nice to ultimately validate the look of the raw screenshots in all locales and device types)
 - Verify that the raw screenshots get generated, and that they all look as expected — especially that the gray overlay we had in #17191 is not present anymore
 - Ideally, run the same test for `bundle exec fastlane screenshots app:jetpack`

@zwarm @AjeshRPai I haven't actually ran those above test steps myself on this PR (and I'm already EOD, and AFK tomorrow), so I'll let you test this one, since you were the ones who discovered and investigated #17191 in the first place.