### PR TITLE
[Blogging Prompts] Prompts List architectural boilerplate

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
@@ -3,25 +3,28 @@ package org.wordpress.android.ui.bloggingprompts.promptslist
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.ui.compose.theme.AppTheme
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class BloggingPromptsListActivity : AppCompatActivity() {
-    @Inject lateinit var tracker: BloggingPromptsListAnalyticsTracker
+    private val viewModel: BloggingPromptsListViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             AppTheme {
-                BloggingPromptsListScreen(::onBackPressed)
+                val uiState by viewModel.uiStateFlow.collectAsState()
+                BloggingPromptsListScreen(uiState, ::onBackPressed)
             }
         }
-        tracker.trackScreenShown()
+        viewModel.start()
     }
 
     // TODO it might be safer bringing in the androidx.activity:activity-compose lib

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.ui.bloggingprompts.promptslist.compose.BloggingPromptsListScreen
 import org.wordpress.android.ui.compose.theme.AppTheme
 
 @AndroidEntryPoint

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListScreen.kt
@@ -1,16 +1,36 @@
 package org.wordpress.android.ui.bloggingprompts.promptslist
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState
+import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState.Content
+import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState.FetchError
+import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState.Loading
+import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState.NetworkError
 import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState.None
+import org.wordpress.android.ui.bloggingprompts.promptslist.model.BloggingPromptsListItemModel
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.util.LocaleManager
+import java.text.DateFormat
 
 @Composable
 fun BloggingPromptsListScreen(
@@ -26,7 +46,53 @@ fun BloggingPromptsListScreen(
                 )
             },
     ) {
-        Text("This is just a placeholder for now: ${uiState::class.simpleName}")
+        Surface(modifier = Modifier.fillMaxSize()) {
+            when (uiState) {
+                is Content -> ListContent(uiState.content)
+                Loading -> LoadingContent()
+                FetchError -> TODO()
+                NetworkError -> TODO()
+                None -> {}
+            }
+        }
+    }
+}
+
+@Composable
+private fun ListContent(
+    promptsList: List<BloggingPromptsListItemModel>
+) {
+    // TODO thomashorta this is all just temporary for now, the actual list item will be created in the next task
+    val dateFormat = DateFormat.getDateInstance(
+            DateFormat.MEDIUM,
+            LocaleManager.getSafeLocale(LocalContext.current)
+    )
+    LazyColumn(
+            Modifier.fillMaxWidth(),
+    ) {
+        items(promptsList) {
+            val answeredText = if (it.isAnswered) "- Answered" else ""
+            Column(Modifier.padding(16.dp)) {
+                Text(
+                        it.text,
+                        style = MaterialTheme.typography.subtitle1
+                )
+                Text(
+                        "${dateFormat.format(it.date)} - ${it.answersCount} answers $answeredText",
+                        style = MaterialTheme.typography.body2
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingContent() {
+    Box(Modifier.fillMaxSize()) {
+        Text(
+                "Loading...",
+                modifier = Modifier.align(Alignment.Center),
+        )
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListScreen.kt
@@ -6,12 +6,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R
+import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState
+import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState.None
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
 
 @Composable
 fun BloggingPromptsListScreen(
+    uiState: UiState,
     onNavigateUp: () -> Unit,
 ) {
     Scaffold(
@@ -23,7 +26,7 @@ fun BloggingPromptsListScreen(
                 )
             },
     ) {
-        Text("This is just a placeholder for now...")
+        Text("This is just a placeholder for now: ${uiState::class.simpleName}")
     }
 }
 
@@ -31,6 +34,6 @@ fun BloggingPromptsListScreen(
 @Composable
 fun BloggingPromptsListScreenPreview() {
     AppTheme {
-        BloggingPromptsListScreen(onNavigateUp = {})
+        BloggingPromptsListScreen(uiState = None, onNavigateUp = {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState
@@ -98,8 +99,10 @@ private fun LoadingContent() {
 
 @Preview
 @Composable
-fun BloggingPromptsListScreenPreview() {
+fun BloggingPromptsListScreenPreview(
+    @PreviewParameter(provider = BloggingPromptsListScreenPreviewProvider::class) uiState: UiState
+) {
     AppTheme {
-        BloggingPromptsListScreen(uiState = None, onNavigateUp = {})
+        BloggingPromptsListScreen(uiState = uiState, onNavigateUp = {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListScreen.kt
@@ -1,18 +1,13 @@
 package org.wordpress.android.ui.bloggingprompts.promptslist
 
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.MainTopAppBar
+import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
 
 @Composable
@@ -21,24 +16,10 @@ fun BloggingPromptsListScreen(
 ) {
     Scaffold(
             topBar = {
-                // TODO extract this logic to a common compose package and fix it to look exactly like the app toolbar
-                TopAppBar(
-                        backgroundColor = MaterialTheme.colors.surface,
-                        contentColor = MaterialTheme.colors.onSurface,
-                        elevation = 0.dp,
-                        title = {
-                            Text(stringResource(R.string.blogging_prompts_list_title))
-                        },
-                        navigationIcon = {
-                            IconButton(
-                                    onClick = { onNavigateUp() }
-                            ) {
-                                Icon(
-                                        Icons.Default.ArrowBack,
-                                        contentDescription = stringResource(R.string.navigate_up_desc)
-                                )
-                            }
-                        }
+                MainTopAppBar(
+                        title = stringResource(R.string.blogging_prompts_list_title),
+                        navigationIcon = NavigationIcons.BackIcon,
+                        onNavigationIconClick = onNavigateUp
                 )
             },
     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListScreenPreviewProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListScreenPreviewProvider.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.bloggingprompts.promptslist
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState
+import org.wordpress.android.ui.bloggingprompts.promptslist.model.BloggingPromptsListItemModel
+import java.util.Date
+
+class BloggingPromptsListScreenPreviewProvider : PreviewParameterProvider<UiState> {
+    override val values: Sequence<UiState>
+        get() = sequenceOf(
+                UiState.None,
+                UiState.Loading,
+                UiState.Content(fakePromptList),
+                // TODO thomashorta add missing UiStates when their content is developed
+        )
+
+    private val fakePromptList = List(11) {
+        BloggingPromptsListItemModel(
+                id = it,
+                text = "Prompt text",
+                date = Date(if (it == 0) 1671678000000 else 1671591600000),
+                isAnswered = it % 2 == 0,
+                answersCount = 10 * it,
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.bloggingprompts.promptslist
 
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,15 +13,22 @@ import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
+@HiltViewModel
 class BloggingPromptsListViewModel @Inject constructor(
     private val fetchBloggingPromptsList: FetchBloggingPromptsListUseCase,
+    private val tracker: BloggingPromptsListAnalyticsTracker,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
 ) : ScopedViewModel(bgDispatcher) {
     private val _uiStateFlow = MutableStateFlow<UiState>(UiState.None)
     val uiStateFlow = _uiStateFlow.asStateFlow()
 
-    fun fetchPrompts() {
+    fun start() {
+        tracker.trackScreenShown()
+        fetchPrompts()
+    }
+
+    private fun fetchPrompts() {
         launch {
             if (!networkUtilsWrapper.isNetworkAvailable()) {
                 _uiStateFlow.update { UiState.NetworkError }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModel.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.ui.bloggingprompts.promptslist
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.bloggingprompts.promptslist.model.BloggingPromptsListItemModel
+import org.wordpress.android.ui.bloggingprompts.promptslist.usecase.FetchBloggingPromptsListUseCase
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+class BloggingPromptsListViewModel @Inject constructor(
+    private val fetchBloggingPromptsList: FetchBloggingPromptsListUseCase,
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+) : ScopedViewModel(bgDispatcher) {
+    private val _uiStateFlow = MutableStateFlow<UiState>(UiState.None)
+    val uiStateFlow = _uiStateFlow.asStateFlow()
+
+    fun fetchPrompts() {
+        launch {
+            if (!networkUtilsWrapper.isNetworkAvailable()) {
+                _uiStateFlow.update { UiState.NetworkError }
+                return@launch
+            }
+
+            _uiStateFlow.update { UiState.Loading }
+
+            try {
+                val prompts = fetchBloggingPromptsList.execute()
+                _uiStateFlow.update { UiState.Content(prompts) }
+            } catch (e: Exception) {
+                _uiStateFlow.update { UiState.FetchError }
+            }
+        }
+    }
+
+    sealed interface UiState {
+        object None : UiState
+        object Loading : UiState
+        data class Content(val content: List<BloggingPromptsListItemModel>) : UiState
+        object FetchError : UiState
+        object NetworkError : UiState
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModel.kt
@@ -37,12 +37,13 @@ class BloggingPromptsListViewModel @Inject constructor(
 
             _uiStateFlow.update { UiState.Loading }
 
-            try {
-                val prompts = fetchBloggingPromptsList.execute()
-                _uiStateFlow.update { UiState.Content(prompts) }
-            } catch (e: Exception) {
-                _uiStateFlow.update { UiState.FetchError }
-            }
+            fetchBloggingPromptsList.execute()
+                    .onSuccess { prompts ->
+                        _uiStateFlow.update { UiState.Content(prompts) }
+                    }
+                    .onFailure {
+                        _uiStateFlow.update { UiState.FetchError }
+                    }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreen.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.bloggingprompts.promptslist
+package org.wordpress.android.ui.bloggingprompts.promptslist.compose
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreenPreviewProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreenPreviewProvider.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.bloggingprompts.promptslist
+package org.wordpress.android.ui.bloggingprompts.promptslist.compose
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/model/BloggingPromptsListItemModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/model/BloggingPromptsListItemModel.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.ui.bloggingprompts.promptslist.model
+
+import java.util.Date
+
+data class BloggingPromptsListItemModel(
+    val id: Int,
+    val text: String,
+    val date: Date,
+    val isAnswered: Boolean,
+    val answersCount: Int,
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt
@@ -10,7 +10,7 @@ import kotlin.random.Random
 class FetchBloggingPromptsListUseCase @Inject constructor() {
     suspend fun execute(): List<BloggingPromptsListItemModel> {
         // delay a bit to simulate a fetch
-        delay(500)
+        delay(1500)
         return generateFakePrompts()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.ui.bloggingprompts.promptslist.usecase
+
+import kotlinx.coroutines.delay
+import org.wordpress.android.ui.bloggingprompts.promptslist.model.BloggingPromptsListItemModel
+import java.util.Calendar
+import java.util.Date
+import javax.inject.Inject
+import kotlin.random.Random
+
+class FetchBloggingPromptsListUseCase @Inject constructor() {
+    suspend fun execute(): List<BloggingPromptsListItemModel> {
+        // delay a bit to simulate a fetch
+        delay(500)
+        return generateFakePrompts()
+    }
+
+    // FAKE DATA GENERATION BELOW
+
+    private fun generateFakePrompts(): List<BloggingPromptsListItemModel> {
+        val calendar = Calendar.getInstance()
+        return List(11) { generateFakePrompt(it, calendar.getDateAndSubtractADay()) }
+    }
+
+    private fun generateFakePrompt(id: Int, date: Date) = BloggingPromptsListItemModel(
+            id = id,
+            text = fakePrompts.random(),
+            date = date,
+            isAnswered = listOf(true, false).random(),
+            answersCount = Random.nextInt(5000),
+    )
+
+    private fun Calendar.getDateAndSubtractADay(): Date {
+        val currentDate = time
+        add(Calendar.DAY_OF_YEAR, -1)
+        return currentDate
+    }
+
+    companion object {
+        private val fakePrompts = listOf(
+                "What makes you feel nostalgic?",
+                "What relationships have a negative impact on you?",
+                "If you started a sports team, what would the colors and mascot be?",
+                "How have your political views changed over time?",
+                "You get to build your perfect space for reading and writing. What’s it like?",
+                "Have you ever been in an automobile accident?"
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt
@@ -7,6 +7,8 @@ import java.util.Date
 import javax.inject.Inject
 import kotlin.random.Random
 
+// TODO thomashorta remove this suppress annotation when this has a real implementation
+@Suppress("MagicNumber")
 class FetchBloggingPromptsListUseCase @Inject constructor() {
     suspend fun execute(): List<BloggingPromptsListItemModel> {
         // delay a bit to simulate a fetch

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.bloggingprompts.promptslist.usecase
 
 import kotlinx.coroutines.delay
 import org.wordpress.android.ui.bloggingprompts.promptslist.model.BloggingPromptsListItemModel
+import org.wordpress.android.ui.bloggingprompts.promptslist.usecase.FetchBloggingPromptsListUseCase.Result.Success
 import java.util.Calendar
 import java.util.Date
 import javax.inject.Inject
@@ -10,10 +11,25 @@ import kotlin.random.Random
 // TODO thomashorta remove this suppress annotation when this has a real implementation
 @Suppress("MagicNumber")
 class FetchBloggingPromptsListUseCase @Inject constructor() {
-    suspend fun execute(): List<BloggingPromptsListItemModel> {
+    suspend fun execute(): Result {
         // delay a bit to simulate a fetch
         delay(1500)
-        return generateFakePrompts()
+        return Success(generateFakePrompts())
+    }
+
+    sealed class Result {
+        class Success(val content: List<BloggingPromptsListItemModel>) : Result()
+        object Failure : Result()
+
+        inline fun onSuccess(block: (List<BloggingPromptsListItemModel>) -> Unit): Result {
+            if (this is Success) block(this.content)
+            return this
+        }
+
+        fun onFailure(block: () -> Unit): Result {
+            if (this is Failure) block()
+            return this
+        }
     }
 
     // FAKE DATA GENERATION BELOW

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/MainTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/MainTopAppBar.kt
@@ -1,0 +1,101 @@
+package org.wordpress.android.ui.compose.components
+
+import android.content.res.Configuration
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.utils.withFullContentAlpha
+
+typealias NavigationIcon = @Composable () -> Unit
+
+/**
+ * Set of ready-to-use Composable functions to be used as navigation icons in the [MainTopAppBar] Composable.
+ */
+object NavigationIcons {
+    val BackIcon: NavigationIcon = {
+        Icon(
+                Icons.Default.ArrowBack,
+                contentDescription = stringResource(R.string.navigate_up_desc)
+        )
+    }
+
+    @Suppress("unused")
+    val CloseIcon: NavigationIcon = {
+        Icon(
+                Icons.Default.Close,
+                contentDescription = stringResource(R.string.close_desc)
+        )
+    }
+}
+
+/**
+ * TopAppBar customized according to app design specs (surface background color and no elevation).
+ *
+ * Extra info and workarounds regarding [TopAppBar]:
+ *
+ * [TopAppBar] from Material internally provide a different [LocalContentAlpha] according to low vs high
+ * contrast use cases. This forces the navigation icon, title, and actions "Composables" to use that alpha.
+ * In addition to that, most people use the default phone settings, which is considered LOW CONTRAST, making
+ * the provided alpha be smaller than 1f, which makes the components mentioned above have some transparency, which
+ * is not aligned with our Design Specs.
+ *
+ * This Composable works around that by setting LocalContentAlpha in the appropriate parts of the code using the helper
+ * [withFullContentAlpha] function, which provides a full alpha to the [LocalContentAlpha] Composition Local.
+ *
+ * @param title The title String to be shown in the top bar.
+ * @param modifier The [Modifier] to be applied to this TopAppBar.
+ * @param navigationIcon The composable to be used as navigation icon, preferably one of the default options from
+ * [NavigationIcons]. It can be an composable function providing an [Icon] as well, since it is used inside an
+ * [IconButton]. Note that leaving this field null will cause the navigation icon to not be shown.
+ * @param onNavigationIconClick The lambda to be invoked when the navigation icon is pressed.
+ */
+@Composable
+fun MainTopAppBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    navigationIcon: NavigationIcon? = null,
+    onNavigationIconClick: () -> Unit = {},
+) {
+    TopAppBar(
+            modifier = modifier,
+            backgroundColor = MaterialTheme.colors.surface,
+            contentColor = MaterialTheme.colors.onSurface,
+            elevation = 0.dp,
+            title = withFullContentAlpha {
+                Text(title)
+            },
+            navigationIcon = navigationIcon?.let {
+                withFullContentAlpha {
+                    IconButton(onClick = onNavigationIconClick) {
+                        navigationIcon()
+                    }
+                }
+            },
+    )
+}
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun MainTopAppBarPreview() {
+    AppTheme {
+        MainTopAppBar(
+                title = "Preview",
+                navigationIcon = NavigationIcons.BackIcon,
+                onNavigationIconClick = {}
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/utils/ComposeUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/utils/ComposeUtils.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.ui.compose.utils
+
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+
+/**
+ * Utility function that returns a Composable function that wraps the [content] inside a [CompositionLocalProvider]
+ * setting the [LocalContentAlpha] to 1f. Useful for using with some Material Composables that override that alpha
+ * Composition Local in a hard-coded fashion (e.g.: TopAppBar). This should not need to be used very often.
+ */
+fun withFullContentAlpha(content: @Composable () -> Unit): @Composable () -> Unit = {
+    CompositionLocalProvider(
+            LocalContentAlpha provides 1f,
+            content = content
+    )
+}

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3091,6 +3091,7 @@
     <string name="notification_settings_switch_desc">Notifications</string>
     <string name="notifications_tab_dialog_switch_desc">Notifications</string>
     <string name="navigate_up_desc">navigate up</string>
+    <string name="close_desc">close</string>
     <string name="fab_add_tag_desc">Create Tag</string>
     <string name="fab_create_desc">Create a post</string>
     <string name="reader_avatar_desc">profile picture</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModelTest.kt
@@ -13,6 +13,8 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.ui.bloggingprompts.promptslist.model.BloggingPromptsListItemModel
 import org.wordpress.android.ui.bloggingprompts.promptslist.usecase.FetchBloggingPromptsListUseCase
+import org.wordpress.android.ui.bloggingprompts.promptslist.usecase.FetchBloggingPromptsListUseCase.Result.Failure
+import org.wordpress.android.ui.bloggingprompts.promptslist.usecase.FetchBloggingPromptsListUseCase.Result.Success
 import org.wordpress.android.util.NetworkUtilsWrapper
 import java.util.Date
 
@@ -44,7 +46,7 @@ class BloggingPromptsListViewModelTest : BaseUnitTest() {
         val promptsList = listOf(BloggingPromptsListItemModel(0, "prompt", Date(), false, 0))
         whenever(fetchBloggingPromptsListUseCase.execute()).doSuspendableAnswer {
             delay(10)
-            promptsList
+            Success(promptsList)
         }
         mockNetworkAvailability(true)
 
@@ -65,7 +67,7 @@ class BloggingPromptsListViewModelTest : BaseUnitTest() {
     fun `given unsuccessful fetch, when start, then update uiState to Loading then FetchError`() = test {
         whenever(fetchBloggingPromptsListUseCase.execute()).doSuspendableAnswer {
             delay(10)
-            error("test exception")
+            Failure
         }
         mockNetworkAvailability(true)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModelTest.kt
@@ -6,7 +6,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.internal.verification.Times
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -38,7 +37,7 @@ class BloggingPromptsListViewModelTest : BaseUnitTest() {
     @Test
     fun `when start, then track screen seen event`() = test {
         viewModel.start()
-        verify(tracker, Times(1)).trackScreenShown()
+        verify(tracker).trackScreenShown()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModelTest.kt
@@ -65,7 +65,7 @@ class BloggingPromptsListViewModelTest : BaseUnitTest() {
     fun `given unsuccessful fetch, when start, then update uiState to Loading then FetchError`() = test {
         whenever(fetchBloggingPromptsListUseCase.execute()).doSuspendableAnswer {
             delay(10)
-            throw Exception("test")
+            error("test exception")
         }
         mockNetworkAvailability(true)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListViewModelTest.kt
@@ -1,0 +1,89 @@
+package org.wordpress.android.ui.bloggingprompts.promptslist
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.bloggingprompts.promptslist.model.BloggingPromptsListItemModel
+import org.wordpress.android.ui.bloggingprompts.promptslist.usecase.FetchBloggingPromptsListUseCase
+import org.wordpress.android.util.NetworkUtilsWrapper
+import java.util.Date
+
+@ExperimentalCoroutinesApi
+class BloggingPromptsListViewModelTest : BaseUnitTest() {
+    @Mock private lateinit var fetchBloggingPromptsListUseCase: FetchBloggingPromptsListUseCase
+    @Mock private lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    lateinit var viewModel: BloggingPromptsListViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = BloggingPromptsListViewModel(
+                fetchBloggingPromptsListUseCase,
+                networkUtilsWrapper,
+                testDispatcher()
+        )
+    }
+
+    @Test
+    fun `given successful fetch, when fetchPrompts, then update uiState to Loading then Content`() = test {
+        val promptsList = listOf(BloggingPromptsListItemModel(0, "prompt", Date(), false, 0))
+        whenever(fetchBloggingPromptsListUseCase.execute()).doSuspendableAnswer {
+            delay(10)
+            promptsList
+        }
+        mockNetworkAvailability(true)
+
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(BloggingPromptsListViewModel.UiState.None)
+
+        viewModel.fetchPrompts()
+
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(BloggingPromptsListViewModel.UiState.Loading)
+
+        advanceUntilIdle()
+
+        val result = viewModel.uiStateFlow.value
+        assertThat(result).isInstanceOf(BloggingPromptsListViewModel.UiState.Content::class.java)
+        assertThat((result as BloggingPromptsListViewModel.UiState.Content).content).isEqualTo(promptsList)
+    }
+
+    @Test
+    fun `given unsuccessful fetch, when fetchPrompts, then update uiState to Loading then FetchError`() = test {
+        whenever(fetchBloggingPromptsListUseCase.execute()).doSuspendableAnswer {
+            delay(10)
+            throw Exception("test")
+        }
+        mockNetworkAvailability(true)
+
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(BloggingPromptsListViewModel.UiState.None)
+
+        viewModel.fetchPrompts()
+
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(BloggingPromptsListViewModel.UiState.Loading)
+
+        advanceUntilIdle()
+
+        val result = viewModel.uiStateFlow.value
+        assertThat(result).isInstanceOf(BloggingPromptsListViewModel.UiState.FetchError::class.java)
+    }
+
+    @Test
+    fun `given network unavailable, when fetchPrompts, then update uiState to Loading then FetchError`() = test {
+        mockNetworkAvailability(false)
+
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(BloggingPromptsListViewModel.UiState.None)
+
+        viewModel.fetchPrompts()
+
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(BloggingPromptsListViewModel.UiState.NetworkError)
+    }
+
+
+    private fun mockNetworkAvailability(isNetworkAvailable: Boolean) {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(isNetworkAvailable)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCaseTest.kt
@@ -5,6 +5,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.bloggingprompts.promptslist.usecase.FetchBloggingPromptsListUseCase.Result
+import org.wordpress.android.ui.bloggingprompts.promptslist.usecase.FetchBloggingPromptsListUseCase.Result.Success
 
 @ExperimentalCoroutinesApi
 class FetchBloggingPromptsListUseCaseTest : BaseUnitTest() {
@@ -18,8 +20,13 @@ class FetchBloggingPromptsListUseCaseTest : BaseUnitTest() {
     @Test
     fun `when execute is called, then return 11 items`() = test {
         val result = useCase.execute()
+
         advanceUntilIdle()
-        assertThat(result).hasSize(11)
-        assertThat(result).allMatch { it.text.isNotBlank() }
+
+        assertThat(result).isInstanceOf(Success::class.java)
+
+        val content = (result as Success).content
+        assertThat(content).hasSize(11)
+        assertThat(content).allMatch { it.text.isNotBlank() }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCaseTest.kt
@@ -5,7 +5,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.ui.bloggingprompts.promptslist.usecase.FetchBloggingPromptsListUseCase.Result
 import org.wordpress.android.ui.bloggingprompts.promptslist.usecase.FetchBloggingPromptsListUseCase.Result.Success
 
 @ExperimentalCoroutinesApi

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCaseTest.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.ui.bloggingprompts.promptslist.usecase
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+
+@ExperimentalCoroutinesApi
+class FetchBloggingPromptsListUseCaseTest : BaseUnitTest() {
+    lateinit var useCase: FetchBloggingPromptsListUseCase
+
+    @Before
+    fun setUp() {
+        useCase = FetchBloggingPromptsListUseCase()
+    }
+
+    @Test
+    fun `when execute is called, then return 11 items`() = test {
+        val result = useCase.execute()
+        advanceUntilIdle()
+        assertThat(result).hasSize(11)
+        assertThat(result).allMatch { it.text.isNotBlank() }
+    }
+}


### PR DESCRIPTION
Part of #17125

Add architectural boilerplate for fetching data and propagating UI state to the Compose screen by creating ViewModel, UseCase, UI State, and view objects, and using fake data for now.

I also created a couple of placeholder UIs for the Content and Loading states, so the changes could be viewed / tested from a usability perspective as well. Note: the UI seen here is not close to the actual spec, that's why there are a couple of TODO comments left in code.

<details>
<summary>Video Demo</summary>

https://user-images.githubusercontent.com/5091503/209221284-66181422-ab80-4518-8780-1cf79d51449f.mp4

Note: the UI is not the final spec and the data is fake at this point.
</details>

To test:
1. Do the steps to enable the Prompts List feature flag found in the test section of https://github.com/wordpress-mobile/WordPress-Android/pull/17675
2. Sign in (if not signed in already)
3. Go to the home dashboard (My Site -> Home)
4. **Verify** the Prompts card is shown
5. Tap the 3-dot menu in the Prompts card
6. Tap the "View more prompts" option
7. **Verify** the Prompts List placeholder activity is shown
8. **Verify** it shows a "Loading..." text for a while
9. **Verify** the content is updated with a fake list of 11 prompts

## Regression Notes
1. Potential unintended areas of impact
- Analytics tracking for the screen view not triggering

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
- ViewModel tests
- UseCase test (just a simple one since fake data generation is happening here for now)

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
