### PR TITLE
Jetpack Focus: Open web links with Jetpack - Add custom scheme deep link receiver

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -379,32 +379,6 @@
             android:theme="@style/WordPress.NoActionBar"
             android:excludeFromRecents="true"
             android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:host="viewpost"
-                    android:scheme="wordpress" />
-                <data
-                    android:host="stats"
-                    android:scheme="wordpress" />
-                <data
-                    android:host="read"
-                    android:scheme="wordpress" />
-                <data
-                    android:host="post"
-                    android:scheme="wordpress" />
-                <data
-                    android:host="notifications"
-                    android:scheme="wordpress" />
-                <data
-                    android:host="home"
-                    android:scheme="wordpress" />
-            </intent-filter>
-
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
@@ -456,6 +430,39 @@
                     android:pathPattern="/notifications/.*"
                     android:scheme="http" />
 
+            </intent-filter>
+        </activity>
+
+        <!-- Custom Wordpress Scheme Deep Linking Activity -->
+        <activity
+            android:name="org.wordpress.android.ui.deeplinks.DeepLinkingCustomIntentReceiverActivity"
+            android:theme="@style/WordPress.NoActionBar"
+            android:excludeFromRecents="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="viewpost"
+                    android:scheme="wordpress" />
+                <data
+                    android:host="stats"
+                    android:scheme="wordpress" />
+                <data
+                    android:host="read"
+                    android:scheme="wordpress" />
+                <data
+                    android:host="post"
+                    android:scheme="wordpress" />
+                <data
+                    android:host="notifications"
+                    android:scheme="wordpress" />
+                <data
+                    android:host="home"
+                    android:scheme="wordpress" />
             </intent-filter>
         </activity>
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import dagger.Reusable
 import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
 import javax.inject.Inject
 
@@ -41,6 +42,15 @@ class ActivityLauncherWrapper @Inject constructor() {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
                 setPackage("com.android.vending")
             }
