### PR TITLE
Fix INSTALL_FAILED_DUPLICATE_PERMISSION error

### DIFF
--- a/WordPress/src/jetpack/AndroidManifest.xml
+++ b/WordPress/src/jetpack/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="org.wordpress.android.permission.DISABLE_NOTIFICATIONS"/>
+    <uses-permission android:name="org.wordpress.android.beta.permission.DISABLE_NOTIFICATIONS"/>
+    <uses-permission android:name="org.wordpress.android.prealpha.permission.DISABLE_NOTIFICATIONS"/>
 
     <application>
         <!-- Deep Linking Activity -->

--- a/WordPress/src/wordpress/AndroidManifest.xml
+++ b/WordPress/src/wordpress/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <permission
-        android:name="org.wordpress.android.permission.DISABLE_NOTIFICATIONS"
+        android:name="${applicationId}.permission.DISABLE_NOTIFICATIONS"
         android:description="@string/notification_disable_broadcast_permission_desc"
         android:label="@string/notification_disable_broadcast_permission_label" />
 
@@ -15,7 +15,7 @@
         <receiver
             android:name=".ui.mysite.jetpackbadge.JetpackAppInstallReceiver"
             android:exported="true"
-            android:permission="org.wordpress.android.permission.DISABLE_NOTIFICATIONS">
+            android:permission="${applicationId}.permission.DISABLE_NOTIFICATIONS">
             <intent-filter>
                 <action android:name="org.wordpress.android.broadcast.DISABLE_NOTIFICATIONS"/>
             </intent-filter>


### PR DESCRIPTION
This fixes the error when you try to install a build flavor when another flavor is installed. This doesn't affect production, it affects only us who can have bot WordPress and WordPress Beta.

To reproduce:
1. Install WordPress Beta or WordPress Prealpha from the Android Studio.
2. Install [wpandroid-21.3-rc-3.apk](https://github.com/wordpress-mobile/WordPress-Android/releases/download/21.3-rc-3.wpandroid-21.3-rc-3.apk) to the same device.
3. You'll get the error. 

**Error**
```
failed to install jpandroid-21.3-rc-1.apk: Failure [INSTALL_FAILED_DUPLICATE_PERMISSION: Package com.jetpack.android attempting to redeclare permission org.wordpress.android.permission.DISABLE_NOTIFICATIONS already owned by org.wordpress.android]
```

**Solution:**
WordPress app defines `org.wordpress.android.permission.DISABLE_NOTIFICATIONS` permission.
WordPress Beta app defines `org.wordpress.android.beta.permission.DISABLE_NOTIFICATIONS` permission.
WordPress PreAlpha app defines `org.wordpress.android.prealpha.permission.DISABLE_NOTIFICATIONS` permission.
Jetpack uses 3 defined permissions above.
Jetpack Beta uses 3 defined permissions above.
Jetpack PreAlpha uses 3 defined permissions above.

Jetpack doesn't need beta and prealpha permissions, but it still has `<uses-permission ...` for them. It would be better if Jetpack would use WordPress permission, but I didn't want to create new `AndroidManifest` files for JP wasabi and JP jalapeno. Note that this permission will be removed when Notifications are removed from WP.

To test:
We need to verify disabling notifications from JP is still working. Repeat instructions for WP+JP, WPbeta+JPbeta, and WPprealpha+JPprealpha.

1. Ensure WP and JP are not installed on your device.
2. Install the WP.
3. Login on WP.
4. Install the JP.
5. Complete the migration flow.
6. Navigate back to WP.
7. Navigate to Notifications.
8. Tap ⚙️ button at the top of the screen.
9. Ensure the Notification Settings switch is off.

## Regression Notes
1. Potential unintended areas of impact
The current "disabling WP notifs from JP" might be broken.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Testing a case including both apps is not applicable with automated tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
