### PR TITLE
[Crash Fix] Don't use same LiveData for Prompts card tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -322,6 +322,7 @@ class MySiteViewModel @Inject constructor(
                 trackCardsAndItemsShownIfNeeded(state)
 
                 bloggingPromptsCardTrackHelper.onDashboardCardsUpdated(
+                    viewModelScope,
                     state.dashboardCardsAndItems.filterIsInstance<DashboardCards>().firstOrNull()
                 )
 
@@ -345,7 +346,6 @@ class MySiteViewModel @Inject constructor(
 
     init {
         dispatcher.register(this)
-        bloggingPromptsCardTrackHelper.initialize(viewModelScope)
     }
 
     @Suppress("LongParameterList")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -10,14 +10,11 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.asFlow
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.map
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.R
@@ -191,6 +188,7 @@ class MySiteViewModel @Inject constructor(
     private val jetpackFeatureRemovalUtils: JetpackFeatureRemovalOverlayUtil,
     private val jetpackFeatureCardHelper: JetpackFeatureCardHelper,
     private val bloggingPromptsSettingsHelper: BloggingPromptsSettingsHelper,
+    private val bloggingPromptsCardTrackHelper: BloggingPromptsCardTrackHelper,
 ) : ScopedViewModel(mainDispatcher) {
     private var isDefaultTabSet: Boolean = false
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
@@ -322,25 +320,21 @@ class MySiteViewModel @Inject constructor(
                 )
                 selectDefaultTabIfNeeded()
                 trackCardsAndItemsShownIfNeeded(state)
+
+                bloggingPromptsCardTrackHelper.onDashboardCardsUpdated(
+                    state.dashboardCardsAndItems.filterIsInstance<DashboardCards>().firstOrNull()
+                )
+
                 state
             } else {
                 buildNoSiteState()
             }
+
+            bloggingPromptsCardTrackHelper.onSiteChanged(site?.id)
+
             UiModel(currentAvatarUrl.orEmpty(), state)
         }
     }
