### PR TITLE
Jetpack Focus: Display Jetpack overlay on app launch in phase 3

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -12,7 +12,7 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayViewModel;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.ForwardToJetpack;
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackAllFeaturesOverlaySource;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource;
 import org.wordpress.android.util.PackageManagerWrapper;
 import org.wordpress.android.util.ToastUtils;
@@ -104,7 +104,7 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
                         true,
                         SiteCreationSource.UNSPECIFIED,
                         false,
-                        JetpackAllFeaturesOverlaySource.UNSPECIFIED)
+                        JetpackFeatureCollectionOverlaySource.UNSPECIFIED)
                 .show(getSupportFragmentManager(), JetpackFeatureFullScreenOverlayFragment.TAG);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
@@ -19,7 +19,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.Dism
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.ForwardToJetpack
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.OpenMigrationInfoLink
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.OpenPlayStore
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackAllFeaturesOverlaySource
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource.UNSPECIFIED
@@ -57,8 +57,8 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
                 getIfSiteCreationOverlay(),
                 getIfDeepLinkOverlay(),
                 getSiteCreationSource(),
-                getIfAllFeaturesOverlay(),
-                getAllFeatureOverlaysSource(),
+                getIfFeatureCollectionOverlay(),
+                getFeatureCollectionOverlaysSource(),
                 RtlUtils.isRtl(view.context)
         )
         binding.setupObservers()
@@ -102,11 +102,11 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
     private fun getSiteCreationSource() =
             arguments?.getSerializable(SITE_CREATION_OVERLAY_SOURCE) as SiteCreationSource
 
-    private fun getIfAllFeaturesOverlay() =
-            arguments?.getSerializable(IS_ALL_FEATURES_OVERLAY) as Boolean
+    private fun getIfFeatureCollectionOverlay() =
+            arguments?.getSerializable(IS_FEATURE_COLLECTION_OVERLAY) as Boolean
 
