### PR TITLE
Reader: Adds new report post icon

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -212,7 +212,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
                     type = REPORT_POST,
                     label = UiStringRes(R.string.reader_menu_report_post),
                     labelColor = R.attr.wpColorError,
-                    iconRes = R.drawable.ic_block_white_24dp,
+                    iconRes = R.drawable.ic_report_white_24dp,
                     iconColor = R.attr.wpColorError,
                     onClicked = onButtonClicked
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -56,7 +56,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
         menuItems.add(SpacerNoAction())
         menuItems.add(buildBlockSite(onButtonClicked))
         menuItems.add(buildReportPost(onButtonClicked))
-        checkAndAddMenuItemForBlockUser(menuItems, onButtonClicked)
+        menuItems.add(buildBlockUser(onButtonClicked))
 
         return menuItems
     }
@@ -189,13 +189,6 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
                     iconColor = R.attr.wpColorError,
                     onClicked = onButtonClicked
             )
-
-    private fun checkAndAddMenuItemForBlockUser(
-        menuItems: MutableList<ReaderPostCardAction>,
-        onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
-    ) {
-        menuItems.add(buildBlockUser(onButtonClicked))
-    }
 
     private fun buildBlockUser(onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit) =
             SecondaryAction(

--- a/WordPress/src/main/res/drawable/ic_report_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_report_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#FFFFFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"/>
+</vector>


### PR DESCRIPTION
## Description
This PR adds a new icon for reporting posts in the Reader (ref `pcdRpT-1ms-p2#comment-2193`)

To test:
1. Open the reader
2. Press the `⋮` button next to a post
3. **Verify** that the report post action has a flag next to it

|Reader post menu|Reader post menu in dark mode|
|---|---|
|![Screenshot_20221206_120025](https://user-images.githubusercontent.com/304044/205881235-c51581b1-faa0-4f3a-8151-65839ab64ebd.png)|![Screenshot_20221206_120530](https://user-images.githubusercontent.com/304044/205881254-2abe5f2b-4951-4694-a058-03317ac4a0e2.png)|

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

6. What automated tests I added (or what prevented me from doing so)
Relied on existing tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.