### PR TITLE
Jetpack Focus: Fix landing page content scrolling issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -137,7 +137,6 @@ import org.wordpress.android.util.BuildConfigWrapper;
 import org.wordpress.android.util.DeviceUtils;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.NetworkUtils;
-import org.wordpress.android.util.PackageManagerWrapper;
 import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.QuickStartUtilsWrapper;
@@ -484,11 +483,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
     }
 
     private void setUpMainView() {
-        setupBottomNav();
-        showMySiteFragment();
-    }
-
-    private void setupBottomNav() {
         if (!mJetpackFeatureRemovalOverlayUtil.shouldHideJetpackFeatures()) {
             enableBottomNavbar();
         } else {
@@ -498,17 +492,25 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
     private void enableBottomNavbar() {
         mBottomNav = findViewById(R.id.bottom_navigation);
-        mBottomNav.setVisibility(View.VISIBLE);
         if (mFirstResume) {
+            mBottomNav.setVisibility(View.VISIBLE);
             mBottomNav.init(getSupportFragmentManager(), this);
+        } else {
+            if (mBottomNav.getVisibility() != View.VISIBLE) {
+                mBottomNav.setVisibility(View.VISIBLE);
+                mBottomNav.init(getSupportFragmentManager(), this);
+            }
         }
     }
 
     private void disableBottomNavbar() {
         if (mBottomNav != null) {
-            mBottomNav.setVisibility(View.GONE);
-            mBottomNav.clear();
+            if (mBottomNav.getVisibility() == View.VISIBLE) {
+                mBottomNav.setVisibility(View.GONE);
+                mBottomNav.clear();
+               }
         }
+        showMySiteFragment();
     }
 
     private void showMySiteFragment() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.HapticFeedbackConstants;
 import android.view.View;
 import android.view.ViewGroup;
@@ -324,6 +325,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
         String authTokenToSet = null;
         boolean canShowAppRatingPrompt = savedInstanceState != null;
 
+        mBottomNav = findViewById(R.id.bottom_navigation);
+        mBottomNav.init(getSupportFragmentManager(), this);
+
         if (savedInstanceState == null) {
             if (!AppPrefs.isInstallationReferrerObtained()) {
                 InstallationReferrerServiceStarter.startService(this, null);
@@ -484,46 +488,13 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
     private void setUpMainView() {
         if (!mJetpackFeatureRemovalOverlayUtil.shouldHideJetpackFeatures()) {
-            enableBottomNavbar();
-        } else {
-            disableBottomNavbar();
-        }
-    }
-
-    private void enableBottomNavbar() {
-        mBottomNav = findViewById(R.id.bottom_navigation);
-        if (mFirstResume) {
-            mBottomNav.setVisibility(View.VISIBLE);
-            mBottomNav.init(getSupportFragmentManager(), this);
-        } else {
-            if (mBottomNav.getVisibility() != View.VISIBLE) {
+            if (mBottomNav != null) {
                 mBottomNav.setVisibility(View.VISIBLE);
-                mBottomNav.init(getSupportFragmentManager(), this);
             }
-        }
-    }
-
-    private void disableBottomNavbar() {
-        if (mBottomNav != null) {
-            if (mBottomNav.getVisibility() == View.VISIBLE) {
-                mBottomNav.setVisibility(View.GONE);
-                mBottomNav.clear();
-               }
-        }
-        showMySiteFragment();
-    }
-
-    private void showMySiteFragment() {
-        MySiteFragment fragment = MySiteFragment.Companion.newInstance();
-        MySiteFragment frag = (MySiteFragment) getSupportFragmentManager().findFragmentByTag(MySiteFragment.TAG);
-        if (frag != null) {
-            getSupportFragmentManager().beginTransaction()
-                                       .replace(R.id.fragment_container, fragment, MySiteFragment.TAG)
-                                       .commitNow();
         } else {
-            getSupportFragmentManager().beginTransaction()
-                                       .add(R.id.fragment_container, fragment, MySiteFragment.TAG)
-                                       .commitNow();
+            if (mBottomNav != null) {
+                mBottomNav.setVisibility(View.GONE);
+            }
         }
     }
 
@@ -1001,6 +972,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
     @Override
     protected void onResume() {
+        Log.i(WPMainActivity.class.getSimpleName(), "***=> onResume");
         super.onResume();
 
         setUpMainView();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -137,6 +137,7 @@ import org.wordpress.android.util.BuildConfigWrapper;
 import org.wordpress.android.util.DeviceUtils;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.PackageManagerWrapper;
 import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.QuickStartUtils;
 import org.wordpress.android.util.QuickStartUtilsWrapper;
@@ -483,24 +484,45 @@ public class WPMainActivity extends LocaleAwareActivity implements
     }
 
     private void setUpMainView() {
+        setupBottomNav();
+        showMySiteFragment();
+    }
+
+    private void setupBottomNav() {
         if (!mJetpackFeatureRemovalOverlayUtil.shouldHideJetpackFeatures()) {
-            mBottomNav = findViewById(R.id.bottom_navigation);
-            mBottomNav.setVisibility(View.VISIBLE);
-            mBottomNav.init(getSupportFragmentManager(), this);
+            enableBottomNavbar();
         } else {
-            if (mBottomNav != null) {
-                mBottomNav.setVisibility(View.GONE);
-                mBottomNav.clear();
-            }
-            showMySiteFragment();
+            disableBottomNavbar();
+        }
+    }
+
+    private void enableBottomNavbar() {
+        mBottomNav = findViewById(R.id.bottom_navigation);
+        mBottomNav.setVisibility(View.VISIBLE);
+        if (mFirstResume) {
+            mBottomNav.init(getSupportFragmentManager(), this);
+        }
+    }
+
+    private void disableBottomNavbar() {
+        if (mBottomNav != null) {
+            mBottomNav.setVisibility(View.GONE);
+            mBottomNav.clear();
         }
     }
 
     private void showMySiteFragment() {
         MySiteFragment fragment = MySiteFragment.Companion.newInstance();
-        getSupportFragmentManager().beginTransaction()
-                                   .add(R.id.fragment_container, fragment, MySiteFragment.TAG)
-                                   .commitNow();
+        MySiteFragment frag = (MySiteFragment) getSupportFragmentManager().findFragmentByTag(MySiteFragment.TAG);
+        if (frag != null) {
+            getSupportFragmentManager().beginTransaction()
+                                       .replace(R.id.fragment_container, fragment, MySiteFragment.TAG)
+                                       .commitNow();
+        } else {
+            getSupportFragmentManager().beginTransaction()
+                                       .add(R.id.fragment_container, fragment, MySiteFragment.TAG)
+                                       .commitNow();
+        }
     }
 
     private void showBloggingPromptsOnboarding() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -105,16 +105,6 @@ class WPMainNavigationView @JvmOverloads constructor(
         currentPosition = AppPrefs.getMainPageIndex(numPages() - 1)
     }
 
-    fun clear() {
-        assignNavigationListeners(false)
-        fragmentManager?.apply {
-            for (fragment in fragments) {
-                beginTransaction().remove(fragment).commit()
-            }
-            popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
-        }
-    }
-
     private fun hideReaderTab() {
         menu.removeItem(R.id.nav_reader)
     }

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -55,7 +55,7 @@
             android:layout_height="wrap_content"
             android:background="?attr/colorSurface"
             app:elevation="@dimen/navbar_elevation"
-            android:visibility="gone"
+            android:visibility="visible"
             app:menu="@menu/bottom_nav_main" />
     </LinearLayout>
 


### PR DESCRIPTION
Fixes #17811 

This PR adjusts:
- The logic for handling the visibility of the nav bar when jetpack focus feature flags move to/from phase 4
- Eliminates the extra MySiteFragment instantiation

cc @jkmassel - This PR is targeting release/21.6, as it's a blocking bug fix. Thanks. :) 

**To test:**
- Install and log in
- Navigate to my site
- Rotate the device
- ✅ Verify the nav bar tabs are still visible and the content is not overlapped when scrolling
- ✅ Tap on each nav tab and verify you are navigated to the correct place
- Navigate to Me -> App Settings > Debug Settings
- Enable `jp_removal_four` and restart the app
 - ✅ Verify the nav bar is not shown
 - Rotate the device
- ✅ Verify the nav bar tabs are not visible and the content is not overlapped when scrolled


## Regression Notes
1. Potential unintended areas of impact
The content is still overlapped

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual

3. What automated tests I added (or what prevented me from doing so)
N/A 

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
