### PR TITLE
Jetpack Focus: Redirect jetpack feature deep links for P4

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenL
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.ShowSignInFlow
 import org.wordpress.android.ui.deeplinks.handlers.DeepLinkHandlers
 import org.wordpress.android.ui.deeplinks.handlers.ServerTrackingHandler
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.viewmodel.Event
@@ -36,7 +37,8 @@ class DeepLinkingIntentReceiverViewModel
     private val serverTrackingHandler: ServerTrackingHandler,
     private val deepLinkTrackingUtils: DeepLinkTrackingUtils,
     private val analyticsUtilsWrapper: AnalyticsUtilsWrapper,
-    private val openWebLinksWithJetpackHelper: DeepLinkOpenWebLinksWithJetpackHelper
+    private val openWebLinksWithJetpackHelper: DeepLinkOpenWebLinksWithJetpackHelper,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) : ScopedViewModel(uiDispatcher) {
     private val _navigateAction = MutableLiveData<Event<NavigateAction>>()
     val navigateAction = _navigateAction as LiveData<Event<NavigateAction>>
@@ -109,7 +111,7 @@ class DeepLinkingIntentReceiverViewModel
      * and builds the navigation action based on them
      */
     private fun handleUrl(uriWrapper: UriWrapper, action: String? = null): Boolean {
-        return buildNavigateAction(uriWrapper)?.also {
+        return interceptNavigationActionIfNeeded(buildNavigateAction(uriWrapper))?.also {
             if (action != null) {
                 deepLinkTrackingUtils.track(action, it, uriWrapper)
             }
@@ -119,6 +121,24 @@ class DeepLinkingIntentReceiverViewModel
                 _navigateAction.value = Event(LoginForResult)
             }
         } != null
+    }
+
+    @Suppress("ComplexMethod")
+    private fun interceptNavigationActionIfNeeded(navigationAction: NavigateAction?): NavigateAction?{
+        if (!jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures())
+            return navigationAction
+
+        return when (navigationAction) {
+           NavigateAction.OpenStats,
+           is NavigateAction.OpenStatsForTimeframe,
+           is NavigateAction.OpenStatsForSite,
+           is NavigateAction.OpenStatsForSiteAndTimeframe,
+           NavigateAction.OpenReader,
+           is NavigateAction.OpenInReader,
+           is NavigateAction.ViewPostInReader,
+           NavigateAction.OpenNotifications -> null
+           else -> navigationAction
+       }
     }
 
     private fun loginIsUnnecessary(action: NavigateAction): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -48,7 +48,6 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFr
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayViewModel;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.ForwardToJetpack;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseFour;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.posts.EditPostActivity;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -48,6 +48,8 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFr
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayViewModel;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.ForwardToJetpack;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseFour;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -163,6 +165,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
     @Inject DeepLinkOpenWebLinksWithJetpackHelper mDeepLinkOpenWebLinksWithJetpackHelper;
     private JetpackFeatureFullScreenOverlayViewModel mJetpackFullScreenViewModel;
     @Inject AccountStore mAccountStore;
+    @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -283,8 +286,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
             host = uri.getHost();
         }
 
-
-        if (uri == null) {
+        if (uri == null || mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
             mReaderTracker.trackDeepLink(AnalyticsTracker.Stat.DEEP_LINKED, action, host, uri);
             // invalid uri so, just show the entry screen
             Intent intent = new Intent(this, WPLaunchActivity.class);

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenI
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.StartCreateSiteFlow
 import org.wordpress.android.ui.deeplinks.handlers.DeepLinkHandlers
 import org.wordpress.android.ui.deeplinks.handlers.ServerTrackingHandler
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.viewmodel.ContextProvider
@@ -53,6 +54,10 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var openWebLinksWithJetpackHelper: DeepLinkOpenWebLinksWithJetpackHelper
+
+    @Mock
+    lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
     private lateinit var viewModel: DeepLinkingIntentReceiverViewModel
     private var isFinished = false
     private lateinit var navigateActions: MutableList<NavigateAction>
@@ -67,7 +72,8 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
             serverTrackingHandler,
             deepLinkTrackingUtils,
             analyticsUtilsWrapper,
-            openWebLinksWithJetpackHelper
+            openWebLinksWithJetpackHelper,
+            jetpackFeatureRemovalPhaseHelper
         )
         isFinished = false
         viewModel.finish.observeForever {


### PR DESCRIPTION
Parent #17339 

This PR intercepts deeps links during phase four as they come into `DeepLinkingIntentReceiverActivity` and `ReaderPostPagerActivity`. Logic will determine if they are Jetpack features and will stop the navigation from taking place. Seamless redirect will work as normal.


**To test:**
Decompress and download the attached links_helper.html file to your device (github doesn't support html file attachments)
[links_helper.html.zip](https://github.com/wordpress-mobile/WordPress-Android/files/10404426/links_helper.html.zip)


*Pre reqs*
- Uninstall all previous versions of JP & WP
- Install the WP APK from this PR and login
- Enable the pre-alpha WP app to handle verified web links links. On a pixel device you will find this under Open By Default > Tap + Add Link > Check all three checkboxes and then click Add.

**Non-Phase 4 Test**
- Tap on each link in the Custom Scheme: Wordpress PreAlpha links section
- ✅ Verify that each link opens to the correct place in the WordPress app
- Tap on  each link in the Custom Scheme: WordPress intents with NO package specified section. Select to open with WP
- ✅ Verify that each link opens to the correct place in the WordPress app
- Tap on each link in the Web Links section 
- ✅ Verify that each link opens to the correct place in the WordPress app


**Phase 4 Test**
- Navigate to Me -> App Settings -> Debug Settings 
- Enable `jp_removal_four` and restart the app
- Tap on each link in the Custom Scheme: Wordpress PreAlpha links section
- ✅ Verify that each link opens to the home view place in the WordPress app
- Tap on  each link in the Custom Scheme: WordPress intents with NO package specified section. Select to open with WP
- ✅ Verify that each link opens to the  home view in the WordPress app
- Tap on each link in the Web Links section 
- ✅ Verify that each link opens to the  home view in the WordPress app


## Regression Notes
1. Potential unintended areas of impact
User are able to deep link into jetpack areas when phase 4 is current

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
