### PR TITLE
[Jetpack Content Migration Flow] Standardize shared login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.QuickStartStatusModel
 import org.wordpress.android.fluxc.model.QuickStartTaskModel
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.localcontentmigration.EligibilityState.Ineligible
+import org.wordpress.android.localcontentmigration.LocalContentEntityData.Companion.IneligibleReason
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
 import org.wordpress.android.models.ReaderPostList
@@ -31,15 +31,8 @@ enum class LocalContentEntity(private val isIdentifiable: Boolean = false) {
     }
 }
 
-sealed class EligibilityState {
-    object Eligible: EligibilityState()
-    sealed class Ineligible: EligibilityState() {
-        object WPNotLoggedIn: Ineligible()
-    }
-}
-
 sealed class LocalContentEntityData {
-    data class EligibilityStatusData(val eligibilityState: EligibilityState): LocalContentEntityData()
+    data class EligibilityStatusData(val isEligible: Boolean, val reason: IneligibleReason?): LocalContentEntityData()
     data class AccessTokenData(val token: String): LocalContentEntityData()
     data class UserFlagsData(
         val flags: Map<String, Any?>,
@@ -51,6 +44,12 @@ sealed class LocalContentEntityData {
     data class SitesData(val sites: List<SiteModel>): LocalContentEntityData()
     data class PostsData(val localIds: List<Int>): LocalContentEntityData()
     data class PostData(val post: PostModel) : LocalContentEntityData()
+    companion object {
+        enum class IneligibleReason {
+            WPNotLoggedIn,
+            ;
+        }
+    }
 }
 
 sealed class LocalMigrationError {
@@ -59,7 +58,7 @@ sealed class LocalMigrationError {
         data class NullCursor(val forEntity: LocalContentEntity): ProviderError()
         data class ParsingException(val forEntity: LocalContentEntity): ProviderError()
     }
-    data class Ineligibility(val reason: Ineligible): LocalMigrationError()
+    data class Ineligibility(val reason: IneligibleReason): LocalMigrationError()
     sealed class FeatureDisabled: LocalMigrationError() {
         object SharedLoginDisabled: FeatureDisabled()
     }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationContentProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationContentProvider.kt
@@ -43,7 +43,9 @@ class LocalMigrationContentProvider: TrustedQueryContentProvider() {
     }
 
     // The first group is the entire match, so we drop that and parse the next captured group as an integer
-    private fun extractEntityId(groups: MatchGroupCollection) = groups.drop(1).first()?.let { parseInt(it.value) }
+    private fun extractEntityId(groups: MatchGroupCollection) = groups.drop(1).firstOrNull()?.let {
+        parseInt(it.value)
+    }
 
     private fun query(entity: LocalContentEntity, localEntityId: Int?): Cursor {
         val context = checkNotNull(context) { "Cannot find context from the provider." }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/SharedLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/SharedLoginHelper.kt
@@ -1,0 +1,32 @@
+package org.wordpress.android.localcontentmigration
+
+import org.wordpress.android.localcontentmigration.LocalContentEntity.AccessToken
+import org.wordpress.android.localcontentmigration.LocalContentEntityData.AccessTokenData
+import org.wordpress.android.localcontentmigration.LocalMigrationError.FeatureDisabled.SharedLoginDisabled
+import org.wordpress.android.localcontentmigration.LocalMigrationError.MigrationAlreadyAttempted.SharedLoginAlreadyAttempted
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
+import org.wordpress.android.sharedlogin.JetpackSharedLoginFlag
+import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import javax.inject.Inject
+
+class SharedLoginHelper @Inject constructor(
+    private val jetpackSharedLoginFlag: JetpackSharedLoginFlag,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val sharedLoginAnalyticsTracker: SharedLoginAnalyticsTracker,
+    private val localMigrationContentResolver: LocalMigrationContentResolver,
+) {
+    fun login() = if (!jetpackSharedLoginFlag.isEnabled()) {
+        Failure(SharedLoginDisabled)
+    } else if (appPrefsWrapper.getIsFirstTrySharedLoginJetpack()) {
+        Failure(SharedLoginAlreadyAttempted)
+    } else {
+        sharedLoginAnalyticsTracker.trackLoginStart()
+        localMigrationContentResolver.getResultForEntityType<AccessTokenData>(AccessToken).thenWith {
+            appPrefsWrapper.saveIsFirstTrySharedLoginJetpack(false)
+            sharedLoginAnalyticsTracker.trackLoginSuccess()
+            Success(it)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/SharedLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/SharedLoginHelper.kt
@@ -19,7 +19,7 @@ class SharedLoginHelper @Inject constructor(
 ) {
     fun login() = if (!jetpackSharedLoginFlag.isEnabled()) {
         Failure(SharedLoginDisabled)
-    } else if (appPrefsWrapper.getIsFirstTrySharedLoginJetpack()) {
+    } else if (!appPrefsWrapper.getIsFirstTrySharedLoginJetpack()) {
         Failure(SharedLoginAlreadyAttempted)
     } else {
         sharedLoginAnalyticsTracker.trackLoginStart()

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -3,9 +3,9 @@ package org.wordpress.android.sharedlogin.resolver
 import android.content.Intent
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.PostActionBuilder
-import org.wordpress.android.localcontentmigration.EligibilityState.Ineligible.WPNotLoggedIn
 import org.wordpress.android.localcontentmigration.LocalContentEntity.EligibilityStatus
 import org.wordpress.android.localcontentmigration.LocalContentEntity.Post
+import org.wordpress.android.localcontentmigration.LocalContentEntityData.Companion.IneligibleReason.WPNotLoggedIn
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.EligibilityStatusData
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostData
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostsData
@@ -56,7 +56,7 @@ class LocalMigrationOrchestrator @Inject constructor(
         when(error) {
             is ProviderError -> Unit
             is Ineligibility -> when (error.reason) {
-                is WPNotLoggedIn -> sharedLoginAnalyticsTracker.trackLoginFailed(ErrorType.WPNotLoggedInError)
+                WPNotLoggedIn -> sharedLoginAnalyticsTracker.trackLoginFailed(ErrorType.WPNotLoggedInError)
             }
             is FeatureDisabled -> Unit
             is MigrationAlreadyAttempted -> Unit

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -3,58 +3,51 @@ package org.wordpress.android.sharedlogin.resolver
 import android.content.Intent
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.PostActionBuilder
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.localcontentmigration.LocalContentEntity.AccessToken
-import org.wordpress.android.localcontentmigration.LocalContentEntityData.AccessTokenData
-import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.localcontentmigration.EligibilityState.Ineligible.WPNotLoggedIn
 import org.wordpress.android.localcontentmigration.LocalContentEntity.EligibilityStatus
 import org.wordpress.android.localcontentmigration.LocalContentEntity.Post
-import org.wordpress.android.localcontentmigration.LocalContentEntity.Sites
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.EligibilityStatusData
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostData
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostsData
-import org.wordpress.android.localcontentmigration.LocalContentEntityData.SitesData
 import org.wordpress.android.localcontentmigration.LocalMigrationContentResolver
 import org.wordpress.android.localcontentmigration.LocalMigrationError
+import org.wordpress.android.localcontentmigration.LocalMigrationError.FeatureDisabled
 import org.wordpress.android.localcontentmigration.LocalMigrationError.Ineligibility
+import org.wordpress.android.localcontentmigration.LocalMigrationError.MigrationAlreadyAttempted
 import org.wordpress.android.localcontentmigration.LocalMigrationError.ProviderError
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
+import org.wordpress.android.localcontentmigration.SharedLoginHelper
 import org.wordpress.android.localcontentmigration.otherwise
 import org.wordpress.android.localcontentmigration.then
+import org.wordpress.android.localcontentmigration.thenWith
 import org.wordpress.android.localcontentmigration.validate
 import org.wordpress.android.reader.savedposts.resolver.ReaderSavedPostsResolver
-import org.wordpress.android.resolver.ResolverUtility
-import org.wordpress.android.sharedlogin.JetpackSharedLoginFlag
 import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker
 import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker.ErrorType
 import org.wordpress.android.ui.main.WPMainActivity
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.userflags.resolver.UserFlagsResolver
 import org.wordpress.android.util.AccountActionBuilderWrapper
 import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
 
 class LocalMigrationOrchestrator @Inject constructor(
-    private val jetpackSharedLoginFlag: JetpackSharedLoginFlag,
     private val contextProvider: ContextProvider,
     private val dispatcher: Dispatcher,
-    private val accountStore: AccountStore,
     private val accountActionBuilderWrapper: AccountActionBuilderWrapper,
-    private val appPrefsWrapper: AppPrefsWrapper,
     private val sharedLoginAnalyticsTracker: SharedLoginAnalyticsTracker,
     private val userFlagsResolver: UserFlagsResolver,
     private val readerSavedPostsResolver: ReaderSavedPostsResolver,
     private val localMigrationContentResolver: LocalMigrationContentResolver,
-    private val resolverUtility: ResolverUtility,
-    private val siteStore: SiteStore,
+    private val sharedLoginHelper: SharedLoginHelper,
 ) {
     fun tryLocalMigration() {
         localMigrationContentResolver.getResultForEntityType<EligibilityStatusData>(EligibilityStatus).validate()
-                .then {
-                    originalTryLocalMigration()
+                .then(sharedLoginHelper::login)
+                .thenWith {
+                    originalTryLocalMigration(it.token)
                     Success(it)
-                }.otherwise(::handleErrors)
+                }
+                .otherwise(::handleErrors)
     }
 
     @Suppress("ForbiddenComment")
@@ -62,49 +55,21 @@ class LocalMigrationOrchestrator @Inject constructor(
     private fun handleErrors(error: LocalMigrationError) {
         when(error) {
             is ProviderError -> Unit
-            is Ineligibility -> Unit
+            is Ineligibility -> when (error.reason) {
+                is WPNotLoggedIn -> sharedLoginAnalyticsTracker.trackLoginFailed(ErrorType.WPNotLoggedInError)
+            }
+            is FeatureDisabled -> Unit
+            is MigrationAlreadyAttempted -> Unit
         }
     }
-    private fun originalTryLocalMigration() {
+    private fun originalTryLocalMigration(accessToken: String) {
         @Suppress("ForbiddenComment")
-        // TODO: We should move this login specific logic to a helper. It can happen as a later step, since the
-        // eligibility check is handled separately now (on the provider side).
-        val isFeatureFlagEnabled = jetpackSharedLoginFlag.isEnabled()
-
-        if (!isFeatureFlagEnabled) {
-            return
-        }
-
-        val hasSelfHostedSites = siteStore.hasSite() && siteStore.sites.any { !it.isUsingWpComRestApi }
-        val isAlreadyLoggedIn = accountStore.hasAccessToken() || hasSelfHostedSites
-        val isFirstTry = appPrefsWrapper.getIsFirstTrySharedLoginJetpack()
-
-        if (isAlreadyLoggedIn || !isFirstTry) {
-            return
-        }
-
-        sharedLoginAnalyticsTracker.trackLoginStart()
-        appPrefsWrapper.saveIsFirstTrySharedLoginJetpack(false)
-        val (accessToken) = localMigrationContentResolver.getDataForEntityType<AccessTokenData>(AccessToken)
-        val (sites) = localMigrationContentResolver.getDataForEntityType<SitesData >(Sites)
-        val hasLocalSelfHostedSites = sites.any { !it.isUsingWpComRestApi }
-        @Suppress("ForbiddenComment")
-        // TODO: Unify error tracking for resolver / provider errors too
-        if (accessToken.isNotEmpty() || hasLocalSelfHostedSites) {
-            runFlow(accessToken, sites)
-        } else {
-            sharedLoginAnalyticsTracker.trackLoginFailed(ErrorType.WPNotLoggedInError)
-        }
-    }
-
-    private fun runFlow(accessToken: String, sites: List<SiteModel>) {
-        val hasSites = sites.isNotEmpty()
-
-        if (hasSites) {
-            resolverUtility.copySitesWithIndexes(sites)
-        }
-
-        sharedLoginAnalyticsTracker.trackLoginSuccess()
+        // TODO: Extract sites migration to helper
+//        val hasSites = sites.isNotEmpty()
+//
+//        if (hasSites) {
+//            resolverUtility.copySitesWithIndexes(sites)
+//        }
         userFlagsResolver.tryGetUserFlags(
                 {
                     readerSavedPostsResolver.tryGetReaderSavedPosts(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -460,7 +460,10 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (!mSelectedSiteRepository.hasSelectedSite()) {
             initSelectedSite();
         }
-        mLocalMigrationOrchestrator.tryLocalMigration();
+
+        if (mBuildConfigWrapper.isJetpackApp()) {
+            mLocalMigrationOrchestrator.tryLocalMigration();
+        }
 
         // TODO: this is temporary to enable testing the migration flow UI
         if (mJetpackAppMigrationFlowUtils.shouldShowMigrationFlow()) {

--- a/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
@@ -25,9 +25,9 @@ import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.localcontentmigration.LocalMigrationContentProvider
 import org.wordpress.android.localcontentmigration.LocalMigrationContentResolver
+import org.wordpress.android.localcontentmigration.SharedLoginHelper
 import org.wordpress.android.reader.savedposts.resolver.ReaderSavedPostsResolver
 import org.wordpress.android.resolver.ContentResolverWrapper
-import org.wordpress.android.resolver.ResolverUtility
 import org.wordpress.android.sharedlogin.JetpackSharedLoginFlag
 import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker
 import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker.ErrorType
@@ -57,22 +57,18 @@ class SharedLoginResolverTest : BaseUnitTest() {
     private val userFlagsResolver: UserFlagsResolver = mock()
     private val readerSavedPostsResolver: ReaderSavedPostsResolver = mock()
     private val localMigrationContentResolver: LocalMigrationContentResolver = mock()
-    private val resolverUtility: ResolverUtility = mock()
     private val siteStore: SiteStore = mock()
+    private val sharedLoginHelper: SharedLoginHelper = mock()
 
     private val classToTest = LocalMigrationOrchestrator(
-            jetpackSharedLoginFlag,
             contextProvider,
             dispatcher,
-            accountStore,
             accountActionBuilderWrapper,
-            appPrefsWrapper,
             sharedLoginAnalyticsTracker,
             userFlagsResolver,
             readerSavedPostsResolver,
             localMigrationContentResolver,
-            resolverUtility,
-            siteStore
+            sharedLoginHelper
     )
     private val sharedDataLoggedInNoSites = SharedLoginData(
             token = "valid",


### PR DESCRIPTION
Fixes #

# Description

This is part of a chain of PRs based on this one: https://github.com/wordpress-mobile/WordPress-Android/pull/17473 which converts the local migration orchestration logic to railroad style. This approach documents the error modes with a unified error model, and facilitates rearrangement enabling composability of the various steps.

To test:

<details>
<summary>
Useful precondition patch to set flags locally
</summary>

```patch
diff --git a/WordPress/build.gradle b/WordPress/build.gradle
index 98bb515903..cd987a2816 100644
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -120,11 +120,11 @@ android {
         buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"
         buildConfigField "boolean", "JETPACK_POWERED", "true"
         buildConfigField "boolean", "JETPACK_POWERED_BOTTOM_SHEET", "false"
-        buildConfigField "boolean", "JETPACK_SHARED_LOGIN", "false"
-        buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "false"
-        buildConfigField "boolean", "JETPACK_BLOGGING_REMINDERS_SYNC", "false"
-        buildConfigField "boolean", "JETPACK_READER_SAVED_POSTS", "false"
-        buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "false"
+        buildConfigField "boolean", "JETPACK_SHARED_LOGIN", "true"
+        buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "true"
+        buildConfigField "boolean", "JETPACK_BLOGGING_REMINDERS_SYNC", "true"
+        buildConfigField "boolean", "JETPACK_READER_SAVED_POSTS", "true"
+        buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "true"
         buildConfigField "boolean", "JETPACK_MIGRATION_FLOW", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_ONE", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_TWO", "false"
```
</details>

Follow the testing steps on this PR: https://github.com/wordpress-mobile/WordPress-Android/pull/17398

## Regression Notes
1. Potential unintended areas of impact
Local migration flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Automated tests will be re-enabled in a later PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
