### PR TITLE
Guard mutex unlock in isLocked check to avoid errors during local data uploads

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -178,7 +178,13 @@ class UploadStarter @Inject constructor(
                         )
                     }
         } finally {
-            mutex.unlock()
+            // If the job of the current coroutine is cancelled while the `lock()` call is suspended,
+            // it results in the mutex ending up unlocked.
+            // We introduced this check to prevent IllegalStateExceptions when `unlock` is called in those cases.
+            // See: https://github.com/wordpress-mobile/WordPress-Android/issues/17463
+            if (mutex.isLocked) {
+                mutex.unlock()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #17463

The goal of this fix is to prevent possible data loss while their content is uploaded to the server.
While we weren't able to reproduce the crash we noticed it occurs for some users when they start the app, if their internet connectivity is active and there are local changes to be synced to the server.

This fix is applied to to prevent possible `IllegalStateException`s when the mutex is already unlocked by the system during a cancellation / completion while the mutex locking function is suspended.

To test:
Nothing much to test here, verify CI checks are green.

## Regression Notes

1. Potential unintended areas of impact
   N/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

3. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
