### PR TITLE
[Jetpack Content Migration Flow] Add Notifications Screen to the flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -72,10 +73,12 @@ private fun JetpackMigrationScreen(viewModel: JetpackMigrationViewModel = viewMo
     Box {
         val uiState by viewModel.uiState.collectAsState()
 
-        when (val state = uiState) {
-            is Content.Welcome -> WelcomeStep(state)
-            is Content.Notifications -> NotificationsStep(state)
-            is Loading -> LoadingState()
+        Crossfade(targetState = uiState) { state ->
+            when (state) {
+                is Content.Welcome -> WelcomeStep(state)
+                is Content.Notifications -> NotificationsStep(state)
+                is Loading -> LoadingState()
+            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Loading
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.LoadingState
+import org.wordpress.android.ui.main.jetpack.migration.compose.state.NotificationsStep
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.WelcomeStep
 import javax.inject.Inject
 
@@ -73,6 +74,7 @@ private fun JetpackMigrationScreen(viewModel: JetpackMigrationViewModel = viewMo
 
         when (val state = uiState) {
             is Content.Welcome -> WelcomeStep(state)
+            is Content.Notifications -> NotificationsStep(state)
             is Loading -> LoadingState()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -78,6 +78,7 @@ class JetpackMigrationViewModel @Inject constructor(
     @Suppress("ForbiddenComment")
     private fun onContinueFromNotificationsClicked() {
         // TODO: Disable notifications in WP app
+        //  See https://github.com/wordpress-mobile/WordPress-Android/pull/17371
         // TODO: Navigate to next step (error? or done)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -104,7 +104,7 @@ class JetpackMigrationViewModel @Inject constructor(
             val subtitle: UiString,
             val message: UiString,
             open val primaryActionButton: ActionButton,
-            open val secondaryActionButton: ActionButton,
+            open val secondaryActionButton: ActionButton? = null,
         ) : UiState() {
             data class Welcome(
                 val userAvatarUrl: String = "",
@@ -125,6 +125,16 @@ class JetpackMigrationViewModel @Inject constructor(
                                 R.string.jp_migration_welcome_site_found_message
                             }
                     ),
+            )
+
+            data class Notifications(
+                override val primaryActionButton: ActionButton,
+            ) : Content(
+                    primaryActionButton = primaryActionButton,
+                    screenIconRes = R.drawable.ic_jetpack_migration_notifications,
+                    title = UiStringRes(R.string.jp_migration_notifications_title),
+                    subtitle = UiStringRes(R.string.jp_migration_notifications_subtitle),
+                    message = UiStringRes(R.string.jp_migration_notifications_disabled_in_wp_message),
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -163,5 +163,12 @@ class JetpackMigrationViewModel @Inject constructor(
                 onClick = onClick,
                 text = UiStringRes(R.string.jp_migration_help_button),
         )
+
+        data class NotificationsPrimaryButton(
+            override val onClick: () -> Unit,
+        ) : ActionButton(
+                onClick = onClick,
+                text = UiStringRes(R.string.jp_migration_continue_button),
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.NotificationsPrimaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomePrimaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomeSecondaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content
@@ -59,15 +60,25 @@ class JetpackMigrationViewModel @Inject constructor(
     @Suppress("ForbiddenComment", "MagicNumber")
     private fun onContinueClicked() {
         (_uiState.value as? Content.Welcome)?.let {
-            // TODO: Update this to trigger data migration logic after processing uiState is emitted:
             viewModelScope.launch {
                 _uiState.value = it.copy(isProcessing = true)
-                // TODO: Remove this temporary delay
-                delay(5000)
-                _uiState.value = it.copy(isProcessing = false)
-                // TODO: navigate to notifications screen
+                // TODO: Replace this temporary delay with migration logic
+                delay(2500)
+                postNotificationsState()
             }
         }
+    }
+
+    private fun postNotificationsState() {
+        _uiState.value = Content.Notifications(
+                primaryActionButton = NotificationsPrimaryButton(::onContinueFromNotificationsClicked),
+        )
+    }
+
+    @Suppress("ForbiddenComment")
+    private fun onContinueFromNotificationsClicked() {
+        // TODO: Disable notifications in WP app
+        // TODO: Navigate to next step (error? or done)
     }
 
     private fun onHelpClicked() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/NotificationsStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/NotificationsStep.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.ui.main.jetpack.migration.compose.state
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R.dimen
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.utils.uiStringText
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.NotificationsPrimaryButton
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState
+import org.wordpress.android.ui.main.jetpack.migration.compose.components.Message
+import org.wordpress.android.ui.main.jetpack.migration.compose.components.PrimaryButton
+import org.wordpress.android.ui.main.jetpack.migration.compose.components.ScreenIcon
+import org.wordpress.android.ui.main.jetpack.migration.compose.components.Subtitle
+import org.wordpress.android.ui.main.jetpack.migration.compose.components.Title
+
+@Composable
+fun NotificationsStep(uiState: UiState.Content.Notifications) = with(uiState) {
+    Box(
+            modifier = Modifier.fillMaxSize()
+    ) {
+        Column(
+                modifier = Modifier.padding(horizontal = dimensionResource(dimen.jp_migration_padding_horizontal))
+        ) {
+            ScreenIcon(iconRes = screenIconRes)
+            Title(text = uiStringText(title))
+            Subtitle(text = uiStringText(subtitle))
+            Message(text = uiStringText(message))
+        }
+        Column(
+                modifier = Modifier.align(Alignment.BottomCenter)
+        ) {
+            PrimaryButton(
+                    text = uiStringText(primaryActionButton.text),
+                    onClick = primaryActionButton.onClick,
+                    modifier = Modifier.padding(bottom = 50.dp),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL)
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PreviewNotificationsStep() {
+    AppTheme {
+        val uiState = UiState.Content.Notifications(NotificationsPrimaryButton {})
+        NotificationsStep(uiState)
+    }
+}

--- a/WordPress/src/main/res/drawable/ic_jetpack_migration_notifications.xml
+++ b/WordPress/src/main/res/drawable/ic_jetpack_migration_notifications.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="129dp"
+    android:height="71dp"
+    android:viewportWidth="129"
+    android:viewportHeight="71">
+    <path
+        android:pathData="M35.5,1.5L35.5,1.5A34,34 0,0 1,69.5 35.5L69.5,35.5A34,34 0,0 1,35.5 69.5L35.5,69.5A34,34 0,0 1,1.5 35.5L1.5,35.5A34,34 0,0 1,35.5 1.5z"
+        android:fillColor="#0675C4"/>
+    <path
+        android:pathData="M38.82,48.5L39.84,47.48L39.62,45.89C39.46,44.8 39.79,43.45 40.35,42.89L45.97,37.28C49.35,33.9 49.35,28.42 45.97,25.04C42.58,21.66 37.1,21.66 33.72,25.04L28.11,30.65C27.55,31.21 26.2,31.54 25.11,31.38L23.52,31.16L22.5,32.18L38.82,48.5ZM29.08,44.72C29.88,44.72 30.6,44.4 31.12,43.87L27.04,39.79C26.51,40.31 26.19,41.03 26.19,41.83C26.19,43.43 27.48,44.72 29.08,44.72Z"
+        android:fillColor="#ffffff"
+        android:fillType="evenOdd"/>
+    <path
+        android:pathData="M35.5,1.5L35.5,1.5A34,34 0,0 1,69.5 35.5L69.5,35.5A34,34 0,0 1,35.5 69.5L35.5,69.5A34,34 0,0 1,1.5 35.5L1.5,35.5A34,34 0,0 1,35.5 1.5z"
+        android:strokeWidth="3"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffffff"/>
+    <path
+        android:pathData="M93.5,1.5L93.5,1.5A34,34 0,0 1,127.5 35.5L127.5,35.5A34,34 0,0 1,93.5 69.5L93.5,69.5A34,34 0,0 1,59.5 35.5L59.5,35.5A34,34 0,0 1,93.5 1.5z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M93.5,3C75.6,3 61,17.56 61,35.5C61,53.44 75.56,68 93.5,68C111.44,68 126,53.44 126,35.5C126,17.56 111.44,3 93.5,3ZM91.83,40.88H75.64L91.83,9.38V40.88ZM95.14,61.54V30.04H111.29L95.14,61.54Z"
+        android:fillColor="#069E08"/>
+    <path
+        android:pathData="M93.5,1.5L93.5,1.5A34,34 0,0 1,127.5 35.5L127.5,35.5A34,34 0,0 1,93.5 69.5L93.5,69.5A34,34 0,0 1,59.5 35.5L59.5,35.5A34,34 0,0 1,93.5 1.5z"
+        android:strokeWidth="3"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffffff"/>
+</vector>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -101,5 +101,5 @@
     <color name="site_creation_intent_item_emoji_bg">#3d3d3d</color>
 
     <!-- Jetpack Migration -->
-    <color name="bg_jp_migration_buttons_panel">@color/black_translucent_90</color>
+    <color name="bg_jp_migration_buttons_panel">#E6121212</color>
 </resources>

--- a/WordPress/src/main/res/values/colors_translucent.xml
+++ b/WordPress/src/main/res/values/colors_translucent.xml
@@ -3,7 +3,6 @@
     <color name="black_translucent_20">#33000000</color>
     <color name="black_translucent_40">#66000000</color>
     <color name="black_translucent_50">#80000000</color>
-    <color name="black_translucent_90">#E6000000</color>
 
     <color name="white_translucent_20">#33ffffff</color>
     <color name="white_translucent_40">#66ffffff</color>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4244,5 +4244,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jp_migration_welcome_site_found_message">We found your site. Continue to transfer all your data and sign in to Jetpack automatically.</string>
     <string name="jp_migration_continue_button">Continue</string>
     <string name="jp_migration_help_button">Need help?</string>
+    <string name="jp_migration_notifications_title">Notifications now come from Jetpack</string>
+    <string name="jp_migration_notifications_subtitle">You’ll get all the same notifications but now they’ll come from the Jetpack app.</string>
+    <string name="jp_migration_notifications_disabled_in_wp_message">We’ve disabled notifications for the WordPress app.</string>
 
 </resources>


### PR DESCRIPTION
Fixes Partially #17372 (doesn't disable notifications in WP which is wip in #17371 nor navigates to next step).

> ~Depends on #17425 so that PR should be reviewed & merged first, then this one is ready for review.
> The `[Status] Not Ready for Merge` label can be removed once the PR it depends on is merged.~

This PR implements the UI for the notifications step in the WordPress to Jetpack migration flow.
It also adds crossfade transition between the migration flow screens.

> 🏁 **All these changes are behind a temporary feature flag.**
>
> 🔔 **Notice:** Once the feature flag is enabled the migration flow will always be presented. The Jetpack app build has to be uninstalled (or "Clear Data" should be done) in order to revert back to the normal functionality. Further development on the data layer will make sure the migration is not attempted again once it's successful. To be partially handled in #17406.

To test:

0. Open the Jetpack app & login
1. Go to `Me` → `App Settings` → `Debug Settings`
2. Enable the `JetpackMigrationFlowFeatureConfig` & restart the app.
3. Tap the `Continue` button on the "Welcome to Jetpack!" screen
   - Note: Temporarily the migration progress is simulated by showing for 2 seconds a processing state.
4. **Expect** to see the "Notifications now come from Jetpack" screen
   - The `Continue` button has no functionality in this PR, that's handled in [#17440](https://github.com/wordpress-mobile/WordPress-Android/pull/17440).

## Previews

| Light | Dark |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/200345642-79f23f76-9ecb-44ea-9209-84ff2a434cd1.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/200345638-e75513d3-2ace-4931-96dd-97a86a0dd13f.png"> |

## Regression Notes

1. Potential unintended areas of impact
   None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

3. What automated tests I added (or what prevented me from doing so)
   None - PR adds only UI and UI state changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
