### PR TITLE
Detekt - Resolve/Suppress All Baseline Warnings - Long methods warnings_ HomePageSettingsDialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
@@ -54,7 +54,7 @@ class HomepageSettingsDialog : DialogFragment() {
 
             viewModel = ViewModelProvider(this@HomepageSettingsDialog, viewModelFactory)
                     .get(HomepageSettingsViewModel::class.java)
-            viewModel.uiState.observe(this@HomepageSettingsDialog, { uiState ->
+            viewModel.uiState.observe(this@HomepageSettingsDialog) { uiState ->
                 uiState?.let {
                     loadingPages.visibility = if (uiState.isLoading) View.VISIBLE else View.GONE
                     enablePositiveButton(uiState.isSaveEnabled)
@@ -65,40 +65,46 @@ class HomepageSettingsDialog : DialogFragment() {
                         loadingError.visibility = View.GONE
                         loadingError.text = null
                     }
-                    when (uiState.isClassicBlogState) {
-                        true -> {
-                            homepageSettingsRadioGroup.checkIfNotChecked(R.id.classic_blog)
-                            dropdownContainer.visibility = View.GONE
-                        }
-                        false -> {
-                            homepageSettingsRadioGroup.checkIfNotChecked(R.id.static_homepage)
-                            if (uiState.pageForPostsState != null && uiState.pageOnFrontState != null) {
-                                dropdownContainer.visibility = View.VISIBLE
-                                setupDropdownItem(
-                                        uiState.pageOnFrontState,
-                                        selectedHomepage,
-                                        viewModel::onPageOnFrontDialogOpened,
-                                        viewModel::onPageOnFrontSelected
-                                )
-                                setupDropdownItem(
-                                        uiState.pageForPostsState,
-                                        selectedPostsPage,
-                                        viewModel::onPageForPostsDialogOpened,
-                                        viewModel::onPageForPostsSelected
-                                )
-                            } else {
-                                dropdownContainer.visibility = View.GONE
-                            }
-                        }
-                    }
+                    isClassicBlogState(uiState)
                 }
-            })
+            }
         }
         viewModel.dismissDialogEvent.observeEvent(this, {
             requireDialog().dismiss()
         })
         viewModel.start(requireNotNull(siteId), isClassicBlog, pageForPostsId, pageOnFrontId)
         return builder.create()
+    }
+
+    private fun SiteSettingsHomepageDialogBinding.isClassicBlogState(
+        uiState: HomepageSettingsUiState
+    ) {
+        when (uiState.isClassicBlogState) {
+            true -> {
+                homepageSettingsRadioGroup.checkIfNotChecked(R.id.classic_blog)
+                dropdownContainer.visibility = View.GONE
+            }
+            false -> {
+                homepageSettingsRadioGroup.checkIfNotChecked(R.id.static_homepage)
+                if (uiState.pageForPostsState != null && uiState.pageOnFrontState != null) {
+                    dropdownContainer.visibility = View.VISIBLE
+                    setupDropdownItem(
+                            uiState.pageOnFrontState,
+                            selectedHomepage,
+                            viewModel::onPageOnFrontDialogOpened,
+                            viewModel::onPageOnFrontSelected
+                    )
+                    setupDropdownItem(
+                            uiState.pageForPostsState,
+                            selectedPostsPage,
+                            viewModel::onPageForPostsDialogOpened,
+                            viewModel::onPageForPostsSelected
+                    )
+                } else {
+                    dropdownContainer.visibility = View.GONE
+                }
+            }
+        }
     }
 
     private fun enablePositiveButton(enabled: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
@@ -69,9 +69,9 @@ class HomepageSettingsDialog : DialogFragment() {
                 }
             }
         }
-        viewModel.dismissDialogEvent.observeEvent(this, {
+        viewModel.dismissDialogEvent.observeEvent(this) {
             requireDialog().dismiss()
-        })
+        }
         viewModel.start(requireNotNull(siteId), isClassicBlog, pageForPostsId, pageOnFrontId)
         return builder.create()
     }

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -15,7 +15,6 @@
     <ID>ComplexMethod:CreatePageListItemActionsUseCase.kt$CreatePageListItemActionsUseCase$fun setupPageActions( listType: PageListType, uploadUiState: PostUploadUiState, siteModel: SiteModel, remoteId: Long ): Set&lt;Action></ID>
     <ID>ComplexMethod:EditorTracker.kt$EditorTracker$@JvmOverloads fun trackEditorEvent( event: TrackableEvent, editorName: String, properties: Map&lt;String, String> = mapOf() )</ID>
     <ID>ComplexMethod:FormattableContentClickHandler.kt$FormattableContentClickHandler$fun onClick( activity: FragmentActivity, clickedSpan: FormattableRange, source: String )</ID>
-    <ID>ComplexMethod:HomepageSettingsDialog.kt$HomepageSettingsDialog$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
     <ID>ComplexMethod:ImagePlaceholderManager.kt$ImagePlaceholderManager$fun getErrorResource(imgType: ImageType): Int?</ID>
     <ID>ComplexMethod:ImagePlaceholderManager.kt$ImagePlaceholderManager$fun getPlaceholderResource(imgType: ImageType): Int?</ID>
     <ID>ComplexMethod:NoticonUtils.kt$NoticonUtils$fun noticonToGridicon(noticon: String): Int</ID>
@@ -69,7 +68,6 @@
     <ID>LongMethod:AuthorsUseCase.kt$AuthorsUseCase$override fun buildUiModel(domainModel: AuthorsModel, uiState: SelectedAuthor): List&lt;BlockListItem></ID>
     <ID>LongMethod:BarChartViewHolder.kt$BarChartViewHolder$private fun BarChart.draw( item: BarChartItem, labelStart: TextView, labelEnd: TextView ): BarCount</ID>
     <ID>LongMethod:ClicksUseCase.kt$ClicksUseCase$override fun buildUiModel(domainModel: ClicksModel, uiState: SelectedClicksGroup): List&lt;BlockListItem></ID>
-    <ID>LongMethod:HomepageSettingsDialog.kt$HomepageSettingsDialog$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
     <ID>LongMethod:ReferrersUseCase.kt$ReferrersUseCase$override fun buildUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List&lt;BlockListItem></ID>
     <ID>LongMethod:SearchListViewModel.kt$SearchListViewModel$private fun PageModel.toPageItem(areActionsEnabled: Boolean): PageItem</ID>
     <ID>LongMethod:SuggestionActivity.kt$SuggestionActivity$private fun initializeActivity(siteModel: SiteModel, suggestionType: SuggestionType)</ID>


### PR DESCRIPTION
Parent: https://github.com/wordpress-mobile/WordPress-Android/issues/17010

This PR resolves/suppresses all complexity related LongMethod warnings for the HomePageSettingsDialog class (see docs [here](https://detekt.dev/docs/rules/complexity#longmethod)):

`1` x LongMethod  (Resolve: f3bed1e7cc937c10e809df487ce3b4f537747787 + 605bcde962a1dae4e833512aa3736d6a86964074 + 796e490211322a45664c5f52f098bada02e7a0b5 )

-----

To test:

- There is nothing much to test here.

- Verifying that all the CI checks are successful should be enough (especially the detekt check).
- However, if you really want to be thorough, you could smoke test the WordPress and/or Jetpack apps to verify that everything works as expected on every screen that relates to these changes. Specifically, you could follow the below steps:

   - Go to the menu tab
   - Click on site settings
   - Select HomePage settings
   - Test that you can change between different homepage settings 

## Regression Notes
1. Potential unintended areas of impact
     can't think of any 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)
     N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
