### PR TITLE
[Blogging Prompts Enhancements] Setting to enable/disable prompts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
@@ -31,7 +31,6 @@ class BloggingPromptsSettingsHelper @Inject constructor(
         updatePromptsCardEnabled(siteId, isEnabled)
     }
 
-    @Suppress("MemberVisibilityCanBePrivate")
     suspend fun updatePromptsCardEnabled(siteId: Int, isEnabled: Boolean) {
         val current = bloggingRemindersStore.bloggingRemindersModel(siteId).firstOrNull() ?: return
         bloggingRemindersStore.updateBloggingReminders(current.copy(isPromptsCardEnabled = isEnabled))

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
@@ -37,15 +37,9 @@ class BloggingPromptsSettingsHelper @Inject constructor(
         bloggingRemindersStore.updateBloggingReminders(current.copy(isPromptsCardEnabled = isEnabled))
     }
 
-    fun isPromptsFeatureAvailableBlocking(): Boolean = runBlocking { isPromptsFeatureAvailable() }
-
-    @Suppress("MemberVisibilityCanBePrivate")
-    suspend fun isPromptsFeatureAvailable(): Boolean {
+    fun isPromptsFeatureAvailable(): Boolean {
         val selectedSite = selectedSiteRepository.getSelectedSite() ?: return false
-        val isPotentialBloggingSite = selectedSite.isPotentialBloggingSite
-
-        return bloggingPromptsFeatureConfig.isEnabled() &&
-                (isPotentialBloggingSite || isPromptIncludedInReminder(selectedSite.localId().value))
+        return bloggingPromptsFeatureConfig.isEnabled() && selectedSite.isPotentialBloggingSite
     }
 
     suspend fun isPromptsFeatureActive(): Boolean {
@@ -71,11 +65,4 @@ class BloggingPromptsSettingsHelper @Inject constructor(
         .bloggingRemindersModel(siteId)
         .firstOrNull()
         ?.isPromptsCardEnabled == true
-
-    private suspend fun isPromptIncludedInReminder(
-        siteId: Int
-    ): Boolean = bloggingRemindersStore
-        .bloggingRemindersModel(siteId)
-        .firstOrNull()
-        ?.isPromptIncluded == true
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
@@ -39,6 +39,7 @@ class BloggingPromptsSettingsHelper @Inject constructor(
 
     fun isPromptsFeatureAvailableBlocking(): Boolean = runBlocking { isPromptsFeatureAvailable() }
 
+    @Suppress("MemberVisibilityCanBePrivate")
     suspend fun isPromptsFeatureAvailable(): Boolean {
         val selectedSite = selectedSiteRepository.getSelectedSite() ?: return false
         val isPotentialBloggingSite = selectedSite.isPotentialBloggingSite

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
@@ -6,10 +6,20 @@ import androidx.lifecycle.map
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.runBlocking
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.DateUtils.isSameDay
+import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig
+import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
+import java.util.Date
 import javax.inject.Inject
 
 class BloggingPromptsSettingsHelper @Inject constructor(
     private val bloggingRemindersStore: BloggingRemindersStore,
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig,
+    private val bloggingPromptsEnhancementsFeatureConfig: BloggingPromptsEnhancementsFeatureConfig,
 ) {
     fun getPromptsCardEnabledLiveData(
         siteId: Int
@@ -26,4 +36,45 @@ class BloggingPromptsSettingsHelper @Inject constructor(
         val current = bloggingRemindersStore.bloggingRemindersModel(siteId).firstOrNull() ?: return
         bloggingRemindersStore.updateBloggingReminders(current.copy(isPromptsCardEnabled = isEnabled))
     }
+
+    fun isPromptsFeatureAvailableBlocking(): Boolean = runBlocking { isPromptsFeatureAvailable() }
+
+    suspend fun isPromptsFeatureAvailable(): Boolean {
+        val selectedSite = selectedSiteRepository.getSelectedSite() ?: return false
+        val isPotentialBloggingSite = selectedSite.isPotentialBloggingSite
+
+        return bloggingPromptsFeatureConfig.isEnabled() &&
+                (isPotentialBloggingSite || isPromptIncludedInReminder(selectedSite.localId().value))
+    }
+
+    suspend fun isPromptsFeatureActive(): Boolean {
+        val siteId = selectedSiteRepository.getSelectedSite()?.localId()?.value ?: return false
+
+        // if the enhancements is turned off, consider the prompts user-enabled, otherwise check the user setting
+        val isPromptsCardUserEnabled = !bloggingPromptsEnhancementsFeatureConfig.isEnabled() ||
+                isPromptsCardEnabled(siteId)
+
+        return isPromptsFeatureAvailable() && isPromptsCardUserEnabled && !isPromptSkippedForToday()
+    }
+
+    private fun isPromptSkippedForToday(): Boolean {
+        val selectedSite = selectedSiteRepository.getSelectedSite() ?: return false
+
+        val promptSkippedDate = appPrefsWrapper.getSkippedPromptDay(selectedSite.localId().value)
+        return promptSkippedDate != null && isSameDay(promptSkippedDate, Date())
+    }
+
+    private suspend fun isPromptsCardEnabled(
+        siteId: Int
+    ): Boolean = bloggingRemindersStore
+        .bloggingRemindersModel(siteId)
+        .firstOrNull()
+        ?.isPromptsCardEnabled == true
+
+    private suspend fun isPromptIncludedInReminder(
+        siteId: Int
+    ): Boolean = bloggingRemindersStore
+        .bloggingRemindersModel(siteId)
+        .firstOrNull()
+        ?.isPromptIncluded == true
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.map
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.runBlocking
+import org.wordpress.android.fluxc.store.BloggingRemindersStore
+import javax.inject.Inject
+
+class BloggingPromptsSettingsHelper @Inject constructor(
+    private val bloggingRemindersStore: BloggingRemindersStore,
+) {
+    fun getPromptsCardEnabledLiveData(
+        siteId: Int
+    ): LiveData<Boolean> = bloggingRemindersStore.bloggingRemindersModel(siteId)
+        .asLiveData()
+        .map { it.isPromptsCardEnabled }
+
+    fun updatePromptsCardEnabledBlocking(siteId: Int, isEnabled: Boolean) = runBlocking {
+        updatePromptsCardEnabled(siteId, isEnabled)
+    }
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    suspend fun updatePromptsCardEnabled(siteId: Int, isEnabled: Boolean) {
+        val current = bloggingRemindersStore.bloggingRemindersModel(siteId).firstOrNull() ?: return
+        bloggingRemindersStore.updateBloggingReminders(current.copy(isPromptsCardEnabled = isEnabled))
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
@@ -41,7 +41,7 @@ class BloggingPromptsSettingsHelper @Inject constructor(
         return bloggingPromptsFeatureConfig.isEnabled() && selectedSite.isPotentialBloggingSite
     }
 
-    suspend fun isPromptsFeatureActive(): Boolean {
+    suspend fun shouldShowPromptsFeature(): Boolean {
         val siteId = selectedSiteRepository.getSelectedSite()?.localId()?.value ?: return false
 
         // if the enhancements is turned off, consider the prompts user-enabled, otherwise check the user setting

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
@@ -65,7 +65,7 @@ class BloggingPromptCardSource @Inject constructor(
                     promptsStore.getPrompts(selectedSite)
                         .map { it.model?.filter { prompt -> isSameDay(prompt.date, Date()) } }
                         .collect { result ->
-                            postState(BloggingPromptUpdate(result?.firstOrNull()))
+                            postValue(BloggingPromptUpdate(result?.firstOrNull()))
                         }
                 } else {
                     postEmptyState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
@@ -61,7 +61,7 @@ class BloggingPromptCardSource @Inject constructor(
         val selectedSite = selectedSiteRepository.getSelectedSite()
         if (selectedSite != null && selectedSite.id == siteLocalId && bloggingPromptsFeatureConfig.isEnabled()) {
             coroutineScope.launch(bgDispatcher) {
-                if (bloggingPromptsSettingsHelper.isPromptsFeatureActive()) {
+                if (bloggingPromptsSettingsHelper.shouldShowPromptsFeature()) {
                     promptsStore.getPrompts(selectedSite)
                         .map { it.model?.filter { prompt -> isSameDay(prompt.date, Date()) } }
                         .collect { result ->
@@ -97,7 +97,7 @@ class BloggingPromptCardSource @Inject constructor(
         if (selectedSite != null && selectedSite.id == siteLocalId) {
             if (bloggingPromptsFeatureConfig.isEnabled()) {
                 coroutineScope.launch(bgDispatcher) {
-                    if (bloggingPromptsSettingsHelper.isPromptsFeatureActive()) {
+                    if (bloggingPromptsSettingsHelper.shouldShowPromptsFeature()) {
                         fetchPromptsAndPostErrorIfAvailable(coroutineScope, selectedSite, isSinglePromptRefresh)
                     } else {
                         postEmptyState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.BloggingPromptUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
-import org.wordpress.android.util.distinct
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.Date
@@ -46,7 +45,7 @@ class BloggingPromptCardSource @Inject constructor(
         result.addSource(refresh) { result.refreshData(coroutineScope, siteLocalId, refresh.value) }
         result.addSource(singleRefresh) { result.refreshData(coroutineScope, siteLocalId, singleRefresh.value, true) }
         refresh()
-        return result
+        return result.distinctUntilChanged()
     }
 
     fun refreshTodayPrompt() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -193,7 +193,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Inject ManageCategoriesFeatureConfig mManageCategoriesFeatureConfig;
     @Inject UiHelpers mUiHelpers;
     @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
-    @Inject BloggingPromptsSettingsHelper mPromptsSettingsManager;
+    @Inject BloggingPromptsSettingsHelper mPromptsSettingsHelper;
 
     private BloggingRemindersViewModel mBloggingRemindersViewModel;
 
@@ -1267,12 +1267,13 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void initBloggingPrompts() {
-        if (!mBloggingPromptsFeatureConfig.isEnabled() || !mBloggingPromptsEnhancementFeatureConfig.isEnabled()) {
+        if (!mPromptsSettingsHelper.isPromptsFeatureAvailableBlocking()
+            || !mBloggingPromptsEnhancementFeatureConfig.isEnabled()) {
             removeBloggingPromptsSettings();
             return;
         }
 
-        mPromptsSettingsManager
+        mPromptsSettingsHelper
                 .getPromptsCardEnabledLiveData(mSite.getId())
                 .observe(getAppCompatActivity(), isEnabled -> {
                     if (mBloggingPromptsPref != null) {
@@ -1282,7 +1283,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void setBloggingPromptsEnabled(boolean newValue) {
-        mPromptsSettingsManager
+        mPromptsSettingsHelper
                 .updatePromptsCardEnabledBlocking(mSite.getId(), newValue);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1252,7 +1252,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                     .getBlogSettingsUiState(mSite.getId())
                     .observe(getAppCompatActivity(), s -> {
                         if (mBloggingRemindersPref != null) {
-                            CharSequence summary = mUiHelpers.getTextOfUiString(getActivity(), s);
+                            final CharSequence summary = mUiHelpers.getTextOfUiString(getActivity(), s);
                             mBloggingRemindersPref.setSummary(summary);
                         }
                     });

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1267,7 +1267,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void initBloggingPrompts() {
-        if (!mPromptsSettingsHelper.isPromptsFeatureAvailableBlocking()
+        if (!mPromptsSettingsHelper.isPromptsFeatureAvailable()
             || !mBloggingPromptsEnhancementFeatureConfig.isEnabled()) {
             removeBloggingPromptsSettings();
             return;

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -146,13 +146,13 @@ class WPMainActivityViewModel @Inject constructor(
 
         setMainFabUiState(false, site)
 
-        loadMainActions(site)
+        launch { loadMainActions(site) }
 
         updateFeatureAnnouncements()
     }
 
     @Suppress("LongMethod")
-    private fun loadMainActions(site: SiteModel?, onFabClicked: Boolean = false) = launch {
+    private suspend fun loadMainActions(site: SiteModel?, onFabClicked: Boolean = false) {
         val actionsList = ArrayList<MainActionListItem>()
         if (bloggingPromptsSettingsHelper.isPromptsFeatureActive()) {
             val prompt = site?.let {
@@ -270,16 +270,18 @@ class WPMainActivityViewModel @Inject constructor(
         _showQuickStarInBottomSheet.postValue(quickStartRepository.activeTask.value == PUBLISH_POST)
 
         if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper) || hasFullAccessToContent(site)) {
-            // The user has at least two create options available for this site (pages and/or story posts),
-            // so we should show a bottom sheet.
-            // Creation options added in the future should also be weighed here.
+            launch {
+                // The user has at least two create options available for this site (pages and/or story posts),
+                // so we should show a bottom sheet.
+                // Creation options added in the future should also be weighed here.
 
-            // Reload main actions, since the first time this is initialized the SiteModel may not contain the
-            // latest info.
-            loadMainActions(site, onFabClicked = true)
+                // Reload main actions, since the first time this is initialized the SiteModel may not contain the
+                // latest info.
+                loadMainActions(site, onFabClicked = true)
 
-            analyticsTracker.track(Stat.MY_SITE_CREATE_SHEET_SHOWN)
-            _isBottomSheetShowing.value = Event(true)
+                analyticsTracker.track(Stat.MY_SITE_CREATE_SHEET_SHOWN)
+                _isBottomSheetShowing.postValue(Event(true))
+            }
         } else {
             // User only has one option - creating a post. Skip the bottom sheet and go straight to that action.
             _createAction.postValue(CREATE_NEW_POST)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -154,7 +154,7 @@ class WPMainActivityViewModel @Inject constructor(
     @Suppress("LongMethod")
     private suspend fun loadMainActions(site: SiteModel?, onFabClicked: Boolean = false) {
         val actionsList = ArrayList<MainActionListItem>()
-        if (bloggingPromptsSettingsHelper.isPromptsFeatureActive()) {
+        if (bloggingPromptsSettingsHelper.shouldShowPromptsFeature()) {
             val prompt = site?.let {
                 if (it.isUsingWpComRestApi) {
                     bloggingPromptsStore.getPromptForDate(it, Date()).firstOrNull()?.model

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
@@ -41,7 +42,6 @@ import org.wordpress.android.util.FluxCUtils
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.SiteUtils.hasFullAccessToContent
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import org.wordpress.android.util.map
 import org.wordpress.android.util.mapNullable
 import org.wordpress.android.util.merge
@@ -66,7 +66,7 @@ class WPMainActivityViewModel @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val accountStore: AccountStore,
     private val siteStore: SiteStore,
-    private val bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig,
+    private val bloggingPromptsSettingsHelper: BloggingPromptsSettingsHelper,
     private val bloggingPromptsStore: BloggingPromptsStore,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
@@ -154,7 +154,7 @@ class WPMainActivityViewModel @Inject constructor(
     @Suppress("LongMethod")
     private fun loadMainActions(site: SiteModel?, onFabClicked: Boolean = false) = launch {
         val actionsList = ArrayList<MainActionListItem>()
-        if (bloggingPromptsFeatureConfig.isEnabled()) {
+        if (bloggingPromptsSettingsHelper.isPromptsFeatureActive()) {
             val prompt = site?.let {
                 if (it.isUsingWpComRestApi) {
                     bloggingPromptsStore.getPromptForDate(it, Date()).firstOrNull()?.model

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -34,6 +34,7 @@
     <string name="pref_key_site_tagline" translatable="false">wp_pref_site_tagline</string>
     <string name="pref_key_site_address" translatable="false">wp_pref_site_address</string>
     <string name="pref_key_site_language" translatable="false">wp_pref_site_language</string>
+    <string name="pref_key_blogging_prompts" translatable="false">wp_pref_blogging_prompts</string>
     <string name="pref_key_site_visibility" translatable="false">wp_pref_site_visibility</string>
     <string name="pref_key_site_username" translatable="false">wp_pref_site_username</string>
     <string name="pref_key_site_password" translatable="false">wp_pref_site_password</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -635,6 +635,7 @@
     <string name="site_settings_timezone_title">Timezone</string>
     <string name="site_settings_timezone_subtitle">Choose a city in your timezone</string>
     <string name="site_settings_blogging_reminders_title">Blogging reminders</string>
+    <string name="site_settings_blogging_prompts_title">Blogging Prompts</string>
     <string name="site_settings_blogging_reminders_and_prompts_title">Reminders and prompts</string>
     <string name="site_settings_posts_per_page_title">Posts per page</string>
     <string name="site_settings_format_entry_custom">Custom</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -63,6 +63,11 @@
             android:key="@string/pref_key_blogging_reminders"
             android:title="@string/site_settings_blogging_reminders_title" />
 
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_blogging_prompts"
+            android:key="@string/pref_key_blogging_prompts"
+            android:title="@string/site_settings_blogging_prompts_title" />
+
     </PreferenceCategory>
 
     <!-- Homepage settings -->

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
@@ -144,7 +144,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     fun `given site is not selected, when isPromptsFeatureActive, then returns false`() = test {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
 
-        val result = helper.isPromptsFeatureActive()
+        val result = helper.shouldShowPromptsFeature()
 
         assertThat(result).isFalse
     }
@@ -159,7 +159,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
             }
         )
 
-        val result = helper.isPromptsFeatureActive()
+        val result = helper.shouldShowPromptsFeature()
 
         assertThat(result).isFalse
     }
@@ -182,7 +182,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
             flowOf(model)
         }
 
-        val result = helper.isPromptsFeatureActive()
+        val result = helper.shouldShowPromptsFeature()
 
         assertThat(result).isFalse
     }
@@ -209,7 +209,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
 
             whenever(appPrefsWrapper.getSkippedPromptDay(any())).thenReturn(Date())
 
-            val result = helper.isPromptsFeatureActive()
+            val result = helper.shouldShowPromptsFeature()
 
             assertThat(result).isFalse
         }
@@ -229,7 +229,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
 
         whenever(appPrefsWrapper.getSkippedPromptDay(any())).thenReturn(Date())
 
-        val result = helper.isPromptsFeatureActive()
+        val result = helper.shouldShowPromptsFeature()
 
         assertThat(result).isFalse
     }
@@ -256,7 +256,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
 
             whenever(appPrefsWrapper.getSkippedPromptDay(any())).thenReturn(null)
 
-            val result = helper.isPromptsFeatureActive()
+            val result = helper.shouldShowPromptsFeature()
 
             assertThat(result).isTrue
         }
@@ -278,7 +278,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
 
             whenever(appPrefsWrapper.getSkippedPromptDay(any())).thenReturn(null)
 
-            val result = helper.isPromptsFeatureActive()
+            val result = helper.shouldShowPromptsFeature()
 
             assertThat(result).isTrue
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
@@ -98,9 +98,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     @Test
     fun `given prompts FF is off and site is potential blog, when isPromptsFeatureAvailable, then returns false`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
-            SiteModel().apply { setIsPotentialBloggingSite(true) }
-        )
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
 
         val result = helper.isPromptsFeatureAvailable()
 
@@ -110,9 +108,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     @Test
     fun `given prompts FF is on and site is not potential blog, when isPromptsFeatureAvailable, then returns false`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
-            SiteModel().apply { setIsPotentialBloggingSite(false) }
-        )
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel(isPotentialBloggingSite = false))
 
         val result = helper.isPromptsFeatureAvailable()
 
@@ -131,9 +127,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     @Test
     fun `given prompts FF is on and site is potential blog, when isPromptsFeatureAvailable, then returns true`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
-            SiteModel().apply { setIsPotentialBloggingSite(true) }
-        )
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
 
         val result = helper.isPromptsFeatureAvailable()
 
@@ -152,12 +146,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     @Test
     fun `given prompts feature not available, when isPromptsFeatureActive, then returns false`() = test {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
-            SiteModel().apply {
-                id = 123
-                setIsPotentialBloggingSite(true)
-            }
-        )
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
 
         val result = helper.shouldShowPromptsFeature()
 
@@ -168,12 +157,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     fun `given enhancements FF on and prompts setting off, when isPromptsFeatureActive, then returns false`() = test {
         // prompts feature is available
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
-            SiteModel().apply {
-                id = 123
-                setIsPotentialBloggingSite(true)
-            }
-        )
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
 
         whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(true)
 
@@ -193,12 +177,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
         test {
             // prompts feature is available
             whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
-            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
-                SiteModel().apply {
-                    id = 123
-                    setIsPotentialBloggingSite(true)
-                }
-            )
+            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
 
             whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(true)
 
@@ -218,12 +197,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     fun `given enhancements FF off and skipped for today, when isPromptsFeatureActive, then returns false`() = test {
         // prompts feature is available
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
-            SiteModel().apply {
-                id = 123
-                setIsPotentialBloggingSite(true)
-            }
-        )
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
 
         whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(false)
 
@@ -240,12 +214,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
         test {
             // prompts feature is available
             whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
-            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
-                SiteModel().apply {
-                    id = 123
-                    setIsPotentialBloggingSite(true)
-                }
-            )
+            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
 
             whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(true)
 
@@ -267,12 +236,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
         test {
             // prompts feature is available
             whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
-            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
-                SiteModel().apply {
-                    id = 123
-                    setIsPotentialBloggingSite(true)
-                }
-            )
+            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
 
             whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(false)
 
@@ -290,5 +254,12 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
             siteId = 123,
             isPromptsCardEnabled = isPromptsCardEnabled,
         )
+
+        private fun createSiteModel(
+            isPotentialBloggingSite: Boolean = true
+        ) = SiteModel().apply {
+            this.id = 123
+            setIsPotentialBloggingSite(isPotentialBloggingSite)
+        }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
@@ -1,0 +1,74 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.BloggingRemindersModel
+import org.wordpress.android.fluxc.store.BloggingRemindersStore
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig
+import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
+
+@ExperimentalCoroutinesApi
+class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
+    @Mock
+    lateinit var bloggingRemindersStore: BloggingRemindersStore
+
+    @Mock
+    lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Mock
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+
+    @Mock
+    lateinit var bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig
+
+    @Mock
+    lateinit var bloggingPromptsEnhancementsFeatureConfig: BloggingPromptsEnhancementsFeatureConfig
+
+    lateinit var helper: BloggingPromptsSettingsHelper
+
+    @Before
+    fun setUp() {
+        helper = BloggingPromptsSettingsHelper(
+            bloggingRemindersStore,
+            selectedSiteRepository,
+            appPrefsWrapper,
+            bloggingPromptsFeatureConfig,
+            bloggingPromptsEnhancementsFeatureConfig,
+        )
+    }
+
+    @Test
+    fun `when getPromptsCardEnabledLiveData then returns the store model isPromptsCardEnabled value`() {
+        val model = createRemindersModel(isPromptIncluded = false, isPromptsCardEnabled = true)
+        whenever(bloggingRemindersStore.bloggingRemindersModel(any())).doAnswer {
+            flowOf(model)
+        }
+
+        var result: Boolean? = null
+        helper.getPromptsCardEnabledLiveData(123).observeForever { result = it }
+
+        assertThat(result).isTrue
+    }
+
+    companion object {
+        private fun createRemindersModel(
+            isPromptIncluded: Boolean,
+            isPromptsCardEnabled: Boolean,
+        ) = BloggingRemindersModel(
+            siteId = 123,
+            isPromptIncluded = isPromptIncluded,
+            isPromptsCardEnabled = isPromptsCardEnabled,
+        )
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
@@ -1,22 +1,27 @@
 package org.wordpress.android.ui.bloggingprompts
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.BloggingRemindersModel
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
+import java.util.Date
 
 @ExperimentalCoroutinesApi
 class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
@@ -49,8 +54,9 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when getPromptsCardEnabledLiveData then returns the store model isPromptsCardEnabled value`() {
-        val model = createRemindersModel(isPromptIncluded = false, isPromptsCardEnabled = true)
+    fun `when getPromptsCardEnabledLiveData, then returns the store model isPromptsCardEnabled value`() {
+        val expectedState = true
+        val model = createRemindersModel(isPromptsCardEnabled = expectedState)
         whenever(bloggingRemindersStore.bloggingRemindersModel(any())).doAnswer {
             flowOf(model)
         }
@@ -58,16 +64,230 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
         var result: Boolean? = null
         helper.getPromptsCardEnabledLiveData(123).observeForever { result = it }
 
+        assertThat(result).isEqualTo(expectedState)
+    }
+
+    @Test
+    fun `when updatePromptsCardEnabledBlocking, then calls suspending version internally`() {
+        val spyHelper = spy(helper)
+
+        whenever(bloggingRemindersStore.bloggingRemindersModel(any())).doAnswer {
+            flowOf()
+        }
+
+        spyHelper.updatePromptsCardEnabledBlocking(123, isEnabled = true)
+
+        verifyBlocking(spyHelper) {
+            updatePromptsCardEnabled(any(), any())
+        }
+    }
+
+    @Test
+    fun `when updatePromptsCardEnabled, then updates the store model`() = test {
+        val expectedState = true
+        val model = createRemindersModel(isPromptsCardEnabled = false)
+        whenever(bloggingRemindersStore.bloggingRemindersModel(any())).doAnswer {
+            flowOf(model)
+        }
+
+        helper.updatePromptsCardEnabled(123, isEnabled = expectedState)
+
+        verify(bloggingRemindersStore).updateBloggingReminders(argThat { isPromptsCardEnabled == expectedState })
+    }
+
+    @Test
+    fun `given prompts FF is off and site is potential blog, when isPromptsFeatureAvailable, then returns false`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
+            SiteModel().apply { setIsPotentialBloggingSite(true) }
+        )
+
+        val result = helper.isPromptsFeatureAvailable()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given prompts FF is on and site is not potential blog, when isPromptsFeatureAvailable, then returns false`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
+            SiteModel().apply { setIsPotentialBloggingSite(false) }
+        )
+
+        val result = helper.isPromptsFeatureAvailable()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given site is not selected, when isPromptsFeatureAvailable, then returns false`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+
+        val result = helper.isPromptsFeatureAvailable()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given prompts FF is on and site is potential blog, when isPromptsFeatureAvailable, then returns true`() {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
+            SiteModel().apply { setIsPotentialBloggingSite(true) }
+        )
+
+        val result = helper.isPromptsFeatureAvailable()
+
         assertThat(result).isTrue
     }
 
+    @Test
+    fun `given site is not selected, when isPromptsFeatureActive, then returns false`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+
+        val result = helper.isPromptsFeatureActive()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given prompts feature not available, when isPromptsFeatureActive, then returns false`() = test {
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
+            SiteModel().apply {
+                id = 123
+                setIsPotentialBloggingSite(true)
+            }
+        )
+
+        val result = helper.isPromptsFeatureActive()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given enhancements FF on and prompts setting off, when isPromptsFeatureActive, then returns false`() = test {
+        // prompts feature is available
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
+            SiteModel().apply {
+                id = 123
+                setIsPotentialBloggingSite(true)
+            }
+        )
+
+        whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(true)
+
+        val model = createRemindersModel(isPromptsCardEnabled = false)
+        whenever(bloggingRemindersStore.bloggingRemindersModel(any())).doAnswer {
+            flowOf(model)
+        }
+
+        val result = helper.isPromptsFeatureActive()
+
+        assertThat(result).isFalse
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `given enhancements FF on and prompts setting on and skipped for today, when isPromptsFeatureActive, then returns false`() =
+        test {
+            // prompts feature is available
+            whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
+                SiteModel().apply {
+                    id = 123
+                    setIsPotentialBloggingSite(true)
+                }
+            )
+
+            whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(true)
+
+            val model = createRemindersModel(isPromptsCardEnabled = true)
+            whenever(bloggingRemindersStore.bloggingRemindersModel(any())).doAnswer {
+                flowOf(model)
+            }
+
+            whenever(appPrefsWrapper.getSkippedPromptDay(any())).thenReturn(Date())
+
+            val result = helper.isPromptsFeatureActive()
+
+            assertThat(result).isFalse
+        }
+
+    @Test
+    fun `given enhancements FF off and skipped for today, when isPromptsFeatureActive, then returns false`() = test {
+        // prompts feature is available
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
+            SiteModel().apply {
+                id = 123
+                setIsPotentialBloggingSite(true)
+            }
+        )
+
+        whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(false)
+
+        whenever(appPrefsWrapper.getSkippedPromptDay(any())).thenReturn(Date())
+
+        val result = helper.isPromptsFeatureActive()
+
+        assertThat(result).isFalse
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `given enhancements FF on and prompts setting on and not skipped for today, when isPromptsFeatureActive, then returns false`() =
+        test {
+            // prompts feature is available
+            whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
+                SiteModel().apply {
+                    id = 123
+                    setIsPotentialBloggingSite(true)
+                }
+            )
+
+            whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(true)
+
+            val model = createRemindersModel(isPromptsCardEnabled = true)
+            whenever(bloggingRemindersStore.bloggingRemindersModel(any())).doAnswer {
+                flowOf(model)
+            }
+
+            whenever(appPrefsWrapper.getSkippedPromptDay(any())).thenReturn(null)
+
+            val result = helper.isPromptsFeatureActive()
+
+            assertThat(result).isTrue
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `given enhancements FF off and not skipped for today, when isPromptsFeatureActive, then returns false`() =
+        test {
+            // prompts feature is available
+            whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(
+                SiteModel().apply {
+                    id = 123
+                    setIsPotentialBloggingSite(true)
+                }
+            )
+
+            whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(false)
+
+            whenever(appPrefsWrapper.getSkippedPromptDay(any())).thenReturn(null)
+
+            val result = helper.isPromptsFeatureActive()
+
+            assertThat(result).isTrue
+        }
+
     companion object {
         private fun createRemindersModel(
-            isPromptIncluded: Boolean,
             isPromptsCardEnabled: Boolean,
         ) = BloggingRemindersModel(
             siteId = 123,
-            isPromptIncluded = isPromptIncluded,
             isPromptsCardEnabled = isPromptsCardEnabled,
         )
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSourceTest.kt
@@ -269,13 +269,12 @@ class BloggingPromptCardSourceTest : BaseUnitTest() {
         advanceUntilIdle()
         println(result)
 
-        assertThat(result.size).isEqualTo(6)
+        assertThat(result.size).isEqualTo(5)
         assertThat(result[0]).isFalse // init
-        assertThat(result[1]).isFalse // build(...) -> getData(...)
-        assertThat(result[2]).isTrue // build(...) -> refresh()
-        assertThat(result[3]).isTrue // build(...) -> bloggingPromptCardSource.fetchPrompts(...) -> success
-        assertThat(result[4]).isFalse // refresh()
-        assertThat(result[5]).isFalse // refreshData(...) -> bloggingPromptCardSource.fetchPrompts(...) -> success
+        assertThat(result[1]).isTrue // build(...) -> refresh()
+        assertThat(result[2]).isTrue // build(...) -> bloggingPromptCardSource.fetchPrompts(...) -> success
+        assertThat(result[3]).isFalse // refresh()
+        assertThat(result[4]).isFalse // refreshData(...) -> bloggingPromptCardSource.fetchPrompts(...) -> success
     }
 
     @Test
@@ -322,13 +321,12 @@ class BloggingPromptCardSourceTest : BaseUnitTest() {
         bloggingPromptCardSource.refresh()
         advanceUntilIdle()
 
-        assertThat(result.size).isEqualTo(6)
+        assertThat(result.size).isEqualTo(5)
         assertThat(result[0]).isFalse // init
-        assertThat(result[1]).isFalse // build(...) -> getData(...)
-        assertThat(result[2]).isTrue // build(...) -> refresh()
-        assertThat(result[3]).isTrue // build(...) -> bloggingPromptCardSource.fetchPrompts(...) -> success
-        assertThat(result[4]).isFalse // refresh()
-        assertThat(result[5]).isFalse // refreshData(...) -> bloggingPromptCardSource.fetchPrompts(...) -> success
+        assertThat(result[1]).isTrue // build(...) -> refresh()
+        assertThat(result[2]).isTrue // build(...) -> bloggingPromptCardSource.fetchPrompts(...) -> success
+        assertThat(result[3]).isFalse // refresh()
+        assertThat(result[4]).isFalse // refreshData(...) -> bloggingPromptCardSource.fetchPrompts(...) -> success
     }
 
     @Test
@@ -344,12 +342,11 @@ class BloggingPromptCardSourceTest : BaseUnitTest() {
         bloggingPromptCardSource.refresh()
         advanceUntilIdle()
 
-        assertThat(result.size).isEqualTo(6)
+        assertThat(result.size).isEqualTo(5)
         assertThat(result[0]).isFalse // init
-        assertThat(result[1]).isFalse // build(...) -> getData(...)
-        assertThat(result[2]).isTrue // build(...) -> refresh()
-        assertThat(result[3]).isTrue // build(...) -> bloggingPromptCardSource.fetchPrompts(...) -> error
-        assertThat(result[4]).isFalse // refresh()
-        assertThat(result[5]).isFalse // refreshData(...) -> bloggingPromptCardSource.fetchPrompts(...) -> error
+        assertThat(result[1]).isTrue // build(...) -> refresh()
+        assertThat(result[2]).isTrue // build(...) -> bloggingPromptCardSource.fetchPrompts(...) -> error
+        assertThat(result[3]).isFalse // refresh()
+        assertThat(result[4]).isFalse // refreshData(...) -> bloggingPromptCardSource.fetchPrompts(...) -> error
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSourceTest.kt
@@ -99,7 +99,7 @@ class BloggingPromptCardSourceTest : BaseUnitTest() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(isBloggingPromptFeatureEnabled)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
         whenever(appPrefsWrapper.getSkippedPromptDay(any())).thenReturn(null)
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(isBloggingPromptFeatureEnabled)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(isBloggingPromptFeatureEnabled)
     }
 
     /* GET DATA */
@@ -191,7 +191,7 @@ class BloggingPromptCardSourceTest : BaseUnitTest() {
     @Test
     fun `given build is invoked, when prompt is not active, then empty state is loaded`() = test {
         val result = mutableListOf<BloggingPromptUpdate>()
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(false)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(false)
         bloggingPromptCardSource.refresh.observeForever { }
 
         bloggingPromptCardSource.build(testScope(), SITE_LOCAL_ID).observeForever {
@@ -209,7 +209,7 @@ class BloggingPromptCardSourceTest : BaseUnitTest() {
         test {
             val result = mutableListOf<BloggingPromptUpdate>()
             whenever(bloggingPromptsStore.getPrompts(eq(siteModel))).thenReturn(flowOf(data))
-            whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(true)
+            whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(true)
             bloggingPromptCardSource.refresh.observeForever { }
 
             bloggingPromptCardSource.build(
@@ -231,7 +231,7 @@ class BloggingPromptCardSourceTest : BaseUnitTest() {
                 setIsPotentialBloggingSite(false)
             }
             whenever(selectedSiteRepository.getSelectedSite()).thenReturn(bloggingSite)
-            whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(false)
+            whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(false)
             bloggingPromptCardSource.refresh.observeForever { }
 
             bloggingPromptCardSource.build(

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -158,7 +158,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         activeTask = MutableLiveData()
         externalFocusPointEvents = mutableListOf()
         whenever(quickStartRepository.activeTask).thenReturn(activeTask)
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(false)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(false)
         whenever(bloggingPromptsStore.getPromptForDate(any(), any())).thenReturn(flowOf(bloggingPrompt))
         whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(false)
         viewModel = WPMainActivityViewModel(
@@ -432,7 +432,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
 
     @Test
     fun `bottom sheet does not show prompt card when prompts feature is not active`() = test {
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(false)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(false)
         startViewModelWithDefaultParameters()
         val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMPT }
         assertThat(hasBloggingPromptAction).isFalse()
@@ -440,7 +440,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
 
     @Test
     fun `bottom sheet does show prompt card when prompts feature is active`() = test {
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(true)
         startViewModelWithDefaultParameters()
         val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMPT }
         assertThat(hasBloggingPromptAction).isTrue()
@@ -448,7 +448,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
 
     @Test
     fun `bottom sheet does not show prompt card when site is self-hosted`() = test {
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(true)
         startViewModelWithDefaultParameters(isWpcomOrJpSite = false)
         val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMPT }
         assertThat(hasBloggingPromptAction).isFalse()
@@ -456,7 +456,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
 
     @Test
     fun `bottom sheet action is ANSWER_BLOGGING_PROMPT when the BP answer button is clicked`() = test {
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(true)
         startViewModelWithDefaultParameters()
         val action = viewModel.mainActions.value?.firstOrNull {
             it.actionType == ANSWER_BLOGGING_PROMPT
@@ -831,7 +831,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should track analytics event when onHelpPromptActionClicked is called`() = test {
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(true)
         startViewModelWithDefaultParameters()
         val action = viewModel.mainActions.value?.first {
             it.actionType == ANSWER_BLOGGING_PROMPT
@@ -842,7 +842,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should trigger openBloggingPromptsOnboarding when onHelpPromptActionClicked is called`() = test {
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(true)
         startViewModelWithDefaultParameters()
         val action = viewModel.mainActions.value?.first {
             it.actionType == ANSWER_BLOGGING_PROMPT
@@ -855,7 +855,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Suppress("MaxLineLength")
     fun `Should track BLOGGING_PROMPTS_CREATE_SHEET_CARD_VIEWED when onFabClicked is called and actions contains AnswerBloggingPromptAction`() =
         test {
-            whenever(bloggingPromptsSettingsHelper.isPromptsFeatureActive()).thenReturn(true)
+            whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(true)
             startViewModelWithDefaultParameters()
             viewModel.onFabClicked(initSite())
             verify(analyticsTrackerWrapper).track(Stat.BLOGGING_PROMPTS_CREATE_SHEET_CARD_VIEWED)

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.87.2'
     wordPressAztecVersion = 'v1.6.2'
-    wordPressFluxCVersion = '2.10.0'
+    wordPressFluxCVersion = '2645-1586c49b418dbee007805e9ba19188b0fb87a3ee'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.87.2'
     wordPressAztecVersion = 'v1.6.2'
-    wordPressFluxCVersion = '2645-1586c49b418dbee007805e9ba19188b0fb87a3ee'
+    wordPressFluxCVersion = 'trunk-5863df97d8427540a8326b995647433882ca0e48'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.2.0'


### PR DESCRIPTION
Part of #17803
Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2645

Add a **Site Setting** to enable / disable the Blogging Prompts feature, which controls the visibility of the dashboard card and action in the "Create Post" Floating Action Button. Currently, the setting only shows up for sites that are considered potential blogs (this might be changed in future PRs), with the Blogging Prompt feature flag ON, AND with the Blogging Prompt Enhancements FF ON as well.

I the BP Enhancements FF is off, then we consider only the original conditions for the feature to show up (Blogging Prompt FF ON and the site is a potential blog). The only change here (even without the FF) is that we no longer check for the prompt being included in the Blogging Reminders, as Prompts and Reminders are separate features and this Reminder-specific setting should not interfere with the Prompts feature visibility. (internal ref: p1675113452461219-slack-C01CW1VMLAF)

Demo:

https://user-images.githubusercontent.com/5091503/215863093-8bbd2929-7d33-48bc-9cf9-eeb84101b600.mp4


## To test:

### Setting only shows up with Enhancements FF on
1. Install Jetpack and log in
2. Open "Debug settings" and make sure `BloggingPromptsEnhancementsFeatureConfig` is disabled
3. Open "My Site" -> "MENU" -> "Site Settings" with a blog selected
7. **Verify** the `Blogging Prompts` setting is NOT available in the `General` section
8. Go back
9. Open "Debug settings" (avatar on top right -> App Settings -> Debug Settings) and enable `BloggingPromptsEnhancementsFeatureConfig` in "Features in Development" section
10. Tap the "Restart the app" button
3. Open "My Site" -> "MENU" -> "Site Settings" with a blog selected
7. **Verify** the `Blogging Prompts` setting is available in the `General` section

### Dashboard Card and FAB action shows up with Enhancements FF off
1. Install Jetpack and log in
2. Open "Debug settings" and make sure `BloggingPromptsEnhancementsFeatureConfig` is disabled
3. Choose a site that is a blog
7. **Verify** the `Blogging Prompts` card is available in the dashboard
8. Tap the FAB to create a post
9. **Verify** the `Blogging Prompts` action is available in the bottom sheet

### Dashboard Card and FAB action only shows up when BP setting is ON if Enhancements FF is ON
1. Install Jetpack and log in
3. Open "Debug settings" and enable `BloggingPromptsEnhancementsFeatureConfig` in "Features in Development" section
4. Tap the "Restart the app" button
5. Open "My Site" -> "MENU" -> "Site Settings" with a blog selected
6. Make sure the `Blogging Prompts` setting is ON in the `General` section
7. Go back to "My Site" -> "HOME"
8. **Verify** the `Blogging Prompts` card is available in the dashboard
9. Tap the FAB to create a post
10. **Verify** the `Blogging Prompts` action is available in the bottom sheet
11. Open "My Site" -> "MENU" -> "Site Settings" with a blog selected
12. Turn off the `Blogging Prompts` setting in the `General` section
7. Go back to "My Site" -> "HOME"
8. **Verify** the `Blogging Prompts` card is NOT available in the dashboard
9. Tap the FAB to create a post
10. **Verify** the `Blogging Prompts` action is NOT available in the bottom sheet

If possible, try going through the tests above selecting a site that is NOT a blog. The Prompts feature and setting should NOT be available at all on that type of site.

## Regression Notes
1. Potential unintended areas of impact
Unexpected behavior changes with the Enhancements Flag off, tracking for the Prompts card viewed being triggered even when the user disables it.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

7. What automated tests I added (or what prevented me from doing so)
Required unit tests were updated and new tests were added, especially for the new `BloggingPromptsSettingsHelper`.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.