### PR TITLE
Detekt - Resolve/Suppress All Baseline Warnings - Long methods warnings_ HomePageSettingsDialog, AuthorUseCase, ClicksUseCase, ReferrersUseCase

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
@@ -54,7 +54,7 @@ class HomepageSettingsDialog : DialogFragment() {
 
             viewModel = ViewModelProvider(this@HomepageSettingsDialog, viewModelFactory)
                     .get(HomepageSettingsViewModel::class.java)
-            viewModel.uiState.observe(this@HomepageSettingsDialog, { uiState ->
+            viewModel.uiState.observe(this@HomepageSettingsDialog) { uiState ->
                 uiState?.let {
                     loadingPages.visibility = if (uiState.isLoading) View.VISIBLE else View.GONE
                     enablePositiveButton(uiState.isSaveEnabled)
@@ -65,40 +65,46 @@ class HomepageSettingsDialog : DialogFragment() {
                         loadingError.visibility = View.GONE
                         loadingError.text = null
                     }
-                    when (uiState.isClassicBlogState) {
-                        true -> {
-                            homepageSettingsRadioGroup.checkIfNotChecked(R.id.classic_blog)
-                            dropdownContainer.visibility = View.GONE
-                        }
-                        false -> {
-                            homepageSettingsRadioGroup.checkIfNotChecked(R.id.static_homepage)
-                            if (uiState.pageForPostsState != null && uiState.pageOnFrontState != null) {
-                                dropdownContainer.visibility = View.VISIBLE
-                                setupDropdownItem(
-                                        uiState.pageOnFrontState,
-                                        selectedHomepage,
-                                        viewModel::onPageOnFrontDialogOpened,
-                                        viewModel::onPageOnFrontSelected
-                                )
-                                setupDropdownItem(
-                                        uiState.pageForPostsState,
-                                        selectedPostsPage,
-                                        viewModel::onPageForPostsDialogOpened,
-                                        viewModel::onPageForPostsSelected
-                                )
-                            } else {
-                                dropdownContainer.visibility = View.GONE
-                            }
-                        }
-                    }
+                    isClassicBlogState(uiState)
                 }
-            })
+            }
         }
         viewModel.dismissDialogEvent.observeEvent(this, {
             requireDialog().dismiss()
         })
         viewModel.start(requireNotNull(siteId), isClassicBlog, pageForPostsId, pageOnFrontId)
         return builder.create()
+    }
+
+    private fun SiteSettingsHomepageDialogBinding.isClassicBlogState(
+        uiState: HomepageSettingsUiState
+    ) {
+        when (uiState.isClassicBlogState) {
+            true -> {
+                homepageSettingsRadioGroup.checkIfNotChecked(R.id.classic_blog)
+                dropdownContainer.visibility = View.GONE
+            }
+            false -> {
+                homepageSettingsRadioGroup.checkIfNotChecked(R.id.static_homepage)
+                if (uiState.pageForPostsState != null && uiState.pageOnFrontState != null) {
+                    dropdownContainer.visibility = View.VISIBLE
+                    setupDropdownItem(
+                            uiState.pageOnFrontState,
+                            selectedHomepage,
+                            viewModel::onPageOnFrontDialogOpened,
+                            viewModel::onPageOnFrontSelected
+                    )
+                    setupDropdownItem(
+                            uiState.pageForPostsState,
+                            selectedPostsPage,
+                            viewModel::onPageForPostsDialogOpened,
+                            viewModel::onPageForPostsSelected
+                    )
+                } else {
+                    dropdownContainer.visibility = View.GONE
+                }
+            }
+        }
     }
 
     private fun enablePositiveButton(enabled: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
@@ -69,9 +69,9 @@ class HomepageSettingsDialog : DialogFragment() {
                 }
             }
         }
-        viewModel.dismissDialogEvent.observeEvent(this, {
+        viewModel.dismissDialogEvent.observeEvent(this) {
             requireDialog().dismiss()
-        })
+        }
         viewModel.start(requireNotNull(siteId), isClassicBlog, pageForPostsId, pageOnFrontId)
         return builder.create()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
