### PR TITLE
[Dependency Updates] Update `androidxAppcompatVersion` to 1.4.2

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -382,6 +382,7 @@ dependencies {
     implementation "androidx.multidex:multidex:$androidXMultidexVersion"
     implementation "androidx.media:media:$androidxMediaVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
+    implementation "androidx.appcompat:appcompat-resources:$androidxAppcompatVersion"
     implementation "androidx.cardview:cardview:$androidxCardviewVersion"
     implementation "androidx.recyclerview:recyclerview:$androidxRecyclerviewVersion"
     implementation "com.google.android.material:material:$googleMaterialVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
     // main
     androidInstallReferrerVersion = '2.2'
     androidVolleyVersion = '1.1.1'
-    androidxAppcompatVersion = '1.1.0'
+    androidxAppcompatVersion = '1.4.2'
     androidxArchCoreVersion = '2.1.0'
     androidxComposeVersion = '1.1.1'
     androidxComposeCompilerVersion = '1.1.1'


### PR DESCRIPTION
Parent #17561
Batch Branch: [deps/main-batch-androidx-core](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-core)

This PR updates `androidxAppcompatVersion` to [1.4.2](https://developer.android.com/jetpack/androidx/releases/appcompat#1.5.1). FYI: This is NOT the latest, not even the previous version of [androidx.core](https://developer.android.com/jetpack/androidx/releases/appcompat).

Also, as part of this update the below transitive dependencies were added:
- On the `WordPress` module (fffeff7505809ed2bdb96fff6cd1533966a02ac3):
    - `androidx.appcompat:appcompat-resources`

-----

Note that the [1.5.1](https://developer.android.com/jetpack/androidx/releases/appcompat#1.5.1) update of `androidxAppcompatVersion` requires libraries and applications that depend on it to compile against version 32 (`Android 12L`) or later of the Android APIs. However, this project is currently compiled against android-31 (`Android 12`).

Thus, until the `compileSdkVersion` of this project gets updated to `32`, updating to `1.5.1` isn't possible.

<details>
  <summary>More details</summary> 

  ```
* What went wrong:
Execution failed for task ':WordPress:checkWordpressWasabiDebugAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > 4 issues were found when checking AAR metadata:
     
       1.  Dependency 'androidx.appcompat:appcompat-resources:1.5.1' requires libraries and applications that
           depend on it to compile against version 32 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Recommended action: Update this project to use a newer compileSdkVersion
           of at least 32, for example 32.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
     
       2.  Dependency 'androidx.appcompat:appcompat:1.5.1' requires libraries and applications that
           depend on it to compile against version 32 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Recommended action: Update this project to use a newer compileSdkVersion
           of at least 32, for example 32.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
     
       3.  Dependency 'androidx.emoji2:emoji2-views-helper:1.2.0' requires libraries and applications that
           depend on it to compile against version 32 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Recommended action: Update this project to use a newer compileSdkVersion
           of at least 32, for example 32.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
     
       4.  Dependency 'androidx.emoji2:emoji2:1.2.0' requires libraries and applications that
           depend on it to compile against version 32 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Recommended action: Update this project to use a newer compileSdkVersion
           of at least 32, for example 32.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
  ```

</details>

Also, note that the latest [1.6.0](https://developer.android.com/jetpack/androidx/releases/appcompat#1.6.0) update of `androidxAppcompatVersion` requires libraries and applications that depend on it to compile against version 33 (`Android 13`) or later of the Android APIs. However, this project is currently compiled against android-31 (`Android 12`).

Thus, until the `compileSdkVersion` of this project gets updated to `33`, updating to `1.6.0` isn't possible.

<details>
  <summary>More details</summary> 

  ```
* What went wrong:
Execution failed for task ':WordPress:checkWordpressWasabiDebugAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > 9 issues were found when checking AAR metadata:
     
       1.  Dependency 'androidx.appcompat:appcompat-resources:1.6.0' requires libraries and applications that
           depend on it to compile against version 33 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Also, the maximum recommended compile SDK version for Android Gradle
           plugin 7.2.1 is 32.
     
           Recommended action: Update this project's version of the Android Gradle
           plugin to one that supports 33, then update this project to use
           compileSdkVerion of at least 33.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
     
       2.  Dependency 'androidx.appcompat:appcompat:1.6.0' requires libraries and applications that
           depend on it to compile against version 33 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Also, the maximum recommended compile SDK version for Android Gradle
           plugin 7.2.1 is 32.
     
           Recommended action: Update this project's version of the Android Gradle
           plugin to one that supports 33, then update this project to use
           compileSdkVerion of at least 33.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
     
       3.  Dependency 'androidx.activity:activity:1.6.0' requires libraries and applications that
           depend on it to compile against version 33 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Also, the maximum recommended compile SDK version for Android Gradle
           plugin 7.2.1 is 32.
     
           Recommended action: Update this project's version of the Android Gradle
           plugin to one that supports 33, then update this project to use
           compileSdkVerion of at least 33.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
     
       4.  Dependency 'androidx.activity:activity-ktx:1.6.0' requires libraries and applications that
           depend on it to compile against version 33 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Also, the maximum recommended compile SDK version for Android Gradle
           plugin 7.2.1 is 32.
     
           Recommended action: Update this project's version of the Android Gradle
           plugin to one that supports 33, then update this project to use
           compileSdkVerion of at least 33.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
     
       5.  Dependency 'androidx.emoji2:emoji2-views-helper:1.2.0' requires libraries and applications that
           depend on it to compile against version 32 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Recommended action: Update this project to use a newer compileSdkVersion
           of at least 32, for example 32.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
     
       6.  Dependency 'androidx.emoji2:emoji2:1.2.0' requires libraries and applications that
           depend on it to compile against version 32 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Recommended action: Update this project to use a newer compileSdkVersion
           of at least 32, for example 32.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
     
       7.  Dependency 'androidx.core:core-ktx:1.9.0' requires libraries and applications that
           depend on it to compile against version 33 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Also, the maximum recommended compile SDK version for Android Gradle
           plugin 7.2.1 is 32.
     
           Recommended action: Update this project's version of the Android Gradle
           plugin to one that supports 33, then update this project to use
           compileSdkVerion of at least 33.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
     
       8.  Dependency 'androidx.core:core:1.9.0' requires libraries and applications that
           depend on it to compile against version 33 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Also, the maximum recommended compile SDK version for Android Gradle
           plugin 7.2.1 is 32.
     
           Recommended action: Update this project's version of the Android Gradle
           plugin to one that supports 33, then update this project to use
           compileSdkVerion of at least 33.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
     
       9.  Dependency 'androidx.annotation:annotation-experimental:1.3.0' requires libraries and applications that
           depend on it to compile against version 33 or later of the
           Android APIs.
     
           :WordPress is currently compiled against android-31.
     
           Also, the maximum recommended compile SDK version for Android Gradle
           plugin 7.2.1 is 32.
     
           Recommended action: Update this project's version of the Android Gradle
           plugin to one that supports 33, then update this project to use
           compileSdkVerion of at least 33.
     
           Note that updating a library or application's compileSdkVersion (which
           allows newer APIs to be used) can be done separately from updating
           targetSdkVersion (which opts the app in to new runtime behavior) and
           minSdkVersion (which determines which devices the app can be installed
           on).
  ```

</details>

And since we are (probably) not going to be updating the `compileSdkVersion` to `32`, but instead will go straight to `33`, updating to both `1.5.1`, `1.6.0` and above will not be possible until then.

-----

PS: @ovitrif I added you as the main reviewer, that is, in addition to the @wordpress-mobile/apps-infrastructure team itself, but randomly, since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid.

-----

To test:

1. See the dependency tree diff result and verify correctness.
2. Thoroughly smoke test both, the WordPress and Jetpack apps, and see if they both work as expected.

-----

### Merge instructions

- [x] Wait for #17696 PR to be approved and merged to `deps/main-batch-androidx-core`.
- [x] Make sure this PR's base is automatically updated to `deps/main-batch-androidx-core`.
- [x] Update PR's base `deps/main-batch-androidx-core` branch with latest `trunk`.
- [x] Update PR with latest `deps/main-batch-androidx-core`.
- [x] Remove `[PR] Not Ready For Merge]` label.
- [x] Prepare and update PR to a `Ready for review` state.
- [x] Assign a reviewer.
- [ ] Merge PR to `deps/main-batch-androidx-core`.

-----

## Regression Notes
1. Potential unintended areas of impact

    - Potential breakage of screens and core functionality as `androidx.appcompat` is a library that is being added as a transitive dependency across lots of `androidx` and `com.google` and `other` libraries.
    - Some of the transitive dependencies added might be causing some kind of misbehaviour.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
