### PR TITLE
Fixes: Try the jetpack app not being shown properly when the font size is large 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -117,13 +117,14 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         }
     }
 
+    @Suppress("unused", "UNUSED_PARAMETER")
     private fun onFeatureSpecificOverlayShown(feature: JetpackOverlayConnectedFeature) {
-        if (isInFeatureSpecificRemovalPhase())
-            jetpackFeatureOverlayShownTracker.setFeatureOverlayShownTimeStamp(
-                    feature,
-                    getCurrentPhasePreference()!!,
-                    System.currentTimeMillis()
-            )
+//        if (isInFeatureSpecificRemovalPhase())
+//            jetpackFeatureOverlayShownTracker.setFeatureOverlayShownTimeStamp(
+//                    feature,
+//                    getCurrentPhasePreference()!!,
+//                    System.currentTimeMillis()
+//            )
     }
 
     fun onOverlayShown(overlayScreenType: JetpackFeatureOverlayScreenType?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -117,14 +117,13 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         }
     }
 
-    @Suppress("unused", "UNUSED_PARAMETER")
     private fun onFeatureSpecificOverlayShown(feature: JetpackOverlayConnectedFeature) {
-//        if (isInFeatureSpecificRemovalPhase())
-//            jetpackFeatureOverlayShownTracker.setFeatureOverlayShownTimeStamp(
-//                    feature,
-//                    getCurrentPhasePreference()!!,
-//                    System.currentTimeMillis()
-//            )
+        if (isInFeatureSpecificRemovalPhase())
+            jetpackFeatureOverlayShownTracker.setFeatureOverlayShownTimeStamp(
+                    feature,
+                    getCurrentPhasePreference()!!,
+                    System.currentTimeMillis()
+            )
     }
 
     fun onOverlayShown(overlayScreenType: JetpackFeatureOverlayScreenType?) {

--- a/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
@@ -20,114 +20,108 @@
         app:tint="?attr/wpColorOnSurfaceMedium"
         tools:ignore="ContentDescription" />
 
-    <LinearLayout
+    <ScrollView
+        android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_gravity="bottom"
-        android:layout_marginTop="@dimen/margin_small"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:fillViewport="true"
+        android:layout_weight="1">
 
-        <ScrollView
-            android:id="@+id/scroll_view"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1">
+            android:layout_height="wrap_content">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <TextView
+                android:id="@+id/title"
+                style="@style/TextAppearance.Material3.HeadlineMedium"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:text="@string/wp_jetpack_powered_reader_powered_by_jetpack"
+                android:textFontWeight="700"
+                app:autoSizeTextType="none"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/illustration_view"
+                tools:targetApi="p" />
 
-                <com.airbnb.lottie.LottieAnimationView
-                    android:id="@+id/illustration_view"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-                    android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-                    android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
-                    android:scaleType="centerCrop"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:lottie_autoPlay="true"
-                    app:lottie_enableMergePathsForKitKatAndAbove="true"
-                    app:lottie_loop="false"
-                    app:lottie_rawRes="@raw/wp2jp_left" />
+            <TextView
+                android:id="@+id/caption"
+                style="?attr/textAppearanceBody1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_large"
+                android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:text="@string/wp_jetpack_powered_reader_powered_by_jetpack_caption"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/title" />
 
-                <TextView
-                    android:id="@+id/title"
-                    style="@style/TextAppearance.Material3.HeadlineMedium"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-                    android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-                    android:layout_marginTop="@dimen/margin_extra_large"
-                    android:text="@string/wp_jetpack_powered_reader_powered_by_jetpack"
-                    android:textFontWeight="700"
-                    app:autoSizeTextType="none"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/illustration_view"
-                    tools:targetApi="p" />
+            <com.airbnb.lottie.LottieAnimationView
+                android:id="@+id/illustration_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
+                android:scaleType="centerCrop"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:lottie_autoPlay="true"
+                app:lottie_enableMergePathsForKitKatAndAbove="true"
+                app:lottie_loop="false"
+                app:lottie_rawRes="@raw/wp2jp_left" />
 
-                <TextView
-                    android:id="@+id/caption"
-                    style="?attr/textAppearanceBody1"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_large"
-                    android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-                    android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-                    android:layout_marginTop="@dimen/margin_extra_large"
-                    android:text="@string/wp_jetpack_powered_reader_powered_by_jetpack_caption"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/title" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/primary_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:backgroundTint="@color/jetpack_green_50"
+                android:maxLines="2"
+                android:gravity="center"
+                android:minHeight="@dimen/margin_64dp"
+                android:text="@string/wp_jetpack_get_new_jetpack_app"
+                android:textAppearance="?attr/textAppearanceSubtitle2"
+                android:textColor="?attr/colorOnSecondary"
+                app:autoSizeMaxTextSize="@dimen/text_sz_medium"
+                app:autoSizeStepGranularity="4sp"
+                app:autoSizeTextType="uniform"
+                app:cornerRadius="@dimen/margin_small_medium"
+                app:layout_constraintBottom_toTopOf="@id/secondary_button"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/caption"
+                app:layout_constraintVertical_bias="1.0" />
 
-            </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/secondary_button"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
+                android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:gravity="center"
+                android:minHeight="@dimen/margin_extra_extra_large"
+                android:textAllCaps="false"
+                android:textAppearance="?attr/textAppearanceSubtitle2"
+                android:textColor="@color/jetpack_green_50"
+                app:autoSizeMaxTextSize="@dimen/text_sz_medium"
+                app:autoSizeStepGranularity="4sp"
+                app:autoSizeTextType="uniform"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                tools:text="Continue to Reader" />
 
-        </ScrollView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/primary_button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-            android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-            android:backgroundTint="@color/jetpack_green_50"
-            android:gravity="center"
-            android:minHeight="@dimen/margin_64dp"
-            android:text="@string/wp_jetpack_get_new_jetpack_app"
-            android:textAppearance="?attr/textAppearanceSubtitle2"
-            android:textColor="?attr/colorOnSecondary"
-            app:autoSizeMaxTextSize="@dimen/text_sz_medium"
-            app:autoSizeStepGranularity="4sp"
-            app:autoSizeTextType="uniform"
-            app:cornerRadius="@dimen/margin_small_medium"
-            app:layout_constraintBottom_toTopOf="@id/secondary_button"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/secondary_button"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
-            android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-            android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-            android:gravity="center"
-            android:minHeight="@dimen/margin_extra_extra_large"
-            android:textAllCaps="false"
-            android:textAppearance="?attr/textAppearanceSubtitle2"
-            android:textColor="@color/jetpack_green_50"
-            app:autoSizeMaxTextSize="@dimen/text_sz_medium"
-            app:autoSizeStepGranularity="4sp"
-            app:autoSizeTextType="uniform"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            tools:text="Continue to Reader" />
-    </LinearLayout>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
@@ -21,7 +21,6 @@
         tools:ignore="ContentDescription" />
 
     <ScrollView
-        android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fillViewport="true"
@@ -30,6 +29,21 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
+
+            <com.airbnb.lottie.LottieAnimationView
+                android:id="@+id/illustration_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
+                android:scaleType="centerCrop"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:lottie_autoPlay="true"
+                app:lottie_enableMergePathsForKitKatAndAbove="true"
+                app:lottie_loop="false"
+                app:lottie_rawRes="@raw/wp2jp_left" />
 
             <TextView
                 android:id="@+id/title"
@@ -60,21 +74,6 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/title" />
-
-            <com.airbnb.lottie.LottieAnimationView
-                android:id="@+id/illustration_view"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-                android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-                android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
-                android:scaleType="centerCrop"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:lottie_autoPlay="true"
-                app:lottie_enableMergePathsForKitKatAndAbove="true"
-                app:lottie_loop="false"
-                app:lottie_rawRes="@raw/wp2jp_left" />
 
             <Button
                 android:id="@+id/primary_button"
@@ -124,6 +123,5 @@
                 tools:text="Continue to Reader" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-
     </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
@@ -82,6 +82,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
                 android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
+                android:layout_marginTop="@dimen/margin_extra_large"
                 android:background="@drawable/bg_rectangle_rounded_jetpack_ripple"
                 app:backgroundTint="@color/jetpack_green_50"
                 android:maxLines="2"

--- a/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
@@ -76,16 +76,18 @@
                 app:lottie_loop="false"
                 app:lottie_rawRes="@raw/wp2jp_left" />
 
-            <com.google.android.material.button.MaterialButton
+            <Button
                 android:id="@+id/primary_button"
+                style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
                 android:layout_marginStart="@dimen/jp_migration_full_screen_overlay_padding_horizontal"
-                android:backgroundTint="@color/jetpack_green_50"
+                android:background="@drawable/bg_rectangle_rounded_jetpack_ripple"
+                app:backgroundTint="@color/jetpack_green_50"
                 android:maxLines="2"
                 android:gravity="center"
-                android:minHeight="@dimen/margin_64dp"
+                android:minHeight="@dimen/jetpack_bottom_sheet_button_height"
                 android:text="@string/wp_jetpack_get_new_jetpack_app"
                 android:textAppearance="?attr/textAppearanceSubtitle2"
                 android:textColor="?attr/colorOnSecondary"

--- a/WordPress/src/main/res/layout-land/jetpack_powered_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout-land/jetpack_powered_bottom_sheet.xml
@@ -84,7 +84,7 @@
             android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
             android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
             android:background="@drawable/bg_rectangle_rounded_jetpack_ripple"
-            app:backgroundTint="@color/jetpack_green_40"
+            app:backgroundTint="@color/jetpack_green_50"
             android:gravity="center"
             android:minHeight="@dimen/jetpack_bottom_sheet_button_height"
             android:text="@string/wp_jetpack_get_new_jetpack_app"

--- a/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
@@ -78,15 +78,16 @@
             app:lottie_loop="false"
             app:lottie_rawRes="@raw/wp2jp_left" />
 
-        <com.google.android.material.button.MaterialButton
+        <Button
             android:id="@+id/primary_button"
+            style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
             android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
-            android:backgroundTint="@color/jetpack_green_50"
+            android:background="@drawable/bg_rectangle_rounded_jetpack_ripple"
+            app:backgroundTint="@color/jetpack_green_50"
             android:gravity="center"
-            android:minHeight="@dimen/margin_64dp"
             android:text="@string/wp_jetpack_get_new_jetpack_app"
             android:textAppearance="?attr/textAppearanceSubtitle2"
             android:textColor="?attr/colorOnSecondary"
@@ -94,8 +95,7 @@
             app:autoSizeStepGranularity="4sp"
             app:autoSizeTextType="uniform"
             android:maxLines="2"
-            app:cornerRadius="@dimen/margin_small_medium"
-            app:layout_constraintBottom_toTopOf="@id/secondary_button"
+            android:minHeight="@dimen/jetpack_bottom_sheet_button_height"            app:layout_constraintBottom_toTopOf="@id/secondary_button"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 

--- a/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
@@ -1,100 +1,87 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/jetpack_powered_bottom_sheet_background">
+    android:layout_marginTop="@dimen/margin_small"
+    android:layout_weight="1"
+    android:fillViewport="true"
+    android:background="@color/jetpack_powered_bottom_sheet_background"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="bottom"
-        android:layout_marginTop="@dimen/margin_small"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
-        <ScrollView
-            android:id="@+id/scroll_view"
+        <ImageButton
+            android:id="@+id/close_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/jetpack_full_screen_overlay_margin_close_button"
+            android:layout_marginTop="@dimen/jetpack_full_screen_overlay_margin_close_button"
+            android:background="?attr/selectableItemBackground"
+            android:padding="@dimen/margin_medium"
+            android:src="@drawable/ic_close_white_24dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/wpColorOnSurfaceMedium"
+            tools:ignore="ContentDescription" />
+
+        <TextView
+            android:id="@+id/title"
+            style="@style/TextAppearance.Material3.HeadlineMedium"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1">
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginTop="@dimen/margin_extra_medium_large"
+            android:text="@string/wp_jetpack_powered_reader_powered_by_jetpack"
+            android:textFontWeight="700"
+            app:autoSizeMaxTextSize="@dimen/text_sz_extra_extra_large"
+            app:autoSizeMinTextSize="@dimen/m3_sys_typescale_headline_medium_text_size"
+            app:autoSizeStepGranularity="2sp"
+            app:autoSizeTextType="uniform"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/illustration_view"
+            tools:targetApi="p" />
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+        <TextView
+            android:id="@+id/caption"
+            style="?attr/textAppearanceBody1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginTop="@dimen/margin_extra_medium_large"
+            android:text="@string/wp_jetpack_powered_reader_powered_by_jetpack_caption"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/title" />
 
-                <ImageButton
-                    android:id="@+id/close_button"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/jetpack_full_screen_overlay_margin_close_button"
-                    android:layout_marginTop="@dimen/jetpack_full_screen_overlay_margin_close_button"
-                    android:background="?attr/selectableItemBackground"
-                    android:padding="@dimen/margin_medium"
-                    android:src="@drawable/ic_close_white_24dp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:tint="?attr/wpColorOnSurfaceMedium"
-                    tools:ignore="ContentDescription" />
-
-                <com.airbnb.lottie.LottieAnimationView
-                    android:id="@+id/illustration_view"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
-                    android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
-                    android:layout_marginTop="@dimen/margin_64dp"
-                    android:scaleType="centerCrop"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/close_button"
-                    app:lottie_autoPlay="true"
-                    app:lottie_enableMergePathsForKitKatAndAbove="true"
-                    app:lottie_loop="false"
-                    app:lottie_rawRes="@raw/wp2jp_left" />
-
-                <TextView
-                    android:id="@+id/title"
-                    style="@style/TextAppearance.Material3.HeadlineMedium"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
-                    android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
-                    android:layout_marginTop="@dimen/margin_extra_medium_large"
-                    android:text="@string/wp_jetpack_powered_reader_powered_by_jetpack"
-                    android:textFontWeight="700"
-                    app:autoSizeMaxTextSize="@dimen/text_sz_extra_extra_large"
-                    app:autoSizeMinTextSize="@dimen/m3_sys_typescale_headline_medium_text_size"
-                    app:autoSizeStepGranularity="2sp"
-                    app:autoSizeTextType="uniform"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/illustration_view"
-                    tools:targetApi="p" />
-
-                <TextView
-                    android:id="@+id/caption"
-                    style="?attr/textAppearanceBody1"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_large"
-                    android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
-                    android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
-                    android:layout_marginTop="@dimen/margin_extra_medium_large"
-                    android:text="@string/wp_jetpack_powered_reader_powered_by_jetpack_caption"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/title" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-        </ScrollView>
+        <com.airbnb.lottie.LottieAnimationView
+            android:id="@+id/illustration_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginTop="@dimen/margin_64dp"
+            android:scaleType="centerCrop"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/close_button"
+            app:lottie_autoPlay="true"
+            app:lottie_enableMergePathsForKitKatAndAbove="true"
+            app:lottie_loop="false"
+            app:lottie_rawRes="@raw/wp2jp_left" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/primary_button"
             android:layout_width="match_parent"
-            android:layout_height="50dp"
+            android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
             android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
             android:backgroundTint="@color/jetpack_green_50"
@@ -106,6 +93,7 @@
             app:autoSizeMaxTextSize="@dimen/text_sz_medium"
             app:autoSizeStepGranularity="4sp"
             app:autoSizeTextType="uniform"
+            android:maxLines="2"
             app:cornerRadius="@dimen/margin_small_medium"
             app:layout_constraintBottom_toTopOf="@id/secondary_button"
             app:layout_constraintEnd_toEndOf="parent"
@@ -117,9 +105,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginBottom="@dimen/margin_64dp"
             android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
             android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginBottom="@dimen/margin_extra_medium_large"
             android:gravity="center"
             android:minHeight="@dimen/margin_extra_extra_large"
             android:textAllCaps="false"
@@ -128,9 +116,11 @@
             app:autoSizeMaxTextSize="@dimen/text_sz_medium"
             app:autoSizeStepGranularity="4sp"
             app:autoSizeTextType="uniform"
+            android:maxLines="2"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             tools:text="Continue to Reader" />
-    </LinearLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>

--- a/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
@@ -28,6 +28,21 @@
             app:tint="?attr/wpColorOnSurfaceMedium"
             tools:ignore="ContentDescription" />
 
+        <com.airbnb.lottie.LottieAnimationView
+            android:id="@+id/illustration_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginTop="@dimen/margin_64dp"
+            android:scaleType="centerCrop"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/close_button"
+            app:lottie_autoPlay="true"
+            app:lottie_enableMergePathsForKitKatAndAbove="true"
+            app:lottie_loop="false"
+            app:lottie_rawRes="@raw/wp2jp_left" />
+
         <TextView
             android:id="@+id/title"
             style="@style/TextAppearance.Material3.HeadlineMedium"
@@ -60,21 +75,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/title" />
-
-        <com.airbnb.lottie.LottieAnimationView
-            android:id="@+id/illustration_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
-            android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
-            android:layout_marginTop="@dimen/margin_64dp"
-            android:scaleType="centerCrop"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/close_button"
-            app:lottie_autoPlay="true"
-            app:lottie_enableMergePathsForKitKatAndAbove="true"
-            app:lottie_loop="false"
-            app:lottie_rawRes="@raw/wp2jp_left" />
 
         <Button
             android:id="@+id/primary_button"
@@ -124,6 +124,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             tools:text="Continue to Reader" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
 
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
@@ -7,9 +7,7 @@
     android:layout_marginTop="@dimen/margin_small"
     android:layout_weight="1"
     android:fillViewport="true"
-    android:background="@color/jetpack_powered_bottom_sheet_background"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintTop_toTopOf="parent">
+    android:background="@color/jetpack_powered_bottom_sheet_background">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -83,21 +81,26 @@
             style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
             android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
             android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginTop="8dp"
             android:background="@drawable/bg_rectangle_rounded_jetpack_ripple"
-            app:backgroundTint="@color/jetpack_green_50"
             android:gravity="center"
+            android:maxLines="2"
+            android:minHeight="@dimen/jetpack_bottom_sheet_button_height"
             android:text="@string/wp_jetpack_get_new_jetpack_app"
             android:textAppearance="?attr/textAppearanceSubtitle2"
             android:textColor="?attr/colorOnSecondary"
             app:autoSizeMaxTextSize="@dimen/text_sz_medium"
             app:autoSizeStepGranularity="4sp"
             app:autoSizeTextType="uniform"
-            android:maxLines="2"
-            android:minHeight="@dimen/jetpack_bottom_sheet_button_height"            app:layout_constraintBottom_toTopOf="@id/secondary_button"
+            app:backgroundTint="@color/jetpack_green_50"
+            app:layout_constraintBottom_toTopOf="@+id/secondary_button"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/caption"
+            app:layout_constraintVertical_bias="1.0" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/secondary_button"

--- a/WordPress/src/main/res/layout/jetpack_powered_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/jetpack_powered_bottom_sheet.xml
@@ -85,7 +85,7 @@
             android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
             android:layout_marginBottom="@dimen/margin_64dp"
             android:background="@drawable/bg_rectangle_rounded_jetpack_ripple"
-            app:backgroundTint="@color/jetpack_green_40"
+            app:backgroundTint="@color/jetpack_green_50"
             android:gravity="center"
             android:minHeight="@dimen/jetpack_bottom_sheet_button_height"
             android:text="@string/wp_jetpack_get_new_jetpack_app"


### PR DESCRIPTION
Fixes #17521 

This PR fixes the issue when the display and font size are large, the button text is not visible. 

## Changes 
1. Makes the button wrap the button text so that its visible. The button text is set to have a max text line of 2 right now
2. Makes the content scrollable including the buttons in Landcape and Portrait mode so that the content as well as the Button texts are visible .

The buttons would be visible on the bottom as before in normal text size and when the display size increases, the buttons will be visible when the content is scrolled. 

|Before Fix | After fix|
|---|---|
|![Screenshot_20221122_193453](https://user-images.githubusercontent.com/17463767/203942748-f7cec7c4-e718-4e71-9573-7097ab972f66.png)|![Screenshot_20221125-165249](https://user-images.githubusercontent.com/17463767/203986771-d37572e7-95ec-4fba-a539-c6a8f3d5c6ad.png)|  

### To test:
Pre- Requisites 
Launch WP app -> Go to my site -> App settings -> Debug settings -> Enable jp_removal_one flag

###  Check if the fonts are displayed properly on Properly in Landscape and Portrait 
1. Launch the app -> Go to my site -> Access stats/reader/notification feature 
4. Verify that the UI is shown properly 

|Landscape|Portrait|
|---|---|
|![Screenshot_20221122_173149](https://user-images.githubusercontent.com/17463767/203309866-2c19bcd3-28aa-4b96-b750-3cc4b4539638.png)|![Screenshot_20221122_173214](https://user-images.githubusercontent.com/17463767/203309879-f30dd92b-f56e-40e1-abaf-55effba07213.png)|  

###  Check if the fonts are displayed properly on increasing the size of the fonts 
1. Go to system settings -> Display and font size -> Increase both display size and font size
2. Launch the app -> Go to my site -> Access stats/reader/notification feature 
5. Verify that the UI is shown properly


|Landscape(Scrollable)|Portrait|
|---|---|
|![Screenshot_20221125-002359](https://user-images.githubusercontent.com/17463767/203991216-9b1f2e6e-32db-4b2d-a440-e30b76c2a7ce.png)|![Screenshot_20221122_173422](https://user-images.githubusercontent.com/17463767/203311797-7b19d5ad-e78d-4c7b-9b0e-799cc935e512.png)|  

Landscape Scrollable - Video capture 
https://user-images.githubusercontent.com/17463767/203991283-b927abb2-1847-4dd0-b536-eb91b2b96789.mp4

cc: @JB184351 @zwarm  for visibility 

## ⚠️ Merge Instructions
- [x] Revert commit ffbe6fe3e33476fb323a744bfcb2d6227ee0abea - used for testing purposes
- [x] Remove Not Ready for Merge label
- [ ] Merge as normal

## Regression Notes
1. Potential unintended areas of impact
Jetpack overlay is not shown properly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
