### PR TITLE
[Jetpack Content Migration Flow] Fixes compile error on temporarily disabled tests

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/SharedLoginResolverTest.kt
@@ -25,9 +25,9 @@ import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.localcontentmigration.LocalMigrationContentProvider
 import org.wordpress.android.localcontentmigration.LocalMigrationContentResolver
+import org.wordpress.android.localcontentmigration.SharedLoginHelper
 import org.wordpress.android.reader.savedposts.resolver.ReaderSavedPostsResolver
 import org.wordpress.android.resolver.ContentResolverWrapper
-import org.wordpress.android.resolver.ResolverUtility
 import org.wordpress.android.sharedlogin.JetpackSharedLoginFlag
 import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker
 import org.wordpress.android.sharedlogin.SharedLoginAnalyticsTracker.ErrorType
@@ -57,22 +57,18 @@ class SharedLoginResolverTest : BaseUnitTest() {
     private val userFlagsResolver: UserFlagsResolver = mock()
     private val readerSavedPostsResolver: ReaderSavedPostsResolver = mock()
     private val localMigrationContentResolver: LocalMigrationContentResolver = mock()
-    private val resolverUtility: ResolverUtility = mock()
     private val siteStore: SiteStore = mock()
+    private val sharedLoginHelper: SharedLoginHelper = mock()
 
     private val classToTest = LocalMigrationOrchestrator(
-            jetpackSharedLoginFlag,
             contextProvider,
             dispatcher,
-            accountStore,
             accountActionBuilderWrapper,
-            appPrefsWrapper,
             sharedLoginAnalyticsTracker,
             userFlagsResolver,
             readerSavedPostsResolver,
             localMigrationContentResolver,
-            resolverUtility,
-            siteStore
+            sharedLoginHelper
     )
     private val sharedDataLoggedInNoSites = SharedLoginData(
             token = "valid",


### PR DESCRIPTION
**Based on: https://github.com/wordpress-mobile/WordPress-Android/pull/17483**

This PR fixes a compile error on temporarily disabled tests so that the CI checks pass.

To test:
Verify that the CI checks pass

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
