### PR TITLE
Jetpack Focus: Open web links with Jetpack - Initialization

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -132,6 +132,7 @@ android {
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_FOUR", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_NEW_USERS", "false"
         buildConfigField "boolean", "PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD", "false"
+        buildConfigField "boolean", "OPEN_WEB_LINKS_WITH_JETPACK_FLOW", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -144,6 +144,7 @@ android {
         buildConfigField "boolean", "ENABLE_WHATS_NEW_FEATURE", "true"
         buildConfigField "boolean", "ENABLE_MY_SITE_DASHBOARD_TABS", "true"
         buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
+        buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "true"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -169,6 +170,7 @@ android {
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"wpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"org.wordpress.android"'
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "false"
+            buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "false"
 
             manifestPlaceholders = [magicLinkScheme:"wordpress"]
         }
@@ -191,6 +193,7 @@ android {
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
+            buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "true"
 
             manifestPlaceholders = [magicLinkScheme:"jetpack"]
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.ui.deeplinks
+
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.DateTimeUtilsWrapper
+import org.wordpress.android.util.FirebaseRemoteConfigWrapper
+import org.wordpress.android.util.PackageManagerWrapper
+import org.wordpress.android.util.config.OpenWebLinksWithJetpackFlowFeatureConfig
+import java.util.Date
+import javax.inject.Inject
+
+class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
+    private val openWebLinksWithJetpackFlowFeatureConfig: OpenWebLinksWithJetpackFlowFeatureConfig,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val firebaseRemoteConfigWrapper: FirebaseRemoteConfigWrapper,
+    private val packageManagerWrapper: PackageManagerWrapper,
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper
+) {
+    fun shouldShowDeepLinkOpenWebLinksWithJetpackOverlay() = showOverlay()
+
+    private fun showOverlay() : Boolean {
+        return openWebLinksWithJetpackFlowFeatureConfig.isEnabled()
+                && isJetpackInstalled()
+                && isWebDeepLinkHandlerComponentEnabled()
+                && isValidOverlayFrequency()
+    }
+
+    private fun isJetpackInstalled() = packageManagerWrapper.isPackageInstalled(JETPACK_PACKAGE_NAME)
+
+    private fun isWebDeepLinkHandlerComponentEnabled() =
+        packageManagerWrapper.isComponentEnabledSettingEnabled(DeepLinkingIntentReceiverActivity::class.java)
+
+    private fun isValidOverlayFrequency() : Boolean {
+        if (!hasOverlayBeenShown()) return true // short circuit if the overlay has never been shown
+
+        return hasExceededOverlayFrequency()
+    }
+
+    private fun hasExceededOverlayFrequency() : Boolean {
+        val frequency = firebaseRemoteConfigWrapper.getOpenWebLinksWithJetpackFlowFrequency()
+        if (frequency == 0L) return false // Only show the overlay 1X and it's already been shown do not show again
+
+        val lastShownDate = Date(getOpenWebLinksWithJetpackOverlayLastShownTimestamp())
+        val daysPastOverlayShown = dateTimeUtilsWrapper.daysBetween(
+                lastShownDate,
+                getTodaysDate())
+        return daysPastOverlayShown >= frequency
+    }
+
+    private fun hasOverlayBeenShown() = getOpenWebLinksWithJetpackOverlayLastShownTimestamp() > 0L
+
+    private fun getOpenWebLinksWithJetpackOverlayLastShownTimestamp() =
+            appPrefsWrapper.getOpenWebLinksWithJetpackOverlayLastShownTimestamp()
+
+    private fun getTodaysDate() = Date(System.currentTimeMillis())
+
+    companion object {
+        const val JETPACK_PACKAGE_NAME = "com.jetpack.android"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -175,6 +175,7 @@ public class AppPrefs {
         SHOULD_SHOW_WEEKLY_ROUNDUP_NOTIFICATION,
 
         SKIPPED_BLOGGING_PROMPT_DAY,
+        OPEN_WEB_LINKS_WITH_JETPACK_OVERLAY_LAST_SHOWN_TIMESTAMP,
     }
 
     /**
@@ -1469,5 +1470,9 @@ public class AppPrefs {
 
     public static void saveIsFirstTryReaderSavedPostsJetpack(final boolean isFirstTry) {
         setBoolean(UndeletablePrefKey.IS_FIRST_TRY_READER_SAVED_POSTS_JETPACK, isFirstTry);
+    }
+
+    public static Long getOpenWebLinksWithJetpackOverlayLastShownTimestamp() {
+        return getLong(DeletablePrefKey.OPEN_WEB_LINKS_WITH_JETPACK_OVERLAY_LAST_SHOWN_TIMESTAMP, 0L);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -251,6 +251,9 @@ class AppPrefsWrapper @Inject constructor() {
     fun saveIsFirstTryReaderSavedPostsJetpack(isFirstTry: Boolean) =
             AppPrefs.saveIsFirstTryReaderSavedPostsJetpack(isFirstTry)
 
+    fun getOpenWebLinksWithJetpackOverlayLastShownTimestamp(): Long =
+            AppPrefs.getOpenWebLinksWithJetpackOverlayLastShownTimestamp()
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/main/java/org/wordpress/android/util/FirebaseRemoteConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/FirebaseRemoteConfigWrapper.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.util
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FirebaseRemoteConfigWrapper @Inject constructor() {
+    fun getOpenWebLinksWithJetpackFlowFrequency() =
+            FirebaseRemoteConfig.getInstance().getLong(OPEN_WEB_LINKS_WITH_JETPACK_FLOW_FREQUENCY_KEY)
+
+    companion object {
+        const val OPEN_WEB_LINKS_WITH_JETPACK_FLOW_FREQUENCY_KEY = "open_web_links_with_jetpack_flow_frequency"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.util
+
+import android.content.ComponentName
+import android.content.pm.PackageManager
+import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.viewmodel.ContextProvider
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PackageManagerWrapper @Inject constructor(
+    private val contextProvider: ContextProvider,
+) {
+    fun isComponentEnabledSettingEnabled(cls: Class<*>): Boolean {
+        return when (getComponentEnabledSetting(cls)) {
+            null -> false
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED -> false
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED -> true
+            else -> isActivityEnabled(cls)
+        }
+    }
+
+    fun isPackageInstalled(packageName: String) =
+            contextProvider.getContext().packageManager.getLaunchIntentForPackage(packageName) != null
+
+    private fun getComponentEnabledSetting(cls: Class<*>) =
+            try {
+                contextProvider.getContext().packageManager.getComponentEnabledSetting(
+                        ComponentName(contextProvider.getContext(), cls)
+                )
+            } catch (e: PackageManager.NameNotFoundException) {
+                AppLog.e(T.UTILS, e)
+                null
+            }
+
+    private fun isActivityEnabled(cls: Class<*>) : Boolean {
+        val context = contextProvider.getContext()
+        val packageInfo =
+                context.packageManager.getPackageInfo(context.packageName, PackageManager.GET_ACTIVITIES)
+        for (activity in packageInfo.activities) {
+            if (activity.name == cls.name) {
+                return activity.enabled // This is the default value (set in AndroidManifest.xml)
+            }
+        }
+        return false
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/OpenWebLinksWithJetpackFlowFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/OpenWebLinksWithJetpackFlowFeatureConfig.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+@Feature(OpenWebLinksWithJetpackFlowFeatureConfig.OPEN_WEB_LINKS_WITH_JETPACK_FLOW, true)
+class OpenWebLinksWithJetpackFlowFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.OPEN_WEB_LINKS_WITH_JETPACK_FLOW,
+        OPEN_WEB_LINKS_WITH_JETPACK_FLOW
+) {
+    override fun isEnabled(): Boolean {
+        return BuildConfig.ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW && super.isEnabled()
+    }
+    companion object {
+        const val OPEN_WEB_LINKS_WITH_JETPACK_FLOW = "open_web_links_with_jetpack_flow"
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelperTest.kt
@@ -1,0 +1,200 @@
+package org.wordpress.android.ui.deeplinks
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.DateTimeUtils
+import org.wordpress.android.util.DateTimeUtilsWrapper
+import org.wordpress.android.util.FirebaseRemoteConfigWrapper
+import org.wordpress.android.util.PackageManagerWrapper
+import org.wordpress.android.util.config.OpenWebLinksWithJetpackFlowFeatureConfig
+import java.util.Date
+
+@RunWith(MockitoJUnitRunner::class)
+class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
+    @Mock lateinit var openWebLinksWithJetpackFlowFeatureConfig: OpenWebLinksWithJetpackFlowFeatureConfig
+    @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock lateinit var firebaseRemoteConfigWrapper: FirebaseRemoteConfigWrapper
+    @Mock lateinit var packageManagerWrapper: PackageManagerWrapper
+    @Mock lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
+
+    private lateinit var helper: DeepLinkOpenWebLinksWithJetpackHelper
+
+    @Before
+    fun setUp() {
+        helper = DeepLinkOpenWebLinksWithJetpackHelper(
+                openWebLinksWithJetpackFlowFeatureConfig,
+                appPrefsWrapper,
+                firebaseRemoteConfigWrapper,
+                packageManagerWrapper,
+                dateTimeUtilsWrapper
+        )
+    }
+
+    @Test
+    fun `when feature flag is off, then show overlay is false`() {
+        setTest(isFeatureFlagEnabled = false)
+
+        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given flow enabled, when JP is not installed, then show overlay is false`() {
+        setTest(
+                isFeatureFlagEnabled = true,
+                isJetpackInstalled = false
+        )
+
+        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given flow enabled & JP is installed, when handler is disabled, then show overlay is false`() {
+        setTest(
+                isFeatureFlagEnabled = true,
+                isJetpackInstalled = true,
+                isDeepLinkComponentEnabled = false
+        )
+
+        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `given flow enabled, JP install, handler enabled, when overlay never been shown, then show overlay is true`() {
+        setTest(
+                isFeatureFlagEnabled = true,
+                isJetpackInstalled = true,
+                isDeepLinkComponentEnabled = true,
+                overlayLastShownTimestamp = 0L
+        )
+
+        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+
+        assertThat(result).isTrue
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `given flow enabled, JP install, handler enabled, overlay shown before, when frequency is only once, then show overlay is false`() {
+        setTest(
+                isFeatureFlagEnabled = true,
+                isJetpackInstalled = true,
+                isDeepLinkComponentEnabled = true,
+                overlayLastShownTimestamp = getDateXDaysAgoInMilliseconds(5),
+                flowFrequency = 0L
+        )
+
+        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given flow is accessed after frequency, when showOverlay is invoked, then show overlay is true`() {
+        setTest(
+                isFeatureFlagEnabled = true,
+                isJetpackInstalled = true,
+                isDeepLinkComponentEnabled = true,
+                overlayLastShownTimestamp = getDateXDaysAgoInMilliseconds(9),
+                flowFrequency = 5L
+        )
+
+        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `given flow is accessed before frequency, when showOverlay is invoked, then show overlay is false`() {
+        setTest(
+                isFeatureFlagEnabled = true,
+                isJetpackInstalled = true,
+                isDeepLinkComponentEnabled = true,
+                overlayLastShownTimestamp = getDateXDaysAgoInMilliseconds(3),
+                flowFrequency = 5L
+        )
+        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given flow is accessed equal to frequency, when showOverlay is invoked, then show overlay is true`() {
+        setTest(
+                isFeatureFlagEnabled = true,
+                isJetpackInstalled = true,
+                isDeepLinkComponentEnabled = true,
+                overlayLastShownTimestamp = getDateXDaysAgoInMilliseconds(1),
+                flowFrequency = 1L
+        )
+
+        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+
+        assertThat(result).isTrue
+    }
+
+    private fun setTest(
+        isFeatureFlagEnabled: Boolean = true,
+        isJetpackInstalled: Boolean = true,
+        isDeepLinkComponentEnabled: Boolean = true,
+        overlayLastShownTimestamp: Long = 0L,
+        flowFrequency: Long = 0L
+    ) {
+        setFeatureEnabled(isFeatureFlagEnabled)
+        setJetpackInstalled(isJetpackInstalled)
+        setDeepLinkHandlerComponentEnabled(isDeepLinkComponentEnabled)
+        setLastShownTimestamp(overlayLastShownTimestamp)
+        setFlowFrequency(flowFrequency)
+        setDaysBetween(overlayLastShownTimestamp)
+    }
+
+    // Helpers
+    private fun setFeatureEnabled(value: Boolean) {
+        whenever(openWebLinksWithJetpackFlowFeatureConfig.isEnabled()).thenReturn(value)
+    }
+
+    private fun setJetpackInstalled(value: Boolean) {
+        whenever(packageManagerWrapper.isPackageInstalled(anyString())).thenReturn(value)
+    }
+
+    private fun setLastShownTimestamp(value: Long) {
+        whenever(appPrefsWrapper.getOpenWebLinksWithJetpackOverlayLastShownTimestamp()).thenReturn(value)
+    }
+
+    private fun setFlowFrequency(value: Long) {
+        whenever(firebaseRemoteConfigWrapper.getOpenWebLinksWithJetpackFlowFrequency()).thenReturn(value)
+    }
+
+    private fun setDaysBetween(lastShownTimestamp: Long) {
+        val between =
+                DateTimeUtils.daysBetween(Date(lastShownTimestamp), Date(getDateXDaysAgoInMilliseconds(0)))
+
+        whenever(dateTimeUtilsWrapper.daysBetween(any(), any())).thenReturn(between)
+    }
+
+    private fun setDeepLinkHandlerComponentEnabled(value: Boolean) {
+        whenever(packageManagerWrapper.isComponentEnabledSettingEnabled(any())).thenReturn(value)
+    }
+
+    private fun getDateXDaysAgoInMilliseconds(daysAgo: Int) =
+            System.currentTimeMillis().minus(DAY_IN_MILLISECONDS * daysAgo)
+
+    companion object {
+        private const val DAY_IN_MILLISECONDS = 86400000
+    }
+}


### PR DESCRIPTION
Parent #17494 

The purpose of this PR is to handle the initialization tasks needed to support the open web links with Jetpack flow.

**Modifications Include**
- Created `OpenWebLinksWithJetpackFlowFeatureConfig` to manage the feature flow
- Enabled the flow for WordPress only in build.gradle
- Added new app pref for `OPEN_WEB_LINKS_WITH_JETPACK_OVERLAY_LAST_SHOWN_TIMESTAMP`
- Created `DeepLinkOpenWebLinksWithJetpackHelper` to manage the rules related to determine when to show the overlay 
- Added `DeepLinkOpenWebLinksWithJetpackHelperTest` to test the rules
- Added `FirebaseRemoteConfigWrapper` to support unit testing for frequency threshold
- Added `PackageManagerWrapper` to support unit testing when checking if the deep link handler component is enabled/disabled

**Merge Instructions**
1. Ensure that #17495 has been merged
2. Remove the "Not ready for merge" label
3. Merge as normal

**To test:**
(1) To test the overlay shown rules.
- Download this branch
- Run the tests in `DeepLinkOpenWebLinksWithJetpackHelperTest`

(2) To test the feature flag
- Launch the app.
- Go to My Site -> Me -> App Settings -> Debug settings.
- ✅ Verify that the open_web_lnks_with_jetpack_flow exists 

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
DeepLinkOpenWebLinksWithJetpackHelperTest

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
