### PR TITLE
[Blogging Prompts] Prompts list feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -110,6 +110,7 @@ android {
         buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "false"
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
+        buildConfigField "boolean", "BLOGGING_PROMPTS_LIST", "false"
         buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"
         buildConfigField "boolean", "QRCODE_AUTH_FLOW", "false"
         buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -222,6 +222,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val isAnswered: Boolean,
                         val promptId: Int,
                         val attribution: BloggingPromptAttribution,
+                        val showViewMoreAction: Boolean,
                         val onShareClick: (String) -> Unit,
                         val onAnswerClick: (PromptID) -> Unit,
                         val onSkipClick: () -> Unit

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -95,6 +95,7 @@ sealed class MySiteCardAndItemBuilderParams {
 
     data class BloggingPromptCardBuilderParams(
         val bloggingPrompt: BloggingPromptModel?,
+        val showViewMoreAction: Boolean,
         val onShareClick: (message: String) -> Unit,
         val onAnswerClick: (promptId: Int) -> Unit,
         val onSkipClick: () -> Unit

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -111,6 +111,7 @@ import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
+import org.wordpress.android.util.config.BloggingPromptsListFeatureConfig
 import org.wordpress.android.util.config.LandOnTheEditorFeatureConfig
 import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
@@ -162,6 +163,7 @@ class MySiteViewModel @Inject constructor(
     private val buildConfigWrapper: BuildConfigWrapper,
     mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig,
     bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig,
+    bloggingPromptsListFeatureConfig: BloggingPromptsListFeatureConfig,
     private val jetpackBrandingUtils: JetpackBrandingUtils,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val bloggingPromptsCardAnalyticsTracker: BloggingPromptsCardAnalyticsTracker,
@@ -203,6 +205,7 @@ class MySiteViewModel @Inject constructor(
 
     private val isMySiteDashboardTabsFeatureConfigEnabled = mySiteDashboardTabsFeatureConfig.isEnabled()
     private val isBloggingPromptsFeatureConfigEnabled = bloggingPromptsFeatureConfig.isEnabled()
+    private val isBloggingPromptsListFeatureConfigEnabled = bloggingPromptsListFeatureConfig.isEnabled()
 
     val isMySiteTabsEnabled: Boolean
         get() = isMySiteDashboardTabsFeatureConfigEnabled &&
@@ -475,6 +478,7 @@ class MySiteViewModel @Inject constructor(
                                 bloggingPrompt = if (isBloggingPromptsFeatureConfigEnabled) {
                                     bloggingPromptUpdate?.promptModel
                                 } else null,
+                                showViewMoreAction = isBloggingPromptsListFeatureConfigEnabled,
                                 onShareClick = this::onBloggingPromptShareClick,
                                 onAnswerClick = this::onBloggingPromptAnswerClick,
                                 onSkipClick = this::onBloggingPromptSkipClicked

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -203,9 +203,9 @@ class MySiteViewModel @Inject constructor(
        as they're already built on site select. */
     private var isSiteSelected = false
 
-    private val isMySiteDashboardTabsFeatureConfigEnabled = mySiteDashboardTabsFeatureConfig.isEnabled()
-    private val isBloggingPromptsFeatureConfigEnabled = bloggingPromptsFeatureConfig.isEnabled()
-    private val isBloggingPromptsListFeatureConfigEnabled = bloggingPromptsListFeatureConfig.isEnabled()
+    private val isMySiteDashboardTabsFeatureConfigEnabled by lazy { mySiteDashboardTabsFeatureConfig.isEnabled() }
+    private val isBloggingPromptsFeatureConfigEnabled by lazy { bloggingPromptsFeatureConfig.isEnabled() }
+    private val isBloggingPromptsListFeatureConfigEnabled by lazy { bloggingPromptsListFeatureConfig.isEnabled() }
 
     val isMySiteTabsEnabled: Boolean
         get() = isMySiteDashboardTabsFeatureConfigEnabled &&

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
@@ -30,9 +30,10 @@ class BloggingPromptCardBuilder @Inject constructor() {
                 isAnswered = params.bloggingPrompt.isAnswered,
                 promptId = params.bloggingPrompt.id,
                 attribution = BloggingPromptAttribution.fromString(params.bloggingPrompt.attribution),
+                showViewMoreAction = params.showViewMoreAction,
                 onShareClick = params.onShareClick,
                 onAnswerClick = params.onAnswerClick,
-                onSkipClick = params.onSkipClick
+                onSkipClick = params.onSkipClick,
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
@@ -89,24 +89,27 @@ class BloggingPromptCardViewHolder(
     }
 
     private fun MySiteBloggingPromptCardBinding.showCardMenu(card: BloggingPromptCardWithData) {
-        val quickStartPopupMenu = PopupMenu(bloggingPromptCardMenu.context, bloggingPromptCardMenu)
-        quickStartPopupMenu.setOnMenuItemClickListener {
-            when (it.itemId) {
-                R.id.view_more -> bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuViewMorePromptsClicked()
-                R.id.skip -> {
-                    bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuSkipThisPromptClicked()
-                    card.onSkipClick.invoke()
+        PopupMenu(bloggingPromptCardMenu.context, bloggingPromptCardMenu).apply {
+            setOnMenuItemClickListener {
+                when (it.itemId) {
+                    R.id.view_more -> bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuViewMorePromptsClicked()
+                    R.id.skip -> {
+                        bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuSkipThisPromptClicked()
+                        card.onSkipClick.invoke()
+                    }
+                    R.id.remove -> bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuRemoveFromDashboardClicked()
+                    R.id.learn_more -> {
+                        bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuLearnMoreClicked()
+                        learnMoreClicked()
+                    }
                 }
-                R.id.remove -> bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuRemoveFromDashboardClicked()
-                R.id.learn_more -> {
-                    bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuLearnMoreClicked()
-                    learnMoreClicked()
-                }
+                return@setOnMenuItemClickListener true
             }
-            return@setOnMenuItemClickListener true
+            inflate(R.menu.blogging_prompt_card_menu)
+            menu.findItem(R.id.view_more)?.isVisible = card.showViewMoreAction
+            MenuCompat.setGroupDividerEnabled(menu, true)
+        }.also {
+            it.show()
         }
-        quickStartPopupMenu.inflate(R.menu.blogging_prompt_card_menu)
-        MenuCompat.setGroupDividerEnabled(quickStartPopupMenu.menu, true)
-        quickStartPopupMenu.show()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsListFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsListFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+@FeatureInDevelopment
+class BloggingPromptsListFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.BLOGGING_PROMPTS_LIST
+) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && BuildConfig.IS_JETPACK_APP
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -341,19 +341,12 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Suppress("LongMethod")
     fun init(
-        isMySiteDashboardTabsFeatureFlagEnabled: Boolean = true,
-        isBloggingPromptsFeatureConfigEnabled: Boolean = true,
-        isBloggingPromptsListFeatureConfigEnabled: Boolean = true,
-        shouldShowJetpackBranding: Boolean = true
+
     ) = test {
         onSiteChange.value = null
         onShowSiteIconProgressBar.value = null
         onSiteSelected.value = null
         selectedSite.value = null
-        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsFeatureConfigEnabled)
-        whenever(bloggingPromptsListFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsListFeatureConfigEnabled)
-        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsFeatureFlagEnabled)
-        whenever(jetpackBrandingUtils.shouldShowJetpackBranding()).thenReturn(shouldShowJetpackBranding)
         whenever(mySiteSourceManager.build(any(), anyOrNull())).thenReturn(partialStates)
         whenever(selectedSiteRepository.siteSelected).thenReturn(onSiteSelected)
         whenever(quickStartRepository.activeTask).thenReturn(activeTask)
@@ -490,9 +483,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given my site tabs feature flag not enabled, when site is selected, then tabs are not visible`() {
-        init(isMySiteDashboardTabsFeatureFlagEnabled = false)
-
-        initSelectedSite()
+        initSelectedSite(isMySiteDashboardTabsFeatureFlagEnabled = false)
 
         assertThat((uiModels.last().state as SiteSelected).tabsUiState.showTabs).isFalse
     }
@@ -576,9 +567,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given tabs not enabled, when site is selected, then default tab is not set`() {
-        init(isMySiteDashboardTabsFeatureFlagEnabled = false)
-
-        initSelectedSite(isMySiteTabsBuildConfigEnabled = false)
+        initSelectedSite(isMySiteTabsBuildConfigEnabled = false, isMySiteDashboardTabsFeatureFlagEnabled = false)
 
         assertThat(tabNavigation).isEmpty()
     }
@@ -1617,10 +1606,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `blogging prompt card is added to the dashboard when FF is ON`() = test {
-        init(isBloggingPromptsFeatureConfigEnabled = true)
-        initSelectedSite()
+        initSelectedSite(isBloggingPromptsFeatureConfigEnabled = true)
 
-        verify(cardsBuilder, times(2)).build(
+        verify(cardsBuilder).build(
                 any(), any(), any(),
                 argWhere {
                     it.bloggingPromptCardBuilderParams.bloggingPrompt != null
@@ -1633,8 +1621,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `blogging prompt card is not added to the dashboard when FF is OFF`() = test {
-        init(isBloggingPromptsFeatureConfigEnabled = false)
-        initSelectedSite()
+        initSelectedSite(isBloggingPromptsFeatureConfigEnabled = false)
 
         verify(cardsBuilder).build(
                 any(), any(), any(),
@@ -1650,10 +1637,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given blogging prompt card, when prompts list FF is ON, view more action is shown`() = test {
-        init(isBloggingPromptsListFeatureConfigEnabled = true)
-        initSelectedSite()
+        initSelectedSite(isBloggingPromptsListFeatureConfigEnabled = true)
 
-        verify(cardsBuilder, times(2)).build(
+        verify(cardsBuilder).build(
                 any(), any(), any(),
                 argWhere {
                     it.bloggingPromptCardBuilderParams.showViewMoreAction == true
@@ -1667,8 +1653,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given blogging prompt card, when prompts list FF is OFF, view more action is not shown`() = test {
-        init(isBloggingPromptsListFeatureConfigEnabled = false)
-        initSelectedSite()
+        initSelectedSite(isBloggingPromptsListFeatureConfigEnabled = false)
 
         verify(cardsBuilder).build(
                 any(), any(), any(),
@@ -2183,10 +2168,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given shouldShowJetpackBranding is true, then the Jetpack badge is visible last`() {
-        init(shouldShowJetpackBranding = true)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
 
-        initSelectedSite()
+        initSelectedSite(shouldShowJetpackBranding = true)
 
         assertThat(getSiteMenuTabLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
         assertThat(getLastItems().last()).isInstanceOf(JetpackBadge::class.java)
@@ -2196,10 +2180,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given shouldShowJetpackBranding is false, then no Jetpack badge is visible`() {
-        init(shouldShowJetpackBranding = false)
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
 
-        initSelectedSite()
+        initSelectedSite(shouldShowJetpackBranding = false)
 
         assertThat(getSiteMenuTabLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
         assertThat(getLastItems().last()).isNotInstanceOf(JetpackBadge::class.java)
@@ -2329,9 +2312,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given selected site with tabs disabled, when all cards and items, then qs card exists`() {
-        init(isMySiteDashboardTabsFeatureFlagEnabled = false)
-
-        initSelectedSite()
+        initSelectedSite(isMySiteDashboardTabsFeatureFlagEnabled = false)
 
         assertThat(getLastItems().filterIsInstance(QuickStartCard::class.java)).isNotEmpty
     }
@@ -2559,8 +2540,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given tabs are disabled, when pull to refresh invoked, then track with tab source is not requested`() {
-        init(isMySiteDashboardTabsFeatureFlagEnabled = false)
-        initSelectedSite(isMySiteTabsBuildConfigEnabled = false)
+        initSelectedSite(isMySiteTabsBuildConfigEnabled = false, isMySiteDashboardTabsFeatureFlagEnabled = false)
 
         viewModel.refresh(true)
 
@@ -2570,9 +2550,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given tabs are disabled, when pull to refresh invoked, then pull-to-refresh is tracked`() {
-        init(isMySiteDashboardTabsFeatureFlagEnabled = false)
-
-        initSelectedSite(isMySiteTabsBuildConfigEnabled = false)
+        initSelectedSite(isMySiteTabsBuildConfigEnabled = false, isMySiteDashboardTabsFeatureFlagEnabled = false)
 
         viewModel.refresh(true)
         assertThat(analyticsTrackerWrapper.track(Stat.MY_SITE_PULL_TO_REFRESH))
@@ -2617,8 +2595,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given tabs are disabled, when quick link stats tapped, then track with tab source is not requested`() {
-        init(isMySiteDashboardTabsFeatureFlagEnabled = false)
-        initSelectedSite(isMySiteTabsBuildConfigEnabled = false)
+        initSelectedSite(isMySiteTabsBuildConfigEnabled = false, isMySiteDashboardTabsFeatureFlagEnabled = false)
 
         requireNotNull(quickActionsStatsClickAction).invoke()
 
@@ -2629,8 +2606,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given tabs are disabled, when quick link pages tapped, then track with tab source is not requested`() {
-        init(isMySiteDashboardTabsFeatureFlagEnabled = false)
-        initSelectedSite(isMySiteTabsBuildConfigEnabled = false)
+        initSelectedSite(isMySiteTabsBuildConfigEnabled = false, isMySiteDashboardTabsFeatureFlagEnabled = false)
 
         requireNotNull(quickActionsPagesClickAction).invoke()
 
@@ -2641,8 +2617,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given tabs are disabled, when quick link posts tapped, then track with tab source is not requested`() {
-        init(isMySiteDashboardTabsFeatureFlagEnabled = false)
-        initSelectedSite(isMySiteTabsBuildConfigEnabled = false)
+        initSelectedSite(isMySiteTabsBuildConfigEnabled = false, isMySiteDashboardTabsFeatureFlagEnabled = false)
 
         requireNotNull(quickActionsPostsClickAction).invoke()
 
@@ -2653,8 +2628,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Test
     fun `given tabs are disabled, when quick link media tapped, then track with tab source is not requested`() {
-        init(isMySiteDashboardTabsFeatureFlagEnabled = false)
-        initSelectedSite(isMySiteTabsBuildConfigEnabled = false)
+        initSelectedSite(isMySiteTabsBuildConfigEnabled = false, isMySiteDashboardTabsFeatureFlagEnabled = false)
 
         requireNotNull(quickActionsMediaClickAction).invoke()
 
@@ -2860,7 +2834,11 @@ class MySiteViewModelTest : BaseUnitTest() {
         isQuickStartInProgress: Boolean = false,
         showStaleMessage: Boolean = false,
         initialScreen: String = MySiteTabType.SITE_MENU.label,
-        isSiteUsingWpComRestApi: Boolean = true
+        isSiteUsingWpComRestApi: Boolean = true,
+        isMySiteDashboardTabsFeatureFlagEnabled: Boolean = true,
+        isBloggingPromptsFeatureConfigEnabled: Boolean = true,
+        isBloggingPromptsListFeatureConfigEnabled: Boolean = true,
+        shouldShowJetpackBranding: Boolean = true
     ) {
         setUpDynamicCardsBuilder(isQuickStartDynamicCardEnabled)
         whenever(
@@ -2871,6 +2849,10 @@ class MySiteViewModelTest : BaseUnitTest() {
         )
         whenever(buildConfigWrapper.isMySiteTabsEnabled).thenReturn(isMySiteTabsBuildConfigEnabled)
         whenever(appPrefsWrapper.getMySiteInitialScreen(any())).thenReturn(initialScreen)
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsFeatureConfigEnabled)
+        whenever(bloggingPromptsListFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsListFeatureConfigEnabled)
+        whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsFeatureFlagEnabled)
+        whenever(jetpackBrandingUtils.shouldShowJetpackBranding()).thenReturn(shouldShowJetpackBranding)
         if (isSiteUsingWpComRestApi) {
             site.setIsWPCom(true)
             site.setIsJetpackConnected(true)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -188,7 +188,7 @@ class CardsBuilderTest {
                         todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                         postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                         bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
-                                mock(), mock(), mock(), mock()
+                                mock(), false, mock(), mock(), mock()
                         )
                 ),
                 quickLinkRibbonBuilderParams = QuickLinkRibbonBuilderParams(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -200,7 +200,7 @@ class CardsBuilderTest : BaseUnitTest() {
                         todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                         postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                         bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
-                                mock(), mock(), mock(), mock()
+                                mock(), false, mock(), mock(), mock()
                         )
                 )
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
@@ -64,33 +64,33 @@ class BloggingPromptCardBuilderTest : BaseUnitTest() {
 
     @Test
     fun `given blogging prompt, when card is built, then return card`() {
-        val statCard = buildBloggingPromptCard(bloggingPrompt)
+        val statCard = buildBloggingPromptCardBuilderParams(bloggingPrompt)
 
         assertThat(statCard).isNotNull()
     }
 
     @Test
     fun `given blogging prompt, when card is built showing view more action, then return matching card`() {
-        val statCard = buildBloggingPromptCard(bloggingPrompt, showViewMoreAction = true)
+        val statCard = buildBloggingPromptCardBuilderParams(bloggingPrompt, showViewMoreAction = true)
 
         assertThat(statCard).isEqualTo(bloggingPromptCard(showViewMoreAction = true))
     }
 
     @Test
     fun `given blogging prompt, when card is built not showing view more action, then return matching card`() {
-        val statCard = buildBloggingPromptCard(bloggingPrompt, showViewMoreAction = false)
+        val statCard = buildBloggingPromptCardBuilderParams(bloggingPrompt, showViewMoreAction = false)
 
         assertThat(statCard).isEqualTo(bloggingPromptCard(showViewMoreAction = false))
     }
 
     @Test
     fun `given no blogging prompt, when card is built, then return null`() {
-        val statCard = buildBloggingPromptCard(null)
+        val statCard = buildBloggingPromptCardBuilderParams(null)
 
         assertThat(statCard).isNull()
     }
 
-    private fun buildBloggingPromptCard(
+    private fun buildBloggingPromptCardBuilderParams(
         bloggingPrompt: BloggingPromptModel?,
         showViewMoreAction: Boolean = false
     ) = builder.build(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
@@ -70,10 +70,17 @@ class BloggingPromptCardBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given blogging prompt, when card is built, then return matching card`() {
-        val statCard = buildBloggingPromptCard(bloggingPrompt)
+    fun `given blogging prompt, when card is built showing view more action, then return matching card`() {
+        val statCard = buildBloggingPromptCard(bloggingPrompt, showViewMoreAction = true)
 
-        assertThat(statCard).isEqualTo(bloggingPromptCard)
+        assertThat(statCard).isEqualTo(bloggingPromptCard(showViewMoreAction = true))
+    }
+
+    @Test
+    fun `given blogging prompt, when card is built not showing view more action, then return matching card`() {
+        val statCard = buildBloggingPromptCard(bloggingPrompt, showViewMoreAction = false)
+
+        assertThat(statCard).isEqualTo(bloggingPromptCard(showViewMoreAction = false))
     }
 
     @Test
@@ -83,23 +90,33 @@ class BloggingPromptCardBuilderTest : BaseUnitTest() {
         assertThat(statCard).isNull()
     }
 
-    private fun buildBloggingPromptCard(bloggingPrompt: BloggingPromptModel?) = builder.build(
-            BloggingPromptCardBuilderParams(bloggingPrompt, onShareClick, onAnswerClick, onSkipClick)
+    private fun buildBloggingPromptCard(
+        bloggingPrompt: BloggingPromptModel?,
+        showViewMoreAction: Boolean = false
+    ) = builder.build(
+            BloggingPromptCardBuilderParams(
+                    bloggingPrompt,
+                    showViewMoreAction,
+                    onShareClick,
+                    onAnswerClick,
+                    onSkipClick
+            )
     )
 
     private val onShareClick: (message: String) -> Unit = { }
     private val onAnswerClick: (promptId: Int) -> Unit = { }
     private val onSkipClick: () -> Unit = { }
 
-    private val bloggingPromptCard = BloggingPromptCardWithData(
+    private fun bloggingPromptCard(showViewMoreAction: Boolean = false) = BloggingPromptCardWithData(
             prompt = UiStringText(PROMPT_TITLE),
             respondents = RESPONDENTS_IN_CARD,
             numberOfAnswers = NUMBER_OF_RESPONDENTS,
             false,
             promptId = 123,
+            attribution = BloggingPromptAttribution.DAY_ONE,
+            showViewMoreAction = showViewMoreAction,
             onShareClick = onShareClick,
             onAnswerClick = onAnswerClick,
-            attribution = BloggingPromptAttribution.DAY_ONE,
-            onSkipClick = onSkipClick
+            onSkipClick = onSkipClick,
     )
 }


### PR DESCRIPTION
Partial work for #17125

Introduces a local feature flag (or `FeatureConfig`) called `BloggingPromptsListFeatureConfig`, which will show/hide the Prompts List feature in the **Jetpack** app ONLY, while it's under development.

A small improvement was also done in the `MySiteViewModel` file, making the `FeatureConfig` reading lazy, which keeps them being done only once but postpones it to when the reading is actually done. This also allows the unit tests setup to be easier, as we can mock these feature flags **after** initializing the class but **before** using the flags and running the test body. It also made it possible to fix a few tests that were initializing the ViewModel multiple times, which could cause multiple observers to be attached to some `LiveData`, resulting in test issues.

<details>
  <summary>Video Demo</summary>

https://user-images.githubusercontent.com/5091503/208130371-0a211963-7915-4e8b-8cff-149d561cf14f.mp4

</details>

To test:
Pre-requisites
- Having a blog site (needs to have a few posts)

### Enabling the FF
1. Open the JetPack app (`jalapeno` or `wasabi` builds)
2. Sign in (if not signed in already)
3. Go to the `home` dashboard (`My Site` -> `Home`)
5. **Verify** the `Prompts` card is shown
6. Tap the 3-dot menu in the `Prompts` card
7. **Verify** the "View more prompts" action is not present
8. Tap on your avatar on the top-right of the screen to open the settings
9. Tap `App Settings`
10. Tap `Debug Settings`
11. Scroll down to the "Features in development" section
12. Enable the `BloggingPromptsListFeatureConfig` option
13. Tap "Restart the app"
14. Back in the `home` dashboard, **verify** the `Prompts` card is shown
15. Tap the 3-dot menu in the `Prompts` card
16. **Verify** the "View more prompts" action **IS SHOWN**

### Disabling the FF
After doing the steps above, you will have the Feature Flag enabled, you can also test if disabling it will hide the action again by following the steps below:
1. Open the JetPack app (`jalapeno` or `wasabi` builds)
2. Sign in (if not signed in already)
3. Go to the `home` dashboard (`My Site` -> `Home`)
5. **Verify** the `Prompts` card is shown
6. Tap the 3-dot menu in the `Prompts` card
7. **Verify** the "View more prompts" action is present (check steps for **Enabling the FF** above)
8. Tap on your avatar on the top-right of the screen to open the settings
9. Tap `App Settings`
10. Tap `Debug Settings`
11. Scroll down to the "Features in development" section
12. Disable the `BloggingPromptsListFeatureConfig` option
13. Tap "Restart the app"
14. Back in the `home` dashboard, **verify** the `Prompts` card is shown
15. Tap the 3-dot menu in the `Prompts` card
16. **Verify** the "View more prompts" action **IS NOT SHOWN** anymore

## Regression Notes
1. Potential unintended areas of impact
- Showing the prompts in WordPress
- Lazy loading of feature flags in the `MySite` page causing wrong behavior

18. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and assured tests were passing properly.

19. What automated tests I added (or what prevented me from doing so)
- added tests to `MySiteViewModelTest` assure the FF value is being passed to the appropriate card builder
- added tests to `BloggingPromptCardBuilderTest` to assure the variable controlling "view mode prompts" visibility is properly set

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
