### PR TITLE
[Blogging Reminders Sync] Including self hosted in reminders

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/bloggingreminders/provider/BloggingRemindersProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/bloggingreminders/provider/BloggingRemindersProvider.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.wordpress.android.WordPress
-import org.wordpress.android.fluxc.model.BloggingRemindersModel
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.provider.query.QueryContentProvider
@@ -50,13 +49,7 @@ class BloggingRemindersProvider : QueryContentProvider() {
                         }.filter { bloggingRemindersModel ->
                             bloggingRemindersModel.enabledDays.isNotEmpty()
                         }
-                        val filteredSiteIds = filteredBloggingReminders.map { bloggingReminder ->
-                            siteStore.getSiteIdForLocalId(bloggingReminder.siteId)
-                        }
-                        val result: Map<RemoteSiteId?, BloggingRemindersModel?> = filteredSiteIds.zip(
-                                filteredBloggingReminders
-                        ).toMap()
-                        queryResult.createCursor(result)
+                        queryResult.createCursor(filteredBloggingReminders)
                     }
                 } else null
             } catch (signatureNotFoundException: SignatureNotFoundException) {

--- a/WordPress/src/main/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolver.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.bloggingreminders.JetpackBloggingRemindersSyncFlag
 import org.wordpress.android.bloggingreminders.provider.BloggingRemindersProvider
 import org.wordpress.android.fluxc.model.BloggingRemindersModel
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.APPLICATION_SCOPE
 import org.wordpress.android.provider.query.QueryResult
 import org.wordpress.android.resolver.ContentResolverWrapper
@@ -30,6 +31,7 @@ class BloggingRemindersResolver @Inject constructor(
     private val contentResolverWrapper: ContentResolverWrapper,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val bloggingRemindersSyncAnalyticsTracker: BloggingRemindersSyncAnalyticsTracker,
+    private val siteStore: SiteStore,
     private val bloggingRemindersStore: BloggingRemindersStore,
     @Named(APPLICATION_SCOPE) private val coroutineScope: CoroutineScope,
     private val reminderScheduler: ReminderScheduler,
@@ -92,7 +94,8 @@ class BloggingRemindersResolver @Inject constructor(
             coroutineScope.launch {
                 var syncCount = 0
                 for (bloggingReminder in reminders) {
-                    if (!isBloggingReminderAlreadySet(bloggingReminder.siteId)) {
+                    val site = siteStore.getSiteByLocalId(bloggingReminder.siteId)
+                    if (site != null && !isBloggingReminderAlreadySet(bloggingReminder.siteId)) {
                         bloggingRemindersStore.updateBloggingReminders(bloggingReminder)
                         setLocalReminderNotification(bloggingReminder)
                         syncCount = syncCount.inc()

--- a/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolverTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.flowOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.MainCoroutineScopeRule
 import org.wordpress.android.bloggingreminders.BloggingRemindersSyncAnalyticsTracker
 import org.wordpress.android.bloggingreminders.BloggingRemindersSyncAnalyticsTracker.ErrorType.QueryBloggingRemindersError
@@ -22,7 +23,6 @@ import org.wordpress.android.bloggingreminders.provider.BloggingRemindersProvide
 import org.wordpress.android.fluxc.model.BloggingRemindersModel
 import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.MONDAY
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.provider.query.QueryResult
 import org.wordpress.android.resolver.ContentResolverWrapper
 import org.wordpress.android.test
@@ -35,7 +35,7 @@ import org.wordpress.android.workers.reminder.ReminderScheduler
 import java.time.DayOfWeek
 
 @ExperimentalCoroutinesApi
-class BloggingRemindersResolverTest {
+class BloggingRemindersResolverTest : BaseUnitTest() {
     @Rule
     @JvmField val coroutineScope = MainCoroutineScopeRule()
 
@@ -46,7 +46,6 @@ class BloggingRemindersResolverTest {
     private val contentResolverWrapper: ContentResolverWrapper = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val bloggingRemindersSyncAnalyticsTracker: BloggingRemindersSyncAnalyticsTracker = mock()
-    private val siteStore: SiteStore = mock()
     private val bloggingRemindersStore: BloggingRemindersStore = mock()
     private val reminderScheduler: ReminderScheduler = mock()
     private val bloggingRemindersModelMapper: BloggingRemindersModelMapper = mock()
@@ -58,7 +57,6 @@ class BloggingRemindersResolverTest {
             contentResolverWrapper,
             appPrefsWrapper,
             bloggingRemindersSyncAnalyticsTracker,
-            siteStore,
             bloggingRemindersStore,
             coroutineScope,
             reminderScheduler,
@@ -95,7 +93,6 @@ class BloggingRemindersResolverTest {
 
     @Test
     fun `Should trigger failure callback if feature flag is DISABLED`() {
-        whenever(appPrefsWrapper.getIsFirstTryBloggingRemindersSyncJetpack()).thenReturn(true)
         whenever(jetpackBloggingRemindersSyncFlag.isEnabled()).thenReturn(false)
         val onFailure: () -> Unit = mock()
         classToTest.trySyncBloggingReminders({}, onFailure)
@@ -120,7 +117,6 @@ class BloggingRemindersResolverTest {
 
     @Test
     fun `Should NOT query ContentResolver if feature flag is DISABLED`() {
-        whenever(appPrefsWrapper.getIsFirstTryBloggingRemindersSyncJetpack()).thenReturn(true)
         whenever(jetpackBloggingRemindersSyncFlag.isEnabled()).thenReturn(false)
         classToTest.trySyncBloggingReminders({}, {})
         verify(contentResolverWrapper, never()).queryUri(any(), any())
@@ -176,13 +172,12 @@ class BloggingRemindersResolverTest {
     @Test
     fun `Should track success if result map has entries`() = test {
         whenever(bloggingRemindersModelMapper.toUiModel(any())).thenReturn(bloggingRemindersUiModel)
-        whenever(siteStore.getLocalIdForRemoteSiteId(123L)).thenReturn(validLocalId)
         whenever(bloggingRemindersStore.bloggingRemindersModel(validLocalId))
                 .thenReturn(flowOf(defaultBloggingRemindersModel))
         featureEnabled()
         whenever(mockCursor.getString(0)).thenReturn(
-                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
-                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+                "[{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
         classToTest.trySyncBloggingReminders({}, {})
         verify(bloggingRemindersSyncAnalyticsTracker).trackSuccess(1)
@@ -192,11 +187,10 @@ class BloggingRemindersResolverTest {
     fun `Should trigger success callback if result map has entries`() = test {
         whenever(bloggingRemindersStore.bloggingRemindersModel(validLocalId))
                 .thenReturn(flowOf(userSetBloggingRemindersModel))
-        whenever(siteStore.getLocalIdForRemoteSiteId(123L)).thenReturn(validLocalId)
         featureEnabled()
         whenever(mockCursor.getString(0)).thenReturn(
-                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
-                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+                "[{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
         val onSuccess: () -> Unit = mock()
         classToTest.trySyncBloggingReminders(onSuccess) {}
@@ -206,13 +200,12 @@ class BloggingRemindersResolverTest {
     @Test
     fun `Should update blogging reminder if site local ID is valid AND store returns default reminder`() = test {
         whenever(bloggingRemindersModelMapper.toUiModel(any())).thenReturn(bloggingRemindersUiModel)
-        whenever(siteStore.getLocalIdForRemoteSiteId(123)).thenReturn(validLocalId)
         whenever(bloggingRemindersStore.bloggingRemindersModel(validLocalId))
                 .thenReturn(flowOf(defaultBloggingRemindersModel))
         featureEnabled()
         whenever(mockCursor.getString(0)).thenReturn(
-                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
-                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+                "[{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
         classToTest.trySyncBloggingReminders({}, {})
         verify(bloggingRemindersStore, times(1)).updateBloggingReminders(
@@ -229,13 +222,12 @@ class BloggingRemindersResolverTest {
     @Test
     fun `Should map blogging reminder when setting local notification`() = test {
         whenever(bloggingRemindersModelMapper.toUiModel(any())).thenReturn(bloggingRemindersUiModel)
-        whenever(siteStore.getLocalIdForRemoteSiteId(123)).thenReturn(validLocalId)
         whenever(bloggingRemindersStore.bloggingRemindersModel(validLocalId))
                 .thenReturn(flowOf(defaultBloggingRemindersModel))
         featureEnabled()
         whenever(mockCursor.getString(0)).thenReturn(
-                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
-                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+                "[{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
         classToTest.trySyncBloggingReminders({}, {})
         verify(bloggingRemindersModelMapper).toUiModel(userSetBloggingRemindersModel)
@@ -244,13 +236,12 @@ class BloggingRemindersResolverTest {
     @Test
     fun `Should schedule blogging reminder local notification`() = test {
         whenever(bloggingRemindersModelMapper.toUiModel(any())).thenReturn(bloggingRemindersUiModel)
-        whenever(siteStore.getLocalIdForRemoteSiteId(123)).thenReturn(validLocalId)
         whenever(bloggingRemindersStore.bloggingRemindersModel(validLocalId))
                 .thenReturn(flowOf(defaultBloggingRemindersModel))
         featureEnabled()
         whenever(mockCursor.getString(0)).thenReturn(
-                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
-                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+                "[{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
         classToTest.trySyncBloggingReminders({}, {})
         verify(reminderScheduler).schedule(
@@ -264,13 +255,10 @@ class BloggingRemindersResolverTest {
     @Test
     fun `Should NOT update blogging reminder if site local ID is invalid`() = test {
         val invalidLocalId = 0
-        whenever(bloggingRemindersStore.bloggingRemindersModel(invalidLocalId))
-                .thenReturn(flowOf(defaultBloggingRemindersModel))
-        whenever(siteStore.getLocalIdForRemoteSiteId(123)).thenReturn(invalidLocalId)
         featureEnabled()
         whenever(mockCursor.getString(0)).thenReturn(
-                "{\"123\":{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
-                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+                "[{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":$invalidLocalId}}]"
         )
         classToTest.trySyncBloggingReminders({}, {})
         verify(bloggingRemindersStore, times(0)).updateBloggingReminders(any())
@@ -280,11 +268,10 @@ class BloggingRemindersResolverTest {
     fun `Should NOT update blogging reminder if reminder is already set`() = test {
         whenever(bloggingRemindersStore.bloggingRemindersModel(validLocalId))
                 .thenReturn(flowOf(userSetBloggingRemindersModel))
-        whenever(siteStore.getLocalIdForRemoteSiteId(123)).thenReturn(validLocalId)
         featureEnabled()
         whenever(mockCursor.getString(0)).thenReturn(
-                "{\"123\":{\"enabledDays\":[],\"hour\":5" +
-                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}}"
+                "[{\"enabledDays\":[],\"hour\":5" +
+                        ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
         classToTest.trySyncBloggingReminders({}, {})
         verify(bloggingRemindersStore, times(0)).updateBloggingReminders(any())

--- a/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersResolverTest.kt
@@ -22,7 +22,9 @@ import org.wordpress.android.bloggingreminders.JetpackBloggingRemindersSyncFlag
 import org.wordpress.android.bloggingreminders.provider.BloggingRemindersProvider
 import org.wordpress.android.fluxc.model.BloggingRemindersModel
 import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.MONDAY
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.provider.query.QueryResult
 import org.wordpress.android.resolver.ContentResolverWrapper
 import org.wordpress.android.test
@@ -46,6 +48,7 @@ class BloggingRemindersResolverTest : BaseUnitTest() {
     private val contentResolverWrapper: ContentResolverWrapper = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val bloggingRemindersSyncAnalyticsTracker: BloggingRemindersSyncAnalyticsTracker = mock()
+    private val siteStore: SiteStore = mock()
     private val bloggingRemindersStore: BloggingRemindersStore = mock()
     private val reminderScheduler: ReminderScheduler = mock()
     private val bloggingRemindersModelMapper: BloggingRemindersModelMapper = mock()
@@ -57,6 +60,7 @@ class BloggingRemindersResolverTest : BaseUnitTest() {
             contentResolverWrapper,
             appPrefsWrapper,
             bloggingRemindersSyncAnalyticsTracker,
+            siteStore,
             bloggingRemindersStore,
             coroutineScope,
             reminderScheduler,
@@ -82,6 +86,7 @@ class BloggingRemindersResolverTest : BaseUnitTest() {
         whenever(wordPressPublicData.currentPackageId()).thenReturn(wordPressCurrentPackageId)
         whenever(mockCursor.getString(0)).thenReturn("{}")
         whenever(contentResolverWrapper.queryUri(contentResolver, uriValue)).thenReturn(mockCursor)
+        whenever(siteStore.getSiteByLocalId(validLocalId)).thenReturn(SiteModel())
     }
 
     @Test


### PR DESCRIPTION
Fixes #17421 

As part of the sync process and self-hosted login we are now synching the SiteModels. Having them synched keeping local ids makes it easier to sync things like blogging reminders since they are based on local site ids. This was on purpose to allow reminders for self-hosted sites and replicating the local site ids permits a simple 1:1 mapping. Note that the solution is not ideal since this makes this resolver dependent on the SiteModel sync to have happen already. But this and in general the overall error management strategy is something possibly better tackled in the provider/resolver orchestrator refactoring that is ongoing.

## To test:
Steps are basically the same as for #17343 but tested for both .COM/JP sites and self-hosted

### Only self-hosted sites present
1. Install WordPress and add one or more self-hosted sites; also enable the jetpackProviderSyncFeatureConfig from the debug menu
2. Add blogging prompts to a couple of different sites;
3. Set the flag isFeatureFlagEnabled to true on SharedLoginResolver.kt, UserFlagsResolver.kt and BloggingRemindersResolver.kt (this cannot be done using the Debug settings screen because that is only available when the user is already logged in);
4. Replace jetpackProviderSyncFeatureConfig.isEnabled() with true on SharedLoginProvider.kt, UserFlagsProvider.kt and BloggingRemindersProvider.kt.
5. Install Jetpack using the same variant (e.g. if installed WordPress version was jalapenoDebug, install Jetpack jalapenoDebug);
6. Jetpack should login automatically after launching, and home screen should be shown;
7. Check if the blogging prompts set on step 2 were set correctly in the site settings.
8. Change the device date/time ahead of the scheduled time of the reminder. A local notification should be triggered, and tapping on it should open the Editor.

### Only .COM/JP sites present
Repeat the previous steps but for step 1 do not add self-hosted sites in the WP app, instead login with a .com user with at least 2 sites.

### .COM/JP AND selfhosted sites present
Repeat the previous steps but for step 1 login with a .com user with at least 2 sites + add 1 or more self-hosted sites.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests

3. What automated tests I added (or what prevented me from doing so)
Updated BloggingRemindersResolverTest to reflect the new approach

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
