### PR TITLE
Disables Notifications in Jetpack removal Phase 4

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -82,6 +82,7 @@ import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityId
 import org.wordpress.android.ui.debug.cookies.DebugCookieManager
 import org.wordpress.android.ui.deeplinks.DeepLinkOpenWebLinksWithJetpackHelper
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalWidgetHelper
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
@@ -217,9 +218,17 @@ class AppInitializer @Inject constructor(
     lateinit var oAuthAuthenticator: OAuthAuthenticator
 
     // For jetpack focus
-    @Inject lateinit var openWebLinksWithJetpackFlowFeatureConfig: OpenWebLinksWithJetpackFlowFeatureConfig
-    @Inject lateinit var openWebLinksWithJetpackHelper: DeepLinkOpenWebLinksWithJetpackHelper
-    @Inject lateinit var jetpackFeatureRemovalWidgetHelper: JetpackFeatureRemovalWidgetHelper
+    @Inject
+    lateinit var openWebLinksWithJetpackFlowFeatureConfig: OpenWebLinksWithJetpackFlowFeatureConfig
+
+    @Inject
+    lateinit var openWebLinksWithJetpackHelper: DeepLinkOpenWebLinksWithJetpackHelper
+
+    @Inject
+    lateinit var jetpackFeatureRemovalWidgetHelper: JetpackFeatureRemovalWidgetHelper
+
+    @Inject
+    lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
     private lateinit var applicationLifecycleMonitor: ApplicationLifecycleMonitor
     lateinit var storyNotificationTrackerProvider: StoryNotificationTrackerProvider
@@ -330,8 +339,7 @@ class AppInitializer @Inject constructor(
 
         initAnalytics(SystemClock.elapsedRealtime() - startDate)
 
-        createNotificationChannelsOnSdk26()
-
+        updateNotificationSettings()
         // Allows vector drawable from resources (in selectors for instance) on Android < 21 (can cause issues with
         // memory usage and the use of Configuration). More information: http://bit.ly/2H1KTQo
         // Note: if removed, this will cause crashes on Android < 21
@@ -963,6 +971,13 @@ class AppInitializer @Inject constructor(
         override fun trackDismissedNotification(storyNotificationType: StoryNotificationType) {
             systemNotificationsTracker.trackDismissedNotification(translateNotificationTypes(storyNotificationType))
         }
+    }
+
+    private fun updateNotificationSettings() {
+        if(!jetpackFeatureRemovalPhaseHelper.shouldShowNotifications())
+            NotificationsUtils.cancelAllNotifications(application)
+        else
+            createNotificationChannelsOnSdk26()
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -12,6 +12,7 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.support.ZendeskHelper;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -37,6 +38,7 @@ public class GCMMessageService extends FirebaseMessagingService {
     @Inject ZendeskHelper mZendeskHelper;
     @Inject SystemNotificationsTracker mSystemNotificationsTracker;
     @Inject GCMMessageHandler mGCMMessageHandler;
+    @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
 
     private void synchronizedHandleDefaultPush(@NonNull Map<String, String> data) {
         // ACTIVE_NOTIFICATIONS_MAP being static, we can't just synchronize the method
@@ -68,6 +70,10 @@ public class GCMMessageService extends FirebaseMessagingService {
         }
 
         if (!mAccountStore.hasAccessToken()) {
+            return;
+        }
+
+        if (!mJetpackFeatureRemovalPhaseHelper.shouldShowNotifications()) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsViewModel.kt
@@ -95,7 +95,7 @@ class DebugSettingsViewModel
     }
 
     private fun onForceShowWeeklyRoundupClick() = launch(bgDispatcher) {
-        if(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures())
+        if(!jetpackFeatureRemovalPhaseHelper.shouldShowNotifications())
             return@launch
         weeklyRoundupNotifier.buildNotifications().forEach {
             notificationManager.notify(it.id, it.asNotificationCompatBuilder(contextProvider.getContext()).build())

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsViewModel.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Type.BUTTON
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Type.FEATURE
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Type.HEADER
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Type.ROW
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.notifications.NotificationManagerWrapper
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.ListItemInteraction.Companion.create
@@ -47,7 +48,8 @@ class DebugSettingsViewModel
     private val debugUtils: DebugUtils,
     private val weeklyRoundupNotifier: WeeklyRoundupNotifier,
     private val notificationManager: NotificationManagerWrapper,
-    private val contextProvider: ContextProvider
+    private val contextProvider: ContextProvider,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) : ScopedViewModel(mainDispatcher) {
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
@@ -93,6 +95,8 @@ class DebugSettingsViewModel
     }
 
     private fun onForceShowWeeklyRoundupClick() = launch(bgDispatcher) {
+        if(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures())
+            return@launch
         weeklyRoundupNotifier.buildNotifications().forEach {
             notificationManager.notify(it.id, it.asNotificationCompatBuilder(contextProvider.getContext()).build())
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -67,6 +67,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
             is PhaseOne, PhaseTwo, PhaseThree -> false
         }
     }
+
+    fun shouldShowNotifications(): Boolean {
+        val currentPhase = getCurrentPhase() ?: return true
+        return when (currentPhase) {
+            is PhaseFour, PhaseNewUsers -> false
+            is PhaseOne, PhaseTwo, PhaseThree -> true
+        }
+    }
 }
 // Global overlay frequency is the frequency at which the overlay is shown across the features
 // no matter which feature was accessed last time

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishNotificationReceiver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishNotificationReceiver.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.push.NotificationType
 import org.wordpress.android.push.NotificationsProcessingService
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import javax.inject.Inject
 
@@ -18,8 +19,14 @@ class PublishNotificationReceiver : BroadcastReceiver() {
 
     @Inject
     lateinit var systemNotificationsTracker: SystemNotificationsTracker
+
+    @Inject
+    lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
     override fun onReceive(context: Context, intent: Intent) {
         (context.applicationContext as WordPress).component().inject(this)
+        if(!jetpackFeatureRemovalPhaseHelper.shouldShowNotifications())
+            return
         val notificationId = intent.getIntExtra(NOTIFICATION_ID, 0)
         val uiModel = publishNotificationReceiverViewModel.loadNotification(notificationId)
         if (uiModel != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore;
 import org.wordpress.android.push.NotificationPushIds;
 import org.wordpress.android.push.NotificationType;
 import org.wordpress.android.push.NotificationsProcessingService;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.mysite.MySiteViewModel;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
@@ -40,11 +41,17 @@ public class QuickStartReminderReceiver extends BroadcastReceiver {
     @Inject QuickStartRepository mQuickStartRepository;
     @Inject QuickStartTracker mQuickStartTracker;
 
+    @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
+
     @Override
     public void onReceive(Context context, Intent intent) {
         String notificationSettingsPrefKey = context.getString(R.string.wp_pref_notifications_main);
         boolean isNotificationSettingsEnabled = mSharedPreferences.getBoolean(notificationSettingsPrefKey, true);
         if (!isNotificationSettingsEnabled) {
+            return;
+        }
+
+        if (!mJetpackFeatureRemovalPhaseHelper.shouldShowNotifications()) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/workers/notification/bloggingprompts/BloggingPromptsOnboardingNotificationHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/notification/bloggingprompts/BloggingPromptsOnboardingNotificationHandler.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.push.NotificationType.BLOGGING_PROMPTS_ONBOARDING
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.notifications.DismissNotificationReceiver
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.workers.notification.local.LocalNotificationHandler
@@ -12,11 +13,12 @@ import javax.inject.Inject
 
 class BloggingPromptsOnboardingNotificationHandler @Inject constructor(
     private val accountStore: AccountStore,
-    private val notificationsTracker: SystemNotificationsTracker
+    private val notificationsTracker: SystemNotificationsTracker,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) : LocalNotificationHandler {
     // TODO @RenanLukas update with show notification business rule
     override fun shouldShowNotification(): Boolean {
-        return accountStore.hasAccessToken()
+        return accountStore.hasAccessToken() && jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()
     }
 
     override fun buildFirstActionPendingIntent(context: Context, notificationId: Int): PendingIntent {

--- a/WordPress/src/main/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationHandler.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.push.NotificationType.CREATE_SITE
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -19,14 +20,18 @@ class CreateSiteNotificationHandler @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val accountStore: AccountStore,
     private val siteStore: SiteStore,
-    private val notificationsTracker: SystemNotificationsTracker
+    private val notificationsTracker: SystemNotificationsTracker,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) : LocalNotificationHandler {
     override fun shouldShowNotification(): Boolean {
         val isNotificationSettingsEnabled = sharedPrefs.getBoolean(
             resourceProvider.getString(R.string.wp_pref_notifications_main),
             true
         )
-        return isNotificationSettingsEnabled && accountStore.hasAccessToken() && !siteStore.hasSite()
+        return isNotificationSettingsEnabled &&
+                accountStore.hasAccessToken() &&
+                !siteStore.hasSite() &&
+                jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()
     }
 
     override fun buildFirstActionPendingIntent(context: Context, notificationId: Int): PendingIntent {

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
@@ -70,7 +70,7 @@ class ReminderNotifier @Inject constructor(
 
     fun shouldNotify(siteId: Int) =
         siteId != NO_SITE_ID && siteStore.getSiteByLocalId(siteId) != null && accountStore.hasAccessToken() &&
-                !jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
+                jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()
 
     companion object {
         const val NO_SITE_ID = -1

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.push.NotificationPushIds.REMINDER_NOTIFICATION_ID
 import org.wordpress.android.push.NotificationType.BLOGGING_REMINDERS
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.posts.PostListType
 import org.wordpress.android.ui.posts.PostsListActivity
 import org.wordpress.android.util.SiteUtils
@@ -23,7 +24,8 @@ class ReminderNotifier @Inject constructor(
     val siteStore: SiteStore,
     val accountStore: AccountStore,
     val reminderNotificationManager: ReminderNotificationManager,
-    val analyticsTracker: BloggingRemindersAnalyticsTracker
+    val analyticsTracker: BloggingRemindersAnalyticsTracker,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) {
     fun notify(siteId: Int) {
         val context = contextProvider.getContext()
@@ -67,7 +69,8 @@ class ReminderNotifier @Inject constructor(
     }
 
     fun shouldNotify(siteId: Int) =
-        siteId != NO_SITE_ID && siteStore.getSiteByLocalId(siteId) != null && accountStore.hasAccessToken()
+        siteId != NO_SITE_ID && siteStore.getSiteByLocalId(siteId) != null && accountStore.hasAccessToken() &&
+                !jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
 
     companion object {
         const val NO_SITE_ID = -1

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/prompt/PromptReminderNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/prompt/PromptReminderNotifier.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.push.NotificationPushIds.REMINDER_NOTIFICATION_ID
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.notifications.DismissNotificationReceiver
 import org.wordpress.android.ui.posts.PostUtils.EntryPoint
 import org.wordpress.android.util.HtmlCompatWrapper
@@ -45,7 +46,8 @@ class PromptReminderNotifier @Inject constructor(
     val bloggingPromptsStore: BloggingPromptsStore,
     val bloggingRemindersAnalyticsTracker: BloggingRemindersAnalyticsTracker,
     val htmlCompatWrapper: HtmlCompatWrapper,
-    private val bloggingRemindersStore: BloggingRemindersStore
+    private val bloggingRemindersStore: BloggingRemindersStore,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) {
     @Suppress("MagicNumber")
     suspend fun notify(siteId: Int) {
@@ -169,7 +171,12 @@ class PromptReminderNotifier @Inject constructor(
         val siteModel = siteStore.getSiteByLocalId(siteId)
         val bloggingRemindersModel = bloggingRemindersStore.bloggingRemindersModel(siteId).first()
         val hasOptedInBloggingPromptsReminders = siteModel != null && bloggingRemindersModel.isPromptIncluded
-        return hasAccessToken && isBloggingPromptsEnabled && hasOptedInBloggingPromptsReminders
+        // In Jetpack feature removal phase 4, all notifications are disabled.
+        val isNotJetpackRemovalPhase4 = !jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
+        return hasAccessToken &&
+                isBloggingPromptsEnabled &&
+                hasOptedInBloggingPromptsReminders &&
+                isNotJetpackRemovalPhase4
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/prompt/PromptReminderNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/prompt/PromptReminderNotifier.kt
@@ -172,11 +172,11 @@ class PromptReminderNotifier @Inject constructor(
         val bloggingRemindersModel = bloggingRemindersStore.bloggingRemindersModel(siteId).first()
         val hasOptedInBloggingPromptsReminders = siteModel != null && bloggingRemindersModel.isPromptIncluded
         // In Jetpack feature removal phase 4, all notifications are disabled.
-        val isNotJetpackRemovalPhase4 = !jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
+        val shouldShowNotificationsInJetpackRemovalPhase = jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()
         return hasAccessToken &&
                 isBloggingPromptsEnabled &&
                 hasOptedInBloggingPromptsReminders &&
-                isNotJetpackRemovalPhase4
+                shouldShowNotificationsInJetpackRemovalPhase
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
@@ -36,7 +36,7 @@ class WeeklyRoundupNotifier @Inject constructor(
     private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) {
     fun shouldShowNotifications() = accountStore.hasAccessToken() &&
-            siteStore.hasSitesAccessedViaWPComRest() && !jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
+            siteStore.hasSitesAccessedViaWPComRest() && jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()
 
     suspend fun buildNotifications(): List<WeeklyRoundupNotification> = coroutineScope {
         siteStore.sitesAccessedViaWPComRest

--- a/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.push.NotificationPushIds.WEEKLY_ROUNDUP_NOTIFICATIO
 import org.wordpress.android.push.NotificationType.WEEKLY_ROUNDUP
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.Organization
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe.WEEK
@@ -31,9 +32,11 @@ class WeeklyRoundupNotifier @Inject constructor(
     private val siteUtils: SiteUtilsWrapper,
     private val weeklyRoundupRepository: WeeklyRoundupRepository,
     private val appPrefs: AppPrefsWrapper,
-    private val statsUtils: StatsUtils
+    private val statsUtils: StatsUtils,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) {
-    fun shouldShowNotifications() = accountStore.hasAccessToken() && siteStore.hasSitesAccessedViaWPComRest()
+    fun shouldShowNotifications() = accountStore.hasAccessToken() &&
+            siteStore.hasSitesAccessedViaWPComRest() && !jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
 
     suspend fun buildNotifications(): List<WeeklyRoundupNotification> = coroutineScope {
         siteStore.sitesAccessedViaWPComRest

--- a/WordPress/src/test/java/org/wordpress/android/ui/debug/DebugSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/debug/DebugSettingsViewModelTest.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Field
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Header
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiItem.Row
 import org.wordpress.android.ui.debug.DebugSettingsViewModel.UiState
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.notifications.NotificationManagerWrapper
 import org.wordpress.android.util.DebugUtils
 import org.wordpress.android.util.config.FeatureFlagConfig
@@ -49,6 +50,10 @@ class DebugSettingsViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var remoteFieldConfigRepository: RemoteFieldConfigRepository
+
+    @Mock
+    lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
     private lateinit var viewModel: DebugSettingsViewModel
     private val uiStates = mutableListOf<UiState>()
 
@@ -63,7 +68,8 @@ class DebugSettingsViewModelTest : BaseUnitTest() {
             debugUtils,
             weeklyRoundupNotifier,
             notificationManager,
-            contextProvider
+            contextProvider,
+            jetpackFeatureRemovalPhaseHelper
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/workers/notification/bloggingprompts/BloggingPromptsOnboardingNotificationHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/notification/bloggingprompts/BloggingPromptsOnboardingNotificationHandlerTest.kt
@@ -26,8 +26,11 @@ class BloggingPromptsOnboardingNotificationHandlerTest {
     @Test
     fun `Should show notification if user has access token`() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(true)
+
         val actual = classToTest.shouldShowNotification()
         val expected = true
+
         assertThat(actual).isEqualTo(expected)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/workers/notification/bloggingprompts/BloggingPromptsOnboardingNotificationHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/notification/bloggingprompts/BloggingPromptsOnboardingNotificationHandlerTest.kt
@@ -7,12 +7,21 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.push.NotificationType.BLOGGING_PROMPTS_ONBOARDING
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 
 class BloggingPromptsOnboardingNotificationHandlerTest {
     private val accountStore: AccountStore = mock()
+
     private val systemNotificationsTracker: SystemNotificationsTracker = mock()
-    private val classToTest = BloggingPromptsOnboardingNotificationHandler(accountStore, systemNotificationsTracker)
+
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper = mock()
+
+    private val classToTest = BloggingPromptsOnboardingNotificationHandler(
+        accountStore,
+        systemNotificationsTracker,
+        jetpackFeatureRemovalPhaseHelper
+    )
 
     @Test
     fun `Should show notification if user has access token`() {

--- a/WordPress/src/test/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationHandlerTest.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.push.NotificationType.CREATE_SITE
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.viewmodel.ResourceProvider
 
@@ -25,6 +26,7 @@ class CreateSiteNotificationHandlerTest {
     private val accountStore: AccountStore = mock()
     private val siteStore: SiteStore = mock()
     private val notificationsTracker: SystemNotificationsTracker = mock()
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper = mock()
 
     @Before
     fun setUp() {
@@ -35,7 +37,8 @@ class CreateSiteNotificationHandlerTest {
             resourceProvider,
             accountStore,
             siteStore,
-            notificationsTracker
+            notificationsTracker,
+            jetpackFeatureRemovalPhaseHelper
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationHandlerTest.kt
@@ -92,6 +92,7 @@ class CreateSiteNotificationHandlerTest {
             )
         ).thenReturn(true)
         whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(true)
 
         assertThat(createSiteNotificationHandler.shouldShowNotification()).isTrue
     }
@@ -106,9 +107,26 @@ class CreateSiteNotificationHandlerTest {
         ).thenReturn(true)
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(siteStore.hasSite()).thenReturn(false)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(true)
 
         assertThat(createSiteNotificationHandler.shouldShowNotification()).isTrue
     }
+
+    @Test
+    fun `should not show notification when in jetpack removal phase 4`() {
+        whenever(
+            sharedPrefs.getBoolean(
+                resourceProvider.getString(R.string.wp_pref_notifications_main),
+                true
+            )
+        ).thenReturn(true)
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(siteStore.hasSite()).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(false)
+
+        assertThat(createSiteNotificationHandler.shouldShowNotification()).isFalse()
+    }
+
 
     @Test
     fun `should track notification shown`() {

--- a/WordPress/src/test/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/notification/createsite/CreateSiteNotificationHandlerTest.kt
@@ -122,9 +122,9 @@ class CreateSiteNotificationHandlerTest {
         ).thenReturn(true)
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(siteStore.hasSite()).thenReturn(true)
-        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(false)
 
-        assertThat(createSiteNotificationHandler.shouldShowNotification()).isFalse()
+
+        assertThat(createSiteNotificationHandler.shouldShowNotification()).isFalse
     }
 
 

--- a/WordPress/src/test/java/org/wordpress/android/workers/reminder/PromptReminderNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/reminder/PromptReminderNotifierTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.store.BloggingRemindersStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import org.wordpress.android.viewmodel.ContextProvider
@@ -36,6 +37,8 @@ class PromptReminderNotifierTest : BaseUnitTest() {
     private val bloggingRemindersStore: BloggingRemindersStore = mock()
     private val bloggingReminder: BloggingRemindersModel = mock()
     private val htmlCompatWrapper: HtmlCompatWrapper = mock()
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper = mock()
+
 
     private val classToTest = PromptReminderNotifier(
         contextProvider = contextProvider,
@@ -47,7 +50,8 @@ class PromptReminderNotifierTest : BaseUnitTest() {
         bloggingPromptsStore = bloggingPromptsStore,
         bloggingRemindersAnalyticsTracker = bloggingRemindersAnalyticsTracker,
         htmlCompatWrapper = htmlCompatWrapper,
-        bloggingRemindersStore = bloggingRemindersStore
+        bloggingRemindersStore = bloggingRemindersStore,
+        jetpackFeatureRemovalPhaseHelper = jetpackFeatureRemovalPhaseHelper
     )
 
     @Before

--- a/WordPress/src/test/java/org/wordpress/android/workers/reminder/PromptReminderNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/reminder/PromptReminderNotifierTest.kt
@@ -95,6 +95,24 @@ class PromptReminderNotifierTest : BaseUnitTest() {
     }
 
     @Test
+    fun `Should NOT notify if the the user in Jetpack feature removal phase 4`() = test {
+        val siteId = 123
+        val siteModel: SiteModel = mock()
+        val enabledPromptBloggingReminderModel = BloggingRemindersModel(
+            siteId = siteId,
+            isPromptIncluded = true
+        )
+        whenever(bloggingRemindersStore.bloggingRemindersModel(any())).thenReturn(
+            flowOf(enabledPromptBloggingReminderModel)
+        )
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(false)
+        whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(siteModel)
+        assertFalse(classToTest.shouldNotify(123))
+    }
+
+    @Test
     fun `Should notify if has access token, flag enabled and user opted in to include prompts in reminders`() = test {
         val siteId = 123
         val siteModel: SiteModel = mock()
@@ -107,6 +125,7 @@ class PromptReminderNotifierTest : BaseUnitTest() {
         )
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
         whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(true)
         whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(siteModel)
         assertTrue(classToTest.shouldNotify(siteId))
     }

--- a/WordPress/src/test/java/org/wordpress/android/workers/reminder/ReminderNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/reminder/ReminderNotifierTest.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
 
@@ -30,6 +31,7 @@ class ReminderNotifierTest {
     private val accountStore: AccountStore = mock()
     private val notificationManager: ReminderNotificationManager = mock()
     private val analyticsTracker: BloggingRemindersAnalyticsTracker = mock()
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper = mock()
 
     @Before
     fun setUp() {
@@ -39,7 +41,8 @@ class ReminderNotifierTest {
             siteStore,
             accountStore,
             notificationManager,
-            analyticsTracker
+            analyticsTracker,
+            jetpackFeatureRemovalPhaseHelper
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.push.NotificationPushIds.WEEKLY_ROUNDUP_NOTIFICATION_ID
 import org.wordpress.android.push.NotificationType.WEEKLY_ROUNDUP
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
@@ -51,6 +52,8 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
     }
     private val statsUtils: StatsUtils = mock()
 
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper = mock()
+
     @Before
     fun setUp() {
         weeklyRoundupNotifier = WeeklyRoundupNotifier(
@@ -63,7 +66,8 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
             siteUtils,
             weeklyRoundupRepository,
             appPrefs,
-            statsUtils
+            statsUtils,
+            jetpackFeatureRemovalPhaseHelper
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
@@ -95,6 +95,15 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
     }
 
     @Test
+    fun `should not show notification when the user is in jetpack feature removal phase`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(siteStore.hasSitesAccessedViaWPComRest()).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(false)
+
+        assertThat(weeklyRoundupNotifier.shouldShowNotifications()).isTrue
+    }
+
+    @Test
     fun `should track notification shown once for each notification`() {
         val numberOfNotifications = 5
 

--- a/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
@@ -90,7 +90,7 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
     fun `should show notification when the user is logged in and has sites`() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(siteStore.hasSitesAccessedViaWPComRest()).thenReturn(true)
-        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(false)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(true)
 
         assertThat(weeklyRoundupNotifier.shouldShowNotifications()).isTrue
     }

--- a/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
@@ -90,6 +90,7 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
     fun `should show notification when the user is logged in and has sites`() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(siteStore.hasSitesAccessedViaWPComRest()).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(false)
 
         assertThat(weeklyRoundupNotifier.shouldShowNotifications()).isTrue
     }
@@ -100,7 +101,7 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
         whenever(siteStore.hasSitesAccessedViaWPComRest()).thenReturn(true)
         whenever(jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()).thenReturn(false)
 
-        assertThat(weeklyRoundupNotifier.shouldShowNotifications()).isTrue
+        assertThat(weeklyRoundupNotifier.shouldShowNotifications()).isFalse()
     }
 
     @Test


### PR DESCRIPTION
Part of #17339 

## Description 
This PR disabled all the Notifications 🔔  when the Jetpack removal phase (jp_removal_four is enabled) is activated. 

## Changes 
This PR disables the following logic 


### Remote notifications 
- [Disables: push notifications in Jetpack feture removal phase 4](https://github.com/wordpress-mobile/WordPress-Android/pull/17797/commits/a0d109027bb6378fde2d8028cc82db80c51103a8)

### Local notifications 

- [Disables: Weekly round up notifications](https://github.com/wordpress-mobile/WordPress-Android/pull/17797/commits/d377da29a5485d3a2116101088526d025c2f0b81)
- [Disables: Blogging reminder notifications in Phase 4](https://github.com/wordpress-mobile/WordPress-Android/pull/17797/commits/affe34bde259106b6d2d4931ee9917c0e6deed17)
- [Disables: Create site notifications in Phase 4](https://github.com/wordpress-mobile/WordPress-Android/pull/17797/commits/4165233c9d9db096ef9804dfe1f774a22c145aae)
- [Disables: Blogging prompt onboarding notifications in Phase 4](https://github.com/wordpress-mobile/WordPress-Android/pull/17797/commits/0bfc407189c49d8128888eb1ea144aa5b05bbde9)
- [Disables: quick start reminder notifications in Phase 4](https://github.com/wordpress-mobile/WordPress-Android/pull/17797/commits/2f4414780634870aeccba6f22a4aed00c5a6212a)
- [Disables: Notifications for the scheduled post](https://github.com/wordpress-mobile/WordPress-Android/pull/17797/commits/8d6ebd3979d25a2363375a2b15bf3af998172ed7)

## 🧪  To test:

### 1. Disables Remote notifications 🔔 
1. Login to the app with a Site 
2. Comment on the post of the site with another account / like the post with another account 
3. Verify that a notification is received 
4. Go to me -> app settings -> Debug settings 
5. enable `jp_removal_four` 
6. Comment on the site with another account / like the post with another account 
7. Verify that no notifications are received 

### 2. Disable weekly round-up notifications 
1. Login to the app with a Site 
2. Go to me -> app settings -> Debug settings 
3. Click at **Force show Weekly Roundup notification**  item 
4. Verify that a notification is received 
5. Go to me -> app settings -> Debug settings 
6. enable `jp_removal_four` 
7. Restart app 
8. Click at **Force show Weekly Roundup notification**  item 
9. Verify that no notifications are received 

### 3. Disables: Quick start reminder notifications in Phase 4
1. Login to the app with a Site having quick start in progress
2. Complete one quick start task (Dont finish the entire quick start tasks) 
3. Close the app 
4. Change the device date to +2 days 
5. Wait for one min
6. Verify that a notification for the next quick start task is shown  
7. Go to me -> app settings -> Debug settings 
8. enable `jp_removal_four` 
9. Repeat the steps 2 - 5
10. Verify that no notifications are received 

### 4. [Disables: Notifications for the scheduled post](https://github.com/wordpress-mobile/WordPress-Android/pull/17797/commits/8d6ebd3979d25a2363375a2b15bf3af998172ed7)
1. Login to the app 
2. Go to a Post/Post settings/Publish settings
3. Set publish time to the future (current time + 11 minutes)
4. Verify that a notification is shown 
5. Go to me -> app settings -> Debug settings
6. enable `jp_removal_four` 
7. Repeat the steps 2 - 4
8. Verify that notification is not shown 

### 5. - [Disables: Create site notifications in Phase 4](https://github.com/wordpress-mobile/WordPress-Android/pull/17797/commits/4165233c9d9db096ef9804dfe1f774a22c145aae)
1. Login to the app with no sites 
2. Go to device settings 
3. Change the device date to +1 day 
4. Verify that a notification for creating a site is shown 
5. Go to me -> app settings -> Debug settings
6. enable `jp_removal_four` 
7. Log out 
8. Repeat steps 1 - 3
9. Verify that no notification is shown  


### 💡  After covering the above test instructions. Checking all the places where the Notification is created, we have added the `jetpackFeatureRemovalPhaseHelper.shouldShowNotifications()` is sufficient. 

## Regression Notes
1. Potential unintended areas of impact
- Notifications are not shown when in normal phase 
- Notifications are shown in Jetpack removal phase 4 

6. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual tests and Unit tests 

7. What automated tests I added (or what prevented me from doing so)
- N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
