### PR TITLE
[Build] Remove Vector Drawables Use Support Library Configuration

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -79,7 +79,6 @@ android {
 
         multiDexEnabled true
 
-        vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'org.wordpress.android.WordPressTestRunner'
 
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ ext {
     androidxRecyclerviewVersion = '1.0.0'
     androidxRoomVersion = '2.3.0'
     androidxSwipeToRefreshVersion = '1.1.0'
-    androidxVectordrawableAnimatedVersion = '1.0.0'
     androidxViewpager2Version = '1.0.0'
     androidxWorkVersion = "2.7.0"
     apacheCommonsTextVersion = '1.10.0'

--- a/libs/image-editor/build.gradle
+++ b/libs/image-editor/build.gradle
@@ -13,8 +13,6 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-        vectorDrawables.useSupportLibrary = true
     }
 
     sourceSets {


### PR DESCRIPTION
This PR is mainly about removing the no longer necessary `vectorDrawables.useSupportLibrary = true` configuration from this project. Since the `minSdkVersion` of this project is currently on `24`, this vector drawables backward compatibility solution is no longer required.

For more info see:
- [Vector drawables backward compatibility solution](https://developer.android.com/develop/ui/views/graphics/vector-drawable-resources#vector-drawables-backward-solution)
- [androidx.vectordrawable.graphics.drawable.VectorDrawableCompat](https://developer.android.com/reference/androidx/vectordrawable/graphics/drawable/VectorDrawableCompat)

-----

Also, as part of this PR, the unused `androidxVectordrawableAnimatedVersion = '1.0.0'` version got removed as well. The dependency that was associated with this version was removed as part of this https://github.com/wordpress-mobile/WordPress-Android/commit/f2a8b18409c39242227691a2223f0168b4f40786 commit. The version should have been removed as part of this commit but got slipped from being removed.

-----

To test:

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you want to be thorough about reviewing this change, you could quickly smoke test both, the WordPress and Jetpack apps, and see if they both work as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
