### PR TITLE
[Blogging Prompts] Create feature flag for blogging prompts enhancements

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -110,6 +110,7 @@ android {
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS_LIST", "false"
+        buildConfigField "boolean", "BLOGGING_PROMPTS_ENHANCEMENTS", "false"
         buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"
         buildConfigField "boolean", "QRCODE_AUTH_FLOW", "false"
         buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsEnhancementsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsEnhancementsFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+@FeatureInDevelopment
+class BloggingPromptsEnhancementsFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+    appConfig,
+    BuildConfig.BLOGGING_PROMPTS_ENHANCEMENTS,
+) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && BuildConfig.IS_JETPACK_APP
+    }
+}


### PR DESCRIPTION
Fixes #17759 

This just creates the `BloggingPromptsEnhancementsFeatureConfig` feature flag as a `@FeatureInDevelopment` flag, without using it yet.

https://user-images.githubusercontent.com/5091503/212395936-a0aa6de0-16de-4ce2-8b6c-988ff0825293.mp4

To test:
1. Open the JetPack app (`jalapeno` or `wasabi` builds)
2. Sign in (if not signed in already)
3. Go to the `home` dashboard (`My Site` -> `Home`)
9. Tap `App Settings`
10. Tap `Debug Settings`
11. Scroll down to the "Features in development" section
12. **Verify** the `BloggingPromptsEnhancementsFeatureConfig` option **IS SHOWN**

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
None, as this does not change behavior, just adds a new FF.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
