### PR TITLE
[Blogging Prompts] Prompts List accessibility improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListItem.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -45,6 +47,7 @@ fun BloggingPromptsListItem(
 ) {
     Column(
             modifier = modifier
+                    .semantics(mergeDescendants = true) { }
                     .background(MaterialTheme.colors.surface)
                     .padding(Margin.ExtraLarge.value),
             verticalArrangement = Arrangement.spacedBy(Margin.Small.value),
@@ -89,7 +92,9 @@ fun BloggingPromptsListItem(
 private fun ItemSubtitleDivider() {
     Text(
             text = stringResource(R.string.blogging_prompts_list_subtitle_divider),
-            modifier = Modifier.padding(horizontal = Margin.Medium.value),
+            modifier = Modifier
+                    .clearAndSetSemantics { }
+                    .padding(horizontal = Margin.Medium.value),
             style = ItemSubtitleTextStyle,
     )
 }


### PR DESCRIPTION
Part of #17125 

Improve accessibility for reading the Prompts List items:
- Make behavior similar to `ListItem` Material component, that is, merge item descendants so they are grouped and read together instead of requiring multiple navigation gestures
- Make the subtitle divider (• - "bullet" character) not be read as "bullet" by the screen reader by clearing its semantics

To test:

Requirement: activate TalkBack (or another screen reader app) and do the steps below.

1. Do the steps to enable the Prompts List feature flag found in the test section of #17675
2. Sign in (if not signed in already)
3. Go to the home dashboard (My Site -> Home)
4. **Verify** the Prompts card is shown
5. Tap the 3-dot menu in the Prompts card
6. Tap the "View more prompts" option
9. **Verify** the list is shown
10. Use screen reader navigation gestures to navigate through the list
11. **Verify** each item is selected as a whole and all content is read

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
