### PR TITLE
Wp support feature flag configuration

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -129,6 +129,7 @@ android {
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_NEW_USERS", "false"
         buildConfigField "boolean", "PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD", "false"
         buildConfigField "boolean", "OPEN_WEB_LINKS_WITH_JETPACK_FLOW", "false"
+        buildConfigField "boolean", "ENABLE_WORDPRESS_SUPPORT_FORUM", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -183,7 +183,7 @@ class HelpActivity : LocaleAwareActivity() {
     }
 
     private fun openWpSupportForum() {
-        // TODO: Enhance this as project evolves
+        // Enhance this as project evolves
         ActivityLauncher.openUrlExternal(this, "https://wordpress.org/support/forum/mobile/")
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -14,6 +14,7 @@ import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -39,12 +40,16 @@ import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.API
 import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.config.WordPressSupportForumFeatureConfig
 import org.wordpress.android.util.image.ImageType.AVATAR_WITHOUT_BACKGROUND
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class HelpActivity : LocaleAwareActivity() {
+    @Inject
+    lateinit var wpSupportForumFeatureConfig: WordPressSupportForumFeatureConfig
+
     @Inject
     lateinit var accountStore: AccountStore
 
@@ -94,7 +99,13 @@ class HelpActivity : LocaleAwareActivity() {
                 actionBar.elevation = 0f // remove shadow
             }
 
-            contactUsButton.setOnClickListener { createNewZendeskTicket() }
+            contactUsButton.setOnClickListener {
+                if (wpSupportForumFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
+                    openWpSupportForum()
+                } else {
+                    createNewZendeskTicket()
+                }
+            }
             faqButton.setOnClickListener { showFaq() }
             myTicketsButton.setOnClickListener { showZendeskTickets() }
             applicationVersion.text = getString(R.string.version_with_name_param, WordPress.versionName)
@@ -169,6 +180,11 @@ class HelpActivity : LocaleAwareActivity() {
             selectedSiteFromExtras,
             extraTagsFromExtras
         )
+    }
+
+    private fun openWpSupportForum() {
+        // TODO: Enhance this as project evolves
+        ActivityLauncher.openUrlExternal(this, "https://wordpress.org/support/forum/mobile/")
     }
 
     private fun showZendeskTickets() {

--- a/WordPress/src/main/java/org/wordpress/android/util/config/WordPressSupportForumFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/WordPressSupportForumFeatureConfig.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.WordPressSupportForumFeatureConfig.Companion.WORDPRESS_SUPPORT_FORUM_REMOTE_FIELD
+import javax.inject.Inject
+
+@Feature(WORDPRESS_SUPPORT_FORUM_REMOTE_FIELD, false)
+class WordPressSupportForumFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.ENABLE_WORDPRESS_SUPPORT_FORUM,
+    WORDPRESS_SUPPORT_FORUM_REMOTE_FIELD
+) {
+    companion object {
+        const val WORDPRESS_SUPPORT_FORUM_REMOTE_FIELD = "wordpress_support_forum_remote_field"
+    }
+}


### PR DESCRIPTION
Adding config for the new WP Support Forum feature flag

<image width=320 src=https://user-images.githubusercontent.com/990349/213974253-028db78d-b52b-4df5-b815-00a1ba7dc6cf.png />


Fixes #17804 

To test:

Setup
- Launch WordPress app
- Navigate to Me > App Settings > Debug settings
- Enable wordpress_support_forum_remote_field under Remote features and Restart the app (scroll down if required)

Test 1
- Navigate to Me > Help & Support
- Tap on Contact Support 
- Verify that it opens the new Mobile Forum on Wordpress.org in the browser

Test 2
- Disable the feature flag that was enabled above and Restart the app
- Try the Test 1 above again
- Verify that it opens the Contact us Zendesk input as before

Test 3
- Launch Jetpack app
- Enable or disable the feature flag and Restart the app
- Verify that it always show Contact us, Zendesk input form as before

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested WP and JP 

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