@@ -99,10 +99,16 @@ class AuthorsUseCase constructor(
 
     override fun buildUiModel(domainModel: AuthorsModel, uiState: SelectedAuthor): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
-
-        if (useCaseMode == BLOCK) {
-            items.add(Title(R.string.stats_authors))
+        val isBlockMode = useCaseMode == BLOCK
+        return if(domainModel.authors.isEmpty()){
+            buildUiModelForNoGroup(isBlockMode)
+        }else{
+            //TODO buildUiModelForGroups(domainModel, uiState, isBlockMode)
         }
+
+
+
+
 
         if (domainModel.authors.isEmpty()) {
             items.add(Empty(R.string.stats_no_data_for_period))
@@ -142,6 +148,16 @@ class AuthorsUseCase constructor(
         }
         return items
     }
+
+    private fun buildUiModelForNoGroup(
+        isBlockMode: Boolean
+    ): List<BlockListItem> {
+        val items = mutableListOf<BlockListItem>()
+        if (isBlockMode) items.add(Title(R.string.stats_authors))
+        items.add(Empty(R.string.stats_no_data_for_period))
+        return items
+    }
+
 
     private fun addPost(
         author: AuthorsModel.Author,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
@@ -98,55 +98,12 @@ class AuthorsUseCase constructor(
     }
 
     override fun buildUiModel(domainModel: AuthorsModel, uiState: SelectedAuthor): List<BlockListItem> {
-        val items = mutableListOf<BlockListItem>()
         val isBlockMode = useCaseMode == BLOCK
         return if(domainModel.authors.isEmpty()){
             buildUiModelForNoGroup(isBlockMode)
         }else{
-            //TODO buildUiModelForGroups(domainModel, uiState, isBlockMode)
+            buildUiModelForGroups(domainModel, uiState, isBlockMode)
         }
-
-
-
-
-
-        if (domainModel.authors.isEmpty()) {
-            items.add(Empty(R.string.stats_no_data_for_period))
-        } else {
-            val header = Header(R.string.stats_author_label, R.string.stats_author_views_label)
-            items.add(header)
-            val maxViews = domainModel.authors.maxByOrNull { it.views }?.views ?: 0
-            domainModel.authors.forEachIndexed { index, author ->
-                val headerItem = ListItemWithIcon(
-                        iconUrl = author.avatarUrl,
-                        iconStyle = AVATAR,
-                        text = author.name,
-                        barWidth = getBarWidth(author.views, maxViews),
-                        value = statsUtils.toFormattedString(author.views),
-                        showDivider = index < domainModel.authors.size - 1,
-                        contentDescription = contentDescriptionHelper.buildContentDescription(
-                                header,
-                                author.name,
-                                author.views
-                        )
-                )
-                if (author.posts.isEmpty()) {
-                    items.add(headerItem)
-                } else {
-                    addPost(author, uiState, items, headerItem)
-                }
-            }
-
-            if (useCaseMode == BLOCK && domainModel.hasMore) {
-                items.add(
-                        Link(
-                                text = R.string.stats_insights_view_more,
-                                navigateAction = create(statsGranularity, this::onViewMoreClicked)
-                        )
-                )
-            }
-        }
-        return items
     }
 
     private fun buildUiModelForNoGroup(
@@ -155,6 +112,48 @@ class AuthorsUseCase constructor(
         val items = mutableListOf<BlockListItem>()
         if (isBlockMode) items.add(Title(R.string.stats_authors))
         items.add(Empty(R.string.stats_no_data_for_period))
+        return items
+    }
+
+    private fun buildUiModelForGroups(
+        domainModel: AuthorsModel,
+        uiState: SelectedAuthor,
+        isBlockMode: Boolean
+    ): List<BlockListItem> {
+        val items = mutableListOf<BlockListItem>()
+        if (isBlockMode) items.add(Title(R.string.stats_authors))
+        val header = Header(R.string.stats_author_label, R.string.stats_author_views_label)
+        items.add(header)
+        val maxViews = domainModel.authors.maxByOrNull { it.views }?.views ?: 0
+        domainModel.authors.forEachIndexed { index, author ->
+            val headerItem = ListItemWithIcon(
+                    iconUrl = author.avatarUrl,
+                    iconStyle = AVATAR,
+                    text = author.name,
+                    barWidth = getBarWidth(author.views, maxViews),
+                    value = statsUtils.toFormattedString(author.views),
+                    showDivider = index < domainModel.authors.size - 1,
+                    contentDescription = contentDescriptionHelper.buildContentDescription(
+                            header,
+                            author.name,
+                            author.views
+                    )
+            )
+            if (author.posts.isEmpty()) {
+                items.add(headerItem)
+            } else {
+                addPost(author, uiState, items, headerItem)
+            }
+        }
+
+        if (useCaseMode == BLOCK && domainModel.hasMore) {
+            items.add(
+                    Link(
+                            text = R.string.stats_insights_view_more,
+                            navigateAction = create(statsGranularity, this::onViewMoreClicked)
+                    )
+            )
+        }
         return items
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/AuthorsUseCase.kt
@@ -127,32 +127,7 @@ class AuthorsUseCase constructor(
                 if (author.posts.isEmpty()) {
                     items.add(headerItem)
                 } else {
-                    val isExpanded = author == uiState.author
-                    items.add(ExpandableItem(headerItem, isExpanded) { changedExpandedState ->
-                        onUiState(SelectedAuthor(if (changedExpandedState) author else null))
-                    })
-                    if (isExpanded) {
-                        items.addAll(author.posts.map { post ->
-                            ListItemWithIcon(
-                                    text = post.title,
-                                    value = statsUtils.toFormattedString(post.views),
-                                    iconStyle = if (author.avatarUrl != null) EMPTY_SPACE else NORMAL,
-                                    textStyle = LIGHT,
-                                    showDivider = false,
-                                    navigationAction = create(
-                                            PostClickParams(post.id, post.url, post.title),
-                                            this::onPostClicked
-                                    ),
-                                    contentDescription = contentDescriptionHelper.buildContentDescription(
-                                            R.string.stats_post_label,
-                                            post.title,
-                                            R.string.stats_post_views_label,
-                                            post.views
-                                    )
-                            )
-                        })
-                        items.add(Divider)
-                    }
+                    addPost(author, uiState, items, headerItem)
                 }
             }
 
@@ -166,6 +141,40 @@ class AuthorsUseCase constructor(
             }
         }
         return items
+    }
+
+    private fun addPost(
+        author: AuthorsModel.Author,
+        uiState: SelectedAuthor,
+        items: MutableList<BlockListItem>,
+        headerItem: ListItemWithIcon
+    ) {
+        val isExpanded = author == uiState.author
+        items.add(ExpandableItem(headerItem, isExpanded) { changedExpandedState ->
+            onUiState(SelectedAuthor(if (changedExpandedState) author else null))
+        })
+        if (isExpanded) {
+            items.addAll(author.posts.map { post ->
+                ListItemWithIcon(
+                        text = post.title,
+                        value = statsUtils.toFormattedString(post.views),
+                        iconStyle = if (author.avatarUrl != null) EMPTY_SPACE else NORMAL,
+                        textStyle = LIGHT,
+                        showDivider = false,
+                        navigationAction = create(
+                                PostClickParams(post.id, post.url, post.title),
+                                this::onPostClicked
+                        ),
+                        contentDescription = contentDescriptionHelper.buildContentDescription(
+                                R.string.stats_post_label,
+                                post.title,
+                                R.string.stats_post_views_label,
+                                post.views
+                        )
+                )
+            })
+            items.add(Divider)
+        }
     }
 
     private fun onViewMoreClicked(statsGranularity: StatsGranularity) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
@@ -97,9 +97,8 @@ class ClicksUseCase constructor(
         return if(domainModel.groups.isEmpty()){
             buildUiModelForNoGroup(isBlockMode)
         }else{
-           //TODO create buildUiModelForGroup method
+            buildUiModelForGroups(domainModel, uiState, isBlockMode)
         }
-
     }
 
     private fun buildUiModelForNoGroup(
@@ -111,11 +110,13 @@ class ClicksUseCase constructor(
         return items
     }
 
-    private fun populateGroup(
-        items: MutableList<BlockListItem>,
+    private fun buildUiModelForGroups(
         domainModel: ClicksModel,
-        uiState: SelectedClicksGroup
-    ) {
+        uiState: SelectedClicksGroup,
+        isBlockMode: Boolean
+    ): List<BlockListItem> {
+        val items = mutableListOf<BlockListItem>()
+        if (isBlockMode) items.add(Title(R.string.stats_clicks))
         val header = Header(R.string.stats_clicks_link_label, R.string.stats_clicks_label)
         items.add(header)
         domainModel.groups.forEachIndexed { index, group ->
@@ -167,6 +168,7 @@ class ClicksUseCase constructor(
                     )
             )
         }
+        return items
     }
 
     private fun onViewMoreClick(statsGranularity: StatsGranularity) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
@@ -102,59 +102,67 @@ class ClicksUseCase constructor(
         if (domainModel.groups.isEmpty()) {
             items.add(Empty(R.string.stats_no_data_for_period))
         } else {
-            val header = Header(R.string.stats_clicks_link_label, R.string.stats_clicks_label)
-            items.add(header)
-            domainModel.groups.forEachIndexed { index, group ->
-                val groupName = group.name
-                val contentDescription = contentDescriptionHelper.buildContentDescription(
-                        header,
-                        groupName ?: "",
-                        group.views ?: 0
-                )
-                val headerItem = ListItemWithIcon(
-                        text = groupName,
-                        value = statsUtils.toFormattedString(group.views),
-                        showDivider = index < domainModel.groups.size - 1,
-                        navigationAction = group.url?.let { create(it, this::onItemClick) },
-                        contentDescription = contentDescription
-                )
-                if (group.clicks.isEmpty()) {
-                    items.add(headerItem)
-                } else {
-                    val isExpanded = group == uiState.group
-                    items.add(ExpandableItem(headerItem, isExpanded) { changedExpandedState ->
-                        onUiState(SelectedClicksGroup(if (changedExpandedState) group else null))
-                    })
-                    if (isExpanded) {
-                        items.addAll(group.clicks.map { click ->
-                            ListItemWithIcon(
-                                    text = click.name,
-                                    textStyle = LIGHT,
-                                    value = statsUtils.toFormattedString(click.views),
-                                    showDivider = false,
-                                    navigationAction = click.url?.let { create(it, this::onItemClick) },
-                                    contentDescription = contentDescriptionHelper.buildContentDescription(
-                                            header,
-                                            click.name,
-                                            click.views
-                                    )
-                            )
-                        })
-                        items.add(Divider)
-                    }
-                }
-            }
-
-            if (useCaseMode == BLOCK && domainModel.hasMore) {
-                items.add(
-                        Link(
-                                text = R.string.stats_insights_view_more,
-                                navigateAction = create(statsGranularity, this::onViewMoreClick)
-                        )
-                )
-            }
+            populateGroup(items, domainModel, uiState)
         }
         return items
+    }
+
+    private fun populateGroup(
+        items: MutableList<BlockListItem>,
+        domainModel: ClicksModel,
+        uiState: SelectedClicksGroup
+    ) {
+        val header = Header(R.string.stats_clicks_link_label, R.string.stats_clicks_label)
+        items.add(header)
+        domainModel.groups.forEachIndexed { index, group ->
+            val groupName = group.name
+            val contentDescription = contentDescriptionHelper.buildContentDescription(
+                    header,
+                    groupName ?: "",
+                    group.views ?: 0
+            )
+            val headerItem = ListItemWithIcon(
+                    text = groupName,
+                    value = statsUtils.toFormattedString(group.views),
+                    showDivider = index < domainModel.groups.size - 1,
+                    navigationAction = group.url?.let { create(it, this::onItemClick) },
+                    contentDescription = contentDescription
+            )
+            if (group.clicks.isEmpty()) {
+                items.add(headerItem)
+            } else {
+                val isExpanded = group == uiState.group
+                items.add(ExpandableItem(headerItem, isExpanded) { changedExpandedState ->
+                    onUiState(SelectedClicksGroup(if (changedExpandedState) group else null))
+                })
+                if (isExpanded) {
+                    items.addAll(group.clicks.map { click ->
+                        ListItemWithIcon(
+                                text = click.name,
+                                textStyle = LIGHT,
+                                value = statsUtils.toFormattedString(click.views),
+                                showDivider = false,
+                                navigationAction = click.url?.let { create(it, this::onItemClick) },
+                                contentDescription = contentDescriptionHelper.buildContentDescription(
+                                        header,
+                                        click.name,
+                                        click.views
+                                )
+                        )
+                    })
+                    items.add(Divider)
+                }
+            }
+        }
+
+        if (useCaseMode == BLOCK && domainModel.hasMore) {
+            items.add(
+                    Link(
+                            text = R.string.stats_insights_view_more,
+                            navigateAction = create(statsGranularity, this::onViewMoreClick)
+                    )
+            )
+        }
     }
 
     private fun onViewMoreClick(statsGranularity: StatsGranularity) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ClicksUseCase.kt
@@ -93,17 +93,21 @@ class ClicksUseCase constructor(
     }
 
     override fun buildUiModel(domainModel: ClicksModel, uiState: SelectedClicksGroup): List<BlockListItem> {
+        val isBlockMode = useCaseMode == BLOCK
+        return if(domainModel.groups.isEmpty()){
+            buildUiModelForNoGroup(isBlockMode)
+        }else{
+           //TODO create buildUiModelForGroup method
+        }
+
+    }
+
+    private fun buildUiModelForNoGroup(
+        isBlockMode: Boolean
+    ): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
-
-        if (useCaseMode == BLOCK) {
-            items.add(Title(R.string.stats_clicks))
-        }
-
-        if (domainModel.groups.isEmpty()) {
-            items.add(Empty(R.string.stats_no_data_for_period))
-        } else {
-            populateGroup(items, domainModel, uiState)
-        }
+        if (isBlockMode) items.add(Title(R.string.stats_clicks))
+        items.add(Empty(R.string.stats_no_data_for_period))
         return items
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -5,6 +5,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
@@ -189,20 +190,28 @@ class ReferrersUseCase(
         }
 
         if (useCaseMode == VIEW_ALL && domainModel.hasMore) {
-            val shouldShowViewMore = itemCount < domainModel.groups.size ||
-                    (useCaseMode == BLOCK && domainModel.hasMore)
-            if (shouldShowViewMore) {
-                items.add(
-                        Link(
-                                text = R.string.stats_insights_view_more,
-                                navigateAction = create(statsGranularity, this::onViewMoreClicked)
-                        )
-                )
-            }
+            showMore(itemCount, domainModel)
         }
         return items
     }
 
+    private fun showMore(
+        itemCount: Int,
+        domainModel: ReferrersModel,
+    ): List<BlockListItem>  {
+        val items = mutableListOf<BlockListItem>()
+        val shouldShowViewMore = itemCount < domainModel.groups.size ||
+                (useCaseMode == BLOCK && domainModel.hasMore)
+        if (shouldShowViewMore) {
+            items.add(
+                    Link(
+                            text = string.stats_insights_view_more,
+                            navigateAction = create(statsGranularity, this::onViewMoreClicked)
+                    )
+            )
+        }
+        return items
+    }
 
     private fun showReferrer(
         group: Group,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -166,33 +166,7 @@ class ReferrersUseCase(
                         onUiState(SelectedGroup(if (changedExpandedState) group.groupId else null))
                     })
                     if (isExpanded) {
-                        items.addAll(group.referrers.map { referrer ->
-                            val referrerSpam = referrer.markedAsSpam
-                            val referrerIcon = buildIcon(referrer.icon, referrerSpam)
-                            val iconStyle = if (group.icon != null && referrer.icon == null && referrerIcon == null) {
-                                EMPTY_SPACE
-                            } else {
-                                NORMAL
-                            }
-                            ListItemWithIcon(
-                                    icon = referrerIcon,
-                                    iconUrl = if (referrerIcon == null) referrer.icon else null,
-                                    iconStyle = iconStyle,
-                                    textStyle = buildTextStyle(referrerSpam),
-                                    text = referrer.name,
-                                    value = statsUtils.toFormattedString(referrer.views),
-                                    showDivider = false,
-                                    navigationAction = referrer.url?.let {
-                                        create(it, this::onItemClick)
-                                    },
-                                    contentDescription = contentDescriptionHelper.buildContentDescription(
-                                            header,
-                                            referrer.name,
-                                            referrer.views
-                                    )
-                            )
-                        })
-                        items.add(Divider)
+                        showReferrer(items, group, header)
                     }
                 }
             }
@@ -209,6 +183,40 @@ class ReferrersUseCase(
             }
         }
         return items
