### PR TITLE
Enable the new landing screen in WordPress app

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+21.8
+-----
+* [*] [WordPress-only] We have redesigned the landing screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17871]
+
 21.7
 -----
 * [*] [internal] Bump Aztec version to `1.6.3` [https://github.com/wordpress-mobile/WordPress-Android/pull/17852]

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -103,7 +103,7 @@ android {
         buildConfigField "boolean", "READER_COMMENTS_MODERATION", "false"
         buildConfigField "boolean", "SITE_INTENT_QUESTION", "true"
         buildConfigField "boolean", "SITE_NAME", "false"
-        buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "false"
+        buildConfigField "boolean", "LANDING_SCREEN_REVAMP", "true"
         buildConfigField "boolean", "LAND_ON_THE_EDITOR", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS_LIST", "false"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/LandingScreenRevampFeatureConfig.kt
@@ -9,8 +9,4 @@ import javax.inject.Inject
  */
 @FeatureInDevelopment
 class LandingScreenRevampFeatureConfig
-@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.LANDING_SCREEN_REVAMP) {
-    override fun isEnabled(): Boolean {
-        return BuildConfig.IS_JETPACK_APP || super.isEnabled()
-    }
-}
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.LANDING_SCREEN_REVAMP)


### PR DESCRIPTION
Closes #17870

This PR enables the new landing screen in the WordPress app. Testing was already done as part of the project implementation.

To be merged only after the `release/21.7` branch is cut.

To test:
1. **Verify** CI checks pass.
2. Open WP and JP app
3. **Verify** The new landing screen is displayed when logged out

## Regression Notes
1. Potential unintended areas of impact
   N/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

3. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
