### PR TITLE
Jetpack Focus: Display feature collection overlay on launch in phase 4

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayContentBuilder.kt
@@ -280,10 +280,12 @@ class JetpackFeatureOverlayContentBuilder @Inject constructor(
         currentPhase: JetpackFeatureRemovalPhase,
         blogPostLink: String?
     ): JetpackFeatureOverlayUIState {
-        val componentVisibility = if (currentPhase == PhaseThree)
-            JetpackFeatureOverlayComponentVisibility.FeatureCollectionPhase.PhaseThree()
-        else
-            JetpackFeatureOverlayComponentVisibility.FeatureCollectionPhase.Final()
+        val componentVisibility = when (currentPhase) {
+            PhaseThree -> JetpackFeatureOverlayComponentVisibility.FeatureCollectionPhase.PhaseThree()
+            JetpackFeatureRemovalPhase.PhaseFour ->
+                JetpackFeatureOverlayComponentVisibility.FeatureCollectionPhase.PhaseFour()
+            else -> JetpackFeatureOverlayComponentVisibility.FeatureCollectionPhase.Final()
+        }
         val content = getContentForFeatureCollection(isRtl, blogPostLink, currentPhase)
         return JetpackFeatureOverlayUIState(componentVisibility, content)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
@@ -35,11 +35,15 @@ class JetpackFeatureOverlayShownTracker @Inject constructor(private val sharedPr
         sharedPrefs.edit().putLong(jetpackOverlayConnectedFeature.getPreferenceKey(phase), timeStamp).apply()
     }
 
-    fun setFeatureCollectionOverlayShown() {
-        sharedPrefs.edit().putBoolean(KEY_FEATURE_COLLECTION_OVERLAY_SHOWN, true).apply()
+    fun setFeatureCollectionOverlayShown(phase: JetpackFeatureRemovalPhase) {
+        sharedPrefs.edit().putBoolean(buildFeatureCollectionOverlayShownKey(phase), true).apply()
     }
 
-    fun getFeatureCollectionOverlayShown() = sharedPrefs.getBoolean(KEY_FEATURE_COLLECTION_OVERLAY_SHOWN, false)
+    fun getFeatureCollectionOverlayShown(phase: JetpackFeatureRemovalPhase) =
+        sharedPrefs.getBoolean(buildFeatureCollectionOverlayShownKey(phase), false)
+
+    private fun buildFeatureCollectionOverlayShownKey(phase: JetpackFeatureRemovalPhase) =
+        KEY_FEATURE_COLLECTION_OVERLAY_SHOWN.plus(phase.trackingName)
 
     companion object {
         const val KEY_FEATURE_COLLECTION_OVERLAY_SHOWN = "KEY_FEATURE_COLLECTION_OVERLAY_SHOWN"

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -61,8 +61,10 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
     }
 
     fun shouldShowFeatureCollectionJetpackOverlay(): Boolean {
-        return !jetpackFeatureOverlayShownTracker.getFeatureCollectionOverlayShown() &&
-                jetpackFeatureRemovalPhaseHelper.getCurrentPhase() == PhaseThree
+        val phase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase() ?: return false
+        val featureCollectionOverlayShown = jetpackFeatureOverlayShownTracker.getFeatureCollectionOverlayShown(phase)
+        return (!featureCollectionOverlayShown && phase == PhaseThree) ||
+                (!featureCollectionOverlayShown && phase == PhaseFour)
     }
 
     private fun isInSiteCreationPhase(): Boolean {
@@ -267,7 +269,9 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
 
     fun onFeatureCollectionOverlayShown(source: JetpackFeatureCollectionOverlaySource) {
         if (source == APP_OPEN) {
-            jetpackFeatureOverlayShownTracker.setFeatureCollectionOverlayShown()
+            jetpackFeatureOverlayShownTracker.setFeatureCollectionOverlayShown(
+                jetpackFeatureRemovalPhaseHelper.getCurrentPhase()!!
+            )
         }
         trackFeatureCollectionOverlayShown(source)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackOverlayUIState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackOverlayUIState.kt
@@ -39,6 +39,12 @@ sealed class JetpackFeatureOverlayComponentVisibility(
             override val migrationText: Boolean = true
         ) : FeatureCollectionPhase()
 
+        class PhaseFour(
+            override val migrationInfoText: Boolean = true,
+            override val closeButton: Boolean = false,
+            override val migrationText: Boolean = true
+        ) : FeatureCollectionPhase()
+
         class Final(override val closeButton: Boolean = false) : FeatureCollectionPhase()
     }
 }


### PR DESCRIPTION
This PR shows the feature collection overlay upon launch in phase four. The overlay will be shown only once.

<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/214911933-d7938a51-ada2-4264-a1fc-cb9e987845d8.png">


**To test:**
- Install the app and log in
- Navigate to Me -> App Settings > Debug Settings
- Enable `jp_removal_three` and restart the app
 - ✅ Verify the feature collection overlay is shown
 - Swipe away the app and reopen
 - ✅ Verify the feature collection overlay is not shown
- Navigate to Me -> App Settings > Debug Settings
- Enable `jp_removal_four` and restart the app
 - ✅ Verify the feature collection overlay is shown
 - Swipe away the app and reopen
 - ✅ Verify the feature collection overlay is not shown

## Regression Notes
1. Potential unintended areas of impact
The overlay is shown more than once or not at all

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
