### PR TITLE
[Tooling] Report Firebase Test Failures as Buildkite Annotations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gem 'nokogiri'
 
 ### Fastlane Plugins
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.0'
+# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.0'
 #gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
-#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: '…'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'firebase-test-return-url'
 
 
 ### Gems needed only for generating Promo Screenshots

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,25 @@
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit
+  revision: d1eff864aed7a7f8a0b3a9da3cb0323373416c2f
+  branch: firebase-test-return-url
+  specs:
+    fastlane-plugin-wpmreleasetoolkit (6.0.0)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -116,29 +138,13 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (6.0.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
     git (1.12.0)
       addressable (~> 2.8)
       rchardet (~> 1.8)
     google-apis-androidpublisher_v3 (0.26.0)
       google-apis-core (>= 0.7, < 2.a)
-    google-apis-core (0.9.0)
+    google-apis-core (0.9.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -147,8 +153,8 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-apis-iamcredentials_v1 (0.15.0)
-      google-apis-core (>= 0.9.0, < 2.a)
+    google-apis-iamcredentials_v1 (0.16.0)
+      google-apis-core (>= 0.9.1, < 2.a)
     google-apis-playcustomapp_v1 (0.10.0)
       google-apis-core (>= 0.7, < 2.a)
     google-apis-storage_v1 (0.19.0)
@@ -159,7 +165,7 @@ GEM
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
     google-cloud-errors (1.3.0)
-    google-cloud-storage (1.43.0)
+    google-cloud-storage (1.44.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
@@ -167,7 +173,7 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
-    googleauth (1.2.0)
+    googleauth (1.3.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -195,7 +201,7 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
-    nokogiri (1.13.8)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -274,7 +280,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 6.0)
+  fastlane-plugin-wpmreleasetoolkit!
   nokogiri
   rmagick (~> 4.1)
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/posts/PostUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/posts/PostUtilsTest.java
@@ -20,11 +20,11 @@ public class PostUtilsTest {
         String collapsedContent = PostUtils.collapseShortcodes(postContent);
 
         // make sure [gallery] now exists and [gallery number] does not
-        assertTrue(collapsedContent.contains("[zzzgallery]"));
+        assertTrue(collapsedContent.contains("[gallery]"));
         assertFalse(collapsedContent.contains("[gallery number]"));
 
         // make sure the unknown shortcode is intact
-        assertTrue(collapsedContent.contains("[zzzunknown shortcode]"));
+        assertTrue(collapsedContent.contains("[unknown shortcode]"));
     }
 
     @Test

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/posts/PostUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/posts/PostUtilsTest.java
@@ -20,11 +20,11 @@ public class PostUtilsTest {
         String collapsedContent = PostUtils.collapseShortcodes(postContent);
 
         // make sure [gallery] now exists and [gallery number] does not
-        assertTrue(collapsedContent.contains("[gallery]"));
+        assertTrue(collapsedContent.contains("[zzzgallery]"));
         assertFalse(collapsedContent.contains("[gallery number]"));
 
         // make sure the unknown shortcode is intact
-        assertTrue(collapsedContent.contains("[unknown shortcode]"));
+        assertTrue(collapsedContent.contains("[zzzunknown shortcode]"));
     }
 
     @Test

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -28,7 +28,7 @@ platform :android do
       version: 30,
       test_apk_path: File.join(apk_dir, 'androidTest', 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug-androidTest.apk'),
       apk_path: File.join(apk_dir, 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug.apk'),
-      test_targets: 'notPackage org.wordpress.android.ui.screenshots',
+      test_targets: 'package org.wordpress.android.ui.posts',
       results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests'),
       crash_on_test_failure: false
     )

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -12,25 +12,25 @@ platform :android do
   #####################################################################################
   desc "Build the application and instrumented tests, then run the tests in Firebase Test Lab"
   lane :build_and_run_instrumented_test do | options |
-   gradle(tasks: ['WordPress:assembleWordPressVanillaDebug', 'WordPress:assembleWordPressVanillaDebugAndroidTest'])
+    gradle(tasks: ['WordPress:assembleWordPressVanillaDebug', 'WordPress:assembleWordPressVanillaDebugAndroidTest'])
 
-   # Run the instrumented tests in Firebase Test Lab
-   firebase_login(
-     key_file: GOOGLE_FIREBASE_SECRETS_PATH
-   )
+    # Run the instrumented tests in Firebase Test Lab
+    firebase_login(
+      key_file: GOOGLE_FIREBASE_SECRETS_PATH
+    )
 
-   apk_dir = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'build', 'outputs', 'apk')
+    apk_dir = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'build', 'outputs', 'apk')
 
-   android_firebase_test(
-     project_id: firebase_secret(name: 'project_id'),
-     key_file: GOOGLE_FIREBASE_SECRETS_PATH,
-     model: 'Pixel2.arm',
-     version: 30,
-     test_apk_path: File.join(apk_dir, 'androidTest', 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug-androidTest.apk'),
-     apk_path: File.join(apk_dir, 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug.apk'),
-     test_targets: 'notPackage org.wordpress.android.ui.screenshots',
-     results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests')
-   )
+    android_firebase_test(
+      project_id: firebase_secret(name: 'project_id'),
+      key_file: GOOGLE_FIREBASE_SECRETS_PATH,
+      model: 'Pixel2.arm',
+      version: 30,
+      test_apk_path: File.join(apk_dir, 'androidTest', 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug-androidTest.apk'),
+      apk_path: File.join(apk_dir, 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug.apk'),
+      test_targets: 'notPackage org.wordpress.android.ui.screenshots',
+      results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests')
+    )
   end
 end
 

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -28,7 +28,7 @@ platform :android do
       version: 30,
       test_apk_path: File.join(apk_dir, 'androidTest', 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug-androidTest.apk'),
       apk_path: File.join(apk_dir, 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug.apk'),
-      test_targets: 'package org.wordpress.android.ui.posts',
+      test_targets: 'notPackage org.wordpress.android.ui.screenshots',
       results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests'),
       crash_on_test_failure: false
     )


### PR DESCRIPTION
> **Warning**: This PR is dependent on https://github.com/wordpress-mobile/release-toolkit/pull/430 to be merged and for a new `release-toolkit` version to be released first.

> **Note**: 🔁  **UPDATE**: I [accidentally merged this PR too soon](https://github.com/wordpress-mobile/WordPress-Android/pull/17581#issuecomment-1332383754), so I had to revert it in #17583 then prepare the same changes again in #17584, which now supersedes this one.

### What

This PR catches test failures happening when running Instrumented Tests in Firebase, and add a Buildkite annotation at the top of the failed build so it's way easier to jump to the details of the test failure on Firebase Console.

### How it looks

[This is how the annotation appears on Buildkite](https://buildkite.com/automattic/wordpress-android/builds/7990) if an Instrumented Test failure occurs:

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/216089/204806330-c2be9899-3f51-490e-ad8c-de1e7dc34f68.png">

### To Test

Observe that the intentional failure that I've forced to happen in 3b2d8b8b7559ed032062e6d5045f1380d50addf3 indeed [generated a Buildkite annotation](https://buildkite.com/automattic/wordpress-android/builds/7990) (see screenshot above) — while a [successful Instrumented Tests run like the one at the HEAD of this branch](https://buildkite.com/automattic/wordpress-android/builds/latest?branch=tooling/firebase-test-failure-annotation) doesn't.

### TODO

 - [ ] Point to the new version/tag of `release-toolkit` once it has landed, then remove the "Not Ready for Merge" label
