### PR TITLE
[Jetpack Content Migration Flow] Standardize posts helper

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/EligibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/EligibilityHelper.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.localcontentmigration
+
+import org.wordpress.android.localcontentmigration.LocalContentEntity.EligibilityStatus
+import org.wordpress.android.localcontentmigration.LocalContentEntityData.EligibilityStatusData
+import javax.inject.Inject
+
+class EligibilityHelper @Inject constructor(
+    private val localMigrationContentResolver: LocalMigrationContentResolver,
+) {
+    fun validate() =
+    localMigrationContentResolver.getResultForEntityType<EligibilityStatusData>(EligibilityStatus).validate()
+}

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -41,6 +41,7 @@ sealed class LocalContentEntityData {
     data class SitesData(val sites: List<SiteModel>): LocalContentEntityData()
     data class PostsData(val localIds: List<Int>): LocalContentEntityData()
     data class PostData(val post: PostModel) : LocalContentEntityData()
+    object EmptyData: LocalContentEntityData()
     companion object {
         enum class IneligibleReason {
             WPNotLoggedIn,

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalPostsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalPostsHelper.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.localcontentmigration
+
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.PostActionBuilder
+import org.wordpress.android.localcontentmigration.LocalContentEntity.Post
+import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostData
+import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostsData
+import org.wordpress.android.localcontentmigration.LocalMigrationError.ProviderError
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
+import javax.inject.Inject
+
+class LocalPostsHelper @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val localMigrationContentResolver: LocalMigrationContentResolver,
+) {
+    fun migratePosts() = localMigrationContentResolver.getResultForEntityType<PostsData>(Post).thenWith { postsData ->
+        postsData.localIds.map { localPostId ->
+            localMigrationContentResolver.getResultForEntityType<PostData>(Post, localPostId)
+        }.reduce { thisResult, nextResult -> thisResult
+                .thenWith(::dispatchPost)
+                .then { nextResult } }
+                .then { Success(postsData) }
+    }
+
+    @Suppress("ForbiddenComment")
+    // TODO: Currently, this only emits an event and doesn't reveal failures. This should be changed to a synchronous
+    // write to the db (similar to the sites migration).
+    private fun dispatchPost(postData: PostData) = run {
+        dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(postData.post))
+        Success(postData)
+    }
+}
+
+private fun <T: LocalContentEntityData, E: ProviderError> LocalMigrationResult<LocalContentEntityData, E>
+        .then(next: () -> LocalMigrationResult<T, E>) = when (this) {
+    is Success -> next()
+    is Failure -> this
+}

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalPostsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalPostsHelper.kt
@@ -5,8 +5,6 @@ import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.localcontentmigration.LocalContentEntity.Post
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostData
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.PostsData
-import org.wordpress.android.localcontentmigration.LocalMigrationError.ProviderError
-import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
 import javax.inject.Inject
 
@@ -15,25 +13,15 @@ class LocalPostsHelper @Inject constructor(
     private val localMigrationContentResolver: LocalMigrationContentResolver,
 ) {
     fun migratePosts() = localMigrationContentResolver.getResultForEntityType<PostsData>(Post).thenWith { postsData ->
-        postsData.localIds.map { localPostId ->
-            localMigrationContentResolver.getResultForEntityType<PostData>(Post, localPostId)
-        }.reduce { thisResult, nextResult -> thisResult
-                .thenWith(::dispatchPost)
-                .then { nextResult } }
-                .then { Success(postsData) }
+        postsData.localIds.foldAllToSingleResult(::dispatchPost)
     }
 
     @Suppress("ForbiddenComment")
     // TODO: Currently, this only emits an event and doesn't reveal failures. This should be changed to a synchronous
     // write to the db (similar to the sites migration).
-    private fun dispatchPost(postData: PostData) = run {
-        dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(postData.post))
-        Success(postData)
-    }
-}
-
-private fun <T: LocalContentEntityData, E: ProviderError> LocalMigrationResult<LocalContentEntityData, E>
-        .then(next: () -> LocalMigrationResult<T, E>) = when (this) {
-    is Success -> next()
-    is Failure -> this
+    private fun dispatchPost(localPostId: Int) =
+            localMigrationContentResolver.getResultForEntityType<PostData>(Post, localPostId).thenWith { postData ->
+                dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(postData.post))
+                Success(postData)
+            }
 }

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -2,10 +2,8 @@ package org.wordpress.android.sharedlogin.resolver
 
 import android.content.Intent
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.localcontentmigration.LocalContentEntity.EligibilityStatus
+import org.wordpress.android.localcontentmigration.EligibilityHelper
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.Companion.IneligibleReason.WPNotLoggedIn
-import org.wordpress.android.localcontentmigration.LocalContentEntityData.EligibilityStatusData
-import org.wordpress.android.localcontentmigration.LocalMigrationContentResolver
 import org.wordpress.android.localcontentmigration.LocalMigrationError
 import org.wordpress.android.localcontentmigration.LocalMigrationError.FeatureDisabled
 import org.wordpress.android.localcontentmigration.LocalMigrationError.Ineligibility
