### PR TITLE
Fix disabling create site notification issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/usecase/UpdateNotificationSettingsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/usecase/UpdateNotificationSettingsUseCase.kt
@@ -8,7 +8,6 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
 import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.viewmodel.ResourceProvider
-import org.wordpress.android.workers.notification.createsite.CreateSiteNotificationScheduler
 import org.wordpress.android.workers.reminder.ReminderConfig.WeeklyReminder
 import org.wordpress.android.workers.reminder.ReminderScheduler
 import org.wordpress.android.workers.weeklyroundup.WeeklyRoundupScheduler
@@ -22,7 +21,6 @@ class UpdateNotificationSettingsUseCase @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val weeklyRoundupScheduler: WeeklyRoundupScheduler,
     private val reminderScheduler: ReminderScheduler,
-    private val createSiteNotificationScheduler: CreateSiteNotificationScheduler,
     private val bloggingRemindersStore: BloggingRemindersStore,
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
 ) {
@@ -33,12 +31,10 @@ class UpdateNotificationSettingsUseCase @Inject constructor(
             // The switch is turned on. Schedule local notifications.
             weeklyRoundupScheduler.scheduleIfNeeded()
             scheduleSavedBloggingReminders()
-            createSiteNotificationScheduler.scheduleCreateSiteNotificationIfNeeded()
         } else {
             // The switch is turned off. Cancel scheduled local notifications.
             weeklyRoundupScheduler.cancel()
             reminderScheduler.cancelAll()
-            createSiteNotificationScheduler.cancelCreateSiteNotification()
         }
     }
 


### PR DESCRIPTION
https://github.com/wordpress-mobile/WordPress-Android/pull/17496 added the ability to disable create site notifications via the Notification Settings switch. But it has an issue mentioned in the PR:

> Create site notifications won't be rescheduled if you turn on the switch again. Two Create site notifications are scheduled when the app is installed the first time. One is for the next day after the install, another one is for 8 days after the first install. If the switch is turned off and turned on in 8 days, create site notifications won't display. I'll discuss this later and change it in a separate PR if necessary.

This PR fixes that issue.

I removed canceling create site notifications on `UpdateNotificationSettingsUseCase`. It's already being handled in `CreateSiteNotificationHandler` when the notification is about to show. Notice the `isNotificationSettingsEnabled` parameter in the check.

https://github.com/wordpress-mobile/WordPress-Android/blob/2edb3e0cba73798cf0121549f4c926600062e26f/WordPress/src/main/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationHandler.kt#L24-L30

**To test:**
If you want to manipulate the code to wait a minute instead of a day, change https://github.com/wordpress-mobile/WordPress-Android/blob/7c0348e4113bf2a86c54face087b3e41a43b1549/WordPress/src/main/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationScheduler.kt#L25
with `delayUnits = TimeUnit.MINUTES`

**When the switch is off**
1. Uninstall the app if installed.
2. Install and launch the WordPress app. 
3. Log in with an account without any site.
5. Navigate to Notifications.
6. Tap ⚙️ button at the top of the screen.
7. Turn off the switch at the top of the page.
8. Wait for the next day. Ensure the create site notification won't be delivered.

**When the switch is turned off and then on again**
1. Uninstall the app if installed.
2. Install and launch the WordPress app. 
3. Log in with an account without any site.
4. Navigate to Notifications.
5. Tap ⚙️ button at the top of the screen.
6. Turn off the switch at the top of the page. Then turn it on again.
7. Wait for the next day. Ensure the create site notification will be delivered.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
