### PR TITLE
Reader: Fix labels translation when language is changed via app settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [**] Adds the functionality to Add, Edit and Delete categories from site settings. [https://github.com/wordpress-mobile/WordPress-Android/pull/17652]
 * [**] [internal] Upgrade React Native from 0.66.2 to 0.69.4 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5193]
+* [*] Reader: Fix translations not applying on some texts when the language is changed via App Settings. [https://github.com/wordpress-mobile/WordPress-Android/pull/17524]
 
 21.3
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
@@ -1,10 +1,10 @@
 package org.wordpress.android.ui.reader.utils
 
-import android.content.Context
 import dagger.Reusable
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType
 import org.wordpress.android.ui.reader.services.update.TagUpdateClientUtilsProvider
+import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
 
 /**
@@ -15,7 +15,7 @@ import javax.inject.Inject
  */
 @Reusable
 class ReaderUtilsWrapper @Inject constructor(
-    private val appContext: Context,
+    private val contextProvider: ContextProvider,
     private val tagUpdateClientUtilsProvider: TagUpdateClientUtilsProvider
 ) {
     fun getResizedImageUrl(imageUrl: String?, width: Int, height: Int, isPrivate: Boolean, isAtomic: Boolean): String? =
@@ -32,10 +32,10 @@ class ReaderUtilsWrapper @Inject constructor(
             ReaderUtils.getTagFromTagName(tagName, tagType)
 
     fun getDefaultTagFromDbOrCreateInMemory() =
-            ReaderUtils.getDefaultTagFromDbOrCreateInMemory(appContext, tagUpdateClientUtilsProvider)
+            ReaderUtils.getDefaultTagFromDbOrCreateInMemory(contextProvider.getContext(), tagUpdateClientUtilsProvider)
 
     fun getLongLikeLabelText(numLikes: Int, isLikedByCurrentUser: Boolean): String =
-            ReaderUtils.getLongLikeLabelText(appContext, numLikes, isLikedByCurrentUser)
+            ReaderUtils.getLongLikeLabelText(contextProvider.getContext(), numLikes, isLikedByCurrentUser)
 
     fun isExternalFeed(blogId: Long, feedId: Long): Boolean = ReaderUtils.isExternalFeed(blogId, feedId)
 
@@ -54,7 +54,7 @@ class ReaderUtilsWrapper @Inject constructor(
     ) = ReaderUtils.commentExists(blogId, postId, commentId)
 
     fun getTextForCommentSnippet(numComments: Int): String? = ReaderUtils.getTextForCommentSnippet(
-            appContext,
+            contextProvider.getContext(),
             numComments
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
@@ -1,17 +1,17 @@
 package org.wordpress.android.util
 
-import android.content.Context
+import org.wordpress.android.viewmodel.ContextProvider
 import java.util.Date
 import javax.inject.Inject
 
 class DateTimeUtilsWrapper @Inject constructor(
     private val localeManagerWrapper: LocaleManagerWrapper,
-    private val appContext: Context
+    private val contextProvider: ContextProvider
 ) {
     fun currentTimeInIso8601(): String =
             DateTimeUtils.iso8601FromTimestamp(localeManagerWrapper.getCurrentCalendar().timeInMillis / 1000)
 
-    fun javaDateToTimeSpan(date: Date?): String = DateTimeUtils.javaDateToTimeSpan(date, appContext)
+    fun javaDateToTimeSpan(date: Date?): String = DateTimeUtils.javaDateToTimeSpan(date, contextProvider.getContext())
 
     fun dateFromIso8601(date: String) = DateTimeUtils.dateFromIso8601(date)
 


### PR DESCRIPTION
Fixes #17171

This PR fixes the localization for the following labels in Reader when the language is changed via App Settings:
- `now` timestamp for reader posts and comments in list
- `Comments` section header for reader posts

To test:
1. Change the app language via `App Settings` → `Interface Language` (e.g. German)
2. Publish a new post on a blog you author and follow
3. Go to `Reader` → `Following`
4. Refresh list to see your brand new post
5. **Expect** the timestamp "now" to be translated
6. Tap on the new post
7. **Expect** the "Comments" header to be translated

### Previews
| "Now" Before | "Now" After |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/203626664-e52456a4-191c-4af4-92f8-95dae7bc84a9.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/203626905-0321d112-a7b2-4753-9d23-676e976a8a65.png"> |

<details>
<summary><h4>💬 Preview "Comments" header</h4></summary>

| "Comments" Before | "Comments" After |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/203627130-1ef2df3a-fba0-472b-84f0-c57e9e921b6d.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/203627211-bc0b7108-cba2-42ca-abb0-131ed085745f.png"> |

</details>

## Regression Notes
1. Potential unintended areas of impact
   N/a

8. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

9. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
