### PR TITLE
Decrease bottom empty space on migration screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/ButtonsColumn.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/ButtonsColumn.kt
@@ -16,7 +16,7 @@ fun ButtonsColumn(
     content: @Composable ColumnScope.() -> Unit
 ) {
     Column(
-            modifier = modifier.padding(bottom = 50.dp)
+            modifier = modifier.padding(bottom = 10.dp)
     ) {
         Divider(
                 color = colorResource(color.gray_10),

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
@@ -86,7 +86,7 @@ fun WelcomeStep(uiState: UiState.Content.Welcome) = with(uiState) {
                             onClick = secondaryActionButton.onClick,
                             enabled = !isProcessing,
                             modifier = Modifier
-                                    .padding(bottom = 50.dp)
+                                    .padding(bottom = 10.dp)
                                     .dimmed(isProcessing),
                     )
                 }


### PR DESCRIPTION
Fixes #17660

This PR reduces the empty space below the buttons on the Jetpack migration flow screens.

> **Note** During implementation I noticed anything less than the current space (`10dp` from container + `10dp` from button) wouldn't look good as the padding above the buttons would be more than the padding below them.

To test:

1. Prerequisite: WordPress app should be installed and logged in
2. Uninstall Jetpack App if installed or clear the app data
3. Run the Jetpack app from this branch
4. **Verify** that the space below the button(s) is smaller on the migration flow screens (including the Delete WP app screen)
5. [Hardcode the error state](https://github.com/wordpress-mobile/WordPress-Android/pull/17588) and repeat the steps above
6. Verify that the the space below the buttons is smaller on the migration error screen

| Welcome | Notifications | Success |
| - | - | - |
| <img width="240" src="https://user-images.githubusercontent.com/4588074/207917576-1b06c0c8-95b3-40e5-8e58-4786cbbdef86.png"> | <img width="240" src="https://user-images.githubusercontent.com/4588074/207917581-1fb0c69f-16be-46cc-9a9b-8c9b756aafbc.png"> | <img width="240" src="https://user-images.githubusercontent.com/4588074/207917589-d9caf498-dec1-4610-99e0-6e681abce23b.png"> |

| Error | Delete |
| - | - |
| <img width="240" src="https://user-images.githubusercontent.com/4588074/207918012-a3262424-ba4b-4265-a1ed-1795bdf9b34f.png"> | <img width="240" src="https://user-images.githubusercontent.com/4588074/207918138-12f0cc2b-c506-444b-835e-20be8529f00e.png"> |

## Regression Notes
1. Potential unintended areas of impact
   N/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

3. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
