### PR TITLE
Bump Aztec version to `1.6.3`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 21.7
 -----
-
+* [*] [internal] Bump Aztec version to `1.6.3` [https://github.com/wordpress-mobile/WordPress-Android/pull/17852]
 
 21.6
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.87.3'
+    gutenbergMobileVersion = 'v1.88.0-alpha1'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-5863df97d8427540a8326b995647433882ca0e48'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.87.3'
-    wordPressAztecVersion = 'v1.6.2'
+    wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-5863df97d8427540a8326b995647433882ca0e48'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'


### PR DESCRIPTION
Bump Aztec library version to the latest version (1.6.3).

**To test:**
### Gutenberg editor
Follow the testing instructions described in the Gutenberg PR: https://github.com/WordPress/gutenberg/pull/47610.

### Classic editor
1. Create a self-hosted site (e.g. using https://jurassic.ninja/).
2. Classic Editor plugin and enable it.
3. Create a post in the web editor.
4. Observe that the editor displayed is the Classic editor.
5. Add some content and save the post.
6. Open the app.
7. Open the saved post.
8. Observe that the editor displayed is the Classic editor.
9. Observe that the editor works as expected.

## Regression Notes
1. Potential unintended areas of impact
Aztec is only used in Gutenberg and the Classic editor so those two areas are the only ones that should be impacted.

10. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested both editors and check that work as expected.

11. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
