### PR TITLE
Detekt - Resolve/Suppress All Baseline Warnings - Long methods warnings_ PublishSettingsFragment & PrepublishingHomeViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
@@ -85,23 +85,7 @@ class PrepublishingHomeViewModel @Inject constructor(
             if (editPostRepository.status != PostStatus.PRIVATE) {
                 showPublicPost(editPostRepository)
             } else {
-                add(
-                        HomeUiState(
-                                actionType = PUBLISH,
-                                actionResult = editPostRepository.getEditablePost()
-                                        ?.let {
-                                            UiStringText(
-                                                    postSettingsUtils.getPublishDateLabel(
-                                                            it
-                                                    )
-                                            )
-                                        },
-                                actionTypeColor = R.color.prepublishing_action_type_disabled_color,
-                                actionResultColor = R.color.prepublishing_action_result_disabled_color,
-                                actionClickable = false,
-                                onActionClicked = null
-                        )
-                )
+                showPrivatePost(editPostRepository)
             }
 
             if (!editPostRepository.isPage) {
@@ -150,6 +134,28 @@ class PrepublishingHomeViewModel @Inject constructor(
         }.toList()
 
         _uiState.postValue(prepublishingHomeUiStateList)
+    }
+
+    private fun MutableList<PrepublishingHomeItemUiState>.showPrivatePost(
+        editPostRepository: EditPostRepository
+    ) {
+        add(
+                HomeUiState(
+                        actionType = PUBLISH,
+                        actionResult = editPostRepository.getEditablePost()
+                                ?.let {
+                                    UiStringText(
+                                            postSettingsUtils.getPublishDateLabel(
+                                                    it
+                                            )
+                                    )
+                                },
+                        actionTypeColor = R.color.prepublishing_action_type_disabled_color,
+                        actionResultColor = R.color.prepublishing_action_result_disabled_color,
+                        actionClickable = false,
+                        onActionClicked = null
+                )
+        )
     }
 
     private fun MutableList<PrepublishingHomeItemUiState>.showPublicPost(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
@@ -83,21 +83,7 @@ class PrepublishingHomeViewModel @Inject constructor(
             }
 
             if (editPostRepository.status != PostStatus.PRIVATE) {
-                add(
-                        HomeUiState(
-                                actionType = PUBLISH,
-                                actionResult = editPostRepository.getEditablePost()
-                                        ?.let {
-                                            UiStringText(
-                                                    postSettingsUtils.getPublishDateLabel(
-                                                            it
-                                                    )
-                                            )
-                                        },
-                                actionClickable = true,
-                                onActionClicked = ::onActionClicked
-                        )
-                )
+                showPublicPost(editPostRepository)
             } else {
                 add(
                         HomeUiState(
@@ -164,6 +150,26 @@ class PrepublishingHomeViewModel @Inject constructor(
         }.toList()
 
         _uiState.postValue(prepublishingHomeUiStateList)
+    }
+
+    private fun MutableList<PrepublishingHomeItemUiState>.showPublicPost(
+        editPostRepository: EditPostRepository
+    ) {
+        add(
+                HomeUiState(
+                        actionType = PUBLISH,
+                        actionResult = editPostRepository.getEditablePost()
+                                ?.let {
+                                    UiStringText(
+                                            postSettingsUtils.getPublishDateLabel(
+                                                    it
+                                            )
+                                    )
+                                },
+                        actionClickable = true,
+                        onActionClicked = ::onActionClicked
+                )
+        )
     }
 
     private fun onStoryTitleChanged(storyTitle: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
@@ -89,23 +89,7 @@ class PrepublishingHomeViewModel @Inject constructor(
             }
 
             if (!editPostRepository.isPage) {
-                add(HomeUiState(
-                        actionType = TAGS,
-                        actionResult = getPostTagsUseCase.getTags(editPostRepository)
-                                ?.let { UiStringText(it) }
-                                ?: run { UiStringRes(R.string.prepublishing_nudges_home_tags_not_set) },
-                        actionClickable = true,
-                        onActionClicked = ::onActionClicked
-                )
-                )
-
-                val categoryString: String = getCategoriesUseCase.getPostCategoriesString(
-                        editPostRepository,
-                        site
-                )
-                if (categoryString.isNotEmpty()) {
-                    UiStringText(categoryString)
-                }
+                showNotSetPost(editPostRepository, site)
             } else {
                 UiStringRes(R.string.prepublishing_nudges_home_categories_not_set)
             }
@@ -134,6 +118,29 @@ class PrepublishingHomeViewModel @Inject constructor(
         }.toList()
 
         _uiState.postValue(prepublishingHomeUiStateList)
+    }
+
+    private fun MutableList<PrepublishingHomeItemUiState>.showNotSetPost(
+        editPostRepository: EditPostRepository,
+        site: SiteModel
+    ) {
+        add(HomeUiState(
+                actionType = TAGS,
+                actionResult = getPostTagsUseCase.getTags(editPostRepository)
+                        ?.let { UiStringText(it) }
+                        ?: run { UiStringRes(R.string.prepublishing_nudges_home_tags_not_set) },
+                actionClickable = true,
+                onActionClicked = ::onActionClicked
+        )
+        )
+
+        val categoryString: String = getCategoriesUseCase.getPostCategoriesString(
+                editPostRepository,
+                site
+        )
+        if (categoryString.isNotEmpty()) {
+            UiStringText(categoryString)
+        }
     }
 
     private fun MutableList<PrepublishingHomeItemUiState>.showPrivatePost(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -56,30 +56,16 @@ abstract class PublishSettingsFragment : Fragment() {
 
         AccessibilityUtils.disableHintAnnouncement(dateAndTime)
         AccessibilityUtils.disableHintAnnouncement(publishNotification)
-
         dateAndTimeContainer.setOnClickListener { showPostDateSelectionDialog() }
-
         setupContent(rootView, viewModel)
 
         observeOnDatePicked()
-
         observeOnPublishedDateChanged()
-
         observeOnNotificationTime()
-
-        observeOnUiModel(
-                dateAndTime,
-                publishNotificationTitle,
-                publishNotification,
-                rootView
-        )
-
+        observeOnUiModel(dateAndTime, publishNotificationTitle, publishNotification, rootView)
         observeOnShowNotificationDialog()
-
         observeOnToast()
-
         observerOnNotificationAdded()
-
         observeOnAddToCalendar()
 
         viewModel.start(getPostRepository())

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -76,14 +76,8 @@ abstract class PublishSettingsFragment : Fragment() {
 
         observeOnShowNotificationDialog()
 
-        viewModel.onToast.observeEvent(viewLifecycleOwner, {
-            ToastUtils.showToast(
-                    context,
-                    it,
-                    SHORT,
-                    Gravity.TOP
-            )
-        })
+        observeOnToast()
+
         viewModel.onNotificationAdded.observeEvent(viewLifecycleOwner, { notification ->
             activity?.let {
                 NotificationManagerCompat.from(it).cancel(notification.id)
@@ -115,6 +109,17 @@ abstract class PublishSettingsFragment : Fragment() {
         })
         viewModel.start(getPostRepository())
         return rootView
+    }
+
+    private fun observeOnToast() {
+        viewModel.onToast.observeEvent(viewLifecycleOwner) {
+            ToastUtils.showToast(
+                    context,
+                    it,
+                    SHORT,
+                    Gravity.TOP
+            )
+        }
     }
 
     private fun observeOnShowNotificationDialog() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -74,9 +74,8 @@ abstract class PublishSettingsFragment : Fragment() {
                 rootView
         )
 
-        viewModel.onShowNotificationDialog.observeEvent(viewLifecycleOwner, { notificationTime ->
-            showNotificationTimeSelectionDialog(notificationTime)
-        })
+        observeOnShowNotificationDialog()
+
         viewModel.onToast.observeEvent(viewLifecycleOwner, {
             ToastUtils.showToast(
                     context,
@@ -118,6 +117,11 @@ abstract class PublishSettingsFragment : Fragment() {
         return rootView
     }
 
+    private fun observeOnShowNotificationDialog() {
+        viewModel.onShowNotificationDialog.observeEvent(viewLifecycleOwner) { notificationTime ->
+            showNotificationTimeSelectionDialog(notificationTime)
+        }
+    }
 
     private fun observeOnUiModel(
         dateAndTime: TextView,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -78,7 +78,23 @@ abstract class PublishSettingsFragment : Fragment() {
 
         observeOnToast()
 
-        viewModel.onNotificationAdded.observeEvent(viewLifecycleOwner, { notification ->
+        observerOnNotificationAdded()
+
+        viewModel.onAddToCalendar.observeEvent(viewLifecycleOwner, { calendarEvent ->
+            val calIntent = Intent(Intent.ACTION_INSERT)
+            calIntent.data = Events.CONTENT_URI
+            calIntent.type = "vnd.android.cursor.item/event"
+            calIntent.putExtra(Events.TITLE, calendarEvent.title)
+            calIntent.putExtra(Events.DESCRIPTION, calendarEvent.description)
+            calIntent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, calendarEvent.startTime)
+            startActivity(calIntent)
+        })
+        viewModel.start(getPostRepository())
+        return rootView
+    }
+
+    private fun observerOnNotificationAdded() {
+        viewModel.onNotificationAdded.observeEvent(viewLifecycleOwner) { notification ->
             activity?.let {
                 NotificationManagerCompat.from(it).cancel(notification.id)
                 val notificationIntent = Intent(it, PublishNotificationReceiver::class.java)
@@ -97,18 +113,7 @@ abstract class PublishSettingsFragment : Fragment() {
                         pendingIntent
                 )
             }
-        })
-        viewModel.onAddToCalendar.observeEvent(viewLifecycleOwner, { calendarEvent ->
-            val calIntent = Intent(Intent.ACTION_INSERT)
-            calIntent.data = Events.CONTENT_URI
-            calIntent.type = "vnd.android.cursor.item/event"
-            calIntent.putExtra(Events.TITLE, calendarEvent.title)
-            calIntent.putExtra(Events.DESCRIPTION, calendarEvent.description)
-            calIntent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, calendarEvent.startTime)
-            startActivity(calIntent)
-        })
-        viewModel.start(getPostRepository())
-        return rootView
+        }
     }
 
     private fun observeOnToast() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -52,9 +52,7 @@ abstract class PublishSettingsFragment : Fragment() {
         val dateAndTimeContainer = rootView.findViewById<LinearLayout>(R.id.publish_time_and_date_container)
         val publishNotification = rootView.findViewById<TextView>(R.id.publish_notification)
         val publishNotificationTitle = rootView.findViewById<TextView>(R.id.publish_notification_title)
-        val publishNotificationContainer = rootView.findViewById<LinearLayout>(R.id.publish_notification_container)
-        val addToCalendarContainer = rootView.findViewById<LinearLayout>(R.id.post_add_to_calendar_container)
-        val addToCalendar = rootView.findViewById<TextView>(R.id.post_add_to_calendar)
+
 
         AccessibilityUtils.disableHintAnnouncement(dateAndTime)
         AccessibilityUtils.disableHintAnnouncement(publishNotification)
@@ -68,35 +66,14 @@ abstract class PublishSettingsFragment : Fragment() {
         observeOnPublishedDateChanged()
 
         observeOnNotificationTime()
-        
-        viewModel.onUiModel.observe(viewLifecycleOwner, {
-            it?.let { uiModel ->
-                dateAndTime.text = uiModel.publishDateLabel
-                publishNotificationTitle.isEnabled = uiModel.notificationEnabled
-                publishNotification.isEnabled = uiModel.notificationEnabled
-                publishNotificationContainer.isEnabled = uiModel.notificationEnabled
-                addToCalendar.isEnabled = uiModel.notificationEnabled
-                addToCalendarContainer.isEnabled = uiModel.notificationEnabled
-                if (uiModel.notificationEnabled) {
-                    publishNotificationContainer.setOnClickListener {
-                        getPostRepository()?.getPost()?.let { postModel ->
-                            viewModel.onShowDialog(postModel)
-                        }
-                    }
-                    addToCalendarContainer.setOnClickListener {
-                        getPostRepository()?.let { postRepository ->
-                            viewModel.onAddToCalendar(postRepository)
-                        }
-                    }
-                } else {
-                    publishNotificationContainer.setOnClickListener(null)
-                    addToCalendarContainer.setOnClickListener(null)
-                }
-                publishNotification.setText(uiModel.notificationLabel)
-                publishNotificationContainer.visibility = if (uiModel.notificationVisible) View.VISIBLE else View.GONE
-                addToCalendarContainer.visibility = if (uiModel.notificationVisible) View.VISIBLE else View.GONE
-            }
-        })
+
+        observeOnUiModel(
+                dateAndTime,
+                publishNotificationTitle,
+                publishNotification,
+                rootView
+        )
+
         viewModel.onShowNotificationDialog.observeEvent(viewLifecycleOwner, { notificationTime ->
             showNotificationTimeSelectionDialog(notificationTime)
         })
@@ -140,6 +117,48 @@ abstract class PublishSettingsFragment : Fragment() {
         viewModel.start(getPostRepository())
         return rootView
     }
+
+
+    private fun observeOnUiModel(
+        dateAndTime: TextView,
+        publishNotificationTitle: TextView,
+        publishNotification: TextView,
+        rootView: ViewGroup,
+    ) {
+        val publishNotificationContainer = rootView.findViewById<LinearLayout>(R.id.publish_notification_container)
+        val addToCalendarContainer = rootView.findViewById<LinearLayout>(R.id.post_add_to_calendar_container)
+        val addToCalendar = rootView.findViewById<TextView>(R.id.post_add_to_calendar)
+
+        viewModel.onUiModel.observe(viewLifecycleOwner) {
+            it?.let { uiModel ->
+                dateAndTime.text = uiModel.publishDateLabel
+                publishNotificationTitle.isEnabled = uiModel.notificationEnabled
+                publishNotification.isEnabled = uiModel.notificationEnabled
+                publishNotificationContainer.isEnabled = uiModel.notificationEnabled
+                addToCalendar.isEnabled = uiModel.notificationEnabled
+                addToCalendarContainer.isEnabled = uiModel.notificationEnabled
+                if (uiModel.notificationEnabled) {
+                    publishNotificationContainer.setOnClickListener {
+                        getPostRepository()?.getPost()?.let { postModel ->
+                            viewModel.onShowDialog(postModel)
+                        }
+                    }
+                    addToCalendarContainer.setOnClickListener {
+                        getPostRepository()?.let { postRepository ->
+                            viewModel.onAddToCalendar(postRepository)
+                        }
+                    }
+                } else {
+                    publishNotificationContainer.setOnClickListener(null)
+                    addToCalendarContainer.setOnClickListener(null)
+                }
+                publishNotification.setText(uiModel.notificationLabel)
+                publishNotificationContainer.visibility = if (uiModel.notificationVisible) View.VISIBLE else View.GONE
+                addToCalendarContainer.visibility = if (uiModel.notificationVisible) View.VISIBLE else View.GONE
+            }
+        }
+    }
+
 
     private fun observeOnNotificationTime() {
         viewModel.onNotificationTime.observe(viewLifecycleOwner) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -63,9 +63,7 @@ abstract class PublishSettingsFragment : Fragment() {
 
         setupContent(rootView, viewModel)
 
-        viewModel.onDatePicked.observeEvent(viewLifecycleOwner, {
-            showPostTimeSelectionDialog()
-        })
+        observeOnDatePicked()
         viewModel.onPublishedDateChanged.observeEvent(viewLifecycleOwner, { date ->
             viewModel.updatePost(date, getPostRepository())
             trackPostScheduled()
@@ -147,6 +145,12 @@ abstract class PublishSettingsFragment : Fragment() {
         })
         viewModel.start(getPostRepository())
         return rootView
+    }
+
+    private fun observeOnDatePicked() {
+        viewModel.onDatePicked.observeEvent(viewLifecycleOwner) {
+            showPostTimeSelectionDialog()
+        }
     }
 
     private fun trackPostScheduled() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -64,10 +64,9 @@ abstract class PublishSettingsFragment : Fragment() {
         setupContent(rootView, viewModel)
 
         observeOnDatePicked()
-        viewModel.onPublishedDateChanged.observeEvent(viewLifecycleOwner, { date ->
-            viewModel.updatePost(date, getPostRepository())
-            trackPostScheduled()
-        })
+
+        observeOnPublishedDateChanged()
+
         viewModel.onNotificationTime.observe(viewLifecycleOwner, {
             it?.let { notificationTime ->
                 getPostRepository()?.let { postRepository ->
@@ -145,6 +144,13 @@ abstract class PublishSettingsFragment : Fragment() {
         })
         viewModel.start(getPostRepository())
         return rootView
+    }
+
+    private fun observeOnPublishedDateChanged() {
+        viewModel.onPublishedDateChanged.observeEvent(viewLifecycleOwner) { date ->
+            viewModel.updatePost(date, getPostRepository())
+            trackPostScheduled()
+        }
     }
 
     private fun observeOnDatePicked() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -80,7 +80,14 @@ abstract class PublishSettingsFragment : Fragment() {
 
         observerOnNotificationAdded()
 
-        viewModel.onAddToCalendar.observeEvent(viewLifecycleOwner, { calendarEvent ->
+        observeOnAddToCalendar()
+
+        viewModel.start(getPostRepository())
+        return rootView
+    }
+
+    private fun observeOnAddToCalendar() {
+        viewModel.onAddToCalendar.observeEvent(viewLifecycleOwner) { calendarEvent ->
             val calIntent = Intent(Intent.ACTION_INSERT)
             calIntent.data = Events.CONTENT_URI
             calIntent.type = "vnd.android.cursor.item/event"
@@ -88,9 +95,7 @@ abstract class PublishSettingsFragment : Fragment() {
             calIntent.putExtra(Events.DESCRIPTION, calendarEvent.description)
             calIntent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, calendarEvent.startTime)
             startActivity(calIntent)
-        })
-        viewModel.start(getPostRepository())
-        return rootView
+        }
     }
 
     private fun observerOnNotificationAdded() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -67,13 +67,8 @@ abstract class PublishSettingsFragment : Fragment() {
 
         observeOnPublishedDateChanged()
 
-        viewModel.onNotificationTime.observe(viewLifecycleOwner, {
-            it?.let { notificationTime ->
-                getPostRepository()?.let { postRepository ->
-                    viewModel.scheduleNotification(postRepository, notificationTime)
-                }
-            }
-        })
+        observeOnNotificationTime()
+        
         viewModel.onUiModel.observe(viewLifecycleOwner, {
             it?.let { uiModel ->
                 dateAndTime.text = uiModel.publishDateLabel
@@ -144,6 +139,16 @@ abstract class PublishSettingsFragment : Fragment() {
         })
         viewModel.start(getPostRepository())
         return rootView
+    }
+
+    private fun observeOnNotificationTime() {
+        viewModel.onNotificationTime.observe(viewLifecycleOwner) {
+            it?.let { notificationTime ->
+                getPostRepository()?.let { postRepository ->
+                    viewModel.scheduleNotification(postRepository, notificationTime)
+                }
+            }
+        }
     }
 
     private fun observeOnPublishedDateChanged() {

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -70,8 +70,6 @@
     <ID>LongMethod:BarChartViewHolder.kt$BarChartViewHolder$private fun BarChart.draw( item: BarChartItem, labelStart: TextView, labelEnd: TextView ): BarCount</ID>
     <ID>LongMethod:ClicksUseCase.kt$ClicksUseCase$override fun buildUiModel(domainModel: ClicksModel, uiState: SelectedClicksGroup): List&lt;BlockListItem></ID>
     <ID>LongMethod:HomepageSettingsDialog.kt$HomepageSettingsDialog$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
-    <ID>LongMethod:PrepublishingHomeViewModel.kt$PrepublishingHomeViewModel$private fun setupHomeUiState( editPostRepository: EditPostRepository, site: SiteModel, isStoryPost: Boolean )</ID>
-    <ID>LongMethod:PublishSettingsFragment.kt$PublishSettingsFragment$override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?</ID>
     <ID>LongMethod:ReferrersUseCase.kt$ReferrersUseCase$override fun buildUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List&lt;BlockListItem></ID>
     <ID>LongMethod:SearchListViewModel.kt$SearchListViewModel$private fun PageModel.toPageItem(areActionsEnabled: Boolean): PageItem</ID>
     <ID>LongMethod:SuggestionActivity.kt$SuggestionActivity$private fun initializeActivity(siteModel: SiteModel, suggestionType: SuggestionType)</ID>


### PR DESCRIPTION
Parent: https://github.com/wordpress-mobile/WordPress-Android/issues/17010

This PR resolves/suppresses all complexity related LongMethod warnings for the PublishSettingsFragment class & PrepublishingHomeViewModel class (see docs [here](https://detekt.dev/docs/rules/complexity#longmethod)):

`2` x LongMethod  (Resolve: 16d4942312a6139c2e65c28175abce7171865907 + ba7f9ccd7e80b96635e93ae17f940550af8fe8b0 + 2725d708cdc366138e97fd63814b30ef63a6e5e6 + eadde85bac5ecd6de5663a04f9f831ca672e1009 + 9bbdd6df26f6e8ca5d04cd803ca824f968e92370 + 66ae4827baf881414b5dccc576a6e710615d4ca9 + b2e6ba103c066bc25eec3fcb46c4c355ffa03d61 + 6fa6603a9fae6d212f04292baadaa879e807075a + 383417fbc6a087f22592a29e963533581dabe479 + 4a661f70fa91795e7b6438f78974b00317bfd531 + 3aac955e7e97a013fed8d5f6d713af4380dd67d8 + 7771a9e469dbbd19b55057e9507ff4c2218c4ce7 )

-----

To test:

- There is nothing much to test here.

- Verifying that all the CI checks are successful should be enough (especially the detekt check).
- However, if you really want to be thorough, you could smoke test the WordPress and/or Jetpack apps to verify that everything works as expected on every screen that relates to these changes. Specifically, you could follow the below steps:

   - Click the FAB(round button at the bottom right corner) to create new post
   - Select site page and choose a layout
   - Click on create page 
   - Click on publish and select publish date 
   - pick a date or publish immediately 


## Regression Notes
1. Potential unintended areas of impact
     can't think of any 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)
     N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
