### PR TITLE
[Dependency Updates] Remove AppCompat Image Editor Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ ext {
     androidInstallReferrerVersion = '2.2'
     androidVolleyVersion = '1.1.1'
     androidxAppcompatVersion = '1.1.0'
-    androidxAppcompatImageEditorVersion = '1.0.2' // TODO: Align 'appcompat' versions.
     androidxArchCoreVersion = '2.0.0'
     androidxComposeVersion = '1.1.1'
     androidxCardviewVersion = '1.0.0'

--- a/libs/image-editor/build.gradle
+++ b/libs/image-editor/build.gradle
@@ -42,7 +42,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "androidx.appcompat:appcompat:$androidxAppcompatImageEditorVersion"
+    implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
     implementation "androidx.viewpager2:viewpager2:$androidxViewpager2Version"
     implementation "com.google.android.material:material:$googleMaterialVersion"


### PR DESCRIPTION
Parent #17561

This `1.0.2` version of `AppCompat` specific to the `image-editor` module is a discrepancy that should be aligned with the main `AppCompat` version used on all other modules.

PS: Actually, this `1.1.0` version is anyway being updated to `1.3.1` due to transitive dependencies. As such, this versioning related configuration change shouldn't matter much.

-----

PS: @AjeshRPai I added you as the main reviewer, that is, in addition to the @wordpress-mobile/apps-infrastructure team itself, but randomly, since I just wanted someone from the `WordPress` team to sign-off on that change for WPAndroid.

-----

To test:

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you want to be thorough about reviewing this change, you could:
    1. See the dependency tree diff result and verify correctness.
    2. Quickly smoke test both, the `WordPress` and `Jetpack` apps, and see if they both work as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

5. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
