### PR TITLE
Fix snackbar color in light color theme

### DIFF
--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -350,7 +350,7 @@
     </style>
 
     <style name="WordPress.SnackbarButton" parent="Widget.MaterialComponents.Button.TextButton.Snackbar">
-        <item name="android:textColor">@color/blue_30</item>
+        <item name="android:textColor">@color/primary_30</item>
     </style>
 
     <style name="WordPress.SnackbarText" parent="@style/Widget.MaterialComponents.Snackbar.TextView">


### PR DESCRIPTION
Fixes #17862 

The blue color from WordPress was hardcoded for the base theme (light). The fix was to use the `primary_30` color instead, which gets the appropriate color depending on the variant (blue for WP, green for JP).

![image](https://user-images.githubusercontent.com/5091503/216123776-f142731b-10fa-44e4-b2f5-f3cc87700492.png)

To test:
Open any snackbar in the app that has an action button.

Example:
1. Create a new post from the Home FAB
2. Give it a title
3. Hit back
5. **Verify** a snackbar saying the Draft was uploaded, with a "Publish" button is shown
6. **Verify** the color matches the expected color, depending on the app being used

## Regression Notes
1. Potential unintended areas of impact
Showing a green button on WordPress.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual Testing

8. What automated tests I added (or what prevented me from doing so)
None / style color change.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
