### PR TITLE
Integrate gutenberg-mobile release 1.87.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+21.5
+-----
+* [*] [internal] Editor: Only register core blocks when `onlyCoreBlocks` capability is enabled [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5293]
+
 21.4
 -----
 * [**] Adds the functionality to Add, Edit and Delete categories from site settings. [https://github.com/wordpress-mobile/WordPress-Android/pull/17652]

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.87.0-alpha1'
+    gutenbergMobileVersion = '5372-49c946717a7fc327d4a73b37bccb4886bc780c6a'
     wordPressAztecVersion = 'v1.6.2'
     wordPressFluxCVersion = 'trunk-84bf7785f5e0820a826598ecdd1fe023377c7741'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5372-49c946717a7fc327d4a73b37bccb4886bc780c6a'
+    gutenbergMobileVersion = '5372-67fdc6ad7d313a6df034e9c7e52f44a481e1a6b6'
     wordPressAztecVersion = 'v1.6.2'
     wordPressFluxCVersion = 'trunk-84bf7785f5e0820a826598ecdd1fe023377c7741'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5372-67fdc6ad7d313a6df034e9c7e52f44a481e1a6b6'
+    gutenbergMobileVersion = 'v1.87.0'
     wordPressAztecVersion = 'v1.6.2'
     wordPressFluxCVersion = 'trunk-84bf7785f5e0820a826598ecdd1fe023377c7741'
     wordPressLoginVersion = '1.0.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.87.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5372

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.