### PR TITLE
Detekt - Resolve/Suppress All Baseline Warnings - Long methods warnings_ PhotoPickerFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -157,14 +157,14 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
     }
 
     private fun observeOnNavigateToPreview() {
-        viewModel.onNavigateToPreview.observeEvent(viewLifecycleOwner, { uri ->
+        viewModel.onNavigateToPreview.observeEvent(viewLifecycleOwner) { uri ->
             MediaPreviewActivity.showPreview(
                     requireContext(),
                     null,
                     uri.toString()
             )
             AccessibilityUtils.setActionModeDoneButtonContentDescription(activity, getString(string.cancel))
-        })
+        }
     }
 
     private fun PhotoPickerFragmentBinding.observeUIState() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -16,7 +16,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PhotoPickerFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
@@ -180,7 +179,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
                     null,
                     uri.toString()
             )
-            AccessibilityUtils.setActionModeDoneButtonContentDescription(activity, getString(string.cancel))
+            AccessibilityUtils.setActionModeDoneButtonContentDescription(activity, getString(R.string.cancel))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -83,7 +83,6 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
         viewModel = ViewModelProvider(this, viewModelFactory).get(PhotoPickerViewModel::class.java)
     }
 
-    @Suppress("DEPRECATION")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -132,6 +131,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun observeOnPermissionsRequested() {
         viewModel.onPermissionsRequested.observeEvent(viewLifecycleOwner) {
             when (it) {
@@ -179,6 +179,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun PhotoPickerFragmentBinding.observeUIState() {
         var isShowingActionMode = false
         viewModel.uiState.observe(viewLifecycleOwner) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -26,6 +26,8 @@ import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.ui.media.MediaPreviewActivity
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel.Visible
+import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.ActionModeUiModel
+import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.ActionModeUiModel.Hidden
 import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AniUtils.Duration.MEDIUM
@@ -115,25 +117,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
 
             recycler.layoutManager = layoutManager
 
-            var isShowingActionMode = false
-            viewModel.uiState.observe(viewLifecycleOwner, Observer {
-                it?.let { uiState ->
-                    setupPhotoList(uiState.photoListUiModel)
-                    setupBottomBar(uiState.bottomBarUiModel)
-                    setupSoftAskView(uiState.softAskViewUiModel)
-                    if (uiState.actionModeUiModel is PhotoPickerViewModel.ActionModeUiModel.Visible &&
-                            !isShowingActionMode
-                    ) {
-                        isShowingActionMode = true
-                        (activity as AppCompatActivity).startSupportActionMode(PhotoPickerActionModeCallback(viewModel))
-                    } else if (uiState.actionModeUiModel is PhotoPickerViewModel.ActionModeUiModel.Hidden &&
-                            isShowingActionMode
-                    ) {
-                        isShowingActionMode = false
-                    }
-                    setupFab(uiState.fabUiModel)
-                }
-            })
+            observeUIState()
 
             viewModel.onNavigateToPreview.observeEvent(viewLifecycleOwner, { uri ->
                 MediaPreviewActivity.showPreview(
@@ -176,6 +160,28 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
 
             viewModel.start(selectedIds, browserType, lastTappedIcon, site)
         }
+    }
+
+    private fun PhotoPickerFragmentBinding.observeUIState() {
+        var isShowingActionMode = false
+        viewModel.uiState.observe(viewLifecycleOwner, Observer {
+            it?.let { uiState ->
+                setupPhotoList(uiState.photoListUiModel)
+                setupBottomBar(uiState.bottomBarUiModel)
+                setupSoftAskView(uiState.softAskViewUiModel)
+                if (uiState.actionModeUiModel is ActionModeUiModel.Visible &&
+                        !isShowingActionMode
+                ) {
+                    isShowingActionMode = true
+                    (activity as AppCompatActivity).startSupportActionMode(PhotoPickerActionModeCallback(viewModel))
+                } else if (uiState.actionModeUiModel is Hidden &&
+                        isShowingActionMode
+                ) {
+                    isShowingActionMode = false
+                }
+                setupFab(uiState.fabUiModel)
+            }
+        })
     }
 
     override fun onDestroyView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -122,13 +122,9 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
 
             observeOnNavigateToPreview()
 
-            viewModel.onInsert.observeEvent(viewLifecycleOwner, { selectedUris ->
-                listener?.onPhotoPickerMediaChosen(selectedUris.map { it.uri })
-            })
+            observeOnInsert()
 
-            viewModel.onIconClicked.observeEvent(viewLifecycleOwner, { (icon, allowMultipleSelection) ->
-                listener?.onPhotoPickerIconClicked(icon, allowMultipleSelection)
-            })
+            observeOnIconClicked()
 
             viewModel.onShowPopupMenu.observeEvent(viewLifecycleOwner, { uiModel ->
                 val popup = PopupMenu(activity, uiModel.view.view)
@@ -153,6 +149,18 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
             setupProgressDialog()
 
             viewModel.start(selectedIds, browserType, lastTappedIcon, site)
+        }
+    }
+
+    private fun observeOnIconClicked() {
+        viewModel.onIconClicked.observeEvent(viewLifecycleOwner) { (icon, allowMultipleSelection) ->
+            listener?.onPhotoPickerIconClicked(icon, allowMultipleSelection)
+        }
+    }
+
+    private fun observeOnInsert() {
+        viewModel.onInsert.observeEvent(viewLifecycleOwner) { selectedUris ->
+            listener?.onPhotoPickerMediaChosen(selectedUris.map { it.uri })
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -11,7 +11,6 @@ import androidx.appcompat.app.AlertDialog.Builder
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.recyclerview.widget.GridLayoutManager
@@ -187,7 +186,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
 
     private fun PhotoPickerFragmentBinding.observeUIState() {
         var isShowingActionMode = false
-        viewModel.uiState.observe(viewLifecycleOwner, Observer {
+        viewModel.uiState.observe(viewLifecycleOwner) {
             it?.let { uiState ->
                 setupPhotoList(uiState.photoListUiModel)
                 setupBottomBar(uiState.bottomBarUiModel)
@@ -204,7 +203,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
                 }
                 setupFab(uiState.fabUiModel)
             }
-        })
+        }
     }
 
     override fun onDestroyView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.ui.media.MediaPreviewActivity
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel.Visible
-import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PermissionsRequested.STORAGE
 import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AniUtils.Duration.MEDIUM
@@ -137,7 +136,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
         viewModel.onPermissionsRequested.observeEvent(viewLifecycleOwner) {
             when (it) {
                 PhotoPickerViewModel.PermissionsRequested.CAMERA -> requestCameraPermission()
-                STORAGE -> requestStoragePermission()
+                PhotoPickerViewModel.PermissionsRequested.STORAGE -> requestStoragePermission()
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.ui.media.MediaPreviewActivity
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel.Visible
-import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PermissionsRequested.CAMERA
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PermissionsRequested.STORAGE
 import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.AniUtils
@@ -137,7 +136,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
     private fun observeOnPermissionsRequested() {
         viewModel.onPermissionsRequested.observeEvent(viewLifecycleOwner) {
             when (it) {
-                CAMERA -> requestCameraPermission()
+                PhotoPickerViewModel.PermissionsRequested.CAMERA -> requestCameraPermission()
                 STORAGE -> requestStoragePermission()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -29,6 +29,8 @@ import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogU
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel.Visible
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.ActionModeUiModel
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.ActionModeUiModel.Hidden
+import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PermissionsRequested.CAMERA
+import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PermissionsRequested.STORAGE
 import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AniUtils.Duration.MEDIUM
@@ -87,7 +89,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
         viewModel = ViewModelProvider(this, viewModelFactory).get(PhotoPickerViewModel::class.java)
     }
 
-    @Suppress("DEPRECATION", "LongMethod")
+    @Suppress("DEPRECATION")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -126,29 +128,37 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
 
             observeOnIconClicked()
 
-            viewModel.onShowPopupMenu.observeEvent(viewLifecycleOwner, { uiModel ->
-                val popup = PopupMenu(activity, uiModel.view.view)
-                for (popupMenuItem in uiModel.items) {
-                    val item = popup.menu
-                            .add(popupMenuItem.title.stringRes)
-                    item.setOnMenuItemClickListener {
-                        popupMenuItem.action()
-                        true
-                    }
-                }
-                popup.show()
-            })
+            observeOnShowPopupMenu()
 
-            viewModel.onPermissionsRequested.observeEvent(viewLifecycleOwner, {
-                when (it) {
-                    PhotoPickerViewModel.PermissionsRequested.CAMERA -> requestCameraPermission()
-                    PhotoPickerViewModel.PermissionsRequested.STORAGE -> requestStoragePermission()
-                }
-            })
+            observeOnPermissionsRequested()
 
             setupProgressDialog()
 
             viewModel.start(selectedIds, browserType, lastTappedIcon, site)
+        }
+    }
+
+    private fun observeOnPermissionsRequested() {
+        viewModel.onPermissionsRequested.observeEvent(viewLifecycleOwner) {
+            when (it) {
+                CAMERA -> requestCameraPermission()
+                STORAGE -> requestStoragePermission()
+            }
+        }
+    }
+
+    private fun observeOnShowPopupMenu() {
+        viewModel.onShowPopupMenu.observeEvent(viewLifecycleOwner) { uiModel ->
+            val popup = PopupMenu(activity, uiModel.view.view)
+            for (popupMenuItem in uiModel.items) {
+                val item = popup.menu
+                        .add(popupMenuItem.title.stringRes)
+                item.setOnMenuItemClickListener {
+                    popupMenuItem.action()
+                    true
+                }
+            }
+            popup.show()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.ui.media.MediaPreviewActivity
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel.Visible
-import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.ActionModeUiModel
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.ActionModeUiModel.Hidden
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PermissionsRequested.CAMERA
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PermissionsRequested.STORAGE
@@ -190,7 +189,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
                 setupPhotoList(uiState.photoListUiModel)
                 setupBottomBar(uiState.bottomBarUiModel)
                 setupSoftAskView(uiState.softAskViewUiModel)
-                if (uiState.actionModeUiModel is ActionModeUiModel.Visible &&
+                if (uiState.actionModeUiModel is PhotoPickerViewModel.ActionModeUiModel.Visible &&
                         !isShowingActionMode
                 ) {
                     isShowingActionMode = true

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.ui.media.MediaPreviewActivity
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel.Visible
-import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.ActionModeUiModel.Hidden
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PermissionsRequested.CAMERA
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PermissionsRequested.STORAGE
 import org.wordpress.android.util.AccessibilityUtils
@@ -194,7 +193,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
                 ) {
                     isShowingActionMode = true
                     (activity as AppCompatActivity).startSupportActionMode(PhotoPickerActionModeCallback(viewModel))
-                } else if (uiState.actionModeUiModel is Hidden &&
+                } else if (uiState.actionModeUiModel is PhotoPickerViewModel.ActionModeUiModel.Hidden &&
                         isShowingActionMode
                 ) {
                     isShowingActionMode = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -321,7 +321,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
 
     private fun setupProgressDialog() {
         var progressDialog: AlertDialog? = null
-        viewModel.uiState.observe(viewLifecycleOwner, Observer {
+        viewModel.uiState.observe(viewLifecycleOwner) {
             it?.progressDialogUiModel?.apply {
                 when (this) {
                     is Visible -> {
@@ -345,7 +345,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
                     }
                 }
             }
-        })
+        }
     }
 
     private fun canShowMediaSourceBottomBar(

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PhotoPickerFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
@@ -119,14 +120,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
 
             observeUIState()
 
-            viewModel.onNavigateToPreview.observeEvent(viewLifecycleOwner, { uri ->
-                MediaPreviewActivity.showPreview(
-                        requireContext(),
-                        null,
-                        uri.toString()
-                )
-                AccessibilityUtils.setActionModeDoneButtonContentDescription(activity, getString(R.string.cancel))
-            })
+            observeOnNavigateToPreview()
 
             viewModel.onInsert.observeEvent(viewLifecycleOwner, { selectedUris ->
                 listener?.onPhotoPickerMediaChosen(selectedUris.map { it.uri })
@@ -160,6 +154,17 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
 
             viewModel.start(selectedIds, browserType, lastTappedIcon, site)
         }
+    }
+
+    private fun observeOnNavigateToPreview() {
+        viewModel.onNavigateToPreview.observeEvent(viewLifecycleOwner, { uri ->
+            MediaPreviewActivity.showPreview(
+                    requireContext(),
+                    null,
+                    uri.toString()
+            )
+            AccessibilityUtils.setActionModeDoneButtonContentDescription(activity, getString(string.cancel))
+        })
     }
 
     private fun PhotoPickerFragmentBinding.observeUIState() {


### PR DESCRIPTION
Parent: https://github.com/wordpress-mobile/WordPress-Android/issues/17010

This PR resolves/suppresses all complexity related LongMethod warnings for the PhotoPickerFragment class (see docs [here](https://detekt.dev/docs/rules/complexity#longmethod)):

`1` x LongMethod  (Resolve: 3c1ba0b1a1016778772da374c22f258a2297c2c9 + 43c89c4d8f443ca50e20a982ef6936604f515dc6 + 49fb4e5b17c223c5eef55f5c8c7498212addc851 + 8f9493474ad724e855ab5c96c7b9ce4234eb9014 + c247f03f2cdd68342ab78929bf4d476215708b0e )

-----

To test:

- There is nothing much to test here.

- Verifying that all the CI checks are successful should be enough (especially the detekt check).
- However, if you really want to be thorough, you could smoke test the WordPress and/or Jetpack apps to verify that everything works as expected on every screen that relates to these changes. Specifically, you could follow the below steps:

   -Go to the menu tab
   -click on media option
   -click on the upload media button or the (+) button at the top right corner
   -select Take Photo
   -capture an image and upload


## Regression Notes
1. Potential unintended areas of impact
     can't think of any 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)
     N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
