### PR TITLE
Excludes self-hosted from user blocking and reporting

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 21.7
 -----
 * [*] [internal] Bump Aztec version to `1.6.3` [https://github.com/wordpress-mobile/WordPress-Android/pull/17852]
+* [*] Reader: Removes the option to block and report reader users for self-hosted sites [https://github.com/wordpress-mobile/WordPress-Android/pull/17866]
 
 21.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -57,7 +57,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
         menuItems.add(SpacerNoAction())
         menuItems.add(buildBlockSite(onButtonClicked))
         menuItems.add(buildReportPost(onButtonClicked))
-        menuItems.add(buildReportUser(onButtonClicked))
+        checkAndAddMenuItemForReportUser(post, menuItems, onButtonClicked)
         checkAndAddMenuItemForBlockUser(post, menuItems, onButtonClicked)
 
         return menuItems
@@ -202,6 +202,16 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
     ) {
         if (!readerUtilsWrapper.isSelfHosted(post.authorBlogId)) {
             menuItems.add(buildBlockUser(onButtonClicked))
+        }
+    }
+
+    private fun checkAndAddMenuItemForReportUser(
+        post: ReaderPost,
+        menuItems: MutableList<ReaderPostCardAction>,
+        onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
+    ) {
+        if (!readerUtilsWrapper.isSelfHosted(post.authorBlogId)) {
+            menuItems.add(buildReportUser(onButtonClicked))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -58,7 +58,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
         menuItems.add(buildBlockSite(onButtonClicked))
         menuItems.add(buildReportPost(onButtonClicked))
         menuItems.add(buildReportUser(onButtonClicked))
-        checkAndAddMenuItemForBlockUser(menuItems, onButtonClicked)
+        checkAndAddMenuItemForBlockUser(post, menuItems, onButtonClicked)
 
         return menuItems
     }
@@ -196,10 +196,13 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
         )
 
     private fun checkAndAddMenuItemForBlockUser(
+        post: ReaderPost,
         menuItems: MutableList<ReaderPostCardAction>,
         onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ) {
-        menuItems.add(buildBlockUser(onButtonClicked))
+        if (!readerUtilsWrapper.isSelfHosted(post.authorBlogId)) {
+            menuItems.add(buildBlockUser(onButtonClicked))
+        }
     }
 
     private fun buildBlockUser(onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit) =

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -57,8 +57,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
         menuItems.add(SpacerNoAction())
         menuItems.add(buildBlockSite(onButtonClicked))
         menuItems.add(buildReportPost(onButtonClicked))
-        checkAndAddMenuItemForReportUser(post, menuItems, onButtonClicked)
-        checkAndAddMenuItemForBlockUser(post, menuItems, onButtonClicked)
+        checkAndAddUserMenuItems(post, menuItems, onButtonClicked)
 
         return menuItems
     }
@@ -195,23 +194,14 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
             onClicked = onButtonClicked
         )
 
