### PR TITLE
Fixes: Global overlay freqeuncy logic

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
@@ -14,7 +14,7 @@ class JetpackFeatureOverlayShownTracker @Inject constructor(private val sharedPr
         getFeatureOverlayShownTimeStamp(READER, phase)?.let { overlayShownTimeStampList.add(it) }
         // No jetpack connected feature is accessed yet
         if (overlayShownTimeStampList.isEmpty()) return null
-        return overlayShownTimeStampList.minOf { it }
+        return overlayShownTimeStampList.maxOf { it }
     }
 
     fun getFeatureOverlayShownTimeStamp(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
@@ -7,7 +7,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature.ST
 import javax.inject.Inject
 
 class JetpackFeatureOverlayShownTracker @Inject constructor(private val sharedPrefs: SharedPreferences) {
-    fun getEarliestOverlayShownTime(phase: JetpackFeatureRemovalOverlayPhase): Long? {
+    fun getTheLastShownOverlayTimeStamp(phase: JetpackFeatureRemovalOverlayPhase): Long? {
         val overlayShownTimeStampList: ArrayList<Long> = arrayListOf()
         getFeatureOverlayShownTimeStamp(STATS, phase)?.let { overlayShownTimeStampList.add(it) }
         getFeatureOverlayShownTimeStamp(NOTIFICATIONS, phase)?.let { overlayShownTimeStampList.add(it) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -102,10 +102,10 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
 
     private fun hasExceededGlobalOverlayFrequency(phase: JetpackFeatureRemovalOverlayPhase): Boolean {
         // Overlay is never shown
-        val overlayShownDate = jetpackFeatureOverlayShownTracker.getEarliestOverlayShownTime(phase)
+        val lastOverlayShownDate = jetpackFeatureOverlayShownTracker.getTheLastShownOverlayTimeStamp(phase)
             ?.let { Date(it) } ?: return true
         val daysPastOverlayShown = dateTimeUtilsWrapper.daysBetween(
-            overlayShownDate,
+            lastOverlayShownDate,
             dateTimeUtilsWrapper.getTodaysDate()
         )
         return daysPastOverlayShown >= PhaseOne.globalOverlayFrequency

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
@@ -236,7 +236,7 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
         val featureAccessedMockedTimeinMillis = (System.currentTimeMillis() -
                 (noOfDaysPastFeatureAccessed * ONE_DAY_TIME_IN_MILLIS))
 
-        whenever(jetpackFeatureOverlayShownTracker.getEarliestOverlayShownTime(PHASE_ONE))
+        whenever(jetpackFeatureOverlayShownTracker.getTheLastShownOverlayTimeStamp(PHASE_ONE))
             .thenReturn(featureAccessedMockedTimeinMillis)
 
         setupMockForFeatureAccessed(noOfDaysPastFeatureAccessed)


### PR DESCRIPTION
Fixes #17770 

This PR fixes global overlay frequency logic. The time returned by the `getEarliestOverlayShownTime` earlier was the first shown overlay date. It has now been refactored to return the last overlay shown time. The function naming has been updated as well to `getTheLastShownOverlayTimeStamp`.

## Test instructions 

### Check global frequency logic 

 - Launch the app with jp_removal_one enabled
 - Go to stats/reader/notifications
 - Verify that the overlays are shown
 - Change the device date to 3 days later - global-specific frequency is 2 days
 - Notice that overlays are shown for the first feature which is accessed and not shown if any other jetpack feature is accessed. 

### Check feature-specific frequency logic 
 - Launch the app with jp_removal_one enabled
 - Go to stats/reader/notifications
 - Verify that the overlays are shown
 - Change the device date to 8 days later - feature-specific overlay frequency is 7 days 
 - Notice that overlays are shown for all the features 

## Regression Notes
1. Potential unintended areas of impact
Overlay not shown at the correct frequency

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
