### PR TITLE
[Blogging Prompts] Change Skip prompt button for better clarity

### DIFF
--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -306,7 +306,6 @@ Language: ar
     <string name="new_site_creation_intents_title">موضوع الموقع</string>
     <string name="quick_start_site_menu_tab_message_short">انقر على &lt;b&gt;%1$s&lt;/b&gt; للمتابعة.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">إزالة من لوحة التحكم</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">تخطي هذه المطالبة</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">عرض مزيد من المطالبات</string>
     <string name="new_site_creation_intents_input_hint">على سبيل المثال الموضة والشعر والسياسة</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d من الإجابات</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -307,7 +307,6 @@ Language: cs_CZ
     <string name="new_site_creation_intents_title">Téma webu</string>
     <string name="quick_start_site_menu_tab_message_short">Pokračujte klepnutím na &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Odebrat z nástěnky</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Přeskočte tuto výzvu</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Zobrazit další výzvy</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Sdílejte výzvu k blogování</string>
     <string name="my_site_blogging_prompt_card_answered_prompt">✓ Odpovězeno</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -307,7 +307,6 @@ Language: de
     <string name="new_site_creation_intents_title">Website-Thema</string>
     <string name="quick_start_site_menu_tab_message_short">Tippe zum Fortfahren auf &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Aus Dashboard entfernen</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Diesen Themenvorschlag überspringen</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Mehr Themenvorschläge anzeigen</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d Antworten</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Blog-Vorschlag teilen</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -255,7 +255,6 @@ Language: en_CA
     <string name="new_site_creation_intents_title">Site topic</string>
     <string name="quick_start_site_menu_tab_message_short">Tap &lt;b&gt;%1$s&lt;/b&gt; to continue.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Remove from dashboard</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Skip this prompt</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">View more prompts</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d answers</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Share blogging prompt</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -303,7 +303,6 @@ Language: en_GB
     <string name="new_site_creation_intents_title">Site topic</string>
     <string name="quick_start_site_menu_tab_message_short">Tap &lt;b&gt;%1$s&lt;/b&gt; to continue.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Remove from dashboard</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Skip this prompt</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">View more prompts</string>
     <string name="site_creation_intent_business">Business</string>
     <string name="site_creation_intent_books">Books</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -221,7 +221,6 @@ Language: es_CO
     <string name="new_site_creation_intents_title">Temática del sitio</string>
     <string name="quick_start_site_menu_tab_message_short">Toca &lt;b&gt;%1$s&lt;/b&gt; para continuar.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Quitar del escritorio</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Omitir este estímulo</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Ver más estímulos</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Comparte el estímulo de bloguear</string>
     <string name="my_site_blogging_prompt_card_answered_prompt">✓ Respondido</string>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -240,7 +240,6 @@ Language: es_VE
     <string name="new_site_creation_intents_title">Temática del sitio</string>
     <string name="quick_start_site_menu_tab_message_short">Toca &lt;b&gt;%1$s&lt;/b&gt; para continuar.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Quitar del escritorio</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Omitir este estímulo</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Ver más estímulos</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Comparte el estímulo de bloguear</string>
     <string name="my_site_blogging_prompt_card_answered_prompt">✓ Respondido</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -316,7 +316,6 @@ Language: es
     <string name="new_site_creation_intents_title">Temática del sitio</string>
     <string name="quick_start_site_menu_tab_message_short">Toca &lt;b&gt;%1$s&lt;/b&gt; para continuar.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Quitar del escritorio</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Omitir este estímulo</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Ver más estímulos</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d respuestas</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Comparte el estímulo de bloguear</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -306,7 +306,6 @@ Language: fr
     <string name="quick_start_site_menu_tab_message_short">Appuyez sur &lt;b&gt;%1$s&lt;/b&gt; pour continuer.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Supprimer du tableau de bord</string>
     <string name="site_creation_intent_art">Art</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Ignorer cette incitation</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Afficher plus d’incitations</string>
     <string name="new_site_creation_intents_input_hint">Par ex. Mode, Poésie, Politique</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d réponses</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -306,7 +306,6 @@ Language: fr
     <string name="quick_start_site_menu_tab_message_short">Appuyez sur &lt;b&gt;%1$s&lt;/b&gt; pour continuer.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Supprimer du tableau de bord</string>
     <string name="site_creation_intent_art">Art</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Ignorer cette incitation</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Afficher plus d’incitations</string>
     <string name="new_site_creation_intents_input_hint">Par ex. Mode, Poésie, Politique</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d réponses</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -278,7 +278,6 @@ Language: gl_ES
     <string name="new_site_creation_intents_title">Temática do sitio</string>
     <string name="quick_start_site_menu_tab_message_short">Toca &lt;b&gt;%1$s&lt;/b&gt; para continuar.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Quitar do escritorio</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Omitir este estímulo</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Ver máis estímulos</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d respostas</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Comparte o estímulo de bloguear</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -307,7 +307,6 @@ Language: he_IL
     <string name="new_site_creation_intents_title">נושא האתר</string>
     <string name="quick_start_site_menu_tab_message_short">יש להקיש &lt;b&gt;%1$s&lt;/b&gt; להמשך.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">להסיר מלוח הבקרה</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">לדלג על הצעה זו</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">להציג הצעות נוספות</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d תשובות</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">לשתף הצעה לפרסום בבלוג</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -307,7 +307,6 @@ Language: id
     <string name="new_site_creation_intents_title">Topik situs</string>
     <string name="quick_start_site_menu_tab_message_short">Ketuk untuk melanjutkan.&lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Hapus dari dasbor</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Lewati prompt ini</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Lihat lebih banyak prompt</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d jawaban</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Bagikan prompt blogging</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -307,7 +307,6 @@ Language: it
     <string name="new_site_creation_intents_title">Tema del sito</string>
     <string name="quick_start_site_menu_tab_message_short">Tocca &lt;b&gt;%1$s&lt;/b&gt; per continuare.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Rimuovi dalla bacheca</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Ignora questa richiesta</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Visualizza altre richieste</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d risposte</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Condividi la richiesta di blogging</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -307,7 +307,6 @@ Language: ja_JP
     <string name="new_site_creation_intents_title">サイトのテーマ</string>
     <string name="quick_start_site_menu_tab_message_short">&lt;b&gt;%1$s&lt;/b&gt; をタップして続行します。</string>
     <string name="my_site_blogging_prompt_card_menu_remove">ダッシュボードから削除</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">このプロンプトをスキップ</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">プロンプトをさらに表示</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d件の回答</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">ブログ作成のプロンプトを共有</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -307,7 +307,6 @@ Language: ko_KR
     <string name="new_site_creation_intents_title">사이트 주제</string>
     <string name="quick_start_site_menu_tab_message_short">계속하려면 &lt;b&gt;%1$s&lt;/b&gt;을(를) 누르세요.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">알림판에서 제거</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">이 프롬프트 건너뛰기</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">더 많은 프롬프트 보기</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d개 답변</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">블로깅 프롬프트 공유</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -297,7 +297,6 @@ Language: nl
     <string name="new_site_creation_intents_title">Onderwerp van de site</string>
     <string name="quick_start_site_menu_tab_message_short">Tik op &lt;b&gt;%1$s&lt;/b&gt; om door te gaan.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Uit dashboard verwijderen</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Sla deze prompt over</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Bekijk meer prompts</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d antwoorden</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Blog-opdracht delen</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -307,7 +307,6 @@ Language: pt_BR
     <string name="new_site_creation_intents_title">Assunto do site</string>
     <string name="quick_start_site_menu_tab_message_short">Toque em &lt;b&gt;%1$s&lt;/b&gt; para continuar.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Remover do painel</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Ignorar esta sugestão</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Visualizar mais sugestões</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d respostas</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Compartilhar sugestão de publicação</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -314,7 +314,6 @@ Language: ro
     <string name="site_creation_intent_art">Artă</string>
     <string name="new_site_creation_intents_title">Subiect site</string>
     <string name="quick_start_site_menu_tab_message_short">Atinge &lt;b&gt;%1$s&lt;/b&gt; pentru a continua.</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Sari peste acest îndemn</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Vezi mai multe îndemnuri</string>
     <string name="new_site_creation_intents_input_hint">De exemplu: modă, poezie, politică</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Înlătură din panoul de control</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -316,7 +316,6 @@ Language: ru
     <string name="new_site_creation_intents_title">Тема сайта</string>
     <string name="quick_start_site_menu_tab_message_short">Нажмите &lt;b&gt;%1$s&lt;/b&gt;, чтобы продолжить.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Удалить с консоли</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Пропустить эту подсказку</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Смотреть другие подсказки</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">Ответы: %d</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Поделиться подсказкой о ведении блога</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -303,7 +303,6 @@ Language: sq_AL
     <string name="new_site_creation_intents_title">Temë sajti</string>
     <string name="quick_start_site_menu_tab_message_short">Prekni &lt;b&gt;%1$s&lt;/b&gt; që të vazhdohet.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Hiqe nga pulti</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Anashkaloje këtë cytje</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Shihni më tepër cytje</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d përgjigje</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Ndani me të tjerë cytje blogimi</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -316,7 +316,6 @@ Language: sv_SE
     <string name="new_site_creation_intents_title">Webbplatsämne</string>
     <string name="quick_start_site_menu_tab_message_short">Tryck &lt;b&gt;%1$s&lt;/b&gt; för att fortsätta.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Ta bort från adminpanelen</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Hoppa över detta förslag</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Visa fler förslag</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d svar</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Dela bloggningsförslag</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -307,7 +307,6 @@ Language: tr
     <string name="new_site_creation_intents_title">Site Konusu</string>
     <string name="quick_start_site_menu_tab_message_short">Devam etmek için &lt;b&gt;%1$s&lt;/b&gt; öğesine dokunun.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Panodan kaldır</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Bu bilgiyi atla</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Daha fazla bilgi görüntüle</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d yanıt</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Blog paylaşma istemi</string>

