### PR TITLE
[Blogging Prompts Enhancements] Add new tag to prompt answer

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -929,7 +929,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     mEditPostRepository.updateAsync(postModel -> {
                         postModel.setContent(loadedPrompt.getContent());
                         postModel.setAnsweredPromptId(loadedPrompt.getPromptId());
-                        postModel.setTagNames(loadedPrompt.getTag());
+                        postModel.setTagNameList(loadedPrompt.getTags());
                         return true;
                     }, (postModel, result) -> {
                         refreshEditorContent();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
@@ -59,7 +59,7 @@ class EditorBloggingPromptsViewModel
     private fun createPromptTags(promptId: Int): List<String> = mutableListOf<String>().apply {
         add(BLOGGING_PROMPT_TAG)
         if (bloggingPromptsEnhancementsFeatureConfig.isEnabled()) {
-            add(BLOGGING_PROMPT_SPECIFIC_TAG_TEMPLATE.format(promptId))
+            add(BLOGGING_PROMPT_ID_TAG.format(promptId))
         }
     }
 
@@ -67,4 +67,4 @@ class EditorBloggingPromptsViewModel
 }
 
 internal const val BLOGGING_PROMPT_TAG = "dailyprompt"
-internal const val BLOGGING_PROMPT_SPECIFIC_TAG_TEMPLATE = "dailyprompt-%s"
+internal const val BLOGGING_PROMPT_ID_TAG = "dailyprompt-%s"

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
@@ -36,11 +36,25 @@ class EditorBloggingPromptsViewModel
     private fun loadPrompt(site: SiteModel, promptId: Int) = launch {
         val prompt = bloggingPromptsStore.getPromptById(site, promptId).first().model
         prompt?.let {
-            _onBloggingPromptLoaded.postValue(Event(EditorLoadedPrompt(promptId, it.content, BLOGGING_PROMPT_TAG)))
+            _onBloggingPromptLoaded.postValue(
+                Event(
+                    EditorLoadedPrompt(
+                        promptId,
+                        it.content,
+                        createPromptTags(promptId)
+                    )
+                )
+            )
         }
     }
 
-    data class EditorLoadedPrompt(val promptId: Int, val content: String, val tag: String)
+    private fun createPromptTags(promptId: Int): List<String> = listOf(
+        BLOGGING_PROMPT_TAG,
+        BLOGGING_PROMPT_SPECIFIC_TAG_TEMPLATE.format(promptId)
+    )
+
+    data class EditorLoadedPrompt(val promptId: Int, val content: String, val tags: List<String>)
 }
 
 internal const val BLOGGING_PROMPT_TAG = "dailyprompt"
+internal const val BLOGGING_PROMPT_SPECIFIC_TAG_TEMPLATE = "dailyprompt-%s"

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.first
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -15,6 +16,7 @@ import javax.inject.Named
 class EditorBloggingPromptsViewModel
 @Inject constructor(
     private val bloggingPromptsStore: BloggingPromptsStore,
+    private val bloggingPromptsEnhancementsFeatureConfig: BloggingPromptsEnhancementsFeatureConfig,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(bgDispatcher) {
     private val _onBloggingPromptLoaded = MutableLiveData<Event<EditorLoadedPrompt>>()
@@ -48,10 +50,12 @@ class EditorBloggingPromptsViewModel
         }
     }
 
-    private fun createPromptTags(promptId: Int): List<String> = listOf(
-        BLOGGING_PROMPT_TAG,
-        BLOGGING_PROMPT_SPECIFIC_TAG_TEMPLATE.format(promptId)
-    )
+    private fun createPromptTags(promptId: Int): List<String> = mutableListOf<String>().apply {
+        add(BLOGGING_PROMPT_TAG)
+        if (bloggingPromptsEnhancementsFeatureConfig.isEnabled()) {
+            add(BLOGGING_PROMPT_SPECIFIC_TAG_TEMPLATE.format(promptId))
+        }
+    }
 
     data class EditorLoadedPrompt(val promptId: Int, val content: String, val tags: List<String>)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/editor/EditorBloggingPromptsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/editor/EditorBloggingPromptsViewModelTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore.BloggingPromptsResult
-import org.wordpress.android.ui.posts.BLOGGING_PROMPT_SPECIFIC_TAG_TEMPLATE
+import org.wordpress.android.ui.posts.BLOGGING_PROMPT_ID_TAG
 import org.wordpress.android.ui.posts.BLOGGING_PROMPT_TAG
 import org.wordpress.android.ui.posts.BloggingPromptsEditorBlockMapper
 import org.wordpress.android.ui.posts.EditorBloggingPromptsViewModel
