### PR TITLE
Jetpack Focus: Update site creation overlay primary button text for Phase Two

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
@@ -246,7 +246,7 @@ class JetpackFeatureOverlayContentBuilder @Inject constructor(
             illustration = if (rtl) R.raw.wp2jp_rtl else R.raw.wp2jp_left,
             title = R.string.wp_jetpack_feature_removal_site_creation_overlay_title,
             caption = UiStringRes(R.string.wp_jetpack_feature_removal_site_creation_overlay_phase_two_description),
-            primaryButtonText = R.string.wp_jetpack_feature_removal_overlay_switch_to_new_jetpack_app,
+            primaryButtonText = R.string.wp_jetpack_feature_removal_site_creation_overlay_phase_two_primary_button,
         )
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4332,6 +4332,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="wp_jetpack_feature_removal_site_creation_overlay_title">Create a new WordPress site with the Jetpack app</string>
     <string name="wp_jetpack_feature_removal_site_creation_overlay_phase_one_description">Jetpack provides stats, notifications and more to help you build and grow the WordPress site of your dreams.</string>
     <string name="wp_jetpack_feature_removal_site_creation_overlay_phase_two_description">Jetpack provides stats, notifications and more to help you build and grow the WordPress site of your dreams.\n\nThe WordPress app no longer supports creating a new site.</string>
+    <string name="wp_jetpack_feature_removal_site_creation_overlay_phase_two_primary_button" translatable="false">@string/wp_jetpack_get_new_jetpack_app</string>
     <string name="wp_jetpack_continue_without_jetpack">Continue without Jetpack</string>
 
     <string name="wp_jetpack_deep_link_overlay_title">Open links in Jetpack?</string>


### PR DESCRIPTION
Fixes #17805 

This PR updates the primary button text for the Site Creation overlay phase 2.
Note: Phase two for site creation is PhaseFour and PhaseNewUsers


Phase One | Phase Two
-- | --
<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/214315984-86076ca3-a7bf-49ff-9764-8d0b66031a3d.png"> | <img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/214315997-02c7008a-9395-48c9-8a97-40376958cd16.png">

To test:
- Install the app
- Navigate to Me > App Settings > Debug Settings
- Enable `jp_removal_four`
- Restart the app
- Tap on the site selector drop down
- Tap on the more menu (3 vertical dots) and select "Add new site"
- ✅ Verify the button text matches the "Phase Two" image above

## Regression Notes
1. Potential unintended areas of impact
The wrong text continues to show

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
