### PR TITLE
Fix LazyColumn crash in Jetpack Welcome Screen (duplicate keys)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -188,7 +188,7 @@ class JetpackMigrationViewModel @Inject constructor(
     }
 
     private fun siteUiFromModel(site: SiteModel) = SiteListItemUiState(
-            id = site.siteId,
+            id = site.id,
             name = siteUtilsWrapper.getSiteNameOrHomeURL(site),
             url = siteUtilsWrapper.getHomeURLOrHostName(site),
             iconUrl = siteUtilsWrapper.getSiteIconUrlOfResourceSize(
@@ -370,7 +370,7 @@ class JetpackMigrationViewModel @Inject constructor(
     }
 
     data class SiteListItemUiState(
-        val id: Long,
+        val id: Int,
         val name: String,
         val url: String,
         val iconUrl: String,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
@@ -192,17 +192,13 @@ private fun SiteListScaffold(
     }
 }
 
-private val previewSiteListItems = mutableListOf<SiteListItemUiState>().apply {
-    repeat(10) {
-        add(
-                SiteListItemUiState(
-                        id = it.toLong(),
-                        name = "Site $it",
-                        url = "site-$it-name.com",
-                        iconUrl = "",
-                )
-        )
-    }
+private val previewSiteListItems = List(10) {
+    SiteListItemUiState(
+            id = it,
+            name = "Site $it",
+            url = "site-$it-name.com",
+            iconUrl = "",
+    )
 }
 
 private val previewUiState = UiState.Content.Welcome(

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
@@ -273,8 +273,8 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
     fun `Should have correct message for Welcome Content when sites size IS GREATER than 1`() {
         val welcomeContent = Content.Welcome(
                 sites = listOf(
-                        SiteListItemUiState(123L, "name", "url", "iconUrl"),
-                        SiteListItemUiState(456L, "name", "url", "iconUrl")
+                        SiteListItemUiState(123, "name", "url", "iconUrl"),
+                        SiteListItemUiState(456, "name", "url", "iconUrl")
                 ),
                 primaryActionButton = WelcomePrimaryButton {},
                 secondaryActionButton = WelcomeSecondaryButton {},
@@ -288,7 +288,7 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
     @Test
     fun `Should have correct message for Welcome Content when sites size IS NOT GREATER than 1`() {
         val welcomeContent = Content.Welcome(
-                sites = listOf(SiteListItemUiState(123L, "name", "url", "iconUrl")),
+                sites = listOf(SiteListItemUiState(123, "name", "url", "iconUrl")),
                 primaryActionButton = WelcomePrimaryButton {},
                 secondaryActionButton = WelcomeSecondaryButton {},
                 onAvatarClicked = {},


### PR DESCRIPTION
Fixes #17702 

The key in the `LazyColumn` was coming from FluxC `siteId` field, which contains the remote ID of the site, but only from WP.com sites. The issue here is that the `siteId` is 0 for self-hosted sites, meaning that **any users with more than 1 self-hosted site would cause duplicate keys in the LazyColumn, crashing the app**. (see [this comment](https://github.com/wordpress-mobile/WordPress-Android/issues/17702#issuecomment-1365972222) for more details)

This PR changes the key to be the local `id` (primary key in the local WellSQL DB inside FluxC), so it should never have duplicate keys, fixing the crash.

<details>
<summary>Steps to reproduce the issue with jalapeno builds</summary>

Crash reproduction demo:

https://user-images.githubusercontent.com/5091503/209694265-5734e4f0-9db9-4329-8fdc-aaf860b01f42.mp4

Steps to reproduce:
1. Uninstall any versions of WordPress and Jetpack you have installed
1. Install WordPress jalapeno version 21.3 or greater (`trunk` should work)
2. Install Jetpack jalapeno version 21.3 or greater (I used `trunk` here as well)
3. Open WordPress
4. Login using a self-hosted site
5. Go to the Site picker (arrow on the top-right, next to site name) from "My Site" tab
6. Hit the `+` icon on the top-right
7. Add another self-hosted site
8. Close WordPress
9. Make sure Jetpack is in a clean install state (clear app data to be sure)
10. Open Jetpack
11. **Verify** the app crashes

</details>

To test:
1. Uninstall any versions of WordPress and Jetpack you have installed
1. Install WordPress jalapeno version 21.3 or greater
2. Install Jetpack jalapeno version with this fix
3. Open WordPress
4. Login using a self-hosted site
5. Go to the Site picker (arrow on the top-right, next to site name) from "My Site" tab
6. Hit the `+` icon on the top-right
7. Add another self-hosted site
8. Close WordPress
9. Make sure Jetpack is in a clean install state (clear app data to be sure)
10. Open Jetpack
11. **Verify** the app shows the Jetpack Welcome Screen

Fix demo:

https://user-images.githubusercontent.com/5091503/209696647-fd5d3dda-2a56-4f04-b8e9-14cb353a5dc0.mp4

## Regression Notes
1. Potential unintended areas of impact
None, this is a very locally scoped change.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
None, since this only changes Compose UI behavior, which is not covered in automated tests currently. I updated unit tests that were using the changed UI state object.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