@@ -101,19 +101,19 @@ class EditorBloggingPromptsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `should not add specific prompt tag if enhancements feature flag is DISABLED`() {
+    fun `should not add prompt id tag if enhancements feature flag is DISABLED`() {
         whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(false)
         viewModel.start(siteModel, 123)
         assertThat(loadedPrompt?.tags).containsOnly(BLOGGING_PROMPT_TAG)
     }
 
     @Test
-    fun `should add specific prompt tag if enhancements feature flag is ENABLED`() {
+    fun `should add prompt id tag if enhancements feature flag is ENABLED`() {
         whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(true)
         viewModel.start(siteModel, 123)
         assertThat(loadedPrompt?.tags).containsOnly(
             BLOGGING_PROMPT_TAG,
-            BLOGGING_PROMPT_SPECIFIC_TAG_TEMPLATE.format(123)
+            BLOGGING_PROMPT_ID_TAG.format(123)
         )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/editor/EditorBloggingPromptsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/editor/EditorBloggingPromptsViewModelTest.kt
@@ -11,14 +11,17 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore.BloggingPromptsResult
+import org.wordpress.android.ui.posts.BLOGGING_PROMPT_SPECIFIC_TAG_TEMPLATE
 import org.wordpress.android.ui.posts.BLOGGING_PROMPT_TAG
 import org.wordpress.android.ui.posts.EditorBloggingPromptsViewModel
 import org.wordpress.android.ui.posts.EditorBloggingPromptsViewModel.EditorLoadedPrompt
+import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig
 import java.util.Date
 
 @ExperimentalCoroutinesApi
@@ -47,10 +50,13 @@ class EditorBloggingPromptsViewModelTest : BaseUnitTest() {
         onBlocking { getPromptById(any(), any()) } doReturn flowOf(bloggingPrompt)
     }
 
+    private val bloggingPromptsEnhancementsFeatureConfig: BloggingPromptsEnhancementsFeatureConfig = mock()
+
     @Before
     fun setUp() {
         viewModel = EditorBloggingPromptsViewModel(
             bloggingPromptsStore,
+            bloggingPromptsEnhancementsFeatureConfig,
             testDispatcher()
         )
 
@@ -67,7 +73,6 @@ class EditorBloggingPromptsViewModelTest : BaseUnitTest() {
 
         assertThat(loadedPrompt?.content).isEqualTo(bloggingPrompt.model?.content)
         assertThat(loadedPrompt?.promptId).isEqualTo(bloggingPrompt.model?.id)
-        assertThat(loadedPrompt?.tag).isEqualTo(BLOGGING_PROMPT_TAG)
 
         verify(bloggingPromptsStore, times(1)).getPromptById(any(), any())
     }
@@ -76,5 +81,22 @@ class EditorBloggingPromptsViewModelTest : BaseUnitTest() {
     fun `should NOT execute start method if prompt ID is less than 0`() = test {
         viewModel.start(siteModel, -1)
         verify(bloggingPromptsStore, times(0)).getPromptById(any(), any())
+    }
+
+    @Test
+    fun `should not add specific prompt tag if enhancements feature flag is DISABLED`() {
+        whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(false)
+        viewModel.start(siteModel, 123)
+        assertThat(loadedPrompt?.tags).containsOnly(BLOGGING_PROMPT_TAG)
+    }
+
+    @Test
+    fun `should add specific prompt tag if enhancements feature flag is ENABLED`() {
+        whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(true)
+        viewModel.start(siteModel, 123)
+        assertThat(loadedPrompt?.tags).containsOnly(
+            BLOGGING_PROMPT_TAG,
+            BLOGGING_PROMPT_SPECIFIC_TAG_TEMPLATE.format(123)
+        )
     }
 }


### PR DESCRIPTION
Fixes #17784 

Add a tag in the form of `dailyprompt-<prompt-id>` to the post (in addition to the existing `dailyprompt` tag).
This should only happen if the Prompts Enhancements flag is turned on.

Demo:

https://user-images.githubusercontent.com/5091503/213288139-77e49bae-1c61-48dd-ab93-cab057938f62.mp4

## To test:
1. Install Jetpack and log in
2. Open "Debug settings" and make sure `BloggingPromptsEnhancementsFeatureConfig` is disabled
3. Open "My Site" -> "HOME" with a blog selected
4. Tap on "Answer prompt" in the prompts card
5. Tap the overflow menu (top right)
6. Tap "Post Settings"
7. **Verify** only the `dailyprompt` tag is added in the `Tags` field
8. Go back all the way to "My Site" -> "HOME"
9. Open "Debug settings" (avatar on top right -> App Settings -> Debug Settings) and enable `BloggingPromptsEnhancementsFeatureConfig` in "Features in Development" section
10. Tap the "Restart the app" button
11. Open "My Site" -> "HOME" with a blog selected
12. Tap on "Answer prompt" in the prompts card
5. Tap the overflow menu (top right)
6. Tap "Post Settings"
7. **Verify** both the `dailyprompt` tag and `dailyprompt-<id>` are added in the `Tags` field

## Regression Notes
1. Potential unintended areas of impact
Blogging prompt answer post not working properly.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + unit tests.

3. What automated tests I added (or what prevented me from doing so)
Unit tests for checking the appropriate tags are added in `EditorBloggingPromptsViewModelTest.kt`.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
