### PR TITLE
Fix migration flow error when changing device settings mid-flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationActivity.kt
@@ -16,9 +16,11 @@ class JetpackMigrationActivity : AppCompatActivity() {
         with(ActivityJetpackMigrationBinding.inflate(layoutInflater)) {
             setContentView(root)
             val showDeleteWpState = intent.getBooleanExtra(KEY_SHOW_DELETE_WP_STATE, false)
-            supportFragmentManager.beginTransaction()
-                    .replace(R.id.fragment_container, JetpackMigrationFragment.newInstance(showDeleteWpState))
-                    .commit()
+            if (savedInstanceState == null) {
+                supportFragmentManager.beginTransaction()
+                        .replace(R.id.fragment_container, JetpackMigrationFragment.newInstance(showDeleteWpState))
+                        .commit()
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -73,6 +73,7 @@ class JetpackMigrationViewModel @Inject constructor(
     private val _actionEvents = Channel<JetpackMigrationActionEvent>(Channel.BUFFERED)
     val actionEvents = _actionEvents.receiveAsFlow()
 
+    private var isStarted = false
     private val migrationStateFlow = MutableStateFlow<LocalMigrationState>(Initial)
     private val continueClickedFlow = MutableStateFlow(false)
     private val notificationContinueClickedFlow = MutableStateFlow(false)
@@ -102,6 +103,9 @@ class JetpackMigrationViewModel @Inject constructor(
     }.stateIn(viewModelScope, SharingStarted.Lazily, Loading)
 
     fun start(showDeleteState: Boolean) {
+        if (isStarted) return
+        isStarted = true
+
         this.showDeleteState = showDeleteState
         tryMigration()
     }


### PR DESCRIPTION
Fixes #17646

This PR ensures the migration flow can be continued if device settings are changed mid-flow.

> **Note**: ~Currently I'm not sure which should be the target branch for this PR, either `trunk` or `release/21.3`.
> Since I started on top of `release/21.3` it's set for the moment to target that branch.
> There are merge conflicts that need to be fixed before this PR can be merged in `21.3`~
> Updated to target `trunk` [as discussed](https://github.com/wordpress-mobile/WordPress-Android/pull/17659#issuecomment-1344352192)

To test:

0. **Prerequisite** WordPress app of the same flavor should be installed and logged in.
1. Uninstall and reinstall Jetpack app but don’t open it.
2. Tap “try the new Jetpack app” in the WordPress app
3. See the “Welcome” screen. (alternately: Tap “continue” to go to the “Notifications come from Jetpack screen” or the flow completion screen)
4. Open Android Settings and change language, or switch light/dark mode.
5. Swipe back over to the Jetpack app.
6. **Expect** To be able to continue (no error screen), from the last shown migration screen 
7. Continue the flow **expecting** it to work as intended without errors.

#### 🧪 Test "Delete WordPress App Screen" for no regression

After completing the flow in the Jetpack app:

1. Tap the "Please delete the WordPress app" card on `My Site`
2. **Expect** to see the screen informing you to delete the WordPress app
3. Open Android Settings and change language, or switch light/dark mode.
4. Go back to the Jetpack app
5. **Expect** to see the screen to delete the WordPress app updated based on the changed settings.
6. Tap the `Got it` button
7. Expect to land on the `My Site` screen

### Preview
https://user-images.githubusercontent.com/4588074/206709216-ad04faee-2c78-4e60-afe7-3eb3186f5e2d.mp4

## Regression Notes
1. Potential unintended areas of impact
   - Delete WP app screen (accessible from from `My Site` after completing the migration flow).
   - Migration flow UI in Jetpack app.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

8. What automated tests I added (or what prevented me from doing so)
   Added test to check migration is not retried.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
