### PR TITLE
[Dependency Updates] Update `androidxArchCoreVersion` to 2.1.0

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -370,6 +370,8 @@ dependencies {
     debugImplementation "com.facebook.stetho:stetho:$stethoVersion"
     debugImplementation "com.facebook.stetho:stetho-okhttp3:$stethoVersion"
 
+    implementation "androidx.arch.core:core-common:$androidxArchCoreVersion"
+    implementation "androidx.arch.core:core-runtime:$androidxArchCoreVersion"
     implementation "com.google.code.gson:gson:$googleGsonVersion"
     implementation "androidx.core:core:$androidxCoreVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
     androidInstallReferrerVersion = '2.2'
     androidVolleyVersion = '1.1.1'
     androidxAppcompatVersion = '1.1.0'
-    androidxArchCoreVersion = '2.0.0'
+    androidxArchCoreVersion = '2.1.0'
     androidxComposeVersion = '1.1.1'
     androidxComposeCompilerVersion = '1.1.1'
     androidxComposeLifecycleVersion = '2.4.1'


### PR DESCRIPTION
Parent #17561
Batch Branch: [deps/main-batch-androidx-core](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-core)

This PR updates `androidxArchCoreVersion` to [2.1.0](https://developer.android.com/jetpack/androidx/releases/arch-core#2.1.0).

Also, as part of this update the below transitive dependencies were added on the `WordPress` module (8884a005f011ca6217c024919ad640abc99ed76d):
- `androidx.arch.core:core-common`
- `androidx.arch.core:core-runtime`

-----

PS: @irfano I added you as the main reviewer, that is, in addition to the @wordpress-mobile/apps-infrastructure  team itself, but randomly, since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid.

-----

To test:

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you want to be thorough about reviewing this change, you could:
    1. See the dependency tree diff result and verify correctness.
    2. Quickly smoke test both, the WordPress and Jetpack apps, and see if they both work as expected.

Note the fact that:
- This `androidxArchCoreVersion` version is only related to testing (see `androidx.arch.core:core-testing`). See `androidx.arch.core` related imports.
- Transitively, this `androidxArchCoreVersion` dependency was already pointing to `2.1.0` anyway.

-----

## Regression Notes
1. Potential unintended areas of impact

Some of the transitive dependencies added might be causing some kind of misbehaviour.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
