### PR TITLE
Disable Story posts when Jetpack features are removed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2395,7 +2395,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 SiteUtils.supportsEmbedVariationFeature(mSite, SiteUtils.WP_INSTAGRAM_EMBED_JETPACK_VERSION),
                 SiteUtils.supportsEmbedVariationFeature(mSite, SiteUtils.WP_LOOM_EMBED_JETPACK_VERSION),
                 SiteUtils.supportsEmbedVariationFeature(mSite, SiteUtils.WP_SMARTFRAME_EMBED_JETPACK_VERSION),
-                SiteUtils.supportsStoriesFeature(mSite),
+                SiteUtils.supportsStoriesFeature(mSite, mJetpackFeatureRemovalPhaseHelper),
                 mSite.isUsingWpComRestApi(),
                 enableXPosts,
                 isUnsupportedBlockEditorEnabled,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.UploadStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.PostListType.DRAFTS
 import org.wordpress.android.ui.posts.PostListType.PUBLISHED
@@ -85,7 +86,8 @@ class PostListMainViewModel @Inject constructor(
     private val savePostToDbUseCase: SavePostToDbUseCase,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
-    private val uploadStarter: UploadStarter
+    private val uploadStarter: UploadStarter,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) : ViewModel(), CoroutineScope {
     private val lifecycleOwner = object : LifecycleOwner {
         val lifecycleRegistry = LifecycleRegistry(this)
@@ -376,7 +378,7 @@ class PostListMainViewModel @Inject constructor(
     }
 
     fun fabClicked() {
-        if (SiteUtils.supportsStoriesFeature(site)) {
+        if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
             _onFabClicked.postValue(Event(Unit))
         } else {
             newPost()
@@ -618,7 +620,7 @@ class PostListMainViewModel @Inject constructor(
     }
 
     fun onFabLongPressed() {
-        if (SiteUtils.supportsStoriesFeature(site)) {
+        if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
             _onFabLongPressedForCreateMenu.postValue(Event(Unit))
         } else {
             _onFabLongPressedForPostList.postValue(Event(Unit))

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorForAllSi
 import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SiteFilter;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.ui.plans.PlansConstants;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.utils.SiteAccessibilityInfo;
@@ -330,8 +331,9 @@ public class SiteUtils {
         return VersionUtils.checkMinimalVersion(site.getSoftwareVersion(), minVersion);
     }
 
-    public static boolean supportsStoriesFeature(SiteModel site) {
-        return site != null && (site.isWPCom() || checkMinimalJetpackVersion(site, WP_STORIES_JETPACK_VERSION));
+    public static boolean supportsStoriesFeature(SiteModel site, JetpackFeatureRemovalPhaseHelper helper) {
+        return site != null && (site.isWPCom() || checkMinimalJetpackVersion(site, WP_STORIES_JETPACK_VERSION))
+               && !helper.shouldRemoveJetpackFeatures();
     }
 
     public static boolean supportsContactInfoFeature(SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.ANSWER_BLOGGING_PROMPT
@@ -67,7 +68,8 @@ class WPMainActivityViewModel @Inject constructor(
     private val siteStore: SiteStore,
     private val bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig,
     private val bloggingPromptsStore: BloggingPromptsStore,
-    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) : ScopedViewModel(mainDispatcher) {
     private var isStarted = false
 
@@ -184,7 +186,7 @@ class WPMainActivityViewModel @Inject constructor(
                         onClickAction = null
                 )
         )
-        if (SiteUtils.supportsStoriesFeature(site)) {
+        if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
             actionsList.add(
                     CreateAction(
                             actionType = CREATE_NEW_STORY,
@@ -260,7 +262,7 @@ class WPMainActivityViewModel @Inject constructor(
 
         _showQuickStarInBottomSheet.postValue(quickStartRepository.activeTask.value == PUBLISH_POST)
 
-        if (SiteUtils.supportsStoriesFeature(site) || hasFullAccessToContent(site)) {
+        if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper) || hasFullAccessToContent(site)) {
             // The user has at least two create options available for this site (pages and/or story posts),
             // so we should show a bottom sheet.
             // Creation options added in the future should also be weighed here.
@@ -334,7 +336,7 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     fun getCreateContentMessageId(site: SiteModel?): Int {
-        return if (SiteUtils.supportsStoriesFeature(site)) {
+        return if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
             getCreateContentMessageIdStoriesFlagOn(hasFullAccessToContent(site))
         } else {
             getCreateContentMessageIdStoriesFlagOff(hasFullAccessToContent(site))

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
@@ -23,7 +24,8 @@ import javax.inject.Inject
 
 class PostListCreateMenuViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) : ViewModel() {
     private var isStarted = false
     private lateinit var site: SiteModel
@@ -143,7 +145,7 @@ class PostListCreateMenuViewModel @Inject constructor(
     }
 
     private fun getCreateContentMessageId(): Int {
-        return if (SiteUtils.supportsStoriesFeature(site)) {
+        return if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
             R.string.create_post_story_fab_tooltip
         } else {
             R.string.create_post_fab_tooltip

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelCopyPostTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelCopyPostTest.kt
@@ -65,7 +65,8 @@ class PostListMainViewModelCopyPostTest : BaseUnitTest() {
                 postListEventListenerFactory = mock(),
                 uploadStarter = mock(),
                 uploadActionUseCase = mock(),
-                savePostToDbUseCase = mock()
+                savePostToDbUseCase = mock(),
+                jetpackFeatureRemovalPhaseHelper = mock()
         )
         viewModel.postListAction.observeForever(onPostListActionObserver)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -57,7 +57,8 @@ class PostListMainViewModelTest : BaseUnitTest() {
                 postListEventListenerFactory = mock(),
                 uploadStarter = uploadStarter,
                 uploadActionUseCase = mock(),
-                savePostToDbUseCase = savePostToDbUseCase
+                savePostToDbUseCase = savePostToDbUseCase,
+                jetpackFeatureRemovalPhaseHelper = mock()
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
@@ -4,7 +4,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.plans.PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
 import org.wordpress.android.ui.plans.PlansConstants.BLOGGER_PLAN_TWO_YEARS_ID
 import org.wordpress.android.ui.plans.PlansConstants.FREE_PLAN_ID
@@ -19,7 +24,10 @@ import org.wordpress.android.util.image.ImageType.P2_BLAVATAR
 import org.wordpress.android.util.image.ImageType.P2_BLAVATAR_CIRCULAR
 import org.wordpress.android.util.image.ImageType.P2_BLAVATAR_ROUNDED_CORNERS
 
+@RunWith(MockitoJUnitRunner::class)
 class SiteUtilsTest {
+    @Mock private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
     @Test
     fun `onFreePlan returns true when site is on free plan`() {
         val site = SiteModel()
@@ -176,7 +184,7 @@ class SiteUtilsTest {
             setIsWPCom(true)
         }
 
-        val supportsStoriesFeature = SiteUtils.supportsStoriesFeature(site)
+        val supportsStoriesFeature = SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)
 
         assertTrue(supportsStoriesFeature)
     }
@@ -187,7 +195,7 @@ class SiteUtilsTest {
             jetpackVersion = SiteUtils.WP_STORIES_JETPACK_VERSION
         }
 
-        val supportsStoriesFeature = SiteUtils.supportsStoriesFeature(site)
+        val supportsStoriesFeature = SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)
 
         assertTrue(supportsStoriesFeature)
     }
@@ -198,7 +206,20 @@ class SiteUtilsTest {
             jetpackVersion = (SiteUtils.WP_STORIES_JETPACK_VERSION.toFloat() - 1).toString()
         }
 
-        val supportsStoriesFeature = SiteUtils.supportsStoriesFeature(site)
+        val supportsStoriesFeature = SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)
+
+        assertFalse(supportsStoriesFeature)
+    }
+
+    @Test
+    fun `supportsStoriesFeature returns false when Jetpack features are removed`() {
+        val site = SiteModel().apply {
+            origin = SiteModel.ORIGIN_WPCOM_REST
+            setIsWPCom(true)
+        }
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(true)
+
+        val supportsStoriesFeature = SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)
 
         assertFalse(supportsStoriesFeature)
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore.BloggingPromptsResult
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.ANSWER_BLOGGING_PROMPT
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
@@ -81,6 +82,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Mock lateinit var bloggingPromptsStore: BloggingPromptsStore
     @Mock lateinit var quickStartType: QuickStartType
     @Mock private lateinit var openBloggingPromptsOnboardingObserver: Observer<Unit>
+    @Mock private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
     private val featureAnnouncement = FeatureAnnouncement(
             "14.7",
@@ -130,6 +132,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         whenever(quickStartRepository.activeTask).thenReturn(activeTask)
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(bloggingPromptsStore.getPromptForDate(any(), any())).thenReturn(flowOf(bloggingPrompt))
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(false)
         viewModel = WPMainActivityViewModel(
                 featureAnnouncementProvider,
                 buildConfigWrapper,
@@ -141,7 +144,8 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
                 siteStore,
                 bloggingPromptsFeatureConfig,
                 bloggingPromptsStore,
-                NoDelayCoroutineDispatcher()
+                NoDelayCoroutineDispatcher(),
+                jetpackFeatureRemovalPhaseHelper
         )
         viewModel.onFeatureAnnouncementRequested.observeForever(
                 onFeatureAnnouncementRequestedObserver

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModelTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_STORY
@@ -25,10 +26,16 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
     @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
     @Mock lateinit var site: SiteModel
+    @Mock private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
     @Before
     fun setUp() {
-        viewModel = PostListCreateMenuViewModel(appPrefsWrapper, analyticsTrackerWrapper)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(false)
+        viewModel = PostListCreateMenuViewModel(
+            appPrefsWrapper,
+            analyticsTrackerWrapper,
+            jetpackFeatureRemovalPhaseHelper
+        )
     }
 
     @Test


### PR DESCRIPTION
Disables the option to create a Story post when the Jetpack-powered features are removed.

Ref: pe7hp4-4k-p2

**To test:**
### 1 - Story post **ENABLED** in **WordPress app**

1. Navigate to App Settings in the WordPress app and open Debug settings.
2. Turn `jp_removal_four` and `jp_removal_new_users` flags off.
3. Navigate to My Site screen.
4. Tap on the floating button located in the low-right corner.
5. Observe that the Story post option is displayed.
6. Navigate to the Posts list screen
7. Tap on the floating button located in the low-right corner.
8. Observe that the Story post option is displayed.

### 2 - Story post **DISABLED** in **WordPress app**

1. Navigate to App Settings in the WordPress app and open Debug settings.
2. Turn `jp_removal_four` flag on.

**NOTE:** It's recommended that the following steps are also checked by turning the `jp_removal_new_users` flag on and  `jp_removal_four` flag off in Debug settings.

3. Navigate to My Site screen.
4. Tap on the floating button located in the low-right corner.
5. Observe that the Story post option is NOT displayed.
6. Navigate to the Posts list screen
7. Tap on the floating button located in the low-right corner.
8. Observe that no option is displayed and that the editor is opened.

### 3- Story post is **ENABLED** in **Jetpack app**

1. Navigate to App Settings in the Jetpack app and open Debug settings.
2. Turn `jp_removal_four` flag on. _This flag should be omitted by the Jetpack app._
3. Navigate to My Site screen.
4. Tap on the floating button located in the low-right corner.
5. Observe that the Story post option is displayed.
6. Navigate to the Posts list screen
7. Tap on the floating button located in the low-right corner.
8. Observe that the Story post option is displayed.

## Regression Notes
1. Potential unintended areas of impact
The changes should only impact the floating Create button located on My Site and Posts list screens.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
