### PR TITLE
Integrate gutenberg-mobile release 1.86.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5350-c0a7db7bb4a22ad7f5de7104be4c8d39182a3204'
+    gutenbergMobileVersion = 'v1.86.1'
     wordPressAztecVersion = 'v1.6.2'
     wordPressFluxCVersion = '2.9.0'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5350-472550a84da5c634a452094733278581dd678737'
+    gutenbergMobileVersion = '5350-c0a7db7bb4a22ad7f5de7104be4c8d39182a3204'
     wordPressAztecVersion = 'v1.6.2'
     wordPressFluxCVersion = '2.9.0'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.86.0'
+    gutenbergMobileVersion = '5350-472550a84da5c634a452094733278581dd678737'
     wordPressAztecVersion = 'v1.6.2'
     wordPressFluxCVersion = '2.9.0'
     wordPressLoginVersion = '1.0.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.86.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5350

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.