### PR TITLE
[Jetpack App] Fix Login Screens Navbar Appear Under System Topbar

### DIFF
--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
@@ -69,7 +69,7 @@ class LoginPrologueRevampedFragment : Fragment() {
 
     override fun onPause() {
         super.onPause()
-        requireActivity().window.setEdgeToEdgeContentDisplay(true)
+        requireActivity().window.setEdgeToEdgeContentDisplay(false)
     }
 
     companion object {


### PR DESCRIPTION
Fixes #17405

To test:
1. Install Jetpack app and make sure you're logged out
2. Tap `Continue with WordPress.com`
3. **Expect** The top navigation bar to appear below the top system bar (see screenshots)
4. Go back
5. Tap `Enter your existing site address`
6. **Expect** The top navigation bar to appear below the top system bar

## Screenshots
| Before | After |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/199495318-d2d1853d-ed3e-4367-8403-ce2533d7bab1.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/199495383-0d2e4d9b-11c3-4314-9ebc-c5664a96c504.png"> |

## Regression Notes
1. Potential unintended areas of impact
   N/a - The code for the right behavior was ready but not applied correctly.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a - Manual testing.

8. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
