### PR TITLE
Jetpack Focus: Show open links with Jetpack Overlay from reader deep link receiver

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -81,6 +81,7 @@ import org.wordpress.android.push.NotificationType
 import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityId
 import org.wordpress.android.ui.debug.cookies.DebugCookieManager
+import org.wordpress.android.ui.deeplinks.DeepLinkOpenWebLinksWithJetpackHelper
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter
@@ -113,6 +114,7 @@ import org.wordpress.android.util.VolleyUtils
 import org.wordpress.android.util.WPActivityUtils
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.util.config.AppConfig
+import org.wordpress.android.util.config.OpenWebLinksWithJetpackFlowFeatureConfig
 import org.wordpress.android.util.enqueuePeriodicUploadWorkRequestForAllSites
 import org.wordpress.android.util.experiments.ExPlat
 import org.wordpress.android.util.image.ImageManager
@@ -160,6 +162,10 @@ class AppInitializer @Inject constructor(
     @Inject @Named("custom-ssl") lateinit var requestQueue: RequestQueue
     @Inject lateinit var imageLoader: FluxCImageLoader
     @Inject lateinit var oAuthAuthenticator: OAuthAuthenticator
+
+    // For jetpack focus
+    @Inject lateinit var openWebLinksWithJetpackFlowFeatureConfig: OpenWebLinksWithJetpackFlowFeatureConfig
+    @Inject lateinit var openWebLinksWithJetpackHelper: DeepLinkOpenWebLinksWithJetpackHelper
 
     private lateinit var applicationLifecycleMonitor: ApplicationLifecycleMonitor
     lateinit var storyNotificationTrackerProvider: StoryNotificationTrackerProvider
@@ -655,6 +661,16 @@ class AppInitializer @Inject constructor(
         }
     }
 
