### PR TITLE
Fix showing sale domain item when it should've been free

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewHolder.kt
@@ -51,20 +51,20 @@ class DomainSuggestionsViewHolder(
 
     private fun getFormattedCost(suggestion: DomainSuggestionItem) = when {
         suggestion.isFree -> suggestion.cost
-        suggestion.isOnSale -> {
+        suggestion.isFreeWithCredits -> {
             HtmlCompat.fromHtml(
                 String.format(
-                    container.context.getString(R.string.domain_suggestions_list_item_cost_on_sale),
-                    suggestion.saleCost,
+                    container.context.getString(R.string.domain_suggestions_list_item_cost_free),
                     suggestion.cost
                 ),
                 HtmlCompat.FROM_HTML_MODE_LEGACY
             )
         }
-        suggestion.isFreeWithCredits -> {
+        suggestion.isOnSale -> {
             HtmlCompat.fromHtml(
                 String.format(
-                    container.context.getString(R.string.domain_suggestions_list_item_cost_free),
+                    container.context.getString(R.string.domain_suggestions_list_item_cost_on_sale),
+                    suggestion.saleCost,
                     suggestion.cost
                 ),
                 HtmlCompat.FROM_HTML_MODE_LEGACY


### PR DESCRIPTION
There was a bug that users eligible for free domains saw sales on the domain when it should've been free. This fixes the bug.

> **Note** for the reviewer
> I just changed the order of cases in when expression. Because `isOnSale` was before `isFreeWithCredits` and that was caused to show the sale without checking the free case.

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/216692377-d2b325f3-5e0d-4934-bcec-63ecbc34e067.png" height=600>|<img src="https://user-images.githubusercontent.com/2471769/216691936-de9ca3e0-9a87-4d5b-aba6-2d5744b517cc.png" height=600>|

Fixes #17885 

To test:
1. Log into an account with a site on a Personal WordPress.com plan for higher where the free domain hasn't been claimed yet.
2. Switch to the MENU view of the My Site tab
3. Tap on the "Register Domain" box
4. In the domain suggestions, notice that domains on sale (e.g. .blog) show "Free for the first year".

## Regression Notes
1. Potential unintended areas of impact
Other types of domains could be affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
~~A test could be added, but it needs refactoring. I skipped it for this PR in order to ship this fix on `21.7`. I'll open a separate PR for refactoring and adding a test.~~ [See my comment](https://github.com/wordpress-mobile/WordPress-Android/pull/17887#issuecomment-1422998140)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
