### PR TITLE
Add Jetpack branding to Scan screens starting from Phase One

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -44,7 +44,6 @@ import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadActivity;
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadFragment;
 import org.wordpress.android.ui.jetpack.restore.RestoreActivity;
 import org.wordpress.android.ui.jetpack.restore.RestoreFragment;
-import org.wordpress.android.ui.jetpack.scan.ScanFragment;
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsFragment;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryFragment;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryListFragment;
@@ -393,8 +392,6 @@ public interface AppComponent {
     void inject(ActivityLogListFragment object);
 
     void inject(ActivityLogDetailFragment object);
-
-    void inject(ScanFragment object);
 
     void inject(ScanHistoryFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -45,7 +45,6 @@ import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadFragment;
 import org.wordpress.android.ui.jetpack.restore.RestoreActivity;
 import org.wordpress.android.ui.jetpack.restore.RestoreFragment;
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsFragment;
-import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryListFragment;
 import org.wordpress.android.ui.layoutpicker.LayoutPreviewFragment;
 import org.wordpress.android.ui.layoutpicker.LayoutsAdapter;
 import org.wordpress.android.ui.main.AddContentAdapter;
@@ -391,8 +390,6 @@ public interface AppComponent {
     void inject(ActivityLogListFragment object);
 
     void inject(ActivityLogDetailFragment object);
-
-    void inject(ScanHistoryListFragment object);
 
     void inject(ThreatDetailsFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -45,7 +45,6 @@ import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadFragment;
 import org.wordpress.android.ui.jetpack.restore.RestoreActivity;
 import org.wordpress.android.ui.jetpack.restore.RestoreFragment;
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsFragment;
-import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryFragment;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryListFragment;
 import org.wordpress.android.ui.layoutpicker.LayoutPreviewFragment;
 import org.wordpress.android.ui.layoutpicker.LayoutsAdapter;
@@ -392,8 +391,6 @@ public interface AppComponent {
     void inject(ActivityLogListFragment object);
 
     void inject(ActivityLogDetailFragment object);
-
-    void inject(ScanHistoryFragment object);
 
     void inject(ScanHistoryListFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -25,7 +25,6 @@ import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel;
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel;
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryListViewModel;
-import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel;
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel;
 import org.wordpress.android.ui.mysite.MySiteViewModel;
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel;
@@ -409,11 +408,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ActivityLogTypeFilterViewModel.class)
     abstract ViewModel activityLogTypeFilterViewModel(ActivityLogTypeFilterViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(ScanHistoryViewModel.class)
-    abstract ViewModel scanHistoryViewModel(ScanHistoryViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -24,7 +24,6 @@ import org.wordpress.android.ui.featureintroduction.FeatureIntroductionViewModel
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel;
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel;
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel;
-import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryListViewModel;
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel;
 import org.wordpress.android.ui.mysite.MySiteViewModel;
 import org.wordpress.android.ui.mysite.dynamiccards.DynamicCardMenuViewModel;
@@ -408,11 +407,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ActivityLogTypeFilterViewModel.class)
     abstract ViewModel activityLogTypeFilterViewModel(ActivityLogTypeFilterViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(ScanHistoryListViewModel.class)
-    abstract ViewModel scanHistoryListViewModel(ScanHistoryListViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -23,7 +23,6 @@ import org.wordpress.android.ui.engagement.UserProfileViewModel;
 import org.wordpress.android.ui.featureintroduction.FeatureIntroductionViewModel;
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel;
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel;
-import org.wordpress.android.ui.jetpack.scan.ScanViewModel;
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryListViewModel;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel;
@@ -410,11 +409,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ActivityLogTypeFilterViewModel.class)
     abstract ViewModel activityLogTypeFilterViewModel(ActivityLogTypeFilterViewModel viewModel);
-
-    @Binds
-    @IntoMap
-    @ViewModelKey(ScanViewModel.class)
-    abstract ViewModel scanViewModel(ScanViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
@@ -49,7 +49,7 @@ class ScanActivity : AppCompatActivity(), ScrollableViewInitializedListener {
     }
 
     private fun initJetpackBanner(scrollableContainerId: Int) {
-        if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
+        if (jetpackBrandingUtils.shouldShowJetpackBrandingForPhaseOne()) {
             binding?.root?.post {
                 val jetpackBannerView = binding?.jetpackBanner?.root ?: return@post
                 val scrollableView = binding?.root?.findViewById<View>(scrollableContainerId) as? RecyclerView

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
@@ -4,14 +4,26 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.RecyclerView
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ScanActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.ScrollableViewInitializedListener
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
+import org.wordpress.android.util.JetpackBrandingUtils
+import org.wordpress.android.util.JetpackBrandingUtils.Screen.SCAN
+import javax.inject.Inject
 
-class ScanActivity : AppCompatActivity() {
+@AndroidEntryPoint
+class ScanActivity : AppCompatActivity(), ScrollableViewInitializedListener {
+    @Inject lateinit var jetpackBrandingUtils: JetpackBrandingUtils
+    private var binding: ScanActivityBinding? = null
+
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         (supportFragmentManager.findFragmentById(R.id.fragment_container_view) as? ScanFragment)?.let {
@@ -23,12 +35,38 @@ class ScanActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         with(ScanActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
-
+            binding = this
             setSupportActionBar(toolbarMain)
         }
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)
+        }
+    }
+
+    override fun onScrollableViewInitialized(containerId: Int) {
+        initJetpackBanner(containerId)
+    }
+
+    private fun initJetpackBanner(scrollableContainerId: Int) {
+        if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
+            binding?.root?.post {
+                val jetpackBannerView = binding?.jetpackBanner?.root ?: return@post
+                val scrollableView = binding?.root?.findViewById<View>(scrollableContainerId) as? RecyclerView
+                        ?: return@post
+
+                jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
+                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
+
+                if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                    binding?.jetpackBanner?.root?.setOnClickListener {
+                        jetpackBrandingUtils.trackBannerTapped(SCAN)
+                        JetpackPoweredBottomSheetFragment
+                                .newInstance()
+                                .show(supportFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
+                    }
+                }
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ScanFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.accounts.HelpActivity.Origin.SCAN_SCREEN_HELP
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreatsConfirmationDialog
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowContactSupport
@@ -25,6 +26,7 @@ import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.FullScreenLoa
 import org.wordpress.android.ui.jetpack.scan.adapters.HorizontalMarginItemDecoration
 import org.wordpress.android.ui.jetpack.scan.adapters.ScanAdapter
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.prefs.EmptyViewRecyclerView
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ColorUtils
 import org.wordpress.android.util.image.ImageManager
@@ -37,6 +39,7 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: ScanViewModel
+    private lateinit var listView: EmptyViewRecyclerView
     private var fixThreatsConfirmationDialog: AlertDialog? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -44,7 +47,15 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         with(ScanFragmentBinding.bind(view)) {
             initDagger()
             initRecyclerView()
+            listView = recyclerView
             initViewModel(getSite(savedInstanceState))
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (activity is ScrollableViewInitializedListener) {
+            (activity as ScrollableViewInitializedListener).onScrollableViewInitialized(listView.id)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -5,9 +5,10 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ScanFragmentBinding
@@ -34,18 +35,17 @@ import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class ScanFragment : Fragment(R.layout.scan_fragment) {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var uiHelpers: UiHelpers
-    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
-    private lateinit var viewModel: ScanViewModel
     private lateinit var listView: EmptyViewRecyclerView
     private var fixThreatsConfirmationDialog: AlertDialog? = null
+    private val viewModel: ScanViewModel by viewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         with(ScanFragmentBinding.bind(view)) {
-            initDagger()
             initRecyclerView()
             listView = recyclerView
             initViewModel(getSite(savedInstanceState))
@@ -57,10 +57,6 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         if (activity is ScrollableViewInitializedListener) {
             (activity as ScrollableViewInitializedListener).onScrollableViewInitialized(listView.id)
         }
-    }
-
-    private fun initDagger() {
-        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun ScanFragmentBinding.initRecyclerView() {
@@ -82,7 +78,6 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
     }
 
     private fun ScanFragmentBinding.initViewModel(site: SiteModel) {
-        viewModel = ViewModelProvider(this@ScanFragment, viewModelFactory).get(ScanViewModel::class.java)
         setupObservers()
         viewModel.start(site)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -6,6 +6,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
@@ -51,6 +52,7 @@ import javax.inject.Named
 
 const val RETRY_DELAY = 300L
 
+@HiltViewModel
 class ScanViewModel @Inject constructor(
     private val scanStateListItemsBuilder: ScanStateListItemsBuilder,
     private val fetchScanStateUseCase: FetchScanStateUseCase,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryActivity.kt
@@ -2,8 +2,10 @@ package org.wordpress.android.ui.jetpack.scan.history
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 
+@AndroidEntryPoint
 class ScanHistoryActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -5,6 +5,7 @@ import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
@@ -33,7 +34,7 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var localeManagerWrapper: LocaleManagerWrapper
     @Inject lateinit var jetpackBrandingUtils: JetpackBrandingUtils
-    private val viewModel: ScanHistoryViewModel by viewModels()
+    private val viewModel: ScanHistoryViewModel by activityViewModels()
     private var binding: ScanHistoryFragmentBinding? = null
 
     private val onTabSelectedListener = object : OnTabSelectedListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -11,6 +11,7 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.google.android.material.tabs.TabLayout.Tab
 import com.google.android.material.tabs.TabLayoutMediator
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.FullscreenErrorWithRetryBinding
@@ -27,6 +28,7 @@ import org.wordpress.android.util.JetpackBrandingUtils.Screen.SCAN
 import org.wordpress.android.util.LocaleManagerWrapper
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), ScrollableViewInitializedListener {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var uiHelpers: UiHelpers
@@ -50,7 +52,6 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding = ScanHistoryFragmentBinding.bind(view).apply {
-            initDagger()
             initViewModel(getSite(savedInstanceState))
             initToolbar()
         }
@@ -59,10 +60,6 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
-    }
-
-    private fun initDagger() {
-        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun ScanHistoryFragmentBinding.initViewModel(site: SiteModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -5,7 +5,7 @@ import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
@@ -30,11 +30,10 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), ScrollableViewInitializedListener {
-    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var localeManagerWrapper: LocaleManagerWrapper
     @Inject lateinit var jetpackBrandingUtils: JetpackBrandingUtils
-    private lateinit var viewModel: ScanHistoryViewModel
+    private val viewModel: ScanHistoryViewModel by viewModels()
     private var binding: ScanHistoryFragmentBinding? = null
 
     private val onTabSelectedListener = object : OnTabSelectedListener {
@@ -63,7 +62,6 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
     }
 
     private fun ScanHistoryFragmentBinding.initViewModel(site: SiteModel) {
-        viewModel = ViewModelProvider(this@ScanHistoryFragment, viewModelFactory).get(ScanHistoryViewModel::class.java)
         setupObservers()
         viewModel.start(site)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -2,8 +2,9 @@ package org.wordpress.android.ui.jetpack.scan.history
 
 import android.os.Bundle
 import android.view.View
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelStoreOwner
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ScanHistoryListFragmentBinding
@@ -20,20 +21,19 @@ import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fragment) {
-    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var uiHelpers: UiHelpers
 
-    private lateinit var viewModel: ScanHistoryListViewModel
-    private lateinit var parentViewModel: ScanHistoryViewModel
+    private val viewModel: ScanHistoryListViewModel by viewModels()
+    private val parentViewModel: ScanHistoryViewModel by activityViewModels()
 
     private var binding: ScanHistoryListFragmentBinding? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding = ScanHistoryListFragmentBinding.bind(view).apply {
-            initDagger()
             initRecyclerView()
             initViewModel(getSite(savedInstanceState), getTabType())
         }
@@ -44,23 +44,12 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
         binding = null
     }
 
-    private fun initDagger() {
-        (requireActivity().application as WordPress).component().inject(this)
-    }
-
     private fun ScanHistoryListFragmentBinding.initRecyclerView() {
         recyclerView.adapter = ScanAdapter(imageManager, uiHelpers)
         recyclerView.itemAnimator = null
     }
 
     private fun ScanHistoryListFragmentBinding.initViewModel(site: SiteModel, tabType: ScanHistoryTabType) {
-        viewModel = ViewModelProvider(
-                this@ScanHistoryListFragment,
-                viewModelFactory
-        ).get(ScanHistoryListViewModel::class.java)
-        parentViewModel = ViewModelProvider(parentFragment as ViewModelStoreOwner, viewModelFactory).get(
-                ScanHistoryViewModel::class.java
-        )
         viewModel.start(tabType, site, parentViewModel)
         setupObservers()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.map
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
@@ -33,6 +34,7 @@ import javax.inject.Named
 
 private const val SKELETON_LOADING_ITEM_COUNT = 10
 
+@HiltViewModel
 class ScanHistoryListViewModel @Inject constructor(
     private val scanThreatItemBuilder: ThreatItemBuilder,
     private val scanTracker: ScanTracker,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import androidx.annotation.DrawableRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
@@ -31,6 +32,7 @@ import javax.inject.Named
 
 private const val RETRY_DELAY = 300L
 
+@HiltViewModel
 class ScanHistoryViewModel @Inject constructor(
     private val scanTracker: ScanTracker,
     private val fetchScanHistoryUseCase: FetchScanHistoryUseCase,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.jetpackoverlay
+
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseFour
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
+import org.wordpress.android.util.BuildConfigWrapper
+import javax.inject.Inject
+
+class JetpackFeatureRemovalBrandingUtil @Inject constructor(
+    private val buildConfigWrapper: BuildConfigWrapper,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
+) {
+    fun shouldShowPhaseOneBranding(): Boolean {
+        if (buildConfigWrapper.isJetpackApp) return false
+        return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
+            PhaseOne,
+            PhaseTwo,
+            PhaseThree,
+            PhaseFour -> true
+            else -> false
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
@@ -4,15 +4,12 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseF
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
-import org.wordpress.android.util.BuildConfigWrapper
 import javax.inject.Inject
 
 class JetpackFeatureRemovalBrandingUtil @Inject constructor(
-    private val buildConfigWrapper: BuildConfigWrapper,
     private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
 ) {
     fun shouldShowPhaseOneBranding(): Boolean {
-        if (buildConfigWrapper.isJetpackApp) return false
         return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
             PhaseOne,
             PhaseTwo,

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -102,7 +102,8 @@ class JetpackBrandingUtils @Inject constructor(
         READER_POST_DETAIL("reader_post_detail"),
         READER_SEARCH("reader_search"),
         SHARE("share"),
-        STATS("stats")
+        STATS("stats"),
+        SCAN("scan")
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -6,6 +6,7 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalBrandingUtil
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.JetpackPoweredBottomSheetFeatureConfig
@@ -15,6 +16,7 @@ import javax.inject.Inject
 class JetpackBrandingUtils @Inject constructor(
     private val jetpackPoweredFeatureConfig: JetpackPoweredFeatureConfig,
     private val jetpackPoweredBottomSheetFeatureConfig: JetpackPoweredBottomSheetFeatureConfig,
+    private val jetpackFeatureRemovalBrandingUtil: JetpackFeatureRemovalBrandingUtil,
     private val selectedSiteRepository: SelectedSiteRepository,
     private val siteUtilsWrapper: SiteUtilsWrapper,
     private val buildConfigWrapper: BuildConfigWrapper,
@@ -22,6 +24,10 @@ class JetpackBrandingUtils @Inject constructor(
 ) {
     fun shouldShowJetpackBranding(): Boolean {
         return isWpComSite() && jetpackPoweredFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
+    }
+
+    fun shouldShowJetpackBrandingForPhaseOne(): Boolean {
+        return shouldShowJetpackBranding() && jetpackFeatureRemovalBrandingUtil.shouldShowPhaseOneBranding()
     }
 
     fun shouldShowJetpackPoweredBottomSheet(): Boolean {

--- a/WordPress/src/main/res/layout/scan_activity.xml
+++ b/WordPress/src/main/res/layout/scan_activity.xml
@@ -2,6 +2,7 @@
 
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -12,7 +13,8 @@
         android:name="org.wordpress.android.ui.jetpack.scan.ScanFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:layout="@layout/scan_fragment" />
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"
@@ -26,6 +28,10 @@
             app:theme="@style/WordPress.ActionBar" />
 
     </com.google.android.material.appbar.AppBarLayout>
+
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/WordPress/src/main/res/layout/scan_history_fragment.xml
+++ b/WordPress/src/main/res/layout/scan_history_fragment.xml
@@ -40,4 +40,8 @@
         android:layout_height="match_parent"
         layout="@layout/fullscreen_error_with_retry" />
 
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
@@ -11,11 +11,9 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.whenever
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
-import org.wordpress.android.util.BuildConfigWrapper
 
 @RunWith(MockitoJUnitRunner::class)
 class JetpackFeatureRemovalBrandingUtilTest {
-    @Mock private lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
     @Rule
@@ -26,21 +24,12 @@ class JetpackFeatureRemovalBrandingUtilTest {
     @Before
     fun setup() {
         jetpackFeatureRemovalBrandingUtil = JetpackFeatureRemovalBrandingUtil(
-                buildConfigWrapper,
                 jetpackFeatureRemovalPhaseHelper,
         )
     }
 
     @Test
-    fun `given jetpack app, when phase one branding is checked, should return false`() {
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
-        val shouldShowBranding = jetpackFeatureRemovalBrandingUtil.shouldShowPhaseOneBranding()
-
-        assertFalse(shouldShowBranding)
-    }
-
-    @Test
-    fun `given phase one, when phase one branding is checked, should return true`() {
+    fun `given phase one started, when phase one branding is checked, should return true`() {
         whenever(jetpackFeatureRemovalPhaseHelper.getCurrentPhase()).thenReturn(PhaseOne)
         val shouldShowBranding = jetpackFeatureRemovalBrandingUtil.shouldShowPhaseOneBranding()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
@@ -32,7 +32,7 @@ class JetpackFeatureRemovalBrandingUtilTest {
     }
 
     @Test
-    fun `given jetpack app, jetpack branding should not show`() {
+    fun `given jetpack app, when phase one branding is checked, should return false`() {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
         val shouldShowBranding = jetpackFeatureRemovalBrandingUtil.shouldShowPhaseOneBranding()
 
@@ -40,7 +40,7 @@ class JetpackFeatureRemovalBrandingUtilTest {
     }
 
     @Test
-    fun `given phase one, jetpack branding should show`() {
+    fun `given phase one, when phase one branding is checked, should return true`() {
         whenever(jetpackFeatureRemovalPhaseHelper.getCurrentPhase()).thenReturn(PhaseOne)
         val shouldShowBranding = jetpackFeatureRemovalBrandingUtil.shouldShowPhaseOneBranding()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
@@ -46,4 +46,12 @@ class JetpackFeatureRemovalBrandingUtilTest {
 
         assertTrue(shouldShowBranding)
     }
+
+    @Test
+    fun `given phase one not started, when phase one branding is checked, should return false`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.getCurrentPhase()).thenReturn(null)
+        val shouldShowBranding = jetpackFeatureRemovalBrandingUtil.shouldShowPhaseOneBranding()
+
+        assertFalse(shouldShowBranding)
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.ui.jetpackoverlay
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
+import org.wordpress.android.util.BuildConfigWrapper
+
+@RunWith(MockitoJUnitRunner::class)
+class JetpackFeatureRemovalBrandingUtilTest {
+    @Mock private lateinit var buildConfigWrapper: BuildConfigWrapper
+    @Mock private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    private lateinit var jetpackFeatureRemovalBrandingUtil: JetpackFeatureRemovalBrandingUtil
+
+    @Before
+    fun setup() {
+        jetpackFeatureRemovalBrandingUtil = JetpackFeatureRemovalBrandingUtil(
+                buildConfigWrapper,
+                jetpackFeatureRemovalPhaseHelper,
+        )
+    }
+
+    @Test
+    fun `given jetpack app, jetpack branding should not show`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
+        val shouldShowBranding = jetpackFeatureRemovalBrandingUtil.shouldShowPhaseOneBranding()
+
+        assertFalse(shouldShowBranding)
+    }
+
+    @Test
+    fun `given phase one, jetpack branding should show`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.getCurrentPhase()).thenReturn(PhaseOne)
+        val shouldShowBranding = jetpackFeatureRemovalBrandingUtil.shouldShowPhaseOneBranding()
+
+        assertTrue(shouldShowBranding)
+    }
+}


### PR DESCRIPTION
Fixes Partially #17334

This PR adds the logic to display the Jetpack powered branding banner on the Scan screens starting from Phase One of features removal.

## To test:

Jetpack branding on Scan screens should be visible starting from phase one of features removal, while it should be hidden when all Jetpack removal flags are disabled.

Normal Phase - Jetpack Branding not shown
- This is the phase when the `Jetpack powered` should **not** be displayed
- Enable this phase by making sure all Jetpack removal flags are disabled

Branded Phase - Jetpack Branding shown
- This is the phase where we show a `Jetpack powered` branding on the Stats screens
- Enable this phase by making sure `jp_removal_one` flag is enabled
- Go to `Me` → `App Settings` → `Debug settings` and **enable** `jp_removal_one`
- Additionally, any other Jetpack removal phase flag should end up in the branding being shown 

Test the following steps in each phase:

#### Testing Steps

1. Open WordPress app and login with site address, ❗ the site should have Jetpack Scan _Daily_ enabled
   1. Additionally, login with your WP.com account and make sure Jetpack is connected to your WP.com account
   2. Make sure the selected site is the self-hosted one, from step `1`
2. Toggle one of the phases based on the notes above testing steps
3. Go to `My Site` → `Menu` tab
4. From menu, under `Jetpack` tap `Scan`
5. If in normal phase, expect no `Jetpack powered` branding
6. If in branded phase:
   1. **Expect** the `Jetpack powered` banner to be visible at the bottom of the screen
   2. Tap the `Jetpack powered` banner
   3. **Expect** the `WordPress is better with Jetpack` bottom sheet to be displayed
   4. **Optionally** tap the `Try the new Jetpack app` button
      1. If Jetpack app is not installed it should open the Play Store to install the app
      2. If Jetpack app is installed, it should be opened
   5. Go back to the WordPress app
7. Tap `History` at the top right of the Scan screen
8. If in normal phase, expect no `Jetpack powered` branding
9. If in branded phase:
   1. **Expect** the `Jetpack powered` banner to be visible at the bottom of the screen
   2. Tap the `Jetpack powered` banner
   3. **Expect** the `WordPress is better with Jetpack` bottom sheet to be displayed
   4. **Optionally** tap the `Try the new Jetpack app` button
      1. If Jetpack app is not installed it should open the Play Store to install the app
      2. If Jetpack app is installed, it should be opened

### Screenshots

> **Note** I've used dummy data for the screenshots to make the Scan screens scrollable.

| Jetpack Scan | Jetpack Scan History |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/207313857-11af481c-cf22-43ca-900e-9cb9d963cdee.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/207313881-aa276063-908c-4879-97a9-9e8b3d71d73e.png"> |

## Regression Notes
1. Potential unintended areas of impact
   Scan and Scan history screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing

3. What automated tests I added (or what prevented me from doing so)
   - Added tests in `JetpackFeatureRemovalBrandingUtilTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
