### PR TITLE
Update wiremockVersion to 2.35.0

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -266,7 +266,7 @@ android {
         // Exclude React Native's JSC and Fabric JNI
         exclude '**/libjscexecutor.so'
         exclude '**/libfabricjni.so'
-        
+
         // Avoid React Native's JNI duplicated classes
         pickFirst '**/libc++_shared.so'
         pickFirst '**/libfbjni.so'
@@ -469,7 +469,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     androidTestImplementation "androidx.test.espresso:espresso-accessibility:$androidxTestEspressoVersion"
-    androidTestImplementation("com.github.tomakehurst:wiremock:$wiremockVersion") {
+    androidTestImplementation("com.github.tomakehurst:wiremock-jre8:$wiremockVersion") {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
         exclude group: 'org.apache.commons', module: 'commons-lang3'
         exclude group: 'asm', module: 'asm'

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ ext {
     androidxTestUiAutomatorVersion = '2.2.0'
     screengrabVersion = '2.1.1'
     squareupMockWebServerVersion = '2.7.5'
-    wiremockVersion = '2.26.3'
+    wiremockVersion = '2.35.0'
     wiremockHttpClientVersion = '4.3.5.1'
 
     // other

--- a/libs/mocks/build.gradle
+++ b/libs/mocks/build.gradle
@@ -11,7 +11,7 @@ android {
 }
 
 dependencies {
-    implementation("com.github.tomakehurst:wiremock:$wiremockVersion") {
+    implementation("com.github.tomakehurst:wiremock-jre8:$wiremockVersion") {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
         exclude group: 'org.apache.commons', module: 'commons-lang3'
         exclude group: 'asm', module: 'asm'


### PR DESCRIPTION
**This update has proven tricky, so please ignore this PR for now.**

Partially closes https://github.com/wordpress-mobile/WordPress-Android/issues/17558.

Updates `wiremockVersion` to [`2.35.0`](https://github.com/wiremock/wiremock/releases/tag/2.35.0).

Note that the dependency path has changed from `com.github.tomakehurst:wiremock` to `com.github.tomakehurst:wiremock-jre8`. [Here are the latest docs.](https://wiremock.org/docs/getting-started/)

**To test:**

Since this dependency change is only related to testing, CI checks should be enough.

## Regression Notes

1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
