### PR TITLE
[Jetpack Migration Flow] Add welcome screen data to successful migration state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -18,9 +18,11 @@ import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
 import org.wordpress.android.localcontentmigration.LocalMigrationState
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.Ineligible
+import org.wordpress.android.localcontentmigration.LocalMigrationState.Migrating
 import org.wordpress.android.localcontentmigration.LocalPostsHelper
 import org.wordpress.android.localcontentmigration.SharedLoginHelper
 import org.wordpress.android.localcontentmigration.SitesMigrationHelper
+import org.wordpress.android.localcontentmigration.WelcomeScreenData
 import org.wordpress.android.localcontentmigration.emitTo
 import org.wordpress.android.localcontentmigration.orElse
 import org.wordpress.android.localcontentmigration.otherwise
@@ -56,7 +58,11 @@ class LocalMigrationOrchestrator @Inject constructor(
                     Failure(error)
                 }
                 .then {
-                    migrationStateFlow.value = Finished.Successful
+                    with (migrationStateFlow) {
+                        value = Finished.Successful(
+                                (value as? Migrating)?.data ?: WelcomeScreenData()
+                        )
+                    }
                     EmptyResult
                 }
                 .otherwise(::handleErrors)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -86,11 +86,12 @@ class JetpackMigrationViewModel @Inject constructor(
                 postActionEvent(FallbackToLogin)
             }
             migrationState is Initial -> emit(Loading)
-            migrationState is Migrating -> emit(
+            migrationState is Migrating
+                    || migrationState is Successful && !continueClicked -> emit(
                     Welcome(
-                            userAvatarUrl = resizeAvatarUrl(migrationState.avatarUrl),
+                            userAvatarUrl = resizeAvatarUrl(migrationState.data.avatarUrl),
                             isProcessing = continueClicked,
-                            sites = migrationState.sites.map(::siteUiFromModel),
+                            sites = migrationState.data.sites.map(::siteUiFromModel),
                             primaryActionButton = WelcomePrimaryButton(::onContinueClicked),
                             secondaryActionButton = WelcomeSecondaryButton(::onHelpClicked),
                     )


### PR DESCRIPTION
Fixes #17550

## Description
This PR fixes a race condition appearing when the data layer gets ahead of the UI. 

## To test:
### Fix
1. Open the WordPress app and login with a user having only one site and a few posts (e.g. 1 post)
2. Go to the Posts list to make sure posts are loaded in the db
3. Open the Jetpack app of the same build variant
4. **Verify** that the welcome screen appears
### Sanity
Follow the testing steps on https://github.com/wordpress-mobile/WordPress-Android/pull/17538

## Regression Notes
1. Potential unintended areas of impact
Jetpack migration flow

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

7. What automated tests I added (or what prevented me from doing so)
Relied on the existing test

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
