### PR TITLE
Jetpack Focus: Open links in Jetpack refactoring

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -663,10 +663,10 @@ class AppInitializer @Inject constructor(
     private fun enableDeepLinkingComponentsIfNeeded() {
         if (openWebLinksWithJetpackFlowFeatureConfig.isEnabled()) {
             if (!AppPrefs.getIsOpenWebLinksWithJetpack()) {
-                openWebLinksWithJetpackHelper.enableDisableOpenWithJetpackComponents(false)
+                openWebLinksWithJetpackHelper.enableDeepLinks()
             }
         } else {
-            openWebLinksWithJetpackHelper.enableDisableOpenWithJetpackComponents(false)
+            openWebLinksWithJetpackHelper.enableDeepLinks()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -52,7 +52,6 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
     fun handleOpenWebLinksWithJetpack() : Boolean {
         try {
             disableDeepLinks()
-            packageManagerWrapper.disableReaderDeepLinks()
             appPrefsWrapper.setIsOpenWebLinksWithJetpack(true)
             return true
         } catch (ex: PackageManager.NameNotFoundException) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -30,7 +30,7 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
 
     fun enableDeepLinks() {
         packageManagerWrapper.enableReaderDeeplinks()
-        packageManagerWrapper.enableComponentEnableSetting(WEB_LINKS_DEEPLINK_ACTIVITY_ALIAS)
+        packageManagerWrapper.enableComponentEnabledSetting(WEB_LINKS_DEEPLINK_ACTIVITY_ALIAS)
     }
 
     fun disableDeepLinks() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -21,7 +21,7 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
     private val buildConfigWrapper: BuildConfigWrapper
 ) {
-    fun shouldShowDeepLinkOpenWebLinksWithJetpackOverlay() = showOverlay()
+    fun shouldShowOpenLinksInJetpackOverlay() = showOverlay()
 
     fun shouldShowAppSetting(): Boolean {
         return openWebLinksWithJetpackFlowFeatureConfig.isEnabled()

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -39,10 +39,10 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
     }
 
     fun onJetpackUninstalled() {
-        resetAll()
+        reset()
     }
 
-    fun resetAll() {
+    fun reset() {
         enableDeepLinks()
         appPrefsWrapper.setIsOpenWebLinksWithJetpack(false)
         appPrefsWrapper.setOpenWebLinksWithJetpackOverlayLastShownTimestamp(0L)

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -49,7 +49,7 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
     }
 
     @Suppress("SwallowedException")
-    fun handleOpenWebLinksWithJetpack() : Boolean {
+    fun handleOpenLinksInJetpackIfPossible() : Boolean {
         try {
             disableDeepLinks()
             appPrefsWrapper.setIsOpenWebLinksWithJetpack(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -28,6 +28,16 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
                 && isJetpackInstalled()
     }
 
+    fun enableDeepLinks() {
+        packageManagerWrapper.enableReaderDeeplinks()
+        packageManagerWrapper.enableComponentEnableSetting(WEB_LINKS_DEEPLINK_ACTIVITY_ALIAS)
+    }
+
+    fun disableDeepLinks() {
+        packageManagerWrapper.disableReaderDeepLinks()
+        packageManagerWrapper.disableComponentEnabledSetting(WEB_LINKS_DEEPLINK_ACTIVITY_ALIAS)
+    }
+
     fun enableDisableOpenWithJetpackComponents(newValue: Boolean) {
         when (newValue) {
             true -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -38,25 +38,12 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
         packageManagerWrapper.disableComponentEnabledSetting(WEB_LINKS_DEEPLINK_ACTIVITY_ALIAS)
     }
 
-    fun enableDisableOpenWithJetpackComponents(newValue: Boolean) {
-        when (newValue) {
-            true -> {
-                packageManagerWrapper.disableReaderDeepLinks()
-                packageManagerWrapper.disableComponentEnabledSetting(WEB_LINKS_DEEPLINK_ACTIVITY_ALIAS)
-            }
-            false -> {
-                packageManagerWrapper.enableReaderDeeplinks()
-                packageManagerWrapper.enableComponentEnableSetting(WEB_LINKS_DEEPLINK_ACTIVITY_ALIAS)
-            }
-        }
-    }
-
     fun handleJetpackUninstalled() {
         resetAll()
     }
 
     fun resetAll() {
-        enableDisableOpenWithJetpackComponents(false)
+        enableDeepLinks()
         appPrefsWrapper.setIsOpenWebLinksWithJetpack(false)
         appPrefsWrapper.setOpenWebLinksWithJetpackOverlayLastShownTimestamp(0L)
     }
@@ -64,7 +51,7 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
     @Suppress("SwallowedException")
     fun handleOpenWebLinksWithJetpack() : Boolean {
         try {
-            enableDisableOpenWithJetpackComponents(true)
+            disableDeepLinks()
             packageManagerWrapper.disableReaderDeepLinks()
             appPrefsWrapper.setIsOpenWebLinksWithJetpack(true)
             return true

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelper.kt
@@ -38,7 +38,7 @@ class DeepLinkOpenWebLinksWithJetpackHelper @Inject constructor(
         packageManagerWrapper.disableComponentEnabledSetting(WEB_LINKS_DEEPLINK_ACTIVITY_ALIAS)
     }
 
-    fun handleJetpackUninstalled() {
+    fun onJetpackUninstalled() {
         resetAll()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -92,7 +92,7 @@ class DeepLinkingIntentReceiverViewModel
 
     fun forwardDeepLinkToJetpack() {
         uriWrapper?.let {
-            if (openWebLinksWithJetpackHelper.handleOpenWebLinksWithJetpack()) {
+            if (openWebLinksWithJetpackHelper.handleOpenLinksInJetpackIfPossible()) {
                 _navigateAction.value = Event(OpenJetpackForDeepLink(action = action, uri = it))
             } else {
                 handleRequest()

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -170,7 +170,7 @@ class DeepLinkingIntentReceiverViewModel
     private fun checkAndShowOpenWebLinksWithJetpackOverlayIfNeeded() : Boolean {
         return if (deepLinkEntryPoint == WEB_LINKS &&
                 accountStore.hasAccessToken() && // Already logged in
-                openWebLinksWithJetpackHelper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()) {
+                openWebLinksWithJetpackHelper.shouldShowOpenLinksInJetpackOverlay()) {
             openWebLinksWithJetpackHelper.onOverlayShown()
             _showOpenWebLinksWithJetpackOverlay.value = Event(Unit)
             true

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
@@ -121,7 +121,7 @@ class JetpackFeatureOverlayContentBuilder @Inject constructor() {
                 title = R.string.wp_jetpack_deep_link_overlay_title,
                 caption = R.string.wp_jetpack_deep_link_overlay_description,
                 primaryButtonText = R.string.wp_jetpack_deep_link_open_in_jetpack,
-                secondaryButtonText = R.string.wp_jetpack_continue_without_jetpack
+                secondaryButtonText = R.string.wp_jetpack_deep_link_open_in_wordpress
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -447,7 +447,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
     private fun enableDeepLinkComponents() {
         packageManagerWrapper.enableReaderDeeplinks()
-        packageManagerWrapper.enableComponentEnableSetting(
+        packageManagerWrapper.enableComponentEnabledSetting(
                 DeepLinkOpenWebLinksWithJetpackHelper.WEB_LINKS_DEEPLINK_ACTIVITY_ALIAS)
         appPrefsWrapper.setOpenWebLinksWithJetpackOverlayLastShownTimestamp(0L)
         appPrefsWrapper.setIsOpenWebLinksWithJetpack(false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1722,11 +1722,11 @@ public class WPMainActivity extends LocaleAwareActivity implements
     private void enableDeepLinkingComponentsIfNeeded() {
         if (mOpenWebLinksWithJetpackFlowFeatureConfig.isEnabled()) {
             if (!AppPrefs.getIsOpenWebLinksWithJetpack()) {
-                mDeepLinkOpenWebLinksWithJetpackHelper.enableDisableOpenWithJetpackComponents(false);
+                mDeepLinkOpenWebLinksWithJetpackHelper.enableDeepLinks();
             }
         } else {
             // re-enable all deep linking components
-            mDeepLinkOpenWebLinksWithJetpackHelper.enableDisableOpenWithJetpackComponents(false);
+            mDeepLinkOpenWebLinksWithJetpackHelper.enableDeepLinks();
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1487,7 +1487,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     private void handleSiteRemoved() {
         mViewModel.handleSiteRemoved();
         if (!mViewModel.isSignedInWPComOrHasWPOrgSite()) {
-            mDeepLinkOpenWebLinksWithJetpackHelper.resetAll();
+            mDeepLinkOpenWebLinksWithJetpackHelper.reset();
             showSignInForResultBasedOnIsJetpackAppBuildConfig(this);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -504,7 +504,7 @@ public class AppSettingsFragment extends PreferenceFragment
             AnalyticsTracker.track(Stat.PRIVACY_SETTINGS_REPORT_CRASHES_TOGGLED, Collections
                     .singletonMap(TRACK_ENABLED, newValue));
         } else if (preference == mOpenWebLinksWithJetpack) {
-            handleEnableDisableOpenWebLinksWithJetpackComponents((Boolean) newValue);
+            handleOpenLinksInJetpack((Boolean) newValue);
         }
         return true;
     }
@@ -701,9 +701,13 @@ public class AppSettingsFragment extends PreferenceFragment
         onPreferenceChange(mLanguagePreference, languageCode);
     }
 
-    private void handleEnableDisableOpenWebLinksWithJetpackComponents(Boolean newValue) {
+    private void handleOpenLinksInJetpack(Boolean newValue) {
         try {
-            mOpenWebLinksWithJetpackHelper.enableDisableOpenWithJetpackComponents(newValue);
+            if (newValue) {
+                mOpenWebLinksWithJetpackHelper.disableDeepLinks();
+            } else {
+                mOpenWebLinksWithJetpackHelper.enableDeepLinks();
+            }
             AppPrefs.setIsOpenWebLinksWithJetpack(newValue);
             AnalyticsTracker.track(AnalyticsTracker.Stat.APP_SETTINGS_OPEN_WEB_LINKS_WITH_JETPACK_CHANGED, Collections
                     .singletonMap(TRACK_ENABLED, newValue));

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -476,7 +476,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
     private Boolean checkAndShowOpenWebLinksWithJetpackOverlayIfNeeded() {
         if (!isSignedInWPComOrHasWPOrgSite()) return false;
 
-        if (!mDeepLinkOpenWebLinksWithJetpackHelper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()) return false;
+        if (!mDeepLinkOpenWebLinksWithJetpackHelper.shouldShowOpenLinksInJetpackOverlay()) return false;
 
         mDeepLinkOpenWebLinksWithJetpackHelper.onOverlayShown();
         JetpackFeatureFullScreenOverlayFragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -259,7 +259,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
         mJetpackFullScreenViewModel.getAction().observe(this,
                 action -> {
                     if (action instanceof ForwardToJetpack) {
-                        if (!mDeepLinkOpenWebLinksWithJetpackHelper.handleOpenWebLinksWithJetpack()) {
+                        if (!mDeepLinkOpenWebLinksWithJetpackHelper.handleOpenLinksInJetpackIfPossible()) {
                             finishDeepLinkRequestFromOverlay(getIntent().getAction(), getIntent().getData());
                         } else {
                             WPActivityUtils.disableReaderDeeplinks(this);

--- a/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
@@ -15,20 +15,6 @@ class PackageManagerWrapper @Inject constructor(
     fun isPackageInstalled(packageName: String) =
             contextProvider.getContext().packageManager.getLaunchIntentForPackage(packageName) != null
 
-    fun disableComponentEnabledSetting(cls: Class<*>) {
-        contextProvider.getContext().packageManager.setComponentEnabledSetting(
-                ComponentName(contextProvider.getContext(), cls),
-                PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP
-        )
-    }
-
-    fun enableComponentEnableSetting(cls: Class<*>) {
-        contextProvider.getContext().packageManager.setComponentEnabledSetting(
-                ComponentName(contextProvider.getContext(), cls),
-                PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP
-        )
-    }
-
     fun disableComponentEnabledSetting(name: String) {
         contextProvider.getContext().packageManager.setComponentEnabledSetting(
                 ComponentName(contextProvider.getContext(), name),

--- a/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
@@ -22,7 +22,7 @@ class PackageManagerWrapper @Inject constructor(
         )
     }
 
-    fun enableComponentEnableSetting(name: String) {
+    fun enableComponentEnabledSetting(name: String) {
         contextProvider.getContext().packageManager.setComponentEnabledSetting(
                 ComponentName(contextProvider.getContext(), name),
                 PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4274,8 +4274,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Open Web Links With Jetpack -->
     <string name="preference_open_links_in_jetpack">Open links in Jetpack</string>
-    <string name="preference_open_links_in_jetpack_setting_change_enable_error">Unable to enable open web links with Jetpack</string>
-    <string name="preference_open_links_in_jetpack_setting_change_disable_error">Unable to disable open web links with Jetpack</string>
+    <string name="preference_open_links_in_jetpack_setting_change_enable_error">Unable to enable open links in Jetpack</string>
+    <string name="preference_open_links_in_jetpack_setting_change_disable_error">Unable to disable open links in Jetpack</string>
 
     <!-- Jetpack feature overlay strings in WordPress App -->
     <string name="wp_jetpack_feature_removal_overlay_phase_one_title_stats">Get your stats using the new Jetpack app</string>
@@ -4298,5 +4298,5 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="wp_jetpack_deep_link_overlay_title">Open links in Jetpack?</string>
     <string name="wp_jetpack_deep_link_overlay_description">It looks like you have the Jetpack app installed.\n\nWould you like to open links in the Jetpack app in the future?\n\nYou can always change this in App Settings > Open links in Jetpack</string>
     <string name="wp_jetpack_deep_link_open_in_jetpack" translatable="false">@string/preference_open_links_in_jetpack</string>
-
+    <string name="wp_jetpack_deep_link_open_in_wordpress">Open links in WordPress</string>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelperTest.kt
@@ -46,7 +46,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
     fun `when feature flag is off, then show overlay is false`() {
         setTest(isFeatureFlagEnabled = false)
 
-        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+        val result = helper.shouldShowOpenLinksInJetpackOverlay()
 
         assertThat(result).isFalse
     }
@@ -58,7 +58,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
                 isJetpackInstalled = false
         )
 
-        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+        val result = helper.shouldShowOpenLinksInJetpackOverlay()
 
         assertThat(result).isFalse
     }
@@ -71,7 +71,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
                 isOpenWebLinksWithJetpack = true
         )
 
-        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+        val result = helper.shouldShowOpenLinksInJetpackOverlay()
 
         assertThat(result).isFalse
     }
@@ -86,7 +86,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
                 overlayLastShownTimestamp = 0L
         )
 
-        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+        val result = helper.shouldShowOpenLinksInJetpackOverlay()
 
         assertThat(result).isTrue
     }
@@ -102,7 +102,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
                 flowFrequency = 0L
         )
 
-        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+        val result = helper.shouldShowOpenLinksInJetpackOverlay()
 
         assertThat(result).isFalse
     }
@@ -117,7 +117,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
                 flowFrequency = 5L
         )
 
-        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+        val result = helper.shouldShowOpenLinksInJetpackOverlay()
 
         assertThat(result).isTrue
     }
@@ -131,7 +131,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
                 overlayLastShownTimestamp = getDateXDaysAgoInMilliseconds(3),
                 flowFrequency = 5L
         )
-        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+        val result = helper.shouldShowOpenLinksInJetpackOverlay()
 
         assertThat(result).isFalse
     }
@@ -146,7 +146,7 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
                 flowFrequency = 1L
         )
 
-        val result = helper.shouldShowDeepLinkOpenWebLinksWithJetpackOverlay()
+        val result = helper.shouldShowOpenLinksInJetpackOverlay()
 
         assertThat(result).isTrue
     }

--- a/WordPress/src/wordpress/java/org/wordpress/android/ui/deeplinks/JetpackAppUninstallReceiver.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/ui/deeplinks/JetpackAppUninstallReceiver.kt
@@ -16,15 +16,15 @@ class JetpackAppUninstallReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
             ACTION_PACKAGE_FULLY_REMOVED -> {
-                disableOpenWebLinksWithJetpack()
+                onJetpackUninstalled()
                 AppLog.i(UTILS,"JetpackAppUninstallReceiver ACTION_PACKAGE_FULLY_REMOVED handled")
             }
         }
     }
 
-    private fun disableOpenWebLinksWithJetpack() {
+    private fun onJetpackUninstalled() {
         // Toggle the appPref to off + re-enable components
-        openWebLinksWithJetpackHelper.handleJetpackUninstalled()
+        openWebLinksWithJetpackHelper.onJetpackUninstalled()
     }
 
     companion object {


### PR DESCRIPTION
Closes #17494 

This PR includes:
-  Minor refactoring in `DeepLinkOpenWebLinksWithJetpackHelper` - rename methods so that they are more concise and easily recognizable.  
- Remove unused methods in PackageManagerWrapper
- In the overlay view, change the secondary text to "Open links in WordPress" instead of the generic feature removal copy

**To test:**
Ensure the overlay view is shown and the secondary action reads "
- Uninstall all version of JP and WP from your device
- Install WP
- Launch the app and login
- Click on the following link with a mobile broswer
<p><a href="https://zieglerkirby.wordpress.com/2022/09/29/knapsack-share">Reader Post</a></p>
- ✅ Verify the overlay is shown and the secondary action reads "Open links in WordPress"

## Regression Notes
1. Potential unintended areas of impact
The overlay secondary text is not updated

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
