### PR TITLE
[JP Install Full Plugin] Implement jetpack install full plugin feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -128,6 +128,7 @@ android {
         buildConfigField "boolean", "PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD", "false"
         buildConfigField "boolean", "OPEN_WEB_LINKS_WITH_JETPACK_FLOW", "false"
         buildConfigField "boolean", "ENABLE_WORDPRESS_SUPPORT_FORUM", "false"
+        buildConfigField "boolean", "JETPACK_INSTALL_FULL_PLUGIN", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackInstallFullPluginFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackInstallFullPluginFeatureConfig.kt
@@ -1,22 +1,16 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.Feature
-import org.wordpress.android.util.config.JetpackInstallFullPluginFeatureConfig.Companion.JETPACK_INSTALL_FULL_PLUGIN_REMOTE_FIELD
+import org.wordpress.android.annotation.FeatureInDevelopment
 import javax.inject.Inject
 
-@Feature(JETPACK_INSTALL_FULL_PLUGIN_REMOTE_FIELD, true)
+@FeatureInDevelopment
 class JetpackInstallFullPluginFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
     appConfig,
     BuildConfig.JETPACK_INSTALL_FULL_PLUGIN,
-    JETPACK_INSTALL_FULL_PLUGIN_REMOTE_FIELD
 ) {
     override fun isEnabled(): Boolean {
         return super.isEnabled() && BuildConfig.IS_JETPACK_APP
-    }
-
-    companion object {
-        const val JETPACK_INSTALL_FULL_PLUGIN_REMOTE_FIELD = "jetpack_install_full_plugin_remote_field"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackInstallFullPluginFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackInstallFullPluginFeatureConfig.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.JetpackInstallFullPluginFeatureConfig.Companion.JETPACK_INSTALL_FULL_PLUGIN_REMOTE_FIELD
+import javax.inject.Inject
+
+@Feature(JETPACK_INSTALL_FULL_PLUGIN_REMOTE_FIELD, true)
+class JetpackInstallFullPluginFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+    appConfig,
+    BuildConfig.JETPACK_INSTALL_FULL_PLUGIN,
+    JETPACK_INSTALL_FULL_PLUGIN_REMOTE_FIELD
+) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && BuildConfig.IS_JETPACK_APP
+    }
+
+    companion object {
+        const val JETPACK_INSTALL_FULL_PLUGIN_REMOTE_FIELD = "jetpack_install_full_plugin_remote_field"
+    }
+}


### PR DESCRIPTION
Fixes #17831 

To test:
Nothing to test yet, since this PR only adds the feature flag without using it.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Built the app.

3. What automated tests I added (or what prevented me from doing so)
Classes that inherit from `FeatureConfig` are currently not testable.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
