### PR TITLE
[Detekt] Ignore MaxLineLength for @Test functions

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkOpenWebLinksWithJetpackHelperTest.kt
@@ -90,7 +90,6 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `given flow enabled, JP install, isOpenWebLinks disabled, when overlay never been shown, then show overlay is true`() {
         setTest(
             isFeatureFlagEnabled = true,
@@ -105,7 +104,6 @@ class DeepLinkOpenWebLinksWithJetpackHelperTest : BaseUnitTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `given flow enabled, JP install, isOpenWebLinks disabled, overlay shown before, when frequency is only once, then show overlay is false`() {
         setTest(
             isFeatureFlagEnabled = true,

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilderTest.kt
@@ -57,7 +57,6 @@ class JetpackFeatureOverlayContentBuilderTest {
         assertEquals(phaseOneStats.overlayContent, getPhaseOneStats())
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `given phase two without remote field post link, when content is built, should return phase two overlay content`() {
         val phaseTwoStats = jetpackFeatureOverlayContentBuilder.build(
@@ -71,7 +70,6 @@ class JetpackFeatureOverlayContentBuilderTest {
         assertEquals(phaseTwoStats.overlayContent, getPhaseTwoStatsWithoutMigrationInfo())
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `given phase two with remote field post link, when content is built, should return phase two overlay content`() {
         val phaseTwoStats = jetpackFeatureOverlayContentBuilder.build(
@@ -90,7 +88,6 @@ class JetpackFeatureOverlayContentBuilderTest {
         assertEquals(phaseTwoStats.overlayContent, actual)
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `given phase two with deadline, when content is built, should return phase two overlay content`() {
         val jpDeadlineDateFromRemoteConfig = "2020-01-01"

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
@@ -195,7 +195,6 @@ class JetpackFeatureRemovalBrandingUtilTest {
         verifyDaysUntilDeadlineCounted()
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `given phase 3 started, when deadline is in 1 week, all other branding should be {Feature} {is,are} moving in 1 week`() {
         givenPhase(PhaseThree)
@@ -215,7 +214,6 @@ class JetpackFeatureRemovalBrandingUtilTest {
         verifyDaysUntilDeadlineCounted()
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `given phase 3 started, when deadline is in 6 days, all other branding should be {Feature} {is,are} moving in n days`() {
         givenPhase(PhaseThree)
@@ -235,7 +233,6 @@ class JetpackFeatureRemovalBrandingUtilTest {
         verifyDaysUntilDeadlineCounted()
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `given phase 3 started, when deadline is in 1 day, all other branding should be {Feature} {is,are} moving in 1 day`() {
         givenPhase(PhaseThree)
@@ -255,7 +252,6 @@ class JetpackFeatureRemovalBrandingUtilTest {
         verifyDaysUntilDeadlineCounted()
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `given phase 3 started, when deadline is in 0 days, all other branding should be {Feature} {is,are} moving in 1 day`() {
         givenPhase(PhaseThree)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -97,7 +98,6 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `given feature removal not started, when shouldShowFeatureSpecificJetpackOverlay invoked, then return false`() {
         setupMockForWpComSite()
         whenever(jetpackFeatureRemovalPhaseHelper.getCurrentPhase()).thenReturn(null)
@@ -109,7 +109,6 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `given feature removal in phase four, when shouldShowFeatureSpecificJetpackOverlay invoked, then return false`() {
         setupMockForWpComSite()
         whenever(jetpackFeatureRemovalPhaseHelper.getCurrentPhase()).thenReturn(PhaseFour)
@@ -121,7 +120,6 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `given feature is never accessed, when shouldShowFeatureSpecificJetpackOverlay invoked, then return true`() {
         setupMockForWpComSite()
         whenever(jetpackFeatureRemovalPhaseHelper.getCurrentPhase()).thenReturn(PhaseThree)
@@ -144,7 +142,6 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `given feature is accessed after feature specific frequency, when shouldShowFeatureSpecificJetpackOverlay invoked, then return true`() {
         setupMockForWpComSite()
         // The passed number should exceed the feature specific overlay frequency
@@ -156,8 +153,8 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
         assertTrue(shouldShowOverlay)
     }
 
-    // @Test
-    @Suppress("MaxLineLength")
+    @Ignore("Test originally ignored in commit a6c3a093e6b64d1dfb34954dd6da6b6012613aef without Ignore annotation")
+    @Test
     fun `given feature is accessed after globalOverlayFrequency, when shouldShowFeatureSpecificJetpackOverlay invoked, then return true`() {
         setupMockForWpComSite()
         // The feature was accessed 3 days ago and the globalOverlayFrequency for phase one is 2
@@ -182,7 +179,6 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `given feature removal not started, when shouldShowSiteCreationOverlay invoked, then return false`() {
         whenever(jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()).thenReturn(null)
 
@@ -193,7 +189,6 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `given feature removal in phase one, when shouldShowSiteCreationOverlay invoked, then return false`() {
         whenever(jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase())
             .thenReturn(JetpackFeatureRemovalSiteCreationPhase.PHASE_ONE)
@@ -205,7 +200,6 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `given feature removal in phase four, when shouldShowSiteCreationOverlay invoked, then return false`() {
         whenever(jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase())
             .thenReturn(JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO)

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUploadProcessingTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUploadProcessingTest.kt
@@ -32,7 +32,6 @@ class PostUtilsUploadProcessingTest {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `replaceMediaFileWithUrlInGutenbergPost replaces temporary local id and url for image block with colliding prefixes`() {
         val oldContent = TestContent.oldImageBlock + TestContent.imageBlockWithPrefixCollision
         val newContent = TestContent.newImageBlock + TestContent.imageBlockWithPrefixCollision

--- a/WordPress/src/test/java/org/wordpress/android/util/experiments/ExPlatTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/experiments/ExPlatTest.kt
@@ -213,7 +213,6 @@ class ExPlatTest : BaseUnitTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `refreshIfNeeded does not interact with store if the user is not authorised and there is no anonymous id`() =
         test {
             setupExperiments(setOf(dummyExperiment))
@@ -226,7 +225,6 @@ class ExPlatTest : BaseUnitTest() {
         }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `forceRefresh does not interact with store if the user is not authorised and there is no anonymous id`() =
         test {
             setupExperiments(setOf(dummyExperiment))

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -851,7 +851,6 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
     fun `Should track BLOGGING_PROMPTS_CREATE_SHEET_CARD_VIEWED when onFabClicked is called and actions contains AnswerBloggingPromptAction`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
         startViewModelWithDefaultParameters()

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -42,3 +42,6 @@ style:
   WildcardImport:
     active: true
     excludeImports: []
+  MaxLineLength:
+    active: true
+    ignoreAnnotated: [ 'Test' ]


### PR DESCRIPTION
This is a minor detekt configuration improvement to avoid having to add the `@Supress("MaxLineLength")` annotation in `@Test` functions, which can have big function names (passing 120 chars) without it being a real problem.

This has the very minor drawback of also ignoring the line length for any code inside those tests, but I don't see it as a problem and I didn't find a single place where test code was exceeding the line length.

The only 3 places in Test files that are still suppressing the `MaxLineLenght` rule are doing so because they are raw string fakes used in tests. [Here](https://github.com/wordpress-mobile/WordPress-Android/blob/0002b4ede131f3bcc8f99596098d3832a81ffa95/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt#L13), [here](https://github.com/wordpress-mobile/WordPress-Android/blob/f799303b5b32f07a2ce25c02c9006b109f741ffb/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt#L62), and [here](https://github.com/wordpress-mobile/WordPress-Android/blob/0002b4ede131f3bcc8f99596098d3832a81ffa95/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt#L3).

It would be really nice to also disable the rule for `raw strings` but this was only added on the latest [detekt 1.22.0 version](https://detekt.dev/docs/rules/style/#maxlinelength) and doing a detekt update can bring in other changes. So for now I am just disabling it for `@Test` annotated functions.
