### PR TITLE
Jetpack focus: Adds site creation source parameter to analytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -96,7 +96,7 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
 
     private void showOverlay() {
         JetpackFeatureFullScreenOverlayFragment
-                .newInstance(null, false, true)
+                .newInstance(null, false, true, null)
                 .show(getSupportFragmentManager(), JetpackFeatureFullScreenOverlayFragment.TAG);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
@@ -18,6 +18,8 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.Dism
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.ForwardToJetpack
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.OpenPlayStore
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource.UNSPECIFIED
 import org.wordpress.android.util.RtlUtils
 import org.wordpress.android.util.extensions.exhaustive
 import org.wordpress.android.util.extensions.setVisible
@@ -46,6 +48,7 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
                 getSiteScreen(),
                 getIfSiteCreationOverlay(),
                 getIfDeepLinkOverlay(),
+                getSiteCreationSource(),
                 RtlUtils.isRtl(view.context)
         )
         binding.setupObservers()
@@ -85,6 +88,9 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
 
     private fun getIfDeepLinkOverlay() =
             arguments?.getSerializable(IS_DEEP_LINK_OVERLAY) as Boolean
+
+    private fun getSiteCreationSource() =
+            arguments?.getSerializable(SITE_CREATION_OVERLAY_SOURCE) as SiteCreationSource
 
     private fun JetpackFeatureRemovalOverlayBinding.setupObservers() {
         viewModel.uiState.observe(viewLifecycleOwner) {
@@ -158,16 +164,19 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
         private const val OVERLAY_SCREEN_TYPE = "KEY_JETPACK_OVERLAY_SCREEN"
         private const val IS_SITE_CREATION_OVERLAY = "KEY_IS_SITE_CREATION_OVERLAY"
         private const val IS_DEEP_LINK_OVERLAY = "KEY_IS_DEEP_LINK_OVERLAY"
+        private const val SITE_CREATION_OVERLAY_SOURCE = "KEY_SITE_CREATION_OVERLAY_SOURCE"
 
         @JvmStatic fun newInstance(
             jetpackFeatureOverlayScreenType: JetpackFeatureOverlayScreenType? = null,
             isSiteCreationOverlay: Boolean = false,
-            isDeepLinkOverlay: Boolean = false
+            isDeepLinkOverlay: Boolean = false,
+            siteCreationSource: SiteCreationSource? = UNSPECIFIED
         ) = JetpackFeatureFullScreenOverlayFragment().apply {
             arguments = Bundle().apply {
                 putSerializable(OVERLAY_SCREEN_TYPE, jetpackFeatureOverlayScreenType)
                 putBoolean(IS_SITE_CREATION_OVERLAY, isSiteCreationOverlay)
                 putBoolean(IS_DEEP_LINK_OVERLAY, isDeepLinkOverlay)
+                putSerializable(SITE_CREATION_OVERLAY_SOURCE, siteCreationSource)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayViewModel.kt
@@ -8,6 +8,8 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackOverlayDismissalType.CLOSE_BUTTON
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackOverlayDismissalType.CONTINUE_BUTTON
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource.UNSPECIFIED
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -27,17 +29,17 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
 
     private lateinit var screenType: JetpackFeatureOverlayScreenType
     private var isSiteCreationOverlayScreen: Boolean = false
+    private var siteCreationOrigin: SiteCreationSource = UNSPECIFIED
     private var isDeepLinkOverlayScreen: Boolean = false
 
     fun openJetpackAppDownloadLink() {
         if (isSiteCreationOverlayScreen) {
             _action.value = JetpackFeatureOverlayActions.OpenPlayStore
-            jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTappedInSiteCreationOverlay()
+            jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTappedInSiteCreationOverlay(siteCreationOrigin)
         } else if (isDeepLinkOverlayScreen) {
             _action.value = JetpackFeatureOverlayActions.ForwardToJetpack
             jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTappedInDeepLinkOverlay()
-        }
-        else {
+        } else {
             _action.value = JetpackFeatureOverlayActions.OpenPlayStore
             jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTapped(screenType)
         }
@@ -46,7 +48,10 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
     fun continueToFeature() {
         _action.value = JetpackFeatureOverlayActions.DismissDialog
         if (isSiteCreationOverlayScreen)
-            jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInSiteCreationOverlay(CONTINUE_BUTTON)
+            jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInSiteCreationOverlay(
+                    siteCreationOrigin,
+                    CONTINUE_BUTTON
+            )
         else if (isDeepLinkOverlayScreen)
             jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInDeepLinkOverlay(CONTINUE_BUTTON)
         else jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissed(screenType, CONTINUE_BUTTON)
@@ -55,7 +60,10 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
     fun closeBottomSheet() {
         _action.value = JetpackFeatureOverlayActions.DismissDialog
         if (isSiteCreationOverlayScreen)
-            jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInSiteCreationOverlay(CLOSE_BUTTON)
+            jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInSiteCreationOverlay(
+                    siteCreationOrigin,
+                    CLOSE_BUTTON
+            )
         else if (isDeepLinkOverlayScreen)
             jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInDeepLinkOverlay(CLOSE_BUTTON)
         else jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissed(screenType, CLOSE_BUTTON)
@@ -66,17 +74,19 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
         overlayScreenType: JetpackFeatureOverlayScreenType?,
         isSiteCreationOverlay: Boolean,
         isDeepLinkOverlay: Boolean,
+        siteCreationSource: SiteCreationSource,
         rtlLayout: Boolean
     ) {
         if (isSiteCreationOverlay) {
             isSiteCreationOverlayScreen = true
+            siteCreationOrigin = siteCreationSource
             _uiState.postValue(
                     jetpackFeatureOverlayContentBuilder.buildSiteCreationOverlayState(
                             getSiteCreationPhase()!!,
                             rtlLayout
                     )
             )
-            jetpackFeatureRemovalOverlayUtil.trackSiteCreationOverlayShown()
+            jetpackFeatureRemovalOverlayUtil.trackSiteCreationOverlayShown(siteCreationOrigin)
             return
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseO
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.SiteUtilsWrapper
@@ -178,31 +179,35 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         )
     }
 
-    fun trackSiteCreationOverlayShown() {
+    fun trackSiteCreationOverlayShown(siteCreationSource: SiteCreationSource) {
         analyticsTrackerWrapper.track(
                 AnalyticsTracker.Stat.JETPACK_REMOVE_SITE_CREATION_OVERLAY_DISPLAYED,
                 mapOf(
-                        CURRENT_PHASE_KEY to jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()?.trackingName
+                        CURRENT_PHASE_KEY to jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()?.trackingName,
+                        SCREEN_TYPE_KEY to siteCreationSource.label
                 )
         )
     }
 
-    fun trackInstallJetpackTappedInSiteCreationOverlay() {
+    fun trackInstallJetpackTappedInSiteCreationOverlay(siteCreationSource: SiteCreationSource) {
         analyticsTrackerWrapper.track(
                 AnalyticsTracker.Stat.JETPACK_REMOVE_SITE_CREATION_OVERLAY_BUTTON_GET_JETPACK_APP_TAPPED,
                 mapOf(
-                        CURRENT_PHASE_KEY to jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()?.trackingName
+                        CURRENT_PHASE_KEY to jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()?.trackingName,
+                        SCREEN_TYPE_KEY to siteCreationSource.label
                 )
         )
     }
 
     fun trackBottomSheetDismissedInSiteCreationOverlay(
+        siteCreationSource: SiteCreationSource,
         dismissalType: JetpackOverlayDismissalType
     ) {
         analyticsTrackerWrapper.track(
                 AnalyticsTracker.Stat.JETPACK_REMOVE_SITE_CREATION_OVERLAY_DISMISSED,
                 mapOf(
                         CURRENT_PHASE_KEY to jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()?.trackingName,
+                        SCREEN_TYPE_KEY to siteCreationSource.label,
                         DISMISSAL_TYPE_KEY to dismissalType.trackingName
                 )
         )
@@ -237,7 +242,6 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
                 )
         )
     }
-
 
     enum class JetpackOverlayDismissalType(val trackingName: String) {
         CLOSE_BUTTON("close"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -73,8 +73,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.site_creation_activity)
-        val siteCreationSource = intent.extras?.getString(ARG_CREATE_SITE_SOURCE)
-        mainViewModel.start(savedInstanceState, SiteCreationSource.fromString(siteCreationSource))
+        mainViewModel.start(savedInstanceState, getSiteCreationSource())
         mainViewModel.preloadThumbnails(this)
 
         observeVMState()
@@ -156,11 +155,17 @@ class SiteCreationActivity : LocaleAwareActivity(),
 
         mainViewModel.showJetpackOverlay.observeEvent(this) {
             val fragment = JetpackFeatureFullScreenOverlayFragment
-                    .newInstance(isSiteCreationOverlay =  true)
+                    .newInstance(isSiteCreationOverlay =  true,
+                            siteCreationSource = getSiteCreationSource())
             if (mainViewModel.siteCreationDisabled)
                 slideInFragment(fragment, JetpackFeatureFullScreenOverlayFragment.TAG)
             else fragment.show(supportFragmentManager, JetpackFeatureFullScreenOverlayFragment.TAG)
         }
+    }
+
+    private fun getSiteCreationSource(): SiteCreationSource {
+        val siteCreationSource = intent.extras?.getString(ARG_CREATE_SITE_SOURCE)
+        return SiteCreationSource.fromString(siteCreationSource)
     }
 
     override fun onIntentSelected(intent: String?) {


### PR DESCRIPTION
Part of #17441 

As part of the discussion [here](p1669301753886849-slack-C04564QS0V7), This PR adds the site creation source parameter to the Site creation overlay events.

Site creation source parameter values added to the tracking events - Values from [SiteCreationSource](WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationSource.kt)
```
signup_epilogue
my_site_no_sites
my_sites
login_epilogue
my_site
deep_link
notification
```

## Testing Instructions

Make sure the Site creation overlay analytics events tracked have the source parameter for Phase one and Phase two. 

Phase One
- This is the phase where we show an overlay but don't fully disable site creation
 - Enable this phase by making sure the "Jetpack Features Removal Phase one" flag is enabled
 - Launch WP app -> Go to my site -> App settings -> Debug settings -> Enable jp_removal_one flag
    
Phase Two
- This is the phase where we show an overlay and fully disable site creation
- Enable this phase by making sure the "Jetpack Features Removal Phase four" flag is enabled
- Launch WP app -> Go to my site -> App settings -> Debug settings -> Enable jp_removal_four flag

Test the following site creation flows and make sure that the tracking events contain the source.

### Site List flow
- Open the app
- Navigate to Sites list
- Tap plus button
- Tap "Create WordPress.com site"
- Verify that Site creation overlay is shown
- ✅ Verify that Tracked: remove_site_creation_overlay_displayed, Properties: {"phase":"two","source":"my_site"}
- Click on **Continue with Jetpack** button 
- ✅ Verify that Tracked: remove_site_creation_overlay_dismissed, Pro perties:{"phase":"one","source":"my_site","dismissal_type":"continue"}
- Dismiss the Overlay using close(x) button 
- ✅ Verify that Tracked: remove_site_creation_overlay_dismissed, Properties:{"phase":"one","source":"my_site","dismissal_type":"close"}

### No Site List flow
- Open the app and login to a WP account having no sites
- Tap Create Site button
- Tap "Create WordPress.com site"
- Verify that Site creation overlay is shown
- ✅ Verify that Tracked: remove_site_creation_overlay_displayed, Properties: {"phase":"one","source":"my_site_no_sites"}
- Click on **Continue with Jetpack** button 
- ✅ Verify that Tracked: remove_site_creation_overlay_dismissed, Pro perties:{"phase":"one","source":"my_site_no_sites","dismissal_type":"continue"}
- Dismiss the Overlay using close(x) button 
- ✅ Verify that Tracked: remove_site_creation_overlay_dismissed, Properties:{"phase":"one","source":"my_site_no_sites","dismissal_type":"close"}

## Login flow
- Open the app
- Logout
- Login using any method
- Tap "Create a new site"
- Verify that Site creation overlay is shown
-  ✅ Verify that Tracked: remove_site_creation_overlay_displayed, Properties: {"phase":"one","source":"login_epilogue"} is shown
- Click on **Continue with Jetpack** button 
- ✅ Verify that Tracked: remove_site_creation_overlay_dismissed, Properties:{"phase":"one","source":"login_epilogue","dismissal_type":"continue"}
- Dismiss the Overlay using close(x) button 
- ✅ Verify that Tracked: remove_site_creation_overlay_dismissed, Properties:{"phase":"one","source":"login_epilogue","dismissal_type":"close"}

## Signup flow
-  Open the app
-  Logout
-  Sign up for a new account
-  Tap "Create a new site"
-  Verify that the Site creation overlay is shown
-  ✅ Verify that Tracked: remove_site_creation_overlay_displayed, Properties: {"phase":"one","source":"signup_epilogue"} is shown
- Click on **Continue with Jetpack** button 
- ✅ Verify that Tracked: remove_site_creation_overlay_dismissed, Properties:{"phase":"one","source":"signup_epilogue","dismissal_type":"continue"}
- Repeat the above steps 
- Dismiss the Overlay using close(x) button 
- ✅ Verify that Tracked: remove_site_creation_overlay_dismissed, Properties:{"phase":"one","source":"signup_epilogue","dismissal_type":"close"}


## Regression Notes
1. Potential unintended areas of impact
Site creation events are not tracked

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.