### PR TITLE
Add autoverify to deep link intent receiver

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -434,7 +434,7 @@
             android:theme="@style/WordPress.NoActionBar"
             android:excludeFromRecents="true"
             android:exported="true">
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
This PR adds the `android:autoVerify="true"` to the WebLinksDeepLinkingIntentReceiverActivity deep link receiver.

To test:
- Uninstall all versions of the apps from the device (including pre-alphas)
- Install the Jetpack app.
- Install the WordPress app and log in.
- Tap on the Stats link displayed on [this webpage](https://href.li/?https://codepen.io/fluiddot/pen/GRGOxBN).
- Observe that link redirects to the WordPress app and the “Open links in Jetpack?” screen is shown.
- Tap on “Open links in Jetpack” button.
- Observe that the Jetpack app is opened.

## Regression Notes
1. Potential unintended areas of impact
Web links don't open

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
