### PR TITLE
Load account data including avatar when completing the migration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.compose.utils.LocaleAwareComposable
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.CompleteFlow
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FallbackToLogin
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FinishActivity
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.Logout
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.ShowHelp
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content
@@ -111,6 +112,7 @@ class JetpackMigrationFragment : Fragment() {
             }
             is Logout -> (requireActivity().application as? WordPress)?.let { viewModel.signOutWordPress(it) }
             is ShowHelp -> launchHelpScreen()
+            is FinishActivity -> requireActivity().finish()
         }
     }
 
@@ -147,9 +149,9 @@ class JetpackMigrationFragment : Fragment() {
             JetpackMigrationFragment().apply {
                 arguments = Bundle().apply {
                     putBoolean(KEY_SHOW_DELETE_WP_STATE, showDeleteWpState)
-                        if (deepLinkData != null) {
-                            putParcelable(KEY_DEEP_LINK_DATA, deepLinkData)
-                        }
+                    if (deepLinkData != null) {
+                        putParcelable(KEY_DEEP_LINK_DATA, deepLinkData)
+                    }
                 }
             }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.NotificationsPrimaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomePrimaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomeSecondaryButton
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FinishActivity
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.CompleteFlow
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FallbackToLogin
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.Logout
@@ -328,7 +329,7 @@ class JetpackMigrationViewModel @Inject constructor(
 
     private fun onGotItClicked() {
         migrationAnalyticsTracker.trackPleaseDeleteWordPressGotItTapped()
-        postActionEvent(CompleteFlow())
+        postActionEvent(FinishActivity)
     }
 
     private fun resizeAvatarUrl(avatarUrl: String) = gravatarUtilsWrapper.fixGravatarUrlWithResource(
@@ -526,6 +527,7 @@ class JetpackMigrationViewModel @Inject constructor(
             val deepLinkData: PreMigrationDeepLinkData? = null,
         ) : JetpackMigrationActionEvent()
 
+        object FinishActivity : JetpackMigrationActionEvent()
         object Logout : JetpackMigrationActionEvent()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.main.jetpack.migration
 
 import android.content.Intent
+import android.text.TextUtils
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
@@ -19,6 +20,8 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker
@@ -77,6 +80,7 @@ class JetpackMigrationViewModel @Inject constructor(
     private val accountStore: AccountStore,
     private val localeManagerWrapper: LocaleManagerWrapper,
     private val jetpackMigrationLanguageUtil: JetpackMigrationLanguageUtil,
+    private val dispatcher: Dispatcher,
 ) : ViewModel() {
     private val _actionEvents = Channel<JetpackMigrationActionEvent>(Channel.BUFFERED)
     val actionEvents = _actionEvents.receiveAsFlow()
@@ -300,7 +304,16 @@ class JetpackMigrationViewModel @Inject constructor(
         migrationEmailHelper.notifyMigrationComplete()
         appPrefsWrapper.setJetpackMigrationCompleted(true)
         appPrefsWrapper.setJetpackMigrationInProgress(false)
+        dispatchFetchAccountActionIfNeeded()
         postActionEvent(CompleteFlow(deepLinkData))
+    }
+
+    private fun dispatchFetchAccountActionIfNeeded() {
+        // User might have opened the Help screen, in which case their account info is already loaded
+        if (accountStore.hasAccessToken() && TextUtils.isEmpty(accountStore.account.userName)) {
+            // Load account info to make sure the avatar will always show on My Site screen
+            dispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
+        }
     }
 
     private fun onHelpClicked(source: HelpButtonSource) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
@@ -9,11 +9,15 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker
 import org.wordpress.android.localcontentmigration.MigrationEmailHelper
@@ -57,6 +61,7 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
     private val accountStore: AccountStore = mock()
     private val localeManagerWrapper: LocaleManagerWrapper = mock()
     private val jetpackMigrationLanguageUtil: JetpackMigrationLanguageUtil = mock()
+    private val dispatcher: Dispatcher = mock()
 
     private lateinit var classToTest: JetpackMigrationViewModel
 
@@ -76,6 +81,7 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
             accountStore = accountStore,
             localeManagerWrapper = localeManagerWrapper,
             jetpackMigrationLanguageUtil = jetpackMigrationLanguageUtil,
+            dispatcher = dispatcher,
         )
         classToTest.refreshAppTheme.observeForever(refreshAppThemeObserver)
         classToTest.refreshAppLanguage.observeForever(refreshAppLanguageObserver)
@@ -132,6 +138,26 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
         successScreen.primaryActionButton.onClick.invoke()
 
         verify(refreshAppThemeObserver).onChanged(Unit)
+    }
+
+    @Test
+    fun `Should dispatch fetch account action when finish button is tapped on success screen if needed`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.account).thenReturn(mock())
+        val successScreen = classToTest.initSuccessScreenUi()
+
+        successScreen.primaryActionButton.onClick.invoke()
+
+        verify(dispatcher).dispatch(argThat { type == AccountAction.FETCH_ACCOUNT })
+    }
+
+    @Test
+    fun `Should not dispatch any action when finish button is tapped on success screen if not needed`() {
+        val successScreen = classToTest.initSuccessScreenUi()
+
+        successScreen.primaryActionButton.onClick.invoke()
+
+        verifyNoInteractions(dispatcher)
     }
 
     // endregion


### PR DESCRIPTION
Fixes #17647

This PR adds the necessary logic to make sure the avatar (profile picture) is always showing on the My Site screen after completing the migration flow.
It also separates and simplifies the logic to dismiss the `You no longer need the WordPress app` screen.

To test:
1. Uninstall all WordPress and Jetpack apps on your device
2. Build & install the WordPress app from this branch
3. Login into the WordPress app with a WordPress.com account having a custom profile picture
4. Build & install the Jetpack app from this branch, using the same flavor as installed the WordPress app
5. **Expect** the app to start on the migration flow
6. Proceed to complete the migration flow
7. **Expect** to land on the `My Site` screen
8. ✅ **Verify** that the user avatar picture in the top right corner is loaded

**Regression** (continue with the next steps to verify there's no regression):

9. Tap on the `Please delete the WordPress app card`
10. Tap on the `Got it` button
11. ✅ **Expect** to land on the `My Site` screen

## Regression Notes
1. Potential unintended areas of impact
   Tapping `Got It` on the `You no longer need the WordPress app` screen.

9. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing.

10. What automated tests I added (or what prevented me from doing so)
   Added unit tests for the new logic in `JetpackMigrationViewModelTest`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
