### PR TITLE
⚠️ Fix Lib Dependency Versions on Incorrect Merge Conflict Resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,6 @@ plugins {
 }
 
 ext {
-    wordPressUtilsVersion = '3.1.0'
-    wordPressLoginVersion = '1.0.0'
-    aztecVersion = 'v1.6.2'
-    gutenbergMobileVersion = 'v1.85.1'
-    storiesVersion = '2.0.0'
-    aboutAutomatticVersion = '1.0.0'
-
     minSdkVersion = 24
     compileSdkVersion = 31
     targetSdkVersion = 31
@@ -27,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.85.0'
+    gutenbergMobileVersion = 'v1.85.1'
     wordPressAztecVersion = 'v1.6.2'
     wordPressEmailChecker2Version = '1.1.0'
     wordPressFluxCVersion = '2.6.0'


### PR DESCRIPTION
@jkmassel @oguzkocer 

There has been an incorrect merge conflict resolution (21551bf65e29817490956b9c65e717333e951101) while working on this [21.3-rc-3 release PR](https://github.com/wordpress-mobile/WordPress-Android/pull/17600), thus me adding you both as reviewers here.

The below were duplicate versions, thus completely removed:

```
wordPressUtilsVersion = '3.1.0'
wordPressLoginVersion = '1.0.0'
aztecVersion = 'v1.6.2'
storiesVersion = '2.0.0'
aboutAutomatticVersion = '1.0.0'
```

The below `gutenbergMobileVersion` is the actual problematic one as it then got overridden by another such declaration, that of `v1.85.0` further below. As such, the end result was that the `v1.85.1` was ignored in favor of the next one.

```
gutenbergMobileVersion = 'v1.85.1'
```

This PR addresses all that.

-----

To test:

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you want to be thorough about reviewing this change, you could:
    1. See the dependency tree diff result and verify correctness.
    2. Quickly smoke test both, the `WordPress` and `Jetpack` apps, and see if they both work as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

Other non `libs` related version are incorrect as well. I tried to double check them, but I didn't do a thorough check on that as well, thinking that the author of the conflict resolution merge commit picked-up those as the source of truth and only changed the source of truth for what was committing above the `min/compile/targetSdkVersion`. @jkmassel please correct me if I am wrong in assuming that's how you resolved the conflict? 🙏 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
