### PR TITLE
Revert "[Tooling] Report Firebase Test Failures as Buildkite Annotations"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gem 'nokogiri'
 
 ### Fastlane Plugins
 
-# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.0'
 #gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'firebase-test-return-url'
+#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: '…'
 
 
 ### Gems needed only for generating Promo Screenshots

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,3 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: d1eff864aed7a7f8a0b3a9da3cb0323373416c2f
-  branch: firebase-test-return-url
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (6.0.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -138,13 +116,29 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-wpmreleasetoolkit (6.0.0)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
     git (1.12.0)
       addressable (~> 2.8)
       rchardet (~> 1.8)
     google-apis-androidpublisher_v3 (0.26.0)
       google-apis-core (>= 0.7, < 2.a)
-    google-apis-core (0.9.1)
+    google-apis-core (0.9.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -153,8 +147,8 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-apis-iamcredentials_v1 (0.16.0)
-      google-apis-core (>= 0.9.1, < 2.a)
+    google-apis-iamcredentials_v1 (0.15.0)
+      google-apis-core (>= 0.9.0, < 2.a)
     google-apis-playcustomapp_v1 (0.10.0)
       google-apis-core (>= 0.7, < 2.a)
     google-apis-storage_v1 (0.19.0)
@@ -165,7 +159,7 @@ GEM
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
     google-cloud-errors (1.3.0)
-    google-cloud-storage (1.44.0)
+    google-cloud-storage (1.43.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
@@ -173,7 +167,7 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
-    googleauth (1.3.0)
+    googleauth (1.2.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -201,7 +195,7 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
-    nokogiri (1.13.9)
+    nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -280,7 +274,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 6.0)
   nokogiri
   rmagick (~> 4.1)
 

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -12,33 +12,25 @@ platform :android do
   #####################################################################################
   desc "Build the application and instrumented tests, then run the tests in Firebase Test Lab"
   lane :build_and_run_instrumented_test do | options |
-    gradle(tasks: ['WordPress:assembleWordPressVanillaDebug', 'WordPress:assembleWordPressVanillaDebugAndroidTest'])
+   gradle(tasks: ['WordPress:assembleWordPressVanillaDebug', 'WordPress:assembleWordPressVanillaDebugAndroidTest'])
 
-    # Run the instrumented tests in Firebase Test Lab
-    firebase_login(
-      key_file: GOOGLE_FIREBASE_SECRETS_PATH
-    )
+   # Run the instrumented tests in Firebase Test Lab
+   firebase_login(
+     key_file: GOOGLE_FIREBASE_SECRETS_PATH
+   )
 
-    apk_dir = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'build', 'outputs', 'apk')
+   apk_dir = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'build', 'outputs', 'apk')
 
-    test_succeeded = android_firebase_test(
-      project_id: firebase_secret(name: 'project_id'),
-      key_file: GOOGLE_FIREBASE_SECRETS_PATH,
-      model: 'Pixel2.arm',
-      version: 30,
-      test_apk_path: File.join(apk_dir, 'androidTest', 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug-androidTest.apk'),
-      apk_path: File.join(apk_dir, 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug.apk'),
-      test_targets: 'notPackage org.wordpress.android.ui.screenshots',
-      results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests'),
-      crash_on_test_failure: false
-    )
-
-    unless test_succeeded
-      details_url = lane_context[SharedValues::FIREBASE_TEST_MORE_DETAILS_URL]
-      message = "Firebase Tests failed. Failure details can be seen [here in Firebase Console](#{details_url})"
-      sh('buildkite-agent', 'annotate', message, '--style', 'error', '--context', 'firebase-test-wordpress-vanilla-debug') if is_ci?
-      UI.test_failure!(message)
-    end
+   android_firebase_test(
+     project_id: firebase_secret(name: 'project_id'),
+     key_file: GOOGLE_FIREBASE_SECRETS_PATH,
+     model: 'Pixel2.arm',
+     version: 30,
+     test_apk_path: File.join(apk_dir, 'androidTest', 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug-androidTest.apk'),
+     apk_path: File.join(apk_dir, 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug.apk'),
+     test_targets: 'notPackage org.wordpress.android.ui.screenshots',
+     results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests')
+   )
   end
 end
 


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-Android#17581 that I accidentally merged too soon before the new release-toolkit was ready