### PR TITLE
Jetpack App: Fix QR Code auth flow not translated in app language

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 21.3
 -----
+* [*] [Jetpack-only] The the QR code scanning flow screens are now translated in the app language. [https://github.com/wordpress-mobile/WordPress-Android/pull/17533]
 * [*] Disable local notifications with Notification Settings switch. [https://github.com/wordpress-mobile/WordPress-Android/pull/17496]
 * [*] [Jetpack-only] Comments: fix a crash in My Site > Comments with Jetpack standalone plugins. [https://github.com/wordpress-mobile/WordPress-Android/pull/17456]
 * [*] [internal] Fix an issue preventing the text and button on the 'WordPress is Better with Jetpack' overlay to be entirely visible with big fonts. [https://github.com/wordpress-mobile/WordPress-Android/pull/17503]

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthActivity.kt
@@ -3,12 +3,12 @@ package org.wordpress.android.ui.qrcodeauth
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.databinding.QrcodeauthActivityBinding
+import org.wordpress.android.ui.LocaleAwareActivity
 
 @AndroidEntryPoint
-class QRCodeAuthActivity : AppCompatActivity() {
+class QRCodeAuthActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 


### PR DESCRIPTION
Fixes #17525

This quick-win fix ensures the screens in the QR code auth flow are translated in the language of the app.
Previously they were not respecting the app language.

To test:

1. Launch Jetpack App
2. Change the language `Me` → `App Settings` → `Interface Language` (e.g. Dutch)
3. Go back, you should land on the `Me` screen
4. Tap `Scan Login Code` (3rd item)
5. On your computer, open a guest browser window and go to https://wordpress.com/log-in/qr
7. Scan the QR code from your computer with the Jetpack app
8. **Expect** The screens in the flow to be translated in the same language as the app

## Previews
| Before | After |
| - | - |
| <video src="https://user-images.githubusercontent.com/4588074/203633194-929e5ef8-5348-4811-aea4-eb16d34b6ae2.mp4" style="width:314px;"></video> | <video src="https://user-images.githubusercontent.com/4588074/203829791-e0168435-457f-4514-a77e-b4c95e9fa8cc.mp4" style="width:314px;"> |

## Regression Notes
1. Potential unintended areas of impact
   N/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

3. What automated tests I added (or what prevented me from doing so)
   N/a - Android code.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
