### PR TITLE
Fix wrong publish date when publishing drafts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2111,8 +2111,10 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 if (publishPost) {
                     // now set status to PUBLISHED - only do this AFTER we have run the isFirstTimePublish() check,
                     // otherwise we'd have an incorrect value
-                    // also re-set the published date in case it was SCHEDULED and they want to publish NOW
-                    if (postModel.getStatus().equals(PostStatus.SCHEDULED.toString())) {
+                    // also re-set the published date in case it was SCHEDULED and they want to publish NOW or
+                    // it should be published immediately based on shouldPublishImmediately logic
+                    if (postModel.getStatus().equals(PostStatus.SCHEDULED.toString())
+                        || mPostUtils.shouldPublishImmediately(postModel)) {
                         postModel.setDateCreated(mDateTimeUtils.currentTimeInIso8601());
                     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
@@ -177,7 +177,7 @@ class EditPostRepository
             UploadService.getPendingOrInProgressMediaUploadsForPost(post)
 
     fun updatePublishDateIfShouldBePublishedImmediately(post: PostModel) {
-        if (postUtils.shouldPublishImmediately(fromPost(post), post.dateCreated)) {
+        if (postUtils.shouldPublishImmediately(post)) {
             post.setDateCreated(DateTimeUtils.iso8601FromDate(localeManagerWrapper.getCurrentCalendar().time))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsUtils.kt
@@ -23,13 +23,13 @@ class PostSettingsUtils
         if (!TextUtils.isEmpty(dateCreated)) {
             val formattedDate = statsDateUtils.formatDateTime(dateCreated)
 
-            if (postModel.isLocalDraft) {
-                if (postUtilsWrapper.isPublishDateInThePast(postModel.dateCreated)) {
+            if (postModel.isLocalDraft || status == PostStatus.DRAFT) {
+                if (postUtilsWrapper.shouldPublishImmediately(postModel)) {
+                    labelToUse = resourceProvider.getString(R.string.immediately)
+                } else if (postUtilsWrapper.isPublishDateInThePast(postModel.dateCreated)) {
                     labelToUse = resourceProvider.getString(R.string.backdated_for, formattedDate)
                 } else if (postUtilsWrapper.isPublishDateInTheFuture(postModel.dateCreated)) {
                     labelToUse = resourceProvider.getString(R.string.schedule_for, formattedDate)
-                } else if (postUtilsWrapper.shouldPublishImmediately(status, postModel.dateCreated)) {
-                    labelToUse = resourceProvider.getString(R.string.immediately)
                 } else {
                     labelToUse = resourceProvider.getString(R.string.publish_on, formattedDate)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -321,9 +321,17 @@ public class PostUtils {
         Date pubDate = DateTimeUtils.dateFromIso8601(postModel.getDateCreated());
         Date modifiedDate = DateTimeUtils.dateFromIso8601(postModel.getLastModified());
         Date now = new Date();
+
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(now);
+        // just use half an hour before now as a threshold to make sure this is not backdated, to avoid false negatives
+        cal.add(Calendar.MINUTE, -30);
+        Date halfHourBack = cal.getTime();
+
         // Publish immediately for posts that don't have any date set yet and drafts with publish dates in the past
         // that were also modified at the same date, meaning the user didn't set that past date deliberately
-        return pubDate == null || (!pubDate.after(now) && pubDate.getTime() == modifiedDate.getTime());
+        return pubDate == null || (!pubDate.after(now) && (pubDate.getTime() == modifiedDate.getTime()
+                || pubDate.after(halfHourBack)));
     }
 
     static boolean shouldPublishImmediately(PostStatus postStatus, String dateCreated) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
@@ -25,8 +25,8 @@ class PostUtilsWrapper @Inject constructor(private val dateProvider: DateProvide
     fun isPostCurrentlyBeingEdited(post: PostImmutableModel) =
             PostUtils.isPostCurrentlyBeingEdited(post)
 
-    fun shouldPublishImmediately(postStatus: PostStatus, dateCreated: String) =
-            PostUtils.shouldPublishImmediately(postStatus, dateCreated)
+    fun shouldPublishImmediately(postModel: PostImmutableModel) =
+            PostUtils.shouldPublishImmediately(postModel)
 
     fun postHasEdits(oldPost: PostImmutableModel?, newPost: PostImmutableModel) =
             PostUtils.postHasEdits(oldPost, newPost)

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostRepositoryTest.kt
@@ -363,7 +363,7 @@ class EditPostRepositoryTest {
         post.setStatus(DRAFT.toString())
         post.setDateCreated(dateCreated)
         editPostRepository.set { post }
-        whenever(postUtils.shouldPublishImmediately(DRAFT, dateCreated)).thenReturn(true)
+        whenever(postUtils.shouldPublishImmediately(post)).thenReturn(true)
 
         editPostRepository.updatePublishDateIfShouldBePublishedImmediately(post)
 
@@ -382,7 +382,7 @@ class EditPostRepositoryTest {
         post.setStatus(PUBLISHED.toString())
         post.setDateCreated(dateCreated)
         editPostRepository.set { post }
-        whenever(postUtils.shouldPublishImmediately(PUBLISHED, dateCreated)).thenReturn(false)
+        whenever(postUtils.shouldPublishImmediately(post)).thenReturn(false)
 
         editPostRepository.updatePublishDateIfShouldBePublishedImmediately(post)
 


### PR DESCRIPTION
Fixes #15244

This is currently just a draft PR for fixing some of the behaviors and issues listed in #15244. This is not a complete fix for everything there right now, and I probably won't be able to wrap this up right now, so I am leaving this draft as a base for further discussion, and a POC of the intention I had with it.

The changes were made to improve the logic of `shouldPublishImmediately` to better match the web logic, which means: * consider draft posts with same `created` and `modified` dates as posts that should be published immediately
* show the "Immediately" string in the prepublishing nudge dialog for draft posts in that case
* make sure the publish date you see in the prepublishing nudge dialog is what is actually going to be the `created` date of the post

Since this doesn't fix the problem of `created` and `modified` dates being slightly different when saving edits in draft posts, these changes also move the logic of having posts with publish date in the past 30-minute window be considered an intention to post "immediately", which was inside `isPublishDateInThePast` before for basically the same reason.

To test:
The issue has more details, and since this is probably staying in Draft state I won't repeat it here right now.

## Regression Notes
1. Potential unintended areas of impact
This changes **post** publishing in general, which means **pages** and other objects based on **posts** will also have the same logic now, which might not be expected (although I think it should make sense in all publishing scenarios).

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested it with posts, and since this is more of a POC / draft, it would need to be properly tested.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
