### PR TITLE
Avoid truncation of 'Try Jetpack" button with big fonts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] [Jetpack-only] Comments: fix a crash in My Site > Comments with Jetpack standalone plugins. [https://github.com/wordpress-mobile/WordPress-Android/pull/17456]
 * [*] [internal] Fix an issue preventing the text and button on the 'WordPress is Better with Jetpack' overlay to be entirely visible with big fonts. [https://github.com/wordpress-mobile/WordPress-Android/pull/17503]
+* [*] [internal] Avoid truncation of the 'Try the new Jetpack app' button text on the Jetpack Powered bottom sheets with big fonts. [https://github.com/wordpress-mobile/WordPress-Android/pull/17511]
 
 21.2
 -----

--- a/WordPress/src/main/res/drawable/bg_rectangle_rounded_jetpack_ripple.xml
+++ b/WordPress/src/main/res/drawable/bg_rectangle_rounded_jetpack_ripple.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/black_translucent_20">
+
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="@dimen/margin_small_medium" />
+        </shape>
+    </item>
+
+</ripple>

--- a/WordPress/src/main/res/layout-land/jetpack_powered_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout-land/jetpack_powered_bottom_sheet.xml
@@ -75,17 +75,18 @@
             </androidx.constraintlayout.widget.ConstraintLayout>
         </ScrollView>
 
-        <com.google.android.material.button.MaterialButton
+        <Button
             android:id="@+id/primary_button"
+            style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
             android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
             android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
-            android:backgroundTint="@color/jetpack_green_40"
+            android:background="@drawable/bg_rectangle_rounded_jetpack_ripple"
+            app:backgroundTint="@color/jetpack_green_40"
             android:gravity="center"
-            android:minHeight="@dimen/margin_64dp"
-            app:cornerRadius="@dimen/margin_small_medium"
+            android:minHeight="@dimen/jetpack_bottom_sheet_button_height"
             android:text="@string/wp_jetpack_get_new_jetpack_app"
             android:textAppearance="?attr/textAppearanceSubtitle2"
             android:textColor="?attr/colorOnSecondary"

--- a/WordPress/src/main/res/layout/jetpack_powered_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/jetpack_powered_bottom_sheet.xml
@@ -76,16 +76,18 @@
             </androidx.constraintlayout.widget.ConstraintLayout>
         </ScrollView>
 
-        <com.google.android.material.button.MaterialButton
+        <Button
             android:id="@+id/primary_button"
+            style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
             android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
             android:layout_marginBottom="@dimen/margin_64dp"
-            android:backgroundTint="@color/jetpack_green_40"
+            android:background="@drawable/bg_rectangle_rounded_jetpack_ripple"
+            app:backgroundTint="@color/jetpack_green_40"
             android:gravity="center"
-            android:minHeight="@dimen/margin_64dp"
+            android:minHeight="@dimen/jetpack_bottom_sheet_button_height"
             app:cornerRadius="@dimen/margin_small_medium"
             android:text="@string/wp_jetpack_get_new_jetpack_app"
             android:textAppearance="?attr/textAppearanceSubtitle2"

--- a/WordPress/src/main/res/layout/jetpack_powered_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/jetpack_powered_bottom_sheet.xml
@@ -88,7 +88,6 @@
             app:backgroundTint="@color/jetpack_green_40"
             android:gravity="center"
             android:minHeight="@dimen/jetpack_bottom_sheet_button_height"
-            app:cornerRadius="@dimen/margin_small_medium"
             android:text="@string/wp_jetpack_get_new_jetpack_app"
             android:textAppearance="?attr/textAppearanceSubtitle2"
             android:textColor="?attr/colorOnSecondary"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -734,4 +734,6 @@
     <dimen name="help_logout_button_margin">15dp</dimen>
     <dimen name="help_logout_button_margin_bottom">68dp</dimen>
 
+    <dimen name="jetpack_bottom_sheet_button_height">52dp</dimen>
+
 </resources>


### PR DESCRIPTION
Fixes #17428

This PR ensures the `Try the new Jetpack app` button is not truncated with big fonts.
The issue was not reproducing for all languages, one of the languages it reproduced with is `French`.

I replaced the `MaterialButton` with a `Button` because I couldn't find any way to make the `MaterialButton` avoid truncation on the bottom sheet.

To test:

#### Test Case 1 - Big Fonts
0. **Prerequisite**: Enable the `jetpack_powered_bottom_sheet_remote_field` feature flag.
1. Set app language to French (`Me` → `App Settings` → `Interface Language`)
2. Set max font size via Accessibility settings on device.
2. Tap the "Jetpack Powered" badge on `Me`, or `My Site` → `Home`
3. **Expect** the primary button to show text on 2 lines (not truncated — see screenshots)
4. Rotate the device to landscape
5. **Expect** the primary button to show normally, with no issues

#### Test Case 2 - Regression
1. Restore default font size via Accessibility settings on device
2. Tap the "Jetpack Powered" badge on `Me`, or `My Site` → `Home`
3. **Expect** to see the `Try the new Jetpack app` styled as before, with no visual regression
4. Rotate the device to landscape
5. **Expect** to see the `Try the new Jetpack app` styled as before, with no visual regression
6. Tap the `Try the new Jetpack app` button
7. **Expect** it to work as before, with no functional regression

### Previews
| Before - Big Fonts | After - Big Fonts | After - Default Fonts |
| - | - | - |
| <img width="230" src="https://user-images.githubusercontent.com/4588074/203350946-65c01bed-06b5-4eb8-b740-a7eb470433fa.jpg"> | <img width="230" src="https://user-images.githubusercontent.com/4588074/203349444-2a62a44d-5311-4cf5-aba5-d740b085721b.jpg"> | <img width="230" src="https://user-images.githubusercontent.com/4588074/203349481-7d4475ff-b482-4745-b9a1-b84a9726b9b7.jpg"> |

## Regression Notes
1. Potential unintended areas of impact
   `Try Jetpack` button without big fonts - on landscape & portrait.

8. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

9. What automated tests I added (or what prevented me from doing so)
   N/a - UI changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
