### PR TITLE
[Jetpack Content Migration Flow] Logs the user out on failure

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.accounts.HelpActivity.Origin.JETPACK_MIGRATION_HELP
@@ -24,6 +25,7 @@ import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.CompleteFlow
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FallbackToLogin
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.Logout
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.ShowHelp
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Error
@@ -68,6 +70,7 @@ class JetpackMigrationFragment : Fragment() {
     private fun handleActionEvents(actionEvent: JetpackMigrationActionEvent) {
         when (actionEvent) {
             is CompleteFlow, FallbackToLogin -> ActivityLauncher.showMainActivity(requireContext())
+            is Logout -> (requireActivity().application as? WordPress)?.let { viewModel.signOutWordPress(it) }
             is ShowHelp -> launchHelpScreen()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -14,7 +14,9 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
+import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker
 import org.wordpress.android.localcontentmigration.LocalMigrationState
 import org.wordpress.android.localcontentmigration.LocalMigrationState.Finished.Failure
@@ -35,6 +37,7 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomeSecondaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.CompleteFlow
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FallbackToLogin
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.Logout
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.ShowHelp
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content.Delete
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content.Done
@@ -63,6 +66,7 @@ class JetpackMigrationViewModel @Inject constructor(
     private val localMigrationOrchestrator: LocalMigrationOrchestrator,
     private val migrationEmailHelper: MigrationEmailHelper,
     private val migrationAnalyticsTracker: ContentMigrationAnalyticsTracker,
+    private val accountStore: AccountStore,
 ) : ViewModel() {
     private val _actionEvents = Channel<JetpackMigrationActionEvent>(Channel.BUFFERED)
     val actionEvents = _actionEvents.receiveAsFlow()
@@ -79,7 +83,7 @@ class JetpackMigrationViewModel @Inject constructor(
             migrationState is Ineligible -> {
                 appPrefsWrapper.setJetpackMigrationEligible(false)
                 emit(Loading)
-                postActionEvent(FallbackToLogin)
+                logoutAndFallbackToLogin()
             }
             migrationState is Initial -> emit(Loading)
             migrationState is Migrating
@@ -159,6 +163,13 @@ class JetpackMigrationViewModel @Inject constructor(
         )
     }
 
+    fun signOutWordPress(application: WordPress) {
+        viewModelScope.launch(Dispatchers.IO) {
+            application.wordPressComSignOut()
+            postActionEvent(CompleteFlow)
+        }
+    }
+
     private fun siteUiFromModel(site: SiteModel) = SiteListItemUiState(
             id = site.siteId,
             name = siteUtilsWrapper.getSiteNameOrHomeURL(site),
@@ -177,6 +188,14 @@ class JetpackMigrationViewModel @Inject constructor(
     private fun onTryAgainClicked() {
         migrationAnalyticsTracker.trackErrorRetryTapped()
         tryMigration()
+    }
+
+    private fun logoutAndFallbackToLogin() {
+        if (accountStore.hasAccessToken()) {
+            postActionEvent(Logout)
+        } else {
+            postActionEvent(FallbackToLogin)
+        }
     }
 
     private fun tryMigration() {
@@ -411,5 +430,6 @@ class JetpackMigrationViewModel @Inject constructor(
         object ShowHelp : JetpackMigrationActionEvent()
         object CompleteFlow : JetpackMigrationActionEvent()
         object FallbackToLogin : JetpackMigrationActionEvent()
+        object Logout : JetpackMigrationActionEvent()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -187,7 +187,7 @@ class JetpackMigrationViewModel @Inject constructor(
 
     private fun onTryAgainClicked() {
         migrationAnalyticsTracker.trackErrorRetryTapped()
-        tryMigration()
+        logoutAndFallbackToLogin()
     }
 
     private fun logoutAndFallbackToLogin() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker
 import org.wordpress.android.localcontentmigration.MigrationEmailHelper
 import org.wordpress.android.localcontentmigration.WelcomeScreenData
@@ -46,6 +47,7 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
     private val preventDuplicateNotifsFeatureConfig: PreventDuplicateNotifsFeatureConfig = mock()
     private val contentMigrationAnalyticsTracker: ContentMigrationAnalyticsTracker = mock()
     private val contextProvider: ContextProvider = mock()
+    private val accountStore: AccountStore = mock()
     private val classToTest = JetpackMigrationViewModel(
             siteUtilsWrapper = siteUtilsWrapper,
             gravatarUtilsWrapper = gravatarUtilsWrapper,
@@ -55,6 +57,7 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
             localMigrationOrchestrator = localMigrationOrchestrator,
             migrationEmailHelper = migrationEmailHelper,
             migrationAnalyticsTracker = contentMigrationAnalyticsTracker,
+            accountStore = accountStore,
     )
 
     @Before


### PR DESCRIPTION
**Based on: https://github.com/wordpress-mobile/WordPress-Android/pull/17585**
**Targeting: `21.3`**

## Description
This PR:
- [Logs the user out before redirecting to the login screen if needed](https://github.com/wordpress-mobile/WordPress-Android/commit/cf62abe5a96dd4ec9238c5ef68b88686b8a665dc)
- [Logs the user out as a way out of the error screen](https://github.com/wordpress-mobile/WordPress-Android/commit/9c9cfaf9d0511efbd5b9005938f2e18308d11224)

## To test:
1. Prerequisite: WordPress app should be installed and logged in
2. Uninstall Jetpack App if installed
3. In `build.gradle` change `JETPACK_LOCAL_USER_FLAGS` build config value to `false`:
   ```
   buildConfigField "boolean", "JETPACK_LOCAL_USER_FLAGS", "false"
   ```
   **Note** _This is a hardcode solution to make the migration flow always fail._
4. Sync project
5. Build and install the Jetpack app of the same flavor that the installed WordPress app is (e.g. `wasabiDebug`)
6. Open the Jetpack app
7. The Error screen of the migration flow should be shown
8. Tap the Retry button
9. Verify that the user lands on the login screen

## Regression Notes
1. Potential unintended areas of impact
Error flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Relied on existing tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