-
-    private val bloggingPromptsCardTrackHelper = BloggingPromptsCardTrackHelper(
-        scope = viewModelScope,
-        tracker = bloggingPromptsCardAnalyticsTracker,
-        siteIdFlow = state.asFlow().map { it.site?.id },
-        dashboardCardsFlow = uiModel.asFlow()
-            .map { it.state as? SiteSelected }
-            .filterNotNull()
-            .map {
-                it.dashboardCardsAndItems.filterIsInstance<DashboardCards>()
-            }
-    )
 
     private fun CardsUpdate.checkAndShowSnackbarError() {
         if (showSnackbarError) {
@@ -351,6 +345,7 @@ class MySiteViewModel @Inject constructor(
 
     init {
         dispatcher.register(this)
+        bloggingPromptsCardTrackHelper.initialize(viewModelScope)
     }
 
     @Suppress("LongParameterList")
@@ -1008,11 +1003,11 @@ class MySiteViewModel @Inject constructor(
         mySiteSourceManager.refresh()
     }
 
-    fun onResume() {
+    fun onResume(currentTab: MySiteTabType) {
         mySiteSourceManager.onResume(isSiteSelected)
         isSiteSelected = false
         checkAndShowQuickStartNotice()
-        bloggingPromptsCardTrackHelper.onResume(quickStartRepository.currentTab)
+        bloggingPromptsCardTrackHelper.onResume(currentTab)
     }
 
     fun clearActiveQuickStartTask() {
@@ -1433,6 +1428,7 @@ class MySiteViewModel @Inject constructor(
         jetpackFeatureCardHelper.hideSwitchToJetpackMenuCard()
         refresh()
     }
+
     private fun onJetpackFeatureCardMoreMenuClick() {
         jetpackFeatureCardHelper.track(Stat.REMOVE_FEATURE_CARD_MENU_ACCESSED)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -501,7 +501,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
 
     override fun onResume() {
         super.onResume()
-        viewModel.onResume()
+        viewModel.onResume(mySiteTabType)
     }
 
     override fun onPause() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/BloggingPromptsCardTrackHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/BloggingPromptsCardTrackHelperTest.kt
@@ -1,10 +1,8 @@
 package org.wordpress.android.ui.mysite
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Before
@@ -22,13 +20,12 @@ import org.wordpress.android.ui.mysite.tabs.MySiteTabType
 @ExperimentalCoroutinesApi
 class BloggingPromptsCardTrackHelperTest : BaseUnitTest() {
     private val bloggingPromptsCardAnalyticsTracker: BloggingPromptsCardAnalyticsTracker = mock()
-    private lateinit var siteIdFlow: MutableSharedFlow<Int?>
-    private lateinit var dashboardCardsFlow: MutableSharedFlow<List<DashboardCards>>
+
+    private lateinit var helper: BloggingPromptsCardTrackHelper
 
     @Before
     fun setUp() {
-        siteIdFlow = MutableSharedFlow()
-        dashboardCardsFlow = MutableSharedFlow()
+        helper = BloggingPromptsCardTrackHelper(bloggingPromptsCardAnalyticsTracker, testDispatcher())
     }
 
     @Suppress("MaxLineLength")
@@ -36,19 +33,20 @@ class BloggingPromptsCardTrackHelperTest : BaseUnitTest() {
     fun `given onResume was called in dashboard, when dashboard cards are received with prompts card, then track once`() =
         test {
             launch {
-                val helper = createBloggingPromptsCardTrackHelper()
                 helper.onResume(MySiteTabType.DASHBOARD)
 
-                // emit with prompt card (transient state)
-                dashboardCardsFlow.emit(
-                    listOf(DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>())))
+                // with prompt card (transient state)
+                helper.onDashboardCardsUpdated(
+                    this,
+                    DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>()))
                 )
 
                 delay(10)
 
-                // emit again with prompt card (final state) to test debounce
-                dashboardCardsFlow.emit(
-                    listOf(DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>())))
+                // again with prompt card (final state) to test debounce
+                helper.onDashboardCardsUpdated(
+                    this,
+                    DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>()))
                 )
 
                 advanceUntilIdle()
@@ -65,19 +63,20 @@ class BloggingPromptsCardTrackHelperTest : BaseUnitTest() {
     fun `given onResume was called in dashboard, when dashboard cards are received without prompts card, then don't track`() =
         test {
             launch {
-                val helper = createBloggingPromptsCardTrackHelper()
                 helper.onResume(MySiteTabType.DASHBOARD)
 
-                // emit with prompt card (transient state)
-                dashboardCardsFlow.emit(
-                    listOf(DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>())))
+                // with prompt card (transient state)
+                helper.onDashboardCardsUpdated(
+                    this,
+                    DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>()))
                 )
 
                 delay(10)
 
-                // emit again without prompt card (final state) to test debounce
-                dashboardCardsFlow.emit(
-                    listOf(DashboardCards(listOf()))
+                // again without prompt card (final state) to test debounce
+                helper.onDashboardCardsUpdated(
+                    this,
+                    DashboardCards(listOf())
                 )
 
                 advanceUntilIdle()
@@ -95,18 +94,18 @@ class BloggingPromptsCardTrackHelperTest : BaseUnitTest() {
     fun `given dashboard cards were received with prompts card, when onResume is called in dashboard, then track once`() =
         test {
             launch {
-                val helper = createBloggingPromptsCardTrackHelper()
-
-                // emit with prompt card (transient state)
-                dashboardCardsFlow.emit(
-                    listOf(DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>())))
+                // with prompt card (transient state)
+                helper.onDashboardCardsUpdated(
+                    this,
+                    DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>()))
                 )
 
                 delay(10)
 
-                // emit again with prompt card (final state) to test debounce
-                dashboardCardsFlow.emit(
-                    listOf(DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>())))
+                // again with prompt card (final state) to test debounce
+                helper.onDashboardCardsUpdated(
+                    this,
+                    DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>()))
                 )
 
                 advanceUntilIdle()
@@ -125,18 +124,18 @@ class BloggingPromptsCardTrackHelperTest : BaseUnitTest() {
     fun `given dashboard cards were received without prompts card, when onResume is called in dashboard, then don't track`() =
         test {
             launch {
-                val helper = createBloggingPromptsCardTrackHelper()
-
-                // emit with prompt card (transient state)
-                dashboardCardsFlow.emit(
-                    listOf(DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>())))
+                // with prompt card (transient state)
+                helper.onDashboardCardsUpdated(
+                    this,
+                    DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>()))
                 )
 
                 delay(10)
 
-                // emit again without prompt card (final state) to test debounce
-                dashboardCardsFlow.emit(
-                    listOf(DashboardCards(listOf()))
+                // again without prompt card (final state) to test debounce
+                helper.onDashboardCardsUpdated(
+                    this,
+                    DashboardCards(listOf())
                 )
 
                 advanceUntilIdle()
@@ -154,12 +153,12 @@ class BloggingPromptsCardTrackHelperTest : BaseUnitTest() {
     fun `given onResume was called in menu, when dashboard cards are received with prompts card, then don't track`() =
         test {
             launch {
-                val helper = createBloggingPromptsCardTrackHelper()
                 helper.onResume(MySiteTabType.SITE_MENU)
 
-                // emit with prompt card (final state)
-                dashboardCardsFlow.emit(
-                    listOf(DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>())))
+                // with prompt card (final state)
+                helper.onDashboardCardsUpdated(
+                    this,
+                    DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>()))
                 )
 
                 advanceUntilIdle()
@@ -175,11 +174,10 @@ class BloggingPromptsCardTrackHelperTest : BaseUnitTest() {
     fun `given dashboard cards were received with prompts card, when onResume is called in menu, then don't track`() =
         test {
             launch {
-                val helper = createBloggingPromptsCardTrackHelper()
-
-                // emit with prompt card (final state)
-                dashboardCardsFlow.emit(
-                    listOf(DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>())))
+                // with prompt card (final state)
+                helper.onDashboardCardsUpdated(
+                    this,
+                    DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>()))
                 )
 
                 advanceUntilIdle()
@@ -196,25 +194,25 @@ class BloggingPromptsCardTrackHelperTest : BaseUnitTest() {
     @Test
     fun `given new site selected, when dashboard cards are updated with prompt card, then track once`() = test {
         launch {
-            val helper = createBloggingPromptsCardTrackHelper()
-
             // old site did not have prompt card
-            dashboardCardsFlow.emit(
-                listOf(DashboardCards(listOf()))
+            helper.onDashboardCardsUpdated(
+                this,
+                DashboardCards(listOf())
             )
 
             // simulate the user was here for a while
             delay(1000L)
 
             // new site selected
-            siteIdFlow.emit(1)
+            helper.onSiteChanged(1)
 
             // screen resumed
             helper.onResume(MySiteTabType.DASHBOARD)
 
             // dashboard cards updated with prompt card
-            dashboardCardsFlow.emit(
-                listOf(DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>())))
+            helper.onDashboardCardsUpdated(
+                this,
+                DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>()))
             )
 
             advanceUntilIdle()
@@ -229,25 +227,25 @@ class BloggingPromptsCardTrackHelperTest : BaseUnitTest() {
     @Test
     fun `given new site selected, when dashboard cards are updated without prompt card, then don't track`() = test {
         launch {
-            val helper = createBloggingPromptsCardTrackHelper()
-
             // old site had prompt card
-            dashboardCardsFlow.emit(
-                listOf(DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>())))
+            helper.onDashboardCardsUpdated(
+                this,
+                DashboardCards(listOf<DashboardCard>(mock<BloggingPromptCardWithData>()))
             )
 
             // simulate the user was here for a while
             delay(1000L)
 
             // new site selected
-            siteIdFlow.emit(1)
+            helper.onSiteChanged(1)
 
             // screen resumed
             helper.onResume(MySiteTabType.DASHBOARD)
 
             // dashboard cards updated without prompt card
-            dashboardCardsFlow.emit(
-                listOf(DashboardCards(listOf()))
+            helper.onDashboardCardsUpdated(
+                this,
+                DashboardCards(listOf())
             )
 
             advanceUntilIdle()
@@ -258,11 +256,4 @@ class BloggingPromptsCardTrackHelperTest : BaseUnitTest() {
             cancel()
         }
     }
-
-    private fun CoroutineScope.createBloggingPromptsCardTrackHelper() = BloggingPromptsCardTrackHelper(
-        this,
-        bloggingPromptsCardAnalyticsTracker,
-        siteIdFlow,
-        dashboardCardsFlow
-    )
 }


### PR DESCRIPTION
Fixes #17917 

The issue here was the usage of some of the `LiveData` for doing the prompts card tracking logic in the `BloggingPromptsCardTrackHelper`. Those data objects were also used for updating the UI and it seems using them as a source for `Flows` was causing problems.

The logic inside `BloggingPromptsCardTrackHelper` was simplified to use simple calls, coroutines, without needing complex Flows nor to capture `CoroutineScope`s. The code is definitely better now that it's simpler.

https://user-images.githubusercontent.com/5091503/217375754-c6f01539-1124-4283-95c7-9d0482ce080b.mov

To test:
1. Log in to a WP.com account
2. Select any site
3. Go to the `My Site` -> `Home` screen
4. Add a self-hosted site
5. Switch between the two

Crashes should no longer be happening when switching between self-hosted and wp.com sites.

## Regression Notes
1. Potential unintended areas of impact
Prompts card tracking.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests.

3. What automated tests I added (or what prevented me from doing so)
Updated unit tests related to this logic.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
