### PR TITLE
Stats revamp fix refresh does not work on details screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
@@ -19,7 +19,9 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
 
-    private val viewModel: InsightsDetailViewModel by viewModels()
+    private lateinit var viewModel: InsightsDetailViewModel
+    private val viewsVisitorsDetailViewModel: ViewsVisitorsDetailViewModel by viewModels()
+    private val totalFollowersDetailViewModel: TotalFollowersDetailViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -53,6 +55,14 @@ class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
 
     private fun initializeViewModels(activity: FragmentActivity) {
         val siteId = activity.intent?.getIntExtra(WordPress.LOCAL_SITE_ID, 0) ?: 0
+        val listType = activity.intent.extras?.get(StatsListFragment.LIST_TYPE)
+
+        viewModel = when (listType) {
+            StatsSection.INSIGHT_DETAIL -> viewsVisitorsDetailViewModel
+            StatsSection.TOTAL_FOLLOWERS_DETAIL -> totalFollowersDetailViewModel
+            else -> viewsVisitorsDetailViewModel
+        }
+
         viewModel.init(siteId)
         setupObservers(viewModel)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
@@ -17,12 +17,13 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 
 @AndroidEntryPoint
 class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
-    private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
-
-    private lateinit var viewModel: InsightsDetailViewModel
     private val viewsVisitorsDetailViewModel: ViewsVisitorsDetailViewModel by viewModels()
     private val totalLikesDetailViewModel: TotalLikesDetailViewModel by viewModels()
+    private val totalCommentsDetailViewModel: TotalCommentsDetailViewModel by viewModels()
     private val totalFollowersDetailViewModel: TotalFollowersDetailViewModel by viewModels()
+
+    private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
+    private lateinit var viewModel: InsightsDetailViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -61,6 +62,7 @@ class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
         viewModel = when (listType) {
             StatsSection.INSIGHT_DETAIL -> viewsVisitorsDetailViewModel
             StatsSection.TOTAL_LIKES_DETAIL -> totalLikesDetailViewModel
+            StatsSection.TOTAL_COMMENTS_DETAIL -> totalCommentsDetailViewModel
             StatsSection.TOTAL_FOLLOWERS_DETAIL -> totalFollowersDetailViewModel
             else -> viewsVisitorsDetailViewModel
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
@@ -21,6 +21,7 @@ class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
 
     private lateinit var viewModel: InsightsDetailViewModel
     private val viewsVisitorsDetailViewModel: ViewsVisitorsDetailViewModel by viewModels()
+    private val totalLikesDetailViewModel: TotalLikesDetailViewModel by viewModels()
     private val totalFollowersDetailViewModel: TotalFollowersDetailViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -59,6 +60,7 @@ class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
 
         viewModel = when (listType) {
             StatsSection.INSIGHT_DETAIL -> viewsVisitorsDetailViewModel
+            StatsSection.TOTAL_LIKES_DETAIL -> totalLikesDetailViewModel
             StatsSection.TOTAL_FOLLOWERS_DETAIL -> totalFollowersDetailViewModel
             else -> viewsVisitorsDetailViewModel
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.stats.refresh.TOTAL_FOLLOWERS_DETAIL_USE_CASE
 import org.wordpress.android.ui.stats.refresh.VIEWS_AND_VISITORS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -18,11 +19,9 @@ import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
-@HiltViewModel
-class InsightsDetailViewModel
-@Inject constructor(
-    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-    @Named(VIEWS_AND_VISITORS_USE_CASE) private val detailUseCase: BaseListUseCase,
+abstract class InsightsDetailViewModel (
+    mainDispatcher: CoroutineDispatcher,
+    private val detailUseCase: BaseListUseCase,
     private val statsSiteProvider: StatsSiteProvider,
     private val networkUtilsWrapper: NetworkUtilsWrapper
 ) : ScopedViewModel(mainDispatcher) {
@@ -64,3 +63,19 @@ class InsightsDetailViewModel
         }
     }
 }
+
+@HiltViewModel
+class ViewsVisitorsDetailViewModel @Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(VIEWS_AND_VISITORS_USE_CASE) private val detailUseCase: BaseListUseCase,
+    statsSiteProvider: StatsSiteProvider,
+    networkUtilsWrapper: NetworkUtilsWrapper
+) : InsightsDetailViewModel(mainDispatcher, detailUseCase, statsSiteProvider, networkUtilsWrapper)
+
+@HiltViewModel
+class TotalFollowersDetailViewModel @Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(TOTAL_FOLLOWERS_DETAIL_USE_CASE) detailUseCase: BaseListUseCase,
+    statsSiteProvider: StatsSiteProvider,
+    networkUtilsWrapper: NetworkUtilsWrapper
+) : InsightsDetailViewModel(mainDispatcher, detailUseCase, statsSiteProvider, networkUtilsWrapper)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.R
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.stats.refresh.TOTAL_FOLLOWERS_DETAIL_USE_CASE
+import org.wordpress.android.ui.stats.refresh.TOTAL_LIKES_DETAIL_USE_CASE
 import org.wordpress.android.ui.stats.refresh.VIEWS_AND_VISITORS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
