### PR TITLE
[Build] Remove Fetch Style Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id "com.automattic.android.fetchstyle"
     id "io.gitlab.arturbosch.detekt"
     id "androidx.navigation.safeargs.kotlin" apply false
     id "com.android.library" apply false

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,7 +18,6 @@ pluginManagement {
         id "io.sentry.android.gradle" version "2.0.0"
         id "io.gitlab.arturbosch.detekt" version gradle.ext.detektVersion
         id "se.bjurr.violations.violation-comments-to-github-gradle-plugin" version "1.67"
-        id "com.automattic.android.fetchstyle" version "1.1"
         id "androidx.navigation.safeargs.kotlin" version gradle.ext.navComponentVersion
     }
     repositories {
@@ -33,10 +32,6 @@ pluginManagement {
     }
     resolutionStrategy {
         eachPlugin {
-            // TODO: Remove this when fetchstyle starts supporting Plugin Marker Artifacts
-            if (requested.id.id == "com.automattic.android.fetchstyle") {
-                useModule("com.automattic.android:fetchstyle:1.1")
-            }
             // TODO: Remove this when 'dagger.hilt' starts supporting Plugin Marker Artifacts
             if (requested.id.id == 'dagger.hilt.android.plugin') {
                 useModule("com.google.dagger:hilt-android-gradle-plugin:$gradle.ext.daggerVersion")


### PR DESCRIPTION
This PR removes the [fetchstyle](https://github.com/Automattic/style-config-android) plugin from the project.

This `style-config-android` plugin is mostly unused and very outdated.

To the Apps Infra's knowledge and checking GE stats no-one is using the `./gradlew downloadConfigs` task to fetch/update the style config files. For years now, almost all Android engineers depend on the default AS style and such like `.idea` configuration.

PS: For more info please refer to this internal discussion here: `C02QANACA/p1667910471807479`

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could try and run the `./gradlew downloadConfigs` task and verify that it is no longer found in the root project for WPAndroid.

-----

## Regression Notes

1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
