### PR TITLE
[Jetpack Install Full Plugin] Add function to check if JP is connected without full plugin

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/SiteModelExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/SiteModelExtensions.kt
@@ -24,3 +24,8 @@ val SiteModel.stateLogInformation: String
             else -> "self_hosted"
         }
     }
+
+fun SiteModel.isJetpackConnectedWithoutFullPlugin(): Boolean =
+    activeJetpackConnectionPlugins?.split(",")?.run {
+        isNotEmpty() && !contains("jetpack") && firstOrNull { it.startsWith("jetpack-") } != null
+    } ?: false

--- a/WordPress/src/test/java/org/wordpress/android/util/extensions/SiteModelExtensionsKtTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/extensions/SiteModelExtensionsKtTest.kt
@@ -1,0 +1,53 @@
+package org.wordpress.android.util.extensions
+
+import org.junit.Test
+import org.wordpress.android.fluxc.model.SiteModel
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SiteModelExtensionsKtTest {
+
+    // region isJetpackConnectedWithoutFullPlugin
+    @Test
+    fun `Should return FALSE if plugins string is null`() {
+        assertFalse(siteModel(null).isJetpackConnectedWithoutFullPlugin())
+    }
+
+    @Test
+    fun `Should return FALSE if plugins string is empty`() {
+        assertFalse(siteModel("").isJetpackConnectedWithoutFullPlugin())
+    }
+
+    @Test
+    fun `Should return FALSE if plugins string is not valid`() {
+        assertFalse(siteModel("something").isJetpackConnectedWithoutFullPlugin())
+    }
+
+    @Test
+    fun `Should return FALSE if plugins list is empty`() {
+        assertFalse(siteModel("").isJetpackConnectedWithoutFullPlugin())
+    }
+
+    @Test
+    fun `Should return FALSE if plugins list contains jetpack`() {
+        assertFalse(siteModel("jetpack-1,jetpack").isJetpackConnectedWithoutFullPlugin())
+    }
+
+    @Test
+    fun `Should return FALSE if plugins list does not contain at least one element that starts with jetpack-`() {
+        assertFalse(siteModel("plugin1,plugin2").isJetpackConnectedWithoutFullPlugin())
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `Should return TRUE if plugins list is not empty, does not contain jetpack and contains at least one element that starts with jetpack-`() {
+        assertTrue(siteModel("jetpack-1").isJetpackConnectedWithoutFullPlugin())
+        assertTrue(siteModel("jetpack-1,something").isJetpackConnectedWithoutFullPlugin())
+    }
+
+    private fun siteModel(activeJpPlugins: String?) =
+        SiteModel().apply {
+            activeJetpackConnectionPlugins = activeJpPlugins
+        }
+    // endregion
+}

--- a/WordPress/src/test/java/org/wordpress/android/util/extensions/SiteModelExtensionsKtTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/extensions/SiteModelExtensionsKtTest.kt
@@ -6,40 +6,40 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SiteModelExtensionsKtTest {
-    // region isJetpackConnectedWithoutFullPlugin
     @Test
-    fun `Should return FALSE if plugins string is null`() {
+    fun `Should return FALSE if plugins string is null when isJetpackConnectedWithoutFullPlugin is called`() {
         assertFalse(siteModel(null).isJetpackConnectedWithoutFullPlugin())
     }
 
     @Test
-    fun `Should return FALSE if plugins string is empty`() {
+    fun `Should return FALSE if plugins string is empty when isJetpackConnectedWithoutFullPlugin is called`() {
         assertFalse(siteModel("").isJetpackConnectedWithoutFullPlugin())
     }
 
     @Test
-    fun `Should return FALSE if plugins string is not valid`() {
+    fun `Should return FALSE if plugins string is not valid when isJetpackConnectedWithoutFullPlugin is called`() {
         assertFalse(siteModel("something").isJetpackConnectedWithoutFullPlugin())
     }
 
     @Test
-    fun `Should return FALSE if plugins list is empty`() {
+    fun `Should return FALSE if plugins list is empty when isJetpackConnectedWithoutFullPlugin is called`() {
         assertFalse(siteModel("").isJetpackConnectedWithoutFullPlugin())
     }
 
     @Test
-    fun `Should return FALSE if plugins list contains jetpack`() {
+    fun `Should return FALSE if plugins list contains jetpack when isJetpackConnectedWithoutFullPlugin is called`() {
         assertFalse(siteModel("jetpack-1,jetpack").isJetpackConnectedWithoutFullPlugin())
     }
 
     @Test
-    fun `Should return FALSE if plugins list does not contain at least one element that starts with jetpack-`() {
+    @Suppress("MaxLineLength")
+    fun `Should return FALSE if plugins list does not contain at least one element that starts with jetpack- when isJetpackConnectedWithoutFullPlugin is called`() {
         assertFalse(siteModel("plugin1,plugin2").isJetpackConnectedWithoutFullPlugin())
     }
 
     @Test
     @Suppress("MaxLineLength")
-    fun `Should return TRUE if plugins list is not empty, does not contain jetpack and contains at least one element that starts with jetpack-`() {
+    fun `Should return TRUE if plugins list is not empty, does not contain jetpack and contains at least one element that starts with jetpack- when isJetpackConnectedWithoutFullPlugin is called`() {
         assertTrue(siteModel("jetpack-1").isJetpackConnectedWithoutFullPlugin())
         assertTrue(siteModel("jetpack-1,something").isJetpackConnectedWithoutFullPlugin())
     }
@@ -48,5 +48,4 @@ class SiteModelExtensionsKtTest {
         SiteModel().apply {
             activeJetpackConnectionPlugins = activeJpPlugins
         }
-    // endregion
 }

--- a/WordPress/src/test/java/org/wordpress/android/util/extensions/SiteModelExtensionsKtTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/extensions/SiteModelExtensionsKtTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SiteModelExtensionsKtTest {
-
     // region isJetpackConnectedWithoutFullPlugin
     @Test
     fun `Should return FALSE if plugins string is null`() {


### PR DESCRIPTION
Fixes #17832 

To test:
This PR only implements the function, so there's nothing to test yet.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Unit tests.

3. What automated tests I added (or what prevented me from doing so)
Added `SiteModelExtensionsKtTest.kt`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
