### PR TITLE
[DO NOT MERGE] Enable the new landing screen in WP app and fix UI tests

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -363,6 +363,7 @@ dependencies {
 
     // To enable Android Studio specific features for Jetpack Compose.
     debugImplementation "androidx.compose.ui:ui-tooling:$androidxComposeVersion"
+    debugImplementation("androidx.compose.ui:ui-test-manifest:$androidxComposeVersion")
     implementation "androidx.compose.ui:ui-tooling-preview:$androidxComposeVersion"
     // To enable Stetho, a debug bridge that enables the Chrome Developer Tools for debug purposes.
     debugImplementation "com.facebook.stetho:stetho:$stethoVersion"
@@ -500,7 +501,7 @@ dependencies {
     androidTestImplementation "androidx.room:room-runtime:$androidxRoomVersion"
     kapt "androidx.room:room-compiler:$androidxRoomVersion"
     androidTestImplementation "androidx.room:room-ktx:$androidxRoomVersion"
-
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$androidxComposeVersion"
     // Enables Java 8+ API desugaring support
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$androidDesugarVersion"
     lintChecks "org.wordpress:lint:$wordPressLintVersion"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -362,8 +362,8 @@ dependencies {
     implementation "org.wordpress:persistentedittext:$wordPressPersistentEditTextVersion"
 
     // To enable Android Studio specific features for Jetpack Compose.
-    debugImplementation "androidx.compose.ui:ui-tooling:$androidxComposeVersion"
     debugImplementation("androidx.compose.ui:ui-test-manifest:$androidxComposeVersion")
+    debugImplementation "androidx.compose.ui:ui-tooling:$androidxComposeVersion"
     implementation "androidx.compose.ui:ui-tooling-preview:$androidxComposeVersion"
     // To enable Stetho, a debug bridge that enables the Chrome Developer Tools for debug purposes.
     debugImplementation "com.facebook.stetho:stetho:$stethoVersion"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -103,7 +103,7 @@ android {
         buildConfigField "boolean", "READER_COMMENTS_MODERATION", "false"
         buildConfigField "boolean", "SITE_INTENT_QUESTION", "true"
         buildConfigField "boolean", "SITE_NAME", "false"
-        buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "false"
+        buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "true"
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS_LIST", "false"

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ContactUsTests.java
@@ -21,7 +21,7 @@ public class ContactUsTests extends BaseTest {
     public void e2eSendButtonEnabledWhenTextIsEntered() {
         try {
             new LoginFlow()
-                .chooseContinueWithWpCom()
+                .chooseContinueWithWpCom(super.mComposeTestRule)
                 .tapHelp()
                 .assertHelpAndSupportScreenLoaded()
                 .openContactUs()
@@ -39,7 +39,7 @@ public class ContactUsTests extends BaseTest {
     @Test
     public void e2eHelpCanBeOpenedWhileEnteringEmail() {
         new LoginFlow()
-                .chooseContinueWithWpCom()
+                .chooseContinueWithWpCom(super.mComposeTestRule)
                 .tapHelp()
                 .assertHelpAndSupportScreenLoaded();
     }
@@ -47,7 +47,7 @@ public class ContactUsTests extends BaseTest {
     @Test
     public void e2eHelpCanBeOpenedWhileEnteringPassword() {
         new LoginFlow()
-                .chooseContinueWithWpCom()
+                .chooseContinueWithWpCom(super.mComposeTestRule)
                 .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                 .tapHelp()
                 .assertHelpAndSupportScreenLoaded();

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -25,7 +25,7 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void e2eLoginWithEmailPassword() {
-        new LoginFlow().chooseContinueWithWpCom(mComposeTestRule)
+        new LoginFlow().chooseContinueWithWpCom(super.mComposeTestRule)
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword(E2E_WP_COM_USER_PASSWORD)
                        .confirmLogin(false);
@@ -33,7 +33,7 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void e2eLoginWithPasswordlessAccount() {
-        new LoginFlow().chooseContinueWithWpCom(mComposeTestRule)
+        new LoginFlow().chooseContinueWithWpCom(super.mComposeTestRule)
                        .enterEmailAddress(E2E_WP_COM_PASSWORDLESS_USER_EMAIL)
                        .openMagicLink()
                        .confirmLogin(false);
@@ -41,7 +41,7 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void e2eLoginWithSiteAddress() {
-        new LoginFlow().chooseEnterYourSiteAddress(mComposeTestRule)
+        new LoginFlow().chooseEnterYourSiteAddress(super.mComposeTestRule)
                        .enterSiteAddress(E2E_WP_COM_USER_SITE_ADDRESS)
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword(E2E_WP_COM_USER_PASSWORD)
@@ -50,7 +50,7 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void e2eLoginWithMagicLink() {
-        new LoginFlow().chooseContinueWithWpCom(mComposeTestRule)
+        new LoginFlow().chooseContinueWithWpCom(super.mComposeTestRule)
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .chooseMagicLink()
                        .openMagicLink()
@@ -59,7 +59,7 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void e2eLoginWithSelfHostedAccount() {
-        new LoginFlow().chooseEnterYourSiteAddress(mComposeTestRule)
+        new LoginFlow().chooseEnterYourSiteAddress(super.mComposeTestRule)
                        .enterSiteAddress(E2E_SELF_HOSTED_USER_SITE_ADDRESS)
                        .enterUsernameAndPassword(E2E_SELF_HOSTED_USER_USERNAME, E2E_SELF_HOSTED_USER_PASSWORD)
                        .confirmLogin(true);

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -1,15 +1,11 @@
 package org.wordpress.android.e2e;
 
-import androidx.compose.ui.test.junit4.ComposeTestRule;
-
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.wordpress.android.e2e.flows.LoginFlow;
 import org.wordpress.android.support.BaseTest;
 
-import static androidx.compose.ui.test.junit4.AndroidComposeTestRule_androidKt.createComposeRule;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_USERNAME;
@@ -22,9 +18,6 @@ import dagger.hilt.android.testing.HiltAndroidTest;
 
 @HiltAndroidTest
 public class LoginTests extends BaseTest {
-    @Rule
-    public ComposeTestRule mComposeTestRule = createComposeRule();
-
     @Before
     public void setUp() {
         logoutIfNecessary();

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -1,11 +1,15 @@
 package org.wordpress.android.e2e;
 
+import androidx.compose.ui.test.junit4.ComposeTestRule;
+
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.wordpress.android.e2e.flows.LoginFlow;
 import org.wordpress.android.support.BaseTest;
 
+import static androidx.compose.ui.test.junit4.AndroidComposeTestRule_androidKt.createComposeRule;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_USERNAME;
@@ -18,6 +22,9 @@ import dagger.hilt.android.testing.HiltAndroidTest;
 
 @HiltAndroidTest
 public class LoginTests extends BaseTest {
+    @Rule
+    public ComposeTestRule mComposeTestRule = createComposeRule();
+
     @Before
     public void setUp() {
         logoutIfNecessary();
@@ -25,7 +32,7 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void e2eLoginWithEmailPassword() {
-        new LoginFlow().chooseContinueWithWpCom()
+        new LoginFlow().chooseContinueWithWpCom(mComposeTestRule)
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword(E2E_WP_COM_USER_PASSWORD)
                        .confirmLogin(false);
@@ -33,7 +40,7 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void e2eLoginWithPasswordlessAccount() {
-        new LoginFlow().chooseContinueWithWpCom()
+        new LoginFlow().chooseContinueWithWpCom(mComposeTestRule)
                        .enterEmailAddress(E2E_WP_COM_PASSWORDLESS_USER_EMAIL)
                        .openMagicLink()
                        .confirmLogin(false);
@@ -41,7 +48,7 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void e2eLoginWithSiteAddress() {
-        new LoginFlow().chooseEnterYourSiteAddress()
+        new LoginFlow().chooseEnterYourSiteAddress(mComposeTestRule)
                        .enterSiteAddress(E2E_WP_COM_USER_SITE_ADDRESS)
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword(E2E_WP_COM_USER_PASSWORD)
@@ -50,7 +57,7 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void e2eLoginWithMagicLink() {
-        new LoginFlow().chooseContinueWithWpCom()
+        new LoginFlow().chooseContinueWithWpCom(mComposeTestRule)
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .chooseMagicLink()
                        .openMagicLink()
@@ -59,7 +66,7 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void e2eLoginWithSelfHostedAccount() {
-        new LoginFlow().chooseEnterYourSiteAddress()
+        new LoginFlow().chooseEnterYourSiteAddress(mComposeTestRule)
                        .enterSiteAddress(E2E_SELF_HOSTED_USER_SITE_ADDRESS)
                        .enterUsernameAndPassword(E2E_SELF_HOSTED_USER_USERNAME, E2E_SELF_HOSTED_USER_PASSWORD)
                        .confirmLogin(true);

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -27,7 +27,7 @@ public class SignUpTests extends BaseTest {
 
     @Test
     public void e2eSignUpWithMagicLink() {
-        new SignupFlow().chooseContinueWithWpCom()
+        new SignupFlow().chooseContinueWithWpCom(super.mComposeTestRule)
                         .enterEmail(E2E_SIGNUP_EMAIL)
                         .openMagicLink()
                         .checkEpilogue(

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.widget.EditText;
 
+import androidx.compose.ui.test.junit4.ComposeTestRule;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.ViewInteraction;
 
@@ -11,6 +12,7 @@ import org.hamcrest.Matchers;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.e2e.pages.HelpAndSupportScreen;
+import org.wordpress.android.util.compose.ComposeUiTestingUtils;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static androidx.test.espresso.Espresso.onView;
@@ -23,6 +25,7 @@ import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_USERNAME;
 import static org.wordpress.android.support.WPSupportUtils.atLeastOneElementWithIdIsDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
+import static org.wordpress.android.support.WPSupportUtils.getTranslatedString;
 import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
@@ -32,6 +35,14 @@ public class LoginFlow {
         // Login Prologue – We want to Continue with WordPress.com, not a site address
         // See LoginPrologueFragment
         clickOn(R.id.continue_with_wpcom_button);
+        return this;
+    }
+
+    public LoginFlow chooseContinueWithWpCom(ComposeTestRule composeTestRule) {
+        // Login Prologue – We want to Continue with WordPress.com, not a site address
+        // See LoginPrologueRevampedFragment
+        new ComposeUiTestingUtils(composeTestRule)
+                .performClickOnNodeWithText(getTranslatedString(R.string.continue_with_wpcom));
         return this;
     }
 
@@ -110,10 +121,11 @@ public class LoginFlow {
         return this;
     }
 
-    public LoginFlow chooseEnterYourSiteAddress() {
+    public LoginFlow chooseEnterYourSiteAddress(ComposeTestRule composeTestRule) {
         // Login Prologue – We want to continue with a site address not a WordPress.com account
-        // See LoginPrologueFragment
-        clickOn(R.id.enter_your_site_address_button);
+        // See LoginPrologueRevampedFragment
+        new ComposeUiTestingUtils(composeTestRule)
+                .performClickOnNodeWithText(getTranslatedString(R.string.enter_your_site_address));
         return this;
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -31,13 +31,6 @@ import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 
 public class LoginFlow {
-    public LoginFlow chooseContinueWithWpCom() {
-        // Login Prologue – We want to Continue with WordPress.com, not a site address
-        // See LoginPrologueFragment
-        clickOn(R.id.continue_with_wpcom_button);
-        return this;
-    }
-
     public LoginFlow chooseContinueWithWpCom(ComposeTestRule composeTestRule) {
         // Login Prologue – We want to Continue with WordPress.com, not a site address
         // See LoginPrologueRevampedFragment

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
@@ -3,10 +3,12 @@ package org.wordpress.android.e2e.flows;
 import android.content.Intent;
 import android.net.Uri;
 
+import androidx.compose.ui.test.junit4.ComposeTestRule;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.ViewInteraction;
 
 import org.wordpress.android.R;
+import org.wordpress.android.util.compose.ComposeUiTestingUtils;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static androidx.test.espresso.Espresso.onView;
@@ -16,14 +18,16 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 import static org.wordpress.android.support.WPSupportUtils.dismissJetpackAdIfPresent;
+import static org.wordpress.android.support.WPSupportUtils.getTranslatedString;
 import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 
 public class SignupFlow {
-    public SignupFlow chooseContinueWithWpCom() {
+    public SignupFlow chooseContinueWithWpCom(ComposeTestRule composeTestRule) {
         // Login Prologue – We want to Continue with WordPress.com, not a site address
-        // See LoginPrologueFragment
-        clickOn(R.id.continue_with_wpcom_button);
+        // See LoginPrologueRevampedFragment
+        new ComposeUiTestingUtils(composeTestRule)
+                .performClickOnNodeWithText(getTranslatedString(R.string.continue_with_wpcom));
         return this;
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -2,6 +2,7 @@ package org.wordpress.android.support;
 
 import android.app.Instrumentation;
 
+import androidx.compose.ui.test.junit4.ComposeTestRule;
 import androidx.test.espresso.accessibility.AccessibilityChecks;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -37,6 +38,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import static androidx.compose.ui.test.junit4.AndroidComposeTestRule_androidKt.createComposeRule;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesTypes;
 import static org.hamcrest.Matchers.anyOf;
@@ -58,10 +60,13 @@ public class BaseTest {
     public InitializationRule mInitializationRule = new InitializationRule();
 
     @Rule(order = 2)
+    public ComposeTestRule mComposeTestRule = createComposeRule();
+
+    @Rule(order = 3)
     public ActivityScenarioRule<WPLaunchActivity> mActivityScenarioRule
             = new ActivityScenarioRule<>(WPLaunchActivity.class);
 
-    @Rule(order = 3)
+    @Rule(order = 4)
     public WireMockRule wireMockRule;
 
     {

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -115,7 +115,7 @@ public class BaseTest {
 
     protected void wpLogin() {
         logoutIfNecessary();
-        new LoginFlow().chooseContinueWithWpCom()
+        new LoginFlow().chooseContinueWithWpCom(mComposeTestRule)
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword(E2E_WP_COM_USER_PASSWORD)
                        .confirmLogin(false);

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/compose/ComposeUiTestingUtils.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/compose/ComposeUiTestingUtils.kt
@@ -7,7 +7,11 @@ import androidx.compose.ui.test.performClick
 class ComposeUiTestingUtils(
     private val composeTestRule: ComposeTestRule
 ) {
-
+    /**
+     * Performs a click on a node with the given text.
+     *
+     * @param text The text of the node to click on.
+     */
     fun performClickOnNodeWithText(text: String) {
         composeTestRule.onNodeWithText(text).performClick()
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/compose/ComposeUiTestingUtils.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/compose/ComposeUiTestingUtils.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.util.compose
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+
+class ComposeUiTestingUtils(
+    private val composeTestRule: ComposeTestRule
+) {
+
+    fun performClickOnNodeWithText(text: String) {
+        composeTestRule.onNodeWithText(text).performClick()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
@@ -9,8 +9,4 @@ import javax.inject.Inject
  */
 @FeatureInDevelopment
 class LandingScreenRevampFeatureConfig
-@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.LANDING_SCREEN_REVAMP) {
-    override fun isEnabled(): Boolean {
-        return BuildConfig.IS_JETPACK_APP || super.isEnabled()
-    }
-}
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.LANDING_SCREEN_REVAMP)


### PR DESCRIPTION
Fixes n/a

> **Warning** Don't merge this PR please... _at least not yet!_.

I created this PR to run the UI tests as a starting point to investigate how to resolve the failures caused by the `Compose` implementation of the new landing screen.


To test:
- **Verify** the `*.instrumented-tests` step in CI is green 🟢 

## Regression Notes
1. Potential unintended areas of impact
   Any UI tests going through the login flow, in both apps: WP & JP.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   CI.

3. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
