### PR TITLE
Android - Add dark mode header icons for migration steps

### DIFF
--- a/WordPress/src/main/res/drawable/ic_jetpack_migration_delete.xml
+++ b/WordPress/src/main/res/drawable/ic_jetpack_migration_delete.xml
@@ -16,5 +16,5 @@
       android:pathData="M90.5,1.5L90.5,1.5A34,34 0,0 1,124.5 35.5L124.5,35.5A34,34 0,0 1,90.5 69.5L90.5,69.5A34,34 0,0 1,56.5 35.5L56.5,35.5A34,34 0,0 1,90.5 1.5z"
       android:strokeWidth="3"
       android:fillColor="#00000000"
-      android:strokeColor="#ffffff"/>
+      android:strokeColor="@color/jetpack_powered_bottom_sheet_background"/>
 </vector>

--- a/WordPress/src/main/res/drawable/ic_jetpack_migration_error.xml
+++ b/WordPress/src/main/res/drawable/ic_jetpack_migration_error.xml
@@ -12,7 +12,7 @@
         android:pathData="M94.73,50.86C94.73,52.17 94.32,53.06 93.7,53.66C93.05,54.25 92.04,54.64 90.46,54.64C88.88,54.64 87.86,54.26 87.16,53.64C86.51,53.04 86.11,52.17 86.11,50.86C86.11,49.45 86.5,48.6 87.13,48.02C87.79,47.41 88.81,46.99 90.46,46.99C92.12,46.99 93.12,47.42 93.73,48C94.34,48.58 94.73,49.45 94.73,50.86ZM124.5,35.5C124.5,16.72 109.29,1.5 90.5,1.5C71.72,1.5 56.5,16.72 56.5,35.5C56.5,54.28 71.72,69.5 90.5,69.5C109.29,69.5 124.5,54.28 124.5,35.5ZM87.33,39.61L86.07,16.36H94.93L93.67,39.61H87.33Z"
         android:strokeWidth="3"
         android:fillColor="#E65054"
-        android:strokeColor="#ffffff"/>
+        android:strokeColor="@color/jetpack_powered_bottom_sheet_background"/>
     <path
         android:pathData="M148.5,1.5L148.5,1.5A34,34 0,0 1,182.5 35.5L182.5,35.5A34,34 0,0 1,148.5 69.5L148.5,69.5A34,34 0,0 1,114.5 35.5L114.5,35.5A34,34 0,0 1,148.5 1.5z"
         android:fillColor="#ffffff"/>
@@ -23,5 +23,5 @@
         android:pathData="M148.5,1.5L148.5,1.5A34,34 0,0 1,182.5 35.5L182.5,35.5A34,34 0,0 1,148.5 69.5L148.5,69.5A34,34 0,0 1,114.5 35.5L114.5,35.5A34,34 0,0 1,148.5 1.5z"
         android:strokeWidth="3"
         android:fillColor="#00000000"
-        android:strokeColor="#ffffff"/>
+        android:strokeColor="@color/jetpack_powered_bottom_sheet_background"/>
 </vector>

--- a/WordPress/src/main/res/drawable/ic_jetpack_migration_notifications.xml
+++ b/WordPress/src/main/res/drawable/ic_jetpack_migration_notifications.xml
@@ -14,7 +14,7 @@
         android:pathData="M35.5,1.5L35.5,1.5A34,34 0,0 1,69.5 35.5L69.5,35.5A34,34 0,0 1,35.5 69.5L35.5,69.5A34,34 0,0 1,1.5 35.5L1.5,35.5A34,34 0,0 1,35.5 1.5z"
         android:strokeWidth="3"
         android:fillColor="#00000000"
-        android:strokeColor="#ffffff"/>
+        android:strokeColor="@color/jetpack_powered_bottom_sheet_background"/>
     <path
         android:pathData="M93.5,1.5L93.5,1.5A34,34 0,0 1,127.5 35.5L127.5,35.5A34,34 0,0 1,93.5 69.5L93.5,69.5A34,34 0,0 1,59.5 35.5L59.5,35.5A34,34 0,0 1,93.5 1.5z"
         android:fillColor="#ffffff"/>
@@ -25,5 +25,5 @@
         android:pathData="M93.5,1.5L93.5,1.5A34,34 0,0 1,127.5 35.5L127.5,35.5A34,34 0,0 1,93.5 69.5L93.5,69.5A34,34 0,0 1,59.5 35.5L59.5,35.5A34,34 0,0 1,93.5 1.5z"
         android:strokeWidth="3"
         android:fillColor="#00000000"
-        android:strokeColor="#ffffff"/>
+        android:strokeColor="@color/jetpack_powered_bottom_sheet_background"/>
 </vector>

