### PR TITLE
Fix RTL tab swipe direction in notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -10,6 +10,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
@@ -41,6 +42,7 @@ import org.wordpress.android.ui.main.WPMainActivity
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsUnseenStatus
+import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition.All
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_ALL
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_COMMENT
@@ -73,7 +75,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            binding?.setSelectedTab(savedInstanceState.getInt(KEY_LAST_TAB_POSITION, TAB_POSITION_ALL))
+            binding?.setSelectedTab(savedInstanceState.getInt(KEY_LAST_TAB_POSITION, All.ordinal))
         }
     }
 
@@ -91,16 +93,10 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
 
             tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
                 override fun onTabSelected(tab: Tab) {
-                    val properties: MutableMap<String, String?> = HashMap(1)
-                    when (tab.position) {
-                        TAB_POSITION_ALL -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_ALL.toString()
-                        TAB_POSITION_COMMENT -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_COMMENT.toString()
-                        TAB_POSITION_FOLLOW -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_FOLLOW.toString()
-                        TAB_POSITION_LIKE -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_LIKE.toString()
-                        TAB_POSITION_UNREAD -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_UNREAD.toString()
-                        else -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_ALL.toString()
-                    }
-                    AnalyticsTracker.track(NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties)
+                    val tabPosition = TabPosition.values().getOrNull(tab.position) ?: All
+                    AnalyticsTracker.track(NOTIFICATION_TAPPED_SEGMENTED_CONTROL, hashMapOf(
+                            NOTIFICATIONS_SELECTED_FILTER to tabPosition.filter.toString()
+                    ))
                     lastTabPosition = tab.position
                 }
 
@@ -108,13 +104,9 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
                 override fun onTabReselected(tab: Tab) = Unit
             })
             viewPager.adapter = NotificationsFragmentAdapter(this@NotificationsListFragment)
-            buildTitles().let { titles ->
-                TabLayoutMediator(tabLayout, viewPager) { tab, position ->
-                    if (0 <= position && position < titles.size) {
-                        tab.text =  titles[position]
-                    }
-                }.attach()
-            }
+            TabLayoutMediator(tabLayout, viewPager) { tab, position ->
+                    tab.text =  TabPosition.values().getOrNull(position)?.let { getString(it.titleRes) } ?: ""
+            }.attach()
             viewPager.setPageTransformer(
                 MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
             )
@@ -143,16 +135,6 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
                         .newInstance(JetpackFeatureOverlayScreenType.NOTIFICATIONS)
                         .show(childFragmentManager, JetpackFeatureFullScreenOverlayFragment.TAG)
         }
