### PR TITLE
[Dependency Updates] Update `androidxWorkManagerVersion` to 2.7.1

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -393,7 +393,6 @@ dependencies {
     implementation "androidx.preference:preference:$androidxPreferenceVersion"
     implementation "androidx.work:work-runtime:$androidxWorkManagerVersion"
     implementation "androidx.work:work-runtime-ktx:$androidxWorkManagerVersion"
-    implementation "androidx.work:work-gcm:$androidxWorkManagerVersion" // GCMNetworkManager on api <= 22
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel:$androidxLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -391,9 +391,9 @@ dependencies {
     implementation "androidx.percentlayout:percentlayout:$androidxPercentlayoutVersion"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeToRefreshVersion"
     implementation "androidx.preference:preference:$androidxPreferenceVersion"
-    implementation "androidx.work:work-runtime:$androidxWorkVersion"
-    implementation "androidx.work:work-runtime-ktx:$androidxWorkVersion"
-    implementation "androidx.work:work-gcm:$androidxWorkVersion" // GCMNetworkManager on api <= 22
+    implementation "androidx.work:work-runtime:$androidxWorkManagerVersion"
+    implementation "androidx.work:work-runtime-ktx:$androidxWorkManagerVersion"
+    implementation "androidx.work:work-gcm:$androidxWorkManagerVersion" // GCMNetworkManager on api <= 22
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel:$androidxLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
@@ -495,7 +495,7 @@ dependencies {
         exclude group: 'com.android.support.test.uiautomator', module: 'uiautomator-v18'
     }
     androidTestImplementation (name:'cloudtestingscreenshotter_lib', ext:'aar') // Screenshots on Firebase Cloud Testing
-    androidTestImplementation "androidx.work:work-testing:$androidxWorkVersion"
+    androidTestImplementation "androidx.work:work-testing:$androidxWorkManagerVersion"
     androidTestImplementation "com.google.dagger:hilt-android-testing:$gradle.ext.daggerVersion"
     kaptAndroidTest "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
     // Necessary because of the failing android tests

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext {
     androidxRoomVersion = '2.3.0'
     androidxSwipeToRefreshVersion = '1.1.0'
     androidxViewpager2Version = '1.0.0'
-    androidxWorkVersion = "2.7.0"
+    androidxWorkManagerVersion = "2.7.0"
     apacheCommonsTextVersion = '1.10.0'
     coilComposeVersion = '1.4.0'
     chrisbanesPhotoviewVersion = '2.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext {
     androidxRoomVersion = '2.3.0'
     androidxSwipeToRefreshVersion = '1.1.0'
     androidxViewpager2Version = '1.0.0'
-    androidxWorkManagerVersion = "2.7.0"
+    androidxWorkManagerVersion = "2.7.1"
     apacheCommonsTextVersion = '1.10.0'
     coilComposeVersion = '1.4.0'
     chrisbanesPhotoviewVersion = '2.3.0'


### PR DESCRIPTION
Parent #17564

This PR update `androidxWorkManagerVersion` to [2.7.1](https://developer.android.com/jetpack/androidx/releases/work#2.7.1).

Also, this PR removes the extra `androidx.work:work-gcm` dependency which adds supported the use of `GCMNetworkManager` as a scheduler when Google Play Services is available for API levels <= 22 (ea2c854989d84afe36c335c6b6129f60ad913781).

-----

PS: @ravishanker I added you as the main reviewer, that is, in addition to the @wordpress-mobile/apps-infrastructure team itself, but not entirely randomly as I am seeing you having some experience on working with these workers/schedulers, and want someone from the WordPress team to be aware of and sign-off on that change for WPAndroid.

-----

To test:

1. See the dependency tree diff result and verify correctness.
2. Thoroughly smoke test any work manager related functionality on both, the WordPress and Jetpack apps, and see if they both work as expected.
3. In addition to the above smoke test, you can expand the below and follow the inner and more explicit test steps within (although verifying on `UploadWorker.kt` should be enough):

<details>
  <summary>1. UploadWorker.kt</summary> 

- Go to `Post` screen.
- Create a new post and publish it.
- Turn device offline.
- Go to this post and update it.
- Notice the warning message: `We'll publish the post when your device is back online.`
- Turn device online.
- Notice this post being automatically uploaded.
- Open this post on a web browser and verify the post is indeed updated.

</details>

<details>
  <summary>2. ReminderWorker.kt</summary> 

- Go to `Site Settings` screen.
- Find the `Blogging` section, click on `Reminders`, toggle-on every day and click on `Update`.
- Notice the `All set!` bottom sheet appearing, click `Done`.
- Close the app, preferably swipe the app off.
- Go to the device's `Settings` app, find the `Date & Time` section, turn `Automatic date & time` off.
- Set the device's date to a day after today.
- Open the app.
- Verify the ` Blogging Reminders` notification appearing. For example, the notification title could be `Daily Prompt`, while the notification description something like `Is there anything you feel too old to do anymore?`.

</details>

<details>
  <summary>3. LocalNotificationWorker.kt</summary> 

- (❓) I am not sure how to test this functionality as I can't easily find the entry point to it.
- (❗️) All I could do to test this was to manually comment out the if check within the `CreateSiteNotificationScheduler.scheduleCreateSiteNotificationIfNeeded()` function and verified that the `LocalNotificationWorker.doWork()` function was called after setting the device's date to day/week after today.

</details>

<details>
  <summary>4. WeeklyRoundupWorker.kt</summary> 

- (❓) I am not sure how to test this functionality as I can't easily find the entry point to it.
- (❗️) All I could do to test this was to manually comment out the if check within the `CreateSiteNotificationScheduler.scheduleCreateSiteNotificationIfNeeded()` function and verified that the `LocalNotificationWorker.doWork()` function was called after setting the device's date to day/week after today.

</details>

-----
## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on any or all scheduling related app functionalities, like post/page offline-to-online upload, blogging reminders, weekly roundup and local notifications.
    - The `androidx.work:work-gcm` that got removed might be causing some kind of misbehaviour (see ea2c854989d84afe36c335c6b6129f60ad913781). Cc @malinajirka as an extra pair of eyes on that. 🙏 

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

5. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
