### PR TITLE
Add Internal Release Notes For 21.6 Changes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,11 @@
 21.6
 -----
 * [*] [internal] [Jetpack-only] Adds additional logging for Jetpack migration errors [https://github.com/wordpress-mobile/WordPress-Android/pull/17748]
-
+* [*] [internal] [Jetpack-only] Adds support to resume the Jetpack migration after interruptions [https://github.com/wordpress-mobile/WordPress-Android/pull/17701]
+* [*] [internal] [Jetpack-only] Adds support to start the Jetpack migration flow from deep links [https://github.com/wordpress-mobile/WordPress-Android/pull/17742]
+* [*] [internal] [Jetpack-only] Adds support to apply the app theme from the WP app in the Jetpack migration flow [https://github.com/wordpress-mobile/WordPress-Android/pull/17749]
+* [*] [internal] [Jetpack-only] Adds support to apply the interface language from the WP app in the Jetpack migration flow [https://github.com/wordpress-mobile/WordPress-Android/pull/17768]
+* [*] [internal] [Jetpack-only] Adds support to migrate the blogging reminders at the start of the Jetpack migration flow [https://github.com/wordpress-mobile/WordPress-Android/pull/17778]
 
 21.5
 -----


### PR DESCRIPTION
This PR adds internal release notes for the Jetpack migration flow changes introduced in [`21.6`](https://github.com/wordpress-mobile/WordPress-Android/milestone/247?closed=1).

To test:
- Nothing to test here, only internal release notes are added.
- **Optional:** Check the PR links of the internal release notes and validate they match the description.

## Regression Notes
1. Potential unintended areas of impact
   N/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

3. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
