### PR TITLE
[Blogging Prompts Enhancements] Fix prompt setting reset after reminder is changed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersModelMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersModelMapper.kt
@@ -30,7 +30,8 @@ class BloggingRemindersModelMapper
             }.toSet(),
             uiModel.hour,
             uiModel.minute,
-            uiModel.isPromptIncluded
+            uiModel.isPromptIncluded,
+            uiModel.isPromptsCardEnabled,
         )
     }
 
@@ -40,7 +41,8 @@ class BloggingRemindersModelMapper
             domainModel.enabledDays.map { DayOfWeek.valueOf(it.name) }.toSet(),
             domainModel.hour,
             domainModel.minute,
-            domainModel.isPromptIncluded
+            domainModel.isPromptIncluded,
+            domainModel.isPromptsCardEnabled,
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersUiModel.kt
@@ -12,7 +12,8 @@ data class BloggingRemindersUiModel(
     val enabledDays: Set<DayOfWeek> = setOf(),
     val hour: Int,
     val minute: Int,
-    val isPromptIncluded: Boolean
+    val isPromptIncluded: Boolean,
+    val isPromptsCardEnabled: Boolean,
 ) {
     fun getNotificationTime(): CharSequence =
         LocalTime.of(hour, minute).format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -81,7 +81,7 @@ class BloggingRemindersViewModel @Inject constructor(
                 Screen.SELECTION -> daySelectionBuilder.buildPrimaryButton(
                     bloggingRemindersModel,
                     isFirstTimeFlow == true,
-                    this::showEpilogue
+                    this::onSelectionButtonClick
                 )
                 Screen.EPILOGUE -> epilogueBuilder.buildPrimaryButton(finish)
             }
@@ -173,7 +173,7 @@ class BloggingRemindersViewModel @Inject constructor(
         return Pair(currentState.hour, currentState.minute)
     }
 
-    private fun showEpilogue(bloggingRemindersModel: BloggingRemindersUiModel?) {
+    private fun onSelectionButtonClick(bloggingRemindersModel: BloggingRemindersUiModel?) {
         analyticsTracker.trackPrimaryButtonPressed(Screen.SELECTION)
         if (bloggingRemindersModel != null) {
             launch {
@@ -212,6 +212,7 @@ class BloggingRemindersViewModel @Inject constructor(
             outState.putInt(SELECTED_HOUR, model.hour)
             outState.putInt(SELECTED_MINUTE, model.minute)
             outState.putBoolean(IS_BLOGGING_PROMPT_INCLUDED, model.isPromptIncluded)
+            outState.putBoolean(IS_PROMPTS_CARD_ENABLED, model.isPromptsCardEnabled)
         }
         _isFirstTimeFlow.value?.let {
             outState.putBoolean(IS_FIRST_TIME_FLOW, it)
@@ -228,12 +229,14 @@ class BloggingRemindersViewModel @Inject constructor(
             val selectedHour = state.getInt(SELECTED_HOUR)
             val selectedMinute = state.getInt(SELECTED_MINUTE)
             val isPromptIncluded = state.getBoolean(IS_BLOGGING_PROMPT_INCLUDED)
+            val isPromptsCardEnabled = state.getBoolean(IS_PROMPTS_CARD_ENABLED)
             _bloggingRemindersModel.value = BloggingRemindersUiModel(
                 siteId,
                 enabledDays,
                 selectedHour,
                 selectedMinute,
-                isPromptIncluded
+                isPromptIncluded,
+                isPromptsCardEnabled,
             )
         }
         _isFirstTimeFlow.value = state.getBoolean(IS_FIRST_TIME_FLOW)
@@ -298,6 +301,7 @@ class BloggingRemindersViewModel @Inject constructor(
         private const val SELECTED_HOUR = "key_selected_hour"
         private const val SELECTED_MINUTE = "key_selected_minute"
         private const val IS_BLOGGING_PROMPT_INCLUDED = "key_is_blogging_prompt_included"
+        private const val IS_PROMPTS_CARD_ENABLED = "key_is_prompts_card_enabled"
         private const val IS_FIRST_TIME_FLOW = "is_first_time_flow"
         private const val SITE_ID = "key_site_id"
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1283,7 +1283,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                 .getPromptsCardEnabledLiveData(mSite.getId())
                 .observe(getAppCompatActivity(), isEnabled -> {
                     if (mBloggingPromptsPref != null) {
-                        mBloggingPromptsPref.setDefaultValue(isEnabled);
+                        mBloggingPromptsPref.setChecked(isEnabled);
                     }
                 });
     }

--- a/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/bloggingreminders/resolver/BloggingRemindersHelperTest.kt
@@ -68,7 +68,7 @@ class BloggingRemindersHelperTest : BaseUnitTest() {
     private val userSetBloggingRemindersModel = BloggingRemindersModel(validLocalId, setOf(MONDAY), 5, 43, false)
     private val defaultBloggingRemindersModel = BloggingRemindersModel(validLocalId)
     private val bloggingRemindersUiModel = BloggingRemindersUiModel(
-        validLocalId, setOf(DayOfWeek.MONDAY), 5, 43, false
+        validLocalId, setOf(DayOfWeek.MONDAY), 5, 43, isPromptIncluded = false, isPromptsCardEnabled = false,
     )
 
     @Before

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTrackerTest.kt
@@ -137,7 +137,7 @@ class BloggingRemindersAnalyticsTrackerTest {
     @Test
     fun `trackRemindersScheduled tracks correct event and properties`() {
         bloggingRemindersUiModel = BloggingRemindersUiModel(
-            1, setOf(MONDAY, THURSDAY, FRIDAY), 14, 30, true
+            1, setOf(MONDAY, THURSDAY, FRIDAY), 14, 30, isPromptIncluded = true, isPromptsCardEnabled = true,
         )
         bloggingRemindersAnalyticsTracker.trackRemindersScheduled(
             bloggingRemindersUiModel.enabledDays.size, bloggingRemindersUiModel.getNotificationTime24hour()

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
@@ -81,7 +81,13 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `builds UI model with no selected days`() {
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, hour = hour, minute = minute, isPromptIncluded = false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            hour = hour,
+            minute = minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
         val dayLabel = UiStringText("Not set")
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
             .thenReturn(dayLabel)
@@ -104,7 +110,8 @@ class DaySelectionBuilderTest {
             setOf(WEDNESDAY, SUNDAY),
             hour,
             minute,
-            isPromptIncluded = false
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
         )
         val dayLabel = UiStringText("Twice a week")
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
@@ -123,7 +130,13 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `click on a day select day`() {
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, hour = hour, minute = minute, isPromptIncluded = false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            hour = hour,
+            minute = minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel)).thenReturn(UiStringText("Once a week"))
 
         val uiModel = daySelectionBuilder.buildSelection(
@@ -142,7 +155,13 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `primary button disabled when model is empty and is first time flow`() {
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, hour = hour, minute = minute, isPromptIncluded = false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            hour = hour,
+            minute = minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
 
         val primaryButton = daySelectionBuilder.buildPrimaryButton(bloggingRemindersModel, true, onConfirm)
 
@@ -162,7 +181,8 @@ class DaySelectionBuilderTest {
             setOf(WEDNESDAY, SUNDAY),
             hour,
             minute,
-            isPromptIncluded = false
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
         )
 
         val primaryButton = daySelectionBuilder.buildPrimaryButton(bloggingRemindersModel, true, onConfirm)
@@ -178,7 +198,13 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `primary button enabled when model is empty and is not first time flow`() {
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, hour = hour, minute = minute, isPromptIncluded = false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            hour = hour,
+            minute = minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
 
         val primaryButton = daySelectionBuilder.buildPrimaryButton(bloggingRemindersModel, false, onConfirm)
 
@@ -200,7 +226,8 @@ class DaySelectionBuilderTest {
             setOf(WEDNESDAY, SUNDAY),
             hour,
             minute,
-            isPromptIncluded = false
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
         )
 
         val primaryButton = daySelectionBuilder.buildPrimaryButton(bloggingRemindersModel, true, onConfirm)
@@ -216,7 +243,14 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `click on primary button confirm selection`() {
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute, false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            setOf(WEDNESDAY, SUNDAY),
+            hour,
+            minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
 
         val primaryButton = daySelectionBuilder.buildPrimaryButton(bloggingRemindersModel, false, onConfirm)
 
@@ -229,7 +263,14 @@ class DaySelectionBuilderTest {
     fun `include prompt switch is visible when days are selected`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
 
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute, false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            setOf(WEDNESDAY, SUNDAY),
+            hour,
+            minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
         val dayLabel = UiStringText("Twice a week")
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
             .thenReturn(dayLabel)
@@ -248,7 +289,13 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `include prompt switch is not visible when days are not selected`() {
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, hour = hour, minute = minute, isPromptIncluded = false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            hour = hour,
+            minute = minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
         val dayLabel = UiStringText("Not set")
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
             .thenReturn(dayLabel)
@@ -269,7 +316,14 @@ class DaySelectionBuilderTest {
     fun `single include prompt switch is visible when FF is on`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
 
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute, false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            setOf(WEDNESDAY, SUNDAY),
+            hour,
+            minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
         val dayLabel = UiStringText("Twice a week")
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
             .thenReturn(dayLabel)
@@ -290,7 +344,14 @@ class DaySelectionBuilderTest {
     fun `include prompt switch is not visible when FF is off`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
 
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute, false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            setOf(WEDNESDAY, SUNDAY),
+            hour,
+            minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
         val dayLabel = UiStringText("Twice a week")
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
             .thenReturn(dayLabel)
@@ -311,7 +372,14 @@ class DaySelectionBuilderTest {
     fun `click on a prompt switch toggles the prompt state`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
 
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute, false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            setOf(WEDNESDAY, SUNDAY),
+            hour,
+            minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
         val dayLabel = UiStringText("Twice a week")
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
             .thenReturn(dayLabel)
@@ -334,7 +402,14 @@ class DaySelectionBuilderTest {
     fun `click on a blogging prompt help button shows blogging prompt dialog`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
 
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(WEDNESDAY, SUNDAY), hour, minute, false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            setOf(WEDNESDAY, SUNDAY),
+            hour,
+            minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
         val dayLabel = UiStringText("Twice a week")
         whenever(dayLabelUtils.buildNTimesLabel(bloggingRemindersModel))
             .thenReturn(dayLabel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/EpilogueBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/EpilogueBuilderTest.kt
@@ -53,7 +53,14 @@ class EpilogueBuilderTest {
 
     @Test
     fun `builds UI model with no selected days`() {
-        val bloggingRemindersModel = BloggingRemindersUiModel(1, setOf(), hour, minute, false)
+        val bloggingRemindersModel = BloggingRemindersUiModel(
+            1,
+            setOf(),
+            hour,
+            minute,
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
+        )
         val uiModel = epilogueBuilder.buildUiItems(bloggingRemindersModel)
 
         assertModelWithNoSelection(uiModel)
@@ -66,7 +73,8 @@ class EpilogueBuilderTest {
             setOf(DayOfWeek.WEDNESDAY, DayOfWeek.SUNDAY),
             hour,
             minute,
-            false
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
         )
         val dayLabel = "twice"
         whenever(dayLabelUtils.buildLowercaseNTimesLabel(bloggingRemindersModel))
@@ -97,7 +105,8 @@ class EpilogueBuilderTest {
             DayOfWeek.values().toSet(),
             hour,
             minute,
-            false
+            isPromptIncluded = false,
+            isPromptsCardEnabled = false,
         )
         val message = "You'll get reminders to blog <b>everyday</b> at <b>10:00 am</b>."
         whenever(


### PR DESCRIPTION
Fixes #17893

Prompts and Reminders settings share the same FluxC model to be persisted, so we need to propagate the whole model value to the Reminders UI model to make sure it will be persisted properly and not reset.


https://user-images.githubusercontent.com/5091503/217286930-b54312bf-7bc2-46ac-b283-e2b0adc9e994.mp4

This also fixes the issue of not properly setting the initial value for the `Show prompts` setting, see this PR's comments for more details.

To test:
1. Select a blogging site
2. Go to `My Site` -> `Menu`
3. Tap `Site Settings`
4. Turn off the `Show prompts` option
5. Set up `Reminders` 
6. **Verify** `Show prompts` keeps its value
7. Clear `Reminders`
8. **Verify** `Show prompts` keeps its value
9. Turn on the `Show prompts` option
5. Set up `Reminders` 
6. **Verify** `Show prompts` keeps its value
7. Clear `Reminders`
8. **Verify** `Show prompts` keeps its value

## Regression Notes
1. Potential unintended areas of impact
N/A

10. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

11. What automated tests I added (or what prevented me from doing so)
Updated existing tests and added new test to avoid regression on this bug.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