-    }
-
-    private fun buildTitles(): List<String> {
-        val result: ArrayList<String> = ArrayList(TAB_COUNT)
-        result.add(TAB_POSITION_ALL, getString(R.string.notifications_tab_title_all))
-        result.add(TAB_POSITION_UNREAD, getString(R.string.notifications_tab_title_unread_notifications))
-        result.add(TAB_POSITION_COMMENT, getString(R.string.notifications_tab_title_comments))
-        result.add(TAB_POSITION_FOLLOW, getString(R.string.notifications_tab_title_follows))
-        result.add(TAB_POSITION_LIKE, getString(R.string.notifications_tab_title_likes))
-        return result
     }
 
     override fun onPause() {
@@ -221,7 +203,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
 
     private class NotificationsFragmentAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {
         override fun getItemCount(): Int {
-            return TAB_COUNT
+            return TabPosition.values().size
         }
 
         override fun createFragment(position: Int): Fragment {
@@ -255,12 +237,13 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         const val NOTE_MODERATE_ID_EXTRA = "moderateNoteId"
         const val NOTE_MODERATE_STATUS_EXTRA = "moderateNoteStatus"
         const val NOTE_CURRENT_LIST_FILTER_EXTRA = "currentFilter"
-        private const val TAB_COUNT = 5
-        const val TAB_POSITION_ALL = 0
-        const val TAB_POSITION_UNREAD = 1
-        const val TAB_POSITION_COMMENT = 2
-        const val TAB_POSITION_FOLLOW = 3
-        const val TAB_POSITION_LIKE = 4
+        enum class TabPosition(@StringRes val titleRes: Int, val filter: FILTERS) {
+            All(R.string.notifications_tab_title_all, FILTER_ALL),
+            Unread(R.string.notifications_tab_title_unread_notifications, FILTER_UNREAD),
+            Comment(R.string.notifications_tab_title_comments, FILTER_COMMENT),
+            Follow(R.string.notifications_tab_title_follows, FILTER_FOLLOW),
+            Like(R.string.notifications_tab_title_likes, FILTER_LIKE);
+        }
         private const val KEY_LAST_TAB_POSITION = "lastTabPosition"
         fun newInstance(): NotificationsListFragment {
             return NotificationsListFragment()

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -36,14 +36,15 @@ import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsCh
 import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsRefreshCompleted
 import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsRefreshError
 import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsUnseenStatus
+import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition
+import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition.All
+import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition.Comment
+import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition.Follow
+import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition.Like
+import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition.Unread
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter.DataLoadedListener
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_ALL
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_COMMENT
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_FOLLOW
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_LIKE
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_UNREAD
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter
 import org.wordpress.android.ui.notifications.utils.NotificationsActions
 import org.wordpress.android.util.AniUtils
@@ -86,16 +87,9 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         val adapter = createOrGetNotesAdapter()
         binding?.notificationsList?.adapter = adapter
         if (savedInstanceState != null) {
-            tabPosition = savedInstanceState.getInt(KEY_TAB_POSITION, NotificationsListFragment.TAB_POSITION_ALL)
+            tabPosition = savedInstanceState.getInt(KEY_TAB_POSITION, All.ordinal)
         }
-        when (tabPosition) {
-            NotificationsListFragment.TAB_POSITION_ALL -> adapter.setFilter(FILTER_ALL)
-            NotificationsListFragment.TAB_POSITION_COMMENT -> adapter.setFilter(FILTER_COMMENT)
-            NotificationsListFragment.TAB_POSITION_FOLLOW -> adapter.setFilter(FILTER_FOLLOW)
-            NotificationsListFragment.TAB_POSITION_LIKE -> adapter.setFilter(FILTER_LIKE)
-            NotificationsListFragment.TAB_POSITION_UNREAD -> adapter.setFilter(FILTER_UNREAD)
-            else -> adapter.setFilter(FILTER_ALL)
-        }
+        (TabPosition.values().getOrNull(tabPosition) ?: All).let { adapter.setFilter(it.filter) }
     }
 
     @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
@@ -121,7 +115,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         arguments?.let {
-            tabPosition = it.getInt(KEY_TAB_POSITION, NotificationsListFragment.TAB_POSITION_ALL)
+            tabPosition = it.getInt(KEY_TAB_POSITION, All.ordinal)
         }
         binding = NotificationsListFragmentPageBinding.bind(view).apply {
             notificationsList.layoutManager = LinearLayoutManager(activity)
@@ -288,7 +282,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
             ActivityLauncher.showSignInForResult(activity)
             return
         }
-        if (tabPosition == NotificationsListFragment.TAB_POSITION_UNREAD) {
+        if (tabPosition == Unread.ordinal) {
             ActivityLauncher.addNewPostForResult(activity, selectedSite, false, POST_FROM_NOTIFS_EMPTY_VIEW, -1, null)
         } else if (activity is WPMainActivity) {
             (requireActivity() as WPMainActivity).setReaderPageActive()
@@ -329,27 +323,27 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         var descriptionResId = 0
         var buttonResId = 0
         when (tabPosition) {
-            NotificationsListFragment.TAB_POSITION_ALL -> {
+            All.ordinal -> {
                 titleResId = R.string.notifications_empty_all
                 descriptionResId = R.string.notifications_empty_action_all
                 buttonResId = R.string.notifications_empty_view_reader
             }
-            NotificationsListFragment.TAB_POSITION_COMMENT -> {
+            Comment.ordinal -> {
                 titleResId = R.string.notifications_empty_comments
                 descriptionResId = R.string.notifications_empty_action_comments
                 buttonResId = R.string.notifications_empty_view_reader
             }
-            NotificationsListFragment.TAB_POSITION_FOLLOW -> {
+            Follow.ordinal -> {
                 titleResId = R.string.notifications_empty_followers
                 descriptionResId = R.string.notifications_empty_action_followers_likes
                 buttonResId = R.string.notifications_empty_view_reader
             }
-            NotificationsListFragment.TAB_POSITION_LIKE -> {
+            Like.ordinal -> {
                 titleResId = R.string.notifications_empty_likes
                 descriptionResId = R.string.notifications_empty_action_followers_likes
                 buttonResId = R.string.notifications_empty_view_reader
             }
-            NotificationsListFragment.TAB_POSITION_UNREAD -> {
+            Unread.ordinal -> {
                 if (selectedSite == null) {
                     titleResId = R.string.notifications_empty_unread
                 } else {

--- a/WordPress/src/main/res/layout/notifications_list_fragment.xml
+++ b/WordPress/src/main/res/layout/notifications_list_fragment.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <org.wordpress.android.widgets.WPViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/view_pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
Fixes #17530

### Description

Notifications is currently using `WPViewPager` (extends `ViewPager`) which does not support RTL. This PR migrates the implementation to use `ViewPager2`, supporting RTL.

To test:

Follow [the steps in the issue](https://github.com/wordpress-mobile/WordPress-Android/issues/17530#issue-1463389504), and expect that the swipe direction for RTL locales works as expected.

## Regression Notes
1. Potential unintended areas of impact
Notifications tabs

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Coverage would require e2e tests for this UI which is currently not established.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
