### PR TITLE
Adds: Jetpack feature removal card for Self hosted and New users 

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -127,6 +127,7 @@ android {
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_THREE", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_FOUR", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_NEW_USERS", "false"
+        buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_SELF_HOSTED_USERS", "false"
         buildConfigField "boolean", "PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD", "false"
         buildConfigField "boolean", "OPEN_WEB_LINKS_WITH_JETPACK_FLOW", "false"
         buildConfigField "boolean", "ENABLE_WORDPRESS_SUPPORT_FORUM", "false"

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayViewModel.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource.UNSPECIFIED
 import org.wordpress.android.util.config.JPDeadlineConfig
+import org.wordpress.android.util.config.PhaseFourBlogPostLinkConfig
 import org.wordpress.android.util.config.PhaseThreeBlogPostLinkConfig
 import org.wordpress.android.util.config.PhaseTwoBlogPostLinkConfig
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -28,7 +29,8 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
     private val jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil,
     private val jpDeadlineConfig: JPDeadlineConfig,
     private val phaseTwoBlogPostLinkConfig: PhaseTwoBlogPostLinkConfig,
-    private val phaseThreeBlogPostLinkConfig: PhaseThreeBlogPostLinkConfig
+    private val phaseThreeBlogPostLinkConfig: PhaseThreeBlogPostLinkConfig,
+    private val phaseFourBlogPostLinkConfig: PhaseFourBlogPostLinkConfig
 ) : ScopedViewModel(mainDispatcher) {
     private val _uiState = SingleLiveEvent<JetpackFeatureOverlayUIState>()
     val uiState: LiveData<JetpackFeatureOverlayUIState> = _uiState
@@ -133,7 +135,7 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
                 jetpackFeatureOverlayContentBuilder.buildFeatureCollectionOverlayState(
                     rtlLayout,
                     getCurrentPhase()!!,
-                    phaseThreeBlogPostLinkConfig.getValue()
+                    getBlogPostLinkForTheCurrentPhase()
                 )
             )
             jetpackFeatureRemovalOverlayUtil.onFeatureCollectionOverlayShown(featureCollectionOverlaySource)
@@ -166,6 +168,15 @@ class JetpackFeatureFullScreenOverlayViewModel @Inject constructor(
             jetpackFeatureRemovalOverlayUtil.trackLearnMoreAboutMigrationClicked(screenType)
         }
         _action.value = OpenMigrationInfoLink(migrationInfoRedirectUrl)
