### PR TITLE
Jetpack Focus: Add hide option to switch to jetpack card menu items

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -141,6 +141,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         data class JetpackSwitchMenu(
             val onClick: ListItemInteraction,
             val onRemindMeLaterItemClick: ListItemInteraction,
+            val onHideMenuItemClick: ListItemInteraction,
             val onMoreMenuClick: ListItemInteraction
         ) : Card(Type.JETPACK_SWITCH_CARD)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -481,6 +481,7 @@ class MySiteViewModel @Inject constructor(
         val jetpackSwitchMenu = MySiteCardAndItem.Card.JetpackSwitchMenu(
             onClick = ListItemInteraction.create(this::onJetpackFeatureCardClick),
             onRemindMeLaterItemClick = ListItemInteraction.create(this::onSwitchToJetpackMenuCardRemindMeLaterClick),
+            onHideMenuItemClick = ListItemInteraction.create(this::onSwitchToJetpackMenuCardHideMenuItemClick),
             onMoreMenuClick = ListItemInteraction.create(this::onJetpackFeatureCardMoreMenuClick)
         ).takeIf {
             jetpackFeatureCardHelper.shouldShowSwitchToJetpackMenuCard()
@@ -1395,6 +1396,10 @@ class MySiteViewModel @Inject constructor(
         refresh()
     }
 
+    private fun onSwitchToJetpackMenuCardHideMenuItemClick() {
+        jetpackFeatureCardHelper.hideSwitchToJetpackMenuCard()
+        refresh()
+    }
     private fun onJetpackFeatureCardMoreMenuClick() {
         jetpackFeatureCardHelper.track(Stat.REMOVE_FEATURE_CARD_MENU_ACCESSED)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/JetpackFeatureCardHelper.kt
@@ -63,6 +63,14 @@ class JetpackFeatureCardHelper @Inject constructor(
         }
     }
 
+    private fun isSwitchToJetpackMenuCardHiddenByUser(): Boolean {
+        return jetpackFeatureRemovalPhaseHelper.getCurrentPhase()?.run {
+            appPrefsWrapper.getShouldHideSwitchToJetpackMenuCard(
+                this
+            )
+        } ?: false
+    }
+
     fun track(stat: Stat) {
         analyticsTrackerWrapper.track(
             stat,
@@ -103,7 +111,8 @@ class JetpackFeatureCardHelper @Inject constructor(
 
     fun shouldShowSwitchToJetpackMenuCard(): Boolean {
         return shouldShowSwitchToJetpackMenuCardInCurrentPhase() &&
-                exceedsShowFrequencyAndResetSwitchToJetpackMenuLastShownTimestampIfNeeded()
+                exceedsShowFrequencyAndResetSwitchToJetpackMenuLastShownTimestampIfNeeded() &&
+                !isSwitchToJetpackMenuCardHiddenByUser()
     }
 
     private fun shouldShowSwitchToJetpackMenuCardInCurrentPhase(): Boolean {
@@ -143,7 +152,12 @@ class JetpackFeatureCardHelper @Inject constructor(
             appPrefsWrapper.setJetpackFeatureCardLastShownTimestamp(it, currentTimeMillis)
         }
     }
-
+    fun hideSwitchToJetpackMenuCard() {
+        track(Stat.REMOVE_FEATURE_CARD_HIDE_TAPPED)
+        jetpackFeatureRemovalPhaseHelper.getCurrentPhase()?.let {
+            appPrefsWrapper.setShouldHideSwitchToJetpackMenuCard(it, true)
+        }
+    }
     companion object {
         const val PHASE = "phase"
         const val FREQUENCY_IN_DAYS = 4

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/SwitchToJetpackMenuCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jetpackfeature/SwitchToJetpackMenuCardViewHolder.kt
@@ -20,6 +20,7 @@ class SwitchToJetpackMenuCardViewHolder(
         switchToAppMoreIcon.setOnClickListener {
             showMoreMenu(
                 card.onRemindMeLaterItemClick,
+                card.onHideMenuItemClick,
                 card.onMoreMenuClick,
                 switchToAppMoreIcon,
             )
@@ -27,6 +28,7 @@ class SwitchToJetpackMenuCardViewHolder(
     }
 
     private fun showMoreMenu(
+        onHideClick: ListItemInteraction,
         onRemindMeLaterClick: ListItemInteraction,
         onMoreMenuClick: ListItemInteraction,
         anchor: View
@@ -37,6 +39,10 @@ class SwitchToJetpackMenuCardViewHolder(
             when (it.itemId) {
                 R.id.jetpack_card_menu_item_remind_me_later -> {
                     onRemindMeLaterClick.click()
+                    return@setOnMenuItemClickListener true
+                }
+                R.id.jetpack_card_menu_item_hide_this -> {
+                    onHideClick.click()
                     return@setOnMenuItemClickListener true
                 }
                 else -> return@setOnMenuItemClickListener true

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -180,7 +180,8 @@ public class AppPrefs {
         OPEN_WEB_LINKS_WITH_JETPACK,
         SHOULD_HIDE_JETPACK_FEATURE_CARD,
         JETPACK_FEATURE_CARD_LAST_SHOWN_TIMESTAMP,
-        SWITCH_TO_JETPACK_MENU_CARD_SHOWN_TIMESTAMP
+        SWITCH_TO_JETPACK_MENU_CARD_SHOWN_TIMESTAMP,
+        SHOULD_HIDE_SWITCH_TO_JETPACK_MENU_CARD,
     }
 
     /**
@@ -1559,5 +1560,17 @@ public class AppPrefs {
 
     public static void setSwitchToJetpackMenuCardLastShownTimestamp(final Long lastShownTimestamp) {
         setLong(DeletablePrefKey.SWITCH_TO_JETPACK_MENU_CARD_SHOWN_TIMESTAMP, lastShownTimestamp);
+    }
+
+    public static Boolean getShouldHideSwitchToJetpackMenuCard(JetpackFeatureRemovalPhase phase) {
+        return prefs().getBoolean(getHideSwitchToJetpackMenuCardWithPhaseKey(phase), false);
+    }
+
+    public static void setShouldHideSwitchToJetpackMenuCard(JetpackFeatureRemovalPhase phase, final boolean isHidden) {
+        prefs().edit().putBoolean(getHideSwitchToJetpackMenuCardWithPhaseKey(phase), isHidden).apply();
+    }
+
+    @NonNull private static String getHideSwitchToJetpackMenuCardWithPhaseKey(JetpackFeatureRemovalPhase phase) {
+        return DeletablePrefKey.SHOULD_HIDE_SWITCH_TO_JETPACK_MENU_CARD.name() + phase.getTrackingName();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -297,6 +297,12 @@ class AppPrefsWrapper @Inject constructor() {
         AppPrefs.setSwitchToJetpackMenuCardLastShownTimestamp(lastShownTimestamp)
     }
 
+    fun getShouldHideSwitchToJetpackMenuCard(jetpackFeatureRemovalPhase: JetpackFeatureRemovalPhase): Boolean =
+        AppPrefs.getShouldHideSwitchToJetpackMenuCard(jetpackFeatureRemovalPhase)
+
+    fun setShouldHideSwitchToJetpackMenuCard(jetpackFeatureRemovalPhase: JetpackFeatureRemovalPhase, isHidden: Boolean) =
+        AppPrefs.setShouldHideSwitchToJetpackMenuCard(jetpackFeatureRemovalPhase, isHidden)
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -300,7 +300,10 @@ class AppPrefsWrapper @Inject constructor() {
     fun getShouldHideSwitchToJetpackMenuCard(jetpackFeatureRemovalPhase: JetpackFeatureRemovalPhase): Boolean =
         AppPrefs.getShouldHideSwitchToJetpackMenuCard(jetpackFeatureRemovalPhase)
 
-    fun setShouldHideSwitchToJetpackMenuCard(jetpackFeatureRemovalPhase: JetpackFeatureRemovalPhase, isHidden: Boolean) =
+    fun setShouldHideSwitchToJetpackMenuCard(
+        jetpackFeatureRemovalPhase: JetpackFeatureRemovalPhase,
+        isHidden: Boolean
+    ) =
         AppPrefs.setShouldHideSwitchToJetpackMenuCard(jetpackFeatureRemovalPhase, isHidden)
 
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()

--- a/WordPress/src/main/res/menu/switch_to_jetpack_card_menu.xml
+++ b/WordPress/src/main/res/menu/switch_to_jetpack_card_menu.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-
     <item
         android:id="@+id/jetpack_card_menu_item_remind_me_later"
         android:title="@string/jetpack_feature_card_menu_item_remind_me_later"
         android:icon="@drawable/ic_time_white_24dp"/>
-    
+
+    <item
+        android:id="@+id/jetpack_card_menu_item_hide_this"
+        android:title="@string/jetpack_feature_card_menu_item_hide_this"
+        android:icon="@drawable/ic_not_visible_white_24dp"/>
 </menu>


### PR DESCRIPTION
Fixes #17858

This PR adds the "hide this" option to the `Switch to Jetpack` menu card for phase 4.

To test:
- Install the app and login
- Navigate to Me -> App Settings -> Debug Settings
- Enable `jp_removal_four` and restart the app
- Navigate back to the menu view
- Tap the 3 dots in the `Switch to Jetpack` menu item
-  ✅ Verify the `Hide` option is available
- Tap on the hide this item
-  ✅ Verify the Switch to Jetpack menu item is no longer visible
- Swipe the app closed and reopen
-  ✅ Verify the Switch to Jetpack menu item is not visible

## Regression Notes
1. Potential unintended areas of impact
The hide option is not shown

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
