### PR TITLE
Disable Stock Photo and Tenor media sources when Jetpack features are removed 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -979,7 +979,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
                     });
         }
 
-        if (mBrowserType.isBrowser()) {
+        if (mBrowserType.isBrowser() && !mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
             popup.getMenu().add(R.string.photo_picker_gif).setOnMenuItemClickListener(
                     item -> {
                         doAddMediaItemClicked(AddMenuItem.ITEM_CHOOSE_GIF);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -64,6 +64,7 @@ import org.wordpress.android.push.NotificationType;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.RequestCodes;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.ui.media.MediaGridFragment.MediaFilter;
 import org.wordpress.android.ui.media.MediaGridFragment.MediaGridListener;
 import org.wordpress.android.ui.media.services.MediaDeleteService;
@@ -126,6 +127,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     @Inject MediaUtilsWrapper mMediaUtilsWrapper;
     @Inject QuickStartRepository mQuickStartRepository;
     @Inject SelectedSiteRepository mSelectedSiteRepository;
+    @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
 
     private SiteModel mSite;
 
@@ -968,7 +970,8 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
                     return true;
                 });
 
-        if (mBrowserType.isBrowser() && mSite.isUsingWpComRestApi()) {
+        if (mBrowserType.isBrowser() && mSite.isUsingWpComRestApi()
+            && !mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
             popup.getMenu().add(R.string.photo_picker_stock_media).setOnMenuItemClickListener(
                     item -> {
                         doAddMediaItemClicked(AddMenuItem.ITEM_CHOOSE_STOCK_MEDIA);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2271,7 +2271,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
                                 mIsNewPost,
                                 gutenbergWebViewAuthorizationData,
                                 gutenbergPropsBuilder,
-                                RequestCodes.EDIT_STORY
+                                RequestCodes.EDIT_STORY,
+                                !mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
                         );
                     } else {
                         // If gutenberg editor is not selected, default to Aztec.

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -106,6 +106,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     public static final String ARG_STORY_BLOCK_EXTERNALLY_EDITED_ORIGINAL_HASH = "story_block_original_hash";
     public static final String ARG_FAILED_MEDIAS = "arg_failed_medias";
     public static final String ARG_FEATURED_IMAGE_ID = "featured_image_id";
+    public static final String ARG_JETPACK_FEATURES_ENABLED = "jetpack_features_enabled";
 
     private static final int CAPTURE_PHOTO_PERMISSION_REQUEST_CODE = 101;
     private static final int CAPTURE_VIDEO_PERMISSION_REQUEST_CODE = 102;
@@ -158,7 +159,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                                                       boolean isNewPost,
                                                       GutenbergWebViewAuthorizationData webViewAuthorizationData,
                                                       GutenbergPropsBuilder gutenbergPropsBuilder,
-                                                      int storyBlockEditRequestCode) {
+                                                      int storyBlockEditRequestCode,
+                                                      boolean jetpackFeaturesEnabled) {
         GutenbergEditorFragment fragment = new GutenbergEditorFragment();
         Bundle args = new Bundle();
         args.putString(ARG_PARAM_TITLE, title);
@@ -167,6 +169,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         args.putParcelable(ARG_GUTENBERG_WEB_VIEW_AUTH_DATA, webViewAuthorizationData);
         args.putParcelable(ARG_GUTENBERG_PROPS_BUILDER, gutenbergPropsBuilder);
         args.putInt(ARG_STORY_EDITOR_REQUEST_CODE, storyBlockEditRequestCode);
+        args.putBoolean(ARG_JETPACK_FEATURES_ENABLED, jetpackFeaturesEnabled);
         fragment.setArguments(args);
         return fragment;
     }
@@ -658,9 +661,11 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             return otherMediaOptions;
         }
 
+        boolean jetpackFeaturesEnabled = arguments.getBoolean(ARG_JETPACK_FEATURES_ENABLED);
         GutenbergWebViewAuthorizationData gutenbergWebViewAuthorizationData =
                 arguments.getParcelable(ARG_GUTENBERG_WEB_VIEW_AUTH_DATA);
-        boolean supportStockPhotos = gutenbergWebViewAuthorizationData.isSiteUsingWPComRestAPI();
+        boolean supportStockPhotos = gutenbergWebViewAuthorizationData.isSiteUsingWPComRestAPI()
+                                     && jetpackFeaturesEnabled;
 
         String packageName = activity.getApplication().getPackageName();
         if (supportStockPhotos) {

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -666,6 +666,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 arguments.getParcelable(ARG_GUTENBERG_WEB_VIEW_AUTH_DATA);
         boolean supportStockPhotos = gutenbergWebViewAuthorizationData.isSiteUsingWPComRestAPI()
                                      && jetpackFeaturesEnabled;
+        boolean supportsTenor = jetpackFeaturesEnabled;
 
         String packageName = activity.getApplication().getPackageName();
         if (supportStockPhotos) {
@@ -674,9 +675,11 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
             otherMediaOptions.add(new MediaOption(MEDIA_SOURCE_STOCK_MEDIA, getString(stockMediaResourceId)));
         }
-        int gifMediaResourceId =
-                getResources().getIdentifier("photo_picker_gif", "string", packageName);
-        otherMediaOptions.add(new MediaOption(GIF_MEDIA, getString(gifMediaResourceId)));
+        if (supportsTenor) {
+            int gifMediaResourceId =
+                    getResources().getIdentifier("photo_picker_gif", "string", packageName);
+            otherMediaOptions.add(new MediaOption(GIF_MEDIA, getString(gifMediaResourceId)));
+        }
 
         return otherMediaOptions;
     }


### PR DESCRIPTION
Disables the option to add media from Stock Photo (free photo library) and Tenor (free GIF library) sources when the Jetpack-powered features are removed.

Ref: pe7hp4-4k-p2

**To test:**
### 1 - StockPhoto and Tenor media sources **ENABLED** in **WordPress app**

1. Navigate to App Settings in the WordPress app and open Debug settings.
2. Turn `jp_removal_four` and `jp_removal_new_users` flags off.
3. Navigate to the Media screen.
4. Tap on the ➕ button to add media.
5. Observe that the _Choose from Free Photo Library_ and _Choose From Tenor_ options are available.
6. Create/edit a post.
7. Add an Image block and observe that different media source options are displayed.
8. Observe that the _Choose from Free Photo Library_ and _Choose From Tenor_ options are available.

### 2 - StockPhoto and Tenor media sources **DISABLED** in **WordPress app**

1. Navigate to App Settings in the WordPress app and open Debug settings.
2. Turn `jp_removal_four` flag on.

**NOTE:** It's recommended that the following steps are also checked by turning the `jp_removal_new_users` flag on and  `jp_removal_four` flag off in Debug settings.

3. Navigate to the Media screen.
4. Tap on the ➕ button to add media.
5. Observe that the _Choose from Free Photo Library_ and _Choose From Tenor_ options are NOT available.
6. Create/edit a post.
7. Add an Image block and observe that different media source options are displayed.
8. Observe that the _Choose from Free Photo Library_ and _Choose From Tenor_ options are NOT available.

### 3- StockPhoto and Tenor media sources **ENABLED** in **Jetpack app**

1. Navigate to App Settings in the Jetpack app and open Debug settings.
2. Turn `jp_removal_four` flag on. _This flag should be omitted by the Jetpack app._
3. Navigate to the Media screen.
4. Tap on the ➕ button to add media.
5. Observe that the _Choose from Free Photo Library_ and _Choose From Tenor_ options are available.
6. Create/edit a post.
7. Add an Image block and observe that different media source options are displayed.
8. Observe that the _Choose from Free Photo Library_ and _Choose From Tenor_ options are available.

## Regression Notes
1. Potential unintended areas of impact
The changes only impact the media addition logic, so no other areas should be impacted.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
