### PR TITLE
[Blogging Prompts Enhancements] Blogging section in site settings

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -121,8 +121,8 @@ public class MySitesPage {
         onData(allOf(
                 instanceOf(WPPreference.class),
                 withKey(getTranslatedString(R.string.pref_key_blogging_reminders)),
-                withTitleText(getTranslatedString(R.string.site_settings_blogging_reminders_and_prompts_title))))
-                .onChildView(withText(getTranslatedString(R.string.site_settings_blogging_reminders_and_prompts_title)))
+                withTitleText(getTranslatedString(R.string.site_settings_blogging_reminders_title))))
+                .onChildView(withText(getTranslatedString(R.string.site_settings_blogging_reminders_title)))
                 .perform(click());
 
         idleFor(4000);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -2041,7 +2041,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void removeBloggingPromptsSettings() {
-        WPPrefUtils.removePreference(this, R.string.pref_key_site_general, R.string.pref_key_blogging_prompts);
+        WPPrefUtils.removePreference(this, R.string.pref_key_blogging, R.string.pref_key_blogging_prompts);
     }
 
     private void removePrivateOptionFromPrivacySetting() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -507,8 +507,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        initBloggingReminders();
-        initBloggingPrompts();
+        initBloggingSection();
     }
 
     private AppCompatActivity getAppCompatActivity() {
@@ -1228,6 +1227,15 @@ public class SiteSettingsFragment extends PreferenceFragment
         bottomSheet.show((getAppCompatActivity()).getSupportFragmentManager(), TIMEZONE_BOTTOM_SHEET_TAG);
     }
 
