### PR TITLE
Fix redeclaring disable notif permission issue

### DIFF
--- a/WordPress/src/jetpack/AndroidManifest.xml
+++ b/WordPress/src/jetpack/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="org.wordpress.android.permission.DISABLE_NOTIFICATIONS"/>
+
     <application>
         <!-- Deep Linking Activity -->
         <activity android:name="org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity"

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -23,13 +23,6 @@
     <!-- GCM all build types configuration -->
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
-    <permission
-        android:name="org.wordpress.android.permission.DISABLE_NOTIFICATIONS"
-        android:description="@string/notification_disable_broadcast_permission_desc"
-        android:label="@string/notification_disable_broadcast_permission_label" />
-
-    <uses-permission android:name="org.wordpress.android.permission.DISABLE_NOTIFICATIONS"/>
-
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -183,7 +183,7 @@ class JetpackMigrationViewModel @Inject constructor(
             val appPackage = BuildConfig.APPLICATION_ID.replace("com.jetpack", "org.wordpress")
             intent.setPackage(appPackage)
             AppLog.d(T.NOTIFS, intent.toString())
-            contextProvider.getContext().sendBroadcast(intent, "org.wordpress.android.permission.DISABLE_NOTIFICATIONS")
+            contextProvider.getContext().sendBroadcast(intent)
         }
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1522,8 +1522,8 @@
     <string name="search_sites">Search sites</string>
     <string name="notifications_no_search_results">No sites matched \'%s\'</string>
     <string name="notification_sound_has_invalid_path">The chosen sound has invalid path. Please choose another.</string>
-    <string name="notification_disable_broadcast_permission_label">disable WordPress notifications</string>
-    <string name="notification_disable_broadcast_permission_desc">Allows the app to disable WordPress notifications.</string>
+    <string name="notification_disable_broadcast_permission_label" tools:ignore="UnusedResources">disable WordPress notifications</string>
+    <string name="notification_disable_broadcast_permission_desc" tools:ignore="UnusedResources">Allows the app to disable WordPress notifications.</string>
 
     <string name="notification_settings_followed_dialog_email_posts_switch">Email me new posts</string>
     <string name="notification_settings_followed_dialog_notification_posts_description">Receive notifications for new posts from this site</string>

--- a/WordPress/src/wordpress/AndroidManifest.xml
+++ b/WordPress/src/wordpress/AndroidManifest.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <permission
+        android:name="org.wordpress.android.permission.DISABLE_NOTIFICATIONS"
+        android:description="@string/notification_disable_broadcast_permission_desc"
+        android:label="@string/notification_disable_broadcast_permission_label" />
+
     <application>
         <provider
             android:name=".localcontentmigration.LocalMigrationContentProvider"


### PR DESCRIPTION
This fixes the error below which occurred while installing vanilla JP when WP is installed. 
```
failed to install jpandroid-21.3-rc-1.apk: Failure [INSTALL_FAILED_DUPLICATE_PERMISSION: Package com.jetpack.android attempting to redeclare permission org.wordpress.android.permission.DISABLE_NOTIFICATIONS already owned by org.wordpress.android]
```

The `org.wordpress.android.permission.DISABLE_NOTIFICATIONS` permission was in the common `AndroidManifest` of apps.

JP is the broadcast sender. WP is the receiver. We were using the permission when receiving via [JetpackAppInstallReceiver](https://github.com/wordpress-mobile/WordPress-Android/blob/release/21.3/WordPress/src/wordpress/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackAppInstallReceiver.kt), and sending from [JetpackMigrationViewModel](https://github.com/wordpress-mobile/WordPress-Android/blob/23f2ed06c08e90df3a01596dd332b736b8d16f48/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt#L179-L188). 
But actually, we can't do that. We should define a custom permission only on sender or receiver. Because in our case WP will be installed when JP is being installed. So, we can only define a custom permission on receiver (WP).

> Note: Custom permissions are registered when the app is installed. The app that defines the custom permission must be installed before the app that uses it.
https://developer.android.com/guide/components/broadcasts#sending-broadcasts-permissions

I removed the sender permission. And move receiver permission to WordPress Manifest.

To test:
We need to verify disabling notifications from JP is still working.

1. Ensure WP and JP are not installed on your device.
2. Install the `vanilla` flavor of WP.
3. Login on WP.
4. Install the `vanilla` flavor of JP.
5. Complete the migration flow.
6. Navigate back to WP.
7. Navigate to Notifications.
8. Tap ⚙️ button at the top of the screen.
9. Ensure the Notification Settings switch is off.

## Regression Notes
1. Potential unintended areas of impact
The current "disabling WP notifs from JP" might be broken.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Testing a case including both apps is not applicable with automated tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
