### PR TITLE
[Blogging Prompts] Prompts List Loading, Error, and Empty states

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListPreviewProviders.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListPreviewProviders.kt
@@ -18,11 +18,13 @@ class BloggingPromptsListScreenPreviewProvider : PreviewParameterProvider<UiStat
     }
 
     override val values: Sequence<UiState> = sequenceOf(
-                UiState.None,
-                UiState.Loading,
-                UiState.Content(fakePromptList),
-                // TODO thomashorta add missing UiStates when their content is developed
-        )
+            UiState.None,
+            UiState.Loading,
+            UiState.Content(fakePromptList),
+            UiState.Content(emptyList()),
+            UiState.FetchError,
+            UiState.NetworkError,
+    )
 }
 
 class BloggingPromptsListItemPreviewProvider : PreviewParameterProvider<BloggingPromptsListItemModel> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreen.kt
@@ -6,10 +6,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListV
 import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState.NetworkError
 import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListViewModel.UiState.None
 import org.wordpress.android.ui.bloggingprompts.promptslist.model.BloggingPromptsListItemModel
+import org.wordpress.android.ui.compose.components.EmptyContent
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
@@ -46,8 +47,8 @@ fun BloggingPromptsListScreen(
             when (uiState) {
                 is Content -> ListContent(uiState.content)
                 Loading -> LoadingContent()
-                FetchError -> TODO()
-                NetworkError -> TODO()
+                FetchError -> FetchErrorContent()
+                NetworkError -> NetworkErrorContent()
                 None -> {}
             }
         }
