### PR TITLE
Logs the user out on backpress in the migration flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
@@ -58,6 +59,7 @@ class JetpackMigrationFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initBackPressHandler()
         observeViewModelEvents()
         val showDeleteWpState = arguments?.getBoolean(KEY_SHOW_DELETE_WP_STATE, false) ?: false
         viewModel.start(showDeleteWpState)
@@ -82,6 +84,18 @@ class JetpackMigrationFragment : Fragment() {
                 null,
                 null
         )
+    }
+
+    private fun initBackPressHandler() {
+        requireActivity().onBackPressedDispatcher.addCallback(
+                viewLifecycleOwner,
+                object : OnBackPressedCallback(
+                        true
+                ) {
+                    override fun handleOnBackPressed() {
+                        viewModel.onBackPressed()
+                    }
+                })
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -174,6 +174,10 @@ class JetpackMigrationViewModel @Inject constructor(
         }
     }
 
+    fun onBackPressed() {
+        logoutAndFallbackToLogin()
+    }
+
     private fun siteUiFromModel(site: SiteModel) = SiteListItemUiState(
             id = site.siteId,
             name = siteUtilsWrapper.getSiteNameOrHomeURL(site),


### PR DESCRIPTION
Partially Fixes #17625

## Description
This PR logs the user out on back button press or swipe back gesture.

## To test
1. Prerequisite: WordPress app should be installed and logged in
2. Uninstall Jetpack App if installed or clear the app data
3. Run the Jetpack app from this branch
4. On the migration welcome screen press back
5. **Verify** that you land on the login screen

## Regression Notes
1. Potential unintended areas of impact
Migration flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Relied on existing tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
