### PR TITLE
[Dependency Updates] Remove Media Dependency

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -382,7 +382,6 @@ dependencies {
     implementation "androidx.activity:activity-ktx:$androidxActivityVersion"
     implementation "androidx.fragment:fragment:$androidxFragmentVersion"
     implementation "androidx.fragment:fragment-ktx:$androidxFragmentVersion"
-    implementation "androidx.media:media:$androidxMediaVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "androidx.appcompat:appcompat-resources:$androidxAppcompatVersion"
     implementation "androidx.cardview:cardview:$androidxCardviewVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ ext {
     androidxFragmentVersion = '1.5.5'
     androidxGridlayoutVersion = '1.0.0'
     androidxLifecycleVersion = '2.5.1'
-    androidxMediaVersion = '1.0.1'
     androidxPercentlayoutVersion = '1.0.0'
     androidxPreferenceVersion = '1.1.0'
     androidxRecyclerviewVersion = '1.0.0'


### PR DESCRIPTION
Parent #17566

This PR is about removing the (seemingly) unnecessary `Media` dependency from this project so as to stop maintaining and supporting updates on it. This `Media` related dependency was added as part the migration process to `AndroidX` for this module back in Jun 2019 (see #9977 and more specifically this b7ac12d358f7238beb0ca48fc56916ff3c6b4128 commit).

There is no `androidx.media` usage in this project. As such, this leftover from back then can be now safely removed.

-----

FYI: However, there exist a number of transitive dependencies that are using 'androidx.media', those are the below:

1. `com.zendesk:support`
2. `com.google.android.exoplayer:exoplayer`
3. `project :libs:editor`
4. `org.wordpress:login`

<details>
  <summary>Transitive Dependencies for Media</summary> 

```
...
com.zendesk:support
    com.zendesk:guide
        androidx.legacy:legacy-support-v4
            androidx.media:media
...
com.google.android.exoplayer:exoplayer
    com.google.android.exoplayer:exoplayer-ui
        androidx.media:media
...
project :libs:editor
    org.wordpress:aztec
        androidx.legacy:legacy-support-v4
            androidx.media:media
    ...
    org.wordpress-mobile.gutenberg-mobile:react-native-gutenberg-bridge
        com.github.wordpress-mobile:react-native-video
            com.google.android.exoplayer:exoplayer
                com.google.android.exoplayer:exoplayer-ui
                    androidx.media:media
            ...
            androidx.media:media
...
org.wordpress:login
    androidx.media:media
...
```

</details>

From the above 4 dependencies that are using `androidx.media` via a transitive dependency:

1. For `com.zendesk:support`, this `Media` related dependency is part of the legacy `AndroidX Support V4` dependency. Thus, I recommend that this `Media` transitive  dependency is not added explicitly, just because of those legacy `AndroidX Support V4` dependencies.
2. For `com.google.android.exoplayer:exoplayer`, this `Media` related dependency is closely related to `Exoplayer UI`. Now, as soon as this is updated, its `Media` dependency should be updated as well, most probably to newer versions of [Media 2](https://developer.android.com/jetpack/androidx/releases/media2), or even the [Media 3](https://developer.android.com/jetpack/androidx/releases/media3) libraries. Thus, I recommend that this `Media` transitive dependency is not added explicitly, just because of that `ExoPlayer` dependency, which will get its transitive dependencies updated on itself being updated to newer versions.
3. For `org.wordpress:aztec'/'org.wordpress-mobile.gutenberg-mobile`, flowing through the `:libs:editor` project dependency, this `Media` related dependency of theirs is part of either the legacy `AndroidX Support V4` dependency or the `ExoPlayer` player dependency. As per the two above points, I recommend that this `Media` transitive dependency is not added explicitly, just because of those.
4. For `org.wordpress:login`, this `Media` related dependency was also added as part the migration process to `AndroidX` (see [login#21](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/21) and more specifically this [login#d3dc35035ae5266039dd9d93b359704c375b8fd2](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/21/commits/d3dc35035ae5266039dd9d93b359704c375b8fd2) commit).

As such, and even though the `Dependency Analysis` plugin recommends to declare this `androidx.media` dependency directly (see below), for the above reasons, this dependency is removed nevertheless.

<details>
  <summary>Dependency Analysis for Media</summary> 

```
Transitively used dependencies that should be declared directly as indicated:
  ...
  implementation 'androidx.media:media:1.2.1'
  ...
```

</details>

-----

PS: @zwarm I added you as the main reviewer, that is, in addition to the @wordpress-mobile/apps-infrastructure team itself, but randomly, since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid.

-----

To test:

1. See the dependency tree diff result and verify correctness.
2. Smoke test any media related functionality on both, the WordPress and Jetpack apps, and see if they both work as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on media related functionalities.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
