### PR TITLE
Disable quick start notifications with Notification Settings switch

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -149,7 +149,6 @@ import org.wordpress.android.ui.publicize.PublicizeWebViewFragment;
 import org.wordpress.android.ui.publicize.adapters.PublicizeConnectionAdapter;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.quickstart.QuickStartFullScreenDialogFragment;
-import org.wordpress.android.ui.quickstart.QuickStartReminderReceiver;
 import org.wordpress.android.ui.reader.CommentNotificationsBottomSheetFragment;
 import org.wordpress.android.ui.reader.ReaderBlogFragment;
 import org.wordpress.android.ui.reader.ReaderCommentListActivity;
@@ -434,8 +433,6 @@ public interface AppComponent {
     void inject(WordPressGlideModule object);
 
     void inject(QuickStartFullScreenDialogFragment object);
-
-    void inject(QuickStartReminderReceiver object);
 
     void inject(MediaGridAdapter object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
@@ -11,7 +11,6 @@ import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.store.QuickStartStore;
 import org.wordpress.android.push.NotificationPushIds;
@@ -27,6 +26,9 @@ import javax.inject.Inject;
 
 import static org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class QuickStartReminderReceiver extends BroadcastReceiver {
     public static final String ARG_QUICK_START_TASK_BATCH = "ARG_QUICK_START_TASK_BATCH";
 
@@ -38,8 +40,6 @@ public class QuickStartReminderReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        ((WordPress) context.getApplicationContext()).component().inject(this);
-
         Bundle bundleWithQuickStartTaskDetails = intent.getBundleExtra(ARG_QUICK_START_TASK_BATCH);
 
         if (bundleWithQuickStartTaskDetails == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
@@ -5,6 +5,7 @@ import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.core.app.NotificationCompat;
@@ -21,6 +22,7 @@ import org.wordpress.android.ui.mysite.MySiteViewModel;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
+import org.wordpress.android.viewmodel.ResourceProvider;
 
 import javax.inject.Inject;
 
@@ -32,6 +34,8 @@ import dagger.hilt.android.AndroidEntryPoint;
 public class QuickStartReminderReceiver extends BroadcastReceiver {
     public static final String ARG_QUICK_START_TASK_BATCH = "ARG_QUICK_START_TASK_BATCH";
 
+    @Inject SharedPreferences mSharedPreferences;
+    @Inject ResourceProvider mResourceProvider;
     @Inject QuickStartStore mQuickStartStore;
     @Inject SystemNotificationsTracker mSystemNotificationsTracker;
     @Inject SelectedSiteRepository mSelectedSiteRepository;
@@ -40,6 +44,12 @@ public class QuickStartReminderReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        String notificationSettingsPrefKey = mResourceProvider.getString(R.string.wp_pref_notifications_main);
+        boolean isNotificationSettingsEnabled = mSharedPreferences.getBoolean(notificationSettingsPrefKey, true);
+        if (!isNotificationSettingsEnabled) {
+            return;
+        }
+
         Bundle bundleWithQuickStartTaskDetails = intent.getBundleExtra(ARG_QUICK_START_TASK_BATCH);
 
         if (bundleWithQuickStartTaskDetails == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
@@ -22,7 +22,6 @@ import org.wordpress.android.ui.mysite.MySiteViewModel;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
-import org.wordpress.android.viewmodel.ResourceProvider;
 
 import javax.inject.Inject;
 
@@ -35,7 +34,6 @@ public class QuickStartReminderReceiver extends BroadcastReceiver {
     public static final String ARG_QUICK_START_TASK_BATCH = "ARG_QUICK_START_TASK_BATCH";
 
     @Inject SharedPreferences mSharedPreferences;
-    @Inject ResourceProvider mResourceProvider;
     @Inject QuickStartStore mQuickStartStore;
     @Inject SystemNotificationsTracker mSystemNotificationsTracker;
     @Inject SelectedSiteRepository mSelectedSiteRepository;
@@ -44,7 +42,7 @@ public class QuickStartReminderReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        String notificationSettingsPrefKey = mResourceProvider.getString(R.string.wp_pref_notifications_main);
+        String notificationSettingsPrefKey = context.getString(R.string.wp_pref_notifications_main);
         boolean isNotificationSettingsEnabled = mSharedPreferences.getBoolean(notificationSettingsPrefKey, true);
         if (!isNotificationSettingsEnabled) {
             return;


### PR DESCRIPTION
This PR adds the ability to prevent quick start notifications with the Notification Settings switch.

I haven't added this to the release notes since I don't think this is a notable change.

### To test:

**Manipulate notification interval**
_For the best, it should be tested without changing the code._ Normally the notification will appear after 2 days. To make it 10 seconds, update [QUICK_START_REMINDER_INTERVAL](https://github.com/wordpress-mobile/WordPress-Android/blob/12a467e4a111d626241e0a5e89f12c76a27e372b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt#L40) to `10000`.

**Scheduling quick start notification**
1. Launch the app.
2. Create a new site. 
3. Tap "Show me around" when it's asked to learn with a quick walkthrough.
4. Quick start items will be shown on "My Site ➞ MENU". Tap "Customize your site" and complete an item. 
5. After completing an item, an alarm for a quick start notification should be set.

**Switch is on**
1. Schedule a quick start notification.
2. Ensure the quick start notification is delivered on time.

**Switch is off**
1. Schedule a quick start notification.
2. Ensure the quick start notification isn't delivered.

## Regression Notes
1. Potential unintended areas of impact
None

4. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
Nothing. It's not easy to test notifications with automated tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
