### PR TITLE
[Jetpack Content Migration Flow] Standardize sites helper

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -65,6 +65,9 @@ sealed class LocalMigrationError {
     sealed class MigrationAlreadyAttempted: LocalMigrationError() {
         object SharedLoginAlreadyAttempted: MigrationAlreadyAttempted()
     }
+    sealed class PersistenceError: LocalMigrationError() {
+        object FailedToSaveSites: PersistenceError()
+    }
 }
 
 sealed class LocalMigrationResult<out T: LocalContentEntityData, out E: LocalMigrationError> {

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/SitesMigrationHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/SitesMigrationHelper.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.localcontentmigration
+
+import org.wordpress.android.localcontentmigration.LocalContentEntity.Sites
+import org.wordpress.android.localcontentmigration.LocalContentEntityData.SitesData
+import org.wordpress.android.localcontentmigration.LocalMigrationError.PersistenceError.FailedToSaveSites
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
+import org.wordpress.android.resolver.ResolverUtility
+import javax.inject.Inject
+
+class SitesMigrationHelper @Inject constructor(
+    private val resolverUtility: ResolverUtility,
+    private val localMigrationContentResolver: LocalMigrationContentResolver,
+) {
+    fun migrateSites() = localMigrationContentResolver.getResultForEntityType<SitesData>(Sites).thenWith { sitesData ->
+        runCatching {
+            resolverUtility.copySitesWithIndexes(sitesData.sites)
+            Success(sitesData)
+        }.getOrDefault(Failure(FailedToSaveSites))
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.localcontentmigration.LocalMigrationContentProvider
 import org.wordpress.android.localcontentmigration.LocalMigrationContentResolver
 import org.wordpress.android.localcontentmigration.SharedLoginHelper
+import org.wordpress.android.localcontentmigration.SitesMigrationHelper
 import org.wordpress.android.reader.savedposts.resolver.ReaderSavedPostsResolver
 import org.wordpress.android.resolver.ContentResolverWrapper
 import org.wordpress.android.sharedlogin.JetpackSharedLoginFlag
@@ -59,6 +60,7 @@ class SharedLoginResolverTest : BaseUnitTest() {
     private val localMigrationContentResolver: LocalMigrationContentResolver = mock()
     private val siteStore: SiteStore = mock()
     private val sharedLoginHelper: SharedLoginHelper = mock()
+    private val sitesMigrationHelper: SitesMigrationHelper = mock()
 
     private val classToTest = LocalMigrationOrchestrator(
             contextProvider,
@@ -68,7 +70,8 @@ class SharedLoginResolverTest : BaseUnitTest() {
             userFlagsResolver,
             readerSavedPostsResolver,
             localMigrationContentResolver,
-            sharedLoginHelper
+            sharedLoginHelper,
+            sitesMigrationHelper,
     )
     private val sharedDataLoggedInNoSites = SharedLoginData(
             token = "valid",


### PR DESCRIPTION
Fixes #

# Description

This is part of a chain of PRs based on this one: https://github.com/wordpress-mobile/WordPress-Android/pull/17473 which converts the local migration orchestration logic to railroad style. This approach documents the error modes with a unified error model, and facilitates rearrangement enabling composability of the various steps.

To test:

<details>
<summary>
Useful precondition patch to set flags locally
</summary>

```patch
diff --git a/WordPress/build.gradle b/WordPress/build.gradle
index 98bb515903..cd987a2816 100644
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -120,11 +120,11 @@ android {
         buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"
         buildConfigField "boolean", "JETPACK_POWERED", "true"
         buildConfigField "boolean", "JETPACK_POWERED_BOTTOM_SHEET", "false"
-        buildConfigField "boolean", "JETPACK_SHARED_LOGIN", "false"
-        buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "false"
-        buildConfigField "boolean", "JETPACK_BLOGGING_REMINDERS_SYNC", "false"
-        buildConfigField "boolean", "JETPACK_READER_SAVED_POSTS", "false"
-        buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "false"
+        buildConfigField "boolean", "JETPACK_SHARED_LOGIN", "true"
+        buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "true"
+        buildConfigField "boolean", "JETPACK_BLOGGING_REMINDERS_SYNC", "true"
+        buildConfigField "boolean", "JETPACK_READER_SAVED_POSTS", "true"
+        buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "true"
         buildConfigField "boolean", "JETPACK_MIGRATION_FLOW", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_ONE", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_TWO", "false"
```
</details>

Follow the testing steps on this PR: https://github.com/wordpress-mobile/WordPress-Android/pull/17398

## Regression Notes
1. Potential unintended areas of impact
Local migration flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Automated tests will be re-enabled in a later PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
