### PR TITLE
[Blogging Prompts Social] Create Feature Flag and use it for "View all answers"

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -108,6 +108,7 @@ android {
         buildConfigField "boolean", "BLOGGING_PROMPTS", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS_LIST", "false"
         buildConfigField "boolean", "BLOGGING_PROMPTS_ENHANCEMENTS", "false"
+        buildConfigField "boolean", "BLOGGING_PROMPTS_SOCIAL", "false"
         buildConfigField "boolean", "QUICK_START_EXISTING_USERS_V2", "false"
         buildConfigField "boolean", "QRCODE_AUTH_FLOW", "false"
         buildConfigField "boolean", "BETA_SITE_DESIGNS", "false"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -96,7 +96,8 @@ sealed class MySiteCardAndItemBuilderParams {
     data class BloggingPromptCardBuilderParams(
         val bloggingPrompt: BloggingPromptModel?,
         val showViewMoreAction: Boolean,
-        val enhancementsEnabled: Boolean,
+        val showViewAnswersAction: Boolean,
+        val showRemoveAction: Boolean,
         val onShareClick: (message: String) -> Unit,
         val onAnswerClick: (promptId: Int) -> Unit,
         val onSkipClick: () -> Unit,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -124,6 +124,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import org.wordpress.android.util.config.BloggingPromptsListFeatureConfig
+import org.wordpress.android.util.config.BloggingPromptsSocialFeatureConfig
 import org.wordpress.android.util.config.LandOnTheEditorFeatureConfig
 import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
@@ -177,6 +178,7 @@ class MySiteViewModel @Inject constructor(
     bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig,
     bloggingPromptsListFeatureConfig: BloggingPromptsListFeatureConfig,
     bloggingPromptsEnhancementsFeatureConfig: BloggingPromptsEnhancementsFeatureConfig,
+    bloggingPromptsSocialFeatureConfig: BloggingPromptsSocialFeatureConfig,
     private val jetpackBrandingUtils: JetpackBrandingUtils,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val bloggingPromptsCardAnalyticsTracker: BloggingPromptsCardAnalyticsTracker,
@@ -227,6 +229,7 @@ class MySiteViewModel @Inject constructor(
     private val isBloggingPromptsEnabled by lazy { bloggingPromptsFeatureConfig.isEnabled() }
     private val isBloggingPromptsListEnabled by lazy { bloggingPromptsListFeatureConfig.isEnabled() }
     private val isBloggingPromptsEnhancementsEnabled by lazy { bloggingPromptsEnhancementsFeatureConfig.isEnabled() }
+    private val isBloggingPromptsSocialEnabled by lazy { bloggingPromptsSocialFeatureConfig.isEnabled() }
 
     val isMySiteTabsEnabled: Boolean
         get() = isMySiteDashboardTabsEnabled &&
@@ -540,7 +543,8 @@ class MySiteViewModel @Inject constructor(
                         bloggingPromptUpdate?.promptModel
                     } else null,
                     showViewMoreAction = isBloggingPromptsListEnabled,
-                    enhancementsEnabled = isBloggingPromptsEnhancementsEnabled,
+                    showViewAnswersAction = isBloggingPromptsSocialEnabled,
+                    showRemoveAction = isBloggingPromptsEnhancementsEnabled,
                     onShareClick = this::onBloggingPromptShareClick,
                     onAnswerClick = this::onBloggingPromptAnswerClick,
                     onSkipClick = this::onBloggingPromptSkipClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class BloggingPromptCardBuilder @Inject constructor() {
     fun build(params: BloggingPromptCardBuilderParams) = params.bloggingPrompt?.let {
-        val trailingLabel = if (params.enhancementsEnabled) {
+        val trailingLabel = if (params.showViewAnswersAction) {
             UiStringRes(
                 R.string.my_site_blogging_prompt_card_view_answers
             )
@@ -38,12 +38,12 @@ class BloggingPromptCardBuilder @Inject constructor() {
             promptId = params.bloggingPrompt.id,
             attribution = BloggingPromptAttribution.fromString(params.bloggingPrompt.attribution),
             showViewMoreAction = params.showViewMoreAction,
-            showRemoveAction = params.enhancementsEnabled,
+            showRemoveAction = params.showRemoveAction,
             onShareClick = params.onShareClick,
             onAnswerClick = params.onAnswerClick,
             onSkipClick = params.onSkipClick,
             onViewMoreClick = params.onViewMoreClick,
-            onViewAnswersClick = params.onViewAnswersClick.takeIf { params.enhancementsEnabled },
+            onViewAnswersClick = params.onViewAnswersClick.takeIf { params.showViewAnswersAction },
             onRemoveClick = params.onRemoveClick,
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsSocialFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsSocialFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+@FeatureInDevelopment
+class BloggingPromptsSocialFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+    appConfig,
+    BuildConfig.BLOGGING_PROMPTS_SOCIAL,
+) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && BuildConfig.IS_JETPACK_APP
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -152,6 +152,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import org.wordpress.android.util.config.BloggingPromptsListFeatureConfig
+import org.wordpress.android.util.config.BloggingPromptsSocialFeatureConfig
 import org.wordpress.android.util.config.LandOnTheEditorFeatureConfig
 import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
@@ -258,6 +259,9 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var bloggingPromptsEnhancementsFeatureConfig: BloggingPromptsEnhancementsFeatureConfig
+
+    @Mock
+    lateinit var bloggingPromptsSocialFeatureConfig: BloggingPromptsSocialFeatureConfig
 
     @Mock
     lateinit var bloggingPromptsSettingsHelper: BloggingPromptsSettingsHelper
@@ -495,6 +499,7 @@ class MySiteViewModelTest : BaseUnitTest() {
             bloggingPromptsFeatureConfig,
             bloggingPromptsListFeatureConfig,
             bloggingPromptsEnhancementsFeatureConfig,
+            bloggingPromptsSocialFeatureConfig,
             jetpackBrandingUtils,
             appPrefsWrapper,
             bloggingPromptsCardAnalyticsTracker,
@@ -1798,13 +1803,13 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     @Suppress("SimplifyBooleanWithConstants")
-    fun `given blogging prompt card, when prompts enhancements FF is ON, view more action is shown`() = test {
-        initSelectedSite(isBloggingPromptsEnhancementsEnabled = true)
+    fun `given blogging prompt card, when prompts social FF is ON, view answers action is shown`() = test {
+        initSelectedSite(isBloggingPromptsSocialEnabled = true)
 
         verify(cardsBuilder).build(
             any(), any(), any(),
             argWhere {
-                it.bloggingPromptCardBuilderParams.enhancementsEnabled == true
+                it.bloggingPromptCardBuilderParams.showViewAnswersAction == true
             },
             any(),
             any()
@@ -1813,13 +1818,43 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     @Suppress("SimplifyBooleanWithConstants")
-    fun `given blogging prompt card, when prompts enhancements FF is OFF, view more action is not shown`() = test {
+    fun `given blogging prompt card, when prompts social FF is OFF, view answers action is not shown`() = test {
+        initSelectedSite(isBloggingPromptsSocialEnabled = false)
+
+        verify(cardsBuilder).build(
+            any(), any(), any(),
+            argWhere {
+                it.bloggingPromptCardBuilderParams.showViewAnswersAction == false
+            },
+            any(),
+            any()
+        )
+    }
+
+    @Test
+    @Suppress("SimplifyBooleanWithConstants")
+    fun `given blogging prompt card, when prompts enhancements FF is ON, remove action is shown`() = test {
+        initSelectedSite(isBloggingPromptsEnhancementsEnabled = true)
+
+        verify(cardsBuilder).build(
+            any(), any(), any(),
+            argWhere {
+                it.bloggingPromptCardBuilderParams.showRemoveAction == true
+            },
+            any(),
+            any()
+        )
+    }
+
+    @Test
+    @Suppress("SimplifyBooleanWithConstants")
+    fun `given blogging prompt card, when prompts enhancements FF is OFF, remove action is not shown`() = test {
         initSelectedSite(isBloggingPromptsEnhancementsEnabled = false)
 
         verify(cardsBuilder).build(
             any(), any(), any(),
             argWhere {
-                it.bloggingPromptCardBuilderParams.enhancementsEnabled == false
+                it.bloggingPromptCardBuilderParams.showRemoveAction == false
             },
             any(),
             any()
@@ -3226,6 +3261,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         isBloggingPromptsEnabled: Boolean = true,
         isBloggingPromptsListEnabled: Boolean = true,
         isBloggingPromptsEnhancementsEnabled: Boolean = true,
+        isBloggingPromptsSocialEnabled: Boolean = true,
         shouldShowJetpackBranding: Boolean = true
     ) {
         setUpDynamicCardsBuilder(isQuickStartDynamicCardEnabled)
@@ -3240,6 +3276,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsEnabled)
         whenever(bloggingPromptsListFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsListEnabled)
         whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsEnhancementsEnabled)
+        whenever(bloggingPromptsSocialFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsSocialEnabled)
         whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsEnabled)
         whenever(jetpackBrandingUtils.shouldShowJetpackBranding()).thenReturn(shouldShowJetpackBranding)
         if (isSiteUsingWpComRestApi) {
@@ -3483,7 +3520,7 @@ class MySiteViewModelTest : BaseUnitTest() {
             promptId = bloggingPromptId,
             attribution = BloggingPromptAttribution.DAY_ONE,
             showViewMoreAction = params.bloggingPromptCardBuilderParams.showViewMoreAction,
-            showRemoveAction = params.bloggingPromptCardBuilderParams.enhancementsEnabled,
+            showRemoveAction = params.bloggingPromptCardBuilderParams.showRemoveAction,
             onShareClick = onBloggingPromptShareClicked!!,
             onAnswerClick = onBloggingPromptAnswerClicked!!,
             onSkipClick = onBloggingPromptSkipClicked!!,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -201,7 +201,16 @@ class CardsBuilderTest {
                 todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                 postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                 bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
-                    mock(), false, false, mock(), mock(), mock(), mock(), mock(), mock(),
+                    mock(),
+                    false,
+                    false,
+                    false,
+                    mock(),
+                    mock(),
+                    mock(),
+                    mock(),
+                    mock(),
+                    mock(),
                 )
             ),
             quickLinkRibbonBuilderParams = QuickLinkRibbonBuilderParams(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -207,7 +207,7 @@ class CardsBuilderTest : BaseUnitTest() {
                 todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                 postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                 bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
-                    mock(), false, false, mock(), mock(), mock(), mock(), mock(), mock()
+                    mock(), false, false, false, mock(), mock(), mock(), mock(), mock(), mock()
                 )
             )
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
@@ -36,7 +36,7 @@ private val RESPONDENTS_IN_CARD = listOf(
     )
 )
 
-private val RESPONDENTS_IN_CARD_ENHANCEMENTS = listOf(
+private val RESPONDENTS_IN_CARD_VIEW_ANSWERS = listOf(
     AvatarItem("http://avatar1.url"),
     AvatarItem("http://avatar2.url"),
     AvatarItem("http://avatar3.url"),
@@ -101,17 +101,31 @@ class BloggingPromptCardBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given blogging prompt, when card is built with prompt enhancements, then return matching card`() {
-        val statCard = buildBloggingPromptCardBuilderParams(bloggingPrompt, enhancementsEnabled = true)
+    fun `given blogging prompt, when card is built showing view answers action, then return matching card`() {
+        val statCard = buildBloggingPromptCardBuilderParams(bloggingPrompt, showViewAnswersAction = true)
 
-        assertThat(statCard).isEqualTo(bloggingPromptCard(enhancementsEnabled = true))
+        assertThat(statCard).isEqualTo(bloggingPromptCard(showViewAnswersAction = true))
     }
 
     @Test
-    fun `given blogging prompt, when card is built without prompt enhancements, then return matching card`() {
-        val statCard = buildBloggingPromptCardBuilderParams(bloggingPrompt, enhancementsEnabled = false)
+    fun `given blogging prompt, when card is built without showing view answers action, then return matching card`() {
+        val statCard = buildBloggingPromptCardBuilderParams(bloggingPrompt, showViewAnswersAction = false)
 
-        assertThat(statCard).isEqualTo(bloggingPromptCard(enhancementsEnabled = false))
+        assertThat(statCard).isEqualTo(bloggingPromptCard(showViewAnswersAction = false))
+    }
+
+    @Test
+    fun `given blogging prompt, when card is built showing remove action, then return matching card`() {
+        val statCard = buildBloggingPromptCardBuilderParams(bloggingPrompt, showRemoveAction = true)
+
+        assertThat(statCard).isEqualTo(bloggingPromptCard(showRemoveAction = true))
+    }
+
+    @Test
+    fun `given blogging prompt, when card is built without remove answers action, then return matching card`() {
+        val statCard = buildBloggingPromptCardBuilderParams(bloggingPrompt, showRemoveAction = false)
+
+        assertThat(statCard).isEqualTo(bloggingPromptCard(showRemoveAction = false))
     }
 
     @Test
@@ -124,12 +138,14 @@ class BloggingPromptCardBuilderTest : BaseUnitTest() {
     private fun buildBloggingPromptCardBuilderParams(
         bloggingPrompt: BloggingPromptModel?,
         showViewMoreAction: Boolean = false,
-        enhancementsEnabled: Boolean = false,
+        showViewAnswersAction: Boolean = false,
+        showRemoveAction: Boolean = false,
     ) = builder.build(
         BloggingPromptCardBuilderParams(
             bloggingPrompt,
             showViewMoreAction,
-            enhancementsEnabled,
+            showViewAnswersAction,
+            showRemoveAction,
             onShareClick,
             onAnswerClick,
             onSkipClick,
@@ -148,21 +164,22 @@ class BloggingPromptCardBuilderTest : BaseUnitTest() {
 
     private fun bloggingPromptCard(
         showViewMoreAction: Boolean = false,
-        enhancementsEnabled: Boolean = false,
+        showViewAnswersAction: Boolean = false,
+        showRemoveAction: Boolean = false,
     ) = BloggingPromptCardWithData(
         prompt = UiStringText(PROMPT_TITLE),
-        respondents = if (enhancementsEnabled) RESPONDENTS_IN_CARD_ENHANCEMENTS else RESPONDENTS_IN_CARD,
+        respondents = if (showViewAnswersAction) RESPONDENTS_IN_CARD_VIEW_ANSWERS else RESPONDENTS_IN_CARD,
         numberOfAnswers = NUMBER_OF_RESPONDENTS,
         false,
         promptId = 123,
         attribution = BloggingPromptAttribution.DAY_ONE,
         showViewMoreAction = showViewMoreAction,
-        showRemoveAction = enhancementsEnabled,
+        showRemoveAction = showRemoveAction,
         onShareClick = onShareClick,
         onAnswerClick = onAnswerClick,
         onSkipClick = onSkipClick,
         onViewMoreClick = onViewMoreClick,
-        onViewAnswersClick = if (enhancementsEnabled) onViewAnswersClick else null,
+        onViewAnswersClick = if (showViewAnswersAction) onViewAnswersClick else null,
         onRemoveClick = onRemoveClick,
     )
 }


### PR DESCRIPTION
Fixes #17854 

Create a new `FeatureInDevelopment` flag for prompt social features: `BloggingPromptsSocialFeatureConfig`. Hide the "View all answers" action behind this new flag instead of using the Enhancements FF.

Demo:

https://user-images.githubusercontent.com/5091503/216432988-b4505302-de85-4882-b553-ffe13682da0b.mp4

## To test:

Same steps to from the "To test" section from #17800 should be done, but enabling / disabling the new `BloggingPromptsSocialFeatureConfig` `FeatureInDevelopment` flag. Here they are:

1. Install Jetpack and log in
2. Open "Debug settings" and make sure `BloggingPromptsSocialFeatureConfig` is disabled ("Features in Development" section)
3. Open "My Site" -> "HOME" with a blog selected
4. **Verify** the Blogging Prompts card is shown
5. **Verify** the text close to the Avatars says "<number> answers" and is not clickable
6. Open "Debug settings" and enable `BloggingPromptsSocialFeatureConfig` (click "Restart the app" to apply)
7. Open "My Site" -> "HOME" with a blog selected
8. **Verify** the Blogging Prompts card is shown
9. **Verify** the text close to the Avatars says "View all responses"
10. Tap either the avatars or the "View all responses" text
11. **Verify** event tracked: `blogging_prompts_my_site_card_view_answers_tapped`
12. **Verify** the Reader is opened for tag `dailyprompt-<prompt-id>`
13. **Verify** event tracked: `reader_tag_previewed, Properties: {"tag":"dailyprompt-<prompt-id>", "source":"blogging_prompts_my_site_card_view_answers"}`

Go over the same steps with the `BloggingPromptsEnhancementsFeatureConfig` turned on to make sure that in both situations the steps and verifications above work as expected.

## Regression Notes
1. Potential unintended areas of impact
Showing or hiding other enhancements-related features.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit testing.

3. What automated tests I added (or what prevented me from doing so)
Updated and added unit tests for checking the new flag and feature toggling.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
