### PR TITLE
Update mockitoVersion to 5.1.1

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -7,6 +7,7 @@ import org.junit.Test
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyArray
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -108,7 +109,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
             scanStore,
             percentFormatter
         )
-        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), any())).thenReturn("")
+        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), anyArray<Any?>())).thenReturn("")
         whenever(resourceProvider.getString(anyInt())).thenReturn(DUMMY_TEXT)
         whenever(site.name).thenReturn((""))
         whenever(site.siteId).thenReturn(TEST_SITE_ID)
@@ -363,7 +364,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         test {
             val clickableText = "clickable help text"
             val descriptionWithClickableText = "description with $clickableText"
-            whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), any()))
+            whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), anyArray<Any>()))
                 .thenReturn(descriptionWithClickableText)
             whenever(resourceProvider.getString(R.string.scan_here_to_help)).thenReturn(clickableText)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
@@ -13,6 +13,7 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyArray
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -160,7 +161,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         )
         actionHandler.initScope(testScope())
         whenever(appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog()).thenReturn(false)
-        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), anyOrNull())).thenReturn(mock())
+        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), anyArray<Any?>())).thenReturn(mock())
         whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(mock())
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.anyArray
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -39,7 +39,7 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
     }
     private val contextProvider: ContextProvider = mock()
     private val resourceProvider: ResourceProvider = mock {
-        on { getString(any(), anyOrNull()) }.thenReturn("mock_string")
+        on { getString(any(), anyArray<Any>()) }.thenReturn("mock_string")
     }
     private val weeklyRoundupScheduler: WeeklyRoundupScheduler = mock()
     private val notificationsTracker: SystemNotificationsTracker = mock()

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
     // test
     assertjVersion = '3.23.1'
     junitVersion = '4.13.2'
-    mockitoVersion = '4.9.0'
+    mockitoVersion = '5.1.0'
     mockitoKotlinVersion = '4.1.0'
 
     // android test

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
     // test
     assertjVersion = '3.23.1'
     junitVersion = '4.13.2'
-    mockitoVersion = '5.1.0'
+    mockitoVersion = '5.1.1'
     mockitoKotlinVersion = '4.1.0'
 
     // android test


### PR DESCRIPTION
Updates `mockitoVersion` to [`5.1.1`](https://github.com/mockito/mockito/releases/tag/v5.1.1) from `4.9.0`.

For an overview of what's changed in the latest version check each version changelog:
- [`5.1.1`](https://github.com/mockito/mockito/releases/tag/v5.1.1)
- [`5.1.0`](https://github.com/mockito/mockito/releases/tag/v5.1.0)
- [`5.0.0`](https://github.com/mockito/mockito/releases/tag/v5.0.0)

> **Note** The only "breaking" change for our unit tests was added in `5.0.0`, which updates the functionality of `any` matchers for methods with vararg parameters.
>
> After the update we had to replace `any()` usages for varargs with `any<Array<*>>()` or `anyArray<T>()` in order to match any number of arguments, since by simply using `any()` it would only match invocations with one parameter.
>
> I went with `anyArray` because it felt easier to write 😅 .
> 
> For more information on this see: [New `type()` method on ArgumentMatcher](https://github.com/mockito/mockito/releases/tag/v5.0.0).

---

To test:
- **Verify** CI checks are green 🟢 

## Regression Notes
1. Potential unintended areas of impact
   Unit tests.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Ran all unit tests and fixed the failures.

3. What automated tests I added (or what prevented me from doing so)
   The PR updates a testing dependency, thus only unit tests are affected. The existing suite was enough.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
