### PR TITLE
Jetpack Focus: Open web links with Jetpack - Add App Setting

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -171,7 +171,7 @@ android {
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"wpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"org.wordpress.android"'
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "false"
-            buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "false"
+            buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "true"
 
             manifestPlaceholders = [magicLinkScheme:"wordpress"]
         }
@@ -194,7 +194,7 @@ android {
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
-            buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "true"
+            buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "false"
 
             manifestPlaceholders = [magicLinkScheme:"jetpack"]
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.deeplinks
 
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.FirebaseRemoteConfigWrapper
 import org.wordpress.android.util.PackageManagerWrapper
@@ -13,9 +14,15 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val firebaseRemoteConfigWrapper: FirebaseRemoteConfigWrapper,
     private val packageManagerWrapper: PackageManagerWrapper,
-    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
+    private val buildConfigWrapper: BuildConfigWrapper
 ) {
     fun shouldShowDeepLinkOpenWebLinksWithJetpackOverlay() = showOverlay()
+
+    fun shouldShowAppSetting(): Boolean {
+        return openWebLinksWithJetpackFlowFeatureConfig.isEnabled()
+                && isJetpackInstalled()
+    }
 
     private fun showOverlay() : Boolean {
         return openWebLinksWithJetpackFlowFeatureConfig.isEnabled()
@@ -24,7 +31,7 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
                 && isValidOverlayFrequency()
     }
 
-    private fun isJetpackInstalled() = packageManagerWrapper.isPackageInstalled(JETPACK_PACKAGE_NAME)
+    private fun isJetpackInstalled() = packageManagerWrapper.isPackageInstalled(getPackageName())
 
     private fun isWebDeepLinkHandlerComponentEnabled() =
         packageManagerWrapper.isComponentEnabledSettingEnabled(DeepLinkingIntentReceiverActivity::class.java)
@@ -52,6 +59,16 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
             appPrefsWrapper.getOpenWebLinksWithJetpackOverlayLastShownTimestamp()
 
     private fun getTodaysDate() = Date(System.currentTimeMillis())
+
+    private fun getPackageName(): String {
+        val appSuffix = buildConfigWrapper.getApplicationId().split(".").last()
+        val appPackage = if (appSuffix.isNotBlank()) {
+            "$JETPACK_PACKAGE_NAME.${appSuffix}"
+        } else {
+            JETPACK_PACKAGE_NAME
+        }
+        return appPackage
+    }
 
     companion object {
         const val JETPACK_PACKAGE_NAME = "com.jetpack.android"

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -1475,4 +1475,8 @@ public class AppPrefs {
     public static Long getOpenWebLinksWithJetpackOverlayLastShownTimestamp() {
         return getLong(DeletablePrefKey.OPEN_WEB_LINKS_WITH_JETPACK_OVERLAY_LAST_SHOWN_TIMESTAMP, 0L);
     }
+
+    public static void setOpenWebLinksWithJetpackOverlayLastShownTimestamp(final Long overlayLastShownTimestamp) {
+        setLong(DeletablePrefKey.OPEN_WEB_LINKS_WITH_JETPACK_OVERLAY_LAST_SHOWN_TIMESTAMP, overlayLastShownTimestamp);
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
@@ -16,6 +16,10 @@ class BuildConfigWrapper @Inject constructor() {
         return BuildConfig.DEBUG
     }
 
+    fun getApplicationId(): String {
+        return BuildConfig.APPLICATION_ID
+    }
+
     fun isDebugSettingsEnabled(): Boolean = BuildConfig.ENABLE_DEBUG_SETTINGS
 
     val isJetpackApp = BuildConfig.IS_JETPACK_APP

--- a/WordPress/src/main/java/org/wordpress/android/util/config/OpenWebLinksWithJetpackFlowFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/OpenWebLinksWithJetpackFlowFeatureConfig.kt
@@ -4,7 +4,7 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-@Feature(OpenWebLinksWithJetpackFlowFeatureConfig.OPEN_WEB_LINKS_WITH_JETPACK_FLOW, true)
+@Feature(OpenWebLinksWithJetpackFlowFeatureConfig.OPEN_WEB_LINKS_WITH_JETPACK_FLOW, false)
 class OpenWebLinksWithJetpackFlowFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -137,6 +137,9 @@
     <!-- Initial Screen -->
     <string name="pref_key_initial_screen" translatable="false">wp_pref_initial_screen</string>
 
+    <!-- Open web links with Jetpack -->
+    <string name="pref_key_open_web_links_with_jetpack" translatable="false">pref_key_open_web_links_with_jetpack</string>
+
     <string name="wp_pref_notifications_root" translatable="false">wp_pref_notifications_root</string>
     <string name="wp_pref_notifications_main" translatable="false">wp_pref_notifications_master</string>
     <string name="wp_pref_custom_notification_sound" translatable="false">wp_pref_custom_notification_sound</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4255,4 +4255,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jp_migration_remove_wp_app_icon_content_description">Remove WordPress App icon</string>
     <string name="jp_migration_finish_button">Finish</string>
 
+    <!-- Open Web Links With Jetpack -->
+    <string name="preference_open_web_links_with_jetpack">Open web links with Jetpack</string>
 </resources>

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -76,6 +76,12 @@
         android:summary="%s"
         android:title="@string/initial_screen" />
 
+    <org.wordpress.android.ui.prefs.WPSwitchPreference
+        android:id="@+id/pref_open_web_links_with_jetpack"
+        android:defaultValue="false"
+        android:key="@string/pref_key_open_web_links_with_jetpack"
+        android:title="@string/preference_open_web_links_with_jetpack" />
+
     <Preference
         android:key="@string/pref_key_whats_new"
         android:title="@string/whats_new_in_version_title" />

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelperTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.FirebaseRemoteConfigWrapper
@@ -25,6 +26,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
     @Mock lateinit var firebaseRemoteConfigWrapper: FirebaseRemoteConfigWrapper
     @Mock lateinit var packageManagerWrapper: PackageManagerWrapper
     @Mock lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
+    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
 
     private lateinit var helper: DeepLinkOpenWebLinksWithJetpackHelper
 
@@ -35,7 +37,8 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
                 appPrefsWrapper,
                 firebaseRemoteConfigWrapper,
                 packageManagerWrapper,
-                dateTimeUtilsWrapper
+                dateTimeUtilsWrapper,
+                buildConfigWrapper
         )
     }
 
@@ -148,6 +151,35 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
         assertThat(result).isTrue
     }
 
+    @Test
+    fun `when feature flag is off, then show app setting is false`() {
+        setTest(isFeatureFlagEnabled = false)
+
+        val result = helper.shouldShowAppSetting()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given flow ff is enabled, when jetpack is not installed, then show app setting is false`() {
+        setTest(isFeatureFlagEnabled = true,
+            isJetpackInstalled = false)
+
+        val result = helper.shouldShowAppSetting()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given flow ff is enabled, when jetpack is installed, then show app setting is true`() {
+        setTest(isFeatureFlagEnabled = true,
+                isJetpackInstalled = true)
+
+        val result = helper.shouldShowAppSetting()
+
+        assertThat(result).isTrue
+    }
+
     private fun setTest(
         isFeatureFlagEnabled: Boolean = true,
         isJetpackInstalled: Boolean = true,
@@ -161,6 +193,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
         setLastShownTimestamp(overlayLastShownTimestamp)
         setFlowFrequency(flowFrequency)
         setDaysBetween(overlayLastShownTimestamp)
+        setPackageName(PACKAGE_NAME)
     }
 
     // Helpers
@@ -191,10 +224,15 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
         whenever(packageManagerWrapper.isComponentEnabledSettingEnabled(any())).thenReturn(value)
     }
 
+    private fun setPackageName(value: String) {
+        whenever(buildConfigWrapper.getApplicationId()).thenReturn(value)
+    }
+
     private fun getDateXDaysAgoInMilliseconds(daysAgo: Int) =
             System.currentTimeMillis().minus(DAY_IN_MILLISECONDS * daysAgo)
 
     companion object {
         private const val DAY_IN_MILLISECONDS = 86400000
+        private const val PACKAGE_NAME = "com.jetpack.android"
     }
 }

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -959,7 +959,8 @@ public final class AnalyticsTracker {
         READER_SAVED_POSTS_START,
         READER_SAVED_POSTS_SUCCESS,
         READER_SAVED_POSTS_FAILED,
-        DEEPLINK_CUSTOM_INTENT_RECEIVED
+        DEEPLINK_CUSTOM_INTENT_RECEIVED,
+        APP_SETTINGS_OPEN_WEB_LINKS_WITH_JETPACK_CHANGED,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2413,6 +2413,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "reader_saved_posts_failed";
             case DEEPLINK_CUSTOM_INTENT_RECEIVED:
                 return "deeplink_custom_intent_received";
+            case APP_SETTINGS_OPEN_WEB_LINKS_WITH_JETPACK_CHANGED:
+                return "app_settings_open_web_links_with_jetpack_changed";
         }
         return null;
     }


