### PR TITLE
Adds: remote feature flag for Jetpack blaze

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -130,6 +130,7 @@ android {
         buildConfigField "boolean", "OPEN_WEB_LINKS_WITH_JETPACK_FLOW", "false"
         buildConfigField "boolean", "ENABLE_WORDPRESS_SUPPORT_FORUM", "false"
         buildConfigField "boolean", "JETPACK_INSTALL_FULL_PLUGIN", "false"
+        buildConfigField "boolean", "ENABLE_BLAZE_FEATURE", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BlazeFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BlazeFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val BLAZE_FEATURE_REMOTE_FIELD = "blaze"
+
+@Feature(BLAZE_FEATURE_REMOTE_FIELD, false)
+class BlazeFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.ENABLE_BLAZE_FEATURE,
+    BLAZE_FEATURE_REMOTE_FIELD
+)


### PR DESCRIPTION
Closes: 17907

## What? 
This PR adds a remote feature flag to the debug settings to turn on/ turn off the blaze features

## Testing?
- Go to app -> Login 
- Go to app settings -> Debug settings 
- Verify that `blaze` is present and the value is false 

 ## Screenshots (optional)
<img src="https://user-images.githubusercontent.com/17463767/217315223-2219cb0a-732c-444b-b149-31694aae65e3.png" width="150" height="280">


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What did I to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
