### PR TITLE
Wp support forum card on help screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -99,41 +99,17 @@ class HelpActivity : LocaleAwareActivity() {
                 actionBar.elevation = 0f // remove shadow
             }
 
-            contactUsButton.setOnClickListener {
-                if (wpSupportForumFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
-                    openWpSupportForum()
-                } else {
-                    createNewZendeskTicket()
-                }
+            if (wpSupportForumFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
+                showSupportForum()
+            } else {
+                showContactUs()
             }
-            faqButton.setOnClickListener { showFaq() }
-            myTicketsButton.setOnClickListener { showZendeskTickets() }
+
             applicationVersion.text = getString(R.string.version_with_name_param, WordPress.versionName)
             applicationLogButton.setOnClickListener { v ->
                 startActivity(Intent(v.context, AppLogViewerActivity::class.java))
             }
 
-            contactEmailContainer.setOnClickListener {
-                var emailSuggestion = AppPrefs.getSupportEmail()
-                if (emailSuggestion.isNullOrEmpty()) {
-                    emailSuggestion = supportHelper
-                        .getSupportEmailAndNameSuggestion(
-                            accountStore.account,
-                            selectedSiteFromExtras
-                        ).first
-                }
-
-                supportHelper.showSupportIdentityInputDialog(
-                    this@HelpActivity,
-                    emailSuggestion,
-                    isNameInputHidden = true
-                ) { email, _ ->
-                    zendeskHelper.setSupportEmail(email)
-                    refreshContactEmailText()
-                    AnalyticsTracker.track(Stat.SUPPORT_IDENTITY_SET)
-                }
-                AnalyticsTracker.track(Stat.SUPPORT_IDENTITY_FORM_VIEWED)
-            }
             if (originFromExtras == Origin.JETPACK_MIGRATION_HELP) {
                 configureForJetpackMigrationHelp()
             }
@@ -200,6 +176,51 @@ class HelpActivity : LocaleAwareActivity() {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("http://apps.wordpress.com/mobile-app-support/"))
         startActivity(intent)
         AnalyticsTracker.track(Stat.SUPPORT_HELP_CENTER_VIEWED)
+    }
+
+    private fun HelpActivityBinding.showContactUs() {
+        contactUsButton.setOnClickListener { createNewZendeskTicket() }
+
+        faqButton.setOnClickListener { showFaq() }
+
+        myTicketsButton.setOnClickListener { showZendeskTickets() }
+
+        contactEmailContainer.setOnClickListener {
+            var emailSuggestion = AppPrefs.getSupportEmail()
+            if (emailSuggestion.isNullOrEmpty()) {
+                emailSuggestion = supportHelper
+                    .getSupportEmailAndNameSuggestion(
+                        accountStore.account,
+                        selectedSiteFromExtras
+                    ).first
+            }
+
+            supportHelper.showSupportIdentityInputDialog(
+                this@HelpActivity,
+                emailSuggestion,
+                isNameInputHidden = true
+            ) { email, _ ->
+                zendeskHelper.setSupportEmail(email)
+                refreshContactEmailText()
+                AnalyticsTracker.track(Stat.SUPPORT_IDENTITY_SET)
+            }
+            AnalyticsTracker.track(Stat.SUPPORT_IDENTITY_FORM_VIEWED)
+        }
+    }
+
+    private fun HelpActivityBinding.showSupportForum() {
+        contactUsButton.isVisible = false
+        faqButton.isVisible = false
+        myTicketsButton.isVisible = false
+        emailContainerTopDivider.isVisible = false
+        contactEmailContainer.isVisible = false
+        emailContainerBottomDivider.isVisible = false
+
+        forumContainer.run {
+            isVisible = true
+            setOnClickListener { openWpSupportForum() }
+        }
+        forumContainerBottomDivider.isVisible = true
     }
 
     private fun HelpActivityBinding.refreshContactEmailText() {

--- a/WordPress/src/main/res/layout/help_activity.xml
+++ b/WordPress/src/main/res/layout/help_activity.xml
@@ -102,6 +102,37 @@
                     style="@style/HelpActivitySingleText"
                     android:text="@string/my_tickets" />
 
+                <LinearLayout
+                    android:id="@+id/forumContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:orientation="vertical"
+                    android:padding="@dimen/margin_extra_large"
+                    android:visibility="gone"
+                    tools:visibility="visible">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/support_forum_title"
+                        android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/support_forum_caption"
+                        android:textAppearance="?attr/textAppearanceCaption" />
+                </LinearLayout>
+
+                <View
+                    android:id="@+id/forumContainerBottomDivider"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/divider_size"
+                    android:background="?android:attr/listDivider"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
+
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/application_log_button"
                     style="@style/HelpActivitySingleText"
@@ -114,6 +145,7 @@
                     tools:text="Version NN.1" />
 
                 <View
+                    android:id="@+id/emailContainerTopDivider"
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/divider_size"
                     android:background="?android:attr/listDivider" />
@@ -141,6 +173,7 @@
                 </LinearLayout>
 
                 <View
+                    android:id="@+id/emailContainerBottomDivider"
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/divider_size"
                     android:background="?android:attr/listDivider" />

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2234,6 +2234,8 @@
     <string name="support_push_notification_title">WordPress</string>
     <string name="support_push_notification_message">New message from \'Help &amp; Support\'</string>
     <string name="contact_fragment_title" translatable="false" tools:ignore="UnusedResources">@string/contact_support</string>
+    <string name="support_forum_title">Community forums</string>
+    <string name="support_forum_caption">Get help from our group of volunteers</string>
 
     <!-- Contact us -->
     <string name="support_ticket_subject">WordPress for Android Support</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2235,7 +2235,7 @@
     <string name="support_push_notification_message">New message from \'Help &amp; Support\'</string>
     <string name="contact_fragment_title" translatable="false" tools:ignore="UnusedResources">@string/contact_support</string>
     <string name="support_forum_title">Community forums</string>
-    <string name="support_forum_caption">Get help from our group of volunteers</string>
+    <string name="support_forum_caption">Get help from our group of volunteers.</string>
 
     <!-- Contact us -->
     <string name="support_ticket_subject">WordPress for Android Support</string>


### PR DESCRIPTION
Adds Forum Support card on Help Screen

Fixes #17807 

|Before|After|
|-|-|
|![Screenshot_20230125_115249](https://user-images.githubusercontent.com/990349/214458755-273edad6-f375-4cd6-a8c0-e1c0ea01b3ef.png)|![Screenshot_20230125_115356](https://user-images.githubusercontent.com/990349/214458783-e751b04a-502d-42d9-9a44-b9995a7b8eee.png)|


To test:

Test 1

- Navigate to Me > Help & Support
- Verify that screen is as shown in **Before** above
- Tap on Contact Support
- Verify that it opens the Zendesk form as before

Test 2

- Navigate to Me > App Settings > Debug settings
- Enable wordpress_support_forum_remote_field under Remote features and Restart the app (scroll down if required)
- Navigate to Me > Help & Support
- Verify that the screen is as shown in **After** above
- Tap on the Community forums row
- Verify that it opens the new Mobile Forum on Wordpress.org in the browser

> **Note**
> An entry point in Gutenberg will be handled in a separate PR

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested with WP and JP app variants

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
