### PR TITLE
Jetpack Focus: Handle create page flow for phase four

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -90,6 +90,7 @@ import org.wordpress.android.ui.deeplinks.DeepLinkOpenWebLinksWithJetpackHelper;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment;
@@ -268,6 +269,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Inject OpenWebLinksWithJetpackFlowFeatureConfig mOpenWebLinksWithJetpackFlowFeatureConfig;
     @Inject QRCodeAuthFlowFeatureConfig mQrCodeAuthFlowFeatureConfig;
     @Inject JetpackFeatureRemovalOverlayUtil mJetpackFeatureRemovalOverlayUtil;
+    @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
 
     @Inject BuildConfigWrapper mBuildConfigWrapper;
 
@@ -599,7 +601,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     handleNewPostAction(PagePostCreationSourcesDetail.POST_FROM_MY_SITE, -1, null);
                     break;
                 case CREATE_NEW_PAGE:
-                    if (mMLPViewModel.canShowModalLayoutPicker()) {
+                    if (mMLPViewModel.canShowModalLayoutPicker()
+                        && !mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
                         mMLPViewModel.createPageFlowTriggered();
                     } else {
                         handleNewPageAction("", "", null,

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.PAGE_FROM_PAGES_LIST
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.ScrollableViewInitializedListener
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment.Companion.MODAL_LAYOUT_PICKER_TAG
 import org.wordpress.android.ui.posts.EditPostActivity
@@ -108,6 +109,9 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
 
     @Inject
     lateinit var uploadUtilsWrapper: UploadUtilsWrapper
+
+    @Inject
+    lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
     @Suppress("DEPRECATION")
     private var progressDialog: ProgressDialog? = null
@@ -371,7 +375,8 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         })
 
         viewModel.createNewPage.observe(viewLifecycleOwner, {
-            if (mlpViewModel.canShowModalLayoutPicker()) {
+            if (mlpViewModel.canShowModalLayoutPicker()
+                && !jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
                 mlpViewModel.createPageFlowTriggered()
             } else {
                 createNewPage()


### PR DESCRIPTION
Parent #17339 

This PR removes the first step in the page creation flow (template selection) when phase four is enabled. 
Creating a page from scratch will still be supported.

**To test:**
- Download and install the WP app
- Login
- Navigate to the My Site tab
- Tap on the floating action button and select `Site Page`
- ✅ Verify that the Site Page flow is started and the template view is visible
- Navigate back out to My Site
- Navigate to the Pages list
- On the pages list, tap on the floating action button
- ✅ Verify that the Site page flow is started and the template view is visible 
- Navigate to -> Debug Settings -> and Enable `jp_removal_four` and restart the app
- Navigate to the My Site tab
- Tap on the floating action button and select `Site Page`
- ✅ Verify that the create page view is visible and the template view is no longer visible
- Navigate back to My Site
- Navigate to the Pages list
- On the pages list, tap on the floating action button
- ✅ Verify that the create page view is visible and the template view is no longer visible

## Regression Notes
1. Potential unintended areas of impact
The create page flow still shows the template view

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
