### PR TITLE
Prevent onMainSwitchCheckedChanged call on initialization

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/PrefMainSwitchToolbarView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/PrefMainSwitchToolbarView.kt
@@ -186,7 +186,10 @@ class PrefMainSwitchToolbarView @JvmOverloads constructor(
      * Loads initial state of the main switch and toolbar
      */
     fun loadInitialState(checkMain: Boolean) {
+        val tmpMainSwitchToolbarListener = mainSwitchToolbarListener
+        mainSwitchToolbarListener = null // Don't trigger the listener for the initialization
         setChecked(checkMain)
+        mainSwitchToolbarListener = tmpMainSwitchToolbarListener
         setToolbarTitle(checkMain)
         toolbarSwitch.visibility = View.VISIBLE
         updateToolbarSwitchForAccessibility()


### PR DESCRIPTION
This fixes the unwanted call of [onMainSwitchCheckedChanged](https://github.com/wordpress-mobile/WordPress-Android/blob/a2bd5b3592187de343a81153d14a7f3aa8dfc591/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.java#L129-L144) when the Notification Settings switch is off, and the Notification Settings screen is launched.
That unwanted call on every launch of the screen causes the wrong track of `notification_settings_app_notifications_disabled` event. This event should be tracked only when the user changed the state of the switch.

To test:
1. Launch the app. 
2. Navigate to Notifications. Tap ⚙️ button at the top of the screen.
3. Turn off the switch at the top of the page.
4. Navigate back.
5. Tap ⚙️ button at the top of the screen again.
6. Check logcat to verify `notification_settings_app_notifications_disabled` is not tracked. Alternatively, you can also use Tracks Live View to check the event.

## Regression Notes
1. Potential unintended areas of impact
Other places using `PrefMainSwitchToolbarView.kt`

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Checked the code for unexpected cases.

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
