### PR TITLE
Flag for preventing duplicate notifications

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -131,6 +131,7 @@ android {
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_THREE", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_FOUR", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_NEW_USERS", "false"
+        buildConfigField "boolean", "PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/PreventDuplicateNotifsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/PreventDuplicateNotifsFeatureConfig.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+/**
+ * This prevents WP notifications when the WP app and JP app is installed.
+ */
+@Feature(PreventDuplicateNotifsFeatureConfig.PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD, false)
+class PreventDuplicateNotifsFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD,
+        PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD
+) {
+    companion object {
+        const val PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD = "prevent_duplicate_notifs_remote_field"
+    }
+}


### PR DESCRIPTION
This adds a flag to prevent WP notifications when the WP app and JP app is installed. 
This flag will be used on JP when [org.wordpress.android.broadcast.DISABLE_NOTIFICATIONS](https://github.com/wordpress-mobile/WordPress-Android/pull/17371) broadcast is sent. If it's true, we'll send the broadcast to disable WP notifs.

**TODO:**
- [x] Remote field will be added to Firebase after `prevent_duplicate_notifs_remote_field` name is approved.

To test:

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