@@ -20,7 +18,6 @@ import org.wordpress.android.localcontentmigration.SitesMigrationHelper
 import org.wordpress.android.localcontentmigration.otherwise
 import org.wordpress.android.localcontentmigration.then
 import org.wordpress.android.localcontentmigration.thenWith
-import org.wordpress.android.localcontentmigration.validate
 import org.wordpress.android.reader.savedposts.resolver.ReaderSavedPostsHelper
 import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker
 import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker.ErrorType
@@ -37,13 +34,13 @@ class LocalMigrationOrchestrator @Inject constructor(
     private val sharedLoginAnalyticsTracker: SharedLoginAnalyticsTracker,
     private val userFlagsHelper: UserFlagsHelper,
     private val readerSavedPostsHelper: ReaderSavedPostsHelper,
-    private val localMigrationContentResolver: LocalMigrationContentResolver,
     private val sharedLoginHelper: SharedLoginHelper,
     private val sitesMigrationHelper: SitesMigrationHelper,
     private val localPostsHelper: LocalPostsHelper,
+        private val eligibilityHelper: EligibilityHelper,
 ) {
     fun tryLocalMigration() {
-        localMigrationContentResolver.getResultForEntityType<EligibilityStatusData>(EligibilityStatus).validate()
+        eligibilityHelper.validate()
                 .then(sitesMigrationHelper::migrateSites)
                 .then(localPostsHelper::migratePosts)
                 .then(userFlagsHelper::migrateUserFlags)

--- a/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
@@ -23,8 +23,9 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.localcontentmigration.EligibilityHelper
 import org.wordpress.android.localcontentmigration.LocalMigrationContentProvider
-import org.wordpress.android.localcontentmigration.LocalMigrationContentResolver
+import org.wordpress.android.localcontentmigration.LocalPostsHelper
 import org.wordpress.android.reader.savedposts.resolver.ReaderSavedPostsHelper
 import org.wordpress.android.localcontentmigration.SharedLoginHelper
 import org.wordpress.android.localcontentmigration.SitesMigrationHelper
@@ -57,10 +58,11 @@ class SharedLoginResolverTest : BaseUnitTest() {
     private val sharedLoginAnalyticsTracker: SharedLoginAnalyticsTracker = mock()
     private val userFlagsResolver: UserFlagsHelper = mock()
     private val readerSavedPostsResolver: ReaderSavedPostsHelper = mock()
-    private val localMigrationContentResolver: LocalMigrationContentResolver = mock()
     private val siteStore: SiteStore = mock()
     private val sharedLoginHelper: SharedLoginHelper = mock()
     private val sitesMigrationHelper: SitesMigrationHelper = mock()
+    private val postsHelper: LocalPostsHelper = mock()
+    private val eligibilityHelper: EligibilityHelper = mock()
 
     private val classToTest = LocalMigrationOrchestrator(
             contextProvider,
@@ -69,10 +71,12 @@ class SharedLoginResolverTest : BaseUnitTest() {
             sharedLoginAnalyticsTracker,
             userFlagsResolver,
             readerSavedPostsResolver,
-            localMigrationContentResolver,
             sharedLoginHelper,
             sitesMigrationHelper,
+            postsHelper,
+            eligibilityHelper,
     )
+
     private val sharedDataLoggedInNoSites = SharedLoginData(
             token = "valid",
             sites = listOf()


### PR DESCRIPTION
Fixes #

# Description

This is part of a chain of PRs based on this one: https://github.com/wordpress-mobile/WordPress-Android/pull/17473 which converts the local migration orchestration logic to railroad style. This approach documents the error modes with a unified error model, and facilitates rearrangement enabling composability of the various steps.

To test:

<details>
<summary>
Useful precondition patch to set flags locally
</summary>

```patch
diff --git a/WordPress/build.gradle b/WordPress/build.gradle
index 98bb515903..cd987a2816 100644
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -120,11 +120,11 @@ android {
         buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"
         buildConfigField "boolean", "JETPACK_POWERED", "true"
         buildConfigField "boolean", "JETPACK_POWERED_BOTTOM_SHEET", "false"
-        buildConfigField "boolean", "JETPACK_SHARED_LOGIN", "false"
-        buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "false"
-        buildConfigField "boolean", "JETPACK_BLOGGING_REMINDERS_SYNC", "false"
-        buildConfigField "boolean", "JETPACK_READER_SAVED_POSTS", "false"
-        buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "false"
+        buildConfigField "boolean", "JETPACK_SHARED_LOGIN", "true"
+        buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "true"
+        buildConfigField "boolean", "JETPACK_BLOGGING_REMINDERS_SYNC", "true"
+        buildConfigField "boolean", "JETPACK_READER_SAVED_POSTS", "true"
+        buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "true"
         buildConfigField "boolean", "JETPACK_MIGRATION_FLOW", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_ONE", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_TWO", "false"
```
</details>

Follow the testing steps on this PR: https://github.com/wordpress-mobile/WordPress-Android/pull/17398

## Regression Notes
1. Potential unintended areas of impact
Local migration flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Automated tests will be re-enabled in a later PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
