### PR TITLE
Fixes: Site creation overlay and Overlay frequency logic 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
@@ -7,14 +7,14 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature.ST
 import javax.inject.Inject
 
 class JetpackFeatureOverlayShownTracker @Inject constructor(private val sharedPrefs: SharedPreferences) {
-    fun getEarliestOverlayShownTime(phase: JetpackFeatureRemovalOverlayPhase): Long? {
+    fun getTheLastShownOverlayTimeStamp(phase: JetpackFeatureRemovalOverlayPhase): Long? {
         val overlayShownTimeStampList: ArrayList<Long> = arrayListOf()
         getFeatureOverlayShownTimeStamp(STATS, phase)?.let { overlayShownTimeStampList.add(it) }
         getFeatureOverlayShownTimeStamp(NOTIFICATIONS, phase)?.let { overlayShownTimeStampList.add(it) }
         getFeatureOverlayShownTimeStamp(READER, phase)?.let { overlayShownTimeStampList.add(it) }
         // No jetpack connected feature is accessed yet
         if (overlayShownTimeStampList.isEmpty()) return null
-        return overlayShownTimeStampList.minOf { it }
+        return overlayShownTimeStampList.maxOf { it }
     }
 
     fun getFeatureOverlayShownTimeStamp(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -96,10 +96,10 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
 
     private fun hasExceededGlobalOverlayFrequency(phase: JetpackFeatureRemovalOverlayPhase): Boolean {
         // Overlay is never shown
-        val overlayShownDate = jetpackFeatureOverlayShownTracker.getEarliestOverlayShownTime(phase)
+        val lastOverlayShownDate = jetpackFeatureOverlayShownTracker.getTheLastShownOverlayTimeStamp(phase)
                 ?.let { Date(it) } ?: return true
         val daysPastOverlayShown = dateTimeUtilsWrapper.daysBetween(
-                overlayShownDate,
+                lastOverlayShownDate,
                 dateTimeUtilsWrapper.getTodaysDate()
         )
         return daysPastOverlayShown >= PhaseOne.globalOverlayFrequency

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -74,7 +74,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         feature: JetpackOverlayConnectedFeature,
         currentPhasePreference: JetpackFeatureRemovalOverlayPhase
     ): Boolean {
-        return (hasExceededFeatureSpecificOverlayFrequency(feature, currentPhasePreference) ||
+        return (hasExceededFeatureSpecificOverlayFrequency(feature, currentPhasePreference) &&
                 hasExceededGlobalOverlayFrequency(currentPhasePreference))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -90,6 +90,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         mainViewModel.writeToBundle(outState)
     }
 
+    @Suppress("LongMethod")
     private fun observeVMState() {
         mainViewModel.navigationTargetObservable
                 .observe(this, Observer { target -> target?.let { showStep(target) } })

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -11,10 +11,14 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.cancel
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.ActivityLauncherWrapper
+import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.JETPACK_PACKAGE_NAME
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.accounts.HelpActivity.Origin
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayViewModel
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.DismissDialog
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.OpenPlayStore
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
 import org.wordpress.android.ui.main.SitePickerActivity
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface
@@ -48,6 +52,7 @@ import org.wordpress.android.ui.sitecreation.verticals.SiteCreationIntentsViewMo
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.config.SiteNameFeatureConfig
+import org.wordpress.android.util.extensions.exhaustive
 import org.wordpress.android.util.wizard.WizardNavigationTarget
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -69,6 +74,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
     private val siteCreationSiteNameViewModel: SiteCreationSiteNameViewModel by viewModels()
     private val jetpackFullScreenViewModel: JetpackFeatureFullScreenOverlayViewModel by viewModels()
     @Inject internal lateinit var jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil
+    @Inject internal lateinit var activityLauncherWrapper: ActivityLauncherWrapper
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -99,8 +105,10 @@ class SiteCreationActivity : LocaleAwareActivity(),
                         intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
                         Triple(true, null, createSiteState.isSiteTitleTaskComplete)
                     }
-                    is SiteCreationCompleted -> Triple(true, createSiteState.localSiteId,
-                            createSiteState.isSiteTitleTaskComplete)
+                    is SiteCreationCompleted -> Triple(
+                            true, createSiteState.localSiteId,
+                            createSiteState.isSiteTitleTaskComplete
+                    )
                 }
                 intent.putExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, localSiteId)
                 intent.putExtra(SitePickerActivity.KEY_SITE_TITLE_TASK_COMPLETED, titleTaskComplete)
@@ -149,14 +157,27 @@ class SiteCreationActivity : LocaleAwareActivity(),
     }
 
     private fun observeOverlayEvents() {
-        jetpackFullScreenViewModel.action.observe(this) { _ ->
+        val fragment = JetpackFeatureFullScreenOverlayFragment
+                .newInstance(
+                        isSiteCreationOverlay = true,
+                        siteCreationSource = getSiteCreationSource()
+                )
+
+        jetpackFullScreenViewModel.action.observe(this) { action ->
             if (mainViewModel.siteCreationDisabled) finish()
+            when (action) {
+                is OpenPlayStore -> {
+                    fragment.dismiss()
+                    activityLauncherWrapper.openPlayStoreLink(this, JETPACK_PACKAGE_NAME)
+                }
+                is DismissDialog -> {
+                    fragment.dismiss()
+                }
+                else -> fragment.dismiss()
+            }.exhaustive
         }
 
         mainViewModel.showJetpackOverlay.observeEvent(this) {
-            val fragment = JetpackFeatureFullScreenOverlayFragment
-                    .newInstance(isSiteCreationOverlay =  true,
-                            siteCreationSource = getSiteCreationSource())
             if (mainViewModel.siteCreationDisabled)
                 slideInFragment(fragment, JetpackFeatureFullScreenOverlayFragment.TAG)
             else fragment.show(supportFragmentManager, JetpackFeatureFullScreenOverlayFragment.TAG)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
@@ -112,6 +113,11 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
                         PHASE_THREE
                 )
         ).thenReturn(null)
+        whenever(
+                jetpackFeatureOverlayShownTracker.getTheLastShownOverlayTimeStamp(
+                        PHASE_THREE
+                )
+        ).thenReturn(null)
 
         val shouldShowOverlay = jetpackFeatureRemovalOverlayUtil
                 .shouldShowFeatureSpecificJetpackOverlay(STATS)
@@ -124,7 +130,7 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
     fun `given feature is accessed after feature specific frequency, when shouldShowFeatureSpecificJetpackOverlay invoked, then return true`() {
         setupMockForWpComSite()
         // The passed number should exceed the feature specific overlay frequency
-        setupMockForFeatureAccessed(8)
+        setUpMockForEarliestAccessedFeature(8)
 
         val shouldShowOverlay = jetpackFeatureRemovalOverlayUtil
                 .shouldShowFeatureSpecificJetpackOverlay(STATS)
@@ -213,8 +219,7 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
         whenever(dateTimeUtilsWrapper.getTodaysDate()).thenReturn(currentMockedDate)
         whenever(
                 dateTimeUtilsWrapper.daysBetween(
-                        Date(featureAccessedMockedTimeinMillis),
-                        currentMockedDate
+                        any(), any()
                 )
         ).thenReturn(noOfDaysPastFeatureAccessed.toInt())
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
@@ -219,11 +219,11 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
         ).thenReturn(noOfDaysPastFeatureAccessed.toInt())
     }
 
-    private fun setUpMockForEarliestAccessedFeature(noOfDaysPastFeatureAccessed:Long) {
+    private fun setUpMockForEarliestAccessedFeature(noOfDaysPastFeatureAccessed: Long) {
         val featureAccessedMockedTimeinMillis = (System.currentTimeMillis() -
                 (noOfDaysPastFeatureAccessed * ONE_DAY_TIME_IN_MILLIS))
 
-        whenever(jetpackFeatureOverlayShownTracker.getEarliestOverlayShownTime(PHASE_ONE))
+        whenever(jetpackFeatureOverlayShownTracker.getTheLastShownOverlayTimeStamp(PHASE_ONE))
                 .thenReturn(featureAccessedMockedTimeinMillis)
 
         setupMockForFeatureAccessed(noOfDaysPastFeatureAccessed)


### PR DESCRIPTION
Fixes #17770 

## Changes 

### 1. Jetpack Overlay logic
This PR fixes global overlay frequency logic. The time returned by the getEarliestOverlayShownTime earlier was the first shown overlay date. It has now been refactored to return the last overlay shown time. The function naming has been updated as well to getTheLastShownOverlayTimeStamp.

### 2. Site creation overlay inputs
This PR fixes the site creation overlay unresponsive buttons mentioned in the [comment](p5T066-3NG-p2#comment-14234) . 

## Test instructions
### 1. Jetpack overlay logic 

#### Check global frequency logic
 1. Launch the app with `jp_removal_one` enabled
 2. Go to stats/reader/notifications
 3.  Verify that the overlays are shown
 4. Change the device date to 3 days later - global-specific frequency is 2 days
 5. Notice that overlays are shown for the first feature which is accessed and not shown if any other jetpack feature is accessed.

#### Check feature-specific frequency logic
1. Launch the app with `jp_removal_one` enabled
2.  Go to stats/reader/notifications
3. Verify that the overlays are shown
4. Change the device date to 8 days later - feature-specific overlay frequency is 7 days
5. Notice that overlays are shown for all the features

### 2. Site creation overlay 

Site creation has two phases.

Phase One
- This is the phase where we show an overlay but don't fully disable site creation
 - Enable this phase by making sure the "Jetpack Features Removal Phase one" flag is enabled
 - Launch WP app -> Go to my site -> App settings -> Debug settings -> Enable jp_removal_one flag
    
Phase Two
- This is the phase where we show an overlay and fully disable site creation
- Enable this phase by making sure the "Jetpack Features Removal Phase four" flag is enabled
- Launch WP app -> Go to my site -> App settings -> Debug settings -> Enable jp_removal_four flag

Test the following in each phase.

#### Site List flow
- Open the app
- Navigate to Sites list
- Tap plus button
- Tap "Create WordPress.com site"
- If in phase one, make sure an overlay is displayed with a continue button visible, and upon dismissing the overlay, the site creation flow starts
- If in phase two, make sure an overlay is displayed without a continue button visible, and upon dismissing the overlay, nothing happens

## Review Instructions 
- Approval from 2 reviewers is enough for the change 

## Regression Notes
1. Potential unintended areas of impact
Overlay logic not working as intended 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.