### PR TITLE
Jetpack Focus: Add Jetpack branding to stats when accessed from published posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -10,7 +10,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.HapticFeedbackConstants;
 import android.view.View;
 import android.view.ViewGroup;
@@ -972,7 +971,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
     @Override
     protected void onResume() {
-        Log.i(WPMainActivity.class.getSimpleName(), "***=> onResume");
         super.onResume();
 
         setUpMainView();

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
@@ -5,14 +5,22 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.RecyclerView
 import dagger.android.support.DaggerFragment
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.StatsDetailFragmentBinding
+import org.wordpress.android.models.JetpackPoweredScreen
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
+import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
+import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
 class StatsDetailFragment : DaggerFragment(R.layout.stats_detail_fragment) {
@@ -21,6 +29,13 @@ class StatsDetailFragment : DaggerFragment(R.layout.stats_detail_fragment) {
 
     @Inject
     lateinit var statsSiteProvider: StatsSiteProvider
+
+    @Inject
+    lateinit var jetpackBrandingUtils: JetpackBrandingUtils
+
+    @Inject
+    lateinit var uiHelpers: UiHelpers
+
     private lateinit var viewModel: StatsDetailViewModel
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
 
@@ -36,18 +51,45 @@ class StatsDetailFragment : DaggerFragment(R.layout.stats_detail_fragment) {
                     it.setDisplayHomeAsUpEnabled(true)
                 }
             }
-            initializeViewModels(nonNullActivity)
+            initializeViewModels(nonNullActivity, savedInstanceState == null)
             initializeViews()
+            initJetpackBanner()
         }
     }
 
+    private fun StatsDetailFragmentBinding.initJetpackBanner() {
+        if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
+            val screen = JetpackPoweredScreen.WithDynamicText.STATS
+            root.post {
+                val jetpackBannerView = jetpackBanner.root
+                val scrollableView = root.findViewById<View>(R.id.recyclerView) as? RecyclerView
+                    ?: return@post
+
+                jetpackBrandingUtils.showJetpackBannerIfScrolledToTop(jetpackBannerView, scrollableView)
+                jetpackBrandingUtils.initJetpackBannerAnimation(jetpackBannerView, scrollableView)
+                jetpackBanner.jetpackBannerText.text = uiHelpers.getTextOfUiString(
+                    requireContext(),
+                    jetpackBrandingUtils.getBrandingTextForScreen(screen)
+                )
+
+                if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) {
+                    jetpackBanner.root.setOnClickListener {
+                        jetpackBrandingUtils.trackBannerTapped(screen)
+                        JetpackPoweredBottomSheetFragment
+                            .newInstance()
+                            .show(childFragmentManager, JetpackPoweredBottomSheetFragment.TAG)
+                    }
+                }
+            }
+        }
+    }
     private fun StatsDetailFragmentBinding.initializeViews() {
         swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
             viewModel.onPullToRefresh()
         }
     }
 
