### PR TITLE
Update assertjVersion to 3.23.1

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCaseTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.test
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchScanStateUseCase.FetchScanState.Failure
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchScanStateUseCase.FetchScanState.Success
 import org.wordpress.android.util.NetworkUtilsWrapper
+import java.util.function.Consumer
 
 @InternalCoroutinesApi
 class FetchScanStateUseCaseTest : BaseUnitTest() {
@@ -148,6 +149,6 @@ class FetchScanStateUseCaseTest : BaseUnitTest() {
 
         val result = useCase.fetchScanState(site = site).toList(mutableListOf())
 
-        assertThat(result).allSatisfy { it is Success }
+        assertThat(result).allSatisfy(Consumer { it is Success })
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardsSourceTest.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.ui.mysite.dynamiccards
 
 import kotlinx.coroutines.InternalCoroutinesApi
-import org.assertj.core.api.Java6Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction
 import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
+import java.util.function.Consumer
 
 private val POST_STATE_DRAFT = PostStatus.DRAFT.toString()
 
@@ -109,11 +110,11 @@ class UploadActionUseCaseTest {
         val siteModel: SiteModel = createSiteModel()
 
         // Act and Assert
-        assertThat(posts).allSatisfy { post ->
+        assertThat(posts).allSatisfy (Consumer { post ->
             val action = uploadActionUseCase.getAutoUploadAction(post, siteModel)
 
             assertThat(action).isEqualTo(UploadAction.DO_NOTHING)
-        }
+        })
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadActionUseCaseTest.kt
@@ -110,7 +110,7 @@ class UploadActionUseCaseTest {
         val siteModel: SiteModel = createSiteModel()
 
         // Act and Assert
-        assertThat(posts).allSatisfy (Consumer { post ->
+        assertThat(posts).allSatisfy(Consumer { post ->
             val action = uploadActionUseCase.getAutoUploadAction(post, siteModel)
 
             assertThat(action).isEqualTo(UploadAction.DO_NOTHING)

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ ext {
 
     // test
     androidxTestCoreVersion = '1.4.0'
-    assertjVersion = '3.11.1'
+    assertjVersion = '3.23.1'
     bouncycastleVersion = '1.64'
     junitVersion = '4.13'
     mockitoVersion = "4.8.1"


### PR DESCRIPTION
Updates `assertjVersion` to [`3.23.1`](https://assertj.github.io/doc/#assertj-core-3-23-1-release-notes).

* After 6539c76a038648f73c021a7be24b0e0a82d145fd, we had `Overload resolution ambiguity` between `Consumer` & `ThrowingConsumer` in `FetchScanStateUseCaseTest` & `UploadActionUseCaseTest`. This is a [documented issue](https://github.com/assertj/assertj/issues/2357). For now, it requires syntax change made in 0d28dfc54cc6de82373d994fee121015f1db2d2e.
* 8a8d1d417f3805971220cda81cee130a12d018db updates the deprecated `org.assertj.core.api.Java6Assertions.assertThat` import with `org.assertj.core.api.Assertions.assertThat` which is what we use in all our other tests.

**To test:**

Since this dependency change is only related to testing, CI checks should be enough.

## Regression Notes

1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
