### PR TITLE
Disable PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -132,7 +132,7 @@ android {
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_THREE", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_FOUR", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_NEW_USERS", "false"
-        buildConfigField "boolean", "PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD", "true"
+        buildConfigField "boolean", "PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD", "false"
         buildConfigField "boolean", "OPEN_WEB_LINKS_WITH_JETPACK_FLOW", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features


### PR DESCRIPTION
This disables the local build flag of disabling WP notifs from JP feature. The purpose is to be able to control the feature remotely.

When the build flag is off, the app reads the remote value.

To test:
Run JP and debug [PreventDuplicateNotifsFeatureConfig](https://github.com/wordpress-mobile/WordPress-Android/blob/e0106406efc44a85dea4038eec3a2af19b516a63/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt#L66) to ensure it's still true.
or
Follow the test instructions in #17513 to ensure the feature is enabled.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
