### PR TITLE
[Build] Remove Multidex Configuration

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -77,8 +77,6 @@ android {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
-        multiDexEnabled true
-
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'org.wordpress.android.WordPressTestRunner'
 
@@ -375,7 +373,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$androidxLifecycleVersion"
     implementation "androidx.fragment:fragment:$androidxFragmentVersion"
     implementation "androidx.fragment:fragment-ktx:$androidxFragmentVersion"
-    implementation "androidx.multidex:multidex:$androidXMultidexVersion"
     implementation "androidx.media:media:$androidxMediaVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "androidx.cardview:cardview:$androidxCardviewVersion"

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.kt
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android
 
+import android.app.Application
 import android.content.Context
-import androidx.multidex.MultiDexApplication
 import com.android.volley.RequestQueue
 import dagger.hilt.EntryPoints
 import org.wordpress.android.AppInitializer.StoryNotificationTrackerProvider
@@ -12,7 +12,7 @@ import org.wordpress.android.modules.AppComponent
  * An abstract class to be extended by {@link WordPressApp} for real application and WordPressTest for UI test
  * application. Containing public static variables and methods to be accessed by other classes.
  */
-abstract class WordPress : MultiDexApplication() {
+abstract class WordPress : Application() {
     val storyNotificationTrackerProvider: StoryNotificationTrackerProvider
         get() = initializer().storyNotificationTrackerProvider
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,6 @@ ext {
     androidxGridlayoutVersion = '1.0.0'
     androidxLifecycleVersion = '2.4.1'
     androidxMediaVersion = '1.0.1'
-    androidXMultidexVersion = '2.0.1'
     androidxPercentlayoutVersion = '1.0.0'
     androidxPreferenceVersion = '1.1.0'
     androidxRecyclerviewVersion = '1.0.0'


### PR DESCRIPTION
This PR is about removing the no longer necessary `multiDexEnabled true` configuration from this project. Since the `minSdkVersion` of this project is currently on `24`, this multidex app configuration is no longer required.

For more info see:
- [Configure your app for multidex](https://developer.android.com/studio/build/multidex#mdex-gradle)
- [Multidex support for Android 5.0 and higher](https://developer.android.com/studio/build/multidex#mdex-on-l)

-----

FYI: Similar work that is already done on other projects:
- [WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/4805)
- [FluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2121)

-----

To test:

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you want to be thorough about reviewing this change, you could quickly smoke test both, the WordPress and Jetpack apps, and see if they both work as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