-    private fun getAllFeatureOverlaysSource() =
-            arguments?.getSerializable(ALL_FEATURES_OVERLAY_SOURCE) as JetpackAllFeaturesOverlaySource
+    private fun getFeatureCollectionOverlaysSource() =
+            arguments?.getSerializable(FEATURE_COLLECTION_OVERLAY_SOURCE) as JetpackFeatureCollectionOverlaySource
 
     private fun JetpackFeatureRemovalOverlayBinding.setupObservers() {
         viewModel.uiState.observe(viewLifecycleOwner) {
@@ -205,8 +205,8 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
         private const val IS_SITE_CREATION_OVERLAY = "KEY_IS_SITE_CREATION_OVERLAY"
         private const val IS_DEEP_LINK_OVERLAY = "KEY_IS_DEEP_LINK_OVERLAY"
         private const val SITE_CREATION_OVERLAY_SOURCE = "KEY_SITE_CREATION_OVERLAY_SOURCE"
-        private const val IS_ALL_FEATURES_OVERLAY = "KEY_IS_ALL_FEATURES_OVERLAY"
-        private const val ALL_FEATURES_OVERLAY_SOURCE = "KEY_ALL_FEATURES_OVERLAY_SOURCE"
+        private const val IS_FEATURE_COLLECTION_OVERLAY = "KEY_IS_FEATURE_COLLECTION_OVERLAY"
+        private const val FEATURE_COLLECTION_OVERLAY_SOURCE = "KEY_FEATURE_COLLECTION_OVERLAY_SOURCE"
 
         @Suppress("LongParameterList")
         @JvmStatic fun newInstance(
@@ -214,16 +214,17 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
             isSiteCreationOverlay: Boolean = false,
             isDeepLinkOverlay: Boolean = false,
             siteCreationSource: SiteCreationSource? = UNSPECIFIED,
-            isAllFeaturesOverlay: Boolean = false,
-            allFeaturesOverlaySource: JetpackAllFeaturesOverlaySource? = JetpackAllFeaturesOverlaySource.UNSPECIFIED
+            isFeatureCollectionOverlay: Boolean = false,
+            featureCollectionOverlaySource: JetpackFeatureCollectionOverlaySource? =
+                    JetpackFeatureCollectionOverlaySource.UNSPECIFIED
         ) = JetpackFeatureFullScreenOverlayFragment().apply {
             arguments = Bundle().apply {
                 putSerializable(OVERLAY_SCREEN_TYPE, jetpackFeatureOverlayScreenType)
                 putBoolean(IS_SITE_CREATION_OVERLAY, isSiteCreationOverlay)
                 putBoolean(IS_DEEP_LINK_OVERLAY, isDeepLinkOverlay)
                 putSerializable(SITE_CREATION_OVERLAY_SOURCE, siteCreationSource)
-                putBoolean(IS_ALL_FEATURES_OVERLAY, isAllFeaturesOverlay)
-                putSerializable(ALL_FEATURES_OVERLAY_SOURCE, allFeaturesOverlaySource)
+                putBoolean(IS_FEATURE_COLLECTION_OVERLAY, isFeatureCollectionOverlay)
+                putSerializable(FEATURE_COLLECTION_OVERLAY_SOURCE, featureCollectionOverlaySource)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayViewModel.kt
@@ -5,7 +5,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.OpenMigrationInfoLink
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackAllFeaturesOverlaySource
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackOverlayDismissalType.CLOSE_BUTTON
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackOverlayDismissalType.CONTINUE_BUTTON
@@ -40,8 +40,8 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
     private var isSiteCreationOverlayScreen: Boolean = false
     private var siteCreationOrigin: SiteCreationSource = UNSPECIFIED
     private var isDeepLinkOverlayScreen: Boolean = false
-    private var isAllFeaturesOverlayScreen: Boolean = false
-    private var allFeaturesOverlayOrigin: JetpackAllFeaturesOverlaySource = JetpackAllFeaturesOverlaySource.UNSPECIFIED
+    private var isFeatureCollectionOverlayScreen: Boolean = false
+    private var featureCollectionOverlayOrigin: JetpackFeatureCollectionOverlaySource = JetpackFeatureCollectionOverlaySource.UNSPECIFIED
 
     fun openJetpackAppDownloadLink() {
         if (isSiteCreationOverlayScreen) {
@@ -50,9 +50,9 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
         } else if (isDeepLinkOverlayScreen) {
             _action.value = JetpackFeatureOverlayActions.ForwardToJetpack
             jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTappedInDeepLinkOverlay()
-        } else if (isAllFeaturesOverlayScreen) {
+        } else if (isFeatureCollectionOverlayScreen) {
             _action.value = JetpackFeatureOverlayActions.OpenPlayStore
-            jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTappedInAllFeaturesOverlay(allFeaturesOverlayOrigin)
+            jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTappedInFeatureCollectionOverlay(featureCollectionOverlayOrigin)
         } else {
             _action.value = JetpackFeatureOverlayActions.OpenPlayStore
             jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTapped(screenType)
@@ -68,9 +68,9 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
             )
         else if (isDeepLinkOverlayScreen)
             jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInDeepLinkOverlay(CONTINUE_BUTTON)
-        else if (isAllFeaturesOverlayScreen)
-            jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInAllFeaturesOverlay(
-                    allFeaturesOverlayOrigin,
+        else if (isFeatureCollectionOverlayScreen)
+            jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInFeatureCollectionOverlay(
+                    featureCollectionOverlayOrigin,
                     CONTINUE_BUTTON)
         else jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissed(screenType, CONTINUE_BUTTON)
     }
@@ -84,9 +84,9 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
             )
         else if (isDeepLinkOverlayScreen)
             jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInDeepLinkOverlay(CLOSE_BUTTON)
-        else if (isAllFeaturesOverlayScreen)
-            jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInAllFeaturesOverlay(
-                    allFeaturesOverlayOrigin,
+        else if (isFeatureCollectionOverlayScreen)
+            jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissedInFeatureCollectionOverlay(
+                    featureCollectionOverlayOrigin,
                     CLOSE_BUTTON
             )
         else jetpackFeatureRemovalOverlayUtil.trackBottomSheetDismissed(screenType, CLOSE_BUTTON)
@@ -98,8 +98,8 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
         isSiteCreationOverlay: Boolean,
         isDeepLinkOverlay: Boolean,
         siteCreationSource: SiteCreationSource,
-        isAllFeaturesOverlay: Boolean,
-        allFeaturesOverlaySource: JetpackAllFeaturesOverlaySource,
+        isFeatureCollectionOverlay: Boolean,
+        featureCollectionOverlaySource: JetpackFeatureCollectionOverlaySource,
         rtlLayout: Boolean
     ) {
         if (isSiteCreationOverlay) {
@@ -122,15 +122,15 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
             return
         }
 
-        if (isAllFeaturesOverlay) {
-            isAllFeaturesOverlayScreen = true
-            allFeaturesOverlayOrigin = allFeaturesOverlaySource
-            _uiState.postValue(jetpackFeatureOverlayContentBuilder.buildAllFeaturesOverlayState(
+        if (isFeatureCollectionOverlay) {
+            isFeatureCollectionOverlayScreen = true
+            featureCollectionOverlayOrigin = featureCollectionOverlaySource
+            _uiState.postValue(jetpackFeatureOverlayContentBuilder.buildFeatureCollectionOverlayState(
                     rtlLayout,
                     getCurrentPhase()!!,
                     phaseThreeBlogPostLinkConfig.getValue()
             ))
-            jetpackFeatureRemovalOverlayUtil.onAllFeatureOverlayShown(allFeaturesOverlaySource)
+            jetpackFeatureRemovalOverlayUtil.onFeatureCollectionOverlayShown(featureCollectionOverlaySource)
             return
         }
 
@@ -152,9 +152,9 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
     private fun getSiteCreationPhase() = jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()
 
     fun openJetpackMigrationInfoLink(migrationInfoRedirectUrl: String) {
-        if (isAllFeaturesOverlayScreen) {
-            jetpackFeatureRemovalOverlayUtil.trackLearnMoreAboutMigrationClickedInAllFeaturesOverlay(
-                    allFeaturesOverlayOrigin
+        if (isFeatureCollectionOverlayScreen) {
+            jetpackFeatureRemovalOverlayUtil.trackLearnMoreAboutMigrationClickedInFeatureCollectionOverlay(
+                    featureCollectionOverlayOrigin
             )
         } else {
             jetpackFeatureRemovalOverlayUtil.trackLearnMoreAboutMigrationClicked(screenType)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayViewModel.kt
@@ -130,7 +130,7 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
                     getCurrentPhase()!!,
                     phaseThreeBlogPostLinkConfig.getValue()
             ))
-            jetpackFeatureRemovalOverlayUtil.trackAllFeatureOverlayShown(allFeaturesOverlaySource)
+            jetpackFeatureRemovalOverlayUtil.onAllFeatureOverlayShown(allFeaturesOverlaySource)
             return
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayViewModel.kt
@@ -41,7 +41,8 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
     private var siteCreationOrigin: SiteCreationSource = UNSPECIFIED
     private var isDeepLinkOverlayScreen: Boolean = false
     private var isFeatureCollectionOverlayScreen: Boolean = false
-    private var featureCollectionOverlayOrigin: JetpackFeatureCollectionOverlaySource = JetpackFeatureCollectionOverlaySource.UNSPECIFIED
+    private var featureCollectionOverlayOrigin: JetpackFeatureCollectionOverlaySource =
+            JetpackFeatureCollectionOverlaySource.UNSPECIFIED
 
     fun openJetpackAppDownloadLink() {
         if (isSiteCreationOverlayScreen) {
@@ -52,7 +53,9 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
             jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTappedInDeepLinkOverlay()
         } else if (isFeatureCollectionOverlayScreen) {
             _action.value = JetpackFeatureOverlayActions.OpenPlayStore
-            jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTappedInFeatureCollectionOverlay(featureCollectionOverlayOrigin)
+            jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTappedInFeatureCollectionOverlay(
+                    featureCollectionOverlayOrigin
+            )
         } else {
             _action.value = JetpackFeatureOverlayActions.OpenPlayStore
             jetpackFeatureRemovalOverlayUtil.trackInstallJetpackTapped(screenType)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
@@ -272,26 +272,26 @@ class JetpackFeatureOverlayContentBuilder @Inject constructor(
     }
 
     // All Feature Overlay
-    fun buildAllFeaturesOverlayState(
+    fun buildFeatureCollectionOverlayState(
         isRtl: Boolean, currentPhase: JetpackFeatureRemovalPhase, blogPostLink: String?
     ): JetpackFeatureOverlayUIState {
-        return getStateForAllFeatures(isRtl, currentPhase, blogPostLink)
+        return getStateForFeatureCollection(isRtl, currentPhase, blogPostLink)
     }
 
-    private fun getStateForAllFeatures(
+    private fun getStateForFeatureCollection(
         isRtl: Boolean,
         currentPhase: JetpackFeatureRemovalPhase,
         blogPostLink: String?
     ): JetpackFeatureOverlayUIState {
         val componentVisibility = if (currentPhase == PhaseThree)
-                JetpackFeatureOverlayComponentVisibility.AllFeaturesPhase.PhaseThree()
+                JetpackFeatureOverlayComponentVisibility.FeatureCollectionPhase.PhaseThree()
             else
-                JetpackFeatureOverlayComponentVisibility.AllFeaturesPhase.Final()
-        val content = getContentForAllFeatures(isRtl, blogPostLink)
+                JetpackFeatureOverlayComponentVisibility.FeatureCollectionPhase.Final()
+        val content = getContentForFeatureCollection(isRtl, blogPostLink)
         return JetpackFeatureOverlayUIState(componentVisibility, content)
     }
 
-    private fun getContentForAllFeatures(isRtl: Boolean, blogPostLink: String?): JetpackFeatureOverlayContent {
+    private fun getContentForFeatureCollection(isRtl: Boolean, blogPostLink: String?): JetpackFeatureOverlayContent {
         return JetpackFeatureOverlayContent(
                 illustration = if (isRtl) R.raw.jp_all_features_rtl else R.raw.jp_all_features_left,
                 title = R.string.wp_jetpack_feature_removal_overlay_phase_two_and_three_title_all_features,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
@@ -34,6 +34,16 @@ class JetpackFeatureOverlayShownTracker @Inject constructor(private val sharedPr
     ) {
         sharedPrefs.edit().putLong(jetpackOverlayConnectedFeature.getPreferenceKey(phase), timeStamp).apply()
     }
+
+    fun setAllFeatureOverlayShown() {
+        sharedPrefs.edit().putBoolean(KEY_ALL_FEATURE_OVERLAY_SHOWN, true).apply()
+    }
+
+    fun getAllFeatureOverlayShown() = sharedPrefs.getBoolean(KEY_ALL_FEATURE_OVERLAY_SHOWN, false)
+
+    companion object {
+        const val KEY_ALL_FEATURE_OVERLAY_SHOWN = "KEY_ALL_FEATURE_OVERLAY_SHOWN"
+    }
 }
 
 enum class JetpackOverlayConnectedFeature(private val featureSpecificPreferenceKey: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
@@ -35,14 +35,14 @@ class JetpackFeatureOverlayShownTracker @Inject constructor(private val sharedPr
         sharedPrefs.edit().putLong(jetpackOverlayConnectedFeature.getPreferenceKey(phase), timeStamp).apply()
     }
 
-    fun setAllFeatureOverlayShown() {
-        sharedPrefs.edit().putBoolean(KEY_ALL_FEATURE_OVERLAY_SHOWN, true).apply()
+    fun setFeatureCollectionOverlayShown() {
+        sharedPrefs.edit().putBoolean(KEY_FEATURE_COLLECTION_OVERLAY_SHOWN, true).apply()
     }
 
-    fun getAllFeatureOverlayShown() = sharedPrefs.getBoolean(KEY_ALL_FEATURE_OVERLAY_SHOWN, false)
+    fun getFeatureCollectionOverlayShown() = sharedPrefs.getBoolean(KEY_FEATURE_COLLECTION_OVERLAY_SHOWN, false)
 
     companion object {
-        const val KEY_ALL_FEATURE_OVERLAY_SHOWN = "KEY_ALL_FEATURE_OVERLAY_SHOWN"
+        const val KEY_FEATURE_COLLECTION_OVERLAY_SHOWN = "KEY_FEATURE_COLLECTION_OVERLAY_SHOWN"
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayPhase.PHASE_ONE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayPhase.PHASE_THREE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayPhase.PHASE_TWO
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackAllFeaturesOverlaySource.APP_OPEN
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType.NOTIFICATIONS
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType.READER
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType.STATS
@@ -51,6 +52,11 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         return shouldShowSiteCreationOverlay() &&
                 jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase() ==
                 JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO
+    }
+
+    fun shouldShowFeatureCollectionJetpackOverlay(): Boolean {
+        return !jetpackFeatureOverlayShownTracker.getAllFeatureOverlayShown() &&
+                jetpackFeatureRemovalPhaseHelper.getCurrentPhase() == PhaseThree
     }
 
     private fun isInSiteCreationPhase(): Boolean {
@@ -253,7 +259,14 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         )
     }
 
-    fun trackAllFeatureOverlayShown(source: JetpackAllFeaturesOverlaySource) {
+    fun onAllFeatureOverlayShown(source: JetpackAllFeaturesOverlaySource) {
+        if (source == APP_OPEN) {
+            jetpackFeatureOverlayShownTracker.setAllFeatureOverlayShown()
+        }
+        trackAllFeatureOverlayShown(source)
+    }
+
+    private fun trackAllFeatureOverlayShown(source: JetpackAllFeaturesOverlaySource) {
         analyticsTrackerWrapper.track(
                 AnalyticsTracker.Stat.JETPACK_REMOVE_FEATURE_OVERLAY_DISPLAYED,
                 mapOf(
@@ -304,13 +317,17 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
 
     enum class JetpackAllFeaturesOverlaySource(val label: String) {
         FEATURE_CARD("card"),
+        APP_OPEN("app_open"),
         UNSPECIFIED("unspecified");
 
         companion object {
             @JvmStatic
-            fun fromString(label: String?) = when (FEATURE_CARD.label) {
-                label -> FEATURE_CARD
-                else -> UNSPECIFIED
+            fun fromString(label: String?): JetpackAllFeaturesOverlaySource {
+                return when (FEATURE_CARD.label) {
+                    label -> FEATURE_CARD
+                    label -> APP_OPEN
+                    else -> UNSPECIFIED
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -324,8 +324,8 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
             @JvmStatic
             fun fromString(label: String?): JetpackFeatureCollectionOverlaySource {
                 return when (FEATURE_CARD.label) {
-                    label -> FEATURE_CARD
-                    label -> APP_OPEN
+                    FEATURE_CARD.label -> FEATURE_CARD
+                    APP_OPEN.label -> APP_OPEN
                     else -> UNSPECIFIED
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -4,7 +4,7 @@ import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayPhase.PHASE_ONE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayPhase.PHASE_THREE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayPhase.PHASE_TWO
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackAllFeaturesOverlaySource.APP_OPEN
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource.APP_OPEN
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType.NOTIFICATIONS
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType.READER
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType.STATS
@@ -55,7 +55,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
     }
 
     fun shouldShowFeatureCollectionJetpackOverlay(): Boolean {
-        return !jetpackFeatureOverlayShownTracker.getAllFeatureOverlayShown() &&
+        return !jetpackFeatureOverlayShownTracker.getFeatureCollectionOverlayShown() &&
                 jetpackFeatureRemovalPhaseHelper.getCurrentPhase() == PhaseThree
     }
 
@@ -259,14 +259,14 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         )
     }
 
-    fun onAllFeatureOverlayShown(source: JetpackAllFeaturesOverlaySource) {
+    fun onFeatureCollectionOverlayShown(source: JetpackFeatureCollectionOverlaySource) {
         if (source == APP_OPEN) {
-            jetpackFeatureOverlayShownTracker.setAllFeatureOverlayShown()
+            jetpackFeatureOverlayShownTracker.setFeatureCollectionOverlayShown()
         }
-        trackAllFeatureOverlayShown(source)
+        trackFeatureCollectionOverlayShown(source)
     }
 
-    private fun trackAllFeatureOverlayShown(source: JetpackAllFeaturesOverlaySource) {
+    private fun trackFeatureCollectionOverlayShown(source: JetpackFeatureCollectionOverlaySource) {
         analyticsTrackerWrapper.track(
                 AnalyticsTracker.Stat.JETPACK_REMOVE_FEATURE_OVERLAY_DISPLAYED,
                 mapOf(
@@ -276,8 +276,8 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         )
     }
 
-    fun trackBottomSheetDismissedInAllFeaturesOverlay(
-        source: JetpackAllFeaturesOverlaySource,
+    fun trackBottomSheetDismissedInFeatureCollectionOverlay(
+        source: JetpackFeatureCollectionOverlaySource,
         dismissalType: JetpackOverlayDismissalType
     ) {
         analyticsTrackerWrapper.track(
@@ -290,7 +290,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         )
     }
 
-    fun trackInstallJetpackTappedInAllFeaturesOverlay(source: JetpackAllFeaturesOverlaySource) {
+    fun trackInstallJetpackTappedInFeatureCollectionOverlay(source: JetpackFeatureCollectionOverlaySource) {
         analyticsTrackerWrapper.track(
                 AnalyticsTracker.Stat.JETPACK_REMOVE_FEATURE_OVERLAY_BUTTON_GET_JETPACK_APP_TAPPED,
                 mapOf(
@@ -300,7 +300,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         )
     }
 
-    fun trackLearnMoreAboutMigrationClickedInAllFeaturesOverlay(source: JetpackAllFeaturesOverlaySource) {
+    fun trackLearnMoreAboutMigrationClickedInFeatureCollectionOverlay(source: JetpackFeatureCollectionOverlaySource) {
         analyticsTrackerWrapper.track(
                 AnalyticsTracker.Stat.JETPACK_REMOVE_FEATURE_OVERLAY_LEARN_MORE_TAPPED,
                 mapOf(
@@ -315,14 +315,14 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         CONTINUE_BUTTON("continue")
     }
 
-    enum class JetpackAllFeaturesOverlaySource(val label: String) {
+    enum class JetpackFeatureCollectionOverlaySource(val label: String) {
         FEATURE_CARD("card"),
         APP_OPEN("app_open"),
         UNSPECIFIED("unspecified");
 
         companion object {
             @JvmStatic
-            fun fromString(label: String?): JetpackAllFeaturesOverlaySource {
+            fun fromString(label: String?): JetpackFeatureCollectionOverlaySource {
                 return when (FEATURE_CARD.label) {
                     label -> FEATURE_CARD
                     label -> APP_OPEN

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -323,7 +323,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         companion object {
             @JvmStatic
             fun fromString(label: String?): JetpackFeatureCollectionOverlaySource {
-                return when (FEATURE_CARD.label) {
+                return when (label) {
                     FEATURE_CARD.label -> FEATURE_CARD
                     APP_OPEN.label -> APP_OPEN
                     else -> UNSPECIFIED

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackOverlayUIState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackOverlayUIState.kt
@@ -33,14 +33,14 @@ sealed class JetpackFeatureOverlayComponentVisibility(
         class All : DeepLinkPhase()
     }
 
-    sealed class AllFeaturesPhase : JetpackFeatureOverlayComponentVisibility() {
+    sealed class FeatureCollectionPhase : JetpackFeatureOverlayComponentVisibility() {
         class PhaseThree(
             override val migrationInfoText: Boolean = true,
             override val closeButton: Boolean = false,
             override val migrationText: Boolean = true
-        ) : AllFeaturesPhase()
+        ) : FeatureCollectionPhase()
 
-        class Final(override val closeButton: Boolean = false) : AllFeaturesPhase()
+        class Final(override val closeButton: Boolean = false) : FeatureCollectionPhase()
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -89,7 +89,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
 import org.wordpress.android.ui.deeplinks.DeepLinkOpenWebLinksWithJetpackHelper;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil;
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackAllFeaturesOverlaySource;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment;
@@ -472,7 +472,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
             mJetpackAppMigrationFlowUtils.startJetpackMigrationFlow();
         }
 
-        displayJetpackAllFeatureOverlayIfNeeded();
+        displayJetpackFeatureCollectionOverlayIfNeeded();
     }
 
     private void showBloggingPromptsOnboarding() {
@@ -508,7 +508,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         }
     }
 
-    private void displayJetpackAllFeatureOverlayIfNeeded() {
+    private void displayJetpackFeatureCollectionOverlayIfNeeded() {
         if (mJetpackFeatureRemovalOverlayUtil.shouldShowFeatureCollectionJetpackOverlay()) {
             JetpackFeatureFullScreenOverlayFragment.newInstance(
                     null,
@@ -516,7 +516,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     false,
                     SiteCreationSource.UNSPECIFIED,
                     true,
-                    JetpackAllFeaturesOverlaySource.APP_OPEN
+                    JetpackFeatureCollectionOverlaySource.APP_OPEN
             ).show(getSupportFragmentManager(), JetpackFeatureFullScreenOverlayFragment.TAG);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -87,6 +87,9 @@ import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsRemind
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
 import org.wordpress.android.ui.deeplinks.DeepLinkOpenWebLinksWithJetpackHelper;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackAllFeaturesOverlaySource;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment;
@@ -264,6 +267,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Inject DeepLinkOpenWebLinksWithJetpackHelper mDeepLinkOpenWebLinksWithJetpackHelper;
     @Inject OpenWebLinksWithJetpackFlowFeatureConfig mOpenWebLinksWithJetpackFlowFeatureConfig;
     @Inject QRCodeAuthFlowFeatureConfig mQrCodeAuthFlowFeatureConfig;
+    @Inject JetpackFeatureRemovalOverlayUtil mJetpackFeatureRemovalOverlayUtil;
 
     @Inject BuildConfigWrapper mBuildConfigWrapper;
 
@@ -467,6 +471,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (mJetpackAppMigrationFlowUtils.shouldShowMigrationFlow()) {
             mJetpackAppMigrationFlowUtils.startJetpackMigrationFlow();
         }
+
+        displayJetpackAllFeatureOverlayIfNeeded();
     }
 
     private void showBloggingPromptsOnboarding() {
@@ -499,6 +505,19 @@ public class WPMainActivity extends LocaleAwareActivity implements
             ActivityLauncher.showSignInForResultJetpackOnly(activity);
         } else {
             ActivityLauncher.showSignInForResult(activity);
+        }
+    }
+
+    private void displayJetpackAllFeatureOverlayIfNeeded() {
+        if (mJetpackFeatureRemovalOverlayUtil.shouldShowFeatureCollectionJetpackOverlay()) {
+            JetpackFeatureFullScreenOverlayFragment.newInstance(
+                    null,
+                    false,
+                    false,
+                    SiteCreationSource.UNSPECIFIED,
+                    true,
+                    JetpackAllFeaturesOverlaySource.APP_OPEN
+            ).show(getSupportFragmentManager(), JetpackFeatureFullScreenOverlayFragment.TAG);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -37,7 +37,7 @@ import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTrac
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackAllFeaturesOverlaySource.FEATURE_CARD
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource.FEATURE_CARD
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.JetpackFeatureCard

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -5,7 +5,7 @@ import com.wordpress.stories.compose.frame.StorySaveEvents.StorySaveResult
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackAllFeaturesOverlaySource
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.util.UriWrapper
 
@@ -81,6 +81,6 @@ sealed class SiteNavigationAction {
     data class OpenTodaysStatsGetMoreViewsExternalUrl(val url: String) : SiteNavigationAction()
     object OpenJetpackPoweredBottomSheet : SiteNavigationAction()
     object OpenJetpackMigrationDeleteWP : SiteNavigationAction()
-    data class OpenJetpackFeatureOverlay(val source: JetpackAllFeaturesOverlaySource) : SiteNavigationAction()
+    data class OpenJetpackFeatureOverlay(val source: JetpackFeatureCollectionOverlaySource) : SiteNavigationAction()
     data class OpenJetpackFeatureCardLearnMoreLink(val url: String) : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -34,7 +34,7 @@ import org.wordpress.android.ui.accounts.LoginEpilogueActivity
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.Companion.RESULT_REGISTERED_DOMAIN_EMAIL
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackAllFeaturesOverlaySource
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource
 import org.wordpress.android.ui.main.SitePickerActivity
 import org.wordpress.android.ui.main.WPMainActivity
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationActivity
@@ -390,11 +390,11 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         startActivity(intent)
     }
 
-    private fun showJetpackFeatureOverlay(source: JetpackAllFeaturesOverlaySource) {
+    private fun showJetpackFeatureOverlay(source: JetpackFeatureCollectionOverlaySource) {
         JetpackFeatureFullScreenOverlayFragment
                 .newInstance(
-                        isAllFeaturesOverlay = true,
-                        allFeaturesOverlaySource = source
+                        isFeatureCollectionOverlay = true,
+                        featureCollectionOverlaySource = source
                 )
                 .show(requireActivity().supportFragmentManager, JetpackFeatureFullScreenOverlayFragment.TAG)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -47,7 +47,7 @@ import org.wordpress.android.ui.deeplinks.DeepLinkTrackingUtils;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayViewModel;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.ForwardToJetpack;
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackAllFeaturesOverlaySource;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -487,7 +487,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
                         true,
                         SiteCreationSource.UNSPECIFIED,
                         false,
-                        JetpackAllFeaturesOverlaySource.UNSPECIFIED)
+                        JetpackFeatureCollectionOverlaySource.UNSPECIFIED)
                 .show(getSupportFragmentManager(), JetpackFeatureFullScreenOverlayFragment.TAG);
         return true;
     }


### PR DESCRIPTION
Fixes #17337 

This PR will show the Jetpack Feature Collection overlay for phase 3. This is the same overlay that is displayed when tapping the Feature Card. It should only be displayed once during Phase 3.

Also included in this PR is a minor name refactor from "AllFeatures" to "FeatureCollection". 

Light | Dark
-- | --
<img width="250" height="500" alt="Light" src="https://user-images.githubusercontent.com/506707/210891143-b2e80545-0b2d-4bbd-ba70-1958b061986c.png"> | <img width="250" height="500" alt="Dark" src="https://user-images.githubusercontent.com/506707/210891160-8e3585bf-18a5-4d42-b939-e9d06a63ff85.png">

The following existing events will be tracked with “source=app_open”.
remove_feature_overlay_displayed
remove_feature_overlay_dismissed
remove_feature_overlay_link_tapped
remove_feature_overlay_button_tapped

**To test:**
- Install WP app
- Login
- ✅ Verify that the Jetpack Feature Collection overlay is not shown
- Navigate to -> Debug Settings -> and Enable `jp_removal_three` then restart the app
- ✅ Verify that the Jetpack Feature Collection overlay is shown
- Close and reopen the app
- ✅ Verify that the Jetpack Feature Collection overlay is not shown


## Regression Notes
1. Potential unintended areas of impact
The overlay is shown too many times or not at all

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
