### PR TITLE
[Jetpack Migration Flow] Migrate app theme, initial screen and recently picked sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
@@ -74,5 +74,6 @@ class UserFlagsProviderHelper @Inject constructor(
             UndeletablePrefKey.SHOULD_SHOW_STORAGE_WARNING.name,
             UndeletablePrefKey.LAST_USED_USER_ID.name,
             contextProvider.getContext().getString(R.string.pref_key_app_theme),
+            contextProvider.getContext().getString(R.string.pref_key_initial_screen),
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
@@ -8,12 +8,14 @@ import org.wordpress.android.localcontentmigration.LocalContentEntityData.UserFl
 import org.wordpress.android.ui.prefs.AppPrefs.DeletablePrefKey
 import org.wordpress.android.ui.prefs.AppPrefs.UndeletablePrefKey
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
 
 class UserFlagsProviderHelper @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     contextProvider: ContextProvider,
+    localeManagerWrapper: LocaleManagerWrapper
 ) : LocalDataProviderHelper {
     override fun getData(localEntityId: Int?): LocalContentEntityData =
             UserFlagsData(
@@ -75,5 +77,7 @@ class UserFlagsProviderHelper @Inject constructor(
             UndeletablePrefKey.LAST_USED_USER_ID.name,
             contextProvider.getContext().getString(R.string.pref_key_app_theme),
             contextProvider.getContext().getString(R.string.pref_key_initial_screen),
+            contextProvider.getContext().getString(R.string.pref_key_send_crash),
+            localeManagerWrapper.getLocalePrefKeyString()
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 
 class UserFlagsProviderHelper @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
-): LocalDataProviderHelper {
+) : LocalDataProviderHelper {
     override fun getData(localEntityId: Int?): LocalContentEntityData =
             UserFlagsData(
                     flags = appPrefsWrapper.getAllPrefs().filter(::shouldInclude),
@@ -60,6 +60,7 @@ class UserFlagsProviderHelper @Inject constructor(
             DeletablePrefKey.READER_DISCOVER_WELCOME_BANNER_SHOWN.name,
             DeletablePrefKey.SHOULD_SCHEDULE_CREATE_SITE_NOTIFICATION.name,
             DeletablePrefKey.SELECTED_SITE_LOCAL_ID.name,
+            DeletablePrefKey.RECENTLY_PICKED_SITE_IDS.name,
             UndeletablePrefKey.THEME_IMAGE_SIZE_WIDTH.name,
             UndeletablePrefKey.BOOKMARKS_SAVED_LOCALLY_DIALOG_SHOWN.name,
             UndeletablePrefKey.IMAGE_OPTIMIZE_PROMO_REQUIRED.name,

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
@@ -1,16 +1,19 @@
 package org.wordpress.android.localcontentmigration
 
 import com.yarolegovich.wellsql.WellSql
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.QuickStartStatusModel
 import org.wordpress.android.fluxc.model.QuickStartTaskModel
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.UserFlagsData
 import org.wordpress.android.ui.prefs.AppPrefs.DeletablePrefKey
 import org.wordpress.android.ui.prefs.AppPrefs.UndeletablePrefKey
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
 
 class UserFlagsProviderHelper @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
+    contextProvider: ContextProvider,
 ) : LocalDataProviderHelper {
     override fun getData(localEntityId: Int?): LocalContentEntityData =
             UserFlagsData(
@@ -69,6 +72,7 @@ class UserFlagsProviderHelper @Inject constructor(
             UndeletablePrefKey.IS_MAIN_FAB_TOOLTIP_DISABLED.name,
             UndeletablePrefKey.SHOULD_SHOW_STORIES_INTRO.name,
             UndeletablePrefKey.SHOULD_SHOW_STORAGE_WARNING.name,
-            UndeletablePrefKey.LAST_USED_USER_ID.name
+            UndeletablePrefKey.LAST_USED_USER_ID.name,
+            contextProvider.getContext().getString(R.string.pref_key_app_theme),
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.ui.main.jetpack.migration.compose.state.ErrorStep
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.LoadingState
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.NotificationsStep
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.WelcomeStep
+import org.wordpress.android.util.AppThemeUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -60,6 +61,7 @@ class JetpackMigrationFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         observeViewModelEvents()
+        observeRefreshAppThemeEvents()
         val showDeleteWpState = arguments?.getBoolean(KEY_SHOW_DELETE_WP_STATE, false) ?: false
         initBackPressHandler(showDeleteWpState)
         viewModel.start(showDeleteWpState)
@@ -67,6 +69,12 @@ class JetpackMigrationFragment : Fragment() {
 
     private fun observeViewModelEvents() {
         viewModel.actionEvents.onEach(this::handleActionEvents).launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun observeRefreshAppThemeEvents() {
+        viewModel.refreshAppTheme.observe(viewLifecycleOwner) {
+            AppThemeUtils.setAppTheme(requireActivity())
+        }
     }
 
     private fun handleActionEvents(actionEvent: JetpackMigrationActionEvent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.main.jetpack.migration
 import android.content.Intent
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -72,6 +74,9 @@ class JetpackMigrationViewModel @Inject constructor(
 ) : ViewModel() {
     private val _actionEvents = Channel<JetpackMigrationActionEvent>(Channel.BUFFERED)
     val actionEvents = _actionEvents.receiveAsFlow()
+
+    private val _refreshAppTheme = MutableLiveData<Unit>()
+    val refreshAppTheme: LiveData<Unit> = _refreshAppTheme
 
     private val migrationStateFlow = MutableStateFlow<LocalMigrationState>(Initial)
     private val continueClickedFlow = MutableStateFlow(false)
@@ -230,6 +235,7 @@ class JetpackMigrationViewModel @Inject constructor(
     }
 
     private fun onFinishClicked() {
+        _refreshAppTheme.value = Unit
         migrationAnalyticsTracker.trackThanksScreenFinishButtonTapped()
         migrationEmailHelper.notifyMigrationComplete()
         appPrefsWrapper.setJetpackMigrationCompleted(true)

--- a/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.java
@@ -304,4 +304,8 @@ public class LocaleManager {
         }
         return displayLanguage;
     }
+
+    public static String getLocalePrefKeyString() {
+        return LANGUAGE_KEY;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/LocaleManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LocaleManagerWrapper.kt
@@ -12,4 +12,5 @@ class LocaleManagerWrapper
     fun getTimeZone(): TimeZone = TimeZone.getDefault()
     fun getCurrentCalendar(): Calendar = Calendar.getInstance(getLocale())
     fun getLanguage(): String = LocaleManager.getLanguage(context)
+    fun getLocalePrefKeyString(): String = LocaleManager.getLocalePrefKeyString()
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
@@ -152,7 +152,6 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
         verify(refreshAppThemeObserver).onChanged(Unit)
     }
 
-
     @Test
     fun `Should track when delete wp app screen is shown`() {
         classToTest.initPleaseDeleteWordPressAppScreenUi()

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.main.jetpack.migration
 
+import androidx.lifecycle.Observer
 import kotlinx.coroutines.flow.first
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -39,6 +40,7 @@ import org.wordpress.android.viewmodel.ContextProvider
 
 @RunWith(MockitoJUnitRunner::class)
 class JetpackMigrationViewModelTest : BaseUnitTest() {
+    private val refreshAppThemeObserver: Observer<Unit> = mock()
     private val siteUtilsWrapper: SiteUtilsWrapper = mock()
     private val gravatarUtilsWrapper: GravatarUtilsWrapper = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock()
@@ -63,6 +65,7 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
     @Before
     fun setUp() {
         whenever(gravatarUtilsWrapper.fixGravatarUrlWithResource(any(), any())).thenReturn("")
+        classToTest.refreshAppTheme.observeForever(refreshAppThemeObserver)
     }
 
     // region ViewModel
@@ -139,6 +142,16 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
 
         verify(contentMigrationAnalyticsTracker).trackThanksScreenFinishButtonTapped()
     }
+
+    @Test
+    fun `Should emit refresh app theme when finish button is tapped on success screen`() {
+        val successScreen = classToTest.initSuccessScreenUi()
+
+        successScreen.primaryActionButton.onClick.invoke()
+
+        verify(refreshAppThemeObserver).onChanged(Unit)
+    }
+
 
     @Test
     fun `Should track when delete wp app screen is shown`() {


### PR DESCRIPTION
Related to #17645

To test
1 - Launch WP and login;
2 - Tap on profile picture (`Me`) -> `App Settings`;
3 - Tap on `Appearance` and select any theme option except `System Default`;
4 - Tap on `Initial Screen` and select any option;
5 - Tap on 'Interface Language' and select a different language
6 - Tap on 'Privacy settings' and change the value of "Crash reports"
7 - Move back to `My Site` screen;
8 - Open the site picker, select a site and repeat with a few different sites (so they appear on top of the site picker list);
9 - Install JP, clear app storage and launch to trigger the migration;
10 - Go through the migration screens: the theme here will be system default, but after the migration is done the app theme should be the same as selected on step 3;
11 - The selected tab on "My Site" should be the same as selected on step 4;
12 - Interface Language: as for the Theme, the migration screen will use the system default language but after the migration is done the app language should be set as per step 5
13 - Privacy settings should be as set on step 6
12 - Open the site picker: the recently picked sites should appear on top (just like WP).

## Regression Notes
1. Potential unintended areas of impact
None

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

4. What automated tests I added (or what prevented me from doing so)
Updated `JetpackMigrationViewModelTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