+    private void initBloggingSection() {
+        initBloggingReminders();
+        initBloggingPrompts();
+
+        // check if there's still any blogging settings visible, if not remove the whole section
+        PreferenceCategory blogging = (PreferenceCategory) findPreference(getString(R.string.pref_key_blogging));
+        if (blogging.getPreferenceCount() == 0) removeBloggingSection();
+    }
+
     private void initBloggingReminders() {
         if (mBloggingRemindersPref == null || !isAdded()) {
             return;
@@ -1236,10 +1244,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (!mBloggingRemindersFeatureConfig.isEnabled()) {
             removeBloggingRemindersSettings();
         } else {
-            if (mBloggingPromptsFeatureConfig.isEnabled()) {
-                mBloggingRemindersPref.setTitle(R.string.site_settings_blogging_reminders_and_prompts_title);
-            }
-
             mBloggingRemindersViewModel = new ViewModelProvider(getAppCompatActivity(), mViewModelFactory)
                     .get(BloggingRemindersViewModel.class);
             BloggingReminderUtils.observeBottomSheet(
@@ -2037,11 +2041,15 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void removeBloggingRemindersSettings() {
-        WPPrefUtils.removePreference(this, R.string.pref_key_site_general, R.string.pref_key_blogging_reminders);
+        WPPrefUtils.removePreference(this, R.string.pref_key_blogging, R.string.pref_key_blogging_reminders);
     }
 
     private void removeBloggingPromptsSettings() {
         WPPrefUtils.removePreference(this, R.string.pref_key_blogging, R.string.pref_key_blogging_prompts);
+    }
+
+    private void removeBloggingSection() {
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_blogging);
     }
 
     private void removePrivateOptionFromPrivacySetting() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1232,7 +1232,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         initBloggingPrompts();
 
         // check if there's still any blogging settings visible, if not remove the whole section
-        PreferenceCategory blogging = (PreferenceCategory) findPreference(getString(R.string.pref_key_blogging));
+        final PreferenceCategory blogging = (PreferenceCategory) findPreference(getString(R.string.pref_key_blogging));
         if (blogging.getPreferenceCount() == 0) removeBloggingSection();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
@@ -248,7 +248,7 @@ public class NotificationsSettingsDialogPreference extends DialogPreference
 
     private void addBloggingReminderSetting(LinearLayout view) {
         view.addView(setupClickSettingView(
-                getContext().getString(R.string.site_settings_blogging_reminders_title),
+                getContext().getString(R.string.site_settings_blogging_reminders_notification_title),
                 mBloggingRemindersProvider != null ? mBloggingRemindersProvider.getSummary(mBlogId) : null,
                 true,
                 (v -> {

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -34,7 +34,6 @@
     <string name="pref_key_site_tagline" translatable="false">wp_pref_site_tagline</string>
     <string name="pref_key_site_address" translatable="false">wp_pref_site_address</string>
     <string name="pref_key_site_language" translatable="false">wp_pref_site_language</string>
-    <string name="pref_key_blogging_prompts" translatable="false">wp_pref_blogging_prompts</string>
     <string name="pref_key_site_visibility" translatable="false">wp_pref_site_visibility</string>
     <string name="pref_key_site_username" translatable="false">wp_pref_site_username</string>
     <string name="pref_key_site_password" translatable="false">wp_pref_site_password</string>
@@ -47,7 +46,6 @@
     <string name="pref_key_site_date_format" translatable="false">wp_pref_site_date_format</string>
     <string name="pref_key_site_time_format" translatable="false">wp_pref_site_time_format</string>
     <string name="pref_key_site_timezone" translatable="false">wp_pref_site_timezone</string>
-    <string name="pref_key_blogging_reminders" translatable="false">wp_pref_blogging_reminders</string>
     <string name="pref_key_site_posts_per_page" translatable="false">wp_pref_site_post_per_page</string>
     <string name="pref_key_site_amp" translatable="false">wp_pref_site_amp</string>
     <string name="pref_key_site_traffic" translatable="false">wp_pref_site_traffic</string>
@@ -90,6 +88,10 @@
     <string name="pref_key_web_address" translatable="false">wp_pref_key_web_address</string>
     <string name="pref_key_change_password" translatable="false">pref_key_change_password</string>
     <string name="pref_key_site_start_over_screen" translatable="false">wp_pref_key_site_start_over_screen</string>
+    <!-- Front page settings -->
+    <string name="pref_key_blogging" translatable="false">wp_pref_key_blogging</string>
+    <string name="pref_key_blogging_reminders" translatable="false">wp_pref_blogging_reminders</string>
+    <string name="pref_key_blogging_prompts" translatable="false">wp_pref_blogging_prompts</string>
     <!-- Front page settings -->
     <string name="pref_key_homepage" translatable="false">wp_pref_key_homepage</string>
     <string name="pref_key_homepage_settings" translatable="false">wp_pref_key_homepage_settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -612,6 +612,7 @@
     <string name="site_settings_traffic_header">Traffic</string>
     <string name="site_settings_performance">Performance</string>
     <string name="site_settings_homepage">Homepage</string>
+    <string name="site_settings_blogging">Blogging</string>
 
     <!-- Preference Titles -->
     <string name="site_settings_title_title">Site Title</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -635,9 +635,9 @@
     <string name="site_settings_time_format_title">Time Format</string>
     <string name="site_settings_timezone_title">Timezone</string>
     <string name="site_settings_timezone_subtitle">Choose a city in your timezone</string>
-    <string name="site_settings_blogging_reminders_title">Blogging reminders</string>
-    <string name="site_settings_blogging_prompts_title">Blogging Prompts</string>
-    <string name="site_settings_blogging_reminders_and_prompts_title">Reminders and prompts</string>
+    <string name="site_settings_blogging_reminders_title">Reminders</string>
+    <string name="site_settings_blogging_prompts_title">Show prompts</string>
+    <string name="site_settings_blogging_reminders_notification_title">Blogging reminders</string>
     <string name="site_settings_posts_per_page_title">Posts per page</string>
     <string name="site_settings_format_entry_custom">Custom</string>
     <string name="site_settings_format_hint_custom">Custom format</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -58,6 +58,14 @@
             android:key="@string/pref_key_site_timezone"
             android:title="@string/site_settings_timezone_title" />
 
+    </PreferenceCategory>
+
+    <!-- Blogging settings -->
+    <PreferenceCategory
+        android:id="@+id/pref_blogging"
+        android:key="@string/pref_key_blogging"
+        android:title="@string/site_settings_blogging">
+
         <org.wordpress.android.ui.prefs.WPPreference
             android:id="@+id/pref_blogging_reminders"
             android:key="@string/pref_key_blogging_reminders"


### PR DESCRIPTION
Part of #17803 

Create a "Blogging" section in the site settings for blogging-specific settings. Also update the settings names to match the new spec: "Reminders" and "Show prompts".

## To test:

1. Install Jetpack and log in
2. Open "Debug settings" and make sure `BloggingPromptsEnhancementsFeatureConfig` is **enabled** ("Features in Development" section) and `blogging_reminders_remote_field` is also **enabled**
3. Open "My Site" -> "Menu" with a blog selected
4. Tap "Site Settings"
5. **Verify** the "Blogging" section is shown
6. **Verify** the settings "Reminders" and "Show prompts" are visible inside the "Blogging" section
2. Open "Debug settings" and turn off `BloggingPromptsEnhancementsFeatureConfig`
3. Open "My Site" -> "Menu" with a blog selected
4. Tap "Site Settings"
5. **Verify** the "Blogging" section is shown
6. **Verify* only the "Reminders" setting is available
2. Open "Debug settings" and turn **on** `BloggingPromptsEnhancementsFeatureConfig`, then turn **off** `blogging_reminders_remote_field`
3. Open "My Site" -> "Menu" with a blog selected
4. Tap "Site Settings"
5. **Verify** the "Blogging" section is shown
6. **Verify** only the "Show prompts" setting is available
2. Open "Debug settings" and turn **off** both `BloggingPromptsEnhancementsFeatureConfig` and `blogging_reminders_remote_field`
3. Open "My Site" -> "Menu" with a blog selected
4. Tap "Site Settings"
5. **Verify** the "Blogging" section is NOT shown

It could be good to also test the setting behaves as expected, even though the code in this PR didn't change that. And also test it is working as expected in WordPress app as well.

## Regression Notes
1. Potential unintended areas of impact
Show / hide settings incorrectly (prompts / reminders).

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
