### PR TITLE
[UI Tests] - Run Jetpack tests locally

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -93,7 +93,8 @@ public class LoginFlow {
 
         // Follow the magic link to continue login
         // Intent is invoked directly rather than through a browser as WireMock is unavailable once in the background
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("wordpress://magic-login?token=valid_token"))
+        final String appVariant = BuildConfig.FLAVOR_app;
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(appVariant + "://magic-login?token=valid_token"))
                 .setPackage(getApplicationContext().getPackageName());
         ActivityScenario.launch(intent);
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
@@ -132,8 +132,7 @@ public class BlockEditorPage {
     }
 
     public void dismissBloggingRemindersAlertIfNeeded() {
-        ViewInteraction bloggingRemindersAlertTitle = onView(withText(R.string.set_your_blogging_reminders_title));
-
+        ViewInteraction bloggingRemindersAlertTitle = onView(withId(R.id.title));
         if (waitForElementToBeDisplayedWithoutFailure(bloggingRemindersAlertTitle)) {
             bloggingRemindersAlertTitle.perform(swipeDown());
         }


### PR DESCRIPTION
There were several UI tests that were failing for Jetpack when running locally. This PR fixes all Jetpack UI tests so they can run without issue locally. The next step is to get the tests running on CI. 

Impacted UI tests:
1. e2ePublishSimplePost
2. e2eLoginWithMagicLink
3. e2eLoginWithPasswordlessAccount

To test:
- Run all UI tests using a Jetpack variant and ensure that all tests pass
- UI tests running against WordPress in CI should not be impacted and continue to pass
