### PR TITLE
Update androidxTestEspressoVersion to 3.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ ext {
     mockitoKotlinVersion = '4.0.0'
 
     // android test
-    androidxTestEspressoVersion = '3.4.0'
+    androidxTestEspressoVersion = '3.5.0'
     androidxTestExtJunitVersion = '1.1.3'
     androidxTestUiAutomatorVersion = '2.2.0'
     screengrabVersion = '2.1.1'


### PR DESCRIPTION
Updates `androidxTestEspressoVersion` to [`3.5.0`](https://developer.android.com/jetpack/androidx/releases/test#espresso-3.5.0).

**To test:**

Since this dependency change is only related to testing, CI checks should be enough.

## Regression Notes

1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
