### PR TITLE
Remove jetpack features in site settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -189,8 +189,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Inject BloggingPromptsFeatureConfig mBloggingPromptsFeatureConfig;
     @Inject ManageCategoriesFeatureConfig mManageCategoriesFeatureConfig;
     @Inject UiHelpers mUiHelpers;
-
-    @Inject JetpackFeatureRemovalPhaseHelper jetpackFeatureRemovalPhaseHelper;
+    @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
 
     private BloggingRemindersViewModel mBloggingRemindersViewModel;
 
@@ -1041,7 +1040,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         }
 
         // hide site accelerator jetpack settings if plugin version < 5.8
-        if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures() || (
+        if (mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures() || (
                 !supportsJetpackSiteAcceleratorSettings(mSite)
                 && mSite.getPlanId() != PlansConstants.BUSINESS_PLAN_ID)) {
             removeJetpackSiteAcceleratorSettings();
@@ -1060,7 +1059,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (!mManageCategoriesFeatureConfig.isEnabled()) {
             removeCategoriesPreference();
         }
-        if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
+        if (mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
             WPPrefUtils.removePreference(this, R.string.pref_key_site_writing,
                     R.string.pref_key_site_related_posts);
             WPPrefUtils.removePreference(this, R.string.pref_key_site_screen,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1030,16 +1030,6 @@ public class SiteSettingsFragment extends PreferenceFragment
             removeNonWPComPreferences();
         }
 
-
-        if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
-            WPPrefUtils.removePreference(this, R.string.pref_key_site_writing,
-                    R.string.pref_key_site_related_posts);
-            WPPrefUtils.removePreference(this, R.string.pref_key_jetpack_settings,
-                    R.string.pref_key_jetpack_security_screen);
-            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen,
-                    R.string.pref_key_jetpack_settings);
-        }
-
         if (!mSite.isUsingWpComRestApi()) {
             WPPrefUtils.removePreference(this, R.string.pref_key_homepage, R.string.pref_key_homepage_settings);
         }
@@ -1069,6 +1059,18 @@ public class SiteSettingsFragment extends PreferenceFragment
         // Hide "Manage" Categories if feature is not enabled
         if (!mManageCategoriesFeatureConfig.isEnabled()) {
             removeCategoriesPreference();
+        }
+        if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_writing,
+                    R.string.pref_key_site_related_posts);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen,
+                    R.string.pref_key_jetpack_settings);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen,
+                    R.string.pref_key_jetpack_performance_settings);
+            WPPrefUtils.removePreference(this, R.string.pref_key_jetpack_performance_settings,
+                    R.string.pref_key_ad_free_video_hosting);
+            WPPrefUtils.removePreference(this, R.string.pref_key_jetpack_performance_more_settings,
+                    R.string.pref_key_jetpack_performance_media_settings);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -77,6 +77,7 @@ import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.ui.plans.PlansConstants;
 import org.wordpress.android.ui.prefs.EditTextPreferenceWithValidation.ValidationType;
 import org.wordpress.android.ui.prefs.SiteSettingsFormatDialog.FormatType;
@@ -188,6 +189,8 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Inject BloggingPromptsFeatureConfig mBloggingPromptsFeatureConfig;
     @Inject ManageCategoriesFeatureConfig mManageCategoriesFeatureConfig;
     @Inject UiHelpers mUiHelpers;
+
+    @Inject JetpackFeatureRemovalPhaseHelper jetpackFeatureRemovalPhaseHelper;
 
     private BloggingRemindersViewModel mBloggingRemindersViewModel;
 
@@ -1038,8 +1041,9 @@ public class SiteSettingsFragment extends PreferenceFragment
         }
 
         // hide site accelerator jetpack settings if plugin version < 5.8
-        if (!supportsJetpackSiteAcceleratorSettings(mSite)
-            && mSite.getPlanId() != PlansConstants.BUSINESS_PLAN_ID) {
+        if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures() || (
+                !supportsJetpackSiteAcceleratorSettings(mSite)
+                && mSite.getPlanId() != PlansConstants.BUSINESS_PLAN_ID)) {
             removeJetpackSiteAcceleratorSettings();
         }
         if (!mSite.isJetpackConnected() || (mSite.getPlanId() != PlansConstants.JETPACK_BUSINESS_PLAN_ID

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1030,6 +1030,16 @@ public class SiteSettingsFragment extends PreferenceFragment
             removeNonWPComPreferences();
         }
 
+
+        if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_writing,
+                    R.string.pref_key_site_related_posts);
+            WPPrefUtils.removePreference(this, R.string.pref_key_jetpack_settings,
+                    R.string.pref_key_jetpack_security_screen);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen,
+                    R.string.pref_key_jetpack_settings);
+        }
+
         if (!mSite.isUsingWpComRestApi()) {
             WPPrefUtils.removePreference(this, R.string.pref_key_homepage, R.string.pref_key_homepage_settings);
         }


### PR DESCRIPTION
Part of #17339 

This PR removes the following items from the Site Settings page in Phase 4 
- **Jetpack Security**
- **Related Posts**
- **Jetpack Performance ( Site accelerator, Lazy load images and Ad-free hosting)**

|Site settings in Normal Phase |   |   |   |   |
|---|---|---|---|---|
| ![Screenshot_20230120_150823](https://user-images.githubusercontent.com/17463767/213674961-eb650933-9dd3-48cf-b96e-9605d8f09d68.png)|![Screenshot_20230120_150856](https://user-images.githubusercontent.com/17463767/213674975-f3f94bd8-8c90-49f5-afbd-9ed0d2114c1c.png)|![Screenshot_20230120_151318](https://user-images.githubusercontent.com/17463767/213674987-3d6c129d-a0a5-4437-aacb-bab688417296.png)|![Screenshot_20230120_151816](https://user-images.githubusercontent.com/17463767/213674994-f988a89b-b5af-4097-bd61-c8ab342fa848.png)|![Screenshot_20230120_151831](https://user-images.githubusercontent.com/17463767/213674997-6addffc6-e627-449c-8933-48708fe2014b.png)|![Uploading |  

## To test:
- Launch the WP app with a Site having jetpack features(including jetpack search as well optionally)
- Go to Menu -> Site Settings 
- Verify that the following options are available in the Site settings ✅ 
- **Jetpack Security Section, Related Posts, Performance Section (Site Accelerator, Lazy load images and Ad-Free hosting)**
- Go to me -> app settings -> debug settings 
- Enable "jp_removal_four"
- Go to Site Settings
- Verify that **Jetpack Security Section, Related Posts, Performance Section (Site Accelerator, Lazy load images and Ad-Free hosting)** are not present 

## Regression Notes
1. Potential unintended areas of impact
Jetpack features are not shown in Site settings properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
