### PR TITLE
Integrate gutenberg-mobile release 1.85.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     wordPressUtilsVersion = '3.1.0'
     wordPressLoginVersion = '1.0.0'
     aztecVersion = 'v1.6.2'
-    gutenbergMobileVersion = 'v1.85.0'
+    gutenbergMobileVersion = '5292-df86dd2993050f32245f05dae5ac2250e29d95e2'
     storiesVersion = '2.0.0'
     aboutAutomatticVersion = '1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     wordPressUtilsVersion = '3.1.0'
     wordPressLoginVersion = '1.0.0'
     aztecVersion = 'v1.6.2'
-    gutenbergMobileVersion = '5292-df86dd2993050f32245f05dae5ac2250e29d95e2'
+    gutenbergMobileVersion = 'v1.85.1'
     storiesVersion = '2.0.0'
     aboutAutomatticVersion = '1.0.0'
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.85.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5292

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.