### PR TITLE
Fix theme inconsistency when Jetpack migration is restarted

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationResult.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationResult.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.AccessTokenData
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.EmptyData
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.SitesData
+import org.wordpress.android.localcontentmigration.LocalContentEntityData.UserFlagsData
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Companion.EmptyResult
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Failure
 import org.wordpress.android.localcontentmigration.LocalMigrationResult.Success
@@ -73,28 +74,29 @@ fun LocalMigrationResult<LocalContentEntityData, LocalMigrationError>.emitTo(
 }
 
 private fun emitDataToFlow(data: LocalContentEntityData, flow: MutableStateFlow<LocalMigrationState>) {
-    if (flow.value is Initial) {
-        when (data) {
-            is AccessTokenData -> flow.value = Migrating(WelcomeScreenData(avatarUrl = data.avatarUrl))
-            is SitesData -> flow.value = Migrating(WelcomeScreenData(sites = data.sites))
-            else -> Unit
-        }
-    } else {
-        when (data) {
-            is AccessTokenData -> (flow.value as? Migrating)?.let { currentState ->
-                flow.value = Migrating(currentState.data.copy(avatarUrl = data.avatarUrl))
+    when (flow.value) {
+        Initial ->
+            when (data) {
+                is AccessTokenData -> flow.value = Migrating(WelcomeScreenData(avatarUrl = data.avatarUrl))
+                is SitesData -> flow.value = Migrating(WelcomeScreenData(sites = data.sites))
+                is UserFlagsData -> flow.value = Migrating(WelcomeScreenData(prefsMigrated = true))
+                else -> Unit
             }
-            is SitesData -> (flow.value as? Migrating)?.let { currentState ->
-                flow.value = Migrating(currentState.data.copy(sites = data.sites))
+        is Migrating ->
+            when (data) {
+                is AccessTokenData -> flow.value = Migrating(flow.value.data.copy(avatarUrl = data.avatarUrl))
+                is SitesData -> flow.value = Migrating(flow.value.data.copy(sites = data.sites))
+                is UserFlagsData -> flow.value = Migrating(flow.value.data.copy(prefsMigrated = true))
+                else -> Unit
             }
-            else -> Unit
-        }
+        else -> Unit
     }
 }
 
 data class WelcomeScreenData(
     val avatarUrl: String = "",
     val sites: List<SiteModel> = emptyList(),
+    val prefsMigrated: Boolean = false,
 )
 
 sealed class LocalMigrationState(val data: WelcomeScreenData = WelcomeScreenData()) {

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -47,7 +47,7 @@ class LocalMigrationOrchestrator @Inject constructor(
         eligibilityHelper.validate()
             .then(sharedLoginHelper::login).emitTo(migrationStateFlow)
             .then(sitesMigrationHelper::migrateSites).emitTo(migrationStateFlow)
-            .then(userFlagsHelper::migrateUserFlags)
+            .then(userFlagsHelper::migrateUserFlags).emitTo(migrationStateFlow)
             .then(readerSavedPostsHelper::migrateReaderSavedPosts)
             .then(localPostsHelper::migratePosts)
             .orElse { error ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -134,6 +134,10 @@ class JetpackMigrationViewModel @Inject constructor(
             migrationAnalyticsTracker.trackWelcomeScreenShown()
         }
 
+        if (data.prefsMigrated) {
+            _refreshAppTheme.value = Unit
+        }
+
         return Welcome(
             userAvatarUrl = resizeAvatarUrl(data.avatarUrl),
             isProcessing = isContinueClicked,

--- a/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestratorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestratorTest.kt
@@ -197,7 +197,7 @@ class LocalMigrationOrchestratorTest : BaseUnitTest() {
         mockHappyPath()
         val mutableStateFlow: MutableStateFlow<LocalMigrationState> = MutableStateFlow(Initial)
         classToTest.tryLocalMigration(mutableStateFlow)
-        val expected = Successful(WelcomeScreenData(avatarUrl, sites))
+        val expected = Successful(WelcomeScreenData(avatarUrl, sites, true))
         val actual = mutableStateFlow.value
         assertTrue(actual is Successful)
         assertEquals(expected.data, actual.data)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/17740

### Description

This PR emits a state update signalling when the user preferences have been migrated. This enables the migration to apply the theme preference on the first run, which can otherwise be inconsistent when the migration is attempted more than once (i.e. after an interruption).

To test:
1. Install WordPress and login
2. Set the WordPress app theme to dark mode (or the opposite of the system default)
3. Install Jetpack
4. Open Jetpack and expect that the migration Welcome screen is shown
5. Expect that the welcome screen has dark mode set (or whatever was manually set in WordPress)


## Regression Notes
1. Potential unintended areas of impact
Migration flow

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and automated unit tests

7. What automated tests I added (or what prevented me from doing so)
None - I'm not sure this could be reliably covered by a unit test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
