### PR TITLE
Add switch to Jetpack in menu items on Phase 4 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
@@ -287,22 +287,40 @@ class JetpackFeatureOverlayContentBuilder @Inject constructor(
             JetpackFeatureOverlayComponentVisibility.FeatureCollectionPhase.PhaseThree()
         else
             JetpackFeatureOverlayComponentVisibility.FeatureCollectionPhase.Final()
-        val content = getContentForFeatureCollection(isRtl, blogPostLink)
+        val content = getContentForFeatureCollection(isRtl, blogPostLink, currentPhase)
         return JetpackFeatureOverlayUIState(componentVisibility, content)
     }
 
-    private fun getContentForFeatureCollection(isRtl: Boolean, blogPostLink: String?): JetpackFeatureOverlayContent {
-        return JetpackFeatureOverlayContent(
-            illustration = if (isRtl) R.raw.jp_all_features_rtl else R.raw.jp_all_features_left,
-            title = R.string.wp_jetpack_feature_removal_overlay_phase_two_and_three_title_all_features,
-            caption = UiStringRes(R.string.wp_jetpack_feature_removal_overlay_phase_three_all_features_description),
-            migrationText = R.string.wp_jetpack_feature_removal_overlay_migration_helper_text,
-            migrationInfoText = if (!blogPostLink.isNullOrEmpty())
-                R.string.wp_jetpack_feature_removal_overlay_learn_more_migration_text else null,
-            migrationInfoUrl = blogPostLink,
-            primaryButtonText = R.string.wp_jetpack_feature_removal_overlay_switch_to_the_jetpack_app,
-            secondaryButtonText = R.string.wp_jetpack_feature_removal_overlay_continue_without_jetpack
-        )
+    private fun getContentForFeatureCollection(
+        isRtl: Boolean,
+        blogPostLink: String?,
+        currentPhase: JetpackFeatureRemovalPhase
+    ): JetpackFeatureOverlayContent {
+        return if (currentPhase == PhaseThree) {
+            JetpackFeatureOverlayContent(
+                illustration = if (isRtl) R.raw.jp_all_features_rtl else R.raw.jp_all_features_left,
+                title = R.string.wp_jetpack_feature_removal_overlay_phase_two_and_three_title_all_features,
+                caption = UiStringRes(R.string.wp_jetpack_feature_removal_overlay_phase_three_all_features_description),
+                migrationText = R.string.wp_jetpack_feature_removal_overlay_migration_helper_text,
+                migrationInfoText = if (!blogPostLink.isNullOrEmpty())
+                    R.string.wp_jetpack_feature_removal_overlay_learn_more_migration_text else null,
+                migrationInfoUrl = blogPostLink,
+                primaryButtonText = R.string.wp_jetpack_feature_removal_overlay_switch_to_the_jetpack_app,
+                secondaryButtonText = R.string.wp_jetpack_feature_removal_overlay_continue_without_jetpack
+            )
+        } else {
+            JetpackFeatureOverlayContent(
+                illustration = if (isRtl) R.raw.jp_all_features_rtl else R.raw.jp_all_features_left,
+                title = R.string.wp_jetpack_feature_removal_overlay_phase_four_title_all_features,
+                caption = UiStringRes(R.string.wp_jetpack_feature_removal_overlay_phase_four_all_features_description),
+                migrationText = R.string.wp_jetpack_feature_removal_overlay_migration_helper_text,
+                migrationInfoText = if (!blogPostLink.isNullOrEmpty())
+                    R.string.wp_jetpack_feature_removal_overlay_learn_more_migration_text else null,
+                migrationInfoUrl = blogPostLink,
+                primaryButtonText = R.string.wp_jetpack_feature_removal_overlay_switch_to_the_jetpack_app,
+                secondaryButtonText = R.string.wp_jetpack_feature_removal_phase_four_secondary_text
+            )
+        }
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackOverlayUIState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackOverlayUIState.kt
@@ -21,8 +21,7 @@ sealed class JetpackFeatureOverlayComponentVisibility(
         override val migrationInfoText: Boolean = true,
         override val closeButton: Boolean = false,
         override val migrationText: Boolean = true
-    ) :
-        JetpackFeatureOverlayComponentVisibility()
+    ) : JetpackFeatureOverlayComponentVisibility()
 
     sealed class SiteCreationPhase : JetpackFeatureOverlayComponentVisibility() {
         class PhaseOne : SiteCreationPhase()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.JetpackFeatureCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinkRibbon
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.JetpackSwitchMenu
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartDynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.InfoItem
@@ -20,6 +21,7 @@ import org.wordpress.android.ui.mysite.cards.dashboard.CardsViewHolder
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptsCardAnalyticsTracker
 import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrationViewHolder
 import org.wordpress.android.ui.mysite.cards.jetpackfeature.JetpackFeatureCardViewHolder
+import org.wordpress.android.ui.mysite.cards.jetpackfeature.JetpackSwitchMenuCardViewHolder
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsViewHolder
 import org.wordpress.android.ui.mysite.cards.quicklinksribbon.QuickLinkRibbonViewHolder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardViewHolder
@@ -69,6 +71,7 @@ class MySiteAdapter(
             MySiteCardAndItem.Type.JETPACK_BADGE.ordinal -> MySiteJetpackBadgeViewHolder(parent)
             MySiteCardAndItem.Type.SINGLE_ACTION_CARD.ordinal -> SingleActionCardViewHolder(parent)
             MySiteCardAndItem.Type.JETPACK_FEATURE_CARD.ordinal -> JetpackFeatureCardViewHolder(parent, uiHelpers)
+            MySiteCardAndItem.Type.JETPACK_SWITCH_CARD.ordinal -> JetpackSwitchMenuCardViewHolder(parent, uiHelpers)
             else -> throw IllegalArgumentException("Unexpected view type")
         }
     }
@@ -87,6 +90,7 @@ class MySiteAdapter(
             is CardsViewHolder -> holder.bind(getItem(position) as DashboardCards)
             is SingleActionCardViewHolder -> holder.bind(getItem(position) as SingleActionCard)
             is JetpackFeatureCardViewHolder -> holder.bind(getItem(position) as JetpackFeatureCard)
+            is JetpackSwitchMenuCardViewHolder -> holder.bind(getItem(position) as JetpackSwitchMenu)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.ui.mysite.cards.dashboard.CardsViewHolder
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptsCardAnalyticsTracker
 import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrationViewHolder
 import org.wordpress.android.ui.mysite.cards.jetpackfeature.JetpackFeatureCardViewHolder
-import org.wordpress.android.ui.mysite.cards.jetpackfeature.JetpackSwitchMenuCardViewHolder
+import org.wordpress.android.ui.mysite.cards.jetpackfeature.SwitchToJetpackMenuCardViewHolder
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsViewHolder
 import org.wordpress.android.ui.mysite.cards.quicklinksribbon.QuickLinkRibbonViewHolder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardViewHolder
@@ -45,6 +45,7 @@ class MySiteAdapter(
     private val quickStartViewPool = RecycledViewPool()
     private var nestedScrollStates = Bundle()
 
+    @Suppress("ComplexMethod")
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MySiteCardAndItemViewHolder<*> {
         return when (viewType) {
             MySiteCardAndItem.Type.QUICK_ACTIONS_CARD.ordinal -> QuickActionsViewHolder(parent, uiHelpers)
@@ -71,7 +72,7 @@ class MySiteAdapter(
             MySiteCardAndItem.Type.JETPACK_BADGE.ordinal -> MySiteJetpackBadgeViewHolder(parent)
             MySiteCardAndItem.Type.SINGLE_ACTION_CARD.ordinal -> SingleActionCardViewHolder(parent)
             MySiteCardAndItem.Type.JETPACK_FEATURE_CARD.ordinal -> JetpackFeatureCardViewHolder(parent, uiHelpers)
-            MySiteCardAndItem.Type.JETPACK_SWITCH_CARD.ordinal -> JetpackSwitchMenuCardViewHolder(parent, uiHelpers)
+            MySiteCardAndItem.Type.JETPACK_SWITCH_CARD.ordinal -> SwitchToJetpackMenuCardViewHolder(parent)
             else -> throw IllegalArgumentException("Unexpected view type")
         }
     }
@@ -90,7 +91,7 @@ class MySiteAdapter(
             is CardsViewHolder -> holder.bind(getItem(position) as DashboardCards)
             is SingleActionCardViewHolder -> holder.bind(getItem(position) as SingleActionCard)
             is JetpackFeatureCardViewHolder -> holder.bind(getItem(position) as JetpackFeatureCard)
-            is JetpackSwitchMenuCardViewHolder -> holder.bind(getItem(position) as JetpackSwitchMenu)
+            is SwitchToJetpackMenuCardViewHolder -> holder.bind(getItem(position) as JetpackSwitchMenu)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.JetpackFeatureCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinkRibbon
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.JetpackSwitchMenu
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartDynamicCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.InfoItem
@@ -33,6 +34,7 @@ object MySiteAdapterDiffCallback : DiffUtil.ItemCallback<MySiteCardAndItem>() {
                         && oldItem.imageResource == updatedItem.imageResource
             }
             oldItem is JetpackFeatureCard && updatedItem is JetpackFeatureCard -> true
+            oldItem is JetpackSwitchMenu && updatedItem is JetpackSwitchMenu -> true
             else -> throw UnsupportedOperationException("Diff not implemented yet")
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -41,7 +41,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         DASHBOARD_CARDS,
         JETPACK_BADGE,
         SINGLE_ACTION_CARD,
-        JETPACK_FEATURE_CARD
+        JETPACK_FEATURE_CARD,
+        JETPACK_SWITCH_CARD
     }
 
     enum class DashboardCardType {
@@ -135,6 +136,13 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
             val onMoreMenuClick: ListItemInteraction,
             val learnMoreUrl: String?,
         ) : Card(JETPACK_FEATURE_CARD)
+
+        data class JetpackSwitchMenu(
+            val onClick: ListItemInteraction,
+            val onRemindMeLaterItemClick: ListItemInteraction,
+            val onHideMenuItemClick: ListItemInteraction,
+            val onMoreMenuClick: ListItemInteraction
+        ) : Card(Type.JETPACK_SWITCH_CARD)
 
         data class DashboardCards(
             val cards: List<DashboardCard>

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -140,7 +140,6 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         data class JetpackSwitchMenu(
             val onClick: ListItemInteraction,
             val onRemindMeLaterItemClick: ListItemInteraction,
-            val onHideMenuItemClick: ListItemInteraction,
             val onMoreMenuClick: ListItemInteraction
         ) : Card(Type.JETPACK_SWITCH_CARD)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -458,6 +458,16 @@ class MySiteViewModel @Inject constructor(
             jetpackFeatureCardHelper.shouldShowJetpackFeatureCard()
         }
 
+        val jetpackSwitchMenu = MySiteCardAndItem.Card.JetpackSwitchMenu(
+            onClick = ListItemInteraction.create(this::onJetpackFeatureCardClick),
+            onHideMenuItemClick = ListItemInteraction.create(this::onJetpackFeatureCardHideMenuItemClick),
+            onRemindMeLaterItemClick = ListItemInteraction.create(this::onJetpackFeatureCardRemindMeLaterClick),
+            onMoreMenuClick = ListItemInteraction.create(this::onJetpackFeatureCardMoreMenuClick)
+        ).takeIf {
+            jetpackFeatureRemovalUtils.shouldHideJetpackFeatures()
+        }
+
+
         val migrationSuccessCard = SingleActionCard(
             textResource = R.string.jp_migration_success_card_message,
             imageResource = R.drawable.ic_wordpress_blue_32dp,
@@ -550,7 +560,10 @@ class MySiteViewModel @Inject constructor(
             } else {
                 null
             }
-        ).takeIf { jetpackBrandingUtils.shouldShowJetpackBranding() }
+        ).takeIf {
+            jetpackBrandingUtils.shouldShowJetpackBranding() &&
+                    !jetpackFeatureRemovalUtils.shouldHideJetpackFeatures()
+        }
 
         return mapOf(
             MySiteTabType.ALL to orderForDisplay(
@@ -560,7 +573,8 @@ class MySiteViewModel @Inject constructor(
                 dynamicCards = dynamicCards,
                 siteItems = siteItems,
                 jetpackBadge = jetpackBadge,
-                jetpackFeatureCard = jetpackFeatureCard
+                jetpackFeatureCard = jetpackFeatureCard,
+                jetpackSwitchMenu = jetpackSwitchMenu
             ),
             MySiteTabType.SITE_MENU to orderForDisplay(
                 infoItem = infoItem,
@@ -575,6 +589,7 @@ class MySiteViewModel @Inject constructor(
                 },
                 siteItems = siteItems,
                 jetpackFeatureCard = jetpackFeatureCard,
+                jetpackSwitchMenu = jetpackSwitchMenu
             ),
             MySiteTabType.DASHBOARD to orderForDisplay(
                 infoItem = infoItem,
@@ -588,7 +603,8 @@ class MySiteViewModel @Inject constructor(
                     listOf()
                 },
                 siteItems = listOf(),
-                jetpackBadge = jetpackBadge
+                jetpackBadge = jetpackBadge,
+                jetpackSwitchMenu = jetpackSwitchMenu
             )
         )
     }
@@ -678,7 +694,8 @@ class MySiteViewModel @Inject constructor(
         dynamicCards: List<MySiteCardAndItem>,
         siteItems: List<MySiteCardAndItem>,
         jetpackBadge: JetpackBadge? = null,
-        jetpackFeatureCard: JetpackFeatureCard? = null
+        jetpackFeatureCard: JetpackFeatureCard? = null,
+        jetpackSwitchMenu: MySiteCardAndItem.Card.JetpackSwitchMenu? = null
     ): List<MySiteCardAndItem> {
         val indexOfDashboardCards = cards.indexOfFirst { it is DashboardCards }
         return mutableListOf<MySiteCardAndItem>().apply {
@@ -693,6 +710,7 @@ class MySiteViewModel @Inject constructor(
             }
             addAll(siteItems)
             jetpackBadge?.let { add(jetpackBadge) }
+            jetpackSwitchMenu?.let { add(jetpackSwitchMenu) }
         }.toList()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -463,7 +463,7 @@ class MySiteViewModel @Inject constructor(
             onRemindMeLaterItemClick = ListItemInteraction.create(this::onSwitchToJetpackMenuCardRemindMeLaterClick),
             onMoreMenuClick = ListItemInteraction.create(this::onJetpackFeatureCardMoreMenuClick)
         ).takeIf {
-            jetpackFeatureRemovalUtils.shouldHideJetpackFeatures()
+            jetpackFeatureRemovalUtils.shouldShowSwitchToJetpackMenuCard()
         }
 
 
@@ -1351,6 +1351,12 @@ class MySiteViewModel @Inject constructor(
     private fun onJetpackFeatureCardRemindMeLaterClick() {
         jetpackFeatureCardHelper.track(Stat.REMOVE_FEATURE_CARD_REMIND_LATER_TAPPED)
         appPrefsWrapper.setJetpackFeatureCardLastShownTimestamp(System.currentTimeMillis())
+        refresh()
+    }
+
+    private fun onSwitchToJetpackMenuCardRemindMeLaterClick() {
+        jetpackFeatureCardHelper.track(Stat.REMOVE_FEATURE_CARD_REMIND_LATER_TAPPED)
+        appPrefsWrapper.setSwitchToJetpackMenuCardLastShownTimestamp(System.currentTimeMillis())
         refresh()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -460,8 +460,7 @@ class MySiteViewModel @Inject constructor(
 
         val jetpackSwitchMenu = MySiteCardAndItem.Card.JetpackSwitchMenu(
             onClick = ListItemInteraction.create(this::onJetpackFeatureCardClick),
-            onHideMenuItemClick = ListItemInteraction.create(this::onJetpackFeatureCardHideMenuItemClick),
-            onRemindMeLaterItemClick = ListItemInteraction.create(this::onJetpackFeatureCardRemindMeLaterClick),
+            onRemindMeLaterItemClick = ListItemInteraction.create(this::onSwitchToJetpackMenuCardRemindMeLaterClick),
             onMoreMenuClick = ListItemInteraction.create(this::onJetpackFeatureCardMoreMenuClick)
         ).takeIf {
             jetpackFeatureRemovalUtils.shouldHideJetpackFeatures()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackSwitchMenuCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackSwitchMenuCardViewHolder.kt
@@ -1,0 +1,58 @@
+package org.wordpress.android.ui.mysite.cards.jetpackfeature
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.widget.PopupMenu
+import org.wordpress.android.R
+import org.wordpress.android.databinding.JetpackFeatureCardBinding
+import org.wordpress.android.databinding.SwitchToJetpackMenuBinding
+import org.wordpress.android.ui.mysite.MySiteCardAndItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.JetpackFeatureCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
+import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.viewBinding
+
+class JetpackSwitchMenuCardViewHolder(
+    parent: ViewGroup,
+    private val uiHelpers: UiHelpers
+) : MySiteCardAndItemViewHolder<SwitchToJetpackMenuBinding>(
+    parent.viewBinding(SwitchToJetpackMenuBinding::inflate)
+) {
+    fun bind(card: MySiteCardAndItem.Card.JetpackSwitchMenu) = with(binding) {
+        mySiteSwitchToJetpackCard.setOnClickListener { card.onClick.click() }
+        switchToAppMoreIcon.setOnClickListener {
+            showMoreMenu(
+                card.onHideMenuItemClick,
+                card.onRemindMeLaterItemClick,
+                card.onMoreMenuClick,
+                switchToAppMoreIcon,
+            )
+        }
+    }
+
+    private fun showMoreMenu(
+        onHideMenuItemClick: ListItemInteraction,
+        onRemindMeLaterClick: ListItemInteraction,
+        onMoreMenuClick: ListItemInteraction,
+        anchor: View
+    ) {
+        onMoreMenuClick.click()
+        val popupMenu = PopupMenu(itemView.context, anchor)
+        popupMenu.setOnMenuItemClickListener {
+            when (it.itemId) {
+                R.id.jetpack_card_menu_item_remind_me_later -> {
+                    onRemindMeLaterClick.click()
+                    return@setOnMenuItemClickListener true
+                }
+                R.id.jetpack_card_menu_item_hide_this -> {
+                    onHideMenuItemClick.click()
+                    return@setOnMenuItemClickListener true
+                }
+                else -> return@setOnMenuItemClickListener true
+            }
+        }
+        popupMenu.inflate(R.menu.jetpack_feature_card_menu)
+        popupMenu.show()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/SwitchToJetpackMenuCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/SwitchToJetpackMenuCardViewHolder.kt
@@ -19,7 +19,6 @@ class SwitchToJetpackMenuCardViewHolder(
         mySiteSwitchToJetpackCard.setOnClickListener { card.onClick.click() }
         switchToAppMoreIcon.setOnClickListener {
             showMoreMenu(
-                card.onHideMenuItemClick,
                 card.onRemindMeLaterItemClick,
                 card.onMoreMenuClick,
                 switchToAppMoreIcon,
@@ -28,7 +27,6 @@ class SwitchToJetpackMenuCardViewHolder(
     }
 
     private fun showMoreMenu(
-        onHideMenuItemClick: ListItemInteraction,
         onRemindMeLaterClick: ListItemInteraction,
         onMoreMenuClick: ListItemInteraction,
         anchor: View
@@ -41,14 +39,10 @@ class SwitchToJetpackMenuCardViewHolder(
                     onRemindMeLaterClick.click()
                     return@setOnMenuItemClickListener true
                 }
-                R.id.jetpack_card_menu_item_hide_this -> {
-                    onHideMenuItemClick.click()
-                    return@setOnMenuItemClickListener true
-                }
                 else -> return@setOnMenuItemClickListener true
             }
         }
-        popupMenu.inflate(R.menu.jetpack_feature_card_menu)
+        popupMenu.inflate(R.menu.switch_to_jetpack_card_menu)
         popupMenu.show()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/SwitchToJetpackMenuCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/SwitchToJetpackMenuCardViewHolder.kt
@@ -4,18 +4,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.PopupMenu
 import org.wordpress.android.R
-import org.wordpress.android.databinding.JetpackFeatureCardBinding
 import org.wordpress.android.databinding.SwitchToJetpackMenuBinding
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.JetpackFeatureCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
 import org.wordpress.android.ui.utils.ListItemInteraction
-import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.extensions.viewBinding
 
-class JetpackSwitchMenuCardViewHolder(
+class SwitchToJetpackMenuCardViewHolder(
     parent: ViewGroup,
-    private val uiHelpers: UiHelpers
 ) : MySiteCardAndItemViewHolder<SwitchToJetpackMenuBinding>(
     parent.viewBinding(SwitchToJetpackMenuBinding::inflate)
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -178,7 +178,8 @@ public class AppPrefs {
         OPEN_WEB_LINKS_WITH_JETPACK_OVERLAY_LAST_SHOWN_TIMESTAMP,
         OPEN_WEB_LINKS_WITH_JETPACK,
         SHOULD_HIDE_JETPACK_FEATURE_CARD,
-        JETPACK_FEATURE_CARD_LAST_SHOWN_TIMESTAMP
+        JETPACK_FEATURE_CARD_LAST_SHOWN_TIMESTAMP,
+        SWITCH_TO_JETPACK_MENU_CARD_SHOWN_TIMESTAMP
     }
 
     /**
@@ -1538,5 +1539,13 @@ public class AppPrefs {
 
     public static void setJetpackFeatureCardLastShownTimestamp(final Long lastShownTimestamp) {
         setLong(DeletablePrefKey.JETPACK_FEATURE_CARD_LAST_SHOWN_TIMESTAMP, lastShownTimestamp);
+    }
+
+    public static Long getSwitchToJetpackMenuCardLastShownTimestamp() {
+        return getLong(DeletablePrefKey.SWITCH_TO_JETPACK_MENU_CARD_SHOWN_TIMESTAMP, 0L);
+    }
+
+    public static void setSwitchToJetpackMenuCardLastShownTimestamp(final Long lastShownTimestamp) {
+        setLong(DeletablePrefKey.SWITCH_TO_JETPACK_MENU_CARD_SHOWN_TIMESTAMP, lastShownTimestamp);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -284,6 +284,12 @@ class AppPrefsWrapper @Inject constructor() {
         AppPrefs.setJetpackFeatureCardLastShownTimestamp(lastShownTimestamp)
     }
 
+    fun getSwitchToJetpackMenuCardLastShownTimestamp(): Long = AppPrefs.getSwitchToJetpackMenuCardLastShownTimestamp()
+
+    fun setSwitchToJetpackMenuCardLastShownTimestamp(lastShownTimestamp: Long) {
+        AppPrefs.setSwitchToJetpackMenuCardLastShownTimestamp(lastShownTimestamp)
+    }
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/main/res/layout/switch_to_jetpack_menu.xml
+++ b/WordPress/src/main/res/layout/switch_to_jetpack_menu.xml
@@ -6,18 +6,34 @@
     android:layout_height="wrap_content">
 
     <ImageView
-        android:id="@+id/switch_to_jetpack_jetpack_icon"
-        style="@style/UpdatedMySiteListRowIcon"
+        android:id="@+id/switch_to_jetpack_icon"
+        android:layout_width="@dimen/my_site_list_row_icon_size"
+        android:layout_height="@dimen/my_site_list_row_icon_size"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
         android:layout_marginBottom="@dimen/margin_large"
         android:layout_marginEnd="@dimen/my_site_list_row_icon_margin_right"
         android:layout_marginTop="@dimen/margin_large"
+        android:gravity="center_vertical"
         android:importantForAccessibility="no"
-        app:icon="@drawable/ic_jetpack_logo_green_24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/switch_to_jetpack_text"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_jetpack_logo_green_24dp" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/switch_to_jetpack_text"
+        style="@style/UpdatedMySiteListRowTextView"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:layout_marginTop="@dimen/margin_large"
+        android:text="@string/wp_jetpack_feature_removal_overlay_switch_to_new_jetpack_app"
+        android:textColor="@color/jetpack_green_50"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/switch_to_app_more_icon"
+        app:layout_constraintStart_toEndOf="@+id/switch_to_jetpack_icon"
         app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
@@ -25,29 +41,10 @@
         style="@style/MySiteListRowSecondaryIcon"
         android:layout_marginStart="@dimen/margin_medium"
         android:importantForAccessibility="no"
-        app:icon="@drawable/ic_more_horiz_white_24dp"
+        app:srcCompat="@drawable/ic_more_horiz_white_24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/switch_to_jetpack_text"
-        app:layout_constraintTop_toTopOf="parent"
-        app:tint="?attr/wpColorOnSurfaceMedium" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline2"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:orientation="vertical" />
-
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/switch_to_jetpack_text"
-        style="@style/UpdatedMySiteListRowTextView"
-        android:layout_marginBottom="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_large"
-        android:textColor="@color/jetpack_green_50"
-        android:text="@string/wp_jetpack_feature_removal_overlay_switch_to_new_jetpack_app"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/switch_to_app_more_icon"
-        app:layout_constraintStart_toEndOf="@+id/switch_to_jetpack_jetpack_icon"
         app:layout_constraintTop_toTopOf="parent" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/switch_to_jetpack_menu.xml
+++ b/WordPress/src/main/res/layout/switch_to_jetpack_menu.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?><!--Publish-->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/my_site_switch_to_jetpack_card"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/switch_to_jetpack_jetpack_icon"
+        style="@style/UpdatedMySiteListRowIcon"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:layout_marginEnd="@dimen/my_site_list_row_icon_margin_right"
+        android:layout_marginTop="@dimen/margin_large"
+        android:importantForAccessibility="no"
+        app:icon="@drawable/ic_jetpack_logo_green_24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/switch_to_jetpack_text"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/switch_to_app_more_icon"
+        style="@style/MySiteListRowSecondaryIcon"
+        android:layout_marginStart="@dimen/margin_medium"
+        android:importantForAccessibility="no"
+        app:icon="@drawable/ic_more_horiz_white_24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/switch_to_jetpack_text"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="?attr/wpColorOnSurfaceMedium" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/switch_to_jetpack_text"
+        style="@style/UpdatedMySiteListRowTextView"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:layout_marginTop="@dimen/margin_large"
+        android:textColor="@color/jetpack_green_50"
+        android:text="@string/wp_jetpack_feature_removal_overlay_switch_to_new_jetpack_app"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/switch_to_app_more_icon"
+        app:layout_constraintStart_toEndOf="@+id/switch_to_jetpack_jetpack_icon"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/switch_to_jetpack_menu.xml
+++ b/WordPress/src/main/res/layout/switch_to_jetpack_menu.xml
@@ -29,7 +29,7 @@
         style="@style/UpdatedMySiteListRowTextView"
         android:layout_marginBottom="@dimen/margin_large"
         android:layout_marginTop="@dimen/margin_large"
-        android:text="@string/wp_jetpack_feature_removal_overlay_switch_to_new_jetpack_app"
+        android:text="@string/wp_jetpack_feature_removal_switch_to_jetpack_app_menu_title"
         android:textColor="@color/jetpack_green_50"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/switch_to_app_more_icon"

--- a/WordPress/src/main/res/menu/switch_to_jetpack_card_menu.xml
+++ b/WordPress/src/main/res/menu/switch_to_jetpack_card_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/jetpack_card_menu_item_remind_me_later"
+        android:title="@string/jetpack_feature_card_menu_item_remind_me_later"
+        android:icon="@drawable/ic_time_white_24dp"/>
+    
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4311,6 +4311,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="wp_jetpack_feature_removal_overlay_switch_to_the_jetpack_app">Switch to the Jetpack app</string>
     <string name="wp_jetpack_feature_removal_overlay_continue_without_jetpack" translatable="false">@string/wp_jetpack_continue_without_jetpack</string>
     <string name="wp_jetpack_feature_removal_overlay_phase_three_all_features_description" translatable="false">@string/wp_jetpack_feature_removal_overlay_phase_two_and_three_description_without_deadline</string>
+    <string name="wp_jetpack_feature_removal_switch_to_jetpack_app_menu_title">Switch to Jetpack </string>
 
     <!-- Deep Linking Activity Aliases -->
     <string name="deep_linking_urilinks_alias_label">urilinks</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4304,6 +4304,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="wp_jetpack_feature_removal_overlay_phase_two_and_three_title_reader">Reader is moving to the Jetpack app</string>
     <string name="wp_jetpack_feature_removal_overlay_phase_two_and_three_title_notifications">Notifications are moving to Jetpack</string>
     <string name="wp_jetpack_feature_removal_overlay_phase_two_and_three_title_all_features">Jetpack features are moving soon.</string>
+    <string name="wp_jetpack_feature_removal_overlay_phase_four_title_all_features">Jetpack features have moved.</string>
+    <string name="wp_jetpack_feature_removal_overlay_phase_four_all_features_description">Stats, Reader, Notifications and other Jetpack powered features have been removed from the WordPress app.</string>
     <string name="wp_jetpack_feature_removal_overlay_phase_two_and_three_description_with_deadline">Stats, Reader, Notifications and other Jetpack powered features will be removed from the WordPress app on %s.</string>
     <string name="wp_jetpack_feature_removal_overlay_phase_two_and_three_description_without_deadline">Stats, Reader, Notifications and other Jetpack powered features will be removed from the WordPress app soon.</string>
     <string name="wp_jetpack_feature_removal_overlay_migration_helper_text">Switching is free and only takes a minute.</string>
@@ -4312,6 +4314,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="wp_jetpack_feature_removal_overlay_continue_without_jetpack" translatable="false">@string/wp_jetpack_continue_without_jetpack</string>
     <string name="wp_jetpack_feature_removal_overlay_phase_three_all_features_description" translatable="false">@string/wp_jetpack_feature_removal_overlay_phase_two_and_three_description_without_deadline</string>
     <string name="wp_jetpack_feature_removal_switch_to_jetpack_app_menu_title">Switch to Jetpack </string>
+    <string name="wp_jetpack_feature_removal_phase_four_secondary_text">Do this later</string>
 
     <!-- Deep Linking Activity Aliases -->
     <string name="deep_linking_urilinks_alias_label">urilinks</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseO
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature.STATS
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.SiteUtilsWrapper
@@ -50,6 +51,9 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
     @Mock
     private lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
 
+    @Mock
+    private lateinit var appPrefsWrapper: AppPrefsWrapper
+
     private lateinit var jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil
 
     private val currentMockedDate = Date(System.currentTimeMillis())
@@ -63,7 +67,8 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
             siteUtilsWrapper,
             buildConfigWrapper,
             dateTimeUtilsWrapper,
-            analyticsTrackerWrapper
+            analyticsTrackerWrapper,
+            appPrefsWrapper
         )
     }
 


### PR DESCRIPTION
Part of #17339 

## Changes 

### 1. Swtich to Jetpack menu 
This PR adds a **Switch to Jetpack** menu item to the bottom of the landing page. On clicking the menu item, the overlay should be shown. This PR also add remind me later option for the menu card which will remove the card from the menu for 4 days and will show up on the landing page after that. 

|Landing page in Phase 4 (light) |  Landing page in Phase 4(dark) | 
|---|---|
| ![Screenshot_20230118_152613](https://user-images.githubusercontent.com/17463767/213141887-8117f791-1fba-46f0-b38f-6518f084ce25.png)  |![nightModePhase4](https://user-images.githubusercontent.com/17463767/213142052-36bb32a9-4d31-4fd2-95a0-54d589df3505.png)|

### 2. Phase 4 overlay content 
This PR adds the necessary strings and logic for showing the Phase 4 overlay on clicking at the menu card

|Jetpack phase 4 Overlay Light | Jetpack phase 4 overlay Dark  |
|---|---|
|![lightModePhase4Overlay](https://user-images.githubusercontent.com/17463767/213150717-66cfb2ac-2758-4b06-baa8-a340bb63035d.png)|![nightModePhase4Overlay](https://user-images.githubusercontent.com/17463767/213150737-2fac0ee7-b3e9-4d1d-8cac-31d67a5645d7.png)|


## 👀 Testing Instructions

1. Launch app 
2. Go to app settings -> debug settings -> and enable "jp_removal_four"
3. Verify the menu card is displayed as the last menu item ✅ 
4. Verify tapping the card displays the overlay ✅ 
5. Verify that the Overlay content shown is as per design in the project spec - [Project spec](pe7hp4-4k-p2)
6. Tap the ellipsis and tap on "Remind me later"
7. The card should be removed
8. Wait for the duration to pass - You can change the device date to a date >4 days for testing purposes
9. Pull to refresh the menu
10. Make sure the menu card is displayed


## Regression Notes
1. Potential unintended areas of impact
- Switch to Jetpack card is not displayed as expected 
- Overlay content shown in phase 4 is not correct

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.