### PR TITLE
Fix total followers guide card condition

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalStatsMapper.kt
@@ -56,7 +56,7 @@ class TotalStatsMapper @Inject constructor(
     }
 
     fun shouldShowFollowersGuideCard(domainModel: Int): Boolean {
-        return domainModel <= 0
+        return domainModel <= 1
     }
 
     fun shouldShowLikesGuideCard(dates: List<PeriodData>): Boolean {


### PR DESCRIPTION
The guide card should appear if the followers count is lower than 2 instead of 1. Since users are followers of their site already, so total followers count is always 1 unless they unfollow their site. 
The condition matches with iOS now.

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/214695077-f1355d14-8253-4385-bd5a-8f21c69168e3.png" height=600>|<img src="https://user-images.githubusercontent.com/2471769/214697284-31316386-0bfa-4b38-9cf9-7173abbbed3d.png" height=600>|


To test:
1. Launch the JP app.
2. Login to a site that has one follower.
3. Navigate to "My Site → Stats".
4. Ensure the Total Followers card is on your screen. If not, add it via the ⚙️ button at the top of the screen,
5. Notice the guide card with the gray background appears when the Total Followers count is 1.

## Regression Notes
1. Potential unintended areas of impact
None

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Nothing

3. What automated tests I added (or what prevented me from doing so)
Nothing because this PR changes only a number.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