--- a/WordPress/src/main/res/values-vi/strings.xml
+++ b/WordPress/src/main/res/values-vi/strings.xml
@@ -198,7 +198,6 @@ Language: vi_VN
     <string name="new_site_creation_intents_title">Chủ đề blog</string>
     <string name="quick_start_site_menu_tab_message_short">Nhấn &lt;b&gt;%1$s&lt;/b&gt; để tiếp tục.</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Xóa khỏi trang tổng quan</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Bỏ qua nhắc nhở</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">Xem nhiều nhắc nhở hơn</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Chia sẻ nhắc viết bài</string>
     <string name="my_site_blogging_prompt_card_answered_prompt">✓ Đã trả lời</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -307,7 +307,6 @@ Language: zh_CN
     <string name="new_site_creation_intents_title">站点主题</string>
     <string name="quick_start_site_menu_tab_message_short">轻点“&lt;b&gt;%1$s&lt;/b&gt;”继续。</string>
     <string name="my_site_blogging_prompt_card_menu_remove">从仪表盘中移除</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">跳过此提示</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">查看更多提示</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d 条回复</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">共享博客提示</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -306,7 +306,6 @@ Language: zh_TW
     <string name="new_site_creation_intents_title">網站主題</string>
     <string name="quick_start_site_menu_tab_message_short">點選「&lt;b&gt;%1$s&lt;/b&gt;」以繼續。</string>
     <string name="my_site_blogging_prompt_card_menu_remove">從儀表板移除</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">略過此提示</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">檢視更多提示</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d 個答案</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">分享網誌提示</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -306,7 +306,6 @@ Language: zh_TW
     <string name="new_site_creation_intents_title">網站主題</string>
     <string name="quick_start_site_menu_tab_message_short">點選「&lt;b&gt;%1$s&lt;/b&gt;」以繼續。</string>
     <string name="my_site_blogging_prompt_card_menu_remove">從儀表板移除</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">略過此提示</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">檢視更多提示</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_other">%d 個答案</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">分享網誌提示</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2324,7 +2324,7 @@
     <string name="my_site_blogging_prompt_card_share" translatable="false">@string/share_action</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Share blogging prompt</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">View more prompts</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Skip this prompt</string>
+    <string name="my_site_blogging_prompt_card_menu_skip">Skip for today</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Remove from dashboard</string>
     <string name="my_site_blogging_prompt_card_attribution_dayone">From <b>DayOne</b></string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Learn more</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2325,7 +2325,6 @@
     <string name="my_site_blogging_prompt_card_share" translatable="false">@string/share_action</string>
     <string name="my_site_blogging_prompt_card_share_chooser_title">Share blogging prompt</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">View more prompts</string>
-    <string name="my_site_blogging_prompt_card_menu_skip">Skip this prompt</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Remove from dashboard</string>
     <string name="my_site_blogging_prompt_card_attribution_dayone">From <b>DayOne</b></string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Learn more</string>


### PR DESCRIPTION
Fixes #17733

Rename the skip Blogging Prompts menu item from "Skip this prompt" to "Skip for today". To avoid inconsistencies in other languages, the translations were deleted.

To test:
1. Open the JetPack app (`jalapeno` or `wasabi` builds)
2. Sign in (if not signed in already)
3. Go to the home dashboard (My Site -> Home)
4. **Verify** the Prompts card is shown
5. Tap the 3-dot menu in the Prompts card
4. **Verify** the menu item says "Skip for today"

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None, string changes only.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
