### PR TITLE
Update squareupMockWebServerVersion to 4.9.3

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -266,7 +266,7 @@ android {
         // Exclude React Native's JSC and Fabric JNI
         exclude '**/libjscexecutor.so'
         exclude '**/libfabricjni.so'
-        
+
         // Avoid React Native's JNI duplicated classes
         pickFirst '**/libc++_shared.so'
         pickFirst '**/libfbjni.so'
@@ -458,7 +458,7 @@ dependencies {
 
     androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"
     androidTestImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
-    androidTestImplementation "com.squareup.okhttp:mockwebserver:$squareupMockWebServerVersion"
+    androidTestImplementation "com.squareup.okhttp3:mockwebserver:$squareupMockWebServerVersion"
     androidTestImplementation "androidx.test.uiautomator:uiautomator:$androidxTestUiAutomatorVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxTestEspressoVersion", {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ ext {
     androidxTestExtJunitVersion = '1.1.4'
     androidxTestUiAutomatorVersion = '2.2.0'
     screengrabVersion = '2.1.1'
-    squareupMockWebServerVersion = '2.7.5'
+    squareupMockWebServerVersion = '4.9.3'
     wiremockVersion = '2.26.3'
     wiremockHttpClientVersion = '4.3.5.1'
 


### PR DESCRIPTION
Partially closes #17558.

Updates `squareupMockWebServerVersion` to [`4.9.3`](https://central.sonatype.dev/artifact/com.squareup.okhttp3/mockwebserver/4.9.3).

Note that the dependency path has changed from `com.squareup.okhttp:mockwebserver` to `com.squareup.okhttp3:mockwebserver`.

**To test:**

Since this dependency change is only related to testing, CI checks should be enough.

## Regression Notes

1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