+    }
+
+    private fun showReferrer(
+        items: MutableList<BlockListItem>,
+        group: Group,
+        header: Header
+    ) {
+        items.addAll(group.referrers.map { referrer ->
+            val referrerSpam = referrer.markedAsSpam
+            val referrerIcon = buildIcon(referrer.icon, referrerSpam)
+            val iconStyle = if (group.icon != null && referrer.icon == null && referrerIcon == null) {
+                EMPTY_SPACE
+            } else {
+                NORMAL
+            }
+            ListItemWithIcon(
+                    icon = referrerIcon,
+                    iconUrl = if (referrerIcon == null) referrer.icon else null,
+                    iconStyle = iconStyle,
+                    textStyle = buildTextStyle(referrerSpam),
+                    text = referrer.name,
+                    value = statsUtils.toFormattedString(referrer.views),
+                    showDivider = false,
+                    navigationAction = referrer.url?.let {
+                        create(it, this::onItemClick)
+                    },
+                    contentDescription = contentDescriptionHelper.buildContentDescription(
+                            header,
+                            referrer.name,
+                            referrer.views
+                    )
+            )
+        })
+        items.add(Divider)
     }
 
     private fun buildPieChartItem(domainModel: ReferrersModel): PieChartItem {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -5,7 +5,6 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
@@ -137,9 +136,7 @@ class ReferrersUseCase(
         val items = mutableListOf<BlockListItem>()
         if (isViewAllMode) items.add(Title(R.string.stats_clicks))
         val header = Header(R.string.stats_referrer_label, R.string.stats_referrer_views_label)
-        if (BuildConfig.IS_JETPACK_APP && useCaseMode == BLOCK_DETAIL) {
-            items.add(buildPieChartItem(domainModel))
-        }
+        buildPieChart(domainModel)
         items.add(header)
         val itemCount = min(itemsToShow, domainModel.groups.size)
 
@@ -195,6 +192,17 @@ class ReferrersUseCase(
         return items
     }
 
+    private fun buildPieChart(
+        domainModel: ReferrersModel
+    ):List<BlockListItem> {
+        val items = mutableListOf<BlockListItem>()
+
+        if (BuildConfig.IS_JETPACK_APP && useCaseMode == BLOCK_DETAIL) {
+            items.add(buildPieChartItem(domainModel))
+        }
+        return items
+    }
+
     private fun showMore(
         itemCount: Int,
         domainModel: ReferrersModel,
@@ -205,7 +213,7 @@ class ReferrersUseCase(
         if (shouldShowViewMore) {
             items.add(
                     Link(
-                            text = string.stats_insights_view_more,
+                            text = R.string.stats_insights_view_more,
                             navigateAction = create(statsGranularity, this::onViewMoreClicked)
                     )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -112,6 +112,12 @@ class ReferrersUseCase(
 
     override fun buildUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
+        val isViewAllMode = useCaseMode != VIEW_ALL
+        return if(domainModel.groups.isEmpty()){
+            buildUiModelForNoGroup(isViewAllMode)
+        }else{
+            // TODO buildUiModelForGroups(domainModel, uiState, isBlockMode)
+        }
 
         if (useCaseMode != VIEW_ALL) {
             items.add(Title(R.string.stats_referrers))
@@ -122,6 +128,15 @@ class ReferrersUseCase(
         } else {
             populateReferrer(items, domainModel, uiState)
         }
+        return items
+    }
+
+    private fun buildUiModelForNoGroup(
+        isViewAllMode: Boolean
+    ): List<BlockListItem> {
+        val items = mutableListOf<BlockListItem>()
+        if (isViewAllMode) items.add(Title(R.string.stats_referrers))
+        items.add(Empty(R.string.stats_no_data_for_period))
         return items
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ReferrersUseCase.kt
@@ -183,6 +183,14 @@ class ReferrersUseCase(
             }
         }
 
+        showViewMore(itemCount, domainModel, items)
+    }
+
+    private fun showViewMore(
+        itemCount: Int,
+        domainModel: ReferrersModel,
+        items: MutableList<BlockListItem>
+    ) {
         val shouldShowViewMore = itemCount < domainModel.groups.size ||
                 (useCaseMode == BLOCK && domainModel.hasMore)
         if (shouldShowViewMore) {

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -66,11 +66,7 @@
     <ID>FunctionParameterNaming:WizardManager.kt$WizardManager$T: WizardStep</ID>
     <ID>LargeClass:PagesViewModel.kt$PagesViewModel : ScopedViewModel</ID>
     <ID>LargeClass:ReaderPostDetailFragment.kt$ReaderPostDetailFragment : ViewPagerFragmentOnActivityBackPressedListenerScrollDirectionListenerReaderCustomViewListenerReaderWebViewPageFinishedListenerReaderWebViewUrlClickListenerPrivateAtCookieProgressDialogOnDismissListenerAutoHideToolbarListener</ID>
-    <ID>LongMethod:AuthorsUseCase.kt$AuthorsUseCase$override fun buildUiModel(domainModel: AuthorsModel, uiState: SelectedAuthor): List&lt;BlockListItem></ID>
     <ID>LongMethod:BarChartViewHolder.kt$BarChartViewHolder$private fun BarChart.draw( item: BarChartItem, labelStart: TextView, labelEnd: TextView ): BarCount</ID>
-    <ID>LongMethod:ClicksUseCase.kt$ClicksUseCase$override fun buildUiModel(domainModel: ClicksModel, uiState: SelectedClicksGroup): List&lt;BlockListItem></ID>
-    <ID>LongMethod:HomepageSettingsDialog.kt$HomepageSettingsDialog$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
-    <ID>LongMethod:ReferrersUseCase.kt$ReferrersUseCase$override fun buildUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List&lt;BlockListItem></ID>
     <ID>LongMethod:SearchListViewModel.kt$SearchListViewModel$private fun PageModel.toPageItem(areActionsEnabled: Boolean): PageItem</ID>
     <ID>LongMethod:SuggestionActivity.kt$SuggestionActivity$private fun initializeActivity(siteModel: SiteModel, suggestionType: SuggestionType)</ID>
     <ID>MagicNumber:ActivityViewHolder.kt$ActivityViewHolder$3</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -21,7 +21,6 @@
     <ID>ComplexMethod:PostActionHandler.kt$PostActionHandler$fun handlePostButton(buttonType: PostListButtonType, post: PostModel, hasAutoSave: Boolean)</ID>
     <ID>ComplexMethod:PostListActionTracker.kt$fun trackPostListAction(site: SiteModel, buttonType: PostListButtonType, postData: PostModel, statsEvent: Stat)</ID>
     <ID>ComplexMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment$private fun ReaderNavigationEvents.handleNavigationEvent()</ID>
-    <ID>ComplexMethod:ReferrersUseCase.kt$ReferrersUseCase$override fun buildUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List&lt;BlockListItem></ID>
     <ID>ComplexMethod:SystemNotificationsTracker.kt$SystemNotificationsTracker$private fun NotificationType.toTypeValue(): String</ID>
     <ID>ComplexMethod:UiModelMapper.kt$UiModelMapper$fun mapInsights( useCaseModels: List&lt;UseCaseModel>, showError: (Int) -> Unit ): UiModel</ID>
     <ID>ComplexMethod:UiModelMapper.kt$UiModelMapper$private fun mapStatsWithOverview( overViewType: StatsType, useCaseModels: List&lt;UseCaseModel>, showError: (Int) -> Unit ): UiModel</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -15,7 +15,6 @@
     <ID>ComplexMethod:CreatePageListItemActionsUseCase.kt$CreatePageListItemActionsUseCase$fun setupPageActions( listType: PageListType, uploadUiState: PostUploadUiState, siteModel: SiteModel, remoteId: Long ): Set&lt;Action></ID>
     <ID>ComplexMethod:EditorTracker.kt$EditorTracker$@JvmOverloads fun trackEditorEvent( event: TrackableEvent, editorName: String, properties: Map&lt;String, String> = mapOf() )</ID>
     <ID>ComplexMethod:FormattableContentClickHandler.kt$FormattableContentClickHandler$fun onClick( activity: FragmentActivity, clickedSpan: FormattableRange, source: String )</ID>
-    <ID>ComplexMethod:HomepageSettingsDialog.kt$HomepageSettingsDialog$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
     <ID>ComplexMethod:ImagePlaceholderManager.kt$ImagePlaceholderManager$fun getErrorResource(imgType: ImageType): Int?</ID>
     <ID>ComplexMethod:ImagePlaceholderManager.kt$ImagePlaceholderManager$fun getPlaceholderResource(imgType: ImageType): Int?</ID>
     <ID>ComplexMethod:NoticonUtils.kt$NoticonUtils$fun noticonToGridicon(noticon: String): Int</ID>


### PR DESCRIPTION
Parent: https://github.com/wordpress-mobile/WordPress-Android/issues/17010

This PR resolves/suppresses all complexity related LongMethod warnings for the HomePageSettingsDialog class, AuthorUseCase class, ClicksUseCase class, and ReferrersUseCase class (see docs [here](https://detekt.dev/docs/rules/complexity#longmethod)):

`4` x LongMethod  (Resolve: ad6bb237a2fb36f796156f9bede0bffd9a66a846 + 1cbf13249099f737bde8e23c46b9dff45fb4f1ff + f887ee07a8cb37ed37dc3b7e545ea717ca435e9e + 4e0cee3cf46405215c5b3cc9c98fdab97bc3bb84 + ccbb810665b27e5e88b2f0f66872046d02ff87e1 + 0431cde47a8ea2377cd69e177b31f66833bf6ea8 + 55311df61850b15373180b119e20fe5d5c065ec5 + 9432e4812c388ff9e87833b4e6eed9df350ab938 )

-----

To test:

- There is nothing much to test here.

- Verifying that all the CI checks are successful should be enough (especially the detekt check).
- However, if you really want to be thorough, you could smoke test the WordPress and/or Jetpack apps to verify that everything works as expected on every screen that relates to these changes. Specifically, you could follow the below steps:

   - Go to the menu tab
   - Click on site settings
   - Select HomePage settings
   - Test that you can change between different homepage settings 

To Test `Stats` 
   - Go to the menu tab
   - Click on Stat
   - Click on `Days` tab and confirm that the correct data for `Referrers`, `Clicks`, and `Authors` are displaying 
   - Do same for `weeks`, `months` and `year` tab 

## Regression Notes
1. Potential unintended areas of impact
     can't think of any 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)
     N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
