### PR TITLE
[Blogging Prompts List] Turn prompts list feature flag on

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsListFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsListFeatureConfig.kt
@@ -4,7 +4,7 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-@Feature(BloggingPromptsListFeatureConfig.BLOGGING_PROMPTS_LIST_REMOTE_FIELD, false)
+@Feature(BloggingPromptsListFeatureConfig.BLOGGING_PROMPTS_LIST_REMOTE_FIELD, true)
 class BloggingPromptsListFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
     appConfig,


### PR DESCRIPTION
Fixes #17879 

Make the default value of the `BloggingPromptsListFeatureConfig` `true`.

To test:
1. Uninstall Jetpack (to make sure the local settings are cleared)
2. Install Jetpack from this build
3. Login and select a blogging site
4. Go to `My Site` -> `HOME`
5. **Verify** Prompts card is shown
6. Tap the overflow menu in the Prompts card
7. **Verify** the `View more prompts` option is shown
8. Tap the option
9. **Verify** the prompts list is shown

## Regression Notes
1. Potential unintended areas of impact
N/A

10. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

11. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
