### PR TITLE
Removes line break to fix text wrapping issue

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4264,7 +4264,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jp_migration_notifications_disabled_in_wp_message">We\'ll turn off notifications from the WordPress app.</string>
     <string name="jp_migration_done_title">Thanks for switching to Jetpack!</string>
     <string name="jp_migration_done_subtitle">We’ve transferred all your data and settings. Everything is right where you left it.</string>
-    <string name="jp_migration_done_delete_wp_message">Please &lt;b&gt;delete the WordPress app&lt;/b&gt; to&lt;br&gt;avoid data conflicts.</string>
+    <string name="jp_migration_done_delete_wp_message">Please &lt;b&gt;delete the WordPress app&lt;/b&gt; to avoid data conflicts.</string>
     <string name="jp_migration_remove_wp_app_icon_content_description">Remove WordPress App icon</string>
     <string name="jp_migration_finish_button">Finish</string>
     <string name="jp_migration_try_again_button">Try again</string>
@@ -4276,7 +4276,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jp_migration_network_error_message">We are unable to transfer your data and settings without a network connection.</string>
     <string name="jp_migration_delete_title">You no longer need the WordPress app</string>
     <string name="jp_migration_delete_subtitle">It looks like you still have the WordPress app installed. We recommend you delete the WordPress app to avoid data conflicts.</string>
-    <string name="jp_migration_delete_message">Please &lt;b&gt;delete the WordPress app&lt;/b&gt; to&lt;br&gt;avoid data conflicts.</string>
+    <string name="jp_migration_delete_message">Please &lt;b&gt;delete the WordPress app&lt;/b&gt; to avoid data conflicts.</string>
     <string name="jp_migration_got_it_button">Got it</string>
     <string name="jp_migration_need_help_button">Need help?</string>
 


### PR DESCRIPTION
Fixes #17657

## Description
Removes line break to fix text wrapping issue. As a result the line breaks on different places depending on the device screen size and/or font size (check screenshots below).

To test:
1. Prerequisite: WordPress app should be installed and logged in
2. Uninstall Jetpack App if installed or clear the app data
3. Run the Jetpack app from this branch
4. Set the device font and/or screen size settings to the desired
5. Verify that the final migration screen line break is the expected

|Final migration screen|Delete app scree|Resolution 1|Resolution 2|
|---|---|---|---|
|![Screenshot_20221213_164716](https://user-images.githubusercontent.com/304044/207376017-74ddb6ec-0f75-4090-9844-f1bc081d3d83.png)|![Screenshot_20221213_164733](https://user-images.githubusercontent.com/304044/207376024-05b796ce-4db6-4372-8fed-4dd7bb442906.png)|![Screenshot_20221213_172139](https://user-images.githubusercontent.com/304044/207376028-099901a6-4baf-402b-9c67-a12cc7ca5777.png)|![Screenshot_20221213_172352](https://user-images.githubusercontent.com/304044/207376032-38c1e3b1-f917-4182-9bc3-f906423b0070.png)|

## Regression Notes
1. Potential unintended areas of impact
N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

8. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