-    private fun initializeViewModels(activity: FragmentActivity) {
+    private fun initializeViewModels(activity: FragmentActivity,  isFirstStart: Boolean) {
         val siteId = activity.intent?.getIntExtra(WordPress.LOCAL_SITE_ID, 0) ?: 0
         statsSiteProvider.start(siteId)
 
@@ -65,13 +107,21 @@ class StatsDetailFragment : DaggerFragment(R.layout.stats_detail_fragment) {
             postUrl
         )
 
-        setupObservers(viewModel)
+        setupObservers(viewModel, isFirstStart)
     }
 
-    private fun setupObservers(viewModel: StatsDetailViewModel) {
+    private fun setupObservers(viewModel: StatsDetailViewModel, isFirstStart: Boolean) {
         viewModel.isRefreshing.observe(viewLifecycleOwner) {
             it?.let { isRefreshing ->
                 swipeToRefreshHelper.isRefreshing = isRefreshing
+            }
+        }
+
+        viewModel.showJetpackOverlay.observeEvent(viewLifecycleOwner) {
+            if (isFirstStart) {
+                JetpackFeatureFullScreenOverlayFragment
+                    .newInstance(JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType.STATS)
+                    .show(childFragmentManager, JetpackFeatureFullScreenOverlayFragment.TAG)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
+import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.stats.refresh.BLOCK_DETAIL_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
@@ -14,6 +16,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.mergeNotNull
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -24,7 +27,8 @@ class StatsDetailViewModel
     @Named(BLOCK_DETAIL_USE_CASE) private val detailUseCase: BaseListUseCase,
     private val statsSiteProvider: StatsSiteProvider,
     private val statsPostProvider: StatsPostProvider,
-    private val networkUtilsWrapper: NetworkUtilsWrapper
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil
 ) : ScopedViewModel(mainDispatcher) {
     private val _isRefreshing = MutableLiveData<Boolean>()
     val isRefreshing: LiveData<Boolean> = _isRefreshing
@@ -36,6 +40,9 @@ class StatsDetailViewModel
     )
     val showSnackbarMessage: LiveData<SnackbarMessageHolder> = _showSnackbarMessage
 
+    private val _showJetpackOverlay = MutableLiveData<Event<Boolean>>()
+    val showJetpackOverlay: LiveData<Event<Boolean>> = _showJetpackOverlay
+
     fun init(
         postId: Long,
         postType: String,
@@ -43,6 +50,15 @@ class StatsDetailViewModel
         postUrl: String?
     ) {
         statsPostProvider.init(postId, postType, postTitle, postUrl)
+
+        if (jetpackFeatureRemovalOverlayUtil.shouldShowFeatureSpecificJetpackOverlay(
+                JetpackOverlayConnectedFeature.STATS)) {
+            showJetpackOverlay()
+        }
+    }
+
+    private fun showJetpackOverlay() {
+        _showJetpackOverlay.value = Event(true)
     }
 
     fun refresh() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -106,7 +106,6 @@ class PostListItemUiStateHelper @Inject constructor(
             shouldRemoveJetpackFeatures = jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
         )
         val defaultActions = createDefaultViewActions(buttonTypes, onButtonClicked)
-        // todo: annmarie
         val compactActions = createCompactViewActions(buttonTypes, onButtonClicked)
 
         val remotePostId = RemotePostId(RemoteId(post.remotePostId))

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.model.post.PostStatus.PUBLISHED
 import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
 import org.wordpress.android.fluxc.model.post.PostStatus.TRASHED
 import org.wordpress.android.fluxc.model.post.PostStatus.UNKNOWN
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.PostModelUploadStatusTracker
@@ -70,7 +71,8 @@ private const val MAX_NUMBER_OF_VISIBLE_ACTIONS_STANDARD = 3
 class PostListItemUiStateHelper @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val uploadUiStateUseCase: PostModelUploadUiStateUseCase,
-    private val labelColorUseCase: PostPageListLabelColorUseCase
+    private val labelColorUseCase: PostPageListLabelColorUseCase,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) {
     @Suppress("LongParameterList", "LongMethod")
     fun createPostListItemUiState(
@@ -100,9 +102,11 @@ class PostListItemUiStateHelper @Inject constructor(
             isLocallyChanged = post.isLocallyChanged,
             uploadUiState = uploadUiState,
             siteHasCapabilitiesToPublish = capabilitiesToPublish,
-            statsSupported = statsSupported
+            statsSupported = statsSupported,
+            shouldRemoveJetpackFeatures = jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
         )
         val defaultActions = createDefaultViewActions(buttonTypes, onButtonClicked)
+        // todo: annmarie
         val compactActions = createCompactViewActions(buttonTypes, onButtonClicked)
 
         val remotePostId = RemotePostId(RemoteId(post.remotePostId))
@@ -369,7 +373,8 @@ class PostListItemUiStateHelper @Inject constructor(
         isLocallyChanged: Boolean,
         uploadUiState: PostUploadUiState,
         siteHasCapabilitiesToPublish: Boolean,
-        statsSupported: Boolean
+        statsSupported: Boolean,
+        shouldRemoveJetpackFeatures: Boolean
     ): List<PostListButtonType> {
         val canRetryUpload = uploadUiState is UploadFailed
         val canCancelPendingAutoUpload = (uploadUiState is UploadWaitingForConnection ||
@@ -381,7 +386,8 @@ class PostListItemUiStateHelper @Inject constructor(
         val canShowStats = statsSupported &&
                 postStatus == PUBLISHED &&
                 !isLocalDraft &&
-                !isLocallyChanged
+                !isLocallyChanged &&
+                !shouldRemoveJetpackFeatures
         val canShowCopy = postStatus == PUBLISHED || postStatus == DRAFT
         val canShowCopyUrlButton = !isLocalDraft && postStatus != TRASHED
         val canShowViewButton = !canRetryUpload && postStatus != TRASHED

--- a/WordPress/src/main/res/layout/stats_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_detail_fragment.xml
@@ -24,6 +24,10 @@
 
         </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
+        <include
+            android:id="@+id/jetpack_banner"
+            layout="@layout/jetpack_banner" />
+
         <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/app_bar_layout"
             android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #17853 

This PR adds Jetpack branding, via banner and overlay view, when navigating to stats from posts > Published Posts > More Menu > Stats item

Phase 1-3 | Phase 4
-- | --
<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/215792928-f61e5b4f-7cf8-44c8-98a0-8cad6b690eb3.png"> | <img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/215856320-c9da4ede-f7e9-4f19-a69a-1bb1bbe8a475.png">

P1 | P2 | P3 
-- | -- | --
<img width="250" height="400" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/215856629-2061fa3f-b0c3-4360-bf7b-f433427bc772.png"> | <img width="250" height="400" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/215856634-06dcb1d4-c3ad-4c6c-8cf3-0279c26a4be3.png">  | <img width="250" height="400" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/215856644-3a9d50b8-878e-42fc-8bd0-6d8e9b8b3ba5.png">

**To test:**
**Jetpack Branding Is Shown**
- Install the app
- Launch and login
- Navigate to Me > App Settings > Debug Settings
- Enable `jp_removal_one` (if not enabled) and restart the App
- Navigate to the posts list > published posts
- Tap on the More menu on a post item
- ✅ Verify the "stats" menu item is visible  
- Tap on Stats
- ✅ Verify the "stats" overlay was visible (first time)
- ✅ Verify the Jetpack banner is visible on the view and matches the phase selected
- Repeat the above steps for `jp_removal_two` and `jp_removal_three`

**Stats menu item is not shown**
- Install the app
- Launch and login
- Navigate to Me > App Settings > Debug Settings
- Enable `jp_removal_four` (if not enabled) and restart the App
- Navigate to the posts list > published posts
- Tap on the More menu on a post item
- ✅ Verify the "stats" menu item is not visible.

## Regression Notes
1. Potential unintended areas of impact
The banner is not shown on the stats detail view 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and reran existing jetpack banner tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