@@ -68,6 +69,14 @@ abstract class InsightsDetailViewModel (
 class ViewsVisitorsDetailViewModel @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
     @Named(VIEWS_AND_VISITORS_USE_CASE) private val detailUseCase: BaseListUseCase,
+    statsSiteProvider: StatsSiteProvider,
+    networkUtilsWrapper: NetworkUtilsWrapper
+) : InsightsDetailViewModel(mainDispatcher, detailUseCase, statsSiteProvider, networkUtilsWrapper)
+
+@HiltViewModel
+class TotalLikesDetailViewModel @Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(TOTAL_LIKES_DETAIL_USE_CASE) detailUseCase: BaseListUseCase,
     statsSiteProvider: StatsSiteProvider,
     networkUtilsWrapper: NetworkUtilsWrapper
 ) : InsightsDetailViewModel(mainDispatcher, detailUseCase, statsSiteProvider, networkUtilsWrapper)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.stats.refresh.TOTAL_COMMENTS_DETAIL_USE_CASE
 import org.wordpress.android.ui.stats.refresh.TOTAL_FOLLOWERS_DETAIL_USE_CASE
 import org.wordpress.android.ui.stats.refresh.TOTAL_LIKES_DETAIL_USE_CASE
 import org.wordpress.android.ui.stats.refresh.VIEWS_AND_VISITORS_USE_CASE
@@ -68,7 +69,7 @@ abstract class InsightsDetailViewModel (
 @HiltViewModel
 class ViewsVisitorsDetailViewModel @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
-    @Named(VIEWS_AND_VISITORS_USE_CASE) private val detailUseCase: BaseListUseCase,
+    @Named(VIEWS_AND_VISITORS_USE_CASE) detailUseCase: BaseListUseCase,
     statsSiteProvider: StatsSiteProvider,
     networkUtilsWrapper: NetworkUtilsWrapper
 ) : InsightsDetailViewModel(mainDispatcher, detailUseCase, statsSiteProvider, networkUtilsWrapper)
@@ -77,6 +78,14 @@ class ViewsVisitorsDetailViewModel @Inject constructor(
 class TotalLikesDetailViewModel @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
     @Named(TOTAL_LIKES_DETAIL_USE_CASE) detailUseCase: BaseListUseCase,
+    statsSiteProvider: StatsSiteProvider,
+    networkUtilsWrapper: NetworkUtilsWrapper
+) : InsightsDetailViewModel(mainDispatcher, detailUseCase, statsSiteProvider, networkUtilsWrapper)
+
+@HiltViewModel
+class TotalCommentsDetailViewModel @Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(TOTAL_COMMENTS_DETAIL_USE_CASE) detailUseCase: BaseListUseCase,
     statsSiteProvider: StatsSiteProvider,
     networkUtilsWrapper: NetworkUtilsWrapper
 ) : InsightsDetailViewModel(mainDispatcher, detailUseCase, statsSiteProvider, networkUtilsWrapper)


### PR DESCRIPTION
This PR fixes pull-to-refresh on Total Likes, Total Comments and Total Followers detail screens

Fixes #17762 

To test:

Test 1
- Launch the JP app.
- On the web, follow your selected site with a different WP account.
- Navigate to Stats.
- Open the Total Followers detail screen by tapping the VIEW MORE button on the Total Followers card.
- On the Web, unfollow your selected site or add a follower.
- Pull-to-refresh the Total Followers detail screen.
- Verify the Total Followers data is refreshed.

Test 2
- Try the above steps, but for Total Likes
- Verify that the Total Likes data refreshes on pull-to-refresh

Test 3
- Try the above steps, but for Total Comments
- Verify that the Total Comments data refreshes on pull-to-refresh

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and automated tests

3. What automated tests I added (or what prevented me from doing so)
Existing tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
