### PR TITLE
Jetpack Focus: Jetpack app uninstall receiver

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -37,6 +37,11 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
         }
     }
 
+    fun handleJetpackUninstalled() {
+        enableDisableOpenWithJetpackComponents(false)
+        appPrefsWrapper.setIsOpenWebLinksWithJetpack(false)
+    }
+
     private fun showOverlay() : Boolean {
         return openWebLinksWithJetpackFlowFeatureConfig.isEnabled()
                 && isJetpackInstalled()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -256,6 +256,9 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun getIsOpenWebLinksWithJetpack(): Boolean = AppPrefs.getIsOpenWebLinksWithJetpack()
 
+    fun setIsOpenWebLinksWithJetpack(isOpenWebLinksWithJetpack: Boolean) =
+            AppPrefs.setIsOpenWebLinksWithJetpack(isOpenWebLinksWithJetpack)
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/wordpress/AndroidManifest.xml
+++ b/WordPress/src/wordpress/AndroidManifest.xml
@@ -15,5 +15,14 @@
                 <action android:name="org.wordpress.android.broadcast.DISABLE_NOTIFICATIONS"/>
             </intent-filter>
         </receiver>
+
+        <receiver
+            android:name=".ui.deeplinks.JetpackAppUninstallReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.PACKAGE_FULLY_REMOVED"/>
+                <data android:scheme="package"/>
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/WordPress/src/wordpress/java/org/wordpress/android/ui/deeplinks/JetpackAppUninstallReceiver.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/ui/deeplinks/JetpackAppUninstallReceiver.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.ui.deeplinks
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_PACKAGE_FULLY_REMOVED
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import org.wordpress.android.util.AppLog.T.UTILS
+
+@AndroidEntryPoint
+class JetpackAppUninstallReceiver : BroadcastReceiver() {
+    @Inject lateinit var openWebLinksWithJetpackHelper: DeepLinkOpenWebLinksWithJetpackHelper
+
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            ACTION_PACKAGE_FULLY_REMOVED -> {
+                disableOpenWebLinksWithJetpack()
+                AppLog.i(UTILS,"JetpackAppUninstallReceiver ACTION_PACKAGE_FULLY_REMOVED handled")
+            }
+        }
+    }
+
+    private fun disableOpenWebLinksWithJetpack() {
+        // Toggle the appPref to off + re-enable components
+        openWebLinksWithJetpackHelper.handleJetpackUninstalled()
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent = Intent(context, JetpackAppUninstallReceiver::class.java)
+    }
+}


### PR DESCRIPTION
Parent #17494

This PR adds the `JetpackAppUninstallReceiver`. 
This broadcast receiver will listen for Jetpack App uninstalls and perform the following actions:
1. Turns off the "Open web links with JetpacK" app setting.
2. Renables the web link deep link handlers

**Merge Instructions**
1. Ensure that #17523  has been merged
2. Remove the "Not ready for merge" label
3. Merge as normal

**To test:**
- Ensure either Jetpack app or Jetpack beta app is installed (from play store)
- Remove any WordPress app instances
- Install WP APK from this PR
- Login to the app
- Navigate to Me → App Settings → Privacy and enable collect information
- Navigate to Me → App Settings → Debug Settings
- Enable the `open_web_lnks_with_jetpack_flow` feature and restart the app
- Navigate to Me → App Settings
- Flip the switch to enable `Open web links with Jetpack` setting
- Navigate out of App Settings
- Navigate to back into Me → App Settings
- ✅ Verify that the `Open web links with Jetpack` setting is still enabled
- Navigate out of App Settings
- Uninstall the Jetpack app (wait for it to finish)
- Open WP app
- Navigate to Me → App Settings
- ✅ Verify that the `Open web links with Jetpack` setting is not enabled

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
