### PR TITLE
[Blogging prompts] Add empty block below blogging prompts block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/BloggingPromptsEditorBlockMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/BloggingPromptsEditorBlockMapper.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
+import javax.inject.Inject
+
+class BloggingPromptsEditorBlockMapper @Inject constructor() {
+    fun map(bloggingPromptModel: BloggingPromptModel): String =
+        """
+        <!-- wp:pullquote -->
+        <figure class="wp-block-pullquote"><blockquote><p>${bloggingPromptModel.text}</p></blockquote></figure>
+        <!-- /wp:pullquote -->
+        <!-- wp:paragraph -->
+        <p></p>
+        <!-- /wp:paragraph -->
+        """
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
@@ -15,7 +15,8 @@ import javax.inject.Named
 class EditorBloggingPromptsViewModel
 @Inject constructor(
     private val bloggingPromptsStore: BloggingPromptsStore,
-    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    private val bloggingPromptsEditorBlockMapper: BloggingPromptsEditorBlockMapper,
 ) : ScopedViewModel(bgDispatcher) {
     private val _onBloggingPromptLoaded = MutableLiveData<Event<EditorLoadedPrompt>>()
     val onBloggingPromptLoaded: LiveData<Event<EditorLoadedPrompt>> = _onBloggingPromptLoaded
@@ -36,7 +37,8 @@ class EditorBloggingPromptsViewModel
     private fun loadPrompt(site: SiteModel, promptId: Int) = launch {
         val prompt = bloggingPromptsStore.getPromptById(site, promptId).first().model
         prompt?.let {
-            _onBloggingPromptLoaded.postValue(Event(EditorLoadedPrompt(promptId, it.content, BLOGGING_PROMPT_TAG)))
+            val promptsBlock = bloggingPromptsEditorBlockMapper.map(it)
+            _onBloggingPromptLoaded.postValue(Event(EditorLoadedPrompt(promptId, promptsBlock, BLOGGING_PROMPT_TAG)))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
@@ -16,9 +16,9 @@ import javax.inject.Named
 class EditorBloggingPromptsViewModel
 @Inject constructor(
     private val bloggingPromptsStore: BloggingPromptsStore,
-    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val bloggingPromptsEditorBlockMapper: BloggingPromptsEditorBlockMapper,
     private val bloggingPromptsEnhancementsFeatureConfig: BloggingPromptsEnhancementsFeatureConfig,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
 ) : ScopedViewModel(bgDispatcher) {
     private val _onBloggingPromptLoaded = MutableLiveData<Event<EditorLoadedPrompt>>()
     val onBloggingPromptLoaded: LiveData<Event<EditorLoadedPrompt>> = _onBloggingPromptLoaded

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/editor/EditorBloggingPromptsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/editor/EditorBloggingPromptsViewModelTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore.BloggingPromptsResult
 import org.wordpress.android.ui.posts.BLOGGING_PROMPT_TAG
+import org.wordpress.android.ui.posts.BloggingPromptsEditorBlockMapper
 import org.wordpress.android.ui.posts.EditorBloggingPromptsViewModel
 import org.wordpress.android.ui.posts.EditorBloggingPromptsViewModel.EditorLoadedPrompt
 import java.util.Date
@@ -46,12 +47,16 @@ class EditorBloggingPromptsViewModelTest : BaseUnitTest() {
     private val bloggingPromptsStore: BloggingPromptsStore = mock {
         onBlocking { getPromptById(any(), any()) } doReturn flowOf(bloggingPrompt)
     }
+    private val bloggingPromptsEditorBlockMapper: BloggingPromptsEditorBlockMapper = mock {
+        on { it.map(any()) } doReturn (bloggingPrompt.model?.content ?: "")
+    }
 
     @Before
     fun setUp() {
         viewModel = EditorBloggingPromptsViewModel(
             bloggingPromptsStore,
-            testDispatcher()
+            testDispatcher(),
+            bloggingPromptsEditorBlockMapper
         )
 
         viewModel.onBloggingPromptLoaded.observeForever {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/BloggingPromptsEditorBlockMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/BloggingPromptsEditorBlockMapperTest.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.posts
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListFixtures
+
+class BloggingPromptsEditorBlockMapperTest {
+    private val classToTest = BloggingPromptsEditorBlockMapper()
+
+    @Test
+    fun `Should return the mapped blogging prompt block when map is called`() {
+        val prompt = BloggingPromptsListFixtures.DOMAIN_MODEL
+        val actual = classToTest.map(prompt)
+        val expected = """
+        <!-- wp:pullquote -->
+        <figure class="wp-block-pullquote"><blockquote><p>${prompt.text}</p></blockquote></figure>
+        <!-- /wp:pullquote -->
+        <!-- wp:paragraph -->
+        <p></p>
+        <!-- /wp:paragraph -->
+        """
+        assertThat(actual).isEqualTo(expected)
+    }
+}


### PR DESCRIPTION
Fixes #17758 

To test:
1 - Install Jetpack and log in;
2- Open "Debug settings" and make sure `BloggingPromptsEnhancementsFeatureConfig` is **disabled**;
3 - Open "My Site" -> "HOME" with a blog selected;
4 - Tap on "Answer prompt" in the prompts card. You should seen the current behavior of blogging prompts in Editor screen:
<img width="479" alt="Screen Shot 2023-01-16 at 6 33 03 PM" src="https://user-images.githubusercontent.com/14964993/212774280-a3b85aa8-a2c9-4228-9ea6-0beeb1483de1.png">

5 - Open "Debug settings" and **enable** `BloggingPromptsEnhancementsFeatureConfig`;
6 - Open "My Site" -> "HOME" with a blog selected;
7 - Tap on "Answer prompt" in the prompts card. You should see the new behavior of blogging prompts in Editor screen, which is the prompt block with an empty block below it:
<img width="479" alt="Screen Shot 2023-01-16 at 6 32 03 PM" src="https://user-images.githubusercontent.com/14964993/212774295-62003863-71fd-4c0e-87bc-994d33a7c1f7.png">

8 - Publish the prompt and open it on web. Every block should be working as expected.


## Regression Notes
1. Potential unintended areas of impact
Blogging prompt block not working as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit tests.

3. What automated tests I added (or what prevented me from doing so)
Update `EditorBloggingPromptsViewModelTest.kt` and implement `BloggingPromptsEditorBlockMapperTest.kt`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
