### PR TITLE
Jetpack Focus: Open web links with Jetpack - Update App pref setting

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -24,17 +24,29 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
                 && isJetpackInstalled()
     }
 
+    fun enableDisableOpenWithJetpackComponents(newValue: Boolean) {
+        when (newValue) {
+            true -> {
+                packageManagerWrapper.enableReaderDeeplinks()
+                packageManagerWrapper.enableComponentEnableSetting(
+                        DeepLinkingIntentReceiverActivity::class.java)
+            }
+            false -> {
+                packageManagerWrapper.disableReaderDeepLinks()
+                packageManagerWrapper.disableComponentEnabledSetting(
+                        DeepLinkingIntentReceiverActivity::class.java)
+            }
+        }
+    }
+
     private fun showOverlay() : Boolean {
         return openWebLinksWithJetpackFlowFeatureConfig.isEnabled()
                 && isJetpackInstalled()
-                && isWebDeepLinkHandlerComponentEnabled()
+                && !isOpenWebLinksWithJetpack()
                 && isValidOverlayFrequency()
     }
 
     private fun isJetpackInstalled() = packageManagerWrapper.isPackageInstalled(getPackageName())
-
-    private fun isWebDeepLinkHandlerComponentEnabled() =
-        packageManagerWrapper.isComponentEnabledSettingEnabled(DeepLinkingIntentReceiverActivity::class.java)
 
     private fun isValidOverlayFrequency() : Boolean {
         if (!hasOverlayBeenShown()) return true // short circuit if the overlay has never been shown
@@ -57,6 +69,8 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
 
     private fun getOpenWebLinksWithJetpackOverlayLastShownTimestamp() =
             appPrefsWrapper.getOpenWebLinksWithJetpackOverlayLastShownTimestamp()
+
+    private fun isOpenWebLinksWithJetpack() = appPrefsWrapper.getIsOpenWebLinksWithJetpack()
 
     private fun getTodaysDate() = Date(System.currentTimeMillis())
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -176,6 +176,7 @@ public class AppPrefs {
 
         SKIPPED_BLOGGING_PROMPT_DAY,
         OPEN_WEB_LINKS_WITH_JETPACK_OVERLAY_LAST_SHOWN_TIMESTAMP,
+        OPEN_WEB_LINKS_WITH_JETPACK,
     }
 
     /**
@@ -1476,7 +1477,15 @@ public class AppPrefs {
         return getLong(DeletablePrefKey.OPEN_WEB_LINKS_WITH_JETPACK_OVERLAY_LAST_SHOWN_TIMESTAMP, 0L);
     }
 
-    public static void setOpenWebLinksWithJetpackOverlayLastShownTimestamp(final Long overlayLastShownTimestamp) {
-        setLong(DeletablePrefKey.OPEN_WEB_LINKS_WITH_JETPACK_OVERLAY_LAST_SHOWN_TIMESTAMP, overlayLastShownTimestamp);
+//    public static void setOpenWebLinksWithJetpackOverlayLastShownTimestamp(final Long overlayLastShownTimestamp) {
+//        setLong(DeletablePrefKey.OPEN_WEB_LINKS_WITH_JETPACK_OVERLAY_LAST_SHOWN_TIMESTAMP, overlayLastShownTimestamp);
+//    }
+
+    public static Boolean getIsOpenWebLinksWithJetpack() {
+        return getBoolean(DeletablePrefKey.OPEN_WEB_LINKS_WITH_JETPACK, false);
+    }
+
+    public static void setIsOpenWebLinksWithJetpack(final boolean isOpenWebLinksWithJetpack) {
+        setBoolean(DeletablePrefKey.OPEN_WEB_LINKS_WITH_JETPACK, isOpenWebLinksWithJetpack);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -254,6 +254,8 @@ class AppPrefsWrapper @Inject constructor() {
     fun getOpenWebLinksWithJetpackOverlayLastShownTimestamp(): Long =
             AppPrefs.getOpenWebLinksWithJetpackOverlayLastShownTimestamp()
 
+    fun getIsOpenWebLinksWithJetpack(): Boolean = AppPrefs.getIsOpenWebLinksWithJetpack()
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -62,6 +62,7 @@ import org.wordpress.android.util.JetpackBrandingUtils.Screen;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.LocaleProvider;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.PackageManagerWrapper;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
@@ -218,8 +219,7 @@ public class AppSettingsFragment extends PreferenceFragment
 
         mStripImageLocation.setChecked(AppPrefs.isStripImageLocation());
 
-        mOpenWebLinksWithJetpack.setChecked(
-                (AppPrefs.getOpenWebLinksWithJetpackOverlayLastShownTimestamp()) == 0L ? false : true);
+        mOpenWebLinksWithJetpack.setChecked(AppPrefs.getIsOpenWebLinksWithJetpack());
 
         mWhatsNew = findPreference(getString(R.string.pref_key_whats_new));
 
@@ -505,8 +505,8 @@ public class AppSettingsFragment extends PreferenceFragment
             AnalyticsTracker.track(Stat.PRIVACY_SETTINGS_REPORT_CRASHES_TOGGLED, Collections
                     .singletonMap(TRACK_ENABLED, newValue));
         } else if (preference == mOpenWebLinksWithJetpack) {
-            AppPrefs.setOpenWebLinksWithJetpackOverlayLastShownTimestamp(
-                    ((Boolean) newValue) ? System.currentTimeMillis() : 0L);
+            AppPrefs.setIsOpenWebLinksWithJetpack((Boolean) newValue);
+            handleEnableDisableOpenWebLinksWithJetpackComponents((Boolean) newValue);
             AnalyticsTracker.track(AnalyticsTracker.Stat.APP_SETTINGS_OPEN_WEB_LINKS_WITH_JETPACK_CHANGED, Collections
                     .singletonMap(TRACK_ENABLED, newValue));
         }
@@ -703,5 +703,18 @@ public class AppSettingsFragment extends PreferenceFragment
     @Override
     public void onLocaleSelected(@NotNull String languageCode) {
         onPreferenceChange(mLanguagePreference, languageCode);
+    }
+
+    private void handleEnableDisableOpenWebLinksWithJetpackComponents(Boolean newValue) {
+        try {
+            mOpenWebLinksWithJetpackHelper.enableDisableOpenWithJetpackComponents(newValue);
+        } catch (Exception e) {
+            ToastUtils.showToast(
+                    getActivity(),
+                    (newValue ? R.string.preference_open_web_links_with_jetpack_setting_change_enable_error
+                            : R.string.preference_open_web_links_with_jetpack_setting_change_disable_error),
+                    ToastUtils.Duration.LONG);
+            AppLog.e(AppLog.T.UTILS, "Unable to enable or disable open with Jetpack components ", e);
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -62,7 +62,6 @@ import org.wordpress.android.util.JetpackBrandingUtils.Screen;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.LocaleProvider;
 import org.wordpress.android.util.NetworkUtils;
-import org.wordpress.android.util.PackageManagerWrapper;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
@@ -505,10 +504,7 @@ public class AppSettingsFragment extends PreferenceFragment
             AnalyticsTracker.track(Stat.PRIVACY_SETTINGS_REPORT_CRASHES_TOGGLED, Collections
                     .singletonMap(TRACK_ENABLED, newValue));
         } else if (preference == mOpenWebLinksWithJetpack) {
-            AppPrefs.setIsOpenWebLinksWithJetpack((Boolean) newValue);
             handleEnableDisableOpenWebLinksWithJetpackComponents((Boolean) newValue);
-            AnalyticsTracker.track(AnalyticsTracker.Stat.APP_SETTINGS_OPEN_WEB_LINKS_WITH_JETPACK_CHANGED, Collections
-                    .singletonMap(TRACK_ENABLED, newValue));
         }
         return true;
     }
@@ -708,6 +704,9 @@ public class AppSettingsFragment extends PreferenceFragment
     private void handleEnableDisableOpenWebLinksWithJetpackComponents(Boolean newValue) {
         try {
             mOpenWebLinksWithJetpackHelper.enableDisableOpenWithJetpackComponents(newValue);
+            AppPrefs.setIsOpenWebLinksWithJetpack(newValue);
+            AnalyticsTracker.track(AnalyticsTracker.Stat.APP_SETTINGS_OPEN_WEB_LINKS_WITH_JETPACK_CHANGED, Collections
+                    .singletonMap(TRACK_ENABLED, newValue));
         } catch (Exception e) {
             ToastUtils.showToast(
                     getActivity(),

--- a/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
@@ -23,6 +23,23 @@ class PackageManagerWrapper @Inject constructor(
     fun isPackageInstalled(packageName: String) =
             contextProvider.getContext().packageManager.getLaunchIntentForPackage(packageName) != null
 
+    fun disableComponentEnabledSetting(cls: Class<*>) {
+        contextProvider.getContext().packageManager.setComponentEnabledSetting(
+                ComponentName(contextProvider.getContext(), cls),
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP
+        )
+    }
+
+    fun enableComponentEnableSetting(cls: Class<*>) {
+        contextProvider.getContext().packageManager.setComponentEnabledSetting(
+                ComponentName(contextProvider.getContext(), cls),
+                PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP
+        )
+    }
+
+    fun disableReaderDeepLinks() = WPActivityUtils.disableReaderDeeplinks(contextProvider.getContext())
+    fun enableReaderDeeplinks() = WPActivityUtils.enableReaderDeeplinks(contextProvider.getContext())
+
     private fun getComponentEnabledSetting(cls: Class<*>) =
             try {
                 contextProvider.getContext().packageManager.getComponentEnabledSetting(

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4266,6 +4266,9 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Open Web Links With Jetpack -->
     <string name="preference_open_web_links_with_jetpack">Open web links with Jetpack</string>
+    <string name="preference_open_web_links_with_jetpack_setting_change_enable_error">Unable to enable open web links with Jetpack</string>
+    <string name="preference_open_web_links_with_jetpack_setting_change_disable_error">Unable to disable open web links with Jetpack</string>
+
 
     <!-- Jetpack feature overlay strings in WordPress App -->
     <string name="wp_jetpack_feature_removal_overlay_phase_one_title_stats">Get your stats using the new Jetpack app</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelperTest.kt
@@ -64,11 +64,11 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given flow enabled & JP is installed, when handler is disabled, then show overlay is false`() {
+    fun `given flow enabled & JP is installed, when isOpenWebLinks setting is enabled, then show overlay is false`() {
         setTest(
                 isFeatureFlagEnabled = true,
                 isJetpackInstalled = true,
-                isDeepLinkComponentEnabled = false
+                isOpenWebLinksWithJetpack = true
         )
 
         val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
@@ -78,11 +78,11 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `given flow enabled, JP install, handler enabled, when overlay never been shown, then show overlay is true`() {
+    fun `given flow enabled, JP install, isOpenWebLinks disabled, when overlay never been shown, then show overlay is true`() {
         setTest(
                 isFeatureFlagEnabled = true,
                 isJetpackInstalled = true,
-                isDeepLinkComponentEnabled = true,
+                isOpenWebLinksWithJetpack = false,
                 overlayLastShownTimestamp = 0L
         )
 
@@ -93,11 +93,11 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `given flow enabled, JP install, handler enabled, overlay shown before, when frequency is only once, then show overlay is false`() {
+    fun `given flow enabled, JP install, isOpenWebLinks disabled, overlay shown before, when frequency is only once, then show overlay is false`() {
         setTest(
                 isFeatureFlagEnabled = true,
                 isJetpackInstalled = true,
-                isDeepLinkComponentEnabled = true,
+                isOpenWebLinksWithJetpack = false,
                 overlayLastShownTimestamp = getDateXDaysAgoInMilliseconds(5),
                 flowFrequency = 0L
         )
@@ -112,7 +112,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
         setTest(
                 isFeatureFlagEnabled = true,
                 isJetpackInstalled = true,
-                isDeepLinkComponentEnabled = true,
+                isOpenWebLinksWithJetpack = false,
                 overlayLastShownTimestamp = getDateXDaysAgoInMilliseconds(9),
                 flowFrequency = 5L
         )
@@ -127,7 +127,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
         setTest(
                 isFeatureFlagEnabled = true,
                 isJetpackInstalled = true,
-                isDeepLinkComponentEnabled = true,
+                isOpenWebLinksWithJetpack = false,
                 overlayLastShownTimestamp = getDateXDaysAgoInMilliseconds(3),
                 flowFrequency = 5L
         )
@@ -141,7 +141,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
         setTest(
                 isFeatureFlagEnabled = true,
                 isJetpackInstalled = true,
-                isDeepLinkComponentEnabled = true,
+                isOpenWebLinksWithJetpack = false,
                 overlayLastShownTimestamp = getDateXDaysAgoInMilliseconds(1),
                 flowFrequency = 1L
         )
@@ -183,13 +183,14 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
     private fun setTest(
         isFeatureFlagEnabled: Boolean = true,
         isJetpackInstalled: Boolean = true,
-        isDeepLinkComponentEnabled: Boolean = true,
+        isOpenWebLinksWithJetpack: Boolean = false,
         overlayLastShownTimestamp: Long = 0L,
         flowFrequency: Long = 0L
     ) {
         setFeatureEnabled(isFeatureFlagEnabled)
         setJetpackInstalled(isJetpackInstalled)
-        setDeepLinkHandlerComponentEnabled(isDeepLinkComponentEnabled)
+        setIsOpenWebLinksWithJetpack(isOpenWebLinksWithJetpack)
+//        setDeepLinkHandlerComponentEnabled(isDeepLinkComponentEnabled)
         setLastShownTimestamp(overlayLastShownTimestamp)
         setFlowFrequency(flowFrequency)
         setDaysBetween(overlayLastShownTimestamp)
@@ -220,8 +221,8 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
         whenever(dateTimeUtilsWrapper.daysBetween(any(), any())).thenReturn(between)
     }
 
-    private fun setDeepLinkHandlerComponentEnabled(value: Boolean) {
-        whenever(packageManagerWrapper.isComponentEnabledSettingEnabled(any())).thenReturn(value)
+    private fun setIsOpenWebLinksWithJetpack(value: Boolean) {
+        whenever(appPrefsWrapper.getIsOpenWebLinksWithJetpack()).thenReturn(value)
     }
 
     private fun setPackageName(value: String) {


### PR DESCRIPTION
Parent #17494 

This PR changes the way the `DeepLinkOpenWebLinksWithJetpackHelper` determines when to show the overlay. Instead of relying on the activity component to be enabled, a new app pref was added to manage the value. Also included in this PR is the logic to enable/disable the actual deep link component. A future PR will add the functionality to update the setting based on the overlay yes/no response.

This setting is only visible:
- When the Open Web Links With Jetpack flow is enabled
- Jetpack is installed on the device
- The current app is WordPress

Note: had to comment out the following unused methods to pass ci checks. This will be uncommented in the next PR.
`setOpenWebLinksWithJetpackOverlayLastShownTimestamp`

<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/203126951-b34f9445-3ef7-421d-8ca7-9e826460f60e.png">

**To test:**
##Test: Setting is not shown when Feature Flag is enabled and JP is not installed##
- Do a clean install of the WP app from this PR 
- Launch WP and login
- Navigate to Me -> App Settings -> Debug
- Enable the "open web links with jetpack" feature flag and restart the app
- Navigate to Me -> App Settings
- ✅ Verify you don't see the "Open web links with Jetpack" setting (as in the screenshot above)

##Test: Setting is not shown when Feature Flag is disabled and JP is not installed##
- Launch WP
- Navigate to Me -> App Settings -> Debug
- Disable the "open web links with jetpack" feature flag and restart the app
- Navigate to Me -> App Settings
- ✅ Verify you don't see the "Open web links with Jetpack" setting (as in the screenshot above)

##Test: Setting is not shown within the JP app when FF is enabled##
- Do a clean install of the JP app from this PR 
- Launch JP and login
- Navigate to Me -> App Settings -> Debug
- Enable the "open web links with jetpack" feature flag and restart the app
- Navigate to Me -> App Settings
- ✅ Verify you don't see the "Open web links with Jetpack" setting (as in the screenshot above)

##Test: Setting is shown within the WP app when FF is enabled and JP is installed##
- Make sure WP & JP are installed on the device
- Launch the WP app
- Enable the "open web links with jetpack" feature flag and restart the app
- Navigate to Me -> App Settings
- ✅ Verify you do see the "Open web links with Jetpack" setting (as in the screenshot above)

## Regression Notes
1. Potential unintended areas of impact
The app showing shows when it shouldn't

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

3. What automated tests I added (or what prevented me from doing so)
Add new tests to `DeepLinkOpenWebLinksWithJetpackHelperTest`

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
