### PR TITLE
Add Jetpack branding to People screens starting from Phase Two

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -38,9 +38,12 @@ import org.wordpress.android.models.RoleUtils;
 import org.wordpress.android.ui.ActionableEmptyView;
 import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.FilteredRecyclerView;
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.GravatarUtils;
+import org.wordpress.android.util.JetpackBrandingUtils;
+import org.wordpress.android.util.JetpackBrandingUtils.Screen;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
@@ -62,6 +65,7 @@ public class PeopleListFragment extends Fragment {
 
     @Inject SiteStore mSiteStore;
     @Inject ImageManager mImageManager;
+    @Inject JetpackBrandingUtils mJetpackBrandingUtils;
 
     public static PeopleListFragment newInstance(SiteModel site) {
         PeopleListFragment peopleListFragment = new PeopleListFragment();
@@ -224,7 +228,27 @@ public class PeopleListFragment extends Fragment {
             }
         });
 
+        showJetpackBannerIfNeeded(rootView);
+
         return rootView;
+    }
+
+    private void showJetpackBannerIfNeeded(final View rootView) {
+        if (mJetpackBrandingUtils.shouldShowJetpackBrandingForPhaseTwo()) {
+            View jetpackBannerView = rootView.findViewById(R.id.jetpack_banner);
+            RecyclerView scrollableView = mFilteredRecyclerView.getInternalRecyclerView();
+
+            mJetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView);
+            mJetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView);
+
+            if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                jetpackBannerView.setOnClickListener(v -> {
+                    mJetpackBrandingUtils.trackBannerTapped(Screen.PEOPLE);
+                    new JetpackPoweredBottomSheetFragment()
+                            .show(getChildFragmentManager(), JetpackPoweredBottomSheetFragment.TAG);
+                });
+            }
+        }
     }
 
     @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
