### PR TITLE
Fixes: Notifications Pending Intent Mutability issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 ext {
-    wordPressUtilsVersion = '112-8415dfedb07dd498a3a42c01e67f92cd049b4583'
+    wordPressUtilsVersion = 'trunk-591eefcd7599adf185cc33cc4098550e2f280454'
     wordPressLoginVersion = '1.0.0'
     aztecVersion = 'v1.6.2'
     gutenbergMobileVersion = 'v1.85.0'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 ext {
-    wordPressUtilsVersion = '3.0.0'
+    wordPressUtilsVersion = '112-8415dfedb07dd498a3a42c01e67f92cd049b4583'
     wordPressLoginVersion = '1.0.0'
     aztecVersion = 'v1.6.2'
     gutenbergMobileVersion = 'v1.85.0'


### PR DESCRIPTION
Fixes #17465 

Dependant fluxC PR - https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/112

Although the sentry crash was pointing to the `LoginWpcomService`, the root cause for the crash was the pending intent created in `AutoForegroundNotification.java`. The Intent created in AutoForegroundNotification.java is used in the site creation service as well. 

I couldn't reproduce the bug on the login flow. But I was able to reproduce it on the site creation flow with the steps below. 

Steps to reproduce the crash 
- Launch app on Android 12 device 
- Create any WordPress site (Site picker -> + -> Create WordPress site -> Select theme -> Choose domain 
- When the message Site creation progress screen is shown put the app in the background
- Notice the log message in terminal and the notifications for site created is not shown

<details>
<summary><h3>Log message</h3></summary>

``
java.lang.RuntimeException: Unable to unbind to service org.wordpress.android.ui.sitecreation.services.SiteCreationService@d918779 with Intent { cmp=org.wordpress.android.prealpha/org.wordpress.android.ui.sitecreation.services.SiteCreationService }: java.lang.IllegalArgumentException: org.wordpress.android.prealpha: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
                                                                            Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
                                                                            	at android.app.ActivityThread.handleUnbindService(ActivityThread.java:4590)
                                                                            	at android.app.ActivityThread.-$$Nest$mhandleUnbindService(Unknown Source:0)
                                                                            	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2172)
                                                                            	at android.os.Handler.dispatchMessage(Handler.java:106)
                                                                            	at android.os.Looper.loopOnce(Looper.java:201)
                                                                            	at android.os.Looper.loop(Looper.java:288)
                                                                            	at android.app.ActivityThread.main(ActivityThread.java:7898)
                                                                            	at java.lang.reflect.Method.invoke(Native Method)
                                                                            	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
                                                                            	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
                                                                            Caused by: java.lang.IllegalArgumentException: org.wordpress.android.prealpha: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
                                                                            Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
                                                                            	at android.app.PendingIntent.checkFlags(PendingIntent.java:401)
                                                                            	at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:484)
                                                                            	at android.app.PendingIntent.getActivity(PendingIntent.java:470)
                                                                            	at android.app.PendingIntent.getActivity(PendingIntent.java:434)
                                                                            	at org.wordpress.android.util.AutoForegroundNotification.getNotificationBuilder(AutoForegroundNotification.java:45)
                                                                            	at org.wordpress.android.util.AutoForegroundNotification.progressIndeterminate(AutoForegroundNotification.java:63)
                                                                            	at org.wordpress.android.ui.sitecreation.services.SiteCreationServiceNotification.createCreatingSiteNotification(SiteCreationServiceNotification.kt:14)
                                                                            	at org.wordpress.android.ui.sitecreation.services.SiteCreationService.getNotification(SiteCreationService.kt:71)
                                                                            	at org.wordpress.android.ui.sitecreation.services.SiteCreationService.getNotification(SiteCreationService.kt:25)
                                                                            	at org.wordpress.android.util.AutoForeground.promoteForeground(AutoForeground.java:153)
                                                                            	at org.wordpress.android.util.AutoForeground.onUnbind(AutoForeground.java:131)
                                                                            	at android.app.ActivityThread.handleUnbindService(ActivityThread.java:4574)
                                                                            	... 9 more
``
</details>


After fix
- Video capture showing the site created notification 

https://user-images.githubusercontent.com/17463767/202568342-87d68b99-6957-45d4-a32b-d7fc50534edd.mp4


To test:
- Test whether the pending mutability error message is shown on logcat in error mode 
- Test whether the site-created notification is shown properly 

Merge Instructions 
- Merge the Dependant fluxC PR 
- Update Utils library version 
- Remove Not Ready for Merge label 
- Merge as usual 

## Regression Notes
1. Potential unintended areas of impact
Notifications not shown properly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
