### PR TITLE
Make 'WordPress is better with Jetpack' bottom sheet text and button fully visible with big fonts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 21.3
 -----
 * [*] [Jetpack-only] Comments: fix a crash in My Site > Comments with Jetpack standalone plugins. [https://github.com/wordpress-mobile/WordPress-Android/pull/17456]
+* [*] [internal] Fix an issue preventing the text and button on the 'WordPress is Better with Jetpack' overlay to be entirely visible with big fonts. [https://github.com/wordpress-mobile/WordPress-Android/pull/17503]
 
 21.2
 -----

--- a/WordPress/src/main/res/layout-land/jetpack_powered_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout-land/jetpack_powered_bottom_sheet.xml
@@ -81,7 +81,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
             android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
-            android:layout_marginBottom="@dimen/margin_64dp"
+            android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
             android:backgroundTint="@color/jetpack_green_40"
             android:gravity="center"
             android:minHeight="@dimen/margin_64dp"

--- a/WordPress/src/main/res/layout-land/jetpack_powered_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout-land/jetpack_powered_bottom_sheet.xml
@@ -4,8 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingStart="@dimen/margin_extra_extra_medium_large"
-    android:paddingEnd="@dimen/margin_extra_extra_medium_large"
     android:background="@color/jetpack_powered_bottom_sheet_background">
 
     <include
@@ -18,59 +16,79 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <com.airbnb.lottie.LottieAnimationView
-        android:id="@+id/illustration_view"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
-        android:scaleType="centerCrop"
+        android:orientation="vertical"
         app:layout_constraintTop_toBottomOf="@id/handle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:lottie_rawRes="@raw/wp2jp_left"
-        app:lottie_enableMergePathsForKitKatAndAbove="true"
-        app:lottie_autoPlay="true"
-        app:lottie_loop="false" />
+        app:layout_constraintBottom_toBottomOf="parent">
 
-    <TextView
-        android:id="@+id/title"
-        style="@style/TextAppearance.Material3.HeadlineMedium"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_extra_medium_large"
-        android:text="@string/wp_jetpack_powered_better_with_jetpack"
-        android:textFontWeight="700"
-        app:layout_constraintTop_toBottomOf="@id/illustration_view"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        tools:targetApi="p" />
+        <ScrollView
+            android:id="@+id/scroll_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
 
-    <TextView
-        android:id="@+id/caption"
-        style="?attr/textAppearanceBody1"
-        android:text="@string/wp_jetpack_powered_features"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_extra_medium_large"
-        app:layout_constraintTop_toBottomOf="@id/title"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="@dimen/margin_extra_extra_medium_large"
+                android:paddingEnd="@dimen/margin_extra_extra_medium_large"
+                android:paddingBottom="@dimen/margin_extra_extra_large">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/primary_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_extra_extra_large"
-        android:layout_marginBottom="@dimen/margin_64dp"
-        android:backgroundTint="@color/jetpack_green_40"
-        android:gravity="center"
-        android:minHeight="@dimen/margin_64dp"
-        app:cornerRadius="@dimen/margin_small_medium"
-        android:text="@string/wp_jetpack_get_new_jetpack_app"
-        android:textAppearance="?attr/textAppearanceSubtitle2"
-        android:textColor="?attr/colorOnSecondary"
-        app:layout_constraintTop_toBottomOf="@id/caption"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+                <com.airbnb.lottie.LottieAnimationView
+                    android:id="@+id/illustration_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
+                    android:scaleType="centerCrop"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:lottie_rawRes="@raw/wp2jp_left"
+                    app:lottie_enableMergePathsForKitKatAndAbove="true"
+                    app:lottie_autoPlay="true"
+                    app:lottie_loop="false" />
 
+                <TextView
+                    android:id="@+id/title"
+                    style="@style/TextAppearance.Material3.HeadlineMedium"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_medium_large"
+                    android:text="@string/wp_jetpack_powered_better_with_jetpack"
+                    android:textFontWeight="700"
+                    app:layout_constraintTop_toBottomOf="@id/illustration_view"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    tools:targetApi="p" />
+
+                <TextView
+                    android:id="@+id/caption"
+                    style="?attr/textAppearanceBody1"
+                    android:text="@string/wp_jetpack_powered_features"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_medium_large"
+                    app:layout_constraintTop_toBottomOf="@id/title"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/primary_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginBottom="@dimen/margin_64dp"
+            android:backgroundTint="@color/jetpack_green_40"
+            android:gravity="center"
+            android:minHeight="@dimen/margin_64dp"
+            app:cornerRadius="@dimen/margin_small_medium"
+            android:text="@string/wp_jetpack_get_new_jetpack_app"
+            android:textAppearance="?attr/textAppearanceSubtitle2"
+            android:textColor="?attr/colorOnSecondary"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/jetpack_powered_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/jetpack_powered_bottom_sheet.xml
@@ -4,8 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingStart="@dimen/margin_extra_extra_medium_large"
-    android:paddingEnd="@dimen/margin_extra_extra_medium_large"
     android:background="@color/jetpack_powered_bottom_sheet_background">
 
     <include
@@ -18,60 +16,80 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <com.airbnb.lottie.LottieAnimationView
-        android:id="@+id/illustration_view"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_64dp"
-        android:scaleType="centerCrop"
+        android:orientation="vertical"
         app:layout_constraintTop_toBottomOf="@id/handle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:lottie_rawRes="@raw/wp2jp_left"
-        app:lottie_enableMergePathsForKitKatAndAbove="true"
-        app:lottie_autoPlay="true"
-        app:lottie_loop="false" />
+        app:layout_constraintBottom_toBottomOf="parent">
 
-    <TextView
-        android:id="@+id/title"
-        style="@style/TextAppearance.Material3.HeadlineMedium"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_extra_medium_large"
-        android:text="@string/wp_jetpack_powered_better_with_jetpack"
-        android:textSize="@dimen/m3_sys_typescale_headline_large_text_size"
-        android:textFontWeight="700"
-        app:layout_constraintTop_toBottomOf="@id/illustration_view"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        tools:targetApi="p" />
+        <ScrollView
+            android:id="@+id/scroll_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
 
-    <TextView
-        android:id="@+id/caption"
-        style="?attr/textAppearanceBody1"
-        android:text="@string/wp_jetpack_powered_features"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_extra_medium_large"
-        app:layout_constraintTop_toBottomOf="@id/title"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="@dimen/margin_extra_extra_medium_large"
+                android:paddingEnd="@dimen/margin_extra_extra_medium_large"
+                android:paddingBottom="@dimen/jetpack_banner_height">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/primary_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/jetpack_banner_height"
-        android:layout_marginBottom="@dimen/margin_64dp"
-        android:backgroundTint="@color/jetpack_green_40"
-        android:gravity="center"
-        android:minHeight="@dimen/margin_64dp"
-        app:cornerRadius="@dimen/margin_small_medium"
-        android:text="@string/wp_jetpack_get_new_jetpack_app"
-        android:textAppearance="?attr/textAppearanceSubtitle2"
-        android:textColor="?attr/colorOnSecondary"
-        app:layout_constraintTop_toBottomOf="@id/caption"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+                <com.airbnb.lottie.LottieAnimationView
+                    android:id="@+id/illustration_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_64dp"
+                    android:scaleType="centerCrop"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:lottie_rawRes="@raw/wp2jp_left"
+                    app:lottie_enableMergePathsForKitKatAndAbove="true"
+                    app:lottie_autoPlay="true"
+                    app:lottie_loop="false" />
 
+                <TextView
+                    android:id="@+id/title"
+                    style="@style/TextAppearance.Material3.HeadlineMedium"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_medium_large"
+                    android:text="@string/wp_jetpack_powered_better_with_jetpack"
+                    android:textSize="@dimen/m3_sys_typescale_headline_large_text_size"
+                    android:textFontWeight="700"
+                    app:layout_constraintTop_toBottomOf="@id/illustration_view"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    tools:targetApi="p" />
+
+                <TextView
+                    android:id="@+id/caption"
+                    style="?attr/textAppearanceBody1"
+                    android:text="@string/wp_jetpack_powered_features"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_medium_large"
+                    app:layout_constraintTop_toBottomOf="@id/title"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/primary_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginBottom="@dimen/margin_64dp"
+            android:backgroundTint="@color/jetpack_green_40"
+            android:gravity="center"
+            android:minHeight="@dimen/margin_64dp"
+            app:cornerRadius="@dimen/margin_small_medium"
+            android:text="@string/wp_jetpack_get_new_jetpack_app"
+            android:textAppearance="?attr/textAppearanceSubtitle2"
+            android:textColor="?attr/colorOnSecondary"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #17429

This PR fixes an issue preventing the text and button of the `WordPress is better with Jetpack` bottom sheet from being entirely visible on some devices with big fonts, by making the content of the  bottom sheet scrollable.

To test:

#### Test Case 1 - Big Fonts
0. **Prerequisite**: Enable the `jetpack_powered_bottom_sheet_remote_field` feature flag.
1. Set max font size via Accessibility settings on device.
2. Tap the "Jetpack Powered" badge on `Me`, or `My Site` → `Home`
3. **Expect** to be able to scroll the content if it's not entirely visible on the screen
4. Rotate device to landscape (make sure `Auto rotate` is enabled)
5. **Expect** to be able to scroll the content.

#### Test Case 2 - Regression
1. Restore default font size via Accessibility settings on device.
2. Tap the "Jetpack Powered" badge on `Me`, or `My Site` → `Home`
3. **Expect** to see the `WordPress is better with Jetpack` styled as before, with no visual regression
4. Rotate device to landscape
5. **Expect** to see the `WordPress is better with Jetpack` styled as before, with no visual regression.

### Previews

#### Portrait

##### With Large Font Size

| Before | After |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/203123712-c3f649a6-afe4-4197-b1c9-d0d3617ac05c.png"> | <video src="https://user-images.githubusercontent.com/4588074/203123722-e1b0cdd7-10c9-46f6-b7da-345a1eff0eea.mp4" style="width:314px;"></video> |

<details>
<summary><h5>With Default Font Size</h5></summary>

| Before | After |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/203123373-ab096113-b567-4a8e-8538-da2ec55a2f27.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/203123487-ff285f89-cef2-4deb-845f-826f9d696f1c.png"> |
</details>

<details>
<summary><h4>Landscape - With Large Font Size</h4></summary>

| Before | After |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/203124715-6bc02242-7b1a-422c-8363-d3d8a21c8420.png"> | <video src="https://user-images.githubusercontent.com/4588074/203124851-88521541-43a3-4ed8-81f2-d8f3cb7257b9.mp4"  controls="controls" muted="muted" class="d-block rounded-bottom-2 border-top width-fit" style="width:314px;"></video> |
</details>

## Regression Notes
7. Potential unintended areas of impact
   Jetpack powered bottom sheet without big fonts - on both portrait & landscape.

8. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

9. What automated tests I added (or what prevented me from doing so)
   N/a - UI changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
