### PR TITLE
[Jetpack Content Migration Flow] Standardize local data migration steps

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/BloggingRemindersProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/BloggingRemindersProviderHelper.kt
@@ -14,7 +14,7 @@ class BloggingRemindersProviderHelper @Inject constructor(
     private val bloggingRemindersStore: BloggingRemindersStore,
     private val siteStore: SiteStore,
 ): LocalDataProviderHelper {
-    override fun getData(localSiteId: Int?, localEntityId: Int?) = BloggingRemindersData(
+    override fun getData(localEntityId: Int?) = BloggingRemindersData(
             reminders = runBlocking {
                 siteStore.sites.mapNotNull { site ->
                     bloggingRemindersStore.bloggingRemindersModel(site.id).first().let {

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalAccessTokenProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalAccessTokenProviderHelper.kt
@@ -7,7 +7,5 @@ import javax.inject.Inject
 class LocalAccessTokenProviderHelper @Inject constructor(
     private val accountStore: AccountStore,
 ): LocalDataProviderHelper {
-    override fun getData(localSiteId: Int?, localEntityId: Int?) = AccessTokenData(
-            token = accountStore.accessToken ?: ""
-    )
+    override fun getData(localEntityId: Int?) = AccessTokenData(token = accountStore.accessToken ?: "")
 }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -5,6 +5,8 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.QuickStartStatusModel
 import org.wordpress.android.fluxc.model.QuickStartTaskModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
 import org.wordpress.android.models.ReaderPostList
 
 enum class LocalContentEntity(private val isIdentifiable: Boolean = false) {
@@ -63,3 +65,14 @@ sealed class LocalMigrationResult<out T: LocalContentEntityData, out E: LocalMig
     data class Failure<E: LocalMigrationError>(val error: E): LocalMigrationResult<Nothing, E>()
 }
 
+fun <T: LocalContentEntityData, U: LocalContentEntityData, E: LocalMigrationError> LocalMigrationResult<T, E>
+        .then(next: (T) -> LocalMigrationResult<U, E>) = when (this) {
+    is Success -> next(this.value)
+    is Failure -> this
+}
+
+fun <T: LocalContentEntityData, E: LocalMigrationError> LocalMigrationResult<T, E>
+        .otherwise(handleError: (E) -> Unit) = when (this) {
+    is Success -> Unit
+    is Failure -> handleError(this.error)
+}

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -7,23 +7,23 @@ import org.wordpress.android.fluxc.model.QuickStartTaskModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.ReaderPostList
 
-enum class LocalContentEntity(private val isSiteContent: Boolean = false) {
+enum class LocalContentEntity(private val isIdentifiable: Boolean = false) {
     EligibilityStatus,
     AccessToken,
     UserFlags,
     ReaderPosts,
     BloggingReminders,
     Sites,
-    Post(isSiteContent = true),
+    Post(isIdentifiable = true),
     ;
 
-    open val contentIdCapturePattern = when (isSiteContent) {
-        true -> Regex("site/(\\d+)/${name}(?:/(\\d+))?")
+    open val contentIdCapturePattern = when (isIdentifiable) {
+        true -> Regex("${name}(?:/(\\d+))?")
         false -> Regex(name)
     }
 
-    open fun getPathForContent(localSiteId: Int?, localEntityId: Int?) = when (this.isSiteContent) {
-        true -> "site/${localSiteId}/${name}${ localEntityId?.let { "/${it}" } ?: "" }"
+    open fun getPathForContent(localEntityId: Int?) = when (this.isIdentifiable) {
+        true -> "${name}${ localEntityId?.let { "/${it}" } ?: "" }"
         false -> name
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -46,3 +46,13 @@ sealed class LocalContentEntityData {
     data class PostsData(val localIds: List<Int>): LocalContentEntityData()
     data class PostData(val post: PostModel) : LocalContentEntityData()
 }
+
+sealed class LocalMigrationError: LocalContentEntityData() {
+    data class ProviderError(val message: String?): LocalMigrationError()
+}
+
+sealed class LocalMigrationResult<out T: LocalContentEntityData, out E: LocalMigrationError> {
+    data class Success<T: LocalContentEntityData>(val value: T): LocalMigrationResult<T, Nothing>()
+    data class Failure<E: LocalMigrationError>(val error: E): LocalMigrationResult<Nothing, E>()
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -28,12 +28,15 @@ enum class LocalContentEntity(private val isIdentifiable: Boolean = false) {
     }
 }
 
-sealed class LocalContentEntityData {
-    data class EligibilityStatusData(
-        val isEligible: Boolean,
-        val siteCount: Int,
-    ): LocalContentEntityData()
+sealed class EligibilityState {
+    object Eligible: EligibilityState()
+    sealed class Ineligible: EligibilityState() {
+        object WPNotLoggedIn: Ineligible()
+    }
+}
 
+sealed class LocalContentEntityData {
+    data class EligibilityStatusData(val eligibilityState: EligibilityState): LocalContentEntityData()
     data class AccessTokenData(val token: String): LocalContentEntityData()
     data class UserFlagsData(
         val flags: Map<String, Any?>,

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -53,7 +53,7 @@ sealed class LocalContentEntityData {
     data class PostData(val post: PostModel) : LocalContentEntityData()
 }
 
-sealed class LocalMigrationError: LocalContentEntityData() {
+sealed class LocalMigrationError {
     sealed class ProviderError: LocalMigrationError() {
         data class NullValueFromQuery(val forEntity: LocalContentEntity): ProviderError()
         data class NullCursor(val forEntity: LocalContentEntity): ProviderError()

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.QuickStartStatusModel
 import org.wordpress.android.fluxc.model.QuickStartTaskModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.localcontentmigration.EligibilityState.Ineligible
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
 import org.wordpress.android.models.ReaderPostList
@@ -58,6 +59,7 @@ sealed class LocalMigrationError: LocalContentEntityData() {
         data class NullCursor(val forEntity: LocalContentEntity): ProviderError()
         data class ParsingException(val forEntity: LocalContentEntity): ProviderError()
     }
+    data class Ineligibility(val reason: Ineligible): LocalMigrationError()
 }
 
 sealed class LocalMigrationResult<out T: LocalContentEntityData, out E: LocalMigrationError> {

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -48,7 +48,11 @@ sealed class LocalContentEntityData {
 }
 
 sealed class LocalMigrationError: LocalContentEntityData() {
-    data class ProviderError(val message: String?): LocalMigrationError()
+    sealed class ProviderError: LocalMigrationError() {
+        data class NullValueFromQuery(val forEntity: LocalContentEntity): ProviderError()
+        data class NullCursor(val forEntity: LocalContentEntity): ProviderError()
+        data class ParsingException(val forEntity: LocalContentEntity): ProviderError()
+    }
 }
 
 sealed class LocalMigrationResult<out T: LocalContentEntityData, out E: LocalMigrationError> {

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
@@ -1,15 +1,26 @@
 package org.wordpress.android.localcontentmigration
 
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.localcontentmigration.EligibilityState.Eligible
+import org.wordpress.android.localcontentmigration.EligibilityState.Ineligible.WPNotLoggedIn
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.EligibilityStatusData
 import javax.inject.Inject
 
 class LocalEligibilityStatusProviderHelper @Inject constructor(
-        private val siteStore: SiteStore,
+    private val siteStore: SiteStore,
+    private val accountStore: AccountStore,
 ): LocalDataProviderHelper {
     override fun getData(localEntityId: Int?): LocalContentEntityData {
         @Suppress("ForbiddenComment")
-        // TODO: check for eligibility on-the-fly
-        return EligibilityStatusData(true, siteStore.sitesCount)
+        // TODO: check for eligibility of local content
+        val hasToken = !accountStore.accessToken.isNullOrBlank()
+        val hasSelfHostedSites = siteStore.sites.any { !it.isUsingWpComRestApi }
+        return EligibilityStatusData(
+                eligibilityState = when (hasToken || hasSelfHostedSites) {
+                    true -> Eligible
+                    false -> WPNotLoggedIn
+                }
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class LocalEligibilityStatusProviderHelper @Inject constructor(
         private val siteStore: SiteStore,
 ): LocalDataProviderHelper {
-    override fun getData(localSiteId: Int?, localEntityId: Int?): LocalContentEntityData {
+    override fun getData(localEntityId: Int?): LocalContentEntityData {
         @Suppress("ForbiddenComment")
         // TODO: check for eligibility on-the-fly
         return EligibilityStatusData(true, siteStore.sitesCount)

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
@@ -5,6 +5,9 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.localcontentmigration.EligibilityState.Eligible
 import org.wordpress.android.localcontentmigration.EligibilityState.Ineligible.WPNotLoggedIn
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.EligibilityStatusData
+import org.wordpress.android.localcontentmigration.LocalMigrationError.Ineligibility
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
 import javax.inject.Inject
 
 class LocalEligibilityStatusProviderHelper @Inject constructor(
@@ -23,4 +26,12 @@ class LocalEligibilityStatusProviderHelper @Inject constructor(
                 }
         )
     }
+}
+
+fun <E: LocalMigrationError> LocalMigrationResult<EligibilityStatusData, E>.validate() = when (this) {
+    is Success -> when(this.value.eligibilityState) {
+        is Eligible -> this
+        is WPNotLoggedIn -> Failure(Ineligibility(this.value.eligibilityState))
+    }
+    is Failure -> this
 }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationContentProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationContentProvider.kt
@@ -38,17 +38,14 @@ class LocalMigrationContentProvider: TrustedQueryContentProvider() {
                 return@firstNotNullOf Pair(entity, match.groups)
             }
         }
-        val (localSiteId, localEntityId) = extractParametersFromGroups(groups)
-        return query(entity, localSiteId, localEntityId)
+        val localEntityId = extractEntityId(groups)
+        return query(entity, localEntityId)
     }
 
-    private fun extractParametersFromGroups(groups: MatchGroupCollection): Pair<Int?, Int?> {
-        // The first group is the entire match, so we drop that and parse the remaining captured groups as integers
-        val parameters = groups.drop(1).mapNotNull { it?.value?.let { id -> parseInt(id) } }
-        return Pair(parameters.getOrNull(0), parameters.getOrNull(1))
-    }
+    // The first group is the entire match, so we drop that and parse the next captured group as an integer
+    private fun extractEntityId(groups: MatchGroupCollection) = groups.drop(1).first()?.let { parseInt(it.value) }
 
-    private fun query(entity: LocalContentEntity, localSiteId: Int?, localEntityId: Int?): Cursor {
+    private fun query(entity: LocalContentEntity, localEntityId: Int?): Cursor {
         val context = checkNotNull(context) { "Cannot find context from the provider." }
         with(EntryPointAccessors.fromApplication(context.applicationContext,
                 LocalMigrationContentProviderEntryPoint::class.java)) {
@@ -59,7 +56,7 @@ class LocalMigrationContentProvider: TrustedQueryContentProvider() {
                 ReaderPosts -> readeSavedPostsProviderHelper().getData()
                 BloggingReminders -> bloggingRemindersProviderHelper().getData()
                 Sites -> localSiteProviderHelper().getData()
-                Post -> localPostProviderHelper().getData(localSiteId, localEntityId)
+                Post -> localPostProviderHelper().getData(localEntityId)
             }
             return queryResult().createCursor(response)
         }
@@ -67,5 +64,5 @@ class LocalMigrationContentProvider: TrustedQueryContentProvider() {
 }
 
 interface LocalDataProviderHelper {
-    fun getData(localSiteId: Int? = null, localEntityId: Int? = null): LocalContentEntityData
+    fun getData(localEntityId: Int? = null): LocalContentEntityData
 }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationContentResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationContentResolver.kt
@@ -13,10 +13,9 @@ import javax.inject.Inject
 @PublishedApi internal fun ContentResolver.query(
     builder: Uri.Builder,
     entityType: LocalContentEntity,
-    siteId: Int?,
     entityId: Int?,
 ) : Cursor {
-    val entityPath = entityType.getPathForContent(siteId, entityId)
+    val entityPath = entityType.getPathForContent(entityId)
     builder.appendEncodedPath(entityPath)
     val cursor = query(builder.build(), arrayOf(), "", arrayOf(), "")
     return checkNotNull(cursor) { "Provider failed for $entityType" }
@@ -30,7 +29,6 @@ class LocalMigrationContentResolver @Inject constructor(
 ){
     inline fun <reified T : LocalContentEntityData> getDataForEntityType(
         entityType: LocalContentEntity,
-        siteId: Int? = null,
         entityId: Int? = null
     ): T {
         wordPressPublicData.currentPackageId().let { packageId ->
@@ -40,7 +38,7 @@ class LocalMigrationContentResolver @Inject constructor(
             }
         }.let { uriBuilder ->
             with (contextProvider.getContext().contentResolver) {
-                val cursor = query(uriBuilder, entityType, siteId, entityId)
+                val cursor = query(uriBuilder, entityType, entityId)
                 val data: T? = cursor.getValue()
                 return checkNotNull(data) { "Failed to parse data from provider for $entityType"}
             }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalPostProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalPostProviderHelper.kt
@@ -1,23 +1,23 @@
 package org.wordpress.android.localcontentmigration
 
 import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostData
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostsData
 import javax.inject.Inject
 
 class LocalPostProviderHelper @Inject constructor(
-        private val siteStore: SiteStore,
         private val postStore: PostStore,
+        private val localMigrationSiteProviderHelper: LocalSiteProviderHelper,
     ): LocalDataProviderHelper {
-    override fun getData(localSiteId: Int?, localEntityId: Int?): LocalContentEntityData {
+    override fun getData(localEntityId: Int?): LocalContentEntityData {
         localEntityId?.let { localPostId ->
             val post = postStore.getPostByLocalPostId(localPostId)
             return PostData(post = post)
         } ?: run {
-            requireNotNull(localSiteId) { "A local site id must be specified when querying site content." }
-            val site = siteStore.getSiteByLocalId(localSiteId)
-            return PostsData(localIds = postStore.getPostsForSite(site).mapNotNull { it.id })
+            val (sites) = localMigrationSiteProviderHelper.getData()
+            return PostsData(localIds = sites.flatMap { site ->
+                postStore.getPostsForSite(site).mapNotNull { it.id }
+            })
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalSiteProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalSiteProviderHelper.kt
@@ -9,7 +9,7 @@ class LocalSiteProviderHelper @Inject constructor(
     private val siteStore: SiteStore,
     private val accountStore: AccountStore,
 ): LocalDataProviderHelper {
-    override fun getData(localSiteId: Int?, localEntityId: Int?): LocalContentEntityData =
+    override fun getData(localEntityId: Int?): SitesData =
             if (accountStore.hasAccessToken())
                 SitesData(sites = siteStore.sites)
             else

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/ReaderSavedPostsProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/ReaderSavedPostsProviderHelper.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 class ReaderSavedPostsProviderHelper @Inject constructor(
     private val readerPostTableWrapper: ReaderPostTableWrapper,
 ): LocalDataProviderHelper {
-    override fun getData(localSiteId: Int?, localEntityId: Int?): LocalContentEntityData =
+    override fun getData(localEntityId: Int?): LocalContentEntityData =
             readerPostTableWrapper.getPostsWithTag(
                     readerTag = ReaderTag("", "", "", "", BOOKMARKED),
                     maxRows = 0,

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class UserFlagsProviderHelper @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
 ): LocalDataProviderHelper {
-    override fun getData(localSiteId: Int?, localEntityId: Int?): LocalContentEntityData =
+    override fun getData(localEntityId: Int?): LocalContentEntityData =
             UserFlagsData(
                     flags = appPrefsWrapper.getAllPrefs().filter(::shouldInclude),
                     quickStartStatusList = getAllQuickStartStatus(),

--- a/WordPress/src/main/java/org/wordpress/android/provider/query/QueryResult.kt
+++ b/WordPress/src/main/java/org/wordpress/android/provider/query/QueryResult.kt
@@ -7,15 +7,10 @@ import java.lang.reflect.Type
 import javax.inject.Inject
 
 class QueryResult @Inject constructor() {
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     inline fun <reified T : Any> getValue(cursor: Cursor, type: Type? = null): T? {
         cursor.moveToFirst()
         val value: String = cursor.getString(0)
-        return try {
-            if (type != null) Gson().fromJson(value, type) else Gson().fromJson(value, T::class.java)
-        } catch (exception: Exception) {
-            null
-        }
+        return if (type != null) Gson().fromJson(value, type) else Gson().fromJson(value, T::class.java)
     }
 
     inline fun <reified T : Any> createCursor(value: T): Cursor {

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -43,6 +43,7 @@ class LocalMigrationOrchestrator @Inject constructor(
     private val siteStore: SiteStore,
 ) {
     fun tryLocalMigration() {
+        localMigrationContentResolver.getResultForEntityType<EligibilityStatusData>(EligibilityStatus)
         val isFeatureFlagEnabled = jetpackSharedLoginFlag.isEnabled()
 
         if (!isFeatureFlagEnabled) {
@@ -99,10 +100,6 @@ class LocalMigrationOrchestrator @Inject constructor(
     }
 
     fun migrateLocalContent() {
-        val (isEligible) = localMigrationContentResolver.getDataForEntityType<EligibilityStatusData>(EligibilityStatus)
-        @Suppress("ForbiddenComment")
-        // TODO: do something more graceful here?
-        if (!isEligible) return
         val posts: PostsData = localMigrationContentResolver.getDataForEntityType(Post)
         for (localPostId in posts.localIds) {
             val postData: PostData = localMigrationContentResolver.getDataForEntityType(Post, localPostId)

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -43,6 +43,9 @@ class LocalMigrationOrchestrator @Inject constructor(
     private val siteStore: SiteStore,
 ) {
     fun tryLocalMigration() {
+        originalTryLocalMigration()
+    }
+    private fun originalTryLocalMigration() {
         localMigrationContentResolver.getResultForEntityType<EligibilityStatusData>(EligibilityStatus)
         val isFeatureFlagEnabled = jetpackSharedLoginFlag.isEnabled()
 

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -66,6 +66,9 @@ class LocalMigrationOrchestrator @Inject constructor(
         }
     }
     private fun originalTryLocalMigration() {
+        @Suppress("ForbiddenComment")
+        // TODO: We should move this login specific logic to a helper. It can happen as a later step, since the
+        // eligibility check is handled separately now (on the provider side).
         val isFeatureFlagEnabled = jetpackSharedLoginFlag.isEnabled()
 
         if (!isFeatureFlagEnabled) {

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -103,13 +103,10 @@ class LocalMigrationOrchestrator @Inject constructor(
         @Suppress("ForbiddenComment")
         // TODO: do something more graceful here?
         if (!isEligible) return
-        val (sites) = localMigrationContentResolver.getDataForEntityType<SitesData >(Sites)
-        for (site in sites) {
-            val posts: PostsData = localMigrationContentResolver.getDataForEntityType(Post, site.id)
-            for (localPostId in posts.localIds) {
-                val postData: PostData = localMigrationContentResolver.getDataForEntityType(Post, site.id, localPostId)
-                dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(postData.post))
-            }
+        val posts: PostsData = localMigrationContentResolver.getDataForEntityType(Post)
+        for (localPostId in posts.localIds) {
+            val postData: PostData = localMigrationContentResolver.getDataForEntityType(Post, localPostId)
+            dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(postData.post))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -460,7 +460,10 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (!mSelectedSiteRepository.hasSelectedSite()) {
             initSelectedSite();
         }
-        mLocalMigrationOrchestrator.tryLocalMigration();
+
+        if (mBuildConfigWrapper.isJetpackApp()) {
+            mLocalMigrationOrchestrator.tryLocalMigration();
+        }
 
         // TODO: this is temporary to enable testing the migration flow UI
         if (mJetpackAppMigrationFlowUtils.shouldShowMigrationFlow()) {

--- a/WordPress/src/test/java/org/wordpress/android/localcontentmigration/LocalContentEntityTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/localcontentmigration/LocalContentEntityTest.kt
@@ -5,34 +5,31 @@ import org.junit.Test
 import org.wordpress.android.localcontentmigration.LocalContentEntity.Post
 
 class LocalContentEntityTest {
-    private val mockSiteId = 7
     private val mockPostId = 42
-    private val mockPostPath = "site/7/Post/42"
-    private val mockPostsPath = "site/7/Post"
+    private val mockPostPath = "Post/42"
+    private val mockPostsPath = "Post"
 
     @Test
     fun `when a post URI path is generated without an entity id`() {
-        val path = Post.getPathForContent(localSiteId = mockSiteId, localEntityId = null)
+        val path = Post.getPathForContent(localEntityId = null)
         assertThat(path).isEqualTo(mockPostsPath)
     }
 
     @Test
     fun `when a post URI path is generated with an entity id`() {
-        val path = Post.getPathForContent(localSiteId = mockSiteId, localEntityId = mockPostId)
+        val path = Post.getPathForContent(localEntityId = mockPostId)
         assertThat(path).isEqualTo(mockPostPath)
     }
 
     @Test
     fun `when a post URI path is captured without an entity id`() {
         val captures = Post.contentIdCapturePattern.matchEntire(mockPostsPath)?.groups?.mapNotNull { it?.value }!!
-        assertThat(captures.getOrNull(1)).isEqualTo("$mockSiteId")
-        assertThat(captures.getOrNull(2)).isNull()
+        assertThat(captures.getOrNull(1)).isNull()
     }
 
     @Test
     fun `when a post URI path is captured with an entity id`() {
         val captures = Post.contentIdCapturePattern.matchEntire(mockPostPath)?.groups?.mapNotNull { it?.value }!!
-        assertThat(captures.getOrNull(1)).isEqualTo("$mockSiteId")
-        assertThat(captures.getOrNull(2)).isEqualTo("$mockPostId")
+        assertThat(captures.getOrNull(1)).isEqualTo("$mockPostId")
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/localcontentmigration/LocalPostProviderHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/localcontentmigration/LocalPostProviderHelperTest.kt
@@ -8,12 +8,12 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostData
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostsData
+import org.wordpress.android.localcontentmigration.LocalContentEntityData.SitesData
 
 class LocalPostProviderHelperTest {
-    private val siteStore: SiteStore = mock()
+    private val siteProviderHelper: LocalSiteProviderHelper = mock()
     private val postStore: PostStore = mock()
     private val mockSiteModel: SiteModel = mock()
     private val mockPostModel: PostModel = mock()
@@ -21,20 +21,19 @@ class LocalPostProviderHelperTest {
 
     private val mockPostId = 42
     private val mockPostId2 = 7
-    private val mockSiteId = 42
     private val mockPostList = listOf(mockPostModel, mockPostModel2)
     private val mockPostIdsList = listOf(mockPostId, mockPostId2)
 
     // Object under test
-    private val localPostProviderHelper = LocalPostProviderHelper(siteStore, postStore)
+    private val localPostProviderHelper = LocalPostProviderHelper(postStore, siteProviderHelper)
 
     @Before
     fun setUp() {
         whenever(postStore.getPostByLocalPostId(mockPostId)).thenReturn(mockPostModel)
         whenever(mockPostModel.id).thenReturn(mockPostId)
         whenever(mockPostModel2.id).thenReturn(mockPostId2)
-        whenever(siteStore.getSiteByLocalId(mockSiteId)).thenReturn(mockSiteModel)
         whenever(postStore.getPostsForSite(mockSiteModel)).thenReturn(mockPostList)
+        whenever(siteProviderHelper.getData()).thenReturn(SitesData(sites = listOf(mockSiteModel)))
     }
 
     @Test
@@ -45,7 +44,7 @@ class LocalPostProviderHelperTest {
 
     @Test
     fun `when a local post id is not specified but a local site id is specified`() {
-        val response = localPostProviderHelper.getData(localSiteId = mockSiteId) as PostsData
+        val response = localPostProviderHelper.getData() as PostsData
         assertThat(response.localIds).isEqualTo(mockPostIdsList)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/17488

# Description

This is the base of a chain of PRs:
 * https://github.com/wordpress-mobile/WordPress-Android/pull/17483
 * https://github.com/wordpress-mobile/WordPress-Android/pull/17484
 * https://github.com/wordpress-mobile/WordPress-Android/pull/17487
 * https://github.com/wordpress-mobile/WordPress-Android/pull/17485
 * https://github.com/wordpress-mobile/WordPress-Android/pull/17486


Which convert the local migration orchestration logic to railroad style. This approach documents the error modes with a unified error model, and facilitates rearrangement enabling composability of the various steps.

To test:

<details>
<summary>
Useful precondition patch to set flags locally
</summary>

```patch
diff --git a/WordPress/build.gradle b/WordPress/build.gradle
index 98bb515903..cd987a2816 100644
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -120,11 +120,11 @@ android {
         buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"
         buildConfigField "boolean", "JETPACK_POWERED", "true"
         buildConfigField "boolean", "JETPACK_POWERED_BOTTOM_SHEET", "false"
-        buildConfigField "boolean", "JETPACK_SHARED_LOGIN", "false"
-        buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "false"
-        buildConfigField "boolean", "JETPACK_BLOGGING_REMINDERS_SYNC", "false"
-        buildConfigField "boolean", "JETPACK_READER_SAVED_POSTS", "false"
-        buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "false"
+        buildConfigField "boolean", "JETPACK_SHARED_LOGIN", "true"
+        buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "true"
+        buildConfigField "boolean", "JETPACK_BLOGGING_REMINDERS_SYNC", "true"
+        buildConfigField "boolean", "JETPACK_READER_SAVED_POSTS", "true"
+        buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "true"
         buildConfigField "boolean", "JETPACK_MIGRATION_FLOW", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_ONE", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_TWO", "false"
```
</details>

Follow the testing steps on this PR: https://github.com/wordpress-mobile/WordPress-Android/pull/17398

## Regression Notes
1. Potential unintended areas of impact
Local migration flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Automated tests will be re-enabled in a later PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
