### PR TITLE
Fixes: Activity not found exception 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
@@ -1,10 +1,13 @@
 package org.wordpress.android.ui
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import dagger.Reusable
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
@@ -32,6 +35,7 @@ class ActivityLauncherWrapper @Inject constructor() {
         remotePreviewType: RemotePreviewType
     ) = ActivityLauncher.previewPostOrPageForResult(activity, site, post, remotePreviewType)
 
+    @Suppress("SwallowedException")
     fun openPlayStoreLink(context: Context, packageName: String) {
         var intent: Intent? = context.packageManager.getLaunchIntentForPackage(packageName)
 
@@ -42,7 +46,16 @@ class ActivityLauncherWrapper @Inject constructor() {
                 setPackage("com.android.vending")
             }
         }
-        context.startActivity(intent)
+        try {
+            context.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            // No Google Play Store installed
+            Toast.makeText(
+                    context,
+                    R.string.install_play_store_to_get_jetpack,
+                    Toast.LENGTH_LONG
+            ).show()
+        }
     }
 
     companion object {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4337,5 +4337,5 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jetpack_feature_card_menu_item_hide_this">Hide this</string>
     <string name="gutenberg_native_featured" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Featured</string>
 
-    <string name="install_play_store_to_get_jetpack">Please install google play store to get the Jetpack app</string>
+    <string name="install_play_store_to_get_jetpack">Please install Google Play Store to get the Jetpack app</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4336,4 +4336,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jetpack_feature_card_menu_item_remind_me_later">Remind me later</string>
     <string name="jetpack_feature_card_menu_item_hide_this">Hide this</string>
     <string name="gutenberg_native_featured" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Featured</string>
+
+    <string name="install_play_store_to_get_jetpack">Please install google play store to get the Jetpack app</string>
 </resources>


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/17789

This PR fixes the crash in the scenario when the user clicks on the Get the jetpack button with no playstore installed on the device. 

[Slack thread discussion ](p1674122756535789-slack-C0180B5PRJ4)

## To test

### No Playstore present 
- Install this PR on an Emulator with no Playstore 
- Login to the app with a wp com account 
- Enable any jetpack feature removal flag(eg: jp_removal_one)
- Go to stats 
- Click on the "Switch to the new Jetpack app" button 
- Verify that a toast with message "Please install google play store to get the Jetpack app" is shown 
- Click on Jetpack powered badge in stats/reader/notifications page 
- Click on "Try the new Jetpack app" button 
- Verify that a toast with message "Please install google play store to get the Jetpack app" is shown 


### Regression testing - Playstore present 
- Install this PR on a device with Playstore 
- Login to the app with a wp com account 
- Enable any jetpack feature removal flag(eg: jp_removal_one)
- Go to stats 
- Click on the "Switch to the new Jetpack app" button 
- Verify that the app Jetpack link on the google play store is opened/the jetpack app is opened if it is installed
- Click on Jetpack powered badge in stats/reader/notifications page 
- Click on "Try the new Jetpack app" button 
- Verify that the app Jetpack link on the google play store is opened/the jetpack app is opened if it is installed

<img width="589" alt="Screenshot 2023-01-19 at 6 07 10 PM" src="https://user-images.githubusercontent.com/17463767/213445395-f27fc3d9-9023-4af7-82d6-a3835e053b5a.png">

cc: @wordpress-mobile/apps-quality for visibility. 

## Regression Notes
1. Potential unintended areas of impact
The play store link of the jetpack app is not shown properly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.