@@ -26,8 +26,11 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.Person;
 import org.wordpress.android.models.RoleUtils;
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.GravatarUtils;
+import org.wordpress.android.util.JetpackBrandingUtils;
+import org.wordpress.android.util.JetpackBrandingUtils.Screen;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 
@@ -60,6 +63,7 @@ public class PersonDetailFragment extends Fragment {
 
     @Inject SiteStore mSiteStore;
     @Inject ImageManager mImageManager;
+    @Inject JetpackBrandingUtils mJetpackBrandingUtils;
 
     public static PersonDetailFragment newInstance(long currentUserId, long personId, int localTableBlogId,
                                                    Person.PersonType personType) {
@@ -135,6 +139,20 @@ public class PersonDetailFragment extends Fragment {
         SiteModel site = mSiteStore.getSiteByLocalId(mLocalTableBlogId);
         if (!isCurrentUser && site != null && site.getHasCapabilityRemoveUsers()) {
             setHasOptionsMenu(true);
+        }
+
+        if (mJetpackBrandingUtils.shouldShowJetpackBrandingForPhaseTwo()) {
+            View jetpackBadgeContainer = rootView.findViewById(R.id.jetpack_badge);
+            jetpackBadgeContainer.setVisibility(View.VISIBLE);
+
+            if (mJetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                View jetpackBadge = jetpackBadgeContainer.findViewById(R.id.jetpack_powered_badge);
+                jetpackBadge.setOnClickListener(v -> {
+                    mJetpackBrandingUtils.trackBadgeTapped(Screen.PERSON);
+                    new JetpackPoweredBottomSheetFragment()
+                            .show(requireActivity().getSupportFragmentManager(), JetpackPoweredBottomSheetFragment.TAG);
+                });
+            }
         }
 
         return rootView;

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -108,6 +108,7 @@ class JetpackBrandingUtils @Inject constructor(
         ME("me"),
         NOTIFICATIONS("notifications"),
         NOTIFICATIONS_SETTINGS("notifications_settings"),
+        PEOPLE("people"),
         READER("reader"),
         READER_POST_DETAIL("reader_post_detail"),
         READER_SEARCH("reader_search"),

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -109,6 +109,7 @@ class JetpackBrandingUtils @Inject constructor(
         NOTIFICATIONS("notifications"),
         NOTIFICATIONS_SETTINGS("notifications_settings"),
         PEOPLE("people"),
+        PERSON("person"),
         READER("reader"),
         READER_POST_DETAIL("reader_post_detail"),
         READER_SEARCH("reader_search"),

--- a/WordPress/src/main/res/layout/people_list_fragment.xml
+++ b/WordPress/src/main/res/layout/people_list_fragment.xml
@@ -52,4 +52,9 @@
             tools:visibility="visible" />
 
     </RelativeLayout>
+
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/person_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/person_detail_fragment.xml
@@ -41,7 +41,7 @@
                     android:id="@+id/person_display_name"
                     style="@style/PersonTextView"
                     android:fontFamily="sans-serif-light"
-                    android:textColor="?attr/colorOnPrimarySurface"
+                    android:textAppearance="?attr/textAppearanceSubtitle1"
                     android:textSize="@dimen/text_sz_extra_large"
                     android:textStyle="bold"
                     tools:text="display_name" />
@@ -49,7 +49,6 @@
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/person_username"
                     style="@style/PersonTextView"
-                    android:textColor="?attr/colorOnPrimarySurface"
                     android:textSize="@dimen/text_sz_large"
                     tools:text="username" />
 

--- a/WordPress/src/main/res/layout/person_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/person_detail_fragment.xml
@@ -124,4 +124,14 @@
         android:layout_below="@id/person_role_container"
         android:background="?android:attr/listDivider" />
 
+    <include
+        android:id="@+id/jetpack_badge"
+        layout="@layout/jetpack_badge"
+        android:layout_below="@id/subscribed_date_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_large"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
 </RelativeLayout>


### PR DESCRIPTION
Fixes partially #17334

This PR adds the Jetpack powered branding to the People screens starting from Phase Two of Features removal.

It also fixes an issue with the user detail text being white (same as the background) in light mode on the Person detail screen.

<details>
<summary>Text Issue Preview</summary>

| Before | After |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/210843342-7fba9c24-b760-411b-9a56-5a46e573c328.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/210843491-8fa1cf01-3ea8-4f1a-89d6-34ebada8ab58.png"> |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/210843363-3bc4b81e-f594-4144-85db-08d4178d157d.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/210843499-deaf5158-2c9c-4df5-9722-0a1e47006379.png"> |
</details>

## To test:
Jetpack Branding on the People screens should be visible starting from Phase Two of Features removal (`jp_removal_two`), while it should be hidden when all Jetpack removal flags are disabled or when Phase One is started.

There are 2 effective scenarios:

- 1️⃣ Not Branded
  - `Jetpack powered` branding should **not** be visible on People screens
  - This phase is active when:
    - All Jetpack removal flags are disabled
    - The `jp_removal_one` flag is enabled
- 2️⃣ Branded
  - `Jetpack powered` branding should **be** visible on People screens
  - This phase is active when any of the following features removal flags are enabled:
    - `jp_removal_two`
    - `jp_removal_three`
    - `jp_removal_four`

The change the features removal flags:
   - Go to `Me` → `App Settings` → `Debug settings` and **toggle** the `jp_removal_NNN` flags (e.g. `jp_removal_two`).

Test using the following steps in each scenario:

### Testing Steps

1. Open the WordPress app and login
2. Toggle one of the feature removals flags based on the above notes
3. Go to `My Site` → `Menu` tab
4. From menu, under 'Configuration' tap `People`
5. 1️⃣ If in '**Not Branded**' scenario:
   1. **Expect** to see **no** `Jetpack powered` branding
   2. Tap on one person list item
   3. **Expect** to see **no** `Jetpack powered` branding
6. 2️⃣ If in '**Branded**' scenario:
   1. **Expect** the `Jetpack powered` _banner_ to be visible at the bottom of the screen
   2. Tap the banner
   3. **Expect** the `WordPress is better with Jetpack` bottom sheet to be displayed
   4. Tap the `Try the new Jetpack app` button
      1. If Jetpack app is not installed it should open the Play Store to install it
      2. If Jetpack app is installed, it should open
   5. Go back to the WordPress app
   6. Tap on one person list item
   7. **Expect** the `Jetpack powered` _badge_ to be visible on the screen
   8. Tap the `Try the new Jetpack app` button
      1. If Jetpack app is not installed it should open the Play Store to install it
      2. If Jetpack app is installed, it should open

### Screenshots

| People list | Person detail |
| - | - |
| <img width="314" src="https://user-images.githubusercontent.com/4588074/210846819-ba69f6b6-0b70-4a98-a5e1-6f67e95a652f.png"> | <img width="314" src="https://user-images.githubusercontent.com/4588074/210846847-1740d4ce-bac9-4942-9b75-d14c34696a18.png"> |

## Regression Notes
1. Potential unintended areas of impact
   People list screen & Person detail screen (WordPress & Jetpack app).

5. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

6. What automated tests I added (or what prevented me from doing so)
   Relied on existing tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
