### PR TITLE
Hide Scan Login Code when 2FA is active.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 21.4
 -----
-
+* [*] [Jetpack-only] Hiding Scan Login QR Code when logged into an account with 2FA. [https://github.com/wordpress-mobile/WordPress-Android/pull/17662]
 
 21.3
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -238,7 +238,6 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
     private fun shouldShowQrCodeLogin(): Boolean {
         return qrCodeAuthFlowFeatureConfig.isEnabled() &&
-                BuildConfig.ENABLE_QRCODE_AUTH_FLOW &&
                 accountStore.hasAccessToken() &&
                 accountStore.account?.twoStepEnabled != true
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -198,10 +198,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        if (qrCodeAuthFlowFeatureConfig.isEnabled() &&
-                BuildConfig.ENABLE_QRCODE_AUTH_FLOW &&
-                accountStore.hasAccessToken() &&
-                accountStore.account?.twoStepEnabled != true) {
+        if (shouldShowQrCodeLogin()) {
             rowScanLoginCode.isVisible = true
 
             rowScanLoginCode.setOnClickListener {
@@ -237,6 +234,13 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
                     .newInstance()
                     .show(childFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
         }
+    }
+
+    private fun shouldShowQrCodeLogin(): Boolean {
+        return qrCodeAuthFlowFeatureConfig.isEnabled() &&
+                BuildConfig.ENABLE_QRCODE_AUTH_FLOW &&
+                accountStore.hasAccessToken() &&
+                accountStore.account?.twoStepEnabled != true
     }
 
     private fun MeFragmentBinding.setRecommendLoadingState(startShimmer: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -200,7 +200,8 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
         if (qrCodeAuthFlowFeatureConfig.isEnabled() &&
                 BuildConfig.ENABLE_QRCODE_AUTH_FLOW &&
-                accountStore.hasAccessToken()) {
+                accountStore.hasAccessToken() &&
+                accountStore.account?.twoStepEnabled != true) {
             rowScanLoginCode.isVisible = true
 
             rowScanLoginCode.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -38,7 +38,6 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.bloggingreminders.resolver.BloggingRemindersResolver;
 import org.wordpress.android.fluxc.Dispatcher;
-import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.AccountModel;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1278,6 +1278,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
             case RequestCodes.APP_SETTINGS:
                 if (resultCode == AppSettingsFragment.LANGUAGE_CHANGED) {
                     appLanguageChanged();
+                } else if (mAccountStore.hasAccessToken()) {
+                    mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
                 }
                 break;
             case RequestCodes.NOTE_DETAIL:
@@ -1436,9 +1438,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
             mBottomNav.showNoteBadge(mAccountStore.getAccount().getHasUnseenNotes());
             if (AppPrefs.getShouldTrackMagicLinkSignup()) {
                 trackMagicLinkSignupIfNeeded();
-            }
-            if (!event.isError() && event.causeOfChange == AccountAction.FETCH_ACCOUNT) {
-                mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -145,6 +145,7 @@ import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.service.InstallationReferrerServiceStarter;
 import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig;
 import org.wordpress.android.util.config.OpenWebLinksWithJetpackFlowFeatureConfig;
+import org.wordpress.android.util.config.QRCodeAuthFlowFeatureConfig;
 import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel;
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel.FocusPointInfo;
@@ -262,6 +263,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Inject JetpackAppMigrationFlowUtils mJetpackAppMigrationFlowUtils;
     @Inject DeepLinkOpenWebLinksWithJetpackHelper mDeepLinkOpenWebLinksWithJetpackHelper;
     @Inject OpenWebLinksWithJetpackFlowFeatureConfig mOpenWebLinksWithJetpackFlowFeatureConfig;
+    @Inject QRCodeAuthFlowFeatureConfig qrCodeAuthFlowFeatureConfig;
 
     @Inject BuildConfigWrapper mBuildConfigWrapper;
 
@@ -951,9 +953,13 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         checkQuickStartNotificationStatus();
 
-        // Update account to update the notification unseen status
         if (mAccountStore.hasAccessToken()) {
+            // Update account to update the notification unseen status
             mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
+            if (qrCodeAuthFlowFeatureConfig.isEnabled()) {
+                // Fetch account settings to update the qr code login menu item visibility in Me screen
+                mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
+            }
         }
 
         ProfilingUtils.split("WPMainActivity.onResume");
@@ -1277,8 +1283,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
             case RequestCodes.APP_SETTINGS:
                 if (resultCode == AppSettingsFragment.LANGUAGE_CHANGED) {
                     appLanguageChanged();
-                } else if (mAccountStore.hasAccessToken()) {
-                    mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
                 }
                 break;
             case RequestCodes.NOTE_DETAIL:

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -263,7 +263,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Inject JetpackAppMigrationFlowUtils mJetpackAppMigrationFlowUtils;
     @Inject DeepLinkOpenWebLinksWithJetpackHelper mDeepLinkOpenWebLinksWithJetpackHelper;
     @Inject OpenWebLinksWithJetpackFlowFeatureConfig mOpenWebLinksWithJetpackFlowFeatureConfig;
-    @Inject QRCodeAuthFlowFeatureConfig qrCodeAuthFlowFeatureConfig;
+    @Inject QRCodeAuthFlowFeatureConfig mQrCodeAuthFlowFeatureConfig;
 
     @Inject BuildConfigWrapper mBuildConfigWrapper;
 
@@ -956,7 +956,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (mAccountStore.hasAccessToken()) {
             // Update account to update the notification unseen status
             mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
-            if (qrCodeAuthFlowFeatureConfig.isEnabled()) {
+            if (mQrCodeAuthFlowFeatureConfig.isEnabled()) {
                 // Fetch account settings to update the qr code login menu item visibility in Me screen
                 mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -38,6 +38,7 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.bloggingreminders.resolver.BloggingRemindersResolver;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.AccountModel;
@@ -1435,6 +1436,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
             mBottomNav.showNoteBadge(mAccountStore.getAccount().getHasUnseenNotes());
             if (AppPrefs.getShouldTrackMagicLinkSignup()) {
                 trackMagicLinkSignupIfNeeded();
+            }
+            if (!event.isError() && event.causeOfChange == AccountAction.FETCH_ACCOUNT) {
+                mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/QRCodeAuthFlowFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/QRCodeAuthFlowFeatureConfig.kt
@@ -11,6 +11,10 @@ class QRCodeAuthFlowFeatureConfig
         BuildConfig.QRCODE_AUTH_FLOW,
         QRCODE_AUTH_FLOW_REMOTE_FIELD
 ) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && BuildConfig.ENABLE_QRCODE_AUTH_FLOW
+    }
+
     companion object {
         const val QRCODE_AUTH_FLOW_REMOTE_FIELD = "qrcode_auth_flow_remote_field"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.86.0'
     wordPressAztecVersion = 'v1.6.2'
-    wordPressFluxCVersion = '2591-95b57f7c2ecb5acd050d113ec39c6ddb4fcffbf1'
+    wordPressFluxCVersion = '2591-9a17742320e81bf4571df1dfd4964e4d1678e742'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.86.0'
     wordPressAztecVersion = 'v1.6.2'
-    wordPressFluxCVersion = '2591-9a17742320e81bf4571df1dfd4964e4d1678e742'
+    wordPressFluxCVersion = 'trunk-35bc4b0194946cdef6aedf45be77e4f1d6dc6126'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.85.1'
     wordPressAztecVersion = 'v1.6.2'
-    wordPressFluxCVersion = '2.6.0'
+    wordPressFluxCVersion = '2591-95b57f7c2ecb5acd050d113ec39c6ddb4fcffbf1'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.1.0'


### PR DESCRIPTION
Fixes #17434

This PR has a companion FluxC PR [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2591) that adds the persistence of the 2FA flag in FluxC db.

That added flag is used in the MeFragment to hide/show the QR login entry.

NOTE: since we do not change that settings in the apps, we do not have an handy entry point where to trigger an update of the cache. Mitigated as reported in [this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/17662#issuecomment-1351624407)

<details>
  <summary>This collapsable documents previous attempts considered for mitigation</summary>
~~I tried to mitigate this by chaining in the WPMainActivity a newFetchSettingsAction in the OnAccountChange event triggered (among others) by the OnResume -> newFetchAccountAction~~

~~The chaining in the WPMainActivity of a newFetchSettingsAction, was making connected tests for signup with magic link (e2eSignUpWithMagicLink) fail (at least most of the time). I'm not sure if it's a test glitch or there can be something more, but I decided to play safer and moved the newFetchSettingsAction mitigation to the onActivityResult in WPMainActivity for when the user navigates back from the Me screen. This seems good enough for the mention mitigation, but let me know wdyt 🙇~~
</details>





| QR login present | QR login NOT present |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/206884996-4652486c-c653-4fad-b303-5c04162d0369.png) | ![image](https://user-images.githubusercontent.com/47797566/206885007-ed6ce5f1-c523-4765-88d3-6160869aec55.png) |

To test:

Testing the visibility of the QR login entry

- Using a .com test account, be sure the 2fa is not setup (or disable it for the test sake)
- Now install both the WP and the JP app
- Login in both with the same account and go in Me screen.
- Check the WP app is not showing the QR login entry whereas the JP app is showing the entry. You should be able to login via the QR code on the web (you can use another browser or an incognito window to avoid logging out from the web)
- Now enable the 2fa 
- In the JP app, go to the main My Site page and then in the Me screen again
- Check the QR login entry is not present

DB upgrade

- Remove the JP app
- Install the JP app from trunk and login. With AS App Inspection note the AccountModel table does not contain the 2fa field
- Now upgrade the JP app with code from this PR
- Open again the JP app and check with AS App Inspection that the 2fa field is now present in the AccountModel table

Check Content copy flow still works

- Install the 21.3 WP app (the 2fa field is not present in the AccountModel table), and login
- Remove the JP app if installed and install again from this PR
- Open the JP app; the Content copy flow should start
- Go through the flow and check it completes correctly
- With AS App Inspection check the 2fa field is present in the AccountModel table of the JP app and the content copy flow had no issue.
- Also check the visibility state of the qr code login menu is consistent with 2fa state

## Regression Notes
1. Potential unintended areas of impact
QR login entry not visible when expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Updated existing unit test in FluxC.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