-    private fun checkAndAddMenuItemForBlockUser(
-        post: ReaderPost,
-        menuItems: MutableList<ReaderPostCardAction>,
-        onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
-    ) {
-        if (!readerUtilsWrapper.isSelfHosted(post.authorBlogId)) {
-            menuItems.add(buildBlockUser(onButtonClicked))
-        }
-    }
-
-    private fun checkAndAddMenuItemForReportUser(
+    private fun checkAndAddUserMenuItems(
         post: ReaderPost,
         menuItems: MutableList<ReaderPostCardAction>,
         onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ) {
         if (!readerUtilsWrapper.isSelfHosted(post.authorBlogId)) {
             menuItems.add(buildReportUser(onButtonClicked))
+            menuItems.add(buildBlockUser(onButtonClicked))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -546,4 +546,12 @@ public class ReaderUtils {
     public static boolean commentExists(long blogId, long postId, long commentId) {
         return ReaderCommentTable.commentExists(blogId, postId, commentId);
     }
+
+    /**
+     * Self-hosted sites have a site id of 0, but we use -1 to indicate a self-hosted site
+     * @param authorBlogId  site id of the post's author
+     */
+    public static boolean isSelfHosted(long authorBlogId) {
+        return authorBlogId < 1;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
@@ -59,4 +59,6 @@ class ReaderUtilsWrapper @Inject constructor(
         contextProvider.getContext(),
         numComments
     )
+
+    fun isSelfHosted(authorBlogId: Long) = ReaderUtils.isSelfHosted(authorBlogId)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilderTest.kt
@@ -338,7 +338,7 @@ class ReaderPostMoreButtonUiStateBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `does not contain block user action for wpcom sites`() = test {
+    fun `does not contain block user action for self-hosted sites`() = test {
         // Arrange
         val post = init()
         whenever(readerUtilsWrapper.isSelfHosted(post.authorId)).thenReturn(true)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilderTest.kt
@@ -244,13 +244,27 @@ class ReaderPostMoreButtonUiStateBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `contains report user action`() = test {
+    fun `contains report user action for wpcom sites`() = test {
         // Arrange
         val post = init()
+        whenever(readerUtilsWrapper.isSelfHosted(post.authorId)).thenReturn(false)
+
         // Act
         val menuItems = builder.buildMoreMenuItems(post, dummyOnClick)
         // Assert
         assertThat(menuItems.find { it.type == ReaderPostCardActionType.REPORT_USER }).isNotNull
+    }
+
+    @Test
+    fun `does not contain report user action for self-hosted sites`() = test {
+        // Arrange
+        val post = init()
+        whenever(readerUtilsWrapper.isSelfHosted(post.authorId)).thenReturn(true)
+
+        // Act
+        val menuItems = builder.buildMoreMenuItems(post, dummyOnClick)
+        // Assert
+        assertThat(menuItems.find { it.type == ReaderPostCardActionType.REPORT_USER }).isNull()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilderTest.kt
@@ -309,6 +309,34 @@ class ReaderPostMoreButtonUiStateBuilderTest : BaseUnitTest() {
         assertThat(menuItems.find { it.type == ReaderPostCardActionType.SPACER_NO_ACTION }).isNotNull
     }
 
+    @Test
+    fun `does contain block user action for wpcom sites`() = test {
+        // Arrange
+        val post = init()
+        whenever(readerUtilsWrapper.isSelfHosted(post.authorId)).thenReturn(false)
+
+        // Act
+        val menuItems = builder.buildMoreMenuItems(post, dummyOnClick)
+        // Assert
+        assertThat(menuItems.find {
+            it.type == ReaderPostCardActionType.BLOCK_USER
+        }).isNotNull()
+    }
+
+    @Test
+    fun `does not contain block user action for wpcom sites`() = test {
+        // Arrange
+        val post = init()
+        whenever(readerUtilsWrapper.isSelfHosted(post.authorId)).thenReturn(true)
+
+        // Act
+        val menuItems = builder.buildMoreMenuItems(post, dummyOnClick)
+        // Assert
+        assertThat(menuItems.find {
+            it.type == ReaderPostCardActionType.BLOCK_USER
+        }).isNull()
+    }
+
     private fun init(
         isFollowed: Boolean = false,
         isNotificationsEnabled: Boolean = false,


### PR DESCRIPTION
Fixes #17826

## Description
Excludes self-hosted from user blocking and reporting to avoid the inconsistent behaviour reported in https://github.com/wordpress-mobile/WordPress-Android/issues/17826 and erroneous user reporting for non WPCOM users.

|Before|After|
|---|---|
|![Screenshot_20230202_165826](https://user-images.githubusercontent.com/304044/216359830-ec00dac9-ec5e-43f7-ac9a-16ae17c753af.png)|![Screenshot_20230202_165913](https://user-images.githubusercontent.com/304044/216359842-fca2d16a-627f-456e-9471-f58a58283522.png)|

## To test:
### Self-hosted
1. In Reader, follow a self-hosted site
2. Tap on the option menu next to a site's post
3. **Verify** that the block user option is not present
4. **Verify** that the report user option is not present
### Sanity
1. In Reader, follow a wpcom site
2. Tap on the option menu next to a site's post
3. **Verify** that the block user option is present
4. **Verify** that the report user option is present

## Regression Notes
1. Potential unintended areas of impact
N/A

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and relied on existing reader test

7. What automated tests I added (or what prevented me from doing so)
Added 3 new test cases in `ReaderPostMoreButtonUiStateBuilderTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
