### PR TITLE
Always Land on My Site after migration flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/UserFlagsProviderHelper.kt
@@ -36,7 +36,6 @@ class UserFlagsProviderHelper @Inject constructor(
     }
 
     private val userFlagsKeysSet: Set<String> = setOf(
-            DeletablePrefKey.MAIN_PAGE_INDEX.name,
             DeletablePrefKey.IMAGE_OPTIMIZE_ENABLED.name,
             DeletablePrefKey.IMAGE_OPTIMIZE_WIDTH.name,
             DeletablePrefKey.IMAGE_OPTIMIZE_QUALITY.name,


### PR DESCRIPTION
Fixes #17655

This PR ensures the user always lands on the `My Site` screen after completing the migration flow.

The functionality is achieved by not migrating the `MAIN_PAGE_INDEX` user preference flag to the Jetpack app. This flag holds the information about the last main screen (My Site / Reader / Notifications) the user had opened, and would ensure the app opens on the same screen during the next launch.

To test:
1. Prerequisite: WordPress app should be installed and logged in
2. In the WordPress app, open Notifications or Reader from the bottom navbar.
3. Uninstall Jetpack App if installed or clear the app data
4. Run the Jetpack app from this branch
5. Complete the migration flow
6. **Verify** You land on the `My Site` screen, even if the WordPress app was on Reader or Notifications screen.

### Preview
https://user-images.githubusercontent.com/4588074/208119166-f77a2645-9470-41fe-84fb-c60a69a0b4f5.mp4

## Regression Notes
1. Potential unintended areas of impact
   N/a

7. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual Testing

8. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
