### PR TITLE
Integrate gutenberg-mobile release 1.86.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 21.4
 -----
-
+* [**] [internal] Upgrade React Native from 0.66.2 to 0.69.4 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5193]
 
 21.3
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.86.0-alpha1'
+    gutenbergMobileVersion = '5310-0033b13af85511ac92137c11f63d80b6bc4d9dca'
     wordPressAztecVersion = 'v1.6.2'
     wordPressFluxCVersion = '2.6.0'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5310-0033b13af85511ac92137c11f63d80b6bc4d9dca'
+    gutenbergMobileVersion = 'v1.86.0'
     wordPressAztecVersion = 'v1.6.2'
     wordPressFluxCVersion = '2.6.0'
     wordPressLoginVersion = '1.0.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.86.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5310

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.