### PR TITLE
Standardize blogging reminders migration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersHelper.kt
@@ -22,7 +22,7 @@ import org.wordpress.android.workers.reminder.ReminderScheduler
 import javax.inject.Inject
 import javax.inject.Named
 
-class BloggingRemindersResolver @Inject constructor(
+class BloggingRemindersHelper @Inject constructor(
     private val jetpackBloggingRemindersSyncFlag: JetpackBloggingRemindersSyncFlag,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val bloggingRemindersSyncAnalyticsTracker: BloggingRemindersSyncAnalyticsTracker,

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationError.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationError.kt
@@ -18,12 +18,14 @@ sealed class LocalMigrationError {
         object SharedLoginDisabled : FeatureDisabled()
         object UserFlagsDisabled : FeatureDisabled()
         object ReaderSavedPostsDisabled : FeatureDisabled()
+        object BloggingRemindersSyncDisabled : FeatureDisabled()
     }
 
     sealed class MigrationAlreadyAttempted : LocalMigrationError() {
         object SharedLoginAlreadyAttempted : MigrationAlreadyAttempted()
         object UserFlagsAlreadyAttempted : MigrationAlreadyAttempted()
         object ReaderSavedPostsAlreadyAttempted : MigrationAlreadyAttempted()
+        object BloggingRemindersSyncAlreadyAttempted : MigrationAlreadyAttempted()
     }
 
     sealed class PersistenceError : LocalMigrationError() {
@@ -31,6 +33,7 @@ sealed class LocalMigrationError {
         object FailedToSaveUserFlags : PersistenceError()
         data class FailedToSaveUserFlagsWithException(val throwable: Throwable) : PersistenceError()
         object FailedToSaveReaderSavedPosts : PersistenceError()
+        data class FailedToSaveBloggingRemindersWithException(val throwable: Throwable) : PersistenceError()
         sealed class LocalPostsPersistenceError : PersistenceError() {
             data class FailedToResetSequenceForPosts(val throwable: Throwable) : LocalPostsPersistenceError()
             data class FailedToInsertLocalPost(val post: PostModel) : LocalPostsPersistenceError()

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationResult.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalMigrationResult.kt
@@ -32,8 +32,8 @@ fun <T : LocalContentEntityData> LocalMigrationResult<LocalContentEntityData, Lo
     is Failure -> this
 }
 
-fun <E : LocalMigrationError> LocalMigrationResult<LocalContentEntityData, E>.orElse(
-    handleError: (E) -> LocalMigrationResult<LocalContentEntityData, LocalMigrationError>
+fun <T : LocalContentEntityData, E : LocalMigrationError> LocalMigrationResult<T, E>.orElse(
+    handleError: (E) -> LocalMigrationResult<T, LocalMigrationError>
 ) = when (this) {
     is Success -> this
     is Failure -> handleError(this.error)

--- a/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestrator.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.sharedlogin.resolver
 
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.wordpress.android.bloggingreminders.resolver.BloggingRemindersHelper
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker.ErrorType.LocalDraftContent
 import org.wordpress.android.localcontentmigration.EligibilityHelper
@@ -42,6 +43,7 @@ class LocalMigrationOrchestrator @Inject constructor(
     private val sitesMigrationHelper: SitesMigrationHelper,
     private val localPostsHelper: LocalPostsHelper,
     private val eligibilityHelper: EligibilityHelper,
+    private val bloggingRemindersHelper: BloggingRemindersHelper,
 ) {
     fun tryLocalMigration(migrationStateFlow: MutableStateFlow<LocalMigrationState>) {
         eligibilityHelper.validate()
@@ -50,6 +52,7 @@ class LocalMigrationOrchestrator @Inject constructor(
             .then(userFlagsHelper::migrateUserFlags)
             .then(readerSavedPostsHelper::migrateReaderSavedPosts)
             .then(localPostsHelper::migratePosts)
+            .then(bloggingRemindersHelper::migrateBloggingReminders)
             .orElse { error ->
                 migrationStateFlow.value = when (error) {
                     is Ineligibility -> Ineligible

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -36,7 +36,6 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
-import org.wordpress.android.bloggingreminders.resolver.BloggingRemindersHelper;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
@@ -172,7 +171,6 @@ import static org.wordpress.android.push.NotificationsProcessingService.ARG_NOTI
 import static org.wordpress.android.ui.JetpackConnectionSource.NOTIFICATIONS;
 
 import dagger.hilt.android.AndroidEntryPoint;
-import kotlin.Unit;
 
 /**
  * Main activity which hosts sites, reader, me and notifications pages

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -264,7 +264,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Inject WeeklyRoundupScheduler mWeeklyRoundupScheduler;
     @Inject MySiteDashboardTodaysStatsCardFeatureConfig mTodaysStatsCardFeatureConfig;
     @Inject QuickStartTracker mQuickStartTracker;
-    @Inject BloggingRemindersHelper mBloggingRemindersHelper;
     @Inject JetpackAppMigrationFlowUtils mJetpackAppMigrationFlowUtils;
     @Inject DeepLinkOpenWebLinksWithJetpackHelper mDeepLinkOpenWebLinksWithJetpackHelper;
     @Inject OpenWebLinksWithJetpackFlowFeatureConfig mOpenWebLinksWithJetpackFlowFeatureConfig;
@@ -1657,9 +1656,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 mSelectedSiteRepository.updateSite(site);
             }
         }
-        mBloggingRemindersHelper.trySyncBloggingReminders(
-                () -> Unit.INSTANCE, () -> Unit.INSTANCE
-        );
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -36,7 +36,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
-import org.wordpress.android.bloggingreminders.resolver.BloggingRemindersResolver;
+import org.wordpress.android.bloggingreminders.resolver.BloggingRemindersHelper;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
@@ -264,7 +264,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Inject WeeklyRoundupScheduler mWeeklyRoundupScheduler;
     @Inject MySiteDashboardTodaysStatsCardFeatureConfig mTodaysStatsCardFeatureConfig;
     @Inject QuickStartTracker mQuickStartTracker;
-    @Inject BloggingRemindersResolver mBloggingRemindersResolver;
+    @Inject BloggingRemindersHelper mBloggingRemindersHelper;
     @Inject JetpackAppMigrationFlowUtils mJetpackAppMigrationFlowUtils;
     @Inject DeepLinkOpenWebLinksWithJetpackHelper mDeepLinkOpenWebLinksWithJetpackHelper;
     @Inject OpenWebLinksWithJetpackFlowFeatureConfig mOpenWebLinksWithJetpackFlowFeatureConfig;
@@ -1657,7 +1657,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 mSelectedSiteRepository.updateSite(site);
             }
         }
-        mBloggingRemindersResolver.trySyncBloggingReminders(
+        mBloggingRemindersHelper.trySyncBloggingReminders(
                 () -> Unit.INSTANCE, () -> Unit.INSTANCE
         );
     }

--- a/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersHelperTest.kt
@@ -37,7 +37,7 @@ import java.time.DayOfWeek
 // TODO: adapt these tests to the unified provider / orchestrator approach
 @Ignore("Disabled for now: will refactor in another PR after unification.")
 @ExperimentalCoroutinesApi
-class BloggingRemindersResolverTest : BaseUnitTest() {
+class BloggingRemindersHelperTest : BaseUnitTest() {
     private val jetpackBloggingRemindersSyncFlag: JetpackBloggingRemindersSyncFlag = mock()
     private val contextProvider: ContextProvider = mock()
     private val wordPressPublicData: WordPressPublicData = mock()
@@ -49,7 +49,7 @@ class BloggingRemindersResolverTest : BaseUnitTest() {
     private val reminderScheduler: ReminderScheduler = mock()
     private val bloggingRemindersModelMapper: BloggingRemindersModelMapper = mock()
     private val localMigrationContentResolver: LocalMigrationContentResolver = mock()
-    private val classToTest = BloggingRemindersResolver(
+    private val classToTest = BloggingRemindersHelper(
         jetpackBloggingRemindersSyncFlag,
         appPrefsWrapper,
         bloggingRemindersSyncAnalyticsTracker,

--- a/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersHelperTest.kt
@@ -55,7 +55,6 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
         bloggingRemindersSyncAnalyticsTracker,
         siteStore,
         bloggingRemindersStore,
-        testScope(),
         reminderScheduler,
         bloggingRemindersModelMapper,
         localMigrationContentResolver,
@@ -85,7 +84,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
     @Test
     fun `Should track start if feature flag is ENABLED and IS first try`() {
         featureEnabled()
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(bloggingRemindersSyncAnalyticsTracker).trackStart()
     }
 
@@ -93,7 +92,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
     fun `Should trigger failure callback if feature flag is DISABLED`() {
         whenever(jetpackBloggingRemindersSyncFlag.isEnabled()).thenReturn(false)
         val onFailure: () -> Unit = mock()
-        classToTest.trySyncBloggingReminders({}, onFailure)
+        classToTest.migrateBloggingReminders()
         verify(onFailure).invoke()
     }
 
@@ -102,21 +101,21 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
         whenever(appPrefsWrapper.getIsFirstTryBloggingRemindersSyncJetpack()).thenReturn(false)
         whenever(jetpackBloggingRemindersSyncFlag.isEnabled()).thenReturn(true)
         val onFailure: () -> Unit = mock()
-        classToTest.trySyncBloggingReminders({}, onFailure)
+        classToTest.migrateBloggingReminders()
         verify(onFailure).invoke()
     }
 
     @Test
     fun `Should save IS NOT first try sync blogging reminders as FALSE if feature flag is ENABLED and IS first try`() {
         featureEnabled()
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(appPrefsWrapper).saveIsFirstTryBloggingRemindersSyncJetpack(false)
     }
 
     @Test
     fun `Should NOT query ContentResolver if feature flag is DISABLED`() {
         whenever(jetpackBloggingRemindersSyncFlag.isEnabled()).thenReturn(false)
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(contentResolverWrapper, never()).queryUri(any(), any())
     }
 
@@ -124,14 +123,14 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
     fun `Should NOT query ContentResolver if IS NOT the first try`() {
         whenever(appPrefsWrapper.getIsFirstTryBloggingRemindersSyncJetpack()).thenReturn(false)
         whenever(jetpackBloggingRemindersSyncFlag.isEnabled()).thenReturn(true)
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(contentResolverWrapper, never()).queryUri(any(), any())
     }
 
     @Test
     fun `Should query ContentResolver if feature flag is ENABLED and IS first try`() {
         featureEnabled()
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
 //        verify(contentResolverWrapper).queryUri(contentResolver, uriValue)
     }
 
@@ -139,7 +138,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
     fun `Should track failed with error QueryBloggingRemindersError if cursor is null`() {
         featureEnabled()
 //        whenever(contentResolverWrapper.queryUri(contentResolver, uriValue)).thenReturn(null)
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(bloggingRemindersSyncAnalyticsTracker).trackFailed(QueryBloggingRemindersError)
     }
 
@@ -148,14 +147,14 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
         featureEnabled()
 //        whenever(contentResolverWrapper.queryUri(contentResolver, uriValue)).thenReturn(null)
         val onFailure: () -> Unit = mock()
-        classToTest.trySyncBloggingReminders({}, onFailure)
+        classToTest.migrateBloggingReminders()
         verify(onFailure).invoke()
     }
 
     @Test
     fun `Should track success with reminders synced count 0 if result map is empty`() {
         featureEnabled()
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(bloggingRemindersSyncAnalyticsTracker).trackSuccess(0)
     }
 
@@ -163,7 +162,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
     fun `Should trigger failure callback if result map is empty`() {
         featureEnabled()
         val onSuccess: () -> Unit = mock()
-        classToTest.trySyncBloggingReminders(onSuccess) {}
+        classToTest.migrateBloggingReminders()
         verify(onSuccess).invoke()
     }
 
@@ -177,7 +176,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
             "[{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
                     ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(bloggingRemindersSyncAnalyticsTracker).trackSuccess(1)
     }
 
@@ -191,7 +190,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
                     ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
         val onSuccess: () -> Unit = mock()
-        classToTest.trySyncBloggingReminders(onSuccess) {}
+        classToTest.migrateBloggingReminders()
         verify(onSuccess).invoke()
     }
 
@@ -205,7 +204,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
             "[{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
                     ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(bloggingRemindersStore, times(1)).updateBloggingReminders(
             BloggingRemindersModel(
                 siteId = validLocalId,
@@ -227,7 +226,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
             "[{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
                     ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(bloggingRemindersModelMapper).toUiModel(userSetBloggingRemindersModel)
     }
 
@@ -241,7 +240,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
             "[{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
                     ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(reminderScheduler).schedule(
             validLocalId,
             bloggingRemindersUiModel.hour,
@@ -258,7 +257,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
             "[{\"enabledDays\":[\"MONDAY\"],\"hour\":5" +
                     ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":$invalidLocalId}}]"
         )
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(bloggingRemindersStore, times(0)).updateBloggingReminders(any())
     }
 
@@ -271,7 +270,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
             "[{\"enabledDays\":[],\"hour\":5" +
                     ",\"isPromptIncluded\":false,\"minute\":43,\"siteId\":123}]"
         )
-        classToTest.trySyncBloggingReminders({}, {})
+        classToTest.migrateBloggingReminders()
         verify(bloggingRemindersStore, times(0)).updateBloggingReminders(any())
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestratorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestratorTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.bloggingreminders.resolver.BloggingRemindersHelper
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker
@@ -19,6 +20,7 @@ import org.wordpress.android.localcontentmigration.LocalContentEntity.ReaderPost
 import org.wordpress.android.localcontentmigration.LocalContentEntity.Sites
 import org.wordpress.android.localcontentmigration.LocalContentEntity.UserFlags
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.AccessTokenData
+import org.wordpress.android.localcontentmigration.LocalContentEntityData.BloggingRemindersData
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.Companion.IneligibleReason.LocalDraftContentIsPresent
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.Companion.IneligibleReason.WPNotLoggedIn
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.EligibilityStatusData
@@ -59,6 +61,7 @@ class LocalMigrationOrchestratorTest : BaseUnitTest() {
     private val sitesMigrationHelper: SitesMigrationHelper = mock()
     private val localPostsHelper: LocalPostsHelper = mock()
     private val eligibilityHelper: EligibilityHelper = mock()
+    private val bloggingRemindersHelper: BloggingRemindersHelper = mock()
     private val classToTest = LocalMigrationOrchestrator(
         sharedLoginAnalyticsTracker,
         migrationAnalyticsTracker,
@@ -68,6 +71,7 @@ class LocalMigrationOrchestratorTest : BaseUnitTest() {
         sitesMigrationHelper,
         localPostsHelper,
         eligibilityHelper,
+        bloggingRemindersHelper,
     )
     private val avatarUrl = "avatarUrl"
     private val sites = listOf(SiteModel(), SiteModel())
@@ -211,6 +215,8 @@ class LocalMigrationOrchestratorTest : BaseUnitTest() {
         whenever(readerSavedPostsHelper.migrateReaderSavedPosts())
             .thenReturn(Success(ReaderPostsData(ReaderPostList())))
         whenever(localPostsHelper.migratePosts()).thenReturn(Success(PostData(PostModel())))
+        whenever(bloggingRemindersHelper.migrateBloggingReminders())
+            .thenReturn(Success(BloggingRemindersData(listOf())))
     }
 
     private fun assertFailure(error: ProviderError) {


### PR DESCRIPTION
Fixes #17752 

### Description

This PR updates the blogging reminders migration step, and moves its invocation to the orchestrator so that the data is migrated during the main migration flow (instead of afterwards in response to an `onSiteChanged` event). This makes the complete flow more robust in the case that a deep link lands in a place where `onSiteChanged` is not subscribed for the blogging reminders migration to complete (relevant to https://github.com/wordpress-mobile/WordPress-Android/pull/17742)

To test:

1. Install WordPress and log in
2. Add blogging prompts to one or more sites
3. Install and run Jetpack using the same variant (e.g. if installed WordPress version was `jalapenoDebug`, install Jetpack `jalapenoDebug`) - expect to see the migration welcome screen
4. Follow the steps to complete the migration
5. Check if the blogging prompts set on step 2 were set correctly in the site settings
6. Change the device date/time ahead of the scheduled time of the reminder. A local notification should be triggered, and tapping on it should open the Editor.

## Regression Notes
1. Potential unintended areas of impact
Migration flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and automated tests.

3. What automated tests I added (or what prevented me from doing so)
The automated tests for this helper are currently disabled, and re-enabling them is large enough scope for a dedicated PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
