### PR TITLE
[Tooling] Delete old `changelogs/1287.txt` files accidentally introduced during #17505

### DIFF
--- a/fastlane/jetpack_metadata/android/en-US/changelogs/1287.txt
+++ b/fastlane/jetpack_metadata/android/en-US/changelogs/1287.txt
@@ -1,2 +1,0 @@
-- You’ll notice a shiny new landing screen in the app that responds to your device’s motion—enjoy!
-- When you’re in the process of editing a page, you can now set a parent page within the child page’s settings.

--- a/fastlane/jetpack_metadata/android/id/changelogs/1287.txt
+++ b/fastlane/jetpack_metadata/android/id/changelogs/1287.txt
@@ -1,3 +1,0 @@
-21,1:
-- You’ll notice a shiny new landing screen in the app that responds to your device’s motion—enjoy!
-- When you’re in the process of editing a page, you can now set a parent page within the child page’s settings.

--- a/fastlane/metadata/android/en-US/changelogs/1287.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1287.txt
@@ -1,1 +1,0 @@
-This update is short and sweet—when you’re in the process of editing a page, you can now set a parent page within the child page’s settings.

--- a/fastlane/metadata/android/es-ES/changelogs/1287.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/1287.txt
@@ -1,2 +1,0 @@
-21.1:
-Esta actualización es breve y dulce – cuando estás editando una página, ahora puedes definir una página superior en los ajustes de la página hija.

--- a/fastlane/metadata/android/fr-CA/changelogs/1287.txt
+++ b/fastlane/metadata/android/fr-CA/changelogs/1287.txt
@@ -1,2 +1,0 @@
-21.1 :
-Cette mise à jour tient en une ligne : lorsque vous modifiez une page, vous pouvez désormais définir une page parente directement depuis les réglages de la page-fille.

--- a/fastlane/metadata/android/fr-FR/changelogs/1287.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/1287.txt
@@ -1,2 +1,0 @@
-21.1 :
-Cette mise à jour tient en une ligne : lorsque vous modifiez une page, vous pouvez désormais définir une page parente directement depuis les réglages de la page-fille.

--- a/fastlane/metadata/android/id/changelogs/1287.txt
+++ b/fastlane/metadata/android/id/changelogs/1287.txt
@@ -1,2 +1,0 @@
-21,1:
-This update is short and sweet—when you’re in the process of editing a page, you can now set a parent page within the child page’s settings.

--- a/fastlane/metadata/android/sv-SE/changelogs/1287.txt
+++ b/fastlane/metadata/android/sv-SE/changelogs/1287.txt
@@ -1,2 +1,0 @@
-21.1:
-En liten, men naggande god uppdatering. Medan du håller på som bäst att redigera en sida kan du nu ange en överordnad sida i inställningarna för den underordnade sidan.


### PR DESCRIPTION
Those files were accidentally introduced during testing and merge of https://github.com/wordpress-mobile/WordPress-Android/pull/17505

They would likely have been [auto-deleted during the next release finalization](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/fastlane/lanes/localization.rb#L189) (the one after the next code freeze that would include them after being cut from `trunk`) in 3 weeks anyway, but better clean them up ASAP now to avoid potential confusion for the Release Manager in 3 weeks.

Kudos @ParaskP7 for noticing them! 💪 