### PR TITLE
Merge editorialized release notes for version 21.5

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -11,20 +11,24 @@ msgstr ""
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_215"
+msgid ""
+"21.5:\n"
+"We’ve been hard at work on extra-technical, behind-the-scenes fixes and updates to keep the Jetpack app running smoothly.\n"
+"\n"
+"- Posticulating features\n"
+"- Rearchitecting interfaces\n"
+"- Reticulating splines\n"
+"- Codifying similitude\n"
+"- Rebuilding the gigaverse\n"
+msgstr ""
+
 msgctxt "release_note_214"
 msgid ""
 "21.4:\n"
 "- You can now add, edit, and delete categories within your site settings.\n"
 "- We fixed a few comment-related translation errors caused by changing your language in App Settings.\n"
 "- You won’t see the Scan Login QR code if your account uses two-factor authentication.\n"
-msgstr ""
-
-msgctxt "release_note_213"
-msgid ""
-"21.3:\n"
-"- Text in the QR code scanning process is translated into your app’s language.\n"
-"- The Notification Settings switch disables weekly roundup, blogging reminder, and site notifications.\n"
-"- We fixed a bug in My Site > Comments that crashed the app for self-hosted sites with certain plugins.\n"
 msgstr ""
 
 #. translators: Title to be displayed in the Play Store. Limit to 30 characters including spaces and commas!

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,2 +1,7 @@
-* [*] [internal] Editor: Only register core blocks when `onlyCoreBlocks` capability is enabled [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5293]
+We’ve been hard at work on extra-technical, behind-the-scenes fixes and updates to keep the Jetpack app running smoothly.
 
+- Posticulating features
+- Rearchitecting interfaces
+- Reticulating splines
+- Codifying similitude
+- Rebuilding the gigaverse

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -11,18 +11,23 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_215"
+msgid ""
+"21.5:\n"
+"We’ve been hard at work on extra-technical, behind-the-scenes fixes and updates to keep the WordPress app running smoothly.\n"
+"\n"
+"- Posticulating features\n"
+"- Rearchitecting interfaces\n"
+"- Reticulating splines\n"
+"- Codifying similitude\n"
+"- Rebuilding the gigaverse\n"
+msgstr ""
+
 msgctxt "release_note_214"
 msgid ""
 "21.4:\n"
 "- You can now add, edit, and delete categories within your site settings.\n"
 "- We fixed a few comment-related translation errors caused by changing your language in App Settings.\n"
-msgstr ""
-
-msgctxt "release_note_213"
-msgid ""
-"21.3:\n"
-"- You can now migrate your site content to the Jetpack app without a hitch.\n"
-"- The Notification Settings switch disables weekly roundup, blogging reminder, and site notifications.\n"
 msgstr ""
 
 #. translators: Shorter Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,2 +1,7 @@
-* [*] [internal] Editor: Only register core blocks when `onlyCoreBlocks` capability is enabled [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5293]
+We’ve been hard at work on extra-technical, behind-the-scenes fixes and updates to keep the WordPress app running smoothly.
 
+- Posticulating features
+- Rearchitecting interfaces
+- Reticulating splines
+- Codifying similitude
+- Rebuilding the gigaverse

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5394-3da49f49e1533dcb92c1b87c425c71eaf345f870'
+    gutenbergMobileVersion = '5394-e38a925144deca0a1c57a52eea8314eba8b8189a'
     wordPressAztecVersion = 'v1.6.2'
     wordPressFluxCVersion = '2.10.0'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5394-e38a925144deca0a1c57a52eea8314eba8b8189a'
+    gutenbergMobileVersion = 'v1.87.1'
     wordPressAztecVersion = 'v1.6.2'
     wordPressFluxCVersion = '2.10.0'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.87.0'
+    gutenbergMobileVersion = '5394-3da49f49e1533dcb92c1b87c425c71eaf345f870'
     wordPressAztecVersion = 'v1.6.2'
     wordPressFluxCVersion = '2.10.0'
     wordPressLoginVersion = '1.0.0'


### PR DESCRIPTION
This release PR includes:

- Editorialized release notes
- A Gutenberg hotfix #17757

I am opening this without a matching beta build to help getting the release notes to translators ASAP.