+    private fun enableDeepLinkingComponentsIfNeeded() {
+        if (openWebLinksWithJetpackFlowFeatureConfig.isEnabled()) {
+            if (!AppPrefs.getIsOpenWebLinksWithJetpack()) {
+                openWebLinksWithJetpackHelper.enableDisableOpenWithJetpackComponents(false)
+            }
+        } else {
+            openWebLinksWithJetpackHelper.enableDisableOpenWithJetpackComponents(false)
+        }
+    }
+
     private fun flushHttpCache() {
         val cache = HttpResponseCache.getInstalled()
         cache?.flush()
@@ -748,8 +764,8 @@ class AppInitializer @Inject constructor(
 
             readerTracker.onAppGoesToBackground()
 
-            // Ensure that the deeplinking activity is re-enabled.
-            WPActivityUtils.enableReaderDeeplinks(context)
+            // Ensure that the deeplinking activity is are re-enabled if needed
+            enableDeepLinkingComponentsIfNeeded()
 
             AnalyticsTracker.track(Stat.APPLICATION_CLOSED, properties)
             AnalyticsTracker.endSession(false)

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -111,7 +111,6 @@ import org.wordpress.android.util.QuickStartUtils
 import org.wordpress.android.util.RateLimitedTask
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.VolleyUtils
-import org.wordpress.android.util.WPActivityUtils
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.util.config.AppConfig
 import org.wordpress.android.util.config.OpenWebLinksWithJetpackFlowFeatureConfig

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -101,7 +101,7 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
 
     private fun getPackageName(): String {
         val appSuffix = buildConfigWrapper.getApplicationId().split(".").last()
-        val appPackage = if (appSuffix.isNotBlank()) {
+        val appPackage = if (appSuffix.isNotBlank() && !appSuffix.equals("ANDROID", ignoreCase = true)) {
             "$JETPACK_PACKAGE_NAME.${appSuffix}"
         } else {
             JETPACK_PACKAGE_NAME

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -42,8 +42,13 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
     }
 
     fun handleJetpackUninstalled() {
+        resetAll()
+    }
+
+    fun resetAll() {
         enableDisableOpenWithJetpackComponents(false)
         appPrefsWrapper.setIsOpenWebLinksWithJetpack(false)
+        appPrefsWrapper.setOpenWebLinksWithJetpackOverlayLastShownTimestamp(0L)
     }
 
     @Suppress("SwallowedException")

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -52,7 +52,6 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
             enableDisableOpenWithJetpackComponents(true)
             packageManagerWrapper.disableReaderDeepLinks()
             appPrefsWrapper.setIsOpenWebLinksWithJetpack(true)
-            appPrefsWrapper.setOpenWebLinksWithJetpackOverlayLastShownTimestamp(System.currentTimeMillis())
             return true
         } catch (ex: PackageManager.NameNotFoundException) {
             AppLog.e(T.UTILS, "Unable to set open web links with Jetpack ${ex.message}")
@@ -104,6 +103,10 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
         }
         return appPackage
     }
+
+    fun onOverlayShown() =
+            appPrefsWrapper.setOpenWebLinksWithJetpackOverlayLastShownTimestamp(System.currentTimeMillis())
+
 
     companion object {
         const val JETPACK_PACKAGE_NAME = "com.jetpack.android"

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayViewModel;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.ForwardToJetpack;
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource;
 import org.wordpress.android.util.PackageManagerWrapper;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UriWrapper;
@@ -96,7 +97,7 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
 
     private void showOverlay() {
         JetpackFeatureFullScreenOverlayFragment
-                .newInstance(null, false, true, null)
+                .newInstance(null, false, true, SiteCreationSource.UNSPECIFIED)
                 .show(getSupportFragmentManager(), JetpackFeatureFullScreenOverlayFragment.TAG);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -171,6 +171,7 @@ class DeepLinkingIntentReceiverViewModel
         return if (deepLinkEntryPoint == WEB_LINKS &&
                 accountStore.hasAccessToken() && // Already logged in
                 openWebLinksWithJetpackHelper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()) {
+            openWebLinksWithJetpackHelper.onOverlayShown()
             _showOpenWebLinksWithJetpackOverlay.value = Event(Unit)
             true
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
@@ -120,7 +120,7 @@ class JetpackFeatureOverlayContentBuilder @Inject constructor() {
                 illustration = if (rtl) R.raw.wp2jp_rtl else R.raw.wp2jp_left,
                 title = R.string.wp_jetpack_deep_link_overlay_title,
                 caption = R.string.wp_jetpack_deep_link_overlay_description,
-                primaryButtonText = R.string.wp_jetpack_deep_link_open_with_jetpack,
+                primaryButtonText = R.string.wp_jetpack_deep_link_open_in_jetpack,
                 secondaryButtonText = R.string.wp_jetpack_continue_without_jetpack
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -58,6 +58,7 @@ import org.wordpress.android.ui.notifications.utils.NotificationsUtils
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MAIN
@@ -103,6 +104,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     @Inject lateinit var qrCodeAuthFlowFeatureConfig: QRCodeAuthFlowFeatureConfig
     @Inject lateinit var jetpackBrandingUtils: JetpackBrandingUtils
     @Inject lateinit var packageManagerWrapper: PackageManagerWrapper
+    @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
     private val viewModel: MeViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -447,6 +449,8 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         packageManagerWrapper.enableReaderDeeplinks()
         packageManagerWrapper.enableComponentEnableSetting(
                 DeepLinkOpenWebLinksWithJetpackHelper.WEB_LINKS_DEEPLINK_ACTIVITY_ALIAS)
+        appPrefsWrapper.setOpenWebLinksWithJetpackOverlayLastShownTimestamp(0L)
+        appPrefsWrapper.setIsOpenWebLinksWithJetpack(false)
     }
 
     @Suppress("DEPRECATION")

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -140,7 +140,6 @@ import org.wordpress.android.util.QuickStartUtilsWrapper;
 import org.wordpress.android.util.ShortcutUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.service.InstallationReferrerServiceStarter;
@@ -401,7 +400,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         }
 
         // Ensure deep linking activities are enabled.They may have been disabled elsewhere and failed to get re-enabled
-        enableComponentsIfNeeded();
+        enableDeepLinkingComponentsIfNeeded();
 
         // monitor whether we're not the default app
         trackDefaultApp();
@@ -933,7 +932,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         // ensure the deep linking activity is enabled. We might be returning from the external-browser
         // viewing of a post
-        WPActivityUtils.enableReaderDeeplinks(this);
+        enableDeepLinkingComponentsIfNeeded();
 
         // We need to track the current item on the screen when this activity is resumed.
         // Ex: Notifications -> notifications detail -> back to notifications
@@ -1719,13 +1718,14 @@ public class WPMainActivity extends LocaleAwareActivity implements
         QuickStartUtils.removeQuickStartFocusPoint(findViewById(R.id.root_view_main));
     }
 
-    private void enableComponentsIfNeeded() {
+    private void enableDeepLinkingComponentsIfNeeded() {
         if (mOpenWebLinksWithJetpackFlowFeatureConfig.isEnabled()) {
             if (!AppPrefs.getIsOpenWebLinksWithJetpack()) {
                 mDeepLinkOpenWebLinksWithJetpackHelper.enableDisableOpenWithJetpackComponents(false);
             }
         } else {
-            WPActivityUtils.enableReaderDeeplinks(this);
+            // re-enable all deep linking components
+            mDeepLinkOpenWebLinksWithJetpackHelper.enableDisableOpenWithJetpackComponents(false);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1487,6 +1487,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     private void handleSiteRemoved() {
         mViewModel.handleSiteRemoved();
         if (!mViewModel.isSignedInWPComOrHasWPOrgSite()) {
+            mDeepLinkOpenWebLinksWithJetpackHelper.resetAll();
             showSignInForResultBasedOnIsJetpackAppBuildConfig(this);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -710,8 +710,8 @@ public class AppSettingsFragment extends PreferenceFragment
         } catch (Exception e) {
             ToastUtils.showToast(
                     getActivity(),
-                    (newValue ? R.string.preference_open_web_links_with_jetpack_setting_change_enable_error
-                            : R.string.preference_open_web_links_with_jetpack_setting_change_disable_error),
+                    (newValue ? R.string.preference_open_links_in_jetpack_setting_change_enable_error
+                            : R.string.preference_open_links_in_jetpack_setting_change_disable_error),
                     ToastUtils.Duration.LONG);
             AppLog.e(AppLog.T.UTILS, "Unable to enable or disable open with Jetpack components ", e);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -66,6 +66,7 @@ import org.wordpress.android.ui.uploads.UploadUtilsWrapper;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UriWrapper;
@@ -473,17 +474,20 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
     }
 
     private Boolean checkAndShowOpenWebLinksWithJetpackOverlayIfNeeded() {
-        if (mAccountStore == null || mAccountStore.hasAccessToken()) return false;
+        if (!isSignedInWPComOrHasWPOrgSite()) return false;
 
-        if (!mDeepLinkOpenWebLinksWithJetpackHelper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()) {
-            return false;
-        }
+        if (!mDeepLinkOpenWebLinksWithJetpackHelper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()) return false;
 
         mDeepLinkOpenWebLinksWithJetpackHelper.onOverlayShown();
         JetpackFeatureFullScreenOverlayFragment
                 .newInstance(null, false, true, SiteCreationSource.UNSPECIFIED)
                 .show(getSupportFragmentManager(), JetpackFeatureFullScreenOverlayFragment.TAG);
         return true;
+    }
+
+    private Boolean isSignedInWPComOrHasWPOrgSite() {
+        if (mAccountStore == null || mSiteStore == null) return false;
+        return FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.viewpager.widget.ViewPager;
 
 import org.greenrobot.eventbus.EventBus;
@@ -40,7 +41,11 @@ import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.WPLaunchActivity;
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInReader;
+import org.wordpress.android.ui.deeplinks.DeepLinkOpenWebLinksWithJetpackHelper;
 import org.wordpress.android.ui.deeplinks.DeepLinkTrackingUtils;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayViewModel;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.ForwardToJetpack;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -53,6 +58,7 @@ import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
 import org.wordpress.android.ui.reader.tracker.ReaderTracker;
 import org.wordpress.android.ui.reader.tracker.ReaderTrackerType;
 import org.wordpress.android.ui.reader.utils.ReaderPostSeenStatusWrapper;
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource;
 import org.wordpress.android.ui.uploads.UploadActionUseCase;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper;
@@ -63,6 +69,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UriWrapper;
 import org.wordpress.android.util.UrlUtilsWrapper;
+import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper;
 import org.wordpress.android.util.config.SeenUnseenWithCounterFeatureConfig;
 import org.wordpress.android.widgets.WPSwipeSnackbar;
@@ -150,11 +157,14 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
     @Inject UrlUtilsWrapper mUrlUtilsWrapper;
     @Inject DeepLinkTrackingUtils mDeepLinkTrackingUtils;
     @Inject SelectedSiteRepository mSelectedSiteRepository;
+    @Inject DeepLinkOpenWebLinksWithJetpackHelper mDeepLinkOpenWebLinksWithJetpackHelper;
+    private JetpackFeatureFullScreenOverlayViewModel mJetpackFullScreenViewModel;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
+        mJetpackFullScreenViewModel = new ViewModelProvider(this).get(JetpackFeatureFullScreenOverlayViewModel.class);
 
         setContentView(R.layout.reader_activity_post_pager);
 
@@ -238,6 +248,26 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
                 false,
                 new WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER)
         );
+
+        observeOverlayEvents();
+    }
+
+    private void observeOverlayEvents() {
+        mJetpackFullScreenViewModel.getAction().observe(this,
+                action -> {
+                    if (action instanceof ForwardToJetpack) {
+                        if (!mDeepLinkOpenWebLinksWithJetpackHelper.handleOpenWebLinksWithJetpack()) {
+                            finishDeepLinkRequestFromOverlay(getIntent().getAction(), getIntent().getData());
+                        } else {
+                            WPActivityUtils.disableReaderDeeplinks(this);
+                            ActivityLauncher.openJetpackForDeeplink(this, getIntent().getAction(),
+                                    new UriWrapper(getIntent().getData()));
+                            finish();
+                        }
+                    } else {
+                        finishDeepLinkRequestFromOverlay(getIntent().getAction(), getIntent().getData());
+                    }
+                });
     }
 
     private void handleDeepLinking() {
@@ -260,6 +290,19 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
             return;
         }
 
+        if (!checkAndShowOpenWebLinksWithJetpackOverlayIfNeeded()) {
+            finishDeepLinkRequest(action, uri);
+        }
+    }
+
+    private void finishDeepLinkRequestFromOverlay(String action, Uri uri) {
+        finishDeepLinkRequest(action, uri);
+        // We interrupted the normal flow to show the overly, we now need to rerun these methods on a dismiss action
+        loadPosts(mBlogId, mPostId);
+        mBackFromLogin = false;
+    }
+
+    private void finishDeepLinkRequest(String action, Uri uri) {
         InterceptType interceptType = InterceptType.READER_BLOG;
         String blogIdentifier = null; // can be an id or a slug
         String postIdentifier = null; // can be an id or a slug
@@ -424,6 +467,16 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
             return false;
         }
 
+        return true;
+    }
+
+    private Boolean checkAndShowOpenWebLinksWithJetpackOverlayIfNeeded() {
+        if (!mDeepLinkOpenWebLinksWithJetpackHelper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()) {
+            return false;
+        }
+        JetpackFeatureFullScreenOverlayFragment
+                .newInstance(null, false, true, SiteCreationSource.UNSPECIFIED)
+                .show(getSupportFragmentManager(), JetpackFeatureFullScreenOverlayFragment.TAG);
         return true;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -474,6 +474,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
         if (!mDeepLinkOpenWebLinksWithJetpackHelper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()) {
             return false;
         }
+        mDeepLinkOpenWebLinksWithJetpackHelper.onOverlayShown();
         JetpackFeatureFullScreenOverlayFragment
                 .newInstance(null, false, true, SiteCreationSource.UNSPECIFIED)
                 .show(getSupportFragmentManager(), JetpackFeatureFullScreenOverlayFragment.TAG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -31,6 +31,7 @@ import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.fluxc.store.SiteStore;
@@ -159,6 +160,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
     @Inject SelectedSiteRepository mSelectedSiteRepository;
     @Inject DeepLinkOpenWebLinksWithJetpackHelper mDeepLinkOpenWebLinksWithJetpackHelper;
     private JetpackFeatureFullScreenOverlayViewModel mJetpackFullScreenViewModel;
+    @Inject AccountStore mAccountStore;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -471,9 +473,12 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
     }
 
     private Boolean checkAndShowOpenWebLinksWithJetpackOverlayIfNeeded() {
+        if (mAccountStore == null || mAccountStore.hasAccessToken()) return false;
+
         if (!mDeepLinkOpenWebLinksWithJetpackHelper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()) {
             return false;
         }
+
         mDeepLinkOpenWebLinksWithJetpackHelper.onOverlayShown();
         JetpackFeatureFullScreenOverlayFragment
                 .newInstance(null, false, true, SiteCreationSource.UNSPECIFIED)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4273,9 +4273,9 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jp_migration_need_help_button">Need help?</string>
 
     <!-- Open Web Links With Jetpack -->
-    <string name="preference_open_web_links_with_jetpack">Open links with Jetpack</string>
-    <string name="preference_open_web_links_with_jetpack_setting_change_enable_error">Unable to enable open web links with Jetpack</string>
-    <string name="preference_open_web_links_with_jetpack_setting_change_disable_error">Unable to disable open web links with Jetpack</string>
+    <string name="preference_open_links_in_jetpack">Open links in Jetpack</string>
+    <string name="preference_open_links_in_jetpack_setting_change_enable_error">Unable to enable open web links with Jetpack</string>
+    <string name="preference_open_links_in_jetpack_setting_change_disable_error">Unable to disable open web links with Jetpack</string>
 
     <!-- Jetpack feature overlay strings in WordPress App -->
     <string name="wp_jetpack_feature_removal_overlay_phase_one_title_stats">Get your stats using the new Jetpack app</string>
@@ -4297,6 +4297,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <string name="wp_jetpack_deep_link_overlay_title">Open links in Jetpack?</string>
     <string name="wp_jetpack_deep_link_overlay_description">It looks like you have the Jetpack app installed.\n\nWould you like to open links in the Jetpack app in the future?\n\nYou can always change this in App Settings > Open links in Jetpack</string>
-    <string name="wp_jetpack_deep_link_open_with_jetpack">Open links in Jetpack</string>
+    <string name="wp_jetpack_deep_link_open_in_jetpack" translatable="false">@string/preference_open_links_in_jetpack</string>
 
 </resources>

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -80,7 +80,7 @@
         android:id="@+id/pref_open_web_links_with_jetpack"
         android:defaultValue="false"
         android:key="@string/pref_key_open_web_links_with_jetpack"
-        android:title="@string/preference_open_web_links_with_jetpack" />
+        android:title="@string/preference_open_links_in_jetpack" />
 
     <Preference
         android:key="@string/pref_key_whats_new"


### PR DESCRIPTION
Parent #17494 

This PR shows the Open links with Jetpack Overlay screen when launched in the ReaderPostPagerActivity context. 

Modifications include
- Updates to `ReaderPostPagerActivity` to launch the overlay or continue handling deep links
- Updates to `AppInitializer` and `WPMainActivity` to handle re-enabling deep linking components if needed.
- Fix the overlay shown timestamp logic so it actually updates the ts on overlay shown (not just on the overlay CTA positive click)

To test:
HTML to test reader link 
`<p><a href="https://zieglerkirby.wordpress.com/2022/09/29/knapsack-share">Reader Post</a></p>`

**Test: Ensure reader deep links are handled as normal**
- Uninstall all previous versions of JP & WP
- Install the WP APK from this PR and login
- Enable the pre-alpha app to handle verified web links links. On a pixel device you will find this under Open By Default > Tap + Add Link > Check all three checkboxes and then click Add.
- Click on the link above from the mobile browser on your device
- ✅ Verify that the WordPress app was launched

**Test: Ensure that overlay is shown and dismiss works**
- Go to My Site -> Me -> App Settings -> Debug settings.
- Enable open_web_lnks_with_jetpack_flow and restart the app
- Navigate to Me -> App Settings
- Disable the Open web links with Jetpack setting if it is enabled
- Click on the link above from the mobile browser on your device
- ✅ Verify that the Open Links with Jetpack overlay is shown
- Tap the "Continue without Jetpack" link
- ✅ Verify that the overlay is dismissed and you are deep linked into reader area of the app (if JP is installed, then in the JP app or if JP is not installed, a browser will open)

**Test: Ensure that overlay is shown and close works**
- Logout of the WP app to reset clear the overlay shown and open links with jetpack setting
- Log in to the app
- Follow the steps in "Test: Ensure that overlay is shown and dismiss works", stopping after the first verify
- Tap the "X' to close the overlay
- ✅ Verify that the overlay is dismissed and you are deep linked into the stat view


## Regression Notes
1. Potential unintended areas of impact
Reader deep links do not work

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
