### PR TITLE
Jetpack Focus: Handle shortcuts in phase four

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShortcutsNavigator.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShortcutsNavigator.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.util.AppLog;
 
 import javax.inject.Inject;
@@ -18,6 +19,8 @@ public class ShortcutsNavigator {
     @Inject ShortcutsNavigator() {
     }
 
+    @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
+
     public void showTargetScreen(String action, Activity activity, SiteModel currentSite) {
         Shortcut shortcut = Shortcut.fromActionString(action);
         if (shortcut == null) {
@@ -28,7 +31,9 @@ public class ShortcutsNavigator {
         switch (shortcut) {
             case OPEN_STATS:
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SHORTCUT_STATS_CLICKED);
-                ActivityLauncher.viewBlogStats(activity, currentSite);
+                if (!mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
+                    ActivityLauncher.viewBlogStats(activity, currentSite);
+                } 
                 break;
             case CREATE_NEW_POST:
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SHORTCUT_NEW_POST_CLICKED);
@@ -43,7 +48,9 @@ public class ShortcutsNavigator {
                 break;
             case OPEN_NOTIFICATIONS:
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SHORTCUT_NOTIFICATIONS_CLICKED);
-                ActivityLauncher.viewNotifications(activity);
+                if (!mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
+                    ActivityLauncher.viewNotifications(activity);
+                }
                 break;
             default:
                 AppLog.e(AppLog.T.MAIN, String.format("Unknown Android Shortcut[%s]", shortcut));


### PR DESCRIPTION
Parent #17339 

This PR handles the "stats" and "notifications" shortcuts when phase 4 is enabled. Tapping an existing shortcut will open the app, but not perform any action.

| Before  | After  |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/506707/211643009-22ad6ec5-fc74-4ff5-b3d0-9c8894ff38bc.mp4">  | <video src="https://user-images.githubusercontent.com/506707/211643022-e2f112cd-a49d-4d02-9de4-9efd2338c12b.mp4">|

**To test:**
- Install the app
- Login
- Background the app
- Long-press on the WP icon and create shortcuts for "stats", "notifications", and "posts"
- Tap on each shortcut created
- ✅ Verify that each shortcut takes you to the correct location within the app 
- Navigate to -> Debug Settings -> and Enable `jp_removal_four` and restart the app
- Tap on each shortcut created in the earlier step
- ✅ Verify that the "stat" and "notifications" shortcut takes you to home view (or simplified view if you are testing this PR after the bottom nav bar/dashboard has been removed)
- Back out of the app
- Tap the "posts" shortcut
- ✅ Verify that the "posts" shortcut takes you to the create post

## Regression Notes
1. Potential unintended areas of impact
The shortcuts still open stats and notifications

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
