### PR TITLE
Prevent logout when going back from delete WP app screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -59,9 +59,9 @@ class JetpackMigrationFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initBackPressHandler()
         observeViewModelEvents()
         val showDeleteWpState = arguments?.getBoolean(KEY_SHOW_DELETE_WP_STATE, false) ?: false
+        initBackPressHandler(showDeleteWpState)
         viewModel.start(showDeleteWpState)
     }
 
@@ -86,7 +86,8 @@ class JetpackMigrationFragment : Fragment() {
         )
     }
 
-    private fun initBackPressHandler() {
+    private fun initBackPressHandler(showDeleteWpState: Boolean) {
+        if (showDeleteWpState) return
         requireActivity().onBackPressedDispatcher.addCallback(
                 viewLifecycleOwner,
                 object : OnBackPressedCallback(


### PR DESCRIPTION
Partially Fixes #17625

This PR prevents logout when navigating back from the `You no longer need the WordPress app` screen.

To test:

#### 1️⃣ Back navigation from migration flow logs the user out (no regression)

1. Prerequisite: WordPress app should be installed and logged in
2. Uninstall Jetpack App if installed or clear the app data
3. Run the Jetpack app from this branch
4. On the migration welcome screen press back
5. **Verify** that you land on the login screen

#### 2️⃣ Back navigation from the `You no longer need the WordPress app` screen
1. Prerequisite: WordPress app should be installed and logged in
2. Uninstall Jetpack App if installed or clear the app data
3. Run the Jetpack app from this branch
4. On the migration flow continue until you land on the `My Site` screen
5. Tap on the `Please delete the WordPress app` card
6. Navigate back (swipe gesture or tap device back button)
7. **Verify** that you land on the `My Site` screen

## Regression Notes
1. Potential unintended areas of impact
   Back navigation from migration flow.

8. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

9. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
