### PR TITLE
Fix blogging reminders null cursor crash on `21.3-rc-3`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationContentResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationContentResolver.kt
@@ -31,16 +31,6 @@ class LocalMigrationContentResolver @Inject constructor(
     @PublishedApi internal val wordPressPublicData: WordPressPublicData,
     @PublishedApi internal val queryResult: QueryResult,
 ){
-    inline fun <reified T : LocalContentEntityData> getDataForEntityType(
-        entityType: LocalContentEntity,
-        entityId: Int? = null
-    ) = getResultForEntityType<T>(entityType, entityId).let {
-        when (it) {
-            is Success -> it.value
-            is Failure -> error(it.error)
-        }
-    }
-
     @PublishedApi internal inline fun <reified T : LocalContentEntityData> Cursor.getValue() =
             queryResult.getValue<T>(this)
 


### PR DESCRIPTION
Fixes #17608

# Description

This guards the blogging reminders migration step in a similar manner to the other migration step, preventing a null cursor (from absent provider or other error) from crashing the app.

To test:

1. Uninstall any Jetpack and WordPress apps.
2. Install Jetpack [release candidate 21.3-rc-3](https://github.com/wordpress-mobile/WordPress-Android/releases/tag/21.3-rc-3)
3. Log in to a WordPress.com account with sites

## Regression Notes
1. Potential unintended areas of impact
Migration flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Out of scope for this fix.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
