### PR TITLE
Disalbe notifications on WP

### DIFF
--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts.login
 
 import android.content.Context
+import android.content.Intent
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -48,7 +49,7 @@ class LoginPrologueRevampedFragment : Fragment() {
             AppTheme {
                 PositionProvider {
                     LoginScreenRevamped(
-                            onWpComLoginClicked = loginPrologueListener::showEmailLoginScreen,
+                            onWpComLoginClicked = { disableNotificationsOnWP() },
                             onSiteAddressLoginClicked = loginPrologueListener::loginViaSiteAddress,
                     )
                 }
@@ -70,6 +71,13 @@ class LoginPrologueRevampedFragment : Fragment() {
     override fun onPause() {
         super.onPause()
         requireActivity().window.setEdgeToEdgeContentDisplay(true)
+    }
+
+    private fun disableNotificationsOnWP() {
+        Intent().also { intent ->
+            intent.action = "org.wordpress.android.broadcast.DISABLE_NOTIFICATIONS"
+            context?.sendBroadcast(intent)
+        }
     }
 
     companion object {

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
@@ -25,6 +25,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.isActive
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.ui.accounts.login.components.ColumnWithFrostedGlassBackground
 import org.wordpress.android.ui.accounts.login.components.JetpackLogo
 import org.wordpress.android.ui.accounts.login.components.LoopingTextWithBackground
@@ -32,6 +33,8 @@ import org.wordpress.android.ui.accounts.login.components.PrimaryButton
 import org.wordpress.android.ui.accounts.login.components.SecondaryButton
 import org.wordpress.android.ui.accounts.login.components.TopLinearGradient
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.extensions.setEdgeToEdgeContentDisplay
 
 val LocalPosition = compositionLocalOf { 0f }
@@ -74,9 +77,18 @@ class LoginPrologueRevampedFragment : Fragment() {
     }
 
     private fun disableNotificationsOnWP() {
+        AppLog.d(T.NOTIFS, "Disable Notifications")
         Intent().also { intent ->
             intent.action = "org.wordpress.android.broadcast.DISABLE_NOTIFICATIONS"
-            context?.sendBroadcast(intent)
+            val appSuffix = BuildConfig.APPLICATION_ID.split(".").last()
+            val appPackage = if (appSuffix.isNotBlank()) {
+                "org.wordpress.android.${appSuffix}"
+            } else {
+                "org.wordpress.android"
+            }
+            intent.setPackage(appPackage)
+            AppLog.d(T.NOTIFS, intent.toString())
+            context?.sendBroadcast(intent, "org.wordpress.android.permission.DISABLE_NOTIFICATIONS")
         }
     }
 

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <!-- GCM all build types configuration -->
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
+    <uses-permission android:name="org.wordpress.android.permission.DISABLE_NOTIFICATIONS"/>
 
     <uses-feature
         android:name="android.hardware.camera"


### PR DESCRIPTION
Test branch only for testing broadcast receiver

Add the following to Jetpack app AndroidManifest.xml
`<uses-permission android:name="org.wordpress.android.permission.DISABLE_NOTIFICATIONS"/>`

and then
       ` Intent().also { intent ->
            intent.action = "org.wordpress.android.broadcast.DISABLE_NOTIFICATIONS"
            context?.sendBroadcast(intent, "org.wordpress.android.permission.DISABLE_NOTIFICATIONS")
        }`



Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
