### PR TITLE
Jetpack Focus: Show overlay on feature card learn more tap

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -447,10 +447,7 @@ class MySiteViewModel @Inject constructor(
         val jetpackFeatureCard = JetpackFeatureCard(
             onClick = ListItemInteraction.create(this::onJetpackFeatureCardClick),
             onHideMenuItemClick = ListItemInteraction.create(this::onJetpackFeatureCardHideMenuItemClick),
-            onLearnMoreClick = ListItemInteraction.create(
-                jetpackFeatureCardHelper.getLearnMoreUrl(),
-                this::onJetpackFeatureCardLearnMoreClick
-            ),
+            onLearnMoreClick = ListItemInteraction.create(this::onJetpackFeatureCardLearnMoreClick),
             onRemindMeLaterItemClick = ListItemInteraction.create(this::onJetpackFeatureCardRemindMeLaterClick),
             onMoreMenuClick = ListItemInteraction.create(this::onJetpackFeatureCardMoreMenuClick),
             learnMoreUrl = jetpackFeatureCardHelper.getLearnMoreUrl()
@@ -1349,9 +1346,9 @@ class MySiteViewModel @Inject constructor(
         refresh()
     }
 
-    private fun onJetpackFeatureCardLearnMoreClick(url: String) {
+    private fun onJetpackFeatureCardLearnMoreClick() {
         jetpackFeatureCardHelper.track(Stat.REMOVE_FEATURE_CARD_LINK_TAPPED)
-        _onNavigation.value = Event(SiteNavigationAction.OpenJetpackFeatureCardLearnMoreLink(url))
+        _onNavigation.value = Event(SiteNavigationAction.OpenJetpackFeatureOverlay(source = FEATURE_CARD))
     }
 
     private fun onJetpackFeatureCardRemindMeLaterClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -82,5 +82,4 @@ sealed class SiteNavigationAction {
     object OpenJetpackPoweredBottomSheet : SiteNavigationAction()
     object OpenJetpackMigrationDeleteWP : SiteNavigationAction()
     data class OpenJetpackFeatureOverlay(val source: JetpackFeatureCollectionOverlaySource) : SiteNavigationAction()
-    data class OpenJetpackFeatureCardLearnMoreLink(val url: String) : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardViewHolder.kt
@@ -28,7 +28,7 @@ class JetpackFeatureCardViewHolder(
                 mySiteJetpackFeatureCardMore,
             )
         }
-        uiHelpers.updateVisibility(mySiteJetpackFeatureCardLearnMore, !card.learnMoreUrl.isNullOrEmpty())
+        uiHelpers.updateVisibility(mySiteJetpackFeatureCardLearnMore, true)
     }
 
     private fun showMoreMenu(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -391,8 +391,6 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         is SiteNavigationAction.OpenJetpackPoweredBottomSheet -> showJetpackPoweredBottomSheet()
         is SiteNavigationAction.OpenJetpackMigrationDeleteWP -> showJetpackMigrationDeleteWP()
         is SiteNavigationAction.OpenJetpackFeatureOverlay -> showJetpackFeatureOverlay(action.source)
-        is SiteNavigationAction.OpenJetpackFeatureCardLearnMoreLink ->
-            ActivityLauncher.openUrlExternal(requireActivity(), action.url)
     }
 
     private fun showJetpackPoweredBottomSheet() {


### PR DESCRIPTION
Fixes #17806 

This PR changes the "learn more" tap behavior of the Feature Card. Instead of launching the url, show the overlay. Also makes sure the Learn More link is always shown on the card.

To test:
- Install app and login
- Navigate to Me > App Settings > Debug Settings
- Enable jp_removal_three flag and restart
- Navigate to the dashboard
- Click at learn more link within the feature card
- ✅ Verify the overlay is shown and the user is not directed to the blog post

## Regression Notes
1. Potential unintended areas of impact
The user is still directed to the blog post

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
