### PR TITLE
Add Jetpack branding to Themes screen starting from Phase Two

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
@@ -18,4 +18,13 @@ class JetpackFeatureRemovalBrandingUtil @Inject constructor(
             else -> false
         }
     }
+
+    fun shouldShowPhaseTwoBranding(): Boolean {
+        return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
+            PhaseTwo,
+            PhaseThree,
+            PhaseFour -> true
+            else -> false
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -4,6 +4,8 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.MenuItem;
+import android.view.View;
+import android.view.View.OnScrollChangeListener;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
@@ -33,12 +35,15 @@ import org.wordpress.android.fluxc.store.ThemeStore.OnWpComThemesChanged;
 import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.LocaleAwareActivity;
+import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.themes.ThemeBrowserFragment.ThemeBrowserFragmentCallback;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.JetpackBrandingUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.widgets.HeaderGridView;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -48,7 +53,8 @@ import javax.inject.Inject;
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
-public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBrowserFragmentCallback {
+public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBrowserFragmentCallback,
+        ScrollableViewInitializedListener {
     public static final int ACTIVATE_THEME = 1;
     public static final String THEME_ID = "theme_id";
 
@@ -62,6 +68,7 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
 
     @Inject ThemeStore mThemeStore;
     @Inject Dispatcher mDispatcher;
+    @Inject JetpackBrandingUtils mJetpackBrandingUtils;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -180,6 +187,53 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
     public void onSwipeToRefresh() {
         fetchInstalledThemesIfJetpackSite();
         fetchWpComThemesIfSyncTimedOut(true);
+    }
+
+    @Override
+    public void onScrollableViewInitialized(int containerId) {
+        if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
+            findViewById(R.id.root_view).post(() -> {
+                View jetpackBannerView = findViewById(R.id.jetpack_banner);
+                HeaderGridView scrollableView = findViewById(containerId);
+
+                showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView);
+                initJetpackBannerAnimation(jetpackBannerView, scrollableView);
+            });
+        }
+    }
+
+    private void showJetpackBannerIfScrolledToTop(View banner, HeaderGridView scrollableView) {
+        banner.setVisibility(View.VISIBLE);
+
+        boolean isEmpty = scrollableView.getAdapter().isEmpty();
+        int scrollOffset = scrollableView.computeVerticalScrollOffset();
+
+        float jetpackBannerHeight = banner.getResources().getDimension(R.dimen.jetpack_banner_height);
+
+        float translationY = scrollOffset == 0 || isEmpty ? 0 : jetpackBannerHeight;
+        banner.setTranslationY(translationY);
+    }
+
+    private void initJetpackBannerAnimation(View banner, HeaderGridView scrollableView) {
+        scrollableView.setOnScrollChangeListener(new OnScrollChangeListener() {
+            private boolean mIsScrollAtTop = true;
+
+            @Override
+            public void onScrollChange(View v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
+                int scrollOffset = scrollableView.computeVerticalScrollOffset();
+
+                if (scrollOffset == 0 && !mIsScrollAtTop) {
+                    // Show the banner by moving up
+                    mIsScrollAtTop = true;
+                    banner.animate().translationY(0f).start();
+                } else if (scrollOffset != 0 && mIsScrollAtTop) {
+                    // Hide the banner by moving down
+                    mIsScrollAtTop = false;
+                    float jetpackBannerHeight = banner.getResources().getDimension(R.dimen.jetpack_banner_height);
+                    banner.animate().translationY(jetpackBannerHeight).start();
+                }
+            }
+        });
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -36,11 +36,13 @@ import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.ScrollableViewInitializedListener;
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.themes.ThemeBrowserFragment.ThemeBrowserFragmentCallback;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.JetpackBrandingUtils;
+import org.wordpress.android.util.JetpackBrandingUtils.Screen;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.widgets.HeaderGridView;
@@ -198,6 +200,14 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
 
                 showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView);
                 initJetpackBannerAnimation(jetpackBannerView, scrollableView);
+
+                if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                    jetpackBannerView.setOnClickListener(v -> {
+                        mJetpackBrandingUtils.trackBannerTapped(Screen.THEMES);
+                        new JetpackPoweredBottomSheetFragment()
+                                .show(getSupportFragmentManager(), JetpackPoweredBottomSheetFragment.TAG);
+                    });
+                }
             });
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -193,7 +193,7 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
 
     @Override
     public void onScrollableViewInitialized(int containerId) {
-        if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
+        if (mJetpackBrandingUtils.shouldShowJetpackBrandingForPhaseTwo()) {
             findViewById(R.id.root_view).post(() -> {
                 View jetpackBannerView = findViewById(R.id.jetpack_banner);
                 HeaderGridView scrollableView = findViewById(containerId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -32,6 +32,7 @@ import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.store.QuickStartStore;
 import org.wordpress.android.fluxc.store.ThemeStore;
 import org.wordpress.android.ui.ActionableEmptyView;
+import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.plans.PlansConstants;
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
 import org.wordpress.android.util.NetworkUtils;
@@ -159,6 +160,14 @@ public class ThemeBrowserFragment extends Fragment
         configureSwipeToRefresh(view);
 
         return view;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (getActivity() instanceof ScrollableViewInitializedListener) {
+            ((ScrollableViewInitializedListener) getActivity()).onScrollableViewInitialized(mGridView.getId());
+        }
     }
 
     private void showQuickStartFocusPoint() {

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -109,7 +109,8 @@ class JetpackBrandingUtils @Inject constructor(
         READER_SEARCH("reader_search"),
         SHARE("share"),
         STATS("stats"),
-        SCAN("scan")
+        SCAN("scan"),
+        THEMES("themes")
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -30,6 +30,10 @@ class JetpackBrandingUtils @Inject constructor(
         return shouldShowJetpackBranding() && jetpackFeatureRemovalBrandingUtil.shouldShowPhaseOneBranding()
     }
 
+    fun shouldShowJetpackBrandingForPhaseTwo(): Boolean {
+        return shouldShowJetpackBranding() && jetpackFeatureRemovalBrandingUtil.shouldShowPhaseTwoBranding()
+    }
+
     fun shouldShowJetpackPoweredBottomSheet(): Boolean {
         return isWpComSite() && jetpackPoweredBottomSheetFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
     }

--- a/WordPress/src/main/java/org/wordpress/android/widgets/HeaderGridView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/HeaderGridView.java
@@ -207,6 +207,11 @@ public class HeaderGridView extends GridView {
         }
     }
 
+    @Override
+    public int computeVerticalScrollOffset() {
+        return super.computeVerticalScrollOffset();
+    }
+
     /**
      * ListAdapter used when a HeaderGridView has header views. This ListAdapter
      * wraps another one and also keeps track of the header views and their

--- a/WordPress/src/main/res/layout/theme_browser_activity.xml
+++ b/WordPress/src/main/res/layout/theme_browser_activity.xml
@@ -25,4 +25,8 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
@@ -11,6 +11,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.whenever
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
 
 @RunWith(MockitoJUnitRunner::class)
 class JetpackFeatureRemovalBrandingUtilTest {
@@ -42,5 +43,29 @@ class JetpackFeatureRemovalBrandingUtilTest {
         val shouldShowBranding = jetpackFeatureRemovalBrandingUtil.shouldShowPhaseOneBranding()
 
         assertFalse(shouldShowBranding)
+    }
+
+    @Test
+    fun `given phase one not started, when phase two branding is checked, should return false`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.getCurrentPhase()).thenReturn(null)
+        val shouldShowBranding = jetpackFeatureRemovalBrandingUtil.shouldShowPhaseTwoBranding()
+
+        assertFalse(shouldShowBranding)
+    }
+
+    @Test
+    fun `given phase one started, when phase two branding is checked, should return false`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.getCurrentPhase()).thenReturn(PhaseOne)
+        val shouldShowBranding = jetpackFeatureRemovalBrandingUtil.shouldShowPhaseTwoBranding()
+
+        assertFalse(shouldShowBranding)
+    }
+
+    @Test
+    fun `given phase two started, when phase two branding is checked, should return true`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.getCurrentPhase()).thenReturn(PhaseTwo)
+        val shouldShowBranding = jetpackFeatureRemovalBrandingUtil.shouldShowPhaseTwoBranding()
+
+        assertTrue(shouldShowBranding)
     }
 }


### PR DESCRIPTION
Fixes Partially #17334

This PR adds the Jetpack powered branding to the Themes screen starting from Phase Two of Features removal.

## To test:
Jetpack Branding on the Themes screen should be visible starting from Phase Two of Features removal (`jp_removal_two`), while it should be hidden when all Jetpack removal flags are disabled or when Phase One is started.

There are 2 effective scenarios:
- Not Branded
  - In this scenario the `Jetpack powered` branding should **not** be visible
  - This phase is active when:
    - All Jetpack removal flags are disabled
    - The `jp_removal_one` flag is enabled
- Branded
  - In this scenario the `Jetpack powered` branding should **be** visible on Themes screen
  - This phase is active when any of the following features removal flags are enabled:
    - `jp_removal_two`
    - `jp_removal_three`
    - `jp_removal_four`

The change the features removal flags:
   - Go to `Me` → `App Settings` → `Debug settings` and **toggle** the `jp_removal_NNN` flags (e.g. `jp_removal_two`).

Test using the following steps in each scenario:

### Testing Steps
1. Open the WordPress app and login
2. Toggle one of the feature removals flags based on the above notes
3. Go to `My Site` → `Menu` tab
4. From menu, under 'Look and Feel' tap `Themes`
5. If in '**Not Branded**' scenario
   - Expect to see **no** `Jetpack powered` branding
6. If in '**Branded**' scenario:
   1. **Expect** the `Jetpack powered` banner to be visible at the bottom of the screen
   2. Tap the banner
   3. **Expect** the `WordPress is better with Jetpack` bottom sheet to be displayed
   4. tap the `Try the new Jetpack app` button
      1. If Jetpack app is not installed it should open the Play Store to install it
      2. If Jetpack app is installed, it should open
7. Go back to the WordPress app
8. Scroll down on the Themes screen
9. **Expect** the `Jetpack powered` banner to hide
10. Scroll back to top
11. **Expect** the `Jetpack powered` banner to show

### Screenshots

| Not Branded | Branded |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/210604393-c34c4e31-c7f3-4d2c-b163-5a19e26a7a82.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/210604759-10180520-9131-4437-8b27-5c7b962b8f37.png"> |

## Regression Notes
1. Potential unintended areas of impact
   Themes screen (WordPress & Jetpack app).

8. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

9. What automated tests I added (or what prevented me from doing so)
   Added tests for the new logic to `JetpackFeatureRemovalBrandingUtilTest`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
