### PR TITLE
Fix JP Banner Click Tracking on Backup Screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_REWIND_ID
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.JetpackBrandingUtils.Screen.ACTIVITY_LOG
+import org.wordpress.android.util.JetpackBrandingUtils.Screen.BACKUPS
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_KEY
 import javax.inject.Inject
 
@@ -28,6 +29,10 @@ import javax.inject.Inject
 class ActivityLogListActivity : LocaleAwareActivity(), ScrollableViewInitializedListener {
     @Inject lateinit var jetpackBrandingUtils: JetpackBrandingUtils
     private var binding: ActivityLogListActivityBinding? = null
+
+    private val isRewindableOnlyFromExtras by lazy {
+        intent.getBooleanExtra(ACTIVITY_LOG_REWINDABLE_ONLY_KEY, false)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -60,7 +65,8 @@ class ActivityLogListActivity : LocaleAwareActivity(), ScrollableViewInitialized
 
                 if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
                     binding?.jetpackBanner?.root?.setOnClickListener {
-                        jetpackBrandingUtils.trackBannerTapped(ACTIVITY_LOG)
+                        val trackingScreenName = if (isRewindableOnlyFromExtras) BACKUPS else ACTIVITY_LOG
+                        jetpackBrandingUtils.trackBannerTapped(trackingScreenName)
                         JetpackPoweredBottomSheetFragment
                                 .newInstance()
                                 .show(supportFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
@@ -81,7 +87,7 @@ class ActivityLogListActivity : LocaleAwareActivity(), ScrollableViewInitialized
      * screen's architecture.
      */
     private fun ActivityLogListActivityBinding.checkAndUpdateUiToBackupScreen() {
-        if (intent.getBooleanExtra(ACTIVITY_LOG_REWINDABLE_ONLY_KEY, false)) {
+        if (isRewindableOnlyFromExtras) {
             setTitle(R.string.backup)
             activityTypeFilter.visibility = View.GONE
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_REWIND_ID
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.JetpackBrandingUtils.Screen.ACTIVITY_LOG
-import org.wordpress.android.util.JetpackBrandingUtils.Screen.BACKUPS
+import org.wordpress.android.util.JetpackBrandingUtils.Screen.BACKUP
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_KEY
 import javax.inject.Inject
 
@@ -65,7 +65,7 @@ class ActivityLogListActivity : LocaleAwareActivity(), ScrollableViewInitialized
 
                 if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
                     binding?.jetpackBanner?.root?.setOnClickListener {
-                        val trackingScreenName = if (isRewindableOnlyFromExtras) BACKUPS else ACTIVITY_LOG
+                        val trackingScreenName = if (isRewindableOnlyFromExtras) BACKUP else ACTIVITY_LOG
                         jetpackBrandingUtils.trackBannerTapped(trackingScreenName)
                         JetpackPoweredBottomSheetFragment
                                 .newInstance()

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -104,7 +104,7 @@ class JetpackBrandingUtils @Inject constructor(
         APP_SETTINGS("app_settings"),
         ACTIVITY_LOG("activity_log"),
         ACTIVITY_LOG_DETAIL("activity_log_detail"),
-        BACKUPS("backups"),
+        BACKUP("backup"),
         HOME("home"),
         ME("me"),
         NOTIFICATIONS("notifications"),

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -104,6 +104,7 @@ class JetpackBrandingUtils @Inject constructor(
         APP_SETTINGS("app_settings"),
         ACTIVITY_LOG("activity_log"),
         ACTIVITY_LOG_DETAIL("activity_log_detail"),
+        BACKUPS("backups"),
         HOME("home"),
         ME("me"),
         NOTIFICATIONS("notifications"),


### PR DESCRIPTION
Fixes Partially #17334

This PR fixes Jetpack Banner click events tracking on the Backup screen.

Since the screen implementation is shared with the Activity Log screen, when tracking click events on the `Jetpack Powered` banner, the screen property was always `activity_log`.

To test:
1. Open WordPress app and login with site address
   - ❗ The site should have **Jetpack Backup** enabled and Jetpack setup done
   - Additionally, login with your WP.com account and make sure Jetpack is connected to your WP.com account
   - Make sure the selected site is the self-hosted one, from step `1`
2. Go to `My Site` → `Menu` tab
3. From menu, under `Jetpack` tap `Backup`
   1. Tap on the `Jetpack powered` banner
   2. **Verify** in logs the tracked event is:
   ```
   🔵 Tracked: jetpack_powered_banner_tapped, Properties: {"screen":"backup"}
   ```
   3. Navigate back
4. Tap on `Activity Log`
   1. Tap on the `Jetpack powered` banner
   2. **Verify** in logs the tracked event is:
   ```
   🔵 Tracked: jetpack_powered_banner_tapped, Properties: {"screen":"activity_log"}
   ```

## Regression Notes
1. Potential unintended areas of impact
   N/a - Low impact.

9. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

10. What automated tests I added (or what prevented me from doing so)
   N/a.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
