### PR TITLE
Local content migration - handle ineligible scenarios gracefully

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationResult.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationResult.kt
@@ -97,6 +97,7 @@ sealed class LocalMigrationState {
     ): LocalMigrationState()
     sealed class Finished: LocalMigrationState() {
         object Successful: Finished()
+        object Ineligible: Finished()
         data class Failure(val error: LocalMigrationError): Finished()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationResult.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationResult.kt
@@ -98,6 +98,5 @@ sealed class LocalMigrationState {
     sealed class Finished: LocalMigrationState() {
         object Successful: Finished()
         data class Failure(val error: LocalMigrationError): Finished()
-        object DeleteOnly: Finished()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.localcontentmigration.LocalMigrationResult.Companio
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
 import org.wordpress.android.localcontentmigration.LocalMigrationState
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished
-import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.DeleteOnly
 import org.wordpress.android.localcontentmigration.LocalPostsHelper
 import org.wordpress.android.localcontentmigration.SharedLoginHelper
 import org.wordpress.android.localcontentmigration.SitesMigrationHelper
@@ -41,11 +40,7 @@ class LocalMigrationOrchestrator @Inject constructor(
     private val localPostsHelper: LocalPostsHelper,
     private val eligibilityHelper: EligibilityHelper,
 ) {
-    fun tryLocalMigration(migrationStateFlow: MutableStateFlow<LocalMigrationState>, showDeleteOnly: Boolean = false) {
-        if (showDeleteOnly) {
-            migrationStateFlow.value = DeleteOnly
-            return
-        }
+    fun tryLocalMigration(migrationStateFlow: MutableStateFlow<LocalMigrationState>) {
         eligibilityHelper.validate()
                 .then(sharedLoginHelper::login).emitTo(migrationStateFlow)
                 .then(sitesMigrationHelper::migrateSites).emitTo(migrationStateFlow)

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.localcontentmigration.LocalMigrationResult.Companio
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
 import org.wordpress.android.localcontentmigration.LocalMigrationState
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished
+import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.Ineligible
 import org.wordpress.android.localcontentmigration.LocalPostsHelper
 import org.wordpress.android.localcontentmigration.SharedLoginHelper
 import org.wordpress.android.localcontentmigration.SitesMigrationHelper
@@ -48,7 +49,10 @@ class LocalMigrationOrchestrator @Inject constructor(
                 .then(readerSavedPostsHelper::migrateReaderSavedPosts)
                 .then(localPostsHelper::migratePosts)
                 .orElse { error ->
-                    migrationStateFlow.value = Finished.Failure(error)
+                    migrationStateFlow.value = when (error) {
+                        is Ineligibility -> Ineligible
+                        else -> Finished.Failure(error)
+                    }
                     Failure(error)
                 }
                 .then {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.accounts.HelpActivity.Origin.JETPACK_MIGRATION_H
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.CompleteFlow
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FallbackToLogin
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.ShowHelp
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Error
@@ -66,7 +67,7 @@ class JetpackMigrationFragment : Fragment() {
 
     private fun handleActionEvents(actionEvent: JetpackMigrationActionEvent) {
         when (actionEvent) {
-            is CompleteFlow -> ActivityLauncher.showMainActivity(requireContext())
+            is CompleteFlow, FallbackToLogin -> ActivityLauncher.showMainActivity(requireContext())
             is ShowHelp -> launchHelpScreen()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.localcontentmigration.LocalMigrationState
-import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.DeleteOnly
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.Failure
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.Successful
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Initial
@@ -73,6 +72,12 @@ class JetpackMigrationViewModel @Inject constructor(
     val uiState = combineTransform(migrationStateFlow, continueClickedFlow, notificationContinueClickedFlow) {
         migrationState, continueClicked, notificationContinueClicked ->
         when {
+            showDeleteState -> emit(
+                    Delete(
+                            primaryActionButton = DeletePrimaryButton(::onGotItClicked),
+                            secondaryActionButton = DeleteSecondaryButton(::onHelpClicked),
+                    )
+            )
             migrationState is Initial -> emit(Loading)
             migrationState is Migrating -> emit(
                     Welcome(
@@ -95,12 +100,6 @@ class JetpackMigrationViewModel @Inject constructor(
                         )
                 )
             }
-            migrationState is DeleteOnly -> emit(
-                    Delete(
-                            primaryActionButton = DeletePrimaryButton(::onGotItClicked),
-                            secondaryActionButton = DeleteSecondaryButton(::onHelpClicked),
-                    )
-            )
             migrationState is Failure -> emit(
                     UiState.Error(
                             primaryActionButton = ErrorPrimaryButton(::onTryAgainClicked),
@@ -160,7 +159,7 @@ class JetpackMigrationViewModel @Inject constructor(
 
     private fun tryMigration() {
             viewModelScope.launch(Dispatchers.IO) {
-                localMigrationOrchestrator.tryLocalMigration(migrationStateFlow, showDeleteState)
+                localMigrationOrchestrator.tryLocalMigration(migrationStateFlow)
             }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.localcontentmigration.LocalMigrationError.Ineligibility
 import org.wordpress.android.localcontentmigration.LocalMigrationState
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.Failure
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.Ineligible

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -14,8 +14,10 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.localcontentmigration.LocalMigrationError.Ineligibility
 import org.wordpress.android.localcontentmigration.LocalMigrationState
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.Failure
+import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.Ineligible
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.Successful
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Initial
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Migrating
@@ -30,6 +32,7 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomePrimaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomeSecondaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.CompleteFlow
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FallbackToLogin
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.ShowHelp
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content.Delete
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content.Done
@@ -78,6 +81,11 @@ class JetpackMigrationViewModel @Inject constructor(
                             secondaryActionButton = DeleteSecondaryButton(::onHelpClicked),
                     )
             )
+            migrationState is Ineligible -> {
+                appPrefsWrapper.setJetpackMigrationEligible(false)
+                emit(Loading)
+                postActionEvent(FallbackToLogin)
+            }
             migrationState is Initial -> emit(Loading)
             migrationState is Migrating -> emit(
                     Welcome(
@@ -371,5 +379,6 @@ class JetpackMigrationViewModel @Inject constructor(
     sealed class JetpackMigrationActionEvent {
         object ShowHelp : JetpackMigrationActionEvent()
         object CompleteFlow : JetpackMigrationActionEvent()
+        object FallbackToLogin: JetpackMigrationActionEvent()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -292,6 +292,9 @@ public class AppPrefs {
 
         // Indicates if the user has completed the Jetpack migration flow
         IS_JETPACK_MIGRATION_COMPLETED,
+
+        // Indicates if the user is eligible for the Jetpack migration flow
+        IS_JETPACK_MIGRATION_ELIGIBLE,
     }
 
     static SharedPreferences prefs() {
@@ -1482,6 +1485,14 @@ public class AppPrefs {
 
     public static void setIsJetpackMigrationCompleted(final boolean isCompleted) {
         setBoolean(UndeletablePrefKey.IS_JETPACK_MIGRATION_COMPLETED, isCompleted);
+    }
+
+    public static boolean getIsJetpackMigrationEligible() {
+        return getBoolean(UndeletablePrefKey.IS_JETPACK_MIGRATION_ELIGIBLE, true);
+    }
+
+    public static void setIsJetpackMigrationEligible(final boolean isEligible) {
+        setBoolean(UndeletablePrefKey.IS_JETPACK_MIGRATION_ELIGIBLE, isEligible);
     }
 
     public static Long getOpenWebLinksWithJetpackOverlayLastShownTimestamp() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -255,6 +255,10 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun isJetpackMigrationCompleted(): Boolean = AppPrefs.getIsJetpackMigrationCompleted()
 
+    fun setJetpackMigrationEligible(isEligible: Boolean) = AppPrefs.setIsJetpackMigrationEligible(isEligible)
+
+    fun isJetpackMigrationEligible() = AppPrefs.getIsJetpackMigrationEligible()
+
     fun getOpenWebLinksWithJetpackOverlayLastShownTimestamp(): Long =
             AppPrefs.getOpenWebLinksWithJetpackOverlayLastShownTimestamp()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/JetpackAppMigrationFlowUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/JetpackAppMigrationFlowUtils.kt
@@ -24,6 +24,7 @@ class JetpackAppMigrationFlowUtils @Inject constructor(
 
     fun shouldShowMigrationFlow() = buildConfigWrapper.isJetpackApp
             && jetpackMigrationFlowFeatureConfig.isEnabled()
+            && appPrefsWrapper.isJetpackMigrationEligible()
             && appPrefsWrapper.getIsFirstTrySharedLoginJetpack()
             && !accountStore.hasAccessToken()
             && isWordPressInstalled()

--- a/WordPress/src/main/java/org/wordpress/android/userflags/resolver/UserFlagsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/userflags/resolver/UserFlagsHelper.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.localcontentmigration.LocalMigrationError.FeatureDi
 import org.wordpress.android.localcontentmigration.LocalMigrationError.MigrationAlreadyAttempted.UserFlagsAlreadyAttempted
 import org.wordpress.android.localcontentmigration.LocalMigrationError.NoUserFlagsFoundError
 import org.wordpress.android.localcontentmigration.LocalMigrationError.PersistenceError.FailedToSaveUserFlags
+import org.wordpress.android.localcontentmigration.LocalMigrationError.PersistenceError.FailedToSaveUserFlagsWithException
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
 import org.wordpress.android.localcontentmigration.thenWith
@@ -67,7 +68,7 @@ class UserFlagsHelper @Inject constructor(
         } else {
             Success(userFlagsData)
         }
-    }.getOrElse { Failure(FailedToSaveUserFlags) }
+    }.getOrElse { Failure(FailedToSaveUserFlagsWithException(it)) }
 
     private fun success(userFlagsData: UserFlagsData) = run {
         appPrefsWrapper.saveIsFirstTryUserFlagsJetpack(false)

--- a/WordPress/src/test/java/org/wordpress/android/localcontentmigration/LocalPostProviderHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/localcontentmigration/LocalPostProviderHelperTest.kt
@@ -62,7 +62,7 @@ class LocalPostProviderHelperTest {
     }
 
     @Test
-    fun `when a local post id is not specified but a local site id is specified`() {
+    fun `when a local post id is not specified`() {
         val response = localPostProviderHelper.getData() as PostsData
         assertThat(response.localIds).isEqualTo(mockPostIdsList)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/utils/JetpackAppMigrationFlowUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/utils/JetpackAppMigrationFlowUtilsTest.kt
@@ -41,6 +41,7 @@ class JetpackAppMigrationFlowUtilsTest {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
         whenever(jetpackMigrationFlowFeatureConfig.isEnabled()).thenReturn(true)
         whenever(appPrefsWrapper.getIsFirstTrySharedLoginJetpack()).thenReturn(true)
+        whenever(appPrefsWrapper.isJetpackMigrationEligible()).thenReturn(true)
         whenever(accountStore.hasAccessToken()).thenReturn(false)
         whenever(wordPressPublicData.currentPackageId()).thenReturn("package")
         whenever(appStatus.isAppInstalled(any())).thenReturn(true)
@@ -63,8 +64,16 @@ class JetpackAppMigrationFlowUtilsTest {
     }
 
     @Test
-    fun `When the jetpackMigrationFlow is not enableed the Jetpack app the migration flow should not be shown`() {
+    fun `When the jetpackMigrationFlow is not enabled the Jetpack app the migration flow should not be shown`() {
         whenever(jetpackMigrationFlowFeatureConfig.isEnabled()).thenReturn(false)
+        val expected = false
+        val actual = jetpackAppMigrationFlowUtils.shouldShowMigrationFlow()
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `When the jetpackMigrationFlow is not eligible the Jetpack app the migration flow should not be shown`() {
+        whenever(appPrefsWrapper.isJetpackMigrationEligible()).thenReturn(false)
         val expected = false
         val actual = jetpackAppMigrationFlowUtils.shouldShowMigrationFlow()
         Assert.assertEquals(expected, actual)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/17542

### Description

This PR handles the ineligible state by falling back to the landing screen, and setting a flag to avoid trying the migration again in the future.

To test:

1. Log out of the WordPress app
2. Clear the data on the Jetpack app (or do a fresh install from this PR)
3. Open the Jetpack app
4. Expect that the migration flow is not presented, and instead the landing screen is shown.

## Regression Notes
1. Potential unintended areas of impact
Local content migration flow

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

6. What automated tests I added (or what prevented me from doing so)
None


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