--- a/WordPress/src/main/res/drawable/ic_jetpack_migration_success.xml
+++ b/WordPress/src/main/res/drawable/ic_jetpack_migration_success.xml
@@ -13,7 +13,7 @@
         android:pathData="M35.5,1.5L35.5,1.5A34,34 0,0 1,69.5 35.5L69.5,35.5A34,34 0,0 1,35.5 69.5L35.5,69.5A34,34 0,0 1,1.5 35.5L1.5,35.5A34,34 0,0 1,35.5 1.5z"
         android:strokeWidth="3"
         android:fillColor="#00000000"
-        android:strokeColor="#ffffff"/>
+        android:strokeColor="@color/jetpack_powered_bottom_sheet_background"/>
     <path
         android:pathData="M93.5,1.5L93.5,1.5A34,34 0,0 1,127.5 35.5L127.5,35.5A34,34 0,0 1,93.5 69.5L93.5,69.5A34,34 0,0 1,59.5 35.5L59.5,35.5A34,34 0,0 1,93.5 1.5z"
         android:fillColor="#ffffff"/>
@@ -24,5 +24,5 @@
         android:pathData="M93.5,1.5L93.5,1.5A34,34 0,0 1,127.5 35.5L127.5,35.5A34,34 0,0 1,93.5 69.5L93.5,69.5A34,34 0,0 1,59.5 35.5L59.5,35.5A34,34 0,0 1,93.5 1.5z"
         android:strokeWidth="3"
         android:fillColor="#00000000"
-        android:strokeColor="#ffffff"/>
+        android:strokeColor="@color/jetpack_powered_bottom_sheet_background"/>
 </vector>

--- a/WordPress/src/main/res/drawable/ic_wordpress_jetpack_logo.xml
+++ b/WordPress/src/main/res/drawable/ic_wordpress_jetpack_logo.xml
@@ -18,5 +18,5 @@
         android:pathData="M90.5,1.5L90.5,1.5A34,34 0,0 1,124.5 35.5L124.5,35.5A34,34 0,0 1,90.5 69.5L90.5,69.5A34,34 0,0 1,56.5 35.5L56.5,35.5A34,34 0,0 1,90.5 1.5z"
         android:strokeWidth="3"
         android:fillColor="#00000000"
-        android:strokeColor="#ffffff"/>
+        android:strokeColor="@color/jetpack_powered_bottom_sheet_background"/>
 </vector>


### PR DESCRIPTION
Fixes #17491

## Description
Sets the color of the migration icon stroke the same with the background

## To test:
1. Prerequisite: WordPress app should be installed and logged in
2. Set the device to dark mode
3. Uninstall Jetpack App if installed or clear the app data
4. Run the Jetpack app from this branch
5. Verify that the icons have the correct stroke color as described in #17491
6. [Hardcode the error state](https://github.com/wordpress-mobile/WordPress-Android/pull/17588) and repeat the steps above
7. Verify that the error screen icons have the correct stroke color as described in #17491
8. Repeat the above steps in day mode and confirm that there is no change

|Welcome dark|Welcome normal|
|---|---|
|![Screenshot_20221214_130032](https://user-images.githubusercontent.com/304044/207580854-48483ac3-2f6b-4e6a-ab8e-6a460ce61bba.png)|![Screenshot_20221214_130142](https://user-images.githubusercontent.com/304044/207580891-58a48c3a-2351-4eb1-930c-db5f958f64dc.png)|

|Notifications dark|Notifications normal|
|---|---|
|![Screenshot_20221214_130043](https://user-images.githubusercontent.com/304044/207580916-375be0d0-8db1-4283-8876-9a46709cf1ab.png)|![Screenshot_20221214_130156](https://user-images.githubusercontent.com/304044/207580940-e99a6c75-376b-4c18-b668-6449a2198502.png)|


|Finish dark|Finish normal|
|---|---|
|![Screenshot_20221214_130052](https://user-images.githubusercontent.com/304044/207580983-46188128-7c77-42be-9221-9a673c10fd8d.png)|![Screenshot_20221214_130205](https://user-images.githubusercontent.com/304044/207580993-addf6f32-5e0f-4f5a-9669-46b49a961df6.png)|

|Delete dark|Delete normal|
|---|---|
|![Screenshot_20221214_130105](https://user-images.githubusercontent.com/304044/207581017-cb213304-0958-47fc-89e6-7ad0395d7167.png)|![Screenshot_20221214_130219](https://user-images.githubusercontent.com/304044/207581034-52b56224-33f2-46c5-98aa-b882c4acd800.png)|

|Error dark|Error normal|
|---|---|
|![Screenshot_20221214_132550](https://user-images.githubusercontent.com/304044/207583176-73392f50-edad-446f-96f4-0d3f5a213f2c.png)|![Screenshot_20221214_132517](https://user-images.githubusercontent.com/304044/207583193-9b2b2d53-01fa-41c4-be27-a12301356f95.png)|


## Regression Notes


1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
