### PR TITLE
Improvements on Category managment feature 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 21.4
 -----
+* [**] Adds the functionality to Add, Edit and Delete categories from site settings. [https://github.com/wordpress-mobile/WordPress-Android/pull/17652]
 * [**] [internal] Upgrade React Native from 0.66.2 to 0.69.4 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5193]
 
 21.3

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -135,8 +135,6 @@ import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.SiteSettingsTagDetailFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsTagListActivity;
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsFragment;
-import org.wordpress.android.ui.prefs.categories.detail.CategoryDetailFragment;
-import org.wordpress.android.ui.prefs.categories.list.CategoriesListFragment;
 import org.wordpress.android.ui.prefs.homepage.HomepageSettingsDialog;
 import org.wordpress.android.ui.prefs.language.LocalePickerBottomSheet;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsFragment;
@@ -601,10 +599,6 @@ public interface AppComponent {
     void inject(BloggingReminderBottomSheetFragment object);
 
     void inject(LocalePickerBottomSheet object);
-
-    void inject(CategoriesListFragment object);
-
-    void inject(CategoryDetailFragment object);
 
     void inject(LayoutPreviewFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -508,18 +508,8 @@ abstract class ViewModelModule {
 
     @Binds
     @IntoMap
-    @ViewModelKey(CategoriesListViewModel.class)
-    abstract ViewModel categoriesViewModel(CategoriesListViewModel viewModel);
-
-    @Binds
-    @IntoMap
     @ViewModelKey(LocalePickerViewModel.class)
     abstract ViewModel localePickerViewModel(LocalePickerViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(CategoryDetailViewModel.class)
-    abstract ViewModel categoryDetailViewModel(CategoryDetailViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -45,8 +45,6 @@ import org.wordpress.android.ui.posts.PrepublishingViewModel;
 import org.wordpress.android.ui.posts.editor.StorePostViewModel;
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsViewModel;
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel;
-import org.wordpress.android.ui.prefs.categories.detail.CategoryDetailViewModel;
-import org.wordpress.android.ui.prefs.categories.list.CategoriesListViewModel;
 import org.wordpress.android.ui.prefs.homepage.HomepageSettingsViewModel;
 import org.wordpress.android.ui.prefs.language.LocalePickerViewModel;
 import org.wordpress.android.ui.prefs.timezone.SiteSettingsTimezoneViewModel;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailActivity.kt
@@ -2,9 +2,11 @@ package org.wordpress.android.ui.prefs.categories.detail
 
 import android.os.Bundle
 import android.view.MenuItem
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.databinding.CategoryDetailActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
+@AndroidEntryPoint
 class CategoryDetailActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailFragment.kt
@@ -15,10 +15,10 @@ import android.widget.AdapterView
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog.Builder
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.CategoryDetailFragmentBinding
 import org.wordpress.android.models.CategoryNode
 import org.wordpress.android.ui.ActivityLauncher
@@ -34,9 +34,9 @@ import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class CategoryDetailFragment : Fragment(R.layout.category_detail_fragment) {
-    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
-    private lateinit var viewModel: CategoryDetailViewModel
+    private val viewModel: CategoryDetailViewModel by viewModels()
     @Inject lateinit var uiHelpers: UiHelpers
     private lateinit var categoryAdapter: ParentCategorySpinnerAdapter
 
@@ -48,7 +48,6 @@ class CategoryDetailFragment : Fragment(R.layout.category_detail_fragment) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)
-        initDagger()
 
         val categoryId = getCategoryId(savedInstanceState)
 
@@ -73,10 +72,6 @@ class CategoryDetailFragment : Fragment(R.layout.category_detail_fragment) {
             return null
         isInEditMode = true
         return categoryId
-    }
-
-    private fun initDagger() {
-        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun CategoryDetailFragmentBinding.initAdapter() {
@@ -139,8 +134,6 @@ class CategoryDetailFragment : Fragment(R.layout.category_detail_fragment) {
     }
 
     private fun CategoryDetailFragmentBinding.initViewModel(categoryId: Long?) {
-        viewModel = ViewModelProvider(this@CategoryDetailFragment, viewModelFactory)
-                .get(CategoryDetailViewModel::class.java)
         startObserving()
         viewModel.start(categoryId)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.prefs.categories.detail
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
@@ -32,6 +33,7 @@ import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
+@HiltViewModel
 class CategoryDetailViewModel @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val networkUtilsWrapper: NetworkUtilsWrapper,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListActivity.kt
@@ -2,9 +2,11 @@ package org.wordpress.android.ui.prefs.categories.list
 
 import android.os.Bundle
 import android.view.MenuItem
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.databinding.SiteSettingsCategoriesListActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
+@AndroidEntryPoint
 class CategoriesListActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListFragment.kt
@@ -3,8 +3,9 @@ package org.wordpress.android.ui.prefs.categories.list
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SiteSettingsCategoriesListFragmentBinding
@@ -18,15 +19,14 @@ import org.wordpress.android.ui.prefs.categories.list.UiState.Loading
 import org.wordpress.android.ui.utils.UiHelpers
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class CategoriesListFragment : Fragment(R.layout.site_settings_categories_list_fragment) {
-    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
-    private lateinit var viewModel: CategoriesListViewModel
+    private val viewModel: CategoriesListViewModel by viewModels()
     @Inject lateinit var uiHelpers: UiHelpers
     private lateinit var adapter: SiteSettingsCategoriesAdapter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initDagger()
 
         with(SiteSettingsCategoriesListFragmentBinding.bind(view)) {
             initRecyclerView()
@@ -36,13 +36,7 @@ class CategoriesListFragment : Fragment(R.layout.site_settings_categories_list_f
         }
     }
 
-    private fun initDagger() {
-        (requireActivity().application as WordPress).component().inject(this)
-    }
-
     private fun SiteSettingsCategoriesListFragmentBinding.initViewModel(site: SiteModel) {
-        viewModel = ViewModelProvider(this@CategoriesListFragment, viewModelFactory)
-                .get(CategoriesListViewModel::class.java)
         setupObservers()
         viewModel.start(site)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.prefs.categories.list
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import org.greenrobot.eventbus.Subscribe
@@ -30,6 +31,7 @@ import javax.inject.Named
 
 private const val RETRY_DELAY = 300L
 
+@HiltViewModel
 class CategoriesListViewModel @Inject constructor(
     private val getCategoriesUseCase: GetCategoriesUseCase,
     private val networkUtilsWrapper: NetworkUtilsWrapper,

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ManageCategoriesFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ManageCategoriesFeatureConfig.kt
@@ -1,17 +1,22 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
 /**
- * Configuration of the my site infrastructure improvements
+ * Configuration of the manage categories feature
  */
-@FeatureInDevelopment
+@Feature(ManageCategoriesFeatureConfig.MANAGE_CATEGORIES_REMOTE_FIELD, true)
 class ManageCategoriesFeatureConfig
 @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
         appConfig,
-        BuildConfig.MANAGE_CATEGORIES
-)
+        BuildConfig.MANAGE_CATEGORIES,
+        MANAGE_CATEGORIES_REMOTE_FIELD
+){
+    companion object {
+        const val MANAGE_CATEGORIES_REMOTE_FIELD = "manage_categories"
+    }
+}


### PR DESCRIPTION
Part of #16058 

This PR has the following changes 
- Updates: Category management-related activities and fragments to the hilt dependency injection 
- Updates: the category flag to remote feature flag from features in Development 
- Adds: release notes for category management feature 

To test:

Note: The Add/Edit/Delete category is already tested and merged with the PR (https://github.com/wordpress-mobile/WordPress-Android/pull/17627). One more round of checking is needed for Regression issues if any 

- Verify that the Category management feature works as expected 
   - Go to My Site -> Menu -> Site Settings -> Categories 
   - Verify that Add/Edit/Delete category works as expected 

- Make sure that the Category management feature is visible in remote features 
  - Go to me -> App settings -> Debug settings 
  - Verify that `manage categories` flag is visible


cc: @zwarm For visibility. 

## Regression Notes
1. Potential unintended areas of impact
Add/Edit/Delete category doesn't work as expected 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests 

3. What automated tests I added (or what prevented me from doing so)
Units tests 

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
