### PR TITLE
[Blogging Prompts and Reminders] Update copies to match spec

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4047,8 +4047,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_reminders_notification_time">Notification time</string>
     <string name="set_your_blogging_prompts_title">Become a better writer by building a habit</string>
     <string name="post_publishing_set_up_blogging_prompts_message">Posting regularly attracts new readers. Tell us when you want to write and we\’ll send you a reminder!</string>
-    <string name="blogging_reminders_prompt_title">Include daily prompt</string>
-    <string name="blogging_reminders_prompt_subtitle">Reminder will include a daily prompt</string>
+    <string name="blogging_reminders_prompt_title">Include a Blogging Prompt</string>
+    <string name="blogging_reminders_prompt_subtitle">Notification will include a word or short phrase for inspiration</string>
     <string name="blogging_prompt_set_reminders">Set reminders</string>
 
     <!-- Stats module disabled error view -->
@@ -4108,11 +4108,11 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_prompts_notification_dismiss">Dismiss</string>
 
     <!-- Blogging Prompts Onboarding -->
-    <string name="blogging_prompts_onboarding_header_title">Introducing Prompts</string>
+    <string name="blogging_prompts_onboarding_header_title">Introducing\nBlogging Prompts</string>
     <string name="blogging_prompts_onboarding_content_top">The best way to become a better writer is to build a writing habit and share with others — that’s where Prompts come in!</string>
     <string name="blogging_prompts_onboarding_content_bottom">We’ll show you a new prompt each day on your dashboard to help get those creative juices flowing!</string>
     <string name="blogging_prompts_onboarding_content_note_title">Note:</string>
-    <string name="blogging_prompts_onboarding_content_note_content">You can learn more and set up reminders at any time in My Site &gt; Settings &gt; Blogging Reminders</string>
+    <string name="blogging_prompts_onboarding_content_note_content">You can control Blogging Prompts and Reminders at any time in My Site &gt; Settings &gt; Blogging</string>
     <string name="blogging_prompts_onboarding_try_it_now">Try it now</string>
     <string name="blogging_prompts_onboarding_remind_me">Remind me</string>
     <string name="blogging_prompts_onboarding_got_it">Got it</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1816,7 +1816,7 @@
     <style name="BloggingPromptsOnboardingTitle">
         <item name="android:textSize">@dimen/text_sz_double_extra_large</item>
         <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="android:maxLines">1</item>
+        <item name="android:maxLines">2</item>
         <item name="android:ellipsize">end</item>
         <item name="android:textStyle">bold</item>
         <item name="android:fontFamily">serif</item>


### PR DESCRIPTION
Fixes #17883

Some strings specs were changed (see issue for details).

![image](https://user-images.githubusercontent.com/5091503/216706512-1a2ecab0-380c-44d5-bc7b-dd5b8c08c5d6.png)

![image](https://user-images.githubusercontent.com/5091503/216706562-bcc46e4f-67e2-419a-afb7-421244f7c3d3.png)

To test:
1. Install Jetpack
2. Select a blogging site
3. **Verify** prompts card is shown
4. Tap the overflow menu in the card
5. Tap "Learn more"
6. **Check** the strings match the new spec
7. Go back
8. Go to `My Site` > `Menu`
9. Tap `Site Settings`
10. Tap `Blogging reminders`
11. Tap any day
12. **Check** the prompt option string matches the new spec

## Regression Notes
1. Potential unintended areas of impact
N/A

14. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

15. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
