### PR TITLE
Update compileSdkVersion to 33

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <!-- GCM all build types configuration -->
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.INSTALL_JETPACK_CAN
 import org.wordpress.android.databinding.JetpackRemoteInstallActivityBinding
 import org.wordpress.android.ui.JetpackConnectionUtils.trackWithSource
 import org.wordpress.android.ui.JetpackRemoteInstallFragment.Companion.TRACKING_SOURCE_KEY
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 
 class JetpackRemoteInstallActivity : LocaleAwareActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,7 +27,7 @@ class JetpackRemoteInstallActivity : LocaleAwareActivity() {
         onBackPressedDispatcher.addCallback {
             trackWithSource(
                 INSTALL_JETPACK_CANCELLED,
-                intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
+                intent.getSerializableExtraCompat(TRACKING_SOURCE_KEY)
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui
 
 import android.os.Bundle
 import android.view.MenuItem
+import androidx.activity.addCallback
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.INSTALL_JETPACK_CANCELLED
 import org.wordpress.android.databinding.JetpackRemoteInstallActivityBinding
@@ -21,21 +22,20 @@ class JetpackRemoteInstallActivity : LocaleAwareActivity() {
             it.setDisplayHomeAsUpEnabled(true)
             it.setTitle(R.string.jetpack)
         }
+
+        onBackPressedDispatcher.addCallback {
+            trackWithSource(
+                INSTALL_JETPACK_CANCELLED,
+                intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
+            )
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    override fun onBackPressed() {
-        trackWithSource(
-            INSTALL_JETPACK_CANCELLED,
-            intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
-        )
-        super.onBackPressed()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -22,6 +22,8 @@ import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActio
 import org.wordpress.android.ui.RequestCodes.JETPACK_LOGIN
 import org.wordpress.android.ui.accounts.LoginActivity
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fragment) {
@@ -44,25 +46,26 @@ class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fr
     private fun JetpackRemoteInstallFragmentBinding.initViewModel(savedInstanceState: Bundle?) {
         requireActivity().let { activity ->
             val intent = activity.intent
-            val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-            val source = intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
-            val retrievedState = savedInstanceState?.getSerializable(VIEW_STATE) as? JetpackRemoteInstallViewState.Type
+            val site = intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
+            val source = intent.getSerializableExtraCompat<JetpackConnectionSource>(TRACKING_SOURCE_KEY)
+            val retrievedState =
+                savedInstanceState?.getSerializableCompat<JetpackRemoteInstallViewState.Type>(VIEW_STATE)
             viewModel = ViewModelProvider(
                 this@JetpackRemoteInstallFragment, viewModelFactory
-            ).get(JetpackRemoteInstallViewModel::class.java)
-            viewModel.start(site, retrievedState)
+            )[JetpackRemoteInstallViewModel::class.java]
+            site?.let { viewModel.start(it, retrievedState) }
 
             initLiveViewStateObserver()
 
-            viewModel.liveActionOnResult.observe(viewLifecycleOwner, Observer { result ->
-                if (result != null) {
+            viewModel.liveActionOnResult.observe(viewLifecycleOwner) { result ->
+                if (result != null && source != null) {
                     when (result.action) {
                         MANUAL_INSTALL -> onManualInstallResultAction(activity, source, result)
                         LOGIN -> onLoginResultAction(activity, source)
                         CONNECT -> onConnectResultAction(activity, source, result)
                     }
                 }
-            })
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -137,7 +137,7 @@ class WPTooltipView @JvmOverloads constructor(
                 .alpha(0f)
                 .setDuration(HIDE_ANIMATION_DURATION)
                 .setListener(object : AnimatorListenerAdapter() {
-                    override fun onAnimationEnd(animation: Animator?) {
+                    override fun onAnimationEnd(animation: Animator) {
                         super.onAnimationEnd(animation)
                         visibility = View.GONE
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModel.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.accounts.UnifiedLoginTracker
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel.State.NoUser
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel.State.ShowUser
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import java.io.Serializable
@@ -55,11 +56,11 @@ class LoginNoSitesViewModel @Inject constructor(
         } else {
             buildStateFromAccountStore()
         }
-        _uiModel.postValue(UiModel(state = state))
+        state?.let { _uiModel.postValue(UiModel(state = it)) }
     }
 
     private fun buildStateFromSavedInstanceState(savedInstanceState: Bundle) =
-        savedInstanceState.getSerializable(KEY_STATE) as State
+        savedInstanceState.getSerializableCompat<State>(KEY_STATE)
 
     private fun buildStateFromAccountStore() =
         accountStore.account?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
@@ -25,7 +25,7 @@ class ActivityLogDetailActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -28,6 +28,8 @@ import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.JetpackBrandingUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.models.JetpackPoweredScreen
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
@@ -84,7 +86,7 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
             val areButtonsVisible = areButtonsVisible(savedInstanceState, activity.intent)
             val isRestoreHidden = isRestoreHidden(savedInstanceState, activity.intent)
 
-            viewModel.start(site, activityLogId, areButtonsVisible, isRestoreHidden)
+            site?.let { siteModel ->  viewModel.start(siteModel, activityLogId, areButtonsVisible, isRestoreHidden) }
         }
 
         if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
@@ -221,7 +223,7 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
 
     private fun sideAndActivityId(savedInstanceState: Bundle?, intent: Intent?) = when {
         savedInstanceState != null -> {
-            val site = savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+            val site = savedInstanceState.getSerializableCompat<SiteModel>(WordPress.SITE)
             val activityLogId = requireNotNull(
                 savedInstanceState.getString(
                     ACTIVITY_LOG_ID_KEY
@@ -230,7 +232,7 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
             site to activityLogId
         }
         intent != null -> {
-            val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
+            val site = intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
             val activityLogId = intent.getStringExtra(ACTIVITY_LOG_ID_KEY) as String
             site to activityLogId
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -108,7 +108,7 @@ class ActivityLogListActivity : LocaleAwareActivity(), ScrollableViewInitialized
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -29,6 +29,8 @@ import org.wordpress.android.ui.prefs.EmptyViewRecyclerView
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_KEY
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel
@@ -87,11 +89,11 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
                 }
             }
 
-            val site = if (savedInstanceState == null) {
+            val site: SiteModel? = if (savedInstanceState == null) {
                 val nonNullIntent = checkNotNull(nonNullActivity.intent)
-                nonNullIntent.getSerializableExtra(WordPress.SITE) as SiteModel
+                nonNullIntent.getSerializableExtraCompat(WordPress.SITE)
             } else {
-                savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+                savedInstanceState.getSerializableCompat(WordPress.SITE)
             }
             val rewindableOnly = nonNullActivity.intent.getBooleanExtra(ACTIVITY_LOG_REWINDABLE_ONLY_KEY, false)
 
@@ -106,7 +108,7 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
 
             setupObservers()
 
-            viewModel.start(site, rewindableOnly)
+            site?.let { viewModel.start(it, rewindableOnly) }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.util.SnackbarItem.Action
 import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.extensions.exhaustive
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -96,9 +97,7 @@ class BloggingPromptsOnboardingDialogFragment : FeatureIntroductionDialogFragmen
     @Suppress("UseCheckOrError")
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        arguments?.let {
-            dialogType = it.getSerializable(KEY_DIALOG_TYPE) as DialogType
-        }
+        arguments?.getSerializableCompat<DialogType>(KEY_DIALOG_TYPE)?.let { dialogType = it }
         (requireActivity().applicationContext as WordPress).component().inject(this)
         if (dialogType == ONBOARDING && context !is BloggingPromptsReminderSchedulerListener) {
             throw IllegalStateException(

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
@@ -27,7 +27,11 @@ class BloggingPromptsListActivity : LocaleAwareActivity() {
         setContent {
             AppTheme {
                 val uiState by viewModel.uiStateFlow.collectAsState()
-                BloggingPromptsListScreen(uiState, ::onBackPressed, viewModel::onPromptListItemClicked)
+                BloggingPromptsListScreen(
+                    uiState,
+                    { onBackPressedDispatcher.onBackPressed() },
+                    viewModel::onPromptListItemClicked
+                )
             }
         }
         observeActions()

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTrac
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source.PUBLISH_FLOW
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.merge
 import org.wordpress.android.util.perform
 import org.wordpress.android.viewmodel.Event
@@ -219,8 +220,8 @@ class BloggingRemindersViewModel @Inject constructor(
     }
 
     fun restoreState(state: Bundle) {
-        state.getSerializable(SELECTED_SCREEN)?.let {
-            _selectedScreen.value = it as Screen
+        state.getSerializableCompat<Screen>(SELECTED_SCREEN)?.let {
+            _selectedScreen.value = it
         }
         val siteId = state.getInt(SITE_ID)
         if (siteId != 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListActionModeCallback.kt
@@ -73,9 +73,10 @@ class CommentListActionModeCallback(
     private fun setItemEnabled(menuItem: MenuItem, actionUiModel: ActionUiModel) {
         menuItem.isVisible = actionUiModel.isVisible
         menuItem.isEnabled = actionUiModel.isEnabled
-        if (menuItem.icon != null) {
+        val currentIcon = menuItem.icon
+        currentIcon?.let {
             // must mutate the drawable to avoid affecting other instances of it
-            val icon = menuItem.icon.mutate()
+            val icon = currentIcon.mutate()
             icon.alpha = if (actionUiModel.isEnabled) ICON_ALPHA_ENABLED else ICON_ALPHA_DISABLED
             menuItem.icon = icon
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.config.UnifiedCommentsDetailFeatureConfig
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import javax.inject.Inject
 
@@ -70,14 +71,12 @@ class UnifiedCommentListFragment : Fragment(R.layout.unified_comment_list_fragme
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
-        viewModel = ViewModelProvider(this, viewModelFactory).get(UnifiedCommentListViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory)[UnifiedCommentListViewModel::class.java]
         activityViewModel = ViewModelProvider(
             requireActivity(),
             viewModelFactory
-        ).get(UnifiedCommentActivityViewModel::class.java)
-        arguments?.let {
-            commentListFilter = it.getSerializable(KEY_COMMENT_LIST_FILTER) as CommentFilter
-        }
+        )[UnifiedCommentActivityViewModel::class.java]
+        arguments?.getSerializableCompat<CommentFilter>(KEY_COMMENT_LIST_FILTER)?.let { commentListFilter = it }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
@@ -116,7 +116,7 @@ class UnifiedCommentsActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditActivity.kt
@@ -8,6 +8,8 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.UnifiedCommentsEditActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 
 class UnifiedCommentsEditActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,19 +19,22 @@ class UnifiedCommentsEditActivity : LocaleAwareActivity() {
             setContentView(root)
         }
 
-        val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-        val commentIdentifier = requireNotNull(intent.getParcelableExtra<CommentIdentifier>(KEY_COMMENT_IDENTIFIER))
+        val site = intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
+        val commentIdentifier =
+            requireNotNull(intent.getParcelableExtraCompat<CommentIdentifier>(KEY_COMMENT_IDENTIFIER))
 
         val fm = supportFragmentManager
-        var editCommentFragment = fm.findFragmentByTag(
+        val editCommentFragment = fm.findFragmentByTag(
             TAG_UNIFIED_EDIT_COMMENT_FRAGMENT
         ) as? UnifiedCommentsEditFragment
 
         if (editCommentFragment == null) {
-            editCommentFragment = UnifiedCommentsEditFragment.newInstance(site, commentIdentifier)
-            fm.beginTransaction()
-                .add(R.id.fragment_container, editCommentFragment, TAG_UNIFIED_EDIT_COMMENT_FRAGMENT)
-                .commit()
+            site?.let {
+                val fragment = UnifiedCommentsEditFragment.newInstance(it, commentIdentifier)
+                fm.beginTransaction()
+                    .add(R.id.fragment_container, fragment, TAG_UNIFIED_EDIT_COMMENT_FRAGMENT)
+                    .commit()
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
@@ -34,6 +34,8 @@ import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarItem.Action
 import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -61,16 +63,16 @@ class UnifiedCommentsEditFragment : Fragment(R.layout.unified_comments_edit_frag
         super.onViewCreated(view, savedInstanceState)
         requireActivity().addMenuProvider(this, viewLifecycleOwner)
 
-        val site = requireArguments().getSerializable(WordPress.SITE) as SiteModel
+        val site = requireArguments().getSerializableCompat<SiteModel>(WordPress.SITE)
         val commentIdentifier = requireNotNull(
-            requireArguments().getParcelable<CommentIdentifier>(
+            requireArguments().getParcelableCompat<CommentIdentifier>(
                 KEY_COMMENT_IDENTIFIER
             )
         )
 
         UnifiedCommentsEditFragmentBinding.bind(view).apply {
             setupToolbar()
-            setupObservers(site, commentIdentifier)
+            site?.let { setupObservers(it, commentIdentifier) }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsActivity.kt
@@ -13,7 +13,7 @@ class DebugSettingsActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesActivity.kt
@@ -13,7 +13,7 @@ class DebugCookiesActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
         android.R.id.home -> {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             true
         }
         else -> super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.deeplinks.handlers.ServerTrackingHandler
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -167,12 +168,11 @@ class DeepLinkingIntentReceiverViewModel
 
     private fun extractSavedInstanceStateIfNeeded(savedInstanceState: Bundle?) {
         savedInstanceState?.let {
-            val uri: Uri? = savedInstanceState.getParcelable(URI_KEY)
+            val uri = savedInstanceState.getParcelableCompat<Uri>(URI_KEY)
             uriWrapper = uri?.let { UriWrapper(it) }
-            deepLinkEntryPoint =
-                DeepLinkEntryPoint.valueOf(
-                    savedInstanceState.getString(DEEP_LINK_ENTRY_POINT_KEY, DeepLinkEntryPoint.DEFAULT.name)
-                )
+            deepLinkEntryPoint = DeepLinkEntryPoint.valueOf(
+                savedInstanceState.getString(DEEP_LINK_ENTRY_POINT_KEY, DeepLinkEntryPoint.DEFAULT.name)
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -134,7 +134,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenD
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationDetails
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationResult
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainSuggestions
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -50,12 +51,14 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
             setContentView(root)
             binding = this
 
-            val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-            val domainRegistrationPurpose = intent.getSerializableExtra(DOMAIN_REGISTRATION_PURPOSE_KEY)
-                    as DomainRegistrationPurpose
+            val site = intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
+            val domainRegistrationPurpose =
+                intent.getSerializableExtraCompat<DomainRegistrationPurpose>(DOMAIN_REGISTRATION_PURPOSE_KEY)
 
             setupToolbar()
-            setupViewModel(site, domainRegistrationPurpose)
+            if (site != null && domainRegistrationPurpose != null) {
+                setupViewModel(site, domainRegistrationPurpose)
+            }
             setupObservers()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.Companion.DOMAIN_REGISTRATION_PURPOSE_KEY
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -38,21 +39,22 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
         super.onViewCreated(view, savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
 
-        mainViewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-            .get(DomainRegistrationMainViewModel::class.java)
+        mainViewModel =
+            ViewModelProvider(requireActivity(), viewModelFactory)[DomainRegistrationMainViewModel::class.java]
 
-        viewModel = ViewModelProvider(this, viewModelFactory)
-            .get(DomainSuggestionsViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory)[DomainSuggestionsViewModel::class.java]
 
         with(DomainSuggestionsFragmentBinding.bind(view)) {
             val intent = requireActivity().intent
-            val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-            val domainRegistrationPurpose = intent.getSerializableExtra(DOMAIN_REGISTRATION_PURPOSE_KEY)
-                    as DomainRegistrationPurpose
+            val site = intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
+            val domainRegistrationPurpose =
+                intent.getSerializableExtraCompat<DomainRegistrationPurpose>(DOMAIN_REGISTRATION_PURPOSE_KEY)
 
             setupViews()
             setupObservers()
-            viewModel.start(site, domainRegistrationPurpose)
+            if (site != null && domainRegistrationPurpose != null) {
+                viewModel.start(site, domainRegistrationPurpose)
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardActivity.kt
@@ -24,7 +24,7 @@ class DomainsDashboardActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistr
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.ClaimDomain
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.GetDomain
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -46,9 +47,9 @@ class DomainsDashboardFragment : Fragment(R.layout.domains_dashboard_fragment) {
 
     private fun setupViewModel() {
         val intent = requireActivity().intent
-        val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-        viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(DomainsDashboardViewModel::class.java)
-        viewModel.start(site)
+        val site = intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)[DomainsDashboardViewModel::class.java]
+        site?.let { viewModel.start(it) }
     }
 
     private fun DomainsDashboardFragmentBinding.setupObservers() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.EngagedPeopleListActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
 import javax.inject.Inject
 
 class EngagedPeopleListActivity : LocaleAwareActivity() {
@@ -22,7 +23,7 @@ class EngagedPeopleListActivity : LocaleAwareActivity() {
             setSupportActionBar(toolbarMain)
         }
 
-        val listScenario = intent.getParcelableExtra<ListScenario>(KEY_LIST_SCENARIO)
+        val listScenario = intent.getParcelableExtraCompat<ListScenario>(KEY_LIST_SCENARIO)
             ?: throw IllegalArgumentException(
                 "List Scenario cannot be null. Make sure to pass a valid List Scenario in the intent"
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
@@ -59,7 +59,7 @@ class EngagedPeopleListActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.WPUrlUtils
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.observeEvent
@@ -93,17 +94,17 @@ class EngagedPeopleListFragment : Fragment() {
         loadingView = view.findViewById(R.id.loading_view)
         emptyView = view.findViewById(R.id.actionable_empty_view)
 
-        val listScenario = requireArguments().getParcelable<ListScenario>(KEY_LIST_SCENARIO)
+        val listScenario = requireArguments().getParcelableCompat<ListScenario>(KEY_LIST_SCENARIO)
 
         val layoutManager = LinearLayoutManager(activity)
 
-        savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(KEY_LIST_STATE)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 
         recycler.layoutManager = layoutManager
 
-        userProfileViewModel.onBottomSheetAction.observeEvent(viewLifecycleOwner, { state ->
+        userProfileViewModel.onBottomSheetAction.observeEvent(viewLifecycleOwner) { state ->
             var bottomSheet = childFragmentManager.findFragmentByTag(USER_PROFILE_BOTTOM_SHEET_TAG)
                     as? UserProfileBottomSheetFragment
 
@@ -118,31 +119,31 @@ class EngagedPeopleListFragment : Fragment() {
                     bottomSheet?.apply { this.dismiss() }
                 }
             }
-        })
+        }
 
-        viewModel.uiState.observe(viewLifecycleOwner, { state ->
+        viewModel.uiState.observe(viewLifecycleOwner) { state ->
             if (!isAdded) return@observe
 
             updateUiState(state)
-        })
+        }
 
-        viewModel.onNavigationEvent.observeEvent(viewLifecycleOwner, { event ->
+        viewModel.onNavigationEvent.observeEvent(viewLifecycleOwner) { event ->
             if (!isAdded) return@observeEvent
 
             manageNavigation(event)
-        })
+        }
 
-        viewModel.onSnackbarMessage.observeEvent(viewLifecycleOwner, { messageHolder ->
+        viewModel.onSnackbarMessage.observeEvent(viewLifecycleOwner) { messageHolder ->
             if (!isAdded || !lifecycle.currentState.isAtLeast(State.RESUMED)) return@observeEvent
 
             showSnackbar(messageHolder)
-        })
+        }
 
-        viewModel.onServiceRequestEvent.observeEvent(viewLifecycleOwner, { serviceRequest ->
+        viewModel.onServiceRequestEvent.observeEvent(viewLifecycleOwner) { serviceRequest ->
             if (!isAdded) return@observeEvent
 
             manageServiceRequest(serviceRequest)
-        })
+        }
 
         viewModel.start(listScenario!!)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/featureintroduction/FeatureIntroductionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/featureintroduction/FeatureIntroductionDialogFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.fragment.app.DialogFragment
@@ -32,9 +33,12 @@ abstract class FeatureIntroductionDialogFragment : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
         object : Dialog(requireContext(), theme) {
-            override fun onBackPressed() {
-                viewModel.onBackButtonClick()
-                super.onBackPressed()
+            override fun onCreate(savedInstanceState: Bundle?) {
+                super.onCreate(savedInstanceState)
+
+                requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+                    viewModel.onBackButtonClick()
+                }
             }
         }.apply {
             setStatusBarAsSurfaceColor()

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.history
 
 import android.os.Bundle
+import androidx.activity.addCallback
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -20,6 +21,8 @@ class HistoryDetailActivity : LocaleAwareActivity() {
             setSupportActionBar(toolbarMain)
         }
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        onBackPressedDispatcher.addCallback(this) { AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED) }
 
         val extras = requireNotNull(intent.extras)
         val revision = extras.getParcelable<Revision>(HistoryDetailContainerFragment.EXTRA_CURRENT_REVISION)
@@ -43,10 +46,5 @@ class HistoryDetailActivity : LocaleAwareActivity() {
         AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED)
         finish()
         return true
-    }
-
-    override fun onBackPressed() {
-        AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED)
-        super.onBackPressed()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.databinding.HistoryDetailActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.history.HistoryListItem.Revision
+import org.wordpress.android.util.extensions.getParcelableCompat
 
 class HistoryDetailActivity : LocaleAwareActivity() {
     companion object {
@@ -25,7 +26,7 @@ class HistoryDetailActivity : LocaleAwareActivity() {
         onBackPressedDispatcher.addCallback(this) { AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED) }
 
         val extras = requireNotNull(intent.extras)
-        val revision = extras.getParcelable<Revision>(HistoryDetailContainerFragment.EXTRA_CURRENT_REVISION)
+        val revision = extras.getParcelableCompat<Revision>(HistoryDetailContainerFragment.EXTRA_CURRENT_REVISION)
         val previousRevisionsIds =
             extras.getLongArray(HistoryDetailContainerFragment.EXTRA_PREVIOUS_REVISIONS_IDS)
         val postId = extras.getLong(HistoryDetailContainerFragment.EXTRA_POST_ID)

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import org.wordpress.android.R
 import org.wordpress.android.ui.history.HistoryListItem.Revision
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.widgets.DiffView
 
 class HistoryDetailFragment : Fragment() {
@@ -16,9 +17,9 @@ class HistoryDetailFragment : Fragment() {
         super.onCreate(savedInstanceState)
 
         mRevision = if (savedInstanceState != null) {
-            savedInstanceState.getParcelable(KEY_REVISION)
+            savedInstanceState.getParcelableCompat(KEY_REVISION)
         } else {
-            arguments?.getParcelable(EXTRA_REVISION)
+            arguments?.getParcelableCompat(EXTRA_REVISION)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
@@ -18,7 +18,7 @@ class BackupDownloadActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
@@ -89,11 +90,12 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
         viewModel = ViewModelProvider(
             this@BackupDownloadFragment,
             viewModelFactory
-        ).get(BackupDownloadViewModel::class.java)
+        )[BackupDownloadViewModel::class.java]
 
         val (site, activityId) = when {
             requireActivity().intent?.extras != null -> {
-                val site = requireNotNull(requireActivity().intent.extras).getSerializable(WordPress.SITE) as SiteModel
+                val site =
+                    requireNotNull(requireActivity().intent.extras).getSerializableCompat<SiteModel>(WordPress.SITE)
                 val activityId = requireNotNull(requireActivity().intent.extras).getString(
                     KEY_BACKUP_DOWNLOAD_ACTIVITY_ID_KEY
                 ) as String
@@ -107,7 +109,7 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
 
         initObservers()
 
-        viewModel.start(site, activityId, savedInstanceState)
+        site?.let { viewModel.start(it, activityId, savedInstanceState) }
     }
 
     private fun JetpackBackupRestoreFragmentBinding.initObservers() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -58,6 +58,7 @@ import org.wordpress.android.ui.jetpack.usecases.GetActivityLogItemUseCase
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
@@ -139,7 +140,7 @@ class BackupDownloadViewModel @Inject constructor(
             // Show the next step only if it's a fresh activity so we can handle the navigation
             wizardManager.showNextStep()
         } else {
-            backupDownloadState = requireNotNull(savedInstanceState.getParcelable(KEY_BACKUP_DOWNLOAD_STATE))
+            backupDownloadState = requireNotNull(savedInstanceState.getParcelableCompat(KEY_BACKUP_DOWNLOAD_STATE))
             val currentStepIndex = savedInstanceState.getInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP)
             wizardManager.setCurrentStepIndex(currentStepIndex)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
@@ -17,7 +17,7 @@ class RestoreActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
@@ -85,11 +86,12 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
     }
 
     private fun JetpackBackupRestoreFragmentBinding.initViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(this@RestoreFragment, viewModelFactory).get(RestoreViewModel::class.java)
+        viewModel = ViewModelProvider(this@RestoreFragment, viewModelFactory)[RestoreViewModel::class.java]
 
         val (site, activityId) = when {
             requireActivity().intent?.extras != null -> {
-                val site = requireNotNull(requireActivity().intent.extras).getSerializable(WordPress.SITE) as SiteModel
+                val site =
+                    requireNotNull(requireActivity().intent.extras).getSerializableCompat<SiteModel>(WordPress.SITE)
                 val activityId = requireNotNull(requireActivity().intent.extras).getString(
                     KEY_RESTORE_ACTIVITY_ID_KEY
                 ) as String
@@ -103,7 +105,7 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
 
         initObservers()
 
-        viewModel.start(site, activityId, savedInstanceState)
+        site?.let { viewModel.start(it, activityId, savedInstanceState) }
     }
 
     private fun JetpackBackupRestoreFragmentBinding.initObservers() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -61,6 +61,7 @@ import org.wordpress.android.ui.jetpack.usecases.GetActivityLogItemUseCase
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
@@ -142,7 +143,7 @@ class RestoreViewModel @Inject constructor(
             // Show the next step only if it's a fresh activity so we can handle the navigation
             wizardManager.showNextStep()
         } else {
-            restoreState = requireNotNull(savedInstanceState.getParcelable(KEY_RESTORE_STATE))
+            restoreState = requireNotNull(savedInstanceState.getParcelableCompat(KEY_RESTORE_STATE))
             val currentStepIndex = savedInstanceState.getInt(KEY_RESTORE_CURRENT_STEP)
             wizardManager.setCurrentStepIndex(currentStepIndex)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
@@ -11,13 +11,13 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ScanActivityBinding
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.models.JetpackPoweredScreen
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -87,7 +87,7 @@ class ScanActivity : AppCompatActivity(), ScrollableViewInitializedListener {
             return true
         } else if (item.itemId == R.id.menu_scan_history) {
             // todo malinjir is it worth introducing a vm?
-            ActivityLauncher.viewScanHistory(this, intent.getSerializableExtra(WordPress.SITE) as SiteModel)
+            ActivityLauncher.viewScanHistory(this, intent.getSerializableExtraCompat(WordPress.SITE))
         }
         return super.onOptionsItemSelected(item)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
@@ -83,7 +83,7 @@ class ScanActivity : AppCompatActivity(), ScrollableViewInitializedListener {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         } else if (item.itemId == R.id.menu_scan_history) {
             // todo malinjir is it worth introducing a vm?

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -30,6 +30,8 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.EmptyViewRecyclerView
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ColorUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
@@ -51,7 +53,7 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         with(ScanFragmentBinding.bind(view)) {
             initRecyclerView()
             listView = recyclerView
-            initViewModel(getSite(savedInstanceState))
+            getSite(savedInstanceState)?.let { initViewModel(it) }
         }
     }
 
@@ -174,11 +176,11 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         fixThreatsConfirmationDialog?.dismiss()
     }
 
-    private fun getSite(savedInstanceState: Bundle?): SiteModel {
+    private fun getSite(savedInstanceState: Bundle?): SiteModel? {
         return if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtra(WordPress.SITE) as SiteModel
+            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
         } else {
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+            savedInstanceState.getSerializableCompat(WordPress.SITE)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsActivity.kt
@@ -20,7 +20,7 @@ class ThreatDetailsActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel.UiSt
 import org.wordpress.android.ui.jetpack.scan.details.adapters.ThreatDetailsAdapter
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
@@ -68,39 +69,37 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
 
     private fun ThreatDetailsFragmentBinding.setupObservers() {
         viewModel.uiState.observe(
-            viewLifecycleOwner,
-            { uiState ->
-                if (uiState is Content) {
-                    refreshContentScreen(uiState)
-                }
+            viewLifecycleOwner
+        ) { uiState ->
+            if (uiState is Content) {
+                refreshContentScreen(uiState)
             }
-        )
+        }
 
-        viewModel.snackbarEvents.observeEvent(viewLifecycleOwner, { it.showSnackbar() })
+        viewModel.snackbarEvents.observeEvent(viewLifecycleOwner) { it.showSnackbar() }
 
         viewModel.navigationEvents.observeEvent(
-            viewLifecycleOwner,
-            { events ->
-                when (events) {
-                    is OpenThreatActionDialog -> showThreatActionDialog(events)
+            viewLifecycleOwner
+        ) { events ->
+            when (events) {
+                is OpenThreatActionDialog -> showThreatActionDialog(events)
 
-                    is ShowUpdatedScanStateWithMessage -> {
-                        val site = requireNotNull(requireActivity().intent.extras)
-                            .getSerializable(WordPress.SITE) as SiteModel
-                        ActivityLauncher.viewScanRequestScanState(requireActivity(), site, events.messageRes)
-                    }
-                    is ShowUpdatedFixState -> {
-                        val site = requireNotNull(requireActivity().intent.extras)
-                            .getSerializable(WordPress.SITE) as SiteModel
-                        ActivityLauncher.viewScanRequestFixState(requireActivity(), site, events.threatId)
-                    }
-                    is ShowGetFreeEstimate -> {
-                        ActivityLauncher.openUrlExternal(context, events.url())
-                    }
-                    is ShowJetpackSettings -> ActivityLauncher.openUrlExternal(context, events.url)
+                is ShowUpdatedScanStateWithMessage -> {
+                    val site = requireNotNull(requireActivity().intent.extras)
+                        .getSerializableCompat<SiteModel>(WordPress.SITE)
+                    ActivityLauncher.viewScanRequestScanState(requireActivity(), site, events.messageRes)
                 }
+                is ShowUpdatedFixState -> {
+                    val site = requireNotNull(requireActivity().intent.extras)
+                        .getSerializableCompat<SiteModel>(WordPress.SITE)
+                    ActivityLauncher.viewScanRequestFixState(requireActivity(), site, events.threatId)
+                }
+                is ShowGetFreeEstimate -> {
+                    ActivityLauncher.openUrlExternal(context, events.url())
+                }
+                is ShowJetpackSettings -> ActivityLauncher.openUrlExternal(context, events.url)
             }
-        )
+        }
     }
 
     private fun ThreatDetailsFragmentBinding.refreshContentScreen(content: Content) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -139,7 +139,7 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), MenuProvid
 
     override fun onMenuItemSelected(menuItem: MenuItem) = when (menuItem.itemId) {
         android.R.id.home -> {
-            requireActivity().onBackPressed()
+            requireActivity().onBackPressedDispatcher.onBackPressed()
             true
         }
         else -> false

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -29,6 +29,8 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.models.JetpackPoweredScreen
 import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -62,7 +64,7 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), MenuProvid
         super.onViewCreated(view, savedInstanceState)
         requireActivity().addMenuProvider(this, viewLifecycleOwner)
         binding = ScanHistoryFragmentBinding.bind(view).apply {
-            initViewModel(getSite(savedInstanceState))
+            getSite(savedInstanceState)?.let { initViewModel(it) }
             initToolbar()
         }
     }
@@ -120,11 +122,11 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), MenuProvid
         }
     }
 
-    private fun getSite(savedInstanceState: Bundle?): SiteModel {
+    private fun getSite(savedInstanceState: Bundle?): SiteModel? {
         return if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtra(WordPress.SITE) as SiteModel
+            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
         } else {
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+            savedInstanceState.getSerializableCompat(WordPress.SITE)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -17,6 +17,9 @@ import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryListViewModel.Sc
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryListViewModel.ScanHistoryUiState.EmptyUiState.EmptyHistory
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -38,7 +41,7 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
         super.onViewCreated(view, savedInstanceState)
         binding = ScanHistoryListFragmentBinding.bind(view).apply {
             initRecyclerView()
-            initViewModel(getSite(savedInstanceState), getTabType())
+            getSite(savedInstanceState)?.let { initViewModel(it, getTabType()) }
         }
     }
 
@@ -77,15 +80,15 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
         ((recyclerView.adapter) as ScanAdapter).update(items)
     }
 
-    private fun getSite(savedInstanceState: Bundle?): SiteModel {
+    private fun getSite(savedInstanceState: Bundle?): SiteModel? {
         return if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtra(WordPress.SITE) as SiteModel
+            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
         } else {
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+            savedInstanceState.getSerializableCompat(WordPress.SITE)
         }
     }
 
-    private fun getTabType(): ScanHistoryTabType = requireNotNull(arguments?.getParcelable(ARG_TAB_TYPE))
+    private fun getTabType(): ScanHistoryTabType = requireNotNull(arguments?.getParcelableCompat(ARG_TAB_TYPE))
 
     override fun getScrollableViewForUniqueIdProvision(): View? = binding?.recyclerView
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.RtlUtils
 import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.extensions.exhaustive
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.extensions.setVisible
 import javax.inject.Inject
 
@@ -55,15 +56,19 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.init(
-            getSiteScreen(),
-            getIfSiteCreationOverlay(),
-            getIfDeepLinkOverlay(),
-            getSiteCreationSource(),
-            getIfFeatureCollectionOverlay(),
-            getFeatureCollectionOverlaysSource(),
-            RtlUtils.isRtl(view.context)
-        )
+        val siteCreationSource = getSiteCreationSource()
+        val featureCollectionOverlaySource = getFeatureCollectionOverlaysSource()
+        if (siteCreationSource != null && featureCollectionOverlaySource != null) {
+            viewModel.init(
+                getSiteScreen(),
+                getIfSiteCreationOverlay(),
+                getIfDeepLinkOverlay(),
+                siteCreationSource,
+                getIfFeatureCollectionOverlay(),
+                featureCollectionOverlaySource,
+                RtlUtils.isRtl(view.context)
+            )
+        }
         binding.setupObservers()
 
         (dialog as? BottomSheetDialog)?.apply {
@@ -93,23 +98,19 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
     }
 
-    private fun getSiteScreen() =
-        arguments?.getSerializable(OVERLAY_SCREEN_TYPE) as JetpackFeatureOverlayScreenType?
+    private fun getSiteScreen() = arguments?.getSerializableCompat<JetpackFeatureOverlayScreenType>(OVERLAY_SCREEN_TYPE)
 
-    private fun getIfSiteCreationOverlay() =
-        arguments?.getSerializable(IS_SITE_CREATION_OVERLAY) as Boolean
+    private fun getIfSiteCreationOverlay() = arguments?.getBoolean(IS_SITE_CREATION_OVERLAY) ?: false
 
-    private fun getIfDeepLinkOverlay() =
-        arguments?.getSerializable(IS_DEEP_LINK_OVERLAY) as Boolean
+    private fun getIfDeepLinkOverlay() = arguments?.getBoolean(IS_DEEP_LINK_OVERLAY) ?: false
 
     private fun getSiteCreationSource() =
-        arguments?.getSerializable(SITE_CREATION_OVERLAY_SOURCE) as SiteCreationSource
+        arguments?.getSerializableCompat<SiteCreationSource>(SITE_CREATION_OVERLAY_SOURCE)
 
-    private fun getIfFeatureCollectionOverlay() =
-        arguments?.getSerializable(IS_FEATURE_COLLECTION_OVERLAY) as Boolean
+    private fun getIfFeatureCollectionOverlay() = arguments?.getBoolean(IS_FEATURE_COLLECTION_OVERLAY) ?: false
 
     private fun getFeatureCollectionOverlaysSource() =
-        arguments?.getSerializable(FEATURE_COLLECTION_OVERLAY_SOURCE) as JetpackFeatureCollectionOverlaySource
+        arguments?.getSerializableCompat<JetpackFeatureCollectionOverlaySource>(FEATURE_COLLECTION_OVERLAY_SOURCE)
 
     private fun JetpackFeatureRemovalOverlayBinding.setupObservers() {
         viewModel.uiState.observe(viewLifecycleOwner) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
@@ -15,6 +15,8 @@ import org.wordpress.android.ui.PreviewModeHandler
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Content
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Error
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableArrayListCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -307,10 +309,10 @@ abstract class LayoutPickerViewModel(
 
     fun loadSavedState(savedInstanceState: Bundle?) {
         if (savedInstanceState == null) return
-        val layouts = savedInstanceState.getParcelableArrayList<LayoutModel>(FETCHED_LAYOUTS)
-        val categories = savedInstanceState.getParcelableArrayList<LayoutCategoryModel>(FETCHED_CATEGORIES)
+        val layouts = savedInstanceState.getParcelableArrayListCompat<LayoutModel>(FETCHED_LAYOUTS)
+        val categories = savedInstanceState.getParcelableArrayListCompat<LayoutCategoryModel>(FETCHED_CATEGORIES)
         val selected = savedInstanceState.getString(SELECTED_LAYOUT)
-        val selectedCategories = (savedInstanceState.getSerializable(SELECTED_CATEGORIES) as? List<*>)
+        val selectedCategories = (savedInstanceState.getSerializableCompat(SELECTED_CATEGORIES) as? List<*>)
             ?.filterIsInstance<String>() ?: listOf()
         val previewMode = savedInstanceState.getString(PREVIEW_MODE, MOBILE.name)
         resetState(selected, ArrayList(selectedCategories.toMutableList()), previewMode)

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutsRowViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutsRowViewHolder.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener
 import org.wordpress.android.R
 import org.wordpress.android.R.dimen
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.extensions.setVisible
 
 sealed class LayoutsRowViewHolder(view: View) : RecyclerView.ViewHolder(view)
@@ -100,7 +101,7 @@ class LayoutsItemViewHolder(
 
     private fun restoreScrollState(recyclerView: RecyclerView, key: String) {
         recyclerView.layoutManager?.apply {
-            val scrollState = nestedScrollStates.getParcelable<Parcelable>(key)
+            val scrollState = nestedScrollStates.getParcelableCompat<Parcelable>(key)
             if (scrollState != null) {
                 onRestoreInstanceState(scrollState)
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
@@ -18,7 +18,7 @@ class MeActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationActivity.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.databinding.ActivityJetpackMigrationBinding
 import org.wordpress.android.ui.utils.PreMigrationDeepLinkData
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
 
 @AndroidEntryPoint
 class JetpackMigrationActivity : AppCompatActivity() {
@@ -18,7 +19,7 @@ class JetpackMigrationActivity : AppCompatActivity() {
             setContentView(root)
             if (savedInstanceState == null) {
                 val showDeleteWpState = intent.getBooleanExtra(KEY_SHOW_DELETE_WP_STATE, false)
-                val deepLinkData = intent.getParcelableExtra<PreMigrationDeepLinkData>(KEY_DEEP_LINK_DATA)
+                val deepLinkData = intent.getParcelableExtraCompat<PreMigrationDeepLinkData>(KEY_DEEP_LINK_DATA)
                 val fragment = JetpackMigrationFragment.newInstance(showDeleteWpState, deepLinkData)
                 supportFragmentManager.beginTransaction()
                     .replace(R.id.fragment_container, fragment)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -44,6 +44,7 @@ import org.wordpress.android.ui.utils.PreMigrationDeepLinkData
 import org.wordpress.android.util.AppThemeUtils
 import org.wordpress.android.util.LocaleManager
 import org.wordpress.android.util.UriWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -77,7 +78,7 @@ class JetpackMigrationFragment : Fragment() {
         observeViewModelEvents()
         observeRefreshAppThemeEvents()
         val showDeleteWpState = arguments?.getBoolean(KEY_SHOW_DELETE_WP_STATE, false) ?: false
-        val deepLinkData = arguments?.getParcelable<PreMigrationDeepLinkData>(KEY_DEEP_LINK_DATA)
+        val deepLinkData = arguments?.getParcelableCompat<PreMigrationDeepLinkData>(KEY_DEEP_LINK_DATA)
         initBackPressHandler(showDeleteWpState)
         viewModel.start(
             showDeleteWpState,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.os.Parcel
 import android.os.Parcelable
 import android.os.Parcelable.Creator
+import androidx.core.os.ParcelCompat
 import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.GIF_MEDIA_IDENTIFIER
 import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.LOCAL_ID
 import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.LOCAL_URI
@@ -82,7 +83,15 @@ data class MediaItem(
                     return when (type) {
                         LOCAL_URI -> {
                             LocalUri(
-                                UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))),
+                                UriWrapper(
+                                    requireNotNull(
+                                        ParcelCompat.readParcelable(
+                                            parcel,
+                                            Uri::class.java.classLoader,
+                                            Uri::class.java
+                                        )
+                                    )
+                                ),
                                 parcel.readInt() != 0
                             )
                         }
@@ -97,7 +106,15 @@ data class MediaItem(
                         }
                         GIF_MEDIA_IDENTIFIER -> {
                             GifMediaIdentifier(
-                                UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))),
+                                UriWrapper(
+                                    requireNotNull(
+                                        ParcelCompat.readParcelable(
+                                            parcel,
+                                            Uri::class.java.classLoader,
+                                            Uri::class.java
+                                        )
+                                    )
+                                ),
                                 parcel.readString()
                             )
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActionModeCallback.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.Lifecycle.Event.ON_START
 import androidx.lifecycle.Lifecycle.Event.ON_STOP
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import androidx.lifecycle.Observer
 import org.wordpress.android.R
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ActionModeUiModel
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -29,7 +28,7 @@ class MediaPickerActionModeCallback(private val viewModel: MediaPickerViewModel)
         lifecycleRegistry.handleLifecycleEvent(ON_START)
         val inflater = actionMode.menuInflater
         inflater.inflate(R.menu.photo_picker_action_mode, menu)
-        viewModel.uiState.observe(this, Observer { uiState ->
+        viewModel.uiState.observe(this) { uiState ->
             when (val uiModel = uiState.actionModeUiModel) {
                 is ActionModeUiModel.Hidden -> {
                     actionMode.finish()
@@ -42,19 +41,20 @@ class MediaPickerActionModeCallback(private val viewModel: MediaPickerViewModel)
                     if (editItemUiModel.isVisible) {
                         editItem.isVisible = true
 
-                        editItem.actionView.let { actionView ->
+                        editItem.actionView?.let { actionView ->
                             actionView.setOnClickListener {
                                 onActionItemClicked(actionMode, editItem)
                             }
                             TooltipCompat.setTooltipText(actionView, editItem.title)
                         }
 
-                        val editItemBadge = editItem.actionView.findViewById<TextView>(R.id.customize_icon_count)
-                        if (editItemUiModel.isCounterBadgeVisible) {
-                            editItemBadge.visibility = View.VISIBLE
-                            editItemBadge.text = editItemUiModel.counterBadgeValue.toString()
-                        } else {
-                            editItemBadge.visibility = View.GONE
+                        editItem.actionView?.findViewById<TextView>(R.id.customize_icon_count)?.let { editItemBadge ->
+                            if (editItemUiModel.isCounterBadgeVisible) {
+                                editItemBadge.visibility = View.VISIBLE
+                                editItemBadge.text = editItemUiModel.counterBadgeValue.toString()
+                            } else {
+                                editItemBadge.visibility = View.GONE
+                            }
                         }
                     } else {
                         editItem.isVisible = false
@@ -67,7 +67,7 @@ class MediaPickerActionModeCallback(private val viewModel: MediaPickerViewModel)
                     }
                 }
             }
-        })
+        }
         return true
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -50,6 +50,8 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MEDIA
 import org.wordpress.android.util.WPMediaUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import java.io.File
 import javax.inject.Inject
 
@@ -118,11 +120,11 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         }
         if (savedInstanceState == null) {
             mediaPickerSetup = MediaPickerSetup.fromIntent(intent)
-            site = intent.getSerializableExtra(WordPress.SITE) as? SiteModel
+            site = intent.getSerializableExtraCompat(WordPress.SITE)
             localPostId = intent.getIntExtra(LOCAL_POST_ID, EMPTY_LOCAL_POST_ID)
         } else {
             mediaPickerSetup = MediaPickerSetup.fromBundle(savedInstanceState)
-            site = savedInstanceState.getSerializable(WordPress.SITE) as? SiteModel
+            site = savedInstanceState.getSerializableCompat(WordPress.SITE)
             localPostId = savedInstanceState.getInt(LOCAL_POST_ID, EMPTY_LOCAL_POST_ID)
         }
         var fragment = pickerFragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -74,6 +74,9 @@ import org.wordpress.android.util.WPLinkMovementMethod
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getParcelableArrayListCompat
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -224,13 +227,13 @@ class MediaPickerFragment : Fragment(), MenuProvider {
         requireActivity().addMenuProvider(this, viewLifecycleOwner)
 
         val mediaPickerSetup = MediaPickerSetup.fromBundle(requireArguments())
-        val site = requireArguments().getSerializable(WordPress.SITE) as? SiteModel
+        val site = requireArguments().getSerializableCompat<SiteModel>(WordPress.SITE)
         var selectedIds: List<Identifier>? = null
         var lastTappedIcon: MediaPickerIcon? = null
         if (savedInstanceState != null) {
             lastTappedIcon = MediaPickerIcon.fromBundle(savedInstanceState)
             if (savedInstanceState.containsKey(KEY_SELECTED_IDS)) {
-                selectedIds = savedInstanceState.getParcelableArrayList<Identifier>(KEY_SELECTED_IDS)?.map { it }
+                selectedIds = savedInstanceState.getParcelableArrayListCompat<Identifier>(KEY_SELECTED_IDS)?.map { it }
             }
         }
 
@@ -239,7 +242,7 @@ class MediaPickerFragment : Fragment(), MenuProvider {
             NUM_COLUMNS
         )
 
-        savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(KEY_LIST_STATE)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
         with(MediaPickerFragmentBinding.bind(view)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -419,13 +419,13 @@ class MediaPickerFragment : Fragment(), MenuProvider {
     private fun initializeSearchView(actionMenuItem: MenuItem) {
         var isExpanding = false
         actionMenuItem.setOnActionExpandListener(object : OnActionExpandListener {
-            override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
+            override fun onMenuItemActionExpand(item: MenuItem): Boolean {
                 viewModel.onSearchExpanded()
                 isExpanding = true
                 return true
             }
 
-            override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
+            override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
                 viewModel.onSearchCollapsed()
                 return true
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -100,7 +100,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         toolbarMain.let { toolbar ->
             toolbar.inflateMenu(R.menu.my_site_menu)
             toolbar.menu.findItem(R.id.me_item)?.let { meMenu ->
-                meMenu.actionView.let { actionView ->
+                meMenu.actionView?.let { actionView ->
                     actionView.contentDescription = meMenu.title
                     actionView.setOnClickListener { viewModel.onAvatarPressed() }
                     TooltipCompat.setTooltipText(actionView, meMenu.title)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonViewHolder.kt
@@ -66,14 +66,14 @@ class QuickLinkRibbonViewHolder(
          * We need to do this immediately, because if we don't, then the next move event could potentially
          * trigger the viewPager to switch tabs
          */
-        override fun onDown(e: MotionEvent?): Boolean = with(binding) {
+        override fun onDown(e: MotionEvent): Boolean = with(binding) {
             quickLinkRibbonItemList.parent.requestDisallowInterceptTouchEvent(true)
             return super.onDown(e)
         }
 
         override fun onScroll(
-            e1: MotionEvent?,
-            e2: MotionEvent?,
+            e1: MotionEvent,
+            e2: MotionEvent,
             distanceX: Float,
             distanceY: Float
         ): Boolean = with(binding) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartDynamicCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartDynamicCardViewHolder.kt
@@ -128,14 +128,14 @@ class QuickStartDynamicCardViewHolder(
          * We need to do this immediately, because if we don't, then the next move event could potentially
          * trigger the viewPager to switch tabs
          */
-        override fun onDown(e: MotionEvent?): Boolean = with(binding) {
+        override fun onDown(e: MotionEvent): Boolean = with(binding) {
             quickStartCardRecyclerView.parent.requestDisallowInterceptTouchEvent(true)
             return super.onDown(e)
         }
 
         override fun onScroll(
-            e1: MotionEvent?,
-            e2: MotionEvent?,
+            e1: MotionEvent,
+            e2: MotionEvent,
             distanceX: Float,
             distanceY: Float
         ): Boolean = with(binding) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartDynamicCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartDynamicCardViewHolder.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartD
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ColorUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.extensions.viewBinding
 
 private const val Y_BUFFER = 10
@@ -90,7 +91,7 @@ class QuickStartDynamicCardViewHolder(
 
     private fun restoreScrollState(recyclerView: RecyclerView, key: String) {
         recyclerView.layoutManager?.apply {
-            val scrollState = nestedScrollStates.getParcelable<Parcelable>(key)
+            val scrollState = nestedScrollStates.getParcelableCompat<Parcelable>(key)
             if (scrollState != null) {
                 onRestoreInstanceState(scrollState)
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredBottomSheetFragment.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.main.WPMainNavigationView.PageType.READER
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredDialogAction.DismissDialog
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredDialogAction.OpenPlayStore
 import org.wordpress.android.util.extensions.exhaustive
+import org.wordpress.android.util.extensions.getSerializableCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -85,7 +86,7 @@ class JetpackPoweredBottomSheetFragment : BottomSheetDialogFragment() {
 
     private fun setupFullScreenViews(view: View) {
         with(JetpackPoweredExpandedBottomSheetBinding.bind(view)) {
-            when (arguments?.getSerializable(KEY_SITE_SCREEN) as? PageType ?: MY_SITE) {
+            when (arguments?.getSerializableCompat(KEY_SITE_SCREEN) ?: MY_SITE) {
                 MY_SITE -> {
                     val animRes = if (rtlLayout(view)) raw.jp_stats_rtl else raw.jp_stats_left
                     illustrationView.setAnimation(animRes)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/DismissNotificationReceiver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/DismissNotificationReceiver.kt
@@ -7,6 +7,7 @@ import androidx.core.app.NotificationManagerCompat
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 class DismissNotificationReceiver : BroadcastReceiver() {
@@ -21,7 +22,7 @@ class DismissNotificationReceiver : BroadcastReceiver() {
     }
 
     private fun trackAnalyticsEvent(intent: Intent) {
-        val stat = intent.getSerializableExtra(EXTRA_STAT_TO_TRACK) as Stat?
+        val stat = intent.getSerializableExtraCompat<Stat>(EXTRA_STAT_TO_TRACK)
         if (stat != null) {
             analyticsTrackerWrapper.track(stat)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -17,6 +17,8 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.SnackbarSequencer
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.pages.PageListViewModel
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType
@@ -88,20 +90,21 @@ class PageListFragment : ViewPagerFragment(R.layout.pages_list_fragment) {
     }
 
     private fun PagesListFragmentBinding.initializeViewModels(activity: FragmentActivity) {
-        val pagesViewModel = ViewModelProvider(activity, viewModelFactory).get(PagesViewModel::class.java)
+        val pagesViewModel = ViewModelProvider(activity, viewModelFactory)[PagesViewModel::class.java]
 
-        val listType = arguments?.getSerializable(typeKey) as PageListType
-        viewModel = ViewModelProvider(this@PageListFragment, viewModelFactory)
-            .get(listType.name, PageListViewModel::class.java)
+        arguments?.getSerializableCompat<PageListType>(typeKey)?.let { listType ->
+            viewModel =
+                ViewModelProvider(this@PageListFragment, viewModelFactory)[listType.name, PageListViewModel::class.java]
 
-        viewModel.start(listType, pagesViewModel)
+            viewModel.start(listType, pagesViewModel)
+        }
 
         setupObservers()
     }
 
     private fun PagesListFragmentBinding.initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
@@ -94,12 +94,12 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), MenuProvider
 
     private fun PageParentFragmentBinding.initializeSearchView() {
         searchAction.setOnActionExpandListener(object : OnActionExpandListener {
-            override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
+            override fun onMenuItemActionExpand(item: MenuItem): Boolean {
                 viewModel.onSearchExpanded(restorePreviousSearch)
                 return true
             }
 
-            override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
+            override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
                 viewModel.onSearchCollapsed()
                 return true
             }
@@ -123,8 +123,8 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), MenuProvider
             }
         })
 
-        val searchEditFrame = searchAction.actionView.findViewById<LinearLayout>(R.id.search_edit_frame)
-        (searchEditFrame.layoutParams as LinearLayout.LayoutParams)
+        val searchEditFrame = searchAction.actionView?.findViewById<LinearLayout>(R.id.search_edit_frame)
+        (searchEditFrame?.layoutParams as LinearLayout.LayoutParams)
             .apply { this.leftMargin = DisplayUtils.dpToPx(activity, SEARCH_ACTION_LEFT_MARGIN_DP) }
 
         viewModel.isSearchExpanded.observe(this@PageParentFragment) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
@@ -25,6 +25,8 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PageParentFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.pages.PageParentViewModel
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
@@ -158,7 +160,7 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), MenuProvider
 
     private fun PageParentFragmentBinding.initializeViews(activity: FragmentActivity, savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 
@@ -184,7 +186,7 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), MenuProvider
         setupObservers()
 
         if (isFirstStart) {
-            val site = activity.intent?.getSerializableExtra(WordPress.SITE) as SiteModel?
+            val site = activity.intent?.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
             val nonNullSite = checkNotNull(site)
             viewModel.start(nonNullSite, pageId)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
@@ -60,7 +60,7 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), MenuProvider
 
     override fun onMenuItemSelected(menuItem: MenuItem) = when (menuItem.itemId) {
         android.R.id.home -> {
-            activity?.onBackPressed()
+            activity?.onBackPressedDispatcher?.onBackPressed()
             true
         }
         R.id.save_parent -> {
@@ -87,7 +87,7 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), MenuProvider
         result.putExtra(EXTRA_PAGE_REMOTE_ID_KEY, pageId)
         result.putExtra(EXTRA_PAGE_PARENT_ID_KEY, viewModel.currentParent.id)
         activity?.setResult(Activity.RESULT_OK, result)
-        activity?.onBackPressed()
+        activity?.onBackPressedDispatcher?.onBackPressed()
     }
 
     private fun PageParentFragmentBinding.initializeSearchView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PagesListFragmentBinding
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.viewmodel.pages.PageParentSearchViewModel
 import org.wordpress.android.viewmodel.pages.PageParentViewModel
 import org.wordpress.android.widgets.RecyclerItemDecoration
@@ -71,7 +72,7 @@ class PageParentSearchFragment : Fragment(R.layout.pages_list_fragment), Corouti
 
     private fun PagesListFragmentBinding.initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 const val EXTRA_PAGE_REMOTE_ID_KEY = "extra_page_remote_id_key"
@@ -39,9 +40,9 @@ class PagesActivity : LocaleAwareActivity(),
 
     private fun handleIntent(intent: Intent) {
         if (intent.hasExtra(ARG_NOTIFICATION_TYPE)) {
-            val notificationType: NotificationType =
-                intent.getSerializableExtra(ARG_NOTIFICATION_TYPE) as NotificationType
-            systemNotificationTracker.trackTappedNotification(notificationType)
+            intent.getSerializableExtraCompat<NotificationType>(ARG_NOTIFICATION_TYPE)?.let { notificationType ->
+                systemNotificationTracker.trackTappedNotification(notificationType)
+            }
         }
 
         if (intent.hasExtra(EXTRA_PAGE_REMOTE_ID_KEY)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
@@ -54,7 +54,7 @@ class PagesActivity : LocaleAwareActivity(),
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -264,12 +264,12 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
 
     private fun PagesFragmentBinding.initializeSearchView() {
         actionMenuItem.setOnActionExpandListener(object : OnActionExpandListener {
-            override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
+            override fun onMenuItemActionExpand(item: MenuItem): Boolean {
                 viewModel.onSearchExpanded(restorePreviousSearch)
                 return true
             }
 
-            override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
+            override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
                 viewModel.onSearchCollapsed()
                 return true
             }
@@ -294,17 +294,17 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         })
 
         // fix the search view margins to match the action bar
-        val searchEditFrame = actionMenuItem.actionView.findViewById<LinearLayout>(R.id.search_edit_frame)
-        (searchEditFrame.layoutParams as LinearLayout.LayoutParams)
+        val searchEditFrame = actionMenuItem.actionView?.findViewById<LinearLayout>(R.id.search_edit_frame)
+        (searchEditFrame?.layoutParams as LinearLayout.LayoutParams)
             .apply { this.leftMargin = DisplayUtils.dpToPx(activity, -8) }
 
-        viewModel.isSearchExpanded.observe(this@PagesFragment, Observer {
+        viewModel.isSearchExpanded.observe(this@PagesFragment) {
             if (it == true) {
                 showSearchList(actionMenuItem)
             } else {
                 hideSearchList(actionMenuItem)
             }
-        })
+        }
     }
 
     private fun PagesFragmentBinding.initializeViewModelObservers(

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PagesListFragmentBinding
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.viewmodel.pages.PagesViewModel
 import org.wordpress.android.viewmodel.pages.SearchListViewModel
 import org.wordpress.android.widgets.RecyclerItemDecoration
@@ -66,7 +67,7 @@ class SearchListFragment : Fragment(R.layout.pages_list_fragment) {
 
     private fun PagesListFragmentBinding.initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/WPEditTextWithChipsOutlined.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/WPEditTextWithChipsOutlined.kt
@@ -551,18 +551,18 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
                     .scaleY(1f)
                     .setDuration(LABEL_ANIMATION_DURATION)
                     .setListener(object : Animator.AnimatorListener {
-                        override fun onAnimationStart(animation: Animator?) {
+                        override fun onAnimationStart(animation: Animator) {
                             label.visibility = View.INVISIBLE
                             hint.visibility = View.VISIBLE
                         }
 
-                        override fun onAnimationEnd(animation: Animator?) {
+                        override fun onAnimationEnd(animation: Animator) {
                         }
 
-                        override fun onAnimationCancel(animation: Animator?) {
+                        override fun onAnimationCancel(animation: Animator) {
                         }
 
-                        override fun onAnimationRepeat(animation: Animator?) {
+                        override fun onAnimationRepeat(animation: Animator) {
                         }
                     }).start()
             }
@@ -581,21 +581,21 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
                     .scaleY(label.height.toFloat() / hint.height)
                     .setDuration(LABEL_ANIMATION_DURATION)
                     .setListener(object : Animator.AnimatorListener {
-                        override fun onAnimationStart(animation: Animator?) {
+                        override fun onAnimationStart(animation: Animator) {
                             setLabelColor(label, colorSurface, outlineColorAlphaFocused)
                             label.visibility = View.VISIBLE
                             hint.visibility = View.VISIBLE
                         }
 
-                        override fun onAnimationEnd(animation: Animator?) {
+                        override fun onAnimationEnd(animation: Animator) {
                             hint.visibility = View.INVISIBLE
                             setLabelColor(label, outlineColorFocused, outlineColorAlphaFocused)
                         }
 
-                        override fun onAnimationCancel(animation: Animator?) {
+                        override fun onAnimationCancel(animation: Animator) {
                         }
 
-                        override fun onAnimationRepeat(animation: Animator?) {
+                        override fun onAnimationRepeat(animation: Animator) {
                         }
                     }).start()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -35,6 +35,8 @@ import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.ViewWrapper
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.WPPermissionUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -90,8 +92,9 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val browserType = requireArguments().getSerializable(MediaBrowserActivity.ARG_BROWSER_TYPE) as MediaBrowserType
-        val site = requireArguments().getSerializable(WordPress.SITE) as? SiteModel
+        val browserType =
+            requireArguments().getSerializableCompat<MediaBrowserType>(MediaBrowserActivity.ARG_BROWSER_TYPE)
+        val site = requireArguments().getSerializableCompat<SiteModel>(WordPress.SITE)
         var selectedIds: List<Long>? = null
         var lastTappedIcon: PhotoPickerIcon? = null
         if (savedInstanceState != null) {
@@ -111,7 +114,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
                 NUM_COLUMNS
             )
 
-            savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
+            savedInstanceState?.getParcelableCompat<Parcelable>(KEY_LIST_STATE)?.let {
                 layoutManager.onRestoreInstanceState(it)
             }
 
@@ -131,7 +134,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
 
             setupProgressDialog()
 
-            viewModel.start(selectedIds, browserType, lastTappedIcon, site)
+            browserType?.let { viewModel.start(selectedIds, it, lastTappedIcon, site) }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanDetailsFragment.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.plans.PlanOffersModel
 import org.wordpress.android.ui.FullScreenDialogFragment.FullScreenDialogContent
 import org.wordpress.android.ui.FullScreenDialogFragment.FullScreenDialogController
 import org.wordpress.android.util.StringUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType
 import javax.inject.Inject
@@ -42,9 +43,9 @@ class PlanDetailsFragment : Fragment(), FullScreenDialogContent {
         (requireActivity().application as WordPress).component().inject(this)
 
         plan = if (savedInstanceState != null) {
-            savedInstanceState.getParcelable(KEY_PLAN)
+            savedInstanceState.getParcelableCompat(KEY_PLAN)
         } else {
-            arguments?.getParcelable(EXTRA_PLAN)
+            arguments?.getParcelableCompat(EXTRA_PLAN)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicDialog.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.android.support.AndroidSupportInjection
 import org.wordpress.android.ui.posts.BasicDialogViewModel.BasicDialogModel
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 /**
@@ -34,7 +35,7 @@ class BasicDialog : AppCompatDialogFragment() {
         setStyle(STYLE_NORMAL, theme)
 
         if (savedInstanceState != null) {
-            model = requireNotNull(savedInstanceState.getParcelable(STATE_KEY_MODEL))
+            model = requireNotNull(savedInstanceState.getParcelableCompat(STATE_KEY_MODEL))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.history.HistoryAdapter
 import org.wordpress.android.ui.history.HistoryListItem
 import org.wordpress.android.ui.history.HistoryListItem.Revision
 import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.viewmodel.history.HistoryViewModel
 import org.wordpress.android.viewmodel.history.HistoryViewModel.HistoryListStatus
@@ -84,11 +85,13 @@ class HistoryListFragment : Fragment(R.layout.history_list_fragment) {
 
             (nonNullActivity.application as WordPress).component().inject(this@HistoryListFragment)
 
-            viewModel = ViewModelProvider(this@HistoryListFragment, viewModelFactory).get(HistoryViewModel::class.java)
-            viewModel.create(
-                localPostId = arguments?.getInt(KEY_POST_LOCAL_ID) ?: 0,
-                site = arguments?.get(KEY_SITE) as SiteModel
-            )
+            viewModel = ViewModelProvider(this@HistoryListFragment, viewModelFactory)[HistoryViewModel::class.java]
+            arguments?.getSerializableCompat<SiteModel>(KEY_SITE)?.let {
+                viewModel.create(
+                    localPostId = arguments?.getInt(KEY_POST_LOCAL_ID) ?: 0,
+                    site = it
+                )
+            }
             updatePostOrPageEmptyView()
             setObservers()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsViewModel
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 class PostDatePickerDialogFragment : DialogFragment() {
@@ -18,15 +19,19 @@ class PostDatePickerDialogFragment : DialogFragment() {
     private lateinit var viewModel: PublishSettingsViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val publishSettingsFragmentType = arguments?.getParcelable<PublishSettingsFragmentType>(
+        val publishSettingsFragmentType = arguments?.getParcelableCompat<PublishSettingsFragmentType>(
             ARG_PUBLISH_SETTINGS_FRAGMENT_TYPE
         )
 
         viewModel = when (publishSettingsFragmentType) {
-            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(EditPostPublishSettingsViewModel::class.java)
-            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(PrepublishingPublishSettingsViewModel::class.java)
+            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[EditPostPublishSettingsViewModel::class.java]
+            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[PrepublishingPublishSettingsViewModel::class.java]
             null -> error("PublishSettingsViewModel not initialized")
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -27,6 +27,8 @@ import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
@@ -80,7 +82,7 @@ class PostListFragment : ViewPagerFragment() {
         (nonNullActivity.application as WordPress).component().inject(this)
 
         val nonNullIntent = checkNotNull(nonNullActivity.intent)
-        val site: SiteModel? = nonNullIntent.getSerializableExtra(WordPress.SITE) as SiteModel?
+        val site = nonNullIntent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
 
         if (site == null) {
             ToastUtils.showToast(nonNullActivity, R.string.blog_not_found, ToastUtils.Duration.SHORT)
@@ -97,7 +99,9 @@ class PostListFragment : ViewPagerFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        postListType = requireNotNull(arguments).getSerializable(EXTRA_POST_LIST_TYPE) as PostListType
+        requireNotNull(arguments).getSerializableCompat<PostListType>(EXTRA_POST_LIST_TYPE)?.let {
+            postListType = it
+        }
 
         if (postListType == SEARCH) {
             recyclerView?.id = R.id.posts_search_recycler_view_id

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.Schedul
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.TEN_MINUTES
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.WHEN_PUBLISHED
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsViewModel
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 class PostNotificationScheduleTimeDialogFragment : DialogFragment() {
@@ -23,15 +24,19 @@ class PostNotificationScheduleTimeDialogFragment : DialogFragment() {
     private lateinit var viewModel: PublishSettingsViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val publishSettingsFragmentType = arguments?.getParcelable<PublishSettingsFragmentType>(
+        val publishSettingsFragmentType = arguments?.getParcelableCompat<PublishSettingsFragmentType>(
             ARG_PUBLISH_SETTINGS_FRAGMENT_TYPE
         )
 
         viewModel = when (publishSettingsFragmentType) {
-            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(EditPostPublishSettingsViewModel::class.java)
-            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(PrepublishingPublishSettingsViewModel::class.java)
+            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[EditPostPublishSettingsViewModel::class.java]
+            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[PrepublishingPublishSettingsViewModel::class.java]
             null -> error("PublishSettingsViewModel not initialized")
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.posts
 
 import android.app.Dialog
 import android.app.TimePickerDialog
-import android.app.TimePickerDialog.OnTimeSetListener
 import android.content.Context
 import android.os.Bundle
 import android.text.format.DateFormat
@@ -13,6 +12,7 @@ import org.wordpress.android.R.style
 import org.wordpress.android.WordPress
 
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsViewModel
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 class PostTimePickerDialogFragment : DialogFragment() {
@@ -21,15 +21,19 @@ class PostTimePickerDialogFragment : DialogFragment() {
     private lateinit var viewModel: PublishSettingsViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val publishSettingsFragmentType = arguments?.getParcelable<PublishSettingsFragmentType>(
+        val publishSettingsFragmentType = arguments?.getParcelableCompat<PublishSettingsFragmentType>(
             ARG_PUBLISH_SETTINGS_FRAGMENT_TYPE
         )
 
         viewModel = when (publishSettingsFragmentType) {
-            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(EditPostPublishSettingsViewModel::class.java)
-            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(PrepublishingPublishSettingsViewModel::class.java)
+            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[EditPostPublishSettingsViewModel::class.java]
+            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[PrepublishingPublishSettingsViewModel::class.java]
             null -> error("PublishSettingsViewModel not initialized")
         }
 
@@ -37,7 +41,7 @@ class PostTimePickerDialogFragment : DialogFragment() {
         val context = ContextThemeWrapper(activity, style.PostSettingsCalendar)
         val timePickerDialog = TimePickerDialog(
             context,
-            OnTimeSetListener { _, selectedHour, selectedMinute ->
+            { _, selectedHour, selectedMinute ->
                 viewModel.onTimeSelected(selectedHour, selectedMinute)
             },
             viewModel.hour ?: 0,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -575,12 +575,12 @@ class PostsListActivity : LocaleAwareActivity(),
 
     private fun PostListActivityBinding.initSearchView() {
         searchActionButton.setOnActionExpandListener(object : OnActionExpandListener {
-            override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
+            override fun onMenuItemActionExpand(item: MenuItem): Boolean {
                 viewModel.onSearchExpanded(restorePreviousSearch)
                 return true
             }
 
-            override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
+            override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
                 viewModel.onSearchCollapsed()
                 return true
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -137,16 +138,19 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
     }
 
     private fun PrepublishingAddCategoryFragmentBinding.initViewModel() {
-        viewModel = ViewModelProvider(this@PrepublishingAddCategoryFragment, viewModelFactory)
-            .get(PrepublishingAddCategoryViewModel::class.java)
-        parentViewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
-            .get(PrepublishingViewModel::class.java)
+        viewModel = ViewModelProvider(
+            this@PrepublishingAddCategoryFragment,
+            viewModelFactory
+        )[PrepublishingAddCategoryViewModel::class.java]
+        parentViewModel =
+            ViewModelProvider(requireParentFragment(), viewModelFactory)[PrepublishingViewModel::class.java]
 
         startObserving()
 
         val needsRequestLayout = requireArguments().getBoolean(PrepublishingTagsFragment.NEEDS_REQUEST_LAYOUT)
-        val siteModel = requireArguments().getSerializable(WordPress.SITE) as SiteModel
-        viewModel.start(siteModel, !needsRequestLayout)
+        requireArguments().getSerializableCompat<SiteModel>(WordPress.SITE)?.let {
+            viewModel.start(it, !needsRequestLayout)
+        }
     }
 
     private fun PrepublishingAddCategoryFragmentBinding.startObserving() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -28,6 +28,8 @@ import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettings
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.KeyboardResizeViewUtil
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -133,31 +135,28 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
     }
 
     private fun initViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(this, viewModelFactory)
-            .get(PrepublishingViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory)[PrepublishingViewModel::class.java]
 
-        viewModel.navigationTarget.observeEvent(this, { navigationState ->
+        viewModel.navigationTarget.observeEvent(this) { navigationState ->
             navigateToScreen(navigationState)
-        })
+        }
 
-        viewModel.dismissBottomSheet.observeEvent(this, {
+        viewModel.dismissBottomSheet.observeEvent(this) {
             dismiss()
-        })
+        }
 
-        viewModel.triggerOnSubmitButtonClickedListener.observeEvent(this, { publishPost ->
+        viewModel.triggerOnSubmitButtonClickedListener.observeEvent(this) { publishPost ->
             prepublishingBottomSheetListener?.onSubmitButtonClicked(publishPost)
-        })
+        }
 
-        viewModel.dismissKeyboard.observeEvent(this, {
+        viewModel.dismissKeyboard.observeEvent(this) {
             ActivityUtils.hideKeyboardForced(view)
-        })
+        }
 
-        val prepublishingScreenState = savedInstanceState?.getParcelable<PrepublishingScreen>(
+        val prepublishingScreenState = savedInstanceState?.getParcelableCompat<PrepublishingScreen>(
             KEY_SCREEN_STATE
         )
-        val site = arguments?.getSerializable(SITE) as SiteModel
-
-        viewModel.start(site, prepublishingScreenState)
+        arguments?.getSerializableCompat<SiteModel>(SITE)?.let { viewModel.start(it, prepublishingScreenState) }
     }
 
     private fun navigateToScreen(navigationTarget: PrepublishingNavigationTarget) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType.AD
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -116,18 +117,19 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
     }
 
     private fun PrepublishingCategoriesFragmentBinding.initViewModel() {
-        viewModel = ViewModelProvider(this@PrepublishingCategoriesFragment, viewModelFactory)
-            .get(PrepublishingCategoriesViewModel::class.java)
-        parentViewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
-            .get(PrepublishingViewModel::class.java)
+        viewModel = ViewModelProvider(
+            this@PrepublishingCategoriesFragment,
+            viewModelFactory
+        )[PrepublishingCategoriesViewModel::class.java]
+        parentViewModel =
+            ViewModelProvider(requireParentFragment(), viewModelFactory)[PrepublishingViewModel::class.java]
         startObserving()
-        val siteModel = requireArguments().getSerializable(WordPress.SITE) as SiteModel
-        val addCategoryRequest: PrepublishingAddCategoryRequest? =
-            arguments?.getSerializable(ADD_CATEGORY_REQUEST) as? PrepublishingAddCategoryRequest
+        val siteModel = requireArguments().getSerializableCompat<SiteModel>(WordPress.SITE)
+        val addCategoryRequest = arguments?.getSerializableCompat<PrepublishingAddCategoryRequest>(ADD_CATEGORY_REQUEST)
         val selectedCategoryIds: List<Long> =
             arguments?.getLongArray(SELECTED_CATEGORY_IDS)?.toList() ?: listOf()
 
-        viewModel.start(getEditPostRepository(), siteModel, addCategoryRequest, selectedCategoryIds)
+        siteModel?.let { viewModel.start(getEditPostRepository(), it, addCategoryRequest, selectedCategoryIds) }
     }
 
     private fun PrepublishingCategoriesFragmentBinding.startObserving() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailActivity.kt
@@ -22,7 +22,7 @@ class CategoryDetailActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListActivity.kt
@@ -22,7 +22,7 @@ class CategoriesListActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListFragment.kt
@@ -17,6 +17,8 @@ import org.wordpress.android.ui.prefs.categories.list.CategoryDetailNavigation.E
 import org.wordpress.android.ui.prefs.categories.list.UiState.Content
 import org.wordpress.android.ui.prefs.categories.list.UiState.Loading
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -34,7 +36,7 @@ class CategoriesListFragment : Fragment(R.layout.site_settings_categories_list_f
             initRecyclerView()
             initFabButton()
             initEmptyView()
-            initViewModel(getSite(savedInstanceState))
+            getSite(savedInstanceState)?.let { initViewModel(it) }
         }
     }
 
@@ -67,11 +69,11 @@ class CategoriesListFragment : Fragment(R.layout.site_settings_categories_list_f
         actionableEmptyView.updateVisibility(false)
     }
 
-    private fun getSite(savedInstanceState: Bundle?): SiteModel {
+    private fun getSite(savedInstanceState: Bundle?): SiteModel? {
         return if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtra(WordPress.SITE) as SiteModel
+            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
         } else {
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+            savedInstanceState.getSerializableCompat(WordPress.SITE)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
@@ -39,9 +39,9 @@ class HomepageSettingsDialog : DialogFragment() {
         var pageForPostsId: Long? = null
         (arguments ?: savedInstanceState)?.let { bundle ->
             siteId = bundle.getInt(KEY_SITE_ID)
-            isClassicBlog = bundle.get(KEY_IS_CLASSIC_BLOG)?.let { it as Boolean }
-            pageOnFrontId = bundle.get(KEY_PAGE_ON_FRONT)?.let { it as Long }
-            pageForPostsId = bundle.get(KEY_PAGE_FOR_POSTS)?.let { it as Long }
+            isClassicBlog = bundle.getBoolean(KEY_IS_CLASSIC_BLOG)
+            pageOnFrontId = bundle.getLong(KEY_PAGE_ON_FRONT)
+            pageForPostsId = bundle.getLong(KEY_PAGE_FOR_POSTS)
         } ?: throw IllegalArgumentException("Site has to be initialized")
         val builder = MaterialAlertDialogBuilder(requireActivity())
         builder.setPositiveButton(R.string.site_settings_accept_homepage) { _, _ -> }
@@ -55,8 +55,8 @@ class HomepageSettingsDialog : DialogFragment() {
             }
             builder.setView(root)
 
-            viewModel = ViewModelProvider(this@HomepageSettingsDialog, viewModelFactory)
-                .get(HomepageSettingsViewModel::class.java)
+            viewModel =
+                ViewModelProvider(this@HomepageSettingsDialog, viewModelFactory)[HomepageSettingsViewModel::class.java]
             viewModel.uiState.observe(this@HomepageSettingsDialog) { uiState ->
                 uiState?.let {
                     loadingPages.visibility = if (uiState.isLoading) View.VISIBLE else View.GONE

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.kt
@@ -76,7 +76,7 @@ class NotificationsSettingsActivity : LocaleAwareActivity(), MainSwitchToolbarLi
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             android.R.id.home -> {
-                onBackPressed()
+                onBackPressedDispatcher.onBackPressed()
                 return true
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFullScreenDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFullScreenDialogFragment.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.QuickStartUtils.getQuickStartListSkippedTracker
 import org.wordpress.android.util.QuickStartUtils.getQuickStartListTappedTracker
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.widgets.WPSnackbar.Companion.make
 import java.io.Serializable
 import javax.inject.Inject
@@ -74,7 +75,7 @@ class QuickStartFullScreenDialogFragment : Fragment(R.layout.quick_start_dialog_
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        tasksType = arguments?.getSerializable(EXTRA_TYPE) as QuickStartTaskType? ?: QuickStartTaskType.UNKNOWN
+        tasksType = arguments?.getSerializableCompat(EXTRA_TYPE) ?: UNKNOWN
         quickStartTracker.trackQuickStartListViewed(tasksType)
         binding.setupQuickStartList()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -126,11 +126,11 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), MenuProvider, 
         }
         menu.findItem(R.id.menu_settings).apply {
             settingsMenuItem = this
-            settingsMenuItemFocusPoint = this.actionView.findViewById(R.id.menu_quick_start_focus_point)
+            settingsMenuItemFocusPoint = this.actionView?.findViewById(R.id.menu_quick_start_focus_point)
             this.isVisible = viewModel.uiState.value?.settingsMenuItemUiState?.isVisible ?: false
             settingsMenuItemFocusPoint?.isVisible =
                 viewModel.uiState.value?.settingsMenuItemUiState?.showQuickStartFocusPoint ?: false
-            this.actionView.setOnClickListener { viewModel.onSettingsActionClicked() }
+            this.actionView?.setOnClickListener { viewModel.onSettingsActionClicked() }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -132,6 +132,8 @@ import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelp
 import org.wordpress.android.util.config.CommentsSnippetFeatureConfig
 import org.wordpress.android.util.config.LikesEnhancementsFeatureConfig
 import org.wordpress.android.util.extensions.getColorFromAttribute
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.extensions.isDarkTheme
 import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
@@ -317,12 +319,14 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         if (args != null) {
             blogId = args.getLong(ReaderConstants.ARG_BLOG_ID)
             postId = args.getLong(ReaderConstants.ARG_POST_ID)
-            directOperation = args.getSerializable(ReaderConstants.ARG_DIRECT_OPERATION) as? DirectOperation
+            directOperation = args.getSerializableCompat(ReaderConstants.ARG_DIRECT_OPERATION)
             commentId = args.getInt(ReaderConstants.ARG_COMMENT_ID)
             isRelatedPost = args.getBoolean(ReaderConstants.ARG_IS_RELATED_POST)
             interceptedUri = args.getString(ReaderConstants.ARG_INTERCEPTED_URI)
             if (args.containsKey(ReaderConstants.ARG_POST_LIST_TYPE)) {
-                this.postListType = args.getSerializable(ReaderConstants.ARG_POST_LIST_TYPE) as ReaderPostListType
+                args.getSerializableCompat<ReaderPostListType>(ReaderConstants.ARG_POST_LIST_TYPE)?.let {
+                    postListType = it
+                }
             }
             postSlugsResolutionUnderway = args.getBoolean(ReaderConstants.KEY_POST_SLUGS_RESOLUTION_UNDERWAY)
         }
@@ -499,7 +503,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private fun initLikeFacesRecycler(savedInstanceState: Bundle?) {
         if (!likesEnhancementsFeatureConfig.isEnabled()) return
         val layoutManager = LinearLayoutManager(activity, LinearLayoutManager.HORIZONTAL, false)
-        savedInstanceState?.getParcelable<Parcelable>(KEY_LIKERS_LIST_STATE)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(KEY_LIKERS_LIST_STATE)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 
@@ -518,7 +522,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         if (!commentsSnippetFeatureConfig.isEnabled()) return
         val layoutManager = LinearLayoutManager(activity)
 
-        savedInstanceState?.getParcelable<Parcelable>(KEY_COMMENTS_SNIPPET_LIST_STATE)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(KEY_COMMENTS_SNIPPET_LIST_STATE)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 
@@ -1082,8 +1086,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         savedInstanceState?.let {
             blogId = it.getLong(ReaderConstants.ARG_BLOG_ID)
             postId = it.getLong(ReaderConstants.ARG_POST_ID)
-            directOperation = it
-                .getSerializable(ReaderConstants.ARG_DIRECT_OPERATION) as? DirectOperation
+            directOperation = it.getSerializableCompat(ReaderConstants.ARG_DIRECT_OPERATION)
             commentId = it.getInt(ReaderConstants.ARG_COMMENT_ID)
             isRelatedPost = it.getBoolean(ReaderConstants.ARG_IS_RELATED_POST)
             interceptedUri = it.getString(ReaderConstants.ARG_INTERCEPTED_URI)
@@ -1092,7 +1095,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             hasTrackedGlobalRelatedPosts = it.getBoolean(ReaderConstants.KEY_ALREADY_TRACKED_GLOBAL_RELATED_POSTS)
             hasTrackedLocalRelatedPosts = it.getBoolean(ReaderConstants.KEY_ALREADY_TRACKED_LOCAL_RELATED_POSTS)
             if (it.containsKey(ReaderConstants.ARG_POST_LIST_TYPE)) {
-                this.postListType = it.getSerializable(ReaderConstants.ARG_POST_LIST_TYPE) as ReaderPostListType
+                it.getSerializableCompat<ReaderPostListType>(ReaderConstants.ARG_POST_LIST_TYPE)
+                    ?.let { argPostListType -> postListType = argPostListType }
             }
             if (it.containsKey(ReaderConstants.KEY_ERROR_MESSAGE)) {
                 errorMessage = it.getString(ReaderConstants.KEY_ERROR_MESSAGE)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.SITES
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.TAGS
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
 import org.wordpress.android.ui.reader.subfilter.SubfilterPagerAdapter
+import org.wordpress.android.util.extensions.getParcelableArrayListCompat
 import javax.inject.Inject
 
 class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
@@ -66,11 +67,12 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
 
         val subfilterVmKey = requireArguments().getString(SUBFILTER_VIEW_MODEL_KEY)!!
         val bottomSheetTitle = requireArguments().getCharSequence(SUBFILTER_TITLE_KEY)!!
-        val categories: ArrayList<SubfilterCategory> = requireArguments()
-            .getParcelableArrayList(SUBFILTER_CATEGORIES_KEY)!!
+        val categories = requireArguments().getParcelableArrayListCompat<SubfilterCategory>(SUBFILTER_CATEGORIES_KEY)!!
 
-        viewModel = ViewModelProvider(parentFragment as ViewModelStoreOwner, viewModelFactory)
-            .get(subfilterVmKey, SubFilterViewModel::class.java)
+        viewModel = ViewModelProvider(
+            parentFragment as ViewModelStoreOwner,
+            viewModelFactory
+        )[subfilterVmKey, SubFilterViewModel::class.java]
 
         val pager = view.findViewById<ViewPager>(R.id.view_pager)
         val tabLayout = view.findViewById<TabLayout>(R.id.tab_layout)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsActivity.kt
@@ -23,7 +23,7 @@ class ReaderInterestsActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewMod
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.LocaleManager
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
@@ -37,7 +38,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val entryPoint = requireActivity().intent.getSerializableExtra(READER_INTEREST_ENTRY_POINT) as? EntryPoint
+        val entryPoint = requireActivity().intent.getSerializableExtraCompat(READER_INTEREST_ENTRY_POINT) as? EntryPoint
             ?: EntryPoint.DISCOVER
         with(ReaderInterestsFragmentLayoutBinding.bind(view)) {
             initDoneButton()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardViewHolder.kt
@@ -58,14 +58,14 @@ class ReaderInterestsCardViewHolder(
          * We need to do this immediately, because if we don't, then the next move event could potentially
          * trigger the viewPager to switch tabs
          */
-        override fun onDown(e: MotionEvent?): Boolean = with(binding) {
+        override fun onDown(e: MotionEvent): Boolean = with(binding) {
             interestsList.parent.requestDisallowInterceptTouchEvent(true)
             return super.onDown(e)
         }
 
         override fun onScroll(
-            e1: MotionEvent?,
-            e2: MotionEvent?,
+            e1: MotionEvent,
+            e2: MotionEvent,
             distanceX: Float,
             distanceY: Float
         ): Boolean = with(binding) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverJobService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverJobService.kt
@@ -37,7 +37,7 @@ class ReaderDiscoverJobService : JobService(), ServiceCompletionListener, Corout
     override fun onStartJob(params: JobParameters): Boolean {
         AppLog.i(READER, "reader discover job service > started")
 
-        val task = DiscoverTasks.values()[(params.extras[ReaderDiscoverServiceStarter.ARG_DISCOVER_TASK] as Int)]
+        val task = DiscoverTasks.values()[params.extras.getInt(ReaderDiscoverServiceStarter.ARG_DISCOVER_TASK)]
 
         readerDiscoverLogic.performTasks(task, params, this, this)
         return true

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverService.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverServiceSt
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.READER
 import org.wordpress.android.util.LocaleManager
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
@@ -56,8 +57,9 @@ class ReaderDiscoverService : Service(), ServiceCompletionListener, CoroutineSco
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent != null && intent.hasExtra(ARG_DISCOVER_TASK)) {
-            val task = intent.getSerializableExtra(ARG_DISCOVER_TASK) as DiscoverTasks
-            readerDiscoverLogic.performTasks(task, null, this, this)
+            intent.getSerializableExtraCompat<DiscoverTasks>(ARG_DISCOVER_TASK)?.let { task ->
+                readerDiscoverLogic.performTasks(task, null, this, this)
+            }
         }
         return START_NOT_STICKY
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
@@ -121,7 +122,7 @@ class SiteCreationMainVM @Inject constructor(
                 showSiteCreationNextStep()
         } else {
             siteCreationCompleted = savedInstanceState.getBoolean(KEY_SITE_CREATION_COMPLETED, false)
-            siteCreationState = requireNotNull(savedInstanceState.getParcelable(KEY_SITE_CREATION_STATE))
+            siteCreationState = requireNotNull(savedInstanceState.getParcelableCompat(KEY_SITE_CREATION_STATE))
             val currentStepIndex = savedInstanceState.getInt(KEY_CURRENT_STEP)
             wizardManager.setCurrentStepIndex(currentStepIndex)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -271,7 +271,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
                 progressText.text = newText
             }
 
-            override fun onAnimationEnd(animation: Animator?) {
+            override fun onAnimationEnd(animation: Animator) {
                 super.onAnimationEnd(animation)
                 animatorSet = null
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AutoForeground.ServiceEventConnection
 import org.wordpress.android.util.ErrorManagedWebViewClient.ErrorManagedWebViewClientListener
 import org.wordpress.android.util.URLFilteredWebViewClient
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 private const val ARG_DATA = "arg_site_creation_data"
@@ -97,7 +98,9 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
         super.onViewCreated(view, savedInstanceState)
         (requireActivity() as AppCompatActivity).supportActionBar?.hide()
 
-        viewModel.start(requireArguments()[ARG_DATA] as SiteCreationState, savedInstanceState)
+        requireArguments().getParcelableCompat<SiteCreationState>(ARG_DATA)?.let {
+            viewModel.start(it, savedInstanceState)
+        }
     }
 
     override fun getContentLayout(): Int {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -49,6 +49,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.UrlUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import javax.inject.Named
@@ -137,7 +138,7 @@ class SitePreviewViewModel @Inject constructor(
         urlWithoutScheme = siteCreationState.domain
         siteTitle = siteCreationState.siteName
 
-        val restoredState = savedState?.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE)
+        val restoredState = savedState?.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE)
 
         init(restoredState ?: SiteNotCreated)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationService.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.AutoForeground
 import org.wordpress.android.util.LocaleManager
 import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
 import javax.inject.Inject
 
 private val INITIAL_STATE = IDLE
@@ -47,7 +48,7 @@ class SiteCreationService : AutoForeground<SiteCreationServiceState>(SiteCreatio
             return Service.START_NOT_STICKY
         }
 
-        val data = intent.getParcelableExtra<SiteCreationServiceData>(ARG_DATA)!!
+        val data = intent.getParcelableExtraCompat<SiteCreationServiceData>(ARG_DATA)!!
         manager.onStart(
             LocaleManager.getLanguageWordPressId(this),
             localeManagerWrapper.getTimeZone().id,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.API
 import org.wordpress.android.util.WPUrlUtils
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 /**
@@ -72,14 +73,16 @@ class StatsConnectJetpackActivity : LocaleAwareActivity() {
             if (TextUtils.isEmpty(mAccountStore.account.userName)) {
                 mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
             } else {
-                startJetpackConnectionFlow(intent.getSerializableExtra(WordPress.SITE) as SiteModel)
+                intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)?.let { startJetpackConnectionFlow(it) }
             }
         }
     }
 
     private fun StatsJetpackConnectionActivityBinding.initViews() {
         jetpackSetup.setOnClickListener {
-            startJetpackConnectionFlow(intent.getSerializableExtra(WordPress.SITE) as SiteModel)
+            intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)?.let { site ->
+                startJetpackConnectionFlow(site)
+            }
         }
         jetpackFaq.setOnClickListener {
             WPWebViewActivity.openURL(this@StatsConnectJetpackActivity, FAQ_URL)
@@ -133,7 +136,7 @@ class StatsConnectJetpackActivity : LocaleAwareActivity() {
                 event.causeOfChange == FETCH_ACCOUNT &&
                 !TextUtils.isEmpty(mAccountStore.account.userName)
             ) {
-                startJetpackConnectionFlow(intent.getSerializableExtra(WordPress.SITE) as SiteModel)
+                intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)?.let { startJetpackConnectionFlow(it) }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -34,7 +34,7 @@ class StatsActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllActivity.kt
@@ -23,7 +23,7 @@ class StatsViewAllActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -34,6 +34,10 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.drawDateSelector
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
@@ -78,13 +82,13 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
             if (intent.hasExtra(ARGS_VIEW_TYPE)) {
                 outState.putSerializable(
                     ARGS_VIEW_TYPE,
-                    intent.getSerializableExtra(ARGS_VIEW_TYPE)
+                    intent.getSerializableExtraCompat(ARGS_VIEW_TYPE)
                 )
             }
             if (intent.hasExtra(ARGS_TIMEFRAME)) {
                 outState.putSerializable(
                     ARGS_TIMEFRAME,
-                    intent.getSerializableExtra(ARGS_TIMEFRAME)
+                    intent.getSerializableExtraCompat(ARGS_TIMEFRAME)
                 )
             }
             outState.putInt(WordPress.LOCAL_SITE_ID, intent.getIntExtra(WordPress.LOCAL_SITE_ID, 0))
@@ -96,7 +100,7 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
     private fun StatsViewAllFragmentBinding.initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
 
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
         with(statsListFragment) {
@@ -153,29 +157,31 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
         savedInstanceState: Bundle?
     ) {
         val nonNullIntent = checkNotNull(activity.intent)
-        val type = if (savedInstanceState == null) {
-            nonNullIntent.getSerializableExtra(ARGS_VIEW_TYPE) as StatsViewType
+        val type: StatsViewType? = if (savedInstanceState == null) {
+            nonNullIntent.getSerializableExtraCompat(ARGS_VIEW_TYPE)
         } else {
-            savedInstanceState.getSerializable(ARGS_VIEW_TYPE) as StatsViewType
+            savedInstanceState.getSerializableCompat(ARGS_VIEW_TYPE)
         }
 
-        val granularity = if (savedInstanceState == null) {
-            nonNullIntent.getSerializableExtra(ARGS_TIMEFRAME) as StatsGranularity?
+        val granularity: StatsGranularity? = if (savedInstanceState == null) {
+            nonNullIntent.getSerializableExtraCompat(ARGS_TIMEFRAME)
         } else {
-            savedInstanceState.getSerializable(ARGS_TIMEFRAME) as StatsGranularity?
+            savedInstanceState.getSerializableCompat(ARGS_TIMEFRAME)
         }
 
         val siteId = savedInstanceState?.getInt(WordPress.LOCAL_SITE_ID, 0)
             ?: nonNullIntent.getIntExtra(WordPress.LOCAL_SITE_ID, 0)
         statsSiteProvider.start(siteId)
 
-        val viewModelFactory = viewModelFactoryBuilder.build(type, granularity)
-        viewModel = ViewModelProvider(activity, viewModelFactory).get(StatsViewAllViewModel::class.java)
+        type?.let {
+            val viewModelFactory = viewModelFactoryBuilder.build(it, granularity)
+            viewModel = ViewModelProvider(activity, viewModelFactory)[StatsViewAllViewModel::class.java]
+        }
 
-        val selectedDate = if (savedInstanceState == null) {
-            nonNullIntent.getParcelableExtra(ARGS_SELECTED_DATE) as SelectedDate?
+        val selectedDate: SelectedDate? = if (savedInstanceState == null) {
+            nonNullIntent.getParcelableExtraCompat(ARGS_SELECTED_DATE)
         } else {
-            savedInstanceState.getParcelable(ARGS_SELECTED_DATE) as SelectedDate?
+            savedInstanceState.getParcelableCompat(ARGS_SELECTED_DATE)
         }
         setupObservers(activity)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.mapNullable
 import org.wordpress.android.util.mergeNotNull
 import org.wordpress.android.viewmodel.Event
@@ -114,10 +115,10 @@ class StatsViewModel
     fun start(intent: Intent, restart: Boolean = false) {
         val localSiteId = intent.getIntExtra(WordPress.LOCAL_SITE_ID, 0)
 
-        val launchedFrom = intent.getSerializableExtra(StatsActivity.ARG_LAUNCHED_FROM)
+        val launchedFrom = intent.getSerializableExtraCompat<Serializable>(StatsActivity.ARG_LAUNCHED_FROM)
         val initialTimeFrame = getInitialTimeFrame(intent)
         val initialSelectedPeriod = intent.getStringExtra(StatsActivity.INITIAL_SELECTED_PERIOD_KEY)
-        val notificationType = intent.getSerializableExtra(ARG_NOTIFICATION_TYPE) as? NotificationType
+        val notificationType = intent.getSerializableExtraCompat<NotificationType>(ARG_NOTIFICATION_TYPE)
         start(localSiteId, launchedFrom, initialTimeFrame, initialSelectedPeriod, restart, notificationType)
     }
 
@@ -135,7 +136,7 @@ class StatsViewModel
     }
 
     private fun getInitialTimeFrame(intent: Intent): StatsSection? {
-        return when (intent.getSerializableExtra(StatsActivity.ARG_DESIRED_TIMEFRAME)) {
+        return when (intent.getSerializableExtraCompat<Serializable>(StatsActivity.ARG_DESIRED_TIMEFRAME)) {
             StatsTimeframe.INSIGHTS -> StatsSection.INSIGHTS
             DAY -> StatsSection.DAYS
             WEEK -> StatsSection.WEEKS

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -27,6 +27,8 @@ import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsNavigator
 import org.wordpress.android.ui.stats.refresh.utils.drawDateSelector
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
@@ -80,7 +82,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         layoutManager?.let {
             outState.putParcelable(listStateKey, it.onSaveInstanceState())
         }
-        (activity?.intent?.getSerializableExtra(LIST_TYPE) as? StatsSection)?.let { sectionFromIntent ->
+        (activity?.intent?.getSerializableExtraCompat<StatsSection>(LIST_TYPE))?.let { sectionFromIntent ->
             outState.putSerializable(LIST_TYPE, sectionFromIntent)
         }
         super.onSaveInstanceState(outState)
@@ -110,7 +112,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         } else {
             StaggeredGridLayoutManager(columns, StaggeredGridLayoutManager.VERTICAL)
         }
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
@@ -32,18 +32,17 @@ class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
 
         val nonNullActivity = requireActivity()
         val listType = nonNullActivity.intent.extras?.getSerializableCompat<StatsSection>(StatsListFragment.LIST_TYPE)
-        with(StatsDetailFragmentBinding.bind(view)) {
-            with(nonNullActivity as AppCompatActivity) {
-                setSupportActionBar(toolbar)
-                supportActionBar?.let { actionBar ->
-                    listType?.let { statsSection -> actionBar.title = getString(statsSection.titleRes) }
-                    actionBar.setHomeButtonEnabled(true)
-                    actionBar.setDisplayHomeAsUpEnabled(true)
-                }
+        val binding = StatsDetailFragmentBinding.bind(view)
+        with(nonNullActivity as AppCompatActivity) {
+            setSupportActionBar(binding.toolbar)
+            supportActionBar?.let { actionBar ->
+                listType?.let { statsSection -> actionBar.title = getString(statsSection.titleRes) }
+                actionBar.setHomeButtonEnabled(true)
+                actionBar.setDisplayHomeAsUpEnabled(true)
             }
-            initializeViewModels(nonNullActivity)
-            initializeViews()
         }
+        initializeViewModels(nonNullActivity)
+        binding.initializeViews()
     }
 
     private fun StatsDetailFragmentBinding.initializeViews() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
@@ -13,7 +13,9 @@ import org.wordpress.android.databinding.StatsDetailFragmentBinding
 import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
+import java.io.Serializable
 
 @AndroidEntryPoint
 class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
@@ -29,14 +31,14 @@ class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
         super.onViewCreated(view, savedInstanceState)
 
         val nonNullActivity = requireActivity()
-        val listType = nonNullActivity.intent.extras?.get(StatsListFragment.LIST_TYPE) as StatsSection
+        val listType = nonNullActivity.intent.extras?.getSerializableCompat<StatsSection>(StatsListFragment.LIST_TYPE)
         with(StatsDetailFragmentBinding.bind(view)) {
             with(nonNullActivity as AppCompatActivity) {
                 setSupportActionBar(toolbar)
-                supportActionBar?.let {
-                    it.title = getString(listType.titleRes)
-                    it.setHomeButtonEnabled(true)
-                    it.setDisplayHomeAsUpEnabled(true)
+                supportActionBar?.let { actionBar ->
+                    listType?.let { statsSection -> actionBar.title = getString(statsSection.titleRes) }
+                    actionBar.setHomeButtonEnabled(true)
+                    actionBar.setDisplayHomeAsUpEnabled(true)
                 }
             }
             initializeViewModels(nonNullActivity)
@@ -52,7 +54,7 @@ class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
 
     private fun initializeViewModels(activity: FragmentActivity) {
         val siteId = activity.intent?.getIntExtra(WordPress.LOCAL_SITE_ID, 0) ?: 0
-        val listType = activity.intent.extras?.get(StatsListFragment.LIST_TYPE)
+        val listType = activity.intent.extras?.getSerializableCompat<Serializable>(StatsListFragment.LIST_TYPE)
 
         viewModel = when (listType) {
             StatsSection.INSIGHT_DETAIL -> viewsVisitorsDetailViewModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
@@ -20,6 +20,8 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
 import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
+import java.io.Serializable
 
 const val POST_ID = "POST_ID"
 const val POST_TYPE = "POST_TYPE"
@@ -33,7 +35,7 @@ class StatsDetailActivity : LocaleAwareActivity() {
         val binding = StatsDetailActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val listType = intent.extras?.get(StatsListFragment.LIST_TYPE)
+        val listType = intent.extras?.getSerializableCompat<Serializable>(StatsListFragment.LIST_TYPE)
 
         if (savedInstanceState == null) {
             supportFragmentManager.commit {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
@@ -51,7 +51,7 @@ class StatsDetailActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
@@ -52,9 +52,9 @@ class StatsDetailFragment : DaggerFragment(R.layout.stats_detail_fragment) {
         statsSiteProvider.start(siteId)
 
         val postId = activity.intent?.getLongExtra(POST_ID, 0L)
-        val postType = activity.intent?.getSerializableExtra(POST_TYPE) as String?
-        val postTitle = activity.intent?.getSerializableExtra(POST_TITLE) as String?
-        val postUrl = activity.intent?.getSerializableExtra(POST_URL) as String?
+        val postType = activity.intent?.getStringExtra(POST_TYPE)
+        val postTitle = activity.intent?.getStringExtra(POST_TITLE)
+        val postUrl = activity.intent?.getStringExtra(POST_URL)
 
         viewModel = ViewModelProvider(this, viewModelFactory)
             .get(StatsSection.DETAIL.name, StatsDetailViewModel::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.toStatsSection
 import org.wordpress.android.ui.stats.refresh.utils.trackWithSection
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.filter
 import java.util.Date
 import javax.inject.Inject
@@ -172,7 +173,7 @@ class SelectedDateProvider
 
     fun onRestoreInstanceState(savedState: Bundle) {
         for (period in listOf(DAYS, WEEKS, MONTHS, YEARS)) {
-            val selectedDate: SelectedDate? = savedState.getParcelable(buildStateKey(period)) as SelectedDate?
+            val selectedDate = savedState.getParcelableCompat<SelectedDate>(buildStateKey(period))
             if (selectedDate != null) {
                 mutableDates[period] = selectedDate
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
+import androidx.core.os.ParcelCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.parcelize.Parceler
@@ -224,7 +225,7 @@ class SelectedDateProvider
                     null
                 }
                 val availableTimeStamps = mutableListOf<Any?>()
-                parcel.readList(availableTimeStamps, null)
+                ParcelCompat.readList(parcel, availableTimeStamps, null, Any::class.java)
                 val availableDates = availableTimeStamps.map { Date(it as Long) }
                 val loading = parcel.readValue(null) as Boolean
                 val error = parcel.readValue(null) as Boolean

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementActivity.kt
@@ -24,7 +24,7 @@ class InsightsManagementActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/StatsAllTimeWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/StatsAllTimeWidgetConfigureActivity.kt
@@ -21,7 +21,7 @@ class StatsAllTimeWidgetConfigureActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureActivity.kt
@@ -21,7 +21,7 @@ class StatsMinifiedWidgetConfigureActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/StatsTodayWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/StatsTodayWidgetConfigureActivity.kt
@@ -21,7 +21,7 @@ class StatsTodayWidgetConfigureActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/StatsViewsWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/StatsViewsWidgetConfigureActivity.kt
@@ -21,7 +21,7 @@ class StatsViewsWidgetConfigureActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/weeks/StatsWeekWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/weeks/StatsWeekWidgetConfigureActivity.kt
@@ -21,7 +21,7 @@ class StatsWeekWidgetConfigureActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.AddNewStoryWithMedia
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.UTILS
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
@@ -109,8 +110,8 @@ class StoriesMediaPickerResultHandler
 
     private fun isWPStoriesMediaBrowserTypeResult(data: Intent): Boolean {
         if (data.hasExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)) {
-            val browserType = data.getSerializableExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)
-            return (browserType as MediaBrowserType).isWPStoriesPicker
+            val browserType = data.getSerializableExtraCompat<MediaBrowserType>(MediaBrowserActivity.ARG_BROWSER_TYPE)
+            return browserType?.isWPStoriesPicker ?: false
         }
         return false
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesTrackerHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesTrackerHelper.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
 import javax.inject.Inject
 
 class StoriesTrackerHelper @Inject constructor() {
@@ -33,7 +34,7 @@ class StoriesTrackerHelper @Inject constructor() {
         val properties = getCommonProperties(event)
         var siteModel: SiteModel? = null
         event.metadata?.let {
-            siteModel = it.getSerializable(WordPress.SITE) as SiteModel
+            siteModel = it.getSerializableCompat(WordPress.SITE)
         }
 
         siteModel?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -15,6 +14,7 @@ import org.wordpress.android.databinding.StoriesIntroDialogFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.extensions.setStatusBarAsSurfaceColor
 import javax.inject.Inject
 
@@ -59,7 +59,7 @@ class StoriesIntroDialogFragment : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val site = requireArguments().getSerializable(WordPress.SITE) as SiteModel
+        val site = requireArguments().getSerializableCompat<SiteModel>(WordPress.SITE)
         with(StoriesIntroDialogFragmentBinding.bind(view)) {
             createStoryIntroButton.setOnClickListener { viewModel.onCreateStoryButtonPressed() }
             storiesIntroBackButton.setOnClickListener { viewModel.onBackButtonPressed() }
@@ -67,20 +67,20 @@ class StoriesIntroDialogFragment : DialogFragment() {
             storyImageFirst.setOnClickListener { viewModel.onStoryPreviewTapped1() }
             storyImageSecond.setOnClickListener { viewModel.onStoryPreviewTapped2() }
         }
-        viewModel.onCreateButtonClicked.observe(this, Observer {
+        viewModel.onCreateButtonClicked.observe(this) {
             activity?.let {
                 mediaPickerLauncher.showStoriesPhotoPickerForResultAndTrack(it, site)
             }
             dismiss()
-        })
+        }
 
-        viewModel.onDialogClosed.observe(this, Observer {
+        viewModel.onDialogClosed.observe(this) {
             dismiss()
-        })
+        }
 
-        viewModel.onStoryOpenRequested.observe(this, Observer { storyUrl ->
+        viewModel.onStoryOpenRequested.observe(this) { storyUrl ->
             ActivityLauncher.openUrlExternal(context, storyUrl)
-        })
+        }
 
         viewModel.start()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
@@ -42,6 +42,8 @@ class SuggestionActivity : LocaleAwareActivity() {
             binding = this
         }
 
+        onBackPressedDispatcher.addCallback(this) { viewModel.trackExit(false) }
+
         val siteModel = intent.getSerializableExtra(INTENT_KEY_SITE_MODEL) as? SiteModel
         val suggestionType = intent.getSerializableExtra(INTENT_KEY_SUGGESTION_TYPE) as? SuggestionType
         when {
@@ -55,11 +57,6 @@ class SuggestionActivity : LocaleAwareActivity() {
         val message = "${this.javaClass.simpleName} started without $key. Finishing Activity."
         AppLog.e(T.EDITOR, message)
         finish()
-    }
-
-    override fun onBackPressed() {
-        viewModel.trackExit(false)
-        super.onBackPressed()
     }
 
     private fun initializeActivity(siteModel: SiteModel, suggestionType: SuggestionType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
@@ -9,6 +9,7 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
+import androidx.activity.addCallback
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.wordpress.android.R
@@ -23,6 +24,7 @@ import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.widgets.SuggestionAutoCompleteText
 import javax.inject.Inject
 
@@ -44,8 +46,8 @@ class SuggestionActivity : LocaleAwareActivity() {
 
         onBackPressedDispatcher.addCallback(this) { viewModel.trackExit(false) }
 
-        val siteModel = intent.getSerializableExtra(INTENT_KEY_SITE_MODEL) as? SiteModel
-        val suggestionType = intent.getSerializableExtra(INTENT_KEY_SUGGESTION_TYPE) as? SuggestionType
+        val siteModel = intent.getSerializableExtraCompat<SiteModel>(INTENT_KEY_SITE_MODEL)
+        val suggestionType = intent.getSerializableExtraCompat<SuggestionType>(INTENT_KEY_SUGGESTION_TYPE)
         when {
             siteModel == null -> abortDueToMissingIntentExtra(INTENT_KEY_SITE_MODEL)
             suggestionType == null -> abortDueToMissingIntentExtra(INTENT_KEY_SUGGESTION_TYPE)

--- a/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
@@ -3,6 +3,8 @@ package org.wordpress.android.util
 import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.pm.PackageManager.ComponentInfoFlags
+import android.os.Build
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
@@ -38,7 +40,15 @@ class PackageManagerWrapper @Inject constructor(
         intent.component?.let {
             try {
                 val context = contextProvider.getContext()
-                val activityInfo = context.packageManager.getActivityInfo(it, PackageManager.GET_META_DATA)
+                val activityInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    context.packageManager.getActivityInfo(
+                        it,
+                        ComponentInfoFlags.of(PackageManager.GET_META_DATA.toLong())
+                    )
+                } else {
+                    @Suppress("DEPRECATION")
+                    context.packageManager.getActivityInfo(it, PackageManager.GET_META_DATA)
+                }
                 return activityInfo.labelRes
             } catch (ex: PackageManager.NameNotFoundException) {
                 AppLog.e(T.UTILS, "Unable to extract label res from activity info")

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
@@ -1,0 +1,50 @@
+package org.wordpress.android.util.extensions
+
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcelable
+import java.io.Serializable
+
+/**
+ * TODO: Remove this file when stable androidx.core 1.10 is released. Use IntentCompat and BundleCompat instead.
+ */
+inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelableExtra(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelableExtra(key) as T?
+    }
+
+inline fun <reified T : Serializable> Intent.getSerializableExtraCompat(key: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getSerializableExtra(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getSerializableExtra(key) as T?
+    }
+
+inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelable(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelable(key)
+    }
+
+inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: String): ArrayList<T>? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelableArrayList(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelableArrayList(key)
+    }
+
+inline fun <reified T : Serializable> Bundle.getSerializableCompat(key: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getSerializable(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getSerializable(key) as T
+    }

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
@@ -7,7 +7,7 @@ import android.os.Parcelable
 import java.io.Serializable
 
 /**
- * TODO: Remove this file when stable androidx.core 1.10 is released. Use IntentCompat and BundleCompat instead.
+ * Remove this file when stable androidx.core 1.10 is released. Use IntentCompat and BundleCompat instead.
  */
 inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String): T? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
@@ -9,7 +9,7 @@ import java.io.Serializable
 /**
  * Remove this file when stable androidx.core 1.10 is released. Use IntentCompat and BundleCompat instead.
  */
-inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String): T? =
+inline fun <reified T : Parcelable?> Intent.getParcelableExtraCompat(key: String): T? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         getParcelableExtra(key, T::class.java)
     } else {
@@ -17,7 +17,7 @@ inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String)
         getParcelableExtra(key) as T?
     }
 
-inline fun <reified T : Serializable> Intent.getSerializableExtraCompat(key: String): T? =
+inline fun <reified T : Serializable?> Intent.getSerializableExtraCompat(key: String): T? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         getSerializableExtra(key, T::class.java)
     } else {
@@ -25,7 +25,7 @@ inline fun <reified T : Serializable> Intent.getSerializableExtraCompat(key: Str
         getSerializableExtra(key) as T?
     }
 
-inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? =
+inline fun <reified T : Parcelable?> Bundle.getParcelableCompat(key: String): T? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         getParcelable(key, T::class.java)
     } else {
@@ -33,7 +33,7 @@ inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? 
         getParcelable(key)
     }
 
-inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: String): ArrayList<T>? =
+inline fun <reified T : Parcelable?> Bundle.getParcelableArrayListCompat(key: String): ArrayList<T>? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         getParcelableArrayList(key, T::class.java)
     } else {
@@ -41,7 +41,7 @@ inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: Str
         getParcelableArrayList(key)
     }
 
-inline fun <reified T : Serializable> Bundle.getSerializableCompat(key: String): T? =
+inline fun <reified T : Serializable?> Bundle.getSerializableCompat(key: String): T? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         getSerializable(key, T::class.java)
     } else {

--- a/WordPress/src/main/java/org/wordpress/android/util/publicdata/PackageManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/publicdata/PackageManagerWrapper.kt
@@ -1,10 +1,20 @@
 package org.wordpress.android.util.publicdata
 
 import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
 import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
 
 class PackageManagerWrapper @Inject constructor(private val contextProvider: ContextProvider) {
     fun getPackageInfo(packageName: String, flags: Int = 0): PackageInfo? =
-        contextProvider.getContext().packageManager.getPackageInfo(packageName, flags)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            contextProvider.getContext().packageManager.getPackageInfo(
+                packageName,
+                PackageManager.PackageInfoFlags.of(flags.toLong())
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            contextProvider.getContext().packageManager.getPackageInfo(packageName, flags)
+        }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/signature/SignatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/signature/SignatureUtils.kt
@@ -28,9 +28,18 @@ class SignatureUtils @Inject constructor(
         trustedPackageId: String,
         trustedSignatureHash: String
     ): Boolean = try {
-        val signingInfo = contextProvider.getContext().packageManager.getPackageInfo(
-            trustedPackageId, PackageManager.GET_SIGNING_CERTIFICATES
-        ).signingInfo
+        val signingInfo = if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+            contextProvider.getContext().packageManager.getPackageInfo(
+                trustedPackageId,
+                PackageManager.PackageInfoFlags.of(PackageManager.GET_SIGNING_CERTIFICATES.toLong())
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            contextProvider.getContext().packageManager.getPackageInfo(
+                trustedPackageId,
+                PackageManager.GET_SIGNING_CERTIFICATES
+            )
+        }.signingInfo
         if (signingInfo.hasMultipleSigners()) {
             throw SignatureNotFoundException()
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.ui.ListDiffCallback
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.plugins.PluginBrowserViewModel.PluginListType.FEATURED
 import org.wordpress.android.viewmodel.plugins.PluginBrowserViewModel.PluginListType.NEW
 import org.wordpress.android.viewmodel.plugins.PluginBrowserViewModel.PluginListType.POPULAR
@@ -138,7 +139,7 @@ class PluginBrowserViewModel @Inject constructor(
             // read from the bundle
             return
         }
-        site = savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+        savedInstanceState.getSerializableCompat<SiteModel>(WordPress.SITE)?.let { site = it }
         searchQuery = requireNotNull(savedInstanceState.getString(KEY_SEARCH_QUERY))
         setTitle(savedInstanceState.getString(KEY_TITLE))
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModelTest.kt
@@ -153,11 +153,11 @@ class LoginNoSitesViewModelTest : BaseUnitTest() {
     }
 
     private fun setupInstanceStateForNoUser() {
-        whenever(savedInstanceState.getSerializableCompat<LoginNoSitesViewModel.State>(KEY_STATE)).thenReturn(NoUser)
+        whenever(savedInstanceState.getSerializableCompat<LoginNoSitesViewModel.State?>(KEY_STATE)).thenReturn(NoUser)
     }
 
     private fun setupInstanceStateForShowUser() {
-        whenever(savedInstanceState.getSerializableCompat<LoginNoSitesViewModel.State>(KEY_STATE)).thenReturn(
+        whenever(savedInstanceState.getSerializableCompat<LoginNoSitesViewModel.State?>(KEY_STATE)).thenReturn(
             ShowUser(
                 userName = USERNAME,
                 displayName = DISPLAY_NAME,

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModelTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.accounts.UnifiedLoginTracker
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel.State.NoUser
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel.State.ShowUser
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel.UiModel
+import org.wordpress.android.util.extensions.getSerializableCompat
 
 private const val USERNAME = "username"
 private const val DISPLAY_NAME = "display_name"
@@ -152,11 +153,11 @@ class LoginNoSitesViewModelTest : BaseUnitTest() {
     }
 
     private fun setupInstanceStateForNoUser() {
-        whenever(savedInstanceState.getSerializable(KEY_STATE)).thenReturn(NoUser)
+        whenever(savedInstanceState.getSerializableCompat<LoginNoSitesViewModel.State>(KEY_STATE)).thenReturn(NoUser)
     }
 
     private fun setupInstanceStateForShowUser() {
-        whenever(savedInstanceState.getSerializable(KEY_STATE)).thenReturn(
+        whenever(savedInstanceState.getSerializableCompat<LoginNoSitesViewModel.State>(KEY_STATE)).thenReturn(
             ShowUser(
                 userName = USERNAME,
                 displayName = DISPLAY_NAME,

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsPr
 import org.wordpress.android.ui.jetpack.usecases.GetActivityLogItemUseCase
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
@@ -426,7 +427,7 @@ class BackupDownloadViewModelTest : BaseUnitTest() {
     private fun startViewModelForProgress() {
         whenever(savedInstanceState.getInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP))
             .thenReturn(BackupDownloadStep.PROGRESS.id)
-        whenever(savedInstanceState.getParcelable<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
+        whenever(savedInstanceState.getParcelableCompat<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
             .thenReturn(backupDownloadState)
         whenever(percentFormatter.format(30))
             .thenReturn("30%")
@@ -439,7 +440,7 @@ class BackupDownloadViewModelTest : BaseUnitTest() {
     private fun startViewModelForComplete(backupDownloadState: BackupDownloadState? = null) {
         whenever(savedInstanceState.getInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP))
             .thenReturn(BackupDownloadStep.COMPLETE.id)
-        whenever(savedInstanceState.getParcelable<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
+        whenever(savedInstanceState.getParcelableCompat<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
             .thenReturn(backupDownloadState)
         startViewModel(savedInstanceState)
     }
@@ -447,7 +448,7 @@ class BackupDownloadViewModelTest : BaseUnitTest() {
     private fun startViewModelForError() {
         whenever(savedInstanceState.getInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP))
             .thenReturn(BackupDownloadStep.ERROR.id)
-        whenever(savedInstanceState.getParcelable<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
+        whenever(savedInstanceState.getParcelableCompat<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
             .thenReturn(backupDownloadState)
         startViewModel(savedInstanceState)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
@@ -60,6 +60,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
@@ -459,7 +460,7 @@ class RestoreViewModelTest : BaseUnitTest() {
     private fun startViewModelForStep(step: RestoreStep, restoreState: RestoreState? = null) {
         whenever(savedInstanceState.getInt(KEY_RESTORE_CURRENT_STEP))
             .thenReturn(step.id)
-        whenever(savedInstanceState.getParcelable<RestoreState>(KEY_RESTORE_STATE))
+        whenever(savedInstanceState.getParcelableCompat<RestoreState>(KEY_RESTORE_STATE))
             .thenReturn(restoreState ?: this.restoreState)
         startViewModel(savedInstanceState)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.Creat
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState.SiteCreationCompleted
 import org.wordpress.android.ui.sitecreation.usecases.FetchHomePageLayoutsUseCase
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -231,7 +232,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
         /* we need to model a real use case of data only existing for steps the user has visited (Segment only in
         this case). Otherwise, subsequent steps' state will be cleared and make the test fail. (issue #10189)*/
         val expectedState = SiteCreationState(segmentId = SEGMENT_ID)
-        whenever(savedInstanceState.getParcelable<SiteCreationState>(KEY_SITE_CREATION_STATE))
+        whenever(savedInstanceState.getParcelableCompat<SiteCreationState>(KEY_SITE_CREATION_STATE))
             .thenReturn(expectedState)
 
         // we need to create a new instance of the VM as the `viewModel` has already been started in setUp()
@@ -252,7 +253,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
         whenever(savedInstanceState.getInt(KEY_CURRENT_STEP)).thenReturn(index)
 
         // siteCreationState is not nullable - we need to set it
-        whenever(savedInstanceState.getParcelable<SiteCreationState>(KEY_SITE_CREATION_STATE))
+        whenever(savedInstanceState.getParcelableCompat<SiteCreationState>(KEY_SITE_CREATION_STATE))
             .thenReturn(SiteCreationState())
 
         // we need to create a new instance of the VM as the `viewModel` has already been started in setUp()
@@ -276,7 +277,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     @Test
     fun `given instance state is not null, when start, then site creation accessed is not tracked`() {
         val expectedState = SiteCreationState(segmentId = SEGMENT_ID)
-        whenever(savedInstanceState.getParcelable<SiteCreationState>(KEY_SITE_CREATION_STATE))
+        whenever(savedInstanceState.getParcelableCompat<SiteCreationState>(KEY_SITE_CREATION_STATE))
             .thenReturn(expectedState)
 
         val newViewModel = getNewViewModel()

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -45,6 +45,7 @@ import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState.S
 import org.wordpress.android.ui.sitecreation.theme.defaultTemplateSlug
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.UrlUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 
 private const val SUB_DOMAIN = "test"
 private const val DOMAIN = ".wordpress.com"
@@ -302,7 +303,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `show fullscreen progress when restoring from SiteNotCreated state`() = testWithSuccessResponse {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
         initViewModel(bundle)
 
         assertThat(viewModel.uiState.value).isInstanceOf(SitePreviewFullscreenProgressUiState::class.java)
@@ -311,7 +312,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `service started when restoring from SiteNotCreated state`() {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
         initViewModel(bundle)
 
         assertThat(viewModel.startCreateSiteService.value).isNotNull
@@ -319,7 +320,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `show fullscreen progress when restoring from SiteNotInLocalDb state`() = testWithSuccessResponse {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
         initViewModel(bundle)
 
         assertThat(viewModel.uiState.value).isInstanceOf(SitePreviewFullscreenProgressUiState::class.java)
@@ -328,7 +329,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `start pre-loading WebView when restoring from SiteNotInLocalDb state`() = testWithSuccessResponse {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE))
             .thenReturn(SiteNotInLocalDb(REMOTE_SITE_ID, false))
         initViewModel(bundle)
 
@@ -337,7 +338,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `fetch newly created SiteModel when restoring from SiteNotInLocalDb state`() = testWithSuccessResponse {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE))
             .thenReturn(SiteNotInLocalDb(REMOTE_SITE_ID, false))
         initViewModel(bundle)
 
@@ -346,7 +347,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `start pre-loading WebView when restoring from SiteCreationCompleted state`() {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE))
             .thenReturn(SiteCreationCompleted(LOCAL_SITE_ID, false))
         initViewModel(bundle)
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 ext {
     minSdkVersion = 24
-    compileSdkVersion = 31
+    compileSdkVersion = 33
     targetSdkVersion = 31
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
     androidxComposeLifecycleVersion = '2.5.1'
     androidxCardviewVersion = '1.0.0'
     androidxConstraintlayoutVersion = '1.1.3'
-    androidxCoreVersion = '1.8.0'
+    androidxCoreVersion = '1.9.0'
     androidxActivityVersion = '1.5.1'
     androidxFragmentVersion = '1.5.5'
     androidxGridlayoutVersion = '1.0.0'

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.imageeditor
 
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.ViewModelProvider
@@ -30,6 +31,12 @@ class EditImageActivity : AppCompatActivity() {
             ?: throw (NullPointerException("Host fragment is null inside ${this::class.java.simpleName} onCreate."))
 
         setupActionBar()
+
+        onBackPressedDispatcher.addCallback(this) {
+            if (hostFragment.childFragmentManager.backStackEntryCount == 0) {
+                ImageEditor.instance.onEditorAction(EditorCancelled)
+            }
+        }
     }
 
     private fun setupActionBar() {
@@ -40,7 +47,7 @@ class EditImageActivity : AppCompatActivity() {
         // Passing in an empty set of top-level destination to display back button on the start destination
         appBarConfiguration = AppBarConfiguration.Builder().setFallbackOnNavigateUpListener {
             // Handle app bar's back button on start destination
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             true
         }.build()
 
@@ -53,17 +60,10 @@ class EditImageActivity : AppCompatActivity() {
             // Using popUpToInclusive for popping the start destination of the graph off the back stack
             // in a multi-module project doesn't seem to be working. Explicitly invoking back action as a workaround.
             // Related issue: https://issuetracker.google.com/issues/147312109
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             true
         } else {
             navController.navigateUp(appBarConfiguration) || super.onSupportNavigateUp()
-        }
-    }
-
-    override fun onBackPressed() {
-        super.onBackPressed()
-        if (hostFragment.childFragmentManager.backStackEntryCount == 0) {
-            ImageEditor.instance.onEditorAction(EditorCancelled)
         }
     }
 }

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.lifecycle.LiveData
@@ -157,11 +158,23 @@ class CropViewModel : ViewModel() {
 
     private fun createCropResult(cropResultCode: Int, cropData: Intent) = CropResult(cropResultCode, cropData)
 
-    private fun getOutputPath(): String =
-        cropOptionsBundleWithFilesInfo.getParcelable<Uri?>(UCrop.EXTRA_OUTPUT_URI)?.path ?: ""
+    private fun getOutputPath(): String {
+        val uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            cropOptionsBundleWithFilesInfo.getParcelable(UCrop.EXTRA_OUTPUT_URI, Uri::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            cropOptionsBundleWithFilesInfo.getParcelable(UCrop.EXTRA_OUTPUT_URI)
+        }
+        return uri?.path ?: ""
+    }
 
     fun getOutputData(cropResult: CropResult): ArrayList<OutputData> {
-        val imageUri: Uri? = cropResult.data.getParcelableExtra(UCrop.EXTRA_OUTPUT_URI)
+        val imageUri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            cropResult.data.getParcelableExtra(UCrop.EXTRA_OUTPUT_URI, Uri::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            cropResult.data.getParcelableExtra(UCrop.EXTRA_OUTPUT_URI)
+        }
 
         return if (imageUri != null) {
             arrayListOf(OutputData(imageUri.toString()))

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -5,6 +5,7 @@ import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.graphics.drawable.Drawable
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.util.Log
@@ -150,7 +151,12 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment), MenuProv
         viewModel = ViewModelProvider(this@PreviewImageFragment).get(PreviewImageViewModel::class.java)
         parentViewModel = ViewModelProvider(requireActivity()).get(EditImageViewModel::class.java)
         setupObservers()
-        val inputData = nonNullIntent.getParcelableArrayListExtra<EditImageData.InputData>(ARG_EDIT_IMAGE_DATA)
+        val inputData = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            nonNullIntent.getParcelableArrayListExtra(ARG_EDIT_IMAGE_DATA, EditImageData.InputData::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            nonNullIntent.getParcelableArrayListExtra(ARG_EDIT_IMAGE_DATA)
+        }
 
         inputData?.let { viewModel.onCreateView(it, ImageEditor.instance) }
     }
@@ -186,7 +192,12 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment), MenuProv
                 if (it.resultCode == RESULT_OK) {
                     val data: Intent = it.data
                     if (data.hasExtra(UCrop.EXTRA_OUTPUT_URI)) {
-                        val imageUri = data.getParcelableExtra(UCrop.EXTRA_OUTPUT_URI) as? Uri
+                        val imageUri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            data.getParcelableExtra(UCrop.EXTRA_OUTPUT_URI, Uri::class.java)
+                        } else {
+                            @Suppress("DEPRECATION")
+                            data.getParcelableExtra(UCrop.EXTRA_OUTPUT_URI)
+                        }
                         imageUri?.let { uri ->
                             viewModel.onCropResult(uri.toString())
                         }


### PR DESCRIPTION
Fixes #17790 

This PR updates compileSdkVersion to 33 and fixes errors and warnings caused by the update. 

_This contains a lot of changes, but they are small and similar. I could publish this via multiple PRs, but multiple PRs would create a burden of merging in order and creating multiple branches based on others. I believe it won't be hard to review this if you follow the commits._

_I've added @ravishanker, but he'll be on support rotation next week. I'd appreciate it if you could review, @ParaskP7._

### Commits
1. 61992b1a9d0e85a831fb6b1203c46d694851fdeb: compileSdkVersion was updated to Android 33.
2. 9446c7fc4850e88dd72647ab639d39090ff03bc4: `onBackPressed` was [deprecated on Android 13](https://developer.android.com/guide/navigation/navigation-custom-back). It's updated only on Kotlin files. Because only errors on Kotlin files prevent the build. `onBackPressed` on Java files can be updated while converting them to Kotlin.
3. a8d466a903d23a4f5bc7565111e60f832571c02a: `CompatExtensions` was added to use in the next commit.
4. d8deb99fbda9b210c6a3ee0ed07c7c9d796cdcbd: Some functions of `Bundle` and `Intent` was deprecated. To update them for Android 13, there are functions in `IntentCompat` and `BundleCompat` but they're available on the `1.10.0-alpha` version which is not stable yet. I used  `CompatExtensions` that I created to update deprecated functions.
5. b767c4651f02c8da74a162ad52eefab4b2492555: Updated some `AnimatorListener` parameters which are not nullable anymore.
6. 44dfcadfdf5faa5e224f3ddb02fd22c1b0c895f4: Updated some `MenuItem` parameters which are not nullable anymore.
7. cf40f4e4ec509e2dcaa2716f222e48673e6bc9f7: Updated some `SimpleOnGestureListener` parameters which are not nullable anymore.
8. 73662bddee739ef5baaebc497eb0156696c82f26: Updated `androidx.core` version to `1.9.0` because we'll need new `ParcelCompat` functions in the next commit.
9. 22a391472c4c5ac57dc2d6ade5422db15f99224c: Use `ParcelCompat` for deprecated functions.
10. 1287b2240d9109416a6aa61c81dd2d370754a7a1: Update deprecated `PackageManager` functions.
11. 37a31139168bf5c80d24c13711d522863f296622: Added `android.permission.POST_NOTIFICATIONS` to fix the build error. Now `NotificationManagerCompat.from(context).notify(id, notification)` shows the error "`Call requires permission which may be rejected by user: code should explicitly check to see if permission is available (with checkPermission) or explicitly handle a potential SecurityException`" but notifications still works on Android 13 and lower versions. https://github.com/wordpress-mobile/WordPress-Android/issues/17714 will be handled later.
12. 995e4479ceb080113ab2dd9b4a0eb9b143033f7c: Fixed unit tests by updating deprecated functions and making superclass of `T` nullable in `CompatExtensions`. This also fixes possible null exceptions on runtime.

> **Note**
> I also took action for some warnings from Android Studio, like removing redundant SAM-constructor if the warning is just inside the function I work on.

To test:
Being able to build and basic smoke test should be enough.

## Regression Notes
1. Potential unintended areas of impact
Since this touches a lot of classes, every screen can be impacted, but no change is expected on runtime. But especially back gestures, passing data between screens and notifications.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested the back gesture manually to verify it's still working. 

3. What automated tests I added (or what prevented me from doing so)
None. This is just a library and deprecated functions update.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