+        }
+        context.startActivity(intent)
+    }
+
+    fun forwardDeepLinkIntent(context: Context, deepLinkIntent: Intent) {
+        val intent = Intent(context, DeepLinkingIntentReceiverActivity::class.java).apply {
+            action = deepLinkIntent.action
+            data = deepLinkIntent.data
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
         context.startActivity(intent)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingCustomIntentReceiverActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingCustomIntentReceiverActivity.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.deeplinks
+
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+/**
+ * An activity to handle custom uri intent deep linking schemes like:
+ * <p>
+ * wordpress://feature
+ * <p>
+ */
+@AndroidEntryPoint
+class DeepLinkingCustomIntentReceiverActivity : AppCompatActivity() {
+    private val viewModel: DeepLinkingCustomIntentReceiverViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel.forwardDeepLink(intent)
+        finish()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingCustomIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingCustomIntentReceiverViewModel.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.ui.deeplinks
+
+import android.content.Intent
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.ui.ActivityLauncherWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.ContextProvider
+import javax.inject.Inject
+
+@HiltViewModel
+class DeepLinkingCustomIntentReceiverViewModel @Inject constructor(
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val activityLauncherWrapper: ActivityLauncherWrapper,
+    private val contextProvider: ContextProvider
+) : ViewModel() {
+    fun forwardDeepLink(intent: Intent) {
+        analyticsTrackerWrapper.track(Stat.DEEPLINK_CUSTOM_INTENT_RECEIVED)
+        activityLauncherWrapper.forwardDeepLinkIntent(contextProvider.getContext(), intent)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingCustomIntentReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingCustomIntentReceiverViewModelTest.kt
@@ -1,0 +1,57 @@
+package org.wordpress.android.ui.deeplinks
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.ui.ActivityLauncherWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.ContextProvider
+
+@RunWith(MockitoJUnitRunner::class)
+class DeepLinkingCustomIntentReceiverViewModelTest : BaseUnitTest() {
+    @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Mock lateinit var activityLauncherWrapper: ActivityLauncherWrapper
+    @Mock lateinit var contextProvider: ContextProvider
+    @Mock lateinit var context: Context
+    private lateinit var viewModel: DeepLinkingCustomIntentReceiverViewModel
+
+    @Before
+    fun setUp() {
+        whenever(contextProvider.getContext()).thenReturn(context)
+        viewModel = DeepLinkingCustomIntentReceiverViewModel(
+                analyticsTrackerWrapper,
+                activityLauncherWrapper,
+                contextProvider)
+    }
+
+    @Test
+    fun `when incoming custom deep link received, then request is tracked`() {
+        viewModel.forwardDeepLink(getDeepLinkIntent())
+
+        verify(analyticsTrackerWrapper).track(eq(Stat.DEEPLINK_CUSTOM_INTENT_RECEIVED))
+    }
+
+    @Test
+    fun `when incoming custom deep link received, then deep link request is forwarded`() {
+        val deepLinkIntent = getDeepLinkIntent()
+
+        viewModel.forwardDeepLink(deepLinkIntent)
+
+        verify(activityLauncherWrapper).forwardDeepLinkIntent(contextProvider.getContext(), deepLinkIntent)
+    }
+
+    private fun getDeepLinkIntent() = Intent(context, DeepLinkingIntentReceiverActivity::class.java).apply {
+        action = "action"
+        data = Uri.EMPTY
+    }
+}

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -958,7 +958,8 @@ public final class AnalyticsTracker {
         BLOGGING_REMINDERS_SYNC_FAILED,
         READER_SAVED_POSTS_START,
         READER_SAVED_POSTS_SUCCESS,
-        READER_SAVED_POSTS_FAILED
+        READER_SAVED_POSTS_FAILED,
+        DEEPLINK_CUSTOM_INTENT_RECEIVED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2411,6 +2411,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "reader_saved_posts_success";
             case READER_SAVED_POSTS_FAILED:
                 return "reader_saved_posts_failed";
+            case DEEPLINK_CUSTOM_INTENT_RECEIVED:
+                return "deeplink_custom_intent_received";
         }
         return null;
     }


### PR DESCRIPTION
Parent #17494 

The purpose of this PR is split the deep link receiver intent into two handlers; one for the custom `wordpress://` scheme and the other for web/app links. 

**Modifications Include**
- `DeepLinkingCustomIntentReceiverActivity` was introduced as the handler for the `wordpress:\\` scheme deep links. Its sole purpose is to track and then forward the request to`DeepLinkingIntentReceiverActivity` for handling as normal.
- Event `DEEPLINK_CUSTOM_INTENT_RECEIVED` was added to track the activity
- `AndroidManifest,xml` was updated to separate the intent filters.
- There were no changes made to `DeepLinkingIntentReceiverActivity`.

**To test:**
  **Prepare device**
  - Uninstall any versions of JP/WP on your device
  - Install both JP and WP prealpha versions from this PR
  - Login to both apps
  - Navigate to Me > App Settings > Privacy Setting > and enable Collect Information
  - Decompress and download the attached `links_helper.html` file to your device (github doesn't support html file attachments)
         
[links_helper.html.zip](https://github.com/wordpress-mobile/WordPress-Android/files/10048034/links_helper.html.zip)

  **WordPress scheme test**
  - Open the links_helper.html in a browser
  - Tap on the “WordPress Stats” Link
  - ✅ Verify that the WordPress app was launched 
  - ✅ Verify that the log contains: 🔵 Tracked: deeplink_custom_intent_received

  **Jetpack scheme test**
  - Open the links_helper.html in a browser
  - Tap on the “Jetpack Stats” Link
  - ✅ Verify that the Jetpack app was launched 
  - ✅ Verify that the log does not contain: 🔵 Tracked: deeplink_custom_intent_received


  **Test that Web links are still functioning**
  - Navigate to the app settings for WordPress on the device
  - Enable the pre-alpha app to handle verified web links links. On a pixel device you will find this under Open By Default > Tap + Add Link > Check all three checkboxes and then click Add
  - Open the links_helper.html in a browser
  - Tap on the “WordPress.com Stats 1234” Link
  - ✅ Verify that the WordPress app was launched 
  - ✅ Verify that the log does not contain: 🔵 Tracked: deeplink_custom_intent_received
        

## Regression Notes
1. Potential unintended areas of impact
`wordpress://` deep links are not handled correctly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Added `DeepLinkingCustomIntentReceiverViewModelTest`

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