+    }
+
+    private fun getBlogPostLinkForTheCurrentPhase(): String? {
+        return when (getCurrentPhase()) {
+            JetpackFeatureRemovalPhase.PhaseTwo -> phaseTwoBlogPostLinkConfig.getValue()
+            JetpackFeatureRemovalPhase.PhaseThree -> phaseThreeBlogPostLinkConfig.getValue()
+            JetpackFeatureRemovalPhase.PhaseFour -> phaseFourBlogPostLinkConfig.getValue()
+            else -> null
+        }
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.jetpackoverlay
 
 import org.wordpress.android.R
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseFour
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseNewUsers
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
@@ -31,8 +29,7 @@ class JetpackFeatureOverlayContentBuilder @Inject constructor(
             is PhaseOne -> getStateForPhaseOne(params, params.feature!!)
             is PhaseTwo -> getStateForPhaseTwo(params)
             is PhaseThree -> getStateForPhaseThree(params)
-            is PhaseFour -> TODO()
-            is PhaseNewUsers -> TODO()
+            else  -> TODO()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
@@ -294,31 +294,41 @@ class JetpackFeatureOverlayContentBuilder @Inject constructor(
         currentPhase: JetpackFeatureRemovalPhase
     ): JetpackFeatureOverlayContent {
         return if (currentPhase == PhaseThree) {
-            JetpackFeatureOverlayContent(
-                illustration = if (isRtl) R.raw.jp_all_features_rtl else R.raw.jp_all_features_left,
-                title = R.string.wp_jetpack_feature_removal_overlay_phase_two_and_three_title_all_features,
-                caption = UiStringRes(R.string.wp_jetpack_feature_removal_overlay_phase_three_all_features_description),
-                migrationText = R.string.wp_jetpack_feature_removal_overlay_migration_helper_text,
-                migrationInfoText = if (!blogPostLink.isNullOrEmpty())
-                    R.string.wp_jetpack_feature_removal_overlay_learn_more_migration_text else null,
-                migrationInfoUrl = blogPostLink,
-                primaryButtonText = R.string.wp_jetpack_feature_removal_overlay_switch_to_the_jetpack_app,
-                secondaryButtonText = R.string.wp_jetpack_feature_removal_overlay_continue_without_jetpack
-            )
+            getJetpackFeatureOverlayContentForPhaseThree(isRtl, blogPostLink)
         } else {
-            JetpackFeatureOverlayContent(
-                illustration = if (isRtl) R.raw.jp_all_features_rtl else R.raw.jp_all_features_left,
-                title = R.string.wp_jetpack_feature_removal_overlay_phase_four_title_all_features,
-                caption = UiStringRes(R.string.wp_jetpack_feature_removal_overlay_phase_four_all_features_description),
-                migrationText = R.string.wp_jetpack_feature_removal_overlay_migration_helper_text,
-                migrationInfoText = if (!blogPostLink.isNullOrEmpty())
-                    R.string.wp_jetpack_feature_removal_overlay_learn_more_migration_text else null,
-                migrationInfoUrl = blogPostLink,
-                primaryButtonText = R.string.wp_jetpack_feature_removal_overlay_switch_to_the_jetpack_app,
-                secondaryButtonText = R.string.wp_jetpack_feature_removal_phase_four_secondary_text
-            )
+            getJetpackFeatureOverlayContentForPhaseFour(isRtl, blogPostLink)
         }
     }
+
+    private fun getJetpackFeatureOverlayContentForPhaseFour(
+        isRtl: Boolean,
+        blogPostLink: String?
+    ) = JetpackFeatureOverlayContent(
+        illustration = if (isRtl) R.raw.jp_all_features_rtl else R.raw.jp_all_features_left,
+        title = R.string.wp_jetpack_feature_removal_overlay_phase_four_title_all_features,
+        caption = UiStringRes(R.string.wp_jetpack_feature_removal_overlay_phase_four_all_features_description),
+        migrationText = R.string.wp_jetpack_feature_removal_overlay_migration_helper_text,
+        migrationInfoText = if (!blogPostLink.isNullOrEmpty())
+            R.string.wp_jetpack_feature_removal_overlay_learn_more_migration_text else null,
+        migrationInfoUrl = blogPostLink,
+        primaryButtonText = R.string.wp_jetpack_feature_removal_overlay_switch_to_the_jetpack_app,
+        secondaryButtonText = R.string.wp_jetpack_feature_removal_phase_four_secondary_text
+    )
+
+    private fun getJetpackFeatureOverlayContentForPhaseThree(
+        isRtl: Boolean,
+        blogPostLink: String?
+    ) = JetpackFeatureOverlayContent(
+        illustration = if (isRtl) R.raw.jp_all_features_rtl else R.raw.jp_all_features_left,
+        title = R.string.wp_jetpack_feature_removal_overlay_phase_two_and_three_title_all_features,
+        caption = UiStringRes(R.string.wp_jetpack_feature_removal_overlay_phase_three_all_features_description),
+        migrationText = R.string.wp_jetpack_feature_removal_overlay_migration_helper_text,
+        migrationInfoText = if (!blogPostLink.isNullOrEmpty())
+            R.string.wp_jetpack_feature_removal_overlay_learn_more_migration_text else null,
+        migrationInfoUrl = blogPostLink,
+        primaryButtonText = R.string.wp_jetpack_feature_removal_overlay_switch_to_the_jetpack_app,
+        secondaryButtonText = R.string.wp_jetpack_feature_removal_overlay_continue_without_jetpack
+    )
 }
 
 data class JetpackFeatureOverlayContentBuilderParams(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -11,11 +11,10 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseFour
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseNewUsers
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseSelfHostedUsers
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseSelfHostedUsers
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DateTimeUtilsWrapper
@@ -27,8 +26,6 @@ import javax.inject.Inject
 private const val CURRENT_PHASE_KEY = "phase"
 private const val SCREEN_TYPE_KEY = "source"
 private const val DISMISSAL_TYPE_KEY = "dismissal_type"
-private const val FREQUENCY_IN_DAYS = 4
-private const val DEFAULT_LAST_SHOWN_TIMESTAMP = 0L
 
 @Suppress("LongParameterList", "TooManyFunctions")
 class JetpackFeatureRemovalOverlayUtil @Inject constructor(
@@ -38,9 +35,9 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
     private val siteUtilsWrapper: SiteUtilsWrapper,
     private val buildConfigWrapper: BuildConfigWrapper,
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val appPrefsWrapper: AppPrefsWrapper
-) {
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    )
+{
     fun shouldShowFeatureSpecificJetpackOverlay(feature: JetpackOverlayConnectedFeature): Boolean {
         return !buildConfigWrapper.isJetpackApp && isWpComSite() &&
                 isInFeatureSpecificRemovalPhase() && hasExceededOverlayFrequency(
@@ -51,27 +48,6 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
 
     fun shouldHideJetpackFeatures(): Boolean {
         return jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
-    }
-
-    fun shouldShowSwitchToJetpackMenuCard(): Boolean {
-        return shouldHideJetpackFeatures() && exceedsShowFrequencyAndResetJetpackFeatureCardLastShownTimestampIfNeeded()
-    }
-
-    private fun exceedsShowFrequencyAndResetJetpackFeatureCardLastShownTimestampIfNeeded(): Boolean {
-        val lastShownTimestamp = appPrefsWrapper.getSwitchToJetpackMenuCardLastShownTimestamp()
-        if (lastShownTimestamp == DEFAULT_LAST_SHOWN_TIMESTAMP) return true
-
-        val lastShownDate = Date(lastShownTimestamp)
-        val daysPastOverlayShown = dateTimeUtilsWrapper.daysBetween(
-            lastShownDate,
-            Date(System.currentTimeMillis())
-        )
-
-        val exceedsFrequency = daysPastOverlayShown >= FREQUENCY_IN_DAYS
-        if (exceedsFrequency) {
-            appPrefsWrapper.setSwitchToJetpackMenuCardLastShownTimestamp(DEFAULT_LAST_SHOWN_TIMESTAMP)
-        }
-        return exceedsFrequency
     }
 
     fun shouldShowSiteCreationOverlay(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseN
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseSelfHostedUsers
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
@@ -49,7 +50,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
     }
 
     fun shouldHideJetpackFeatures(): Boolean {
-        return jetpackFeatureRemovalPhaseHelper.getCurrentPhase() == PhaseFour
+        return jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
     }
 
     fun shouldShowSwitchToJetpackMenuCard(): Boolean {
@@ -101,7 +102,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
                 when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
                     null -> false
                     PhaseOne, PhaseTwo, PhaseThree -> true
-                    PhaseFour, PhaseNewUsers -> false
+                    PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
                 }
     }
 
@@ -132,10 +133,10 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
     private fun hasExceededGlobalOverlayFrequency(phase: JetpackFeatureRemovalOverlayPhase): Boolean {
         // Overlay is never shown
         val lastOverlayShownDate = jetpackFeatureOverlayShownTracker.getTheLastShownOverlayTimeStamp(phase)
-                ?.let { Date(it) } ?: return true
+            ?.let { Date(it) } ?: return true
         val daysPastOverlayShown = dateTimeUtilsWrapper.daysBetween(
-                lastOverlayShownDate,
-                dateTimeUtilsWrapper.getTodaysDate()
+            lastOverlayShownDate,
+            dateTimeUtilsWrapper.getTodaysDate()
         )
         return daysPastOverlayShown >= PhaseOne.globalOverlayFrequency
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -67,8 +67,8 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
     fun shouldRemoveJetpackFeatures(): Boolean {
         val currentPhase = getCurrentPhase() ?: return false
         return when (currentPhase) {
-            is PhaseFour, PhaseNewUsers -> true
-            is PhaseOne, PhaseTwo, PhaseThree, PhaseSelfHostedUsers -> false
+            is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers-> true
+            is PhaseOne, PhaseTwo, PhaseThree -> false
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -39,7 +39,7 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
 ) {
     fun getCurrentPhase(): JetpackFeatureRemovalPhase? {
         return if (buildConfigWrapper.isJetpackApp) null
-        else if (jetpackFeatureRemovalSelfHostedUsersConfig.isEnabled()) PhaseNewUsers
+        else if (jetpackFeatureRemovalSelfHostedUsersConfig.isEnabled()) PhaseSelfHostedUsers
         else if (jetpackFeatureRemovalNewUsersConfig.isEnabled()) PhaseNewUsers
         else if (jetpackFeatureRemovalPhaseFourConfig.isEnabled()) PhaseFour
         else if (jetpackFeatureRemovalPhaseThreeConfig.isEnabled()) PhaseThree

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseN
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseSelfHostedUsers
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_ONE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO
 import org.wordpress.android.util.BuildConfigWrapper
@@ -13,6 +14,7 @@ import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseFourConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseOneConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseThreeConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseTwoConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalSelfHostedUsersConfig
 import javax.inject.Inject
 
 private const val PHASE_ONE_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS = 2
@@ -32,10 +34,12 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
     private val jetpackFeatureRemovalPhaseTwoConfig: JetpackFeatureRemovalPhaseTwoConfig,
     private val jetpackFeatureRemovalPhaseThreeConfig: JetpackFeatureRemovalPhaseThreeConfig,
     private val jetpackFeatureRemovalPhaseFourConfig: JetpackFeatureRemovalPhaseFourConfig,
-    private val jetpackFeatureRemovalNewUsersConfig: JetpackFeatureRemovalNewUsersConfig
+    private val jetpackFeatureRemovalNewUsersConfig: JetpackFeatureRemovalNewUsersConfig,
+    private val jetpackFeatureRemovalSelfHostedUsersConfig: JetpackFeatureRemovalSelfHostedUsersConfig
 ) {
     fun getCurrentPhase(): JetpackFeatureRemovalPhase? {
         return if (buildConfigWrapper.isJetpackApp) null
+        else if (jetpackFeatureRemovalSelfHostedUsersConfig.isEnabled()) PhaseNewUsers
         else if (jetpackFeatureRemovalNewUsersConfig.isEnabled()) PhaseNewUsers
         else if (jetpackFeatureRemovalPhaseFourConfig.isEnabled()) PhaseFour
         else if (jetpackFeatureRemovalPhaseThreeConfig.isEnabled()) PhaseThree
@@ -48,7 +52,7 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         val currentPhase = getCurrentPhase() ?: return null
         return when (currentPhase) {
             is PhaseOne, PhaseTwo, PhaseThree -> PHASE_ONE
-            is PhaseFour, PhaseNewUsers -> PHASE_TWO
+            is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> PHASE_TWO
         }
     }
 
@@ -56,7 +60,7 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         val currentPhase = getCurrentPhase() ?: return null
         return when (currentPhase) {
             is PhaseOne, PhaseTwo, PhaseThree -> PHASE_ONE
-            is PhaseFour, PhaseNewUsers -> PHASE_TWO
+            is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> PHASE_TWO
         }
     }
 
@@ -64,14 +68,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         val currentPhase = getCurrentPhase() ?: return false
         return when (currentPhase) {
             is PhaseFour, PhaseNewUsers -> true
-            is PhaseOne, PhaseTwo, PhaseThree -> false
+            is PhaseOne, PhaseTwo, PhaseThree, PhaseSelfHostedUsers -> false
         }
     }
 
     fun shouldShowNotifications(): Boolean {
         val currentPhase = getCurrentPhase() ?: return true
         return when (currentPhase) {
-            is PhaseFour, PhaseNewUsers -> false
+            is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
             is PhaseOne, PhaseTwo, PhaseThree -> true
         }
     }
@@ -105,7 +109,8 @@ sealed class JetpackFeatureRemovalPhase(
     )
 
     object PhaseFour : JetpackFeatureRemovalPhase(trackingName = "four")
-    object PhaseNewUsers : JetpackFeatureRemovalPhase(trackingName = "new")
+    object PhaseNewUsers : JetpackFeatureRemovalPhase(trackingName = "new_users")
+    object PhaseSelfHostedUsers : JetpackFeatureRemovalPhase(trackingName = "self_hosted")
 }
 
 enum class JetpackFeatureRemovalSiteCreationPhase(val trackingName: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -129,6 +129,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         }
 
         data class JetpackFeatureCard(
+            val content: UiString?,
             val onClick: ListItemInteraction,
             val onRemindMeLaterItemClick: ListItemInteraction,
             val onHideMenuItemClick: ListItemInteraction,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -445,6 +445,7 @@ class MySiteViewModel @Inject constructor(
             )
         )
         val jetpackFeatureCard = JetpackFeatureCard(
+            content = jetpackFeatureCardHelper.getCardContent(),
             onClick = ListItemInteraction.create(this::onJetpackFeatureCardClick),
             onHideMenuItemClick = ListItemInteraction.create(this::onJetpackFeatureCardHideMenuItemClick),
             onLearnMoreClick = ListItemInteraction.create(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -706,7 +706,6 @@ class MySiteViewModel @Inject constructor(
         val indexOfDashboardCards = cards.indexOfFirst { it is DashboardCards }
         return mutableListOf<MySiteCardAndItem>().apply {
             infoItem?.let { add(infoItem) }
-            jetpackFeatureCard?.let { add(jetpackFeatureCard) }
             migrationSuccessCard?.let { add(migrationSuccessCard) }
             addAll(cards)
             if (indexOfDashboardCards == -1) {
@@ -717,6 +716,9 @@ class MySiteViewModel @Inject constructor(
             addAll(siteItems)
             jetpackBadge?.let { add(jetpackBadge) }
             jetpackSwitchMenu?.let { add(jetpackSwitchMenu) }
+            if (jetpackFeatureCardHelper.shouldShowFeatureCardAtTop())
+                jetpackFeatureCard?.let { add(0, jetpackFeatureCard) }
+            else jetpackFeatureCard?.let { add(jetpackFeatureCard) }
         }.toList()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1357,8 +1357,7 @@ class MySiteViewModel @Inject constructor(
     }
 
     private fun onJetpackFeatureCardRemindMeLaterClick() {
-        jetpackFeatureCardHelper.track(Stat.REMOVE_FEATURE_CARD_REMIND_LATER_TAPPED)
-        appPrefsWrapper.setJetpackFeatureCardLastShownTimestamp(System.currentTimeMillis())
+        jetpackFeatureCardHelper.setJetpackFeatureCardLastShownTimeStamp(System.currentTimeMillis())
         refresh()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -464,7 +464,7 @@ class MySiteViewModel @Inject constructor(
             onRemindMeLaterItemClick = ListItemInteraction.create(this::onSwitchToJetpackMenuCardRemindMeLaterClick),
             onMoreMenuClick = ListItemInteraction.create(this::onJetpackFeatureCardMoreMenuClick)
         ).takeIf {
-            jetpackFeatureRemovalUtils.shouldShowSwitchToJetpackMenuCard()
+            jetpackFeatureCardHelper.shouldShowSwitchToJetpackMenuCard()
         }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1347,8 +1347,7 @@ class MySiteViewModel @Inject constructor(
     }
 
     private fun onJetpackFeatureCardHideMenuItemClick() {
-        jetpackFeatureCardHelper.track(Stat.REMOVE_FEATURE_CARD_HIDE_TAPPED)
-        appPrefsWrapper.setShouldHideJetpackFeatureCard(true)
+        jetpackFeatureCardHelper.hideJetpackFeatureCard()
         refresh()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
@@ -84,7 +84,8 @@ class JetpackFeatureCardHelper @Inject constructor(
     }
 
     private fun exceedsShowFrequencyAndResetJetpackFeatureCardLastShownTimestampIfNeeded(): Boolean {
-        val lastShownTimestamp = appPrefsWrapper.getJetpackFeatureCardLastShownTimestamp()
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase() ?: return false
+        val lastShownTimestamp = appPrefsWrapper.getJetpackFeatureCardLastShownTimestamp(currentPhase)
         if (lastShownTimestamp == DEFAULT_LAST_SHOWN_TIMESTAMP) return true
 
         val lastShownDate = Date(lastShownTimestamp)
@@ -95,7 +96,7 @@ class JetpackFeatureCardHelper @Inject constructor(
 
         val exceedsFrequency = daysPastOverlayShown >= FREQUENCY_IN_DAYS
         if (exceedsFrequency) {
-            appPrefsWrapper.setJetpackFeatureCardLastShownTimestamp(DEFAULT_LAST_SHOWN_TIMESTAMP)
+            appPrefsWrapper.setJetpackFeatureCardLastShownTimestamp(currentPhase, DEFAULT_LAST_SHOWN_TIMESTAMP)
         }
         return exceedsFrequency
     }
@@ -133,6 +134,13 @@ class JetpackFeatureCardHelper @Inject constructor(
         track(Stat.REMOVE_FEATURE_CARD_HIDE_TAPPED)
         jetpackFeatureRemovalPhaseHelper.getCurrentPhase()?.let {
             appPrefsWrapper.setShouldHideJetpackFeatureCard(it, true)
+        }
+    }
+
+    fun setJetpackFeatureCardLastShownTimeStamp(currentTimeMillis: Long) {
+        track(Stat.REMOVE_FEATURE_CARD_REMIND_LATER_TAPPED)
+        jetpackFeatureRemovalPhaseHelper.getCurrentPhase()?.let {
+            appPrefsWrapper.setJetpackFeatureCardLastShownTimestamp(it, currentTimeMillis)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
@@ -93,6 +93,34 @@ class JetpackFeatureCardHelper @Inject constructor(
         return exceedsFrequency
     }
 
+    fun shouldShowSwitchToJetpackMenuCard(): Boolean {
+        return shouldShowSwitchToJetpackMenuCardInCurrentPhase() &&
+                exceedsShowFrequencyAndResetSwitchToJetpackMenuLastShownTimestampIfNeeded()
+    }
+
+    private fun shouldShowSwitchToJetpackMenuCardInCurrentPhase(): Boolean {
+        return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
+            is JetpackFeatureRemovalPhase.PhaseFour -> true
+            else -> false
+        }
+    }
+    private fun exceedsShowFrequencyAndResetSwitchToJetpackMenuLastShownTimestampIfNeeded(): Boolean {
+        val lastShownTimestamp = appPrefsWrapper.getSwitchToJetpackMenuCardLastShownTimestamp()
+        if (lastShownTimestamp == DEFAULT_LAST_SHOWN_TIMESTAMP) return true
+
+        val lastShownDate = Date(lastShownTimestamp)
+        val daysPastOverlayShown = dateTimeUtilsWrapper.daysBetween(
+            lastShownDate,
+            Date(System.currentTimeMillis())
+        )
+
+        val exceedsFrequency = daysPastOverlayShown >= FREQUENCY_IN_DAYS
+        if (exceedsFrequency) {
+            appPrefsWrapper.setSwitchToJetpackMenuCardLastShownTimestamp(DEFAULT_LAST_SHOWN_TIMESTAMP)
+        }
+        return exceedsFrequency
+    }
+
     companion object {
         const val PHASE = "phase"
         const val FREQUENCY_IN_DAYS = 4

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.util.config.PhaseThreeBlogPostLinkConfig
 import java.util.Date
 import javax.inject.Inject
 
-
 class JetpackFeatureCardHelper @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val appPrefsWrapper: AppPrefsWrapper,
@@ -83,6 +82,7 @@ class JetpackFeatureCardHelper @Inject constructor(
             url
     }
 
+    @Suppress("ReturnCount")
     private fun exceedsShowFrequencyAndResetJetpackFeatureCardLastShownTimestampIfNeeded(): Boolean {
         val currentPhase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase() ?: return false
         val lastShownTimestamp = appPrefsWrapper.getJetpackFeatureCardLastShownTimestamp(currentPhase)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.mysite.cards.jetpackfeature
 
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseNewUsers
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseSelfHostedUsers
@@ -15,6 +16,7 @@ import org.wordpress.android.util.config.PhaseThreeBlogPostLinkConfig
 import java.util.Date
 import javax.inject.Inject
 
+
 class JetpackFeatureCardHelper @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val appPrefsWrapper: AppPrefsWrapper,
@@ -25,11 +27,17 @@ class JetpackFeatureCardHelper @Inject constructor(
 ) {
     fun shouldShowJetpackFeatureCard(): Boolean {
         val isWordPressApp = !buildConfigWrapper.isJetpackApp
-        val shouldShowCardIntheCurrentPhase = shouldShowJetpackFeatureCardInCurrentPhase()
+        val shouldShowCardInCurrentPhase = shouldShowJetpackFeatureCardInCurrentPhase()
         val shouldHideJetpackFeatureCard = appPrefsWrapper.getShouldHideJetpackFeatureCard()
         val exceedsShowFrequency = exceedsShowFrequencyAndResetJetpackFeatureCardLastShownTimestampIfNeeded()
-        return isWordPressApp && shouldShowCardIntheCurrentPhase &&
+        return isWordPressApp && shouldShowCardInCurrentPhase &&
                 !shouldHideJetpackFeatureCard && exceedsShowFrequency
+    }
+    fun shouldShowFeatureCardAtTop(): Boolean {
+        return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
+            is PhaseThree, PhaseSelfHostedUsers -> true
+            else -> false
+        }
     }
 
     private fun shouldShowJetpackFeatureCardInCurrentPhase(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
@@ -1,9 +1,13 @@
 package org.wordpress.android.ui.mysite.cards.jetpackfeature
 
+import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseNewUsers
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseSelfHostedUsers
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -21,10 +25,28 @@ class JetpackFeatureCardHelper @Inject constructor(
 ) {
     fun shouldShowJetpackFeatureCard(): Boolean {
         val isWordPressApp = !buildConfigWrapper.isJetpackApp
-        val isPhase3 = jetpackFeatureRemovalPhaseHelper.getCurrentPhase() == JetpackFeatureRemovalPhase.PhaseThree
+        val shouldShowCardIntheCurrentPhase = shouldShowJetpackFeatureCardInCurrentPhase()
         val shouldHideJetpackFeatureCard = appPrefsWrapper.getShouldHideJetpackFeatureCard()
         val exceedsShowFrequency = exceedsShowFrequencyAndResetJetpackFeatureCardLastShownTimestampIfNeeded()
-        return isWordPressApp && isPhase3 && !shouldHideJetpackFeatureCard && exceedsShowFrequency
+        return isWordPressApp && shouldShowCardIntheCurrentPhase &&
+                !shouldHideJetpackFeatureCard && exceedsShowFrequency
+    }
+
+    private fun shouldShowJetpackFeatureCardInCurrentPhase(): Boolean {
+        return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
+            is PhaseThree, PhaseNewUsers, PhaseSelfHostedUsers -> true
+            else -> false
+        }
+    }
+
+    fun getCardContent(): UiString.UiStringRes? {
+        return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
+            is PhaseThree ->
+                UiString.UiStringRes(R.string.jetpack_feature_card_content_phase_three)
+            is PhaseNewUsers, PhaseSelfHostedUsers ->
+                UiString.UiStringRes(R.string.jetpack_feature_card_content_phase_self_hosted_and_new_users)
+            else -> null
+        }
     }
 
     fun track(stat: Stat) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardViewHolder.kt
@@ -18,6 +18,7 @@ class JetpackFeatureCardViewHolder(
     parent.viewBinding(JetpackFeatureCardBinding::inflate)
 ) {
     fun bind(card: JetpackFeatureCard) = with(binding) {
+        uiHelpers.setTextOrHide(mySiteJetpackFeatureCardContent, card.content)
         mySiteJetpackFeatureCardCta.setOnClickListener { card.onClick.click() }
         mySiteJetpackFeatureCardLearnMore.setOnClickListener { card.onLearnMoreClick.click() }
         mySiteJetpackFeatureCardMore.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -368,7 +368,7 @@ public class AppPrefs {
     }
 
     public static void putInt(final PrefKey key, final int value) {
-        prefs().edit().putInt(key.name(), value) .apply();
+        prefs().edit().putInt(key.name(), value).apply();
     }
 
     public static void setInt(PrefKey key, int value) {
@@ -389,7 +389,7 @@ public class AppPrefs {
     }
 
     public static void putStringSet(final PrefKey key, final Set<String> value) {
-        prefs().edit().putStringSet(key.name(), value) .apply();
+        prefs().edit().putStringSet(key.name(), value).apply();
     }
 
     private static void remove(PrefKey key) {
@@ -1534,18 +1534,24 @@ public class AppPrefs {
         prefs().edit().putBoolean(getHideJetpackFeatureCardWithPhaseKey(phase), isHidden).apply();
     }
 
-    public static Long getJetpackFeatureCardLastShownTimestamp() {
-        return getLong(DeletablePrefKey.JETPACK_FEATURE_CARD_LAST_SHOWN_TIMESTAMP, 0L);
+    public static Long getJetpackFeatureCardLastShownTimestamp(JetpackFeatureRemovalPhase jetpackFeatureRemovalPhase) {
+        return prefs().getLong(getJetpackFeatureCardLastShownTimeStampWithPhaseKey(jetpackFeatureRemovalPhase), 0L);
     }
 
-    public static void setJetpackFeatureCardLastShownTimestamp(final Long lastShownTimestamp) {
-        setLong(DeletablePrefKey.JETPACK_FEATURE_CARD_LAST_SHOWN_TIMESTAMP, lastShownTimestamp);
+    public static void setJetpackFeatureCardLastShownTimestamp(JetpackFeatureRemovalPhase jetpackFeatureRemovalPhase,
+                                                               final Long lastShownTimestamp) {
+        prefs().edit().putLong(getJetpackFeatureCardLastShownTimeStampWithPhaseKey(jetpackFeatureRemovalPhase),
+                lastShownTimestamp).apply();
     }
 
     @NonNull private static String getHideJetpackFeatureCardWithPhaseKey(JetpackFeatureRemovalPhase phase) {
         return DeletablePrefKey.SHOULD_HIDE_JETPACK_FEATURE_CARD.name() + phase.getTrackingName();
     }
 
+    @NonNull
+    private static String getJetpackFeatureCardLastShownTimeStampWithPhaseKey(JetpackFeatureRemovalPhase phase) {
+        return DeletablePrefKey.JETPACK_FEATURE_CARD_LAST_SHOWN_TIMESTAMP.name() + phase.getTrackingName();
+    }
 
     public static Long getSwitchToJetpackMenuCardLastShownTimestamp() {
         return getLong(DeletablePrefKey.SWITCH_TO_JETPACK_MENU_CARD_SHOWN_TIMESTAMP, 0L);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -20,6 +20,7 @@ import org.wordpress.android.models.PeopleListFilter;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.ActivityId;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType;
 import org.wordpress.android.ui.posts.AuthorFilterSelection;
@@ -380,7 +381,7 @@ public class AppPrefs {
     }
 
     public static void putBoolean(final PrefKey key, final boolean value) {
-        prefs().edit().putBoolean(key.name(), value) .apply();
+        prefs().edit().putBoolean(key.name(), value).apply();
     }
 
     public static void setBoolean(PrefKey key, boolean value) {
@@ -1525,12 +1526,12 @@ public class AppPrefs {
         setBoolean(DeletablePrefKey.OPEN_WEB_LINKS_WITH_JETPACK, isOpenWebLinksWithJetpack);
     }
 
-    public static Boolean getShouldHideJetpackFeatureCard() {
-        return getBoolean(DeletablePrefKey.SHOULD_HIDE_JETPACK_FEATURE_CARD, false);
+    public static Boolean getShouldHideJetpackFeatureCard(JetpackFeatureRemovalPhase phase) {
+        return prefs().getBoolean(getHideJetpackFeatureCardWithPhaseKey(phase), false);
     }
 
-    public static void setShouldHideJetpackFeatureCard(final boolean isHidden) {
-        setBoolean(DeletablePrefKey.SHOULD_HIDE_JETPACK_FEATURE_CARD, isHidden);
+    public static void setShouldHideJetpackFeatureCard(JetpackFeatureRemovalPhase phase, final boolean isHidden) {
+        prefs().edit().putBoolean(getHideJetpackFeatureCardWithPhaseKey(phase), isHidden).apply();
     }
 
     public static Long getJetpackFeatureCardLastShownTimestamp() {
@@ -1540,6 +1541,11 @@ public class AppPrefs {
     public static void setJetpackFeatureCardLastShownTimestamp(final Long lastShownTimestamp) {
         setLong(DeletablePrefKey.JETPACK_FEATURE_CARD_LAST_SHOWN_TIMESTAMP, lastShownTimestamp);
     }
+
+    @NonNull private static String getHideJetpackFeatureCardWithPhaseKey(JetpackFeatureRemovalPhase phase) {
+        return DeletablePrefKey.SHOULD_HIDE_JETPACK_FEATURE_CARD.name() + phase.getTrackingName();
+    }
+
 
     public static Long getSwitchToJetpackMenuCardLastShownTimestamp() {
         return getLong(DeletablePrefKey.SWITCH_TO_JETPACK_MENU_CARD_SHOWN_TIMESTAMP, 0L);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.prefs
 import org.wordpress.android.fluxc.model.JetpackCapability
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase
 import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.PostListViewLayoutType
 import org.wordpress.android.ui.prefs.AppPrefs.PrefKey
@@ -274,9 +275,11 @@ class AppPrefsWrapper @Inject constructor() {
     fun setIsOpenWebLinksWithJetpack(isOpenWebLinksWithJetpack: Boolean) =
         AppPrefs.setIsOpenWebLinksWithJetpack(isOpenWebLinksWithJetpack)
 
-    fun getShouldHideJetpackFeatureCard(): Boolean = AppPrefs.getShouldHideJetpackFeatureCard()
+    fun getShouldHideJetpackFeatureCard(jetpackFeatureRemovalPhase: JetpackFeatureRemovalPhase): Boolean =
+        AppPrefs.getShouldHideJetpackFeatureCard(jetpackFeatureRemovalPhase)
 
-    fun setShouldHideJetpackFeatureCard(isHidden: Boolean) = AppPrefs.setShouldHideJetpackFeatureCard(isHidden)
+    fun setShouldHideJetpackFeatureCard(jetpackFeatureRemovalPhase: JetpackFeatureRemovalPhase, isHidden: Boolean) =
+        AppPrefs.setShouldHideJetpackFeatureCard(jetpackFeatureRemovalPhase, isHidden)
 
     fun getJetpackFeatureCardLastShownTimestamp(): Long = AppPrefs.getJetpackFeatureCardLastShownTimestamp()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -281,10 +281,14 @@ class AppPrefsWrapper @Inject constructor() {
     fun setShouldHideJetpackFeatureCard(jetpackFeatureRemovalPhase: JetpackFeatureRemovalPhase, isHidden: Boolean) =
         AppPrefs.setShouldHideJetpackFeatureCard(jetpackFeatureRemovalPhase, isHidden)
 
-    fun getJetpackFeatureCardLastShownTimestamp(): Long = AppPrefs.getJetpackFeatureCardLastShownTimestamp()
+    fun getJetpackFeatureCardLastShownTimestamp(jetpackFeatureRemovalPhase: JetpackFeatureRemovalPhase): Long =
+        AppPrefs.getJetpackFeatureCardLastShownTimestamp(jetpackFeatureRemovalPhase)
 
-    fun setJetpackFeatureCardLastShownTimestamp(lastShownTimestamp: Long) {
-        AppPrefs.setJetpackFeatureCardLastShownTimestamp(lastShownTimestamp)
+    fun setJetpackFeatureCardLastShownTimestamp(
+        jetpackFeatureRemovalPhase: JetpackFeatureRemovalPhase,
+        lastShownTimestamp: Long
+    ) {
+        AppPrefs.setJetpackFeatureCardLastShownTimestamp(jetpackFeatureRemovalPhase, lastShownTimestamp)
     }
 
     fun getSwitchToJetpackMenuCardLastShownTimestamp(): Long = AppPrefs.getSwitchToJetpackMenuCardLastShownTimestamp()

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalSelfHostedUsersConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalSelfHostedUsersConfig.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.JetpackFeatureRemovalSelfHostedUsersConfig.Companion.JETPACK_FEATURE_REMOVAL_SELF_HOSTED_USERS_REMOTE_FIELD
+import javax.inject.Inject
+
+/**
+ * Configuration for Jetpack feature removal phase new users
+ */
+@Feature(JETPACK_FEATURE_REMOVAL_SELF_HOSTED_USERS_REMOTE_FIELD, false)
+class JetpackFeatureRemovalSelfHostedUsersConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.JETPACK_FEATURE_REMOVAL_SELF_HOSTED_USERS,
+    JETPACK_FEATURE_REMOVAL_SELF_HOSTED_USERS_REMOTE_FIELD
+) {
+    companion object {
+        const val JETPACK_FEATURE_REMOVAL_SELF_HOSTED_USERS_REMOTE_FIELD = "jp_removal_self_hosted"
+    }
+}

--- a/WordPress/src/main/res/layout/jetpack_feature_card.xml
+++ b/WordPress/src/main/res/layout/jetpack_feature_card.xml
@@ -45,13 +45,13 @@
             android:ellipsize="end"
             android:lineSpacingMultiplier="1.2"
             android:maxLines="5"
-            android:text="@string/jetpack_feature_card_content"
+            android:text="@string/jetpack_feature_card_content_phase_three"
             android:textAlignment="viewStart"
             android:textAppearance="?attr/textAppearanceSubtitle1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/my_site_jetpack_feature_card_logo"
-            tools:text="@string/jetpack_feature_card_content" />
+            tools:text="@string/jetpack_feature_card_content_phase_three" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/my_site_jetpack_feature_card_learn_more"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4342,7 +4342,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="gutenberg_native_s_converted_to_regular_block" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">%s converted to regular block</string>
 
     <!-- Jetpack Feature Card -->
-    <string name="jetpack_feature_card_content">Stats, Reader, Notifications and other features will soon move to the Jetpack mobile app.</string>
+    <string name="jetpack_feature_card_content_phase_three">Stats, Reader, Notifications and other features will soon move to the Jetpack mobile app.</string>
+    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notications and more with Jetpack.</string>
     <string name="jetpack_feature_card_learn_more" translatable="false">@string/learn_more</string>
     <string name="jetpack_feature_card_menu_item_remind_me_later">Remind me later</string>
     <string name="jetpack_feature_card_menu_item_hide_this">Hide this</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseO
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature.STATS
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.SiteUtilsWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
@@ -52,9 +52,6 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
     @Mock
     private lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
 
-    @Mock
-    private lateinit var appPrefsWrapper: AppPrefsWrapper
-
     private lateinit var jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil
 
     private val currentMockedDate = Date(System.currentTimeMillis())
@@ -68,8 +65,7 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
             siteUtilsWrapper,
             buildConfigWrapper,
             dateTimeUtilsWrapper,
-            analyticsTrackerWrapper,
-            appPrefsWrapper
+            analyticsTrackerWrapper
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseN
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseSelfHostedUsers
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_ONE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO
 import org.wordpress.android.util.BuildConfigWrapper
@@ -22,6 +23,7 @@ import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseFourConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseOneConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseThreeConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseTwoConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalSelfHostedUsersConfig
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -44,6 +46,9 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
     @Mock
     private lateinit var jetpackFeatureRemovalNewUsersConfig: JetpackFeatureRemovalNewUsersConfig
 
+    @Mock
+    private lateinit var jetpackFeatureRemovalSelfHostedUsersConfig: JetpackFeatureRemovalSelfHostedUsersConfig
+
     private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
     @Before
@@ -54,7 +59,8 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
             jetpackFeatureRemovalPhaseTwoConfig,
             jetpackFeatureRemovalPhaseThreeConfig,
             jetpackFeatureRemovalPhaseFourConfig,
-            jetpackFeatureRemovalNewUsersConfig
+            jetpackFeatureRemovalNewUsersConfig,
+            jetpackFeatureRemovalSelfHostedUsersConfig
         )
     }
 
@@ -111,6 +117,15 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
         val currentPhase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase()
 
         assertEquals(currentPhase, PhaseNewUsers)
+    }
+
+    @Test
+    fun `given self hosted users config true, when current phase is fetched, then return self hosted users config`() {
+        whenever(jetpackFeatureRemovalSelfHostedUsersConfig.isEnabled()).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase()
+
+        assertEquals(currentPhase, PhaseSelfHostedUsers)
     }
 
     // site creation phase tests

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2876,13 +2876,26 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when feature card criteria is met, then items do contain feature card`() = test {
+    fun `when feature card criteria is met + show at top, then items do contain feature card`() = test {
         whenever(jetpackFeatureCardHelper.shouldShowJetpackFeatureCard()).thenReturn(true)
+        whenever(jetpackFeatureCardHelper.shouldShowFeatureCardAtTop()).thenReturn(true)
 
         initSelectedSite()
 
         assertThat(getSiteMenuTabLastItems()[0]).isInstanceOf(JetpackFeatureCard::class.java)
         assertThat(getLastItems()[0]).isInstanceOf(JetpackFeatureCard::class.java)
+    }
+
+    @Test
+    fun `when feature card criteria is met + show at bottom, then items do contain feature card`() = test {
+        whenever(jetpackFeatureCardHelper.shouldShowJetpackFeatureCard()).thenReturn(true)
+        whenever(jetpackFeatureCardHelper.shouldShowFeatureCardAtTop()).thenReturn(false)
+
+        initSelectedSite()
+
+        assertThat(getSiteMenuTabLastItems()[getSiteMenuTabLastItems().size - 1])
+            .isInstanceOf(JetpackFeatureCard::class.java)
+        assertThat(getLastItems()[getLastItems().size - 1]).isInstanceOf(JetpackFeatureCard::class.java)
     }
 
     @Test
@@ -2932,7 +2945,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         findJetpackFeatureCard()?.onHideMenuItemClick?.click()
 
-        verify(jetpackFeatureCardHelper).track(Stat.REMOVE_FEATURE_CARD_HIDE_TAPPED)
+        verify(jetpackFeatureCardHelper).hideJetpackFeatureCard()
     }
 
     @Test
@@ -2942,7 +2955,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         findJetpackFeatureCard()?.onRemindMeLaterItemClick?.click()
 
-        verify(jetpackFeatureCardHelper).track(Stat.REMOVE_FEATURE_CARD_REMIND_LATER_TAPPED)
+        verify(jetpackFeatureCardHelper).setJetpackFeatureCardLastShownTimeStamp(any())
     }
 
     private fun findQuickActionsCard() = getLastItems().find { it is QuickActionsCard } as QuickActionsCard?

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelperTest.kt
@@ -114,7 +114,7 @@ class JetpackFeatureCardHelperTest {
     ) {
         setPhase(phase)
         setIsJetpackApp(isJetpackApp)
-        setIsCardHiddenByUser(isCardHiddenByUser)
+        setIsCardHiddenByUser(phase, isCardHiddenByUser)
         setLastShownTimestamp(lastShownTimestamp)
         setDaysBetween(lastShownTimestamp)
     }
@@ -128,8 +128,8 @@ class JetpackFeatureCardHelperTest {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(value)
     }
 
-    private fun setIsCardHiddenByUser(value: Boolean) {
-        whenever(appPrefsWrapper.getShouldHideJetpackFeatureCard()).thenReturn(value)
+    private fun setIsCardHiddenByUser(phase: JetpackFeatureRemovalPhase, value: Boolean) {
+        whenever(appPrefsWrapper.getShouldHideJetpackFeatureCard(phase)).thenReturn(value)
     }
 
     private fun setLastShownTimestamp(value: Long) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelperTest.kt
@@ -115,7 +115,7 @@ class JetpackFeatureCardHelperTest {
         setPhase(phase)
         setIsJetpackApp(isJetpackApp)
         setIsCardHiddenByUser(phase, isCardHiddenByUser)
-        setLastShownTimestamp(lastShownTimestamp)
+        setLastShownTimestamp(phase, lastShownTimestamp)
         setDaysBetween(lastShownTimestamp)
     }
 
@@ -132,8 +132,8 @@ class JetpackFeatureCardHelperTest {
         whenever(appPrefsWrapper.getShouldHideJetpackFeatureCard(phase)).thenReturn(value)
     }
 
-    private fun setLastShownTimestamp(value: Long) {
-        whenever(appPrefsWrapper.getJetpackFeatureCardLastShownTimestamp()).thenReturn(value)
+    private fun setLastShownTimestamp(phase: JetpackFeatureRemovalPhase, value: Long) {
+        whenever(appPrefsWrapper.getJetpackFeatureCardLastShownTimestamp(phase)).thenReturn(value)
     }
 
     private fun setDaysBetween(lastShownTimestamp: Long) {


### PR DESCRIPTION
Part of #17338 & #17680 

## 🗒️  Description 
This PR adds the Jetpack feature removal card for Self-hosted and New users in the Menu when the users are on Jetpack feature removal phase 4 

⭐  Note: the Overlay changes for Self-hosted and New users will be taken up in a separate PR. 

|Phase 3 | Phase 4   | New users Phase   |  Self hosted Users Phase| 
|---|---|---|---|
|![screenshot_phase3_](https://user-images.githubusercontent.com/17463767/214562115-b55b185f-e8aa-4de4-a419-134a336edbbc.png) | ![screenshot_phase4_](https://user-images.githubusercontent.com/17463767/214562120-38b473fd-8750-4a3d-b0c2-72f9a88452f7.png) |![screenshot_phase_new_users_](https://user-images.githubusercontent.com/17463767/214562080-984fe3d4-d60e-4325-8421-e018e333cd48.png) |![screenshot_phase_self_hosted_](https://user-images.githubusercontent.com/17463767/214562100-e8415ec7-43ad-499e-aee7-0a04d0ba86c7.png)|


## ⭐  Major Commits 

### Feature Changes 
1. [Adds: the build config and remote flag for Self hosted users phase](https://github.com/wordpress-mobile/WordPress-Android/pull/17813/commits/0aced82dbd3f4ba693481e91a9d19befc4014700)
2. [Updates: Logic to show Jetpack feature card in menu](https://github.com/wordpress-mobile/WordPress-Android/pull/17813/commits/e1bd7d382952d32ae7d00a7892ff26556d7e3872)
3. [Adds: the logic to position the feature card in menu depending on phase](https://github.com/wordpress-mobile/WordPress-Android/pull/17813/commits/a000ea56942649d59723f0a336793ced3f5168bb)
4. [Updates: the logic of hiding Jetpack feature removal card](https://github.com/wordpress-mobile/WordPress-Android/pull/17813/commits/0b24e2fae8fe0010be8349fd65e9ed36571a2fc7)
5. [Updates: the logic of last shown Jetpack feature removal card](https://github.com/wordpress-mobile/WordPress-Android/pull/17813/commits/f48fbf0f63ea9bf5217c8e65187f28934db8726c)

### General Improvements 
1.  [Moves: Switch to Jetpack menu card logic to JetpackFeatureCardHelper](https://github.com/wordpress-mobile/WordPress-Android/pull/17813/commits/0891be3d814b1754e97c94c25a6a0622e89b450b)
2. [Updates: the logic of passing the blog post link for the current phase](https://github.com/wordpress-mobile/WordPress-Android/pull/17813/commits/343e90912dd7d328b8146bb56b06e06bad391a07)

## 🧪  Test Instructions 

### 1. Check if the Jetpack feature removal card is displayed for all the Phases
Please test the phase three and phase 4 cards (switch to jetpack) to verify that there are no regression issues. 

1. Sign into the app with a wp com account 
2. Go to app settings -> debug settings -> enable `jp_removal_three`  
3. ✅ Verify that the card content and position aligns with the Project spec 
4. Tapping the card should show an overlay with the correct tracking events (Note: the overlay for New users and Self-hosted users will be taken up later)
5. 🔁 Repeat the steps(2-4)  for **Phase 4**, **New users Phase**, and **Self-hosted Users**

### 2. Check if the Remind me later works as expected across phases 
1. Sign into the app with a wp com account 
2. Navigate to -> Debug Settings -> and Enable jp_removal_three and restart the app
3. Navigate to My Site
4. ✅ Verify that the Jetpack Feature card is shown
5. Tap on the More "horizontal ellipse" to launch the more menu
6. Tap on the **Remind me later** item
7. ✅ Verify the view refreshes and that the Jetpack Feature card is no longer shown
8. Swipe the app close
9. The card is shown four days later. To test that, Change the device date to today + 4 days and Relaunch the app
10. ✅ Verify the Jetpack Feature card is shown
11. 🔁  To verify that **Remind me later** in the previous phase doesn't affect the next phase, Repeat steps 5-7 to hide the card
12. Enable the next phase **Phase 4**, **New users Phase**, and **Self-hosted Users** 
13. 🔁 Repeat the steps(2-12)  for **Phase 4**, **New users Phase**, and **Self-hosted Users**

### 3. Hide this card works as expected across phases (Hide card is not available in Phase 4)
1. Install WP app
2. Login
3. Navigate to Me -> App Settings -> Privacy Settings and turn on Collection Information
4. Navigate to -> Debug Settings -> and Enable jp_removal_three and restart the app *Note: this value remains across log outs
5. Navigate to My Site
6. ✅ Verify that the Jetpack Feature card is shown
7. Tap on the More "horizontal ellipse" to launch the more menu
8. Tap on the **Hide this** item
9.  ✅ Verify the view refreshes and the Jetpack Feature card is no longer shown
10. Swipe the app closed
11. Relaunch the app
12. ✅ Verify the Jetpack Feature card is no longer shown
13. 🔁  To verify that **Hide this** in the previous phase doesn't affect the next phase, Repeat steps 5-7 to hide the card
14. Enable the next phase  **Phase 4**, **New users Phase**, and **Self-hosted Users** 
15. For Phase 4, ensure the "Switch to jetpack menu is displayed."
16. 🔁 Repeat the steps(2-12) for  **New users Phase**, and **Self-hosted Users**


## Regression Notes
1. Potential unintended areas of impact
- Jetpack feature card in menu is not shown as expected 
- Jetpack feature card menu options (Remind me later and Hide this) doesn't work as expected 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing 
- Unit tests 

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
