### PR TITLE
[Blogging prompts] Fix DayOne attribution string translation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/CompactBloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/CompactBloggingPromptCardViewHolder.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.main
 
 import android.view.ViewGroup
+import org.wordpress.android.R
 import org.wordpress.android.databinding.BloggingPromptCardCompactBinding
 import org.wordpress.android.ui.main.MainActionListItem.AnswerBloggingPromptAction
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptAttribution.DAY_ONE
@@ -21,6 +22,10 @@ class CompactBloggingPromptCardViewHolder(
         )
         uiHelpers.setTextOrHide(promptContent, cardPrompt)
         uiHelpers.updateVisibility(attributionContainer, action.attribution == DAY_ONE)
+
+        attributionContent.text = htmlCompatWrapper.fromHtml(
+            attributionContent.context.getString(R.string.my_site_blogging_prompt_card_attribution_dayone)
+        )
 
         answerButton.setOnClickListener {
             action.onClickAction?.invoke(action.promptId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts
 
 import android.view.ViewGroup
 import androidx.appcompat.widget.PopupMenu
+import androidx.core.text.HtmlCompat
 import androidx.core.view.MenuCompat
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
@@ -39,6 +40,10 @@ class BloggingPromptCardViewHolder(
         uiHelpers.updateVisibility(answerButton, !card.isAnswered)
 
         uiHelpers.updateVisibility(attributionContainer, card.attribution == DAY_ONE)
+
+        attributionContent.text = htmlCompatWrapper.fromHtml(
+            attributionContent.context.getString(R.string.my_site_blogging_prompt_card_attribution_dayone)
+        )
 
         bloggingPromptCardMenu.setOnClickListener {
             bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuClicked()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts
 
 import android.view.ViewGroup
 import androidx.appcompat.widget.PopupMenu
-import androidx.core.text.HtmlCompat
 import androidx.core.view.MenuCompat
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap

--- a/WordPress/src/main/res/layout/blogging_prompt_card_compact.xml
+++ b/WordPress/src/main/res/layout/blogging_prompt_card_compact.xml
@@ -81,11 +81,12 @@
                 android:src="@drawable/ic_dayone_24dp" />
 
             <TextView
+                android:id="@+id/attribution_content"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/margin_small"
-                android:text="@string/my_site_blogging_prompt_card_attribution_dayone"
-                android:textAppearance="?attr/textAppearanceCaption" />
+                android:textAppearance="?attr/textAppearanceCaption"
+                tools:text="@string/my_site_blogging_prompt_card_attribution_dayone" />
 
         </LinearLayout>
 

--- a/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
+++ b/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
@@ -80,11 +80,12 @@
                 android:src="@drawable/ic_dayone_24dp" />
 
             <TextView
+                android:id="@+id/attribution_content"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/margin_small"
-                android:text="@string/my_site_blogging_prompt_card_attribution_dayone"
-                android:textAppearance="?attr/textAppearanceCaption" />
+                android:textAppearance="?attr/textAppearanceCaption"
+                tools:text="@string/my_site_blogging_prompt_card_attribution_dayone" />
 
         </LinearLayout>
 

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -136,7 +136,6 @@ Language: ar
     <string name="hpp_title">اختيار قالب</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">مطالبة التدوين اليوم التي تم تخطيها</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">معرفة المزيد</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">من </string>
     <string name="stats_follower_types_pie_chart_total_label">الإجماليات</string>
     <string name="stats_referrers_pie_chart_others">الأخرى</string>
     <string name="stats_referrers_pie_chart_search">البحث</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -137,7 +137,6 @@ Language: cs_CZ
     <string name="hpp_title">Zvolit šablonu</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Dnešní výzva k blogování byla přeskočena</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Zjistit více</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Od </string>
     <string name="stats_follower_types_pie_chart_total_label">Celkem</string>
     <string name="stats_referrers_pie_chart_others">Ostatní</string>
     <string name="stats_referrers_pie_chart_search">Hledat</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -137,7 +137,6 @@ Language: de
     <string name="hpp_title">Wähle ein Theme</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Heutigen Blog-Vorschlag übersprungen</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Mehr erfahren</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Von </string>
     <string name="stats_follower_types_pie_chart_total_label">Gesamt</string>
     <string name="stats_referrers_pie_chart_others">Sonstiges</string>
     <string name="stats_referrers_pie_chart_search">Suche</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -85,7 +85,6 @@ Language: en_CA
     <string name="hpp_title">Choose a theme</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Skipped today\'s blogging prompt</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Learn more</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">From </string>
     <string name="stats_follower_types_pie_chart_total_label">Totals</string>
     <string name="stats_referrers_pie_chart_others">Others</string>
     <string name="stats_referrers_pie_chart_search">Search</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -137,7 +137,6 @@ Language: en_GB
     <string name="hpp_title">Choose a theme</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Skipped today\'s blogging prompt</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Learn more</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">From </string>
     <string name="stats_follower_types_pie_chart_total_label">Totals</string>
     <string name="stats_referrers_pie_chart_others">Others</string>
     <string name="stats_referrers_pie_chart_search">Search</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -51,7 +51,6 @@ Language: es_CO
     <string name="hpp_title">Elige un tema</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Me he saltado el estímulo para bloguear de hoy</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Más información</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Desde </string>
     <string name="stats_follower_types_pie_chart_total_label">Totales</string>
     <string name="stats_referrers_pie_chart_others">Otros</string>
     <string name="stats_referrers_pie_chart_search">Buscar</string>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -70,7 +70,6 @@ Language: es_VE
     <string name="hpp_title">Elige un tema</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Me he saltado el estímulo para bloguear de hoy</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Más información</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Desde </string>
     <string name="stats_follower_types_pie_chart_total_label">Totales</string>
     <string name="stats_referrers_pie_chart_others">Otros</string>
     <string name="stats_referrers_pie_chart_search">Buscar</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -146,7 +146,6 @@ Language: es
     <string name="hpp_title">Elige un tema</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Me he saltado el estímulo para bloguear de hoy</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Más información</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Desde </string>
     <string name="stats_follower_types_pie_chart_total_label">Totales</string>
     <string name="stats_referrers_pie_chart_others">Otros</string>
     <string name="stats_referrers_pie_chart_search">Buscar</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -134,7 +134,6 @@ Language: fr
     <string name="hpp_recommended_title">Idéal pour %s</string>
     <string name="hpp_preview_tapped_theme">Prévisualiser le thème %s</string>
     <string name="hpp_title">Choisir un thème</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">De </string>
     <string name="stats_follower_types_pie_chart_total_label">Totaux</string>
     <string name="stats_referrers_pie_chart_others">Autres</string>
     <string name="stats_referrers_pie_chart_search">Rechercher</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -134,7 +134,6 @@ Language: fr
     <string name="hpp_recommended_title">Idéal pour %s</string>
     <string name="hpp_preview_tapped_theme">Prévisualiser le thème %s</string>
     <string name="hpp_title">Choisir un thème</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">De </string>
     <string name="stats_follower_types_pie_chart_total_label">Totaux</string>
     <string name="stats_referrers_pie_chart_others">Autres</string>
     <string name="stats_referrers_pie_chart_search">Rechercher</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -108,7 +108,6 @@ Language: gl_ES
     <string name="hpp_title">Elixe un tema</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Salteime o estímulo para bloguear de hoxe</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Máis información</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Desde </string>
     <string name="stats_follower_types_pie_chart_total_label">Totais</string>
     <string name="stats_referrers_pie_chart_others">Outros</string>
     <string name="stats_referrers_pie_chart_search">Buscar</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -137,7 +137,6 @@ Language: he_IL
     <string name="hpp_title">לבחור ערכת עיצוב</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">דילגת על ההצעה של היום לפרסום בבלוג</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">למידע נוסף</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">מאת </string>
     <string name="stats_follower_types_pie_chart_total_label">סך הכול</string>
     <string name="stats_referrers_pie_chart_others">אחרים</string>
     <string name="stats_referrers_pie_chart_search">לחפש</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -137,7 +137,6 @@ Language: id
     <string name="hpp_title">Pilih tema</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Prompt blogging hari ini yang dilewati</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Pelajari selengkapnya</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Dari </string>
     <string name="stats_follower_types_pie_chart_total_label">Total</string>
     <string name="stats_referrers_pie_chart_others">Lainnya</string>
     <string name="stats_referrers_pie_chart_search">Cari</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -137,7 +137,6 @@ Language: it
     <string name="hpp_title">Scegli un tema</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Richiesta di blogging ignorata oggi</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Scopri di più</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Da </string>
     <string name="stats_follower_types_pie_chart_total_label">Totale</string>
     <string name="stats_referrers_pie_chart_others">Altro</string>
     <string name="stats_referrers_pie_chart_search">Cerca</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -137,7 +137,6 @@ Language: ja_JP
     <string name="hpp_title">テーマを選択</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">今日のブログ作成のプロンプトをスキップしました</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">さらに詳しく</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">から </string>
     <string name="stats_follower_types_pie_chart_total_label">合計</string>
     <string name="stats_referrers_pie_chart_others">その他</string>
     <string name="stats_referrers_pie_chart_search">検索</string>

--- a/WordPress/src/main/res/values-kmr/strings.xml
+++ b/WordPress/src/main/res/values-kmr/strings.xml
@@ -17,7 +17,6 @@ Language: ku_TR
     <string name="post_settings_author">Nivîskar</string>
     <string name="app_rating_title">%s ket serê te?</string>
     <string name="stats_referrers_pie_chart_total_label">Dîtin</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Ji</string>
     <string name="stats_referrers_pie_chart_search">Lê bigere</string>
     <string name="stats_referrers_pie_chart_others">Yên din</string>
     <string name="stats_follower_types_pie_chart_total_label">Giştî</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -137,7 +137,6 @@ Language: ko_KR
     <string name="hpp_title">테마 선택</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">건너뛴 오늘의 블로깅 프롬프트</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">더 알아보기</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">시작 </string>
     <string name="stats_follower_types_pie_chart_total_label">합계</string>
     <string name="stats_referrers_pie_chart_others">기타</string>
     <string name="stats_referrers_pie_chart_search">검색</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -127,7 +127,6 @@ Language: nl
     <string name="hpp_title">Kies een thema</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Heeft de blogmelding van vandaag overgeslagen</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Meer informatie</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Van </string>
     <string name="stats_follower_types_pie_chart_total_label">Totalen</string>
     <string name="stats_referrers_pie_chart_others">Anderen</string>
     <string name="stats_referrers_pie_chart_search">Zoeken</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -137,7 +137,6 @@ Language: pt_BR
     <string name="hpp_title">Escolha um tema</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Sugestão de publicação do dia ignorada</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Saiba mais</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">De </string>
     <string name="stats_follower_types_pie_chart_total_label">Totais</string>
     <string name="stats_referrers_pie_chart_others">Outros</string>
     <string name="stats_referrers_pie_chart_search">Pesquisa</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -151,7 +151,6 @@ Language: ro
     <string name="stats_follower_types_pie_chart_total_label">Total</string>
     <string name="stats_referrers_pie_chart_others">Altele</string>
     <string name="stats_referrers_pie_chart_search">Caută</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Din</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Azi am omis îndemnul pentru publicare</string>
     <string name="stats_action_card_schedule_post_title">Îți programezi articolele</string>
     <string name="stats_action_card_blogging_reminders_button_label">Setează reamintirile</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -146,7 +146,6 @@ Language: ru
     <string name="hpp_title">Выберите тему</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Пропущенная подсказка по ведению блога</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Узнать больше</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">От </string>
     <string name="stats_follower_types_pie_chart_total_label">Всего</string>
     <string name="stats_referrers_pie_chart_others">Другие</string>
     <string name="stats_referrers_pie_chart_search">Поиск</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -135,7 +135,6 @@ Language: sq_AL
     <string name="hpp_title">Zgjidhni një temë</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">U anashkalua cytja e sotme për blogim</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Mësoni më tepër</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Nga</string>
     <string name="stats_follower_types_pie_chart_total_label">Gjithsej</string>
     <string name="stats_referrers_pie_chart_others">Të tjera</string>
     <string name="stats_referrers_pie_chart_search">Kërkim</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -146,7 +146,6 @@ Language: sv_SE
     <string name="hpp_title">Välj ett tema</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Hoppade över dagens bloggningsförslag</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Läs mer</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Från </string>
     <string name="stats_follower_types_pie_chart_total_label">Totalt</string>
     <string name="stats_referrers_pie_chart_others">Övriga</string>
     <string name="stats_referrers_pie_chart_search">Sök</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -137,7 +137,6 @@ Language: tr
     <string name="hpp_title">Bir tema seçin</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Bugünün blog istemi atlandı</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Daha fazlasını öğrenin</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Kimden </string>
     <string name="stats_follower_types_pie_chart_total_label">Toplam</string>
     <string name="stats_referrers_pie_chart_others">Diğerleri</string>
     <string name="stats_referrers_pie_chart_search">Ara</string>

--- a/WordPress/src/main/res/values-vi/strings.xml
+++ b/WordPress/src/main/res/values-vi/strings.xml
@@ -29,7 +29,6 @@ Language: vi_VN
     <string name="hpp_title">Chọn một chủ đề</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Bỏ qua nhắc nhở hôm nay</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Tìm hiểu thêm</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">Từ</string>
     <string name="stats_follower_types_pie_chart_total_label">Tổng cộng</string>
     <string name="stats_referrers_pie_chart_others">Khác</string>
     <string name="stats_referrers_pie_chart_search">Tìm kiếm</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -137,7 +137,6 @@ Language: zh_CN
     <string name="hpp_title">选择主题</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">跳过今日的博客提示</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">了解更多</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">来源 </string>
     <string name="stats_follower_types_pie_chart_total_label">共计</string>
     <string name="stats_referrers_pie_chart_others">其他</string>
     <string name="stats_referrers_pie_chart_search">搜索</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -136,7 +136,6 @@ Language: zh_TW
     <string name="hpp_title">選擇佈景主題</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">已略過今天的網誌提示</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">瞭解更多</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">來自 </string>
     <string name="stats_follower_types_pie_chart_total_label">總計</string>
     <string name="stats_referrers_pie_chart_others">其他</string>
     <string name="stats_referrers_pie_chart_search">搜尋</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -136,7 +136,6 @@ Language: zh_TW
     <string name="hpp_title">選擇佈景主題</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">已略過今天的網誌提示</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">瞭解更多</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">來自 </string>
     <string name="stats_follower_types_pie_chart_total_label">總計</string>
     <string name="stats_referrers_pie_chart_others">其他</string>
     <string name="stats_referrers_pie_chart_search">搜尋</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2321,7 +2321,7 @@
     <string name="my_site_blogging_prompt_card_menu_view_more">View more prompts</string>
     <string name="my_site_blogging_prompt_card_menu_skip">Skip for today</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Remove from dashboard</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">From <b>DayOne</b></string>
+    <string name="my_site_blogging_prompt_card_attribution_dayone">From &lt;b&gt;DayOne&lt;/b&gt;</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Learn more</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Skipped today\'s blogging prompt</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_one">1 answer</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2326,7 +2326,7 @@
     <string name="my_site_blogging_prompt_card_share_chooser_title">Share blogging prompt</string>
     <string name="my_site_blogging_prompt_card_menu_view_more">View more prompts</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Remove from dashboard</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">From <b>DayOne</b></string>
+    <string name="my_site_blogging_prompt_card_attribution_dayone">From &lt;b&gt;DayOne&lt;/b&gt;</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Learn more</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Skipped today\'s blogging prompt</string>
     <string name="my_site_blogging_prompt_card_number_of_answers_one">1 answer</string>


### PR DESCRIPTION
Fixes #17772 

As mentioned by @AliSoftware [here](https://github.com/wordpress-mobile/WordPress-Android/issues/17772#issuecomment-1385545339), the issue happens because this string is using an unescaped HTML tag, which makes the "DayOne" part of it be out of the expected `strings.xml` hierarchy.

This PR escapes the HTML tag and makes sure we are using it correctly (needs to be set in code using the `HtmlCompat` helper class). To avoid the wrong translation in the meantime during localized tests, I also removed translations from other `strings.xml` files.

To test:
Since the "new" string still needs to be translated by GlotPress, the English string will show up for other languages for now, so the steps below and the result should be the same in all languages (please test at least a couple if possible):

1. Install the Jetpack app
2. Login with a WP.com account
3. Select a site that is a blog (has posts)
4. Go to My Site -> Home
5. **Verify** the Prompts card is showing
6. **Verify** the "From **DayOne**" attribution string is showing and styled correctly (DayOne should be bold)

## Regression Notes
1. Potential unintended areas of impact
Other usages of this string showing the escaped string.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and ensured the string is only ever set in code.

8. What automated tests I added (or what prevented me from doing so)
None, UI/String changes.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