### PR DESCRIPTION
Parent #17494 

This PR adds the “open web links with Jetpack” setting to the App Settings view. 
This setting is only visible:
- When the Open Web Links With Jetpack flow is enabled
- Jetpack is installed on the device
- The current app is WordPress

**Merge Instructions**
1. Ensure that #17497 has been merged
2. Remove the "Not ready for merge" label
3. Merge as normal

<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/203126951-b34f9445-3ef7-421d-8ca7-9e826460f60e.png">

**To test:**
##Test: Setting is not shown when Feature Flag is enabled and JP is not installed##
- Do a clean install of the WP app from this PR 
- Launch WP and login
- Navigate to Me -> App Settings -> Debug
- Enable the "open web links with jetpack" feature flag and restart the app
- Navigate to Me -> App Settings
- ✅ Verify you don't see the "Open web links with Jetpack" setting (as in the screenshot above)

##Test: Setting is not shown when Feature Flag is disabled and JP is not installed##
- Launch WP
- Navigate to Me -> App Settings -> Debug
- Disable the "open web links with jetpack" feature flag and restart the app
- Navigate to Me -> App Settings
- ✅ Verify you don't see the "Open web links with Jetpack" setting (as in the screenshot above)

##Test: Setting is not shown within the JP app when FF is enabled##
- Do a clean install of the JP app from this PR 
- Launch JP and login
- Navigate to Me -> App Settings -> Debug
- Enable the "open web links with jetpack" feature flag and restart the app
- Navigate to Me -> App Settings
- ✅ Verify you don't see the "Open web links with Jetpack" setting (as in the screenshot above)

##Test: Setting is shown within the WP app when FF is enabled and JP is installed##
- Make sure WP & JP are installed on the device
- Launch the WP app
- Enable the "open web links with jetpack" feature flag and restart the app
- Navigate to Me -> App Settings
- ✅ Verify you do see the "Open web links with Jetpack" setting (as in the screenshot above)

## Regression Notes
1. Potential unintended areas of impact
The app showing shows when it shouldn't

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

3. What automated tests I added (or what prevented me from doing so)
Add new tests to `DeepLinkOpenWebLinksWithJetpackHelperTest`

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
