### PR TITLE
[Tooling] Report Firebase Test Failures as Buildkite Annotations (take 2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gem 'nokogiri'
 
 ### Fastlane Plugins
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.0'
+# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.0'
 #gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
-#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: '…'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'trunk'
 
 
 ### Gems needed only for generating Promo Screenshots

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gem 'nokogiri'
 
 ### Fastlane Plugins
 
-# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.0'
-#gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'trunk'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.1'
+# gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
+# gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'trunk'
 
 
 ### Gems needed only for generating Promo Screenshots

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,3 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: b6ffaac84ecc8f53729fa51667d97e284b7a4040
-  branch: trunk
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (6.0.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -138,6 +116,21 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-wpmreleasetoolkit (6.1.0)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
     git (1.12.0)
       addressable (~> 2.8)
@@ -188,9 +181,6 @@ GEM
       concurrent-ruby (~> 1.0)
     jmespath (1.6.1)
     json (2.6.2)
-    jsonlint (0.3.0)
-      oj (~> 3)
-      optimist (~> 3)
     jwt (2.5.0)
     memoist (0.16.2)
     mini_magick (4.11.0)
@@ -207,8 +197,6 @@ GEM
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    oj (3.13.23)
-    optimist (3.0.1)
     options (2.3.2)
     optparse (0.1.1)
     os (1.1.4)
@@ -280,7 +268,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 6.1)
   nokogiri
   rmagick (~> 4.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,25 @@
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit
+  revision: b6ffaac84ecc8f53729fa51667d97e284b7a4040
+  branch: trunk
+  specs:
+    fastlane-plugin-wpmreleasetoolkit (6.0.0)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -116,29 +138,13 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (6.0.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
     git (1.12.0)
       addressable (~> 2.8)
       rchardet (~> 1.8)
     google-apis-androidpublisher_v3 (0.26.0)
       google-apis-core (>= 0.7, < 2.a)
-    google-apis-core (0.9.0)
+    google-apis-core (0.9.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -147,8 +153,8 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-apis-iamcredentials_v1 (0.15.0)
-      google-apis-core (>= 0.9.0, < 2.a)
+    google-apis-iamcredentials_v1 (0.16.0)
+      google-apis-core (>= 0.9.1, < 2.a)
     google-apis-playcustomapp_v1 (0.10.0)
       google-apis-core (>= 0.7, < 2.a)
     google-apis-storage_v1 (0.19.0)
@@ -159,7 +165,7 @@ GEM
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
     google-cloud-errors (1.3.0)
-    google-cloud-storage (1.43.0)
+    google-cloud-storage (1.44.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
@@ -167,7 +173,7 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
-    googleauth (1.2.0)
+    googleauth (1.3.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -195,7 +201,7 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
-    nokogiri (1.13.8)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -274,7 +280,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 6.0)
+  fastlane-plugin-wpmreleasetoolkit!
   nokogiri
   rmagick (~> 4.1)
 

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -12,25 +12,25 @@ platform :android do
   #####################################################################################
   desc "Build the application and instrumented tests, then run the tests in Firebase Test Lab"
   lane :build_and_run_instrumented_test do | options |
-   gradle(tasks: ['WordPress:assembleWordPressVanillaDebug', 'WordPress:assembleWordPressVanillaDebugAndroidTest'])
+    gradle(tasks: ['WordPress:assembleWordPressVanillaDebug', 'WordPress:assembleWordPressVanillaDebugAndroidTest'])
 
-   # Run the instrumented tests in Firebase Test Lab
-   firebase_login(
-     key_file: GOOGLE_FIREBASE_SECRETS_PATH
-   )
+    # Run the instrumented tests in Firebase Test Lab
+    firebase_login(
+      key_file: GOOGLE_FIREBASE_SECRETS_PATH
+    )
 
-   apk_dir = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'build', 'outputs', 'apk')
+    apk_dir = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'build', 'outputs', 'apk')
 
-   android_firebase_test(
-     project_id: firebase_secret(name: 'project_id'),
-     key_file: GOOGLE_FIREBASE_SECRETS_PATH,
-     model: 'Pixel2.arm',
-     version: 30,
-     test_apk_path: File.join(apk_dir, 'androidTest', 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug-androidTest.apk'),
-     apk_path: File.join(apk_dir, 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug.apk'),
-     test_targets: 'notPackage org.wordpress.android.ui.screenshots',
-     results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests')
-   )
+    android_firebase_test(
+      project_id: firebase_secret(name: 'project_id'),
+      key_file: GOOGLE_FIREBASE_SECRETS_PATH,
+      model: 'Pixel2.arm',
+      version: 30,
+      test_apk_path: File.join(apk_dir, 'androidTest', 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug-androidTest.apk'),
+      apk_path: File.join(apk_dir, 'wordpressVanilla', 'debug', 'org.wordpress.android-wordpress-vanilla-debug.apk'),
+      test_targets: 'notPackage org.wordpress.android.ui.screenshots',
+      results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests')
+    )
   end
 end
 

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -33,10 +33,13 @@ platform :android do
       crash_on_test_failure: false
     )
 
-    unless test_succeeded
+    annotation_ctx = 'firebase-test-wordpress-vanilla-debug'
+    if test_succeeded
+      sh("buildkite-agent annotation remove --context '#{annotation_ctx}' || true") if is_ci?
+    else
       details_url = lane_context[SharedValues::FIREBASE_TEST_MORE_DETAILS_URL]
       message = "Firebase Tests failed. Failure details can be seen [here in Firebase Console](#{details_url})"
-      sh('buildkite-agent', 'annotate', message, '--style', 'error', '--context', 'firebase-test-wordpress-vanilla-debug') if is_ci?
+      sh('buildkite-agent', 'annotate', message, '--style', 'error', '--context', annotation_ctx) if is_ci?
       UI.test_failure!(message)
     end
   end


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPress-Android/pull/17581 for details

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/216089/204806330-c2be9899-3f51-490e-ad8c-de1e7dc34f68.png">

> **Warning** This PR should NOT be merged until we do a new version of the `release-toolkit` that ships with the changes from https://github.com/wordpress-mobile/release-toolkit/pull/430

### Why?

I accidentally merged https://github.com/wordpress-mobile/WordPress-Android/pull/17581 too soon, before a new release for the `release-toolkit` was done and I could point to it.

So I reverted the early merge in https://github.com/wordpress-mobile/WordPress-Android/pull/17583, and here we are in this PR, preparing the exact same changes again (that were already approved in #17581), but this time we will make sure to wait for a new release before merging it… right?

### TODO

 - [x] Point to the new version of `release-toolkit` once one gets published, then remove the Not Ready for Merge label once done.