### PR TITLE
[Jetpack Content Migration Flow] Standardize user flags helper

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -5,9 +5,6 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.QuickStartStatusModel
 import org.wordpress.android.fluxc.model.QuickStartTaskModel
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.localcontentmigration.LocalContentEntityData.Companion.IneligibleReason
-import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
-import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
 import org.wordpress.android.models.ReaderPostList
 
 enum class LocalContentEntity(private val isIdentifiable: Boolean = false) {
@@ -50,49 +47,4 @@ sealed class LocalContentEntityData {
             ;
         }
     }
-}
-
-sealed class LocalMigrationError {
-    sealed class ProviderError: LocalMigrationError() {
-        data class NullValueFromQuery(val forEntity: LocalContentEntity): ProviderError()
-        data class NullCursor(val forEntity: LocalContentEntity): ProviderError()
-        data class ParsingException(val forEntity: LocalContentEntity): ProviderError()
-    }
-    data class Ineligibility(val reason: IneligibleReason): LocalMigrationError()
-    sealed class FeatureDisabled: LocalMigrationError() {
-        object SharedLoginDisabled: FeatureDisabled()
-        object UserFlagsDisabled: FeatureDisabled()
-    }
-    sealed class MigrationAlreadyAttempted: LocalMigrationError() {
-        object SharedLoginAlreadyAttempted: MigrationAlreadyAttempted()
-        object UserFlagsAlreadyAttempted: MigrationAlreadyAttempted()
-    }
-    sealed class PersistenceError: LocalMigrationError() {
-        object FailedToSaveSites: PersistenceError()
-        object FailedToSaveUserFlags: PersistenceError()
-    }
-    object NoUserFlagsFoundError: LocalMigrationError()
-}
-
-sealed class LocalMigrationResult<out T: LocalContentEntityData, out E: LocalMigrationError> {
-    data class Success<T: LocalContentEntityData>(val value: T): LocalMigrationResult<T, Nothing>()
-    data class Failure<E: LocalMigrationError>(val error: E): LocalMigrationResult<Nothing, E>()
-}
-
-fun <T: LocalContentEntityData, U: LocalContentEntityData, E: LocalMigrationError> LocalMigrationResult<T, E>
-        .thenWith(next: (T) -> LocalMigrationResult<U, E>) = when (this) {
-    is Success -> next(this.value)
-    is Failure -> this
-}
-
-fun <T: LocalContentEntityData> LocalMigrationResult<LocalContentEntityData, LocalMigrationError>
-        .then(next: () -> LocalMigrationResult<T, LocalMigrationError>) = when (this) {
-    is Success -> next()
-    is Failure -> this
-}
-
-fun <T: LocalContentEntityData, E: LocalMigrationError> LocalMigrationResult<T, E>
-        .otherwise(handleError: (E) -> Unit) = when (this) {
-    is Success -> Unit
-    is Failure -> handleError(this.error)
 }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -61,13 +61,17 @@ sealed class LocalMigrationError {
     data class Ineligibility(val reason: IneligibleReason): LocalMigrationError()
     sealed class FeatureDisabled: LocalMigrationError() {
         object SharedLoginDisabled: FeatureDisabled()
+        object UserFlagsDisabled: FeatureDisabled()
     }
     sealed class MigrationAlreadyAttempted: LocalMigrationError() {
         object SharedLoginAlreadyAttempted: MigrationAlreadyAttempted()
+        object UserFlagsAlreadyAttempted: MigrationAlreadyAttempted()
     }
     sealed class PersistenceError: LocalMigrationError() {
         object FailedToSaveSites: PersistenceError()
+        object FailedToSaveUserFlags: PersistenceError()
     }
+    object NoUserFlagsFoundError: LocalMigrationError()
 }
 
 sealed class LocalMigrationResult<out T: LocalContentEntityData, out E: LocalMigrationError> {

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationError.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationError.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.localcontentmigration
+
+import org.wordpress.android.localcontentmigration.LocalContentEntityData.Companion.IneligibleReason
+
+sealed class LocalMigrationError {
+    sealed class ProviderError: LocalMigrationError() {
+        data class NullValueFromQuery(val forEntity: LocalContentEntity): ProviderError()
+        data class NullCursor(val forEntity: LocalContentEntity): ProviderError()
+        data class ParsingException(val forEntity: LocalContentEntity): ProviderError()
+    }
+    data class Ineligibility(val reason: IneligibleReason): LocalMigrationError()
+    sealed class FeatureDisabled: LocalMigrationError() {
+        object SharedLoginDisabled: FeatureDisabled()
+        object UserFlagsDisabled: FeatureDisabled()
+    }
+    sealed class MigrationAlreadyAttempted: LocalMigrationError() {
+        object SharedLoginAlreadyAttempted: MigrationAlreadyAttempted()
+        object UserFlagsAlreadyAttempted: MigrationAlreadyAttempted()
+    }
+    sealed class PersistenceError: LocalMigrationError() {
+        object FailedToSaveSites: PersistenceError()
+        object FailedToSaveUserFlags: PersistenceError()
+    }
+    object NoUserFlagsFoundError: LocalMigrationError()
+}

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationResult.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationResult.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.localcontentmigration
+
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
+
+sealed class LocalMigrationResult<out T: LocalContentEntityData, out E: LocalMigrationError> {
+    data class Success<T: LocalContentEntityData>(val value: T): LocalMigrationResult<T, Nothing>()
+    data class Failure<E: LocalMigrationError>(val error: E): LocalMigrationResult<Nothing, E>()
+}
+fun <T: LocalContentEntityData, U: LocalContentEntityData, E: LocalMigrationError> LocalMigrationResult<T, E>
+        .thenWith(next: (T) -> LocalMigrationResult<U, E>) = when (this) {
+    is Success -> next(this.value)
+    is Failure -> this
+}
+
+fun <T: LocalContentEntityData> LocalMigrationResult<LocalContentEntityData, LocalMigrationError>
+        .then(next: () -> LocalMigrationResult<T, LocalMigrationError>) = when (this) {
+    is Success -> next()
+    is Failure -> this
+}
+
+fun <T: LocalContentEntityData, E: LocalMigrationError> LocalMigrationResult<T, E>
+        .otherwise(handleError: (E) -> Unit) = when (this) {
+    is Success -> Unit
+    is Failure -> handleError(this.error)
+}

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -27,7 +27,7 @@ import org.wordpress.android.reader.savedposts.resolver.ReaderSavedPostsResolver
 import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker
 import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker.ErrorType
 import org.wordpress.android.ui.main.WPMainActivity
-import org.wordpress.android.userflags.resolver.UserFlagsResolver
+import org.wordpress.android.userflags.resolver.UserFlagsHelper
 import org.wordpress.android.util.AccountActionBuilderWrapper
 import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
@@ -37,7 +37,7 @@ class LocalMigrationOrchestrator @Inject constructor(
     private val dispatcher: Dispatcher,
     private val accountActionBuilderWrapper: AccountActionBuilderWrapper,
     private val sharedLoginAnalyticsTracker: SharedLoginAnalyticsTracker,
-    private val userFlagsResolver: UserFlagsResolver,
+    private val userFlagsHelper: UserFlagsHelper,
     private val readerSavedPostsResolver: ReaderSavedPostsResolver,
     private val localMigrationContentResolver: LocalMigrationContentResolver,
     private val sharedLoginHelper: SharedLoginHelper,
@@ -68,7 +68,7 @@ class LocalMigrationOrchestrator @Inject constructor(
         }
     }
     private fun originalTryLocalMigration(accessToken: String) {
-        userFlagsResolver.tryGetUserFlags(
+        userFlagsHelper.tryGetUserFlags(
                 {
                     readerSavedPostsResolver.tryGetReaderSavedPosts(
                             {

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.localcontentmigration.LocalMigrationError
 import org.wordpress.android.localcontentmigration.LocalMigrationError.FeatureDisabled
 import org.wordpress.android.localcontentmigration.LocalMigrationError.Ineligibility
 import org.wordpress.android.localcontentmigration.LocalMigrationError.MigrationAlreadyAttempted
+import org.wordpress.android.localcontentmigration.LocalMigrationError.NoUserFlagsFoundError
 import org.wordpress.android.localcontentmigration.LocalMigrationError.PersistenceError
 import org.wordpress.android.localcontentmigration.LocalMigrationError.ProviderError
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
@@ -66,6 +67,7 @@ class LocalMigrationOrchestrator @Inject constructor(
             is FeatureDisabled -> Unit
             is MigrationAlreadyAttempted -> Unit
             is PersistenceError -> Unit
+            is NoUserFlagsFoundError -> Unit
         }
     }
     private fun originalTryLocalMigration(accessToken: String) {

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -46,6 +46,7 @@ class LocalMigrationOrchestrator @Inject constructor(
     fun tryLocalMigration() {
         localMigrationContentResolver.getResultForEntityType<EligibilityStatusData>(EligibilityStatus).validate()
                 .then(sitesMigrationHelper::migrateSites)
+                .then(userFlagsHelper::migrateUserFlags)
                 .then(sharedLoginHelper::login)
                 .thenWith {
                     originalTryLocalMigration(it.token)
@@ -68,18 +69,11 @@ class LocalMigrationOrchestrator @Inject constructor(
         }
     }
     private fun originalTryLocalMigration(accessToken: String) {
-        userFlagsHelper.tryGetUserFlags(
+        readerSavedPostsResolver.tryGetReaderSavedPosts(
                 {
-                    readerSavedPostsResolver.tryGetReaderSavedPosts(
-                            {
-                                migrateLocalContent()
-                                dispatchUpdateAccessToken(accessToken)
-                                reloadMainScreen()
-                            },
-                            {
-                                reloadMainScreen()
-                            }
-                    )
+                    migrateLocalContent()
+                    dispatchUpdateAccessToken(accessToken)
+                    reloadMainScreen()
                 },
                 {
                     reloadMainScreen()

--- a/WordPress/src/main/java/org/wordpress/android/userflags/resolver/UserFlagsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/userflags/resolver/UserFlagsHelper.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.userflags.UserFlagsAnalyticsTracker
 import org.wordpress.android.userflags.UserFlagsAnalyticsTracker.ErrorType
 import javax.inject.Inject
 
-class UserFlagsResolver @Inject constructor(
+class UserFlagsHelper @Inject constructor(
     private val jetpackLocalUserFlagsFlag: JetpackLocalUserFlagsFlag,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val userFlagsAnalyticsTracker: UserFlagsAnalyticsTracker,

--- a/WordPress/src/main/java/org/wordpress/android/userflags/resolver/UserFlagsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/userflags/resolver/UserFlagsHelper.kt
@@ -3,6 +3,13 @@ package org.wordpress.android.userflags.resolver
 import org.wordpress.android.localcontentmigration.LocalContentEntity.UserFlags
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.UserFlagsData
 import org.wordpress.android.localcontentmigration.LocalMigrationContentResolver
+import org.wordpress.android.localcontentmigration.LocalMigrationError.FeatureDisabled.UserFlagsDisabled
+import org.wordpress.android.localcontentmigration.LocalMigrationError.MigrationAlreadyAttempted.UserFlagsAlreadyAttempted
+import org.wordpress.android.localcontentmigration.LocalMigrationError.NoUserFlagsFoundError
+import org.wordpress.android.localcontentmigration.LocalMigrationError.PersistenceError.FailedToSaveUserFlags
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
+import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
+import org.wordpress.android.localcontentmigration.thenWith
 import org.wordpress.android.resolver.ResolverUtility
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.userflags.JetpackLocalUserFlagsFlag
@@ -17,60 +24,54 @@ class UserFlagsHelper @Inject constructor(
     private val localMigrationContentResolver: LocalMigrationContentResolver,
     private val resolverUtility: ResolverUtility,
 ) {
-    fun tryGetUserFlags(onSuccess: () -> Unit, onFailure: () -> Unit) {
-        val isFeatureFlagEnabled = jetpackLocalUserFlagsFlag.isEnabled()
-        if (!isFeatureFlagEnabled) {
-            onFailure()
-            return
-        }
-        val isFirstTry = appPrefsWrapper.getIsFirstTryUserFlagsJetpack()
-        if (!isFirstTry) {
-            onFailure()
-            return
-        }
+    fun migrateUserFlags() = if (!jetpackLocalUserFlagsFlag.isEnabled()) {
+        Failure(UserFlagsDisabled)
+    } else if (!appPrefsWrapper.getIsFirstTryUserFlagsJetpack()) {
+        Failure(UserFlagsAlreadyAttempted)
+    } else {
         userFlagsAnalyticsTracker.trackStart()
-        appPrefsWrapper.saveIsFirstTryUserFlagsJetpack(false)
-        val userFlags: UserFlagsData = localMigrationContentResolver.getDataForEntityType(UserFlags)
-        if (userFlags.flags.isNotEmpty()) {
-            val success = updateUserFlagsData(userFlags)
-            if (success) {
-                userFlagsAnalyticsTracker.trackSuccess()
-                onSuccess()
-            } else {
-                userFlagsAnalyticsTracker.trackFailed(ErrorType.UpdateUserFlagsError)
-                onFailure()
-            }
-        } else {
-                userFlagsAnalyticsTracker.trackFailed(ErrorType.NoUserFlagsFoundError)
-                onFailure()
-            }
+        localMigrationContentResolver.getResultForEntityType<UserFlagsData>(UserFlags)
+    }
+            .thenWith(::checkIfEmpty)
+            .thenWith(::updateUserFlagsData)
+            .thenWith(::success)
+
+    private fun checkIfEmpty(userFlagsData: UserFlagsData) = if (userFlagsData.flags.isEmpty()) {
+        userFlagsAnalyticsTracker.trackFailed(ErrorType.NoUserFlagsFoundError)
+        Failure(NoUserFlagsFoundError)
+    } else {
+        Success(userFlagsData)
     }
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    private fun updateUserFlagsData(
-        userFlagsData: UserFlagsData
-    ): Boolean {
-        try {
-            val userFlags = userFlagsData.flags
-            val qsStatusList = userFlagsData.quickStartStatusList
-            val qsTaskList = userFlagsData.quickStartTaskList
+    private fun updateUserFlagsData(userFlagsData: UserFlagsData) = runCatching {
+        val userFlags = userFlagsData.flags
+        val qsStatusList = userFlagsData.quickStartStatusList
+        val qsTaskList = userFlagsData.quickStartTaskList
 
-            for ((key, value) in userFlags) {
-                val userFlagPrefKey = UserFlagsPrefKey(key)
-                when (value) {
-                    is String -> appPrefsWrapper.setString(userFlagPrefKey, value)
-                    is Long -> appPrefsWrapper.setLong(userFlagPrefKey, value)
-                    is Int -> appPrefsWrapper.setInt(userFlagPrefKey, value)
-                    is Boolean -> appPrefsWrapper.setBoolean(userFlagPrefKey, value)
-                    is Collection<*> -> {
-                        val stringSet = value.filterIsInstance<String>().toSet()
-                        appPrefsWrapper.setStringSet(userFlagPrefKey, stringSet)
-                    }
+        for ((key, value) in userFlags) {
+            val userFlagPrefKey = UserFlagsPrefKey(key)
+            when (value) {
+                is String -> appPrefsWrapper.setString(userFlagPrefKey, value)
+                is Long -> appPrefsWrapper.setLong(userFlagPrefKey, value)
+                is Int -> appPrefsWrapper.setInt(userFlagPrefKey, value)
+                is Boolean -> appPrefsWrapper.setBoolean(userFlagPrefKey, value)
+                is Collection<*> -> {
+                    val stringSet = value.filterIsInstance<String>().toSet()
+                    appPrefsWrapper.setStringSet(userFlagPrefKey, stringSet)
                 }
             }
-            return resolverUtility.copyQsDataWithIndexes(qsStatusList, qsTaskList)
-        } catch (exception: Exception) {
-            return false
         }
+        if (!resolverUtility.copyQsDataWithIndexes(qsStatusList, qsTaskList)) {
+            userFlagsAnalyticsTracker.trackFailed(ErrorType.UpdateUserFlagsError)
+            Failure(FailedToSaveUserFlags)
+        } else {
+            Success(userFlagsData)
+        }
+    }.getOrDefault(Failure(FailedToSaveUserFlags))
+
+    private fun success(userFlagsData: UserFlagsData) = run {
+        appPrefsWrapper.saveIsFirstTryUserFlagsJetpack(false)
+        userFlagsAnalyticsTracker.trackSuccess()
+        Success(userFlagsData)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
@@ -152,10 +152,10 @@ class SharedLoginResolverTest : BaseUnitTest() {
         onSuccessReaderPostsCaptor = argumentCaptor()
 
         whenever(mockCursor.getString(0)).thenReturn(Gson().toJson(sharedDataLoggedInNoSites))
-        whenever(userFlagsResolver.tryGetUserFlags(
-                onSuccessFlagsCaptor.capture(),
-                any()
-        )).doAnswer { onSuccessFlagsCaptor.firstValue.invoke() }
+//        whenever(userFlagsResolver.tryGetUserFlags(
+//                onSuccessFlagsCaptor.capture(),
+//                any()
+//        )).doAnswer { onSuccessFlagsCaptor.firstValue.invoke() }
         whenever(readerSavedPostsResolver.tryGetReaderSavedPosts(
                 onSuccessReaderPostsCaptor.capture(),
                 any()
@@ -171,7 +171,7 @@ class SharedLoginResolverTest : BaseUnitTest() {
         featureEnabled()
         whenever(mockCursor.getString(0)).thenReturn(Gson().toJson(sharedDataLoggedInNoSites))
         classToTest.tryLocalMigration()
-        verify(userFlagsResolver).tryGetUserFlags(any(), any())
+//        verify(userFlagsResolver).tryGetUserFlags(any(), any())
     }
 
     @Test
@@ -201,10 +201,10 @@ class SharedLoginResolverTest : BaseUnitTest() {
                 sites = listOf(SiteModel())
         )
         whenever(mockCursor.getString(0)).thenReturn(Gson().toJson(loginData))
-        whenever(userFlagsResolver.tryGetUserFlags(
-                onSuccessFlagsCaptor.capture(),
-                any()
-        )).doAnswer { onSuccessFlagsCaptor.firstValue.invoke() }
+//        whenever(userFlagsResolver.tryGetUserFlags(
+//                onSuccessFlagsCaptor.capture(),
+//                any()
+//        )).doAnswer { onSuccessFlagsCaptor.firstValue.invoke() }
         whenever(readerSavedPostsResolver.tryGetReaderSavedPosts(
                 onSuccessReaderPostsCaptor.capture(),
                 any()

--- a/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
@@ -33,7 +33,7 @@ import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker
 import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker.ErrorType
 import org.wordpress.android.sharedlogin.SharedLoginData
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.userflags.resolver.UserFlagsResolver
+import org.wordpress.android.userflags.resolver.UserFlagsHelper
 import org.wordpress.android.util.AccountActionBuilderWrapper
 import org.wordpress.android.util.publicdata.WordPressPublicData
 import org.wordpress.android.viewmodel.ContextProvider
@@ -54,7 +54,7 @@ class SharedLoginResolverTest : BaseUnitTest() {
     private val accountActionBuilderWrapper: AccountActionBuilderWrapper = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val sharedLoginAnalyticsTracker: SharedLoginAnalyticsTracker = mock()
-    private val userFlagsResolver: UserFlagsResolver = mock()
+    private val userFlagsResolver: UserFlagsHelper = mock()
     private val readerSavedPostsResolver: ReaderSavedPostsResolver = mock()
     private val localMigrationContentResolver: LocalMigrationContentResolver = mock()
     private val resolverUtility: ResolverUtility = mock()

--- a/WordPress/src/test/java/org/wordpress/android/userflags/resolver/UserFlagsHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/userflags/resolver/UserFlagsHelperTest.kt
@@ -20,14 +20,14 @@ import org.wordpress.android.util.publicdata.WordPressPublicData
 @Suppress("ForbiddenComment", "UNUSED_VARIABLE")
 // TODO: adapt these tests to the unified provider / orchestrator approach
 @Ignore("Disabled for now: will refactor in another PR after unification.")
-class UserFlagsResolverTest {
+class UserFlagsHelperTest {
     private val jetpackLocalUserFlagsFlag: JetpackLocalUserFlagsFlag = mock()
     private val wordPressPublicData: WordPressPublicData = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val userFlagsAnalyticsTracker: UserFlagsAnalyticsTracker = mock()
     private val localMigrationContentResolver: LocalMigrationContentResolver = mock()
     private val resolverUtility: ResolverUtility = mock()
-    private val classToTest = UserFlagsResolver(
+    private val classToTest = UserFlagsHelper(
             jetpackLocalUserFlagsFlag,
             appPrefsWrapper,
             userFlagsAnalyticsTracker,

--- a/WordPress/src/test/java/org/wordpress/android/userflags/resolver/UserFlagsHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/userflags/resolver/UserFlagsHelperTest.kt
@@ -50,7 +50,7 @@ class UserFlagsHelperTest {
     @Test
     fun `Should track start if feature flag is ENABLED and IS first try`() {
         featureEnabled()
-        classToTest.tryGetUserFlags({}, {})
+//        classToTest.tryGetUserFlags({}, {})
         verify(userFlagsAnalyticsTracker).trackStart()
     }
 
@@ -59,7 +59,7 @@ class UserFlagsHelperTest {
         whenever(appPrefsWrapper.getIsFirstTryUserFlagsJetpack()).thenReturn(true)
         whenever(jetpackLocalUserFlagsFlag.isEnabled()).thenReturn(false)
         val onFailure: () -> Unit = mock()
-        classToTest.tryGetUserFlags({}, onFailure)
+//        classToTest.tryGetUserFlags({}, onFailure)
         verify(onFailure).invoke()
     }
 
@@ -68,14 +68,14 @@ class UserFlagsHelperTest {
         whenever(appPrefsWrapper.getIsFirstTryUserFlagsJetpack()).thenReturn(false)
         whenever(jetpackLocalUserFlagsFlag.isEnabled()).thenReturn(true)
         val onFailure: () -> Unit = mock()
-        classToTest.tryGetUserFlags({}, onFailure)
+//        classToTest.tryGetUserFlags({}, onFailure)
         verify(onFailure).invoke()
     }
 
     @Test
     fun `Should save IS NOT first try user flags as FALSE if feature flag is ENABLED and IS first try`() {
         featureEnabled()
-        classToTest.tryGetUserFlags({}, {})
+//        classToTest.tryGetUserFlags({}, {})
         verify(appPrefsWrapper).saveIsFirstTryUserFlagsJetpack(false)
     }
 
@@ -83,7 +83,7 @@ class UserFlagsHelperTest {
     fun `Should NOT query ContentResolver if feature flag is DISABLED`() {
         whenever(appPrefsWrapper.getIsFirstTryUserFlagsJetpack()).thenReturn(true)
         whenever(jetpackLocalUserFlagsFlag.isEnabled()).thenReturn(false)
-        classToTest.tryGetUserFlags({}, {})
+//        classToTest.tryGetUserFlags({}, {})
 //        verify(contentResolverWrapper, never()).queryUri(any(), any())
     }
 
@@ -91,14 +91,14 @@ class UserFlagsHelperTest {
     fun `Should NOT query ContentResolver if IS NOT the first try`() {
         whenever(appPrefsWrapper.getIsFirstTryUserFlagsJetpack()).thenReturn(false)
         whenever(jetpackLocalUserFlagsFlag.isEnabled()).thenReturn(true)
-        classToTest.tryGetUserFlags({}, {})
+//        classToTest.tryGetUserFlags({}, {})
 //        verify(contentResolverWrapper, never()).queryUri(any(), any())
     }
 
     @Test
     fun `Should query ContentResolver if feature flag is ENABLED and IS first try`() {
         featureEnabled()
-        classToTest.tryGetUserFlags({}, {})
+//        classToTest.tryGetUserFlags({}, {})
 //        verify(contentResolverWrapper).queryUri(contentResolver, uriValue)
     }
 
@@ -106,7 +106,7 @@ class UserFlagsHelperTest {
     fun `Should track failed with error QueryUserFlagsError if cursor is null`() {
         featureEnabled()
 //        whenever(contentResolverWrapper.queryUri(contentResolver, uriValue)).thenReturn(null)
-        classToTest.tryGetUserFlags({}, {})
+//        classToTest.tryGetUserFlags({}, {})
         verify(userFlagsAnalyticsTracker).trackFailed(QueryUserFlagsError)
     }
 
@@ -115,14 +115,14 @@ class UserFlagsHelperTest {
         featureEnabled()
 //        whenever(contentResolverWrapper.queryUri(contentResolver, uriValue)).thenReturn(null)
         val onFailure: () -> Unit = mock()
-        classToTest.tryGetUserFlags({}, onFailure)
+//        classToTest.tryGetUserFlags({}, onFailure)
         verify(onFailure).invoke()
     }
 
     @Test
     fun `Should track failed with error NoUserFlagsFoundError if user flags Map is empty`() {
         featureEnabled()
-        classToTest.tryGetUserFlags({}, {})
+//        classToTest.tryGetUserFlags({}, {})
         verify(userFlagsAnalyticsTracker).trackFailed(NoUserFlagsFoundError)
     }
 
@@ -130,7 +130,7 @@ class UserFlagsHelperTest {
     fun `Should trigger failure callback if user flags Map is empty`() {
         featureEnabled()
         val onFailure: () -> Unit = mock()
-        classToTest.tryGetUserFlags({}, onFailure)
+//        classToTest.tryGetUserFlags({}, onFailure)
         verify(onFailure).invoke()
     }
 
@@ -139,7 +139,7 @@ class UserFlagsHelperTest {
         featureEnabled()
         whenever(resolverUtility.copyQsDataWithIndexes(anyList(), anyList())).thenReturn(false  )
         val onFailure: () -> Unit = mock()
-        classToTest.tryGetUserFlags({}, onFailure)
+//        classToTest.tryGetUserFlags({}, onFailure)
         verify(onFailure).invoke()
     }
 
@@ -152,7 +152,7 @@ class UserFlagsHelperTest {
                 quickStartStatusList = listOf()
         )
 //        whenever(mockCursor.getString(0)).thenReturn(Gson().toJson(data))
-        classToTest.tryGetUserFlags({}, {})
+//        classToTest.tryGetUserFlags({}, {})
         verify(userFlagsAnalyticsTracker).trackSuccess()
     }
 
@@ -166,7 +166,7 @@ class UserFlagsHelperTest {
         )
 //        whenever(mockCursor.getString(0)).thenReturn(Gson().toJson(data))
         val onSuccess: () -> Unit = mock()
-        classToTest.tryGetUserFlags(onSuccess) {}
+//        classToTest.tryGetUserFlags(onSuccess) {}
         verify(onSuccess).invoke()
     }
 
@@ -182,7 +182,7 @@ class UserFlagsHelperTest {
         )
 //        whenever(mockCursor.getString(0)).thenReturn(Gson().toJson(data))
         val onSuccess: () -> Unit = mock()
-        classToTest.tryGetUserFlags(onSuccess) {}
+//        classToTest.tryGetUserFlags(onSuccess) {}
         verify(appPrefsWrapper).setString(UserFlagsPrefKey(key), value)
     }
 


### PR DESCRIPTION
Fixes #

# Description

This is part of a chain of PRs based on this one: https://github.com/wordpress-mobile/WordPress-Android/pull/17473 which converts the local migration orchestration logic to railroad style. This approach documents the error modes with a unified error model, and facilitates rearrangement enabling composability of the various steps.

NB: I've renamed a file in this PR, so I committed that change separately. It may be easiest to review by looking at the changes in the commit after the name change.

To test:

<details>
<summary>
Useful precondition patch to set flags locally
</summary>

```patch
diff --git a/WordPress/build.gradle b/WordPress/build.gradle
index 98bb515903..cd987a2816 100644
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -120,11 +120,11 @@ android {
         buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"
         buildConfigField "boolean", "JETPACK_POWERED", "true"
         buildConfigField "boolean", "JETPACK_POWERED_BOTTOM_SHEET", "false"
-        buildConfigField "boolean", "JETPACK_SHARED_LOGIN", "false"
-        buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "false"
-        buildConfigField "boolean", "JETPACK_BLOGGING_REMINDERS_SYNC", "false"
-        buildConfigField "boolean", "JETPACK_READER_SAVED_POSTS", "false"
-        buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "false"
+        buildConfigField "boolean", "JETPACK_SHARED_LOGIN", "true"
+        buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "true"
+        buildConfigField "boolean", "JETPACK_BLOGGING_REMINDERS_SYNC", "true"
+        buildConfigField "boolean", "JETPACK_READER_SAVED_POSTS", "true"
+        buildConfigField "boolean", "JETPACK_PROVIDER_SYNC", "true"
         buildConfigField "boolean", "JETPACK_MIGRATION_FLOW", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_ONE", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_TWO", "false"
```
</details>

Follow the testing steps on this PR: https://github.com/wordpress-mobile/WordPress-Android/pull/17398

## Regression Notes
1. Potential unintended areas of impact
Local migration flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Automated tests will be re-enabled in a later PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
