### PR TITLE
Finish the activity after logging out

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -212,12 +212,14 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             startActivity(Intent(activity, UnifiedAboutActivity::class.java))
         })
 
-        viewModel.showDisconnectDialog.observeEvent(viewLifecycleOwner, {
-            when (it) {
-                true -> showDisconnectDialog()
-                false -> hideDisconnectDialog()
+        viewModel.showDisconnectDialog.observeEvent(viewLifecycleOwner) {
+            if(it) {
+                showDisconnectDialog()
+            } else {
+                hideDisconnectDialog()
+                activity?.finish()
             }
-        })
+        }
 
         viewModel.recommendUiState.observeEvent(viewLifecycleOwner, {
             if (!isAdded) return@observeEvent

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -212,14 +212,12 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             startActivity(Intent(activity, UnifiedAboutActivity::class.java))
         })
 
-        viewModel.showDisconnectDialog.observeEvent(viewLifecycleOwner) {
-            if(it) {
-                showDisconnectDialog()
-            } else {
-                hideDisconnectDialog()
-                activity?.finish()
+        viewModel.showDisconnectDialog.observeEvent(viewLifecycleOwner, {
+            when (it) {
+                true -> showDisconnectDialog()
+                false -> hideDisconnectDialog()
             }
-        }
+        })
 
         viewModel.recommendUiState.observeEvent(viewLifecycleOwner, {
             if (!isAdded) return@observeEvent

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -498,7 +498,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (BuildConfig.IS_JETPACK_APP) {
             ActivityLauncher.showSignInForResultJetpackOnly(activity);
         } else {
-            ActivityLauncher.showSignInForResult(activity);
+            ActivityLauncher.showSignInForResult(activity, true);
         }
     }
 


### PR DESCRIPTION
This finishes the current activity after logging out. (Internal ref: p5T066-3Lb-p2#comment-14141)

To test:
1. Launch the app and log in.
2. Tap your avatar on the top of the My Site screen.
3. Tap "Log out" button.
4. Ensure it's logged out successfully.

## Regression Notes
1. Potential unintended areas of impact
Some flow could be broken after logging out and logging in again.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.