@@ -58,26 +59,59 @@ fun BloggingPromptsListScreen(
 private fun ListContent(
     promptsList: List<BloggingPromptsListItemModel>
 ) {
-    LazyColumn(Modifier.fillMaxSize()) {
-        itemsIndexed(promptsList) { index, item ->
-            if (index != 0) Divider()
+    if (promptsList.isEmpty()) {
+        NoContent()
+    } else {
+        LazyColumn(Modifier.fillMaxSize()) {
+            itemsIndexed(promptsList) { index, item ->
+                if (index != 0) Divider()
 
-            BloggingPromptsListItem(
-                    model = item,
-                    modifier = Modifier.fillMaxWidth()
-            )
+                BloggingPromptsListItem(
+                        model = item,
+                        modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }
 }
 
 @Composable
+private fun NoContent() {
+    EmptyContent(
+            title = "No prompts yet",
+            image = R.drawable.img_illustration_empty_results_216dp,
+            modifier = Modifier.fillMaxSize(),
+    )
+}
+
+@Composable
 private fun LoadingContent() {
-    Box(Modifier.fillMaxSize()) {
-        Text(
-                "Loading...",
-                modifier = Modifier.align(Alignment.Center),
-        )
+    Box(
+            Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
     }
+}
+
+@Composable
+private fun FetchErrorContent() {
+    EmptyContent(
+            title = "Oops",
+            subtitle = "There was an error loading prompts.",
+            image = R.drawable.img_illustration_empty_results_216dp,
+            modifier = Modifier.fillMaxSize(),
+    )
+}
+
+@Composable
+private fun NetworkErrorContent() {
+    EmptyContent(
+            title = "Unable to load this content right now.",
+            subtitle = "Check your network connection and try again.",
+            image = R.drawable.img_illustration_cloud_off_152dp,
+            modifier = Modifier.fillMaxSize(),
+    )
 }
 
 @Preview

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreen.kt
@@ -78,7 +78,7 @@ private fun ListContent(
 @Composable
 private fun NoContent() {
     EmptyContent(
-            title = "No prompts yet",
+            title = stringResource(R.string.blogging_prompts_list_no_prompts),
             image = R.drawable.img_illustration_empty_results_216dp,
             modifier = Modifier.fillMaxSize(),
     )
@@ -97,8 +97,8 @@ private fun LoadingContent() {
 @Composable
 private fun FetchErrorContent() {
     EmptyContent(
-            title = "Oops",
-            subtitle = "There was an error loading prompts.",
+            title = stringResource(R.string.blogging_prompts_list_error_fetch_title),
+            subtitle = stringResource(R.string.blogging_prompts_list_error_fetch_subtitle),
             image = R.drawable.img_illustration_empty_results_216dp,
             modifier = Modifier.fillMaxSize(),
     )
@@ -107,8 +107,8 @@ private fun FetchErrorContent() {
 @Composable
 private fun NetworkErrorContent() {
     EmptyContent(
-            title = "Unable to load this content right now.",
-            subtitle = "Check your network connection and try again.",
+            title = stringResource(R.string.blogging_prompts_list_error_network_title),
+            subtitle = stringResource(R.string.blogging_prompts_list_error_network_subtitle),
             image = R.drawable.img_illustration_cloud_off_152dp,
             modifier = Modifier.fillMaxSize(),
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/EmptyContent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/EmptyContent.kt
@@ -31,6 +31,20 @@ private fun Modifier.emptyContentTextModifier() = padding(horizontal = 30.dp).re
 /**
  * Reusable component for empty screen states such as: empty lists, errors, and loading states. Based on the existing
  * [ActionableEmptyView] implementation, which is used throughout the project in the XML view screens.
+ *
+ * Note: this currently has a subset of the implementation of [ActionableEmptyView], see params below.
+ *
+ * @param modifier [Modifier] applied on the box that wraps the content of this Composable, the actual content is not
+ * directly affected, so use this mainly to define the size and padding of the composable.
+ * @param title (optional) [String] that will be displayed as title.
+ * @param subtitle (optional) [String] that will be displayed as subtitle.
+ * @param image (optional) Drawable resource ID for the image that will be displayed. Note the drawable original size
+ * is directly used when displaying the image.
+ * @param imageContentDescription (optional) Content Description passed directly to the internal [Image] Composable
+ * showing the [image] drawable, for accessibility purposes.
+ *
+ * @see Modifier
+ * @see Image
  */
 @Composable
 fun EmptyContent(

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/EmptyContent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/EmptyContent.kt
@@ -7,18 +7,26 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.LocalContentColor
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidthIn
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActionableEmptyView
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.unit.Margin
+
+private fun Modifier.emptyContentTextModifier() = padding(horizontal = 30.dp).requiredWidthIn(max = 440.dp)
 
 /**
  * Reusable component for empty screen states such as: empty lists, errors, and loading states. Based on the existing
@@ -46,32 +54,45 @@ fun EmptyContent(
                 )
             }
 
-            // show spacer if something will be shown below
-            if (title != null || subtitle != null) {
+            // show spacer if something will be shown below and something was shown above
+            if (image != null && (title != null || subtitle != null)) {
                 Spacer(Modifier.height(Margin.ExtraLarge.value))
             }
 
-            title?.let {
-                Text(
-                        it,
-                        style = MaterialTheme.typography.subtitle1 // TODO thomashorta set the correct style
-                )
-            }
-            subtitle?.let {
-                // if there's a subtitle, add a spacer before it
-                Spacer(Modifier.height(Margin.Medium.value))
+            // To match text color in ActionableEmptyView we need to provide the "medium" content alpha from Material
+            CompositionLocalProvider(
+                    LocalContentAlpha provides ContentAlpha.medium,
+            ) {
+                title?.let {
+                    Text(
+                            it,
+                            modifier = Modifier.emptyContentTextModifier(),
+                            style = MaterialTheme.typography.subtitle1.copy(
+                                    fontSize = FontSize.ExtraLarge.value,
+                            )
+                    )
+                }
 
-                Text(
-                        it,
-                        color = LocalContentColor.current.copy(alpha = 0.6f),
-                        style = MaterialTheme.typography.subtitle2 // TODO thomashorta set the correct style
-                )
+                // show spacer if something will be shown below and title was shown above
+                if (subtitle != null && title != null) {
+                    Spacer(Modifier.height(Margin.Medium.value))
+                }
+
+                subtitle?.let {
+                    Text(
+                            it,
+                            modifier = Modifier.emptyContentTextModifier(),
+                            style = MaterialTheme.typography.subtitle1.copy(
+                                    fontSize = FontSize.Large.value,
+                            )
+                    )
+                }
             }
         }
     }
 }
 
-@Preview(showBackground = true)
+@Preview(name = "Everything", showBackground = true)
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EmptyContentPreview() {
@@ -80,6 +101,75 @@ fun EmptyContentPreview() {
                 title = "Title",
                 subtitle = "Subtitle",
                 image = R.drawable.img_illustration_empty_results_216dp,
+        )
+    }
+}
+
+@Preview(name = "Image Only", showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun EmptyContentImagePreview() {
+    AppTheme {
+        EmptyContent(
+                image = R.drawable.img_illustration_empty_results_216dp,
+        )
+    }
+}
+
+@Preview(name = "Image and Title Only", showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun EmptyContentImageTitlePreview() {
+    AppTheme {
+        EmptyContent(
+                title = "Title",
+                image = R.drawable.img_illustration_empty_results_216dp,
+        )
+    }
+}
+
+@Preview(name = "Image and Subtitle Only", showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun EmptyContentImageSubtitlePreview() {
+    AppTheme {
+        EmptyContent(
+                subtitle = "Subtitle",
+                image = R.drawable.img_illustration_empty_results_216dp,
+        )
+    }
+}
+
+@Preview(name = "Title Only", showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun EmptyContentTitlePreview() {
+    AppTheme {
+        EmptyContent(
+                title = "Title",
+        )
+    }
+}
+
+@Preview(name = "Title and Subtitle Only", showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun EmptyContentTitleSubtitlePreview() {
+    AppTheme {
+        EmptyContent(
+                title = "Title",
+                subtitle = "Subtitle",
+        )
+    }
+}
+
+@Preview(name = "Subtitle Only", showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun EmptyContentSubtitlePreview() {
+    AppTheme {
+        EmptyContent(
+                subtitle = "Subtitle",
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/EmptyContent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/EmptyContent.kt
@@ -1,0 +1,85 @@
+package org.wordpress.android.ui.compose.components
+
+import android.content.res.Configuration
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.R
+import org.wordpress.android.ui.ActionableEmptyView
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.unit.Margin
+
+/**
+ * Reusable component for empty screen states such as: empty lists, errors, and loading states. Based on the existing
+ * [ActionableEmptyView] implementation, which is used throughout the project in the XML view screens.
+ */
+@Composable
+fun EmptyContent(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    subtitle: String? = null,
+    @DrawableRes image: Int? = null,
+    imageContentDescription: String? = null,
+) {
+    Box(
+            modifier = modifier,
+            contentAlignment = Alignment.Center,
+    ) {
+        Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            image?.let { imageRes ->
+                Image(
+                        painterResource(imageRes),
+                        contentDescription = imageContentDescription
+                )
+            }
+
+            // show spacer if something will be shown below
+            if (title != null || subtitle != null) {
+                Spacer(Modifier.height(Margin.ExtraLarge.value))
+            }
+
+            title?.let {
+                Text(
+                        it,
+                        style = MaterialTheme.typography.subtitle1 // TODO thomashorta set the correct style
+                )
+            }
+            subtitle?.let {
+                // if there's a subtitle, add a spacer before it
+                Spacer(Modifier.height(Margin.Medium.value))
+
+                Text(
+                        it,
+                        color = LocalContentColor.current.copy(alpha = 0.6f),
+                        style = MaterialTheme.typography.subtitle2 // TODO thomashorta set the correct style
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun EmptyContentPreview() {
+    AppTheme {
+        EmptyContent(
+                title = "Title",
+                subtitle = "Subtitle",
+                image = R.drawable.img_illustration_empty_results_216dp,
+        )
+    }
+}

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4126,6 +4126,11 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_prompts_list_number_of_answers_one">1 answer</string>
     <string name="blogging_prompts_list_number_of_answers_other">%d answers</string>
     <string name="blogging_prompts_list_subtitle_divider" translatable="false">•</string>
+    <string name="blogging_prompts_list_no_prompts">No prompts yet</string>
+    <string name="blogging_prompts_list_error_fetch_title">Oops</string>
+    <string name="blogging_prompts_list_error_fetch_subtitle">There was an error loading prompts.</string>
+    <string name="blogging_prompts_list_error_network_title">Unable to load this content right now</string>
+    <string name="blogging_prompts_list_error_network_subtitle">Check your network connection and try again.</string>
 
     <!-- Editor module -->
     <string name="post_content" tools:ignore="UnusedResources" a8c-src-lib="module:editor">Content</string>


### PR DESCRIPTION
Part of #17125

Add missing UI states for the Blogging Prompts List Screen: Empty (no prompts), Fetch Error, Network Error, and Loading. The screenshots in #17125 are from iOS UI so it will not map exactly 1 to 1 to the UIs created here, since we already have a standard of how to show these "Empty" views with [ActionableEmptyView](https://github.com/wordpress-mobile/WordPress-Android/blob/1c76b4cc309e39e44be0719016874e5c2eb2b0f6/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt). See the screenshots below for the actual Android implementation.

Also, since this uses `Compose`, a component matching `ActionableEmptyView` was created for `Compose`, called `EmptyContent`. It currently does not have feature parity with `ActionableEmptyView` but it uses the exact same styles to be visually the same. The idea here was to implement only what was needed for this screen and then improve it in the future as we need more features (like an action button).

Android UI states implementation:

| Loading | Empty | Network Error | Fetch Error |
| --- | --- | --- | --- |
| ![17125-promptslist-state-loading](https://user-images.githubusercontent.com/5091503/211100817-8d018ff4-435c-47d4-aa1b-63ea30e3a7df.png) | ![17125-promptslist-state-empty](https://user-images.githubusercontent.com/5091503/211100717-f4c91598-9c7b-453c-b17c-9c0d4597a819.png) | ![17125-promptslist-state-error-network](https://user-images.githubusercontent.com/5091503/211100883-86cd5888-b26e-450c-b385-16ef4aaed042.png) | ![17125-promptslist-state-error-fetch](https://user-images.githubusercontent.com/5091503/211100907-1d33910b-9409-4a47-b7ac-33969d92bcce.png) |

## To test:

### Initial steps for all cases
1. Do the steps to enable the Prompts List feature flag found in the test section of #17675
2. Sign in (if not signed in already)
3. Go to the home dashboard (My Site -> Home)
4. **Verify** the Prompts card is shown

### Loading + Success state
1. Tap the 3-dot menu in the Prompts card
6. Tap the "View more prompts" option
8. **Verify** the Loading Progress Bar (circular) is shown briefly while fetching data
9. **Verify** the content is updated with the real list of past prompts (today + 10 days before) after loading

### Network Error state
1. Tap the 3-dot menu in the Prompts card
6. Enable **Airplane mode** in your Android Settings (notification bar)
7. Tap the "View more prompts" option
9. **Verify** the network error state UI is shown
10. Don't forget to turn **Airplane mode** of again before testing other states

### Loading + Empty List state
_Note: since the Happy path is already implemented, this needs code changes to be tested_

In code, go to FetchBloggingPromptsLitUseCase line 20 and change to return an `emptyList()` in the `Result.Success`.

Original:
https://github.com/wordpress-mobile/WordPress-Android/blob/9f787bed0ae93be2fcce13a8390a012b9bbca5a1/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt#L20

Change to:
```kotlin
?.let { Result.Success(emptyList()) } // success if fetchBloggingPrompts was not null
```

Steps:
1. Tap the "View more prompts" option
8. **Verify** the Loading Progress Bar (circular) is shown briefly while fetching data
9. **Verify** the content is updated to the Empty list (no prompts) state UI

### Loading + Fetch Error state
_Note: since the Happy path is already implemented, this needs code changes to be tested_

In code, go to FetchBloggingPromptsLitUseCase line 20 and change to return `null` instead of `Result.Success`.

Original:
https://github.com/wordpress-mobile/WordPress-Android/blob/9f787bed0ae93be2fcce13a8390a012b9bbca5a1/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt#L20

Change to:
```kotlin
?.let { null } // success if fetchBloggingPrompts was not null
```

Steps:
1. Tap the "View more prompts" option
8. **Verify** the Loading Progress Bar (circular) is shown briefly while fetching data
9. **Verify** the content is updated to the Fetch error state UI

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A, UI changes only.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
