### PR TITLE
[Tooling] Improve Prototype (aka Installable) Build comment and metadata

### DIFF
--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -7,4 +7,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane "build_and_upload_$1_installable_build"
+bundle exec fastlane "build_and_upload_$1_prototype_build"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -95,16 +95,16 @@ steps:
           - "**/build/instrumented-tests/**/*"
 
   #################
-  # Create Installable Builds for WP and JP
+  # Create Prototype Builds for WP and JP
   #################
-  - group: "📲 Installable Builds"
+  - group: "📲 Prototype Builds"
     steps:
-      - label: ":wordpress: :android: Installable Build"
-        command: ".buildkite/commands/installable-build.sh wordpress"
+      - label: ":wordpress: :android: Prototype Build"
+        command: ".buildkite/commands/prototype-build.sh wordpress"
         if: build.pull_request.id != null
         plugins: *common_plugins
 
-      - label: ":jetpack: :android: Installable Build"
-        command: ".buildkite/commands/installable-build.sh jetpack"
+      - label: ":jetpack: :android: Prototype Build"
+        command: ".buildkite/commands/prototype-build.sh jetpack"
         if: build.pull_request.id != null
         plugins: *common_plugins

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -71,7 +71,7 @@ android {
         applicationId "org.wordpress.android"
         archivesBaseName = "$applicationId"
 
-        versionName project.findProperty("installableBuildVersionName") ?: versionProperties.getProperty("versionName")
+        versionName project.findProperty("prototypeBuildVersionName") ?: versionProperties.getProperty("versionName")
         versionCode versionProperties.getProperty("versionCode").toInteger()
 
         minSdkVersion rootProject.minSdkVersion
@@ -220,8 +220,7 @@ android {
             dimension "buildType"
         }
 
-        // Used for CI builds on PRs (aka "Installable Builds"). Can be used locally when a developer needs
-        // to install multiple versions of the app on the same device.
+        // Used for CI builds on PRs (aka "Prototype Builds"). Can be used locally when a developer needs to install multiple versions of the app on the same device.
         // AppName: WordPress Pre-Alpha/Jetpack Pre-Alpha
         jalapeno {
             isDefault true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,9 +25,9 @@ APP_SPECIFIC_VALUES = {
 
 UPLOAD_TO_PLAY_STORE_JSON_KEY = File.join(Dir.home, '.configure', 'wordpress-android', 'secrets', 'google-upload-credentials.json')
 
-INSTALLABLE_BUILD_FLAVOR = 'Jalapeno'.freeze
-INSTALLABLE_BUILD_TYPE = 'Debug'.freeze
-INSTALLABLE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
+PROTOTYPE_BUILD_FLAVOR = 'Jalapeno'.freeze
+PROTOTYPE_BUILD_TYPE = 'Debug'.freeze
+PROTOTYPE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
 
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 FASTLANE_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'fastlane')

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -135,49 +135,49 @@ platform :android do
   end
 
   #####################################################################################
-  # build_and_upload_installable_build
+  # build_and_upload_wordpress_prototype_build
   # -----------------------------------------------------------------------------------
-  # Build a WordPress Installable Build and make it available for download
+  # Build a WordPress Prototype Build and make it available for download
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_installable_build
+  # bundle exec fastlane build_and_upload_wordpress_prototype_build
   #####################################################################################
-  desc 'Build an Installable Build and make it available for download'
-  lane :build_and_upload_wordpress_installable_build do
+  desc 'Build a WordPress Prototype Build and make it available for download'
+  lane :build_and_upload_wordpress_prototype_build do
     UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
 
-    versionName = generate_installable_build_number
+    versionName = generate_prototype_build_number
     gradle(
       task: 'assemble',
-      flavor: "WordPress#{INSTALLABLE_BUILD_FLAVOR}",
-      build_type: INSTALLABLE_BUILD_TYPE,
-      properties: { installableBuildVersionName: versionName }
+      flavor: "WordPress#{PROTOTYPE_BUILD_FLAVOR}",
+      build_type: PROTOTYPE_BUILD_TYPE,
+      properties: { prototypeBuildVersionName: versionName }
     )
 
-    upload_installable_build(product: 'WordPress', versionName: versionName)
+    upload_prototype_build(product: 'WordPress', versionName: versionName)
   end
 
   #####################################################################################
-  # build_and_upload_jetpack_installable_build
+  # build_and_upload_jetpack_prototype_build
   # -----------------------------------------------------------------------------------
-  # Build a Jetpack Installable Build and make it available for download
+  # Build a Jetpack Prototype Build and make it available for download
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_installable_build
+  # bundle exec fastlane build_and_upload_jetpack_prototype_build
   #####################################################################################
-  desc 'Build an Installable Build and make it available for download'
-  lane :build_and_upload_jetpack_installable_build do
+  desc 'Build a Jetpack Prototype Build and make it available for download'
+  lane :build_and_upload_jetpack_prototype_build do
     UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
 
-    versionName = generate_installable_build_number
+    versionName = generate_prototype_build_number
     gradle(
       task: 'assemble',
-      flavor: "Jetpack#{INSTALLABLE_BUILD_FLAVOR}",
-      build_type: INSTALLABLE_BUILD_TYPE,
-      properties: { installableBuildVersionName: versionName }
+      flavor: "Jetpack#{PROTOTYPE_BUILD_FLAVOR}",
+      build_type: PROTOTYPE_BUILD_TYPE,
+      properties: { prototypeBuildVersionName: versionName }
     )
 
-    upload_installable_build(product: 'Jetpack', versionName: versionName)
+    upload_prototype_build(product: 'Jetpack', versionName: versionName)
   end
 
   #####################################################################################
@@ -248,8 +248,8 @@ platform :android do
   #
   # @param [String] product the display name of the app to upload to S3. 'WordPress' or 'Jetpack'
   #
-  def upload_installable_build(product:, versionName:)
-    filename = "#{product.downcase}-installable-build-#{generate_installable_build_number}.apk"
+  def upload_prototype_build(product:, versionName:)
+    filename = "#{product.downcase}-prototype-build-#{versionName}.apk"
 
     upload_path = upload_to_s3(
       bucket: 'a8c-apps-public-artifacts',
@@ -260,12 +260,12 @@ platform :android do
 
     return if ENV['BUILDKITE_PULL_REQUEST'].nil?
 
-    install_url = "#{INSTALLABLE_BUILD_DOMAIN}/#{upload_path}"
+    install_url = "#{PROTOTYPE_BUILD_DOMAIN}/#{upload_path}"
     comment_body = prototype_build_details_comment(
       app_display_name: product,
       app_icon: ":#{product.downcase}:", # Use Buildkite emoji based on product name
       download_url: install_url,
-      metadata: { Flavor: INSTALLABLE_BUILD_FLAVOR, 'Build Type': INSTALLABLE_BUILD_TYPE },
+      metadata: { Flavor: PROTOTYPE_BUILD_FLAVOR, 'Build Type': PROTOTYPE_BUILD_TYPE },
       footnote: '<em>Note: Google Login is not supported on these builds.</em>',
       fold: true
     )
@@ -273,19 +273,19 @@ platform :android do
     comment_on_pr(
       project: GHHELPER_REPO,
       pr_number: Integer(ENV['BUILDKITE_PULL_REQUEST']),
-      reuse_identifier: "#{product.downcase}-installable-build-link",
+      reuse_identifier: "#{product.downcase}-prototype-build-link",
       body: comment_body
     )
 
     if ENV['BUILDKITE']
-      message = "#{product} Installable Build: [#{filename}](#{install_url})"
-      buildkite_annotate(style: 'info', context: "installable-build-#{product}", message: message)
-      buildkite_metadata(set: { versionName: versionName, 'build:flavor': INSTALLABLE_BUILD_FLAVOR, 'build:type': INSTALLABLE_BUILD_TYPE })
+      message = "#{product} Prototype Build: [#{filename}](#{install_url})"
+      buildkite_annotate(style: 'info', context: "prototype-build-#{product}", message: message)
+      buildkite_metadata(set: { versionName: versionName, 'build:flavor': PROTOTYPE_BUILD_FLAVOR, 'build:type': PROTOTYPE_BUILD_TYPE })
     end
   end
 
   # This function is Buildkite-specific
-  def generate_installable_build_number
+  def generate_prototype_build_number
     if ENV['BUILDKITE']
       commit = ENV['BUILDKITE_COMMIT'][0, 7]
       branch = ENV['BUILDKITE_BRANCH'].parameterize

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -277,7 +277,7 @@ platform :android do
 
     if ENV['BUILDKITE']
       message = "#{product} Installable Build: [#{filename}](#{install_url})"
-      sh('buildkite-agent', 'annotate', message, '--style', 'info', '--context', "installable-build-#{product}")
+      buildkite_annotate(style: 'info', context: "installable-build-#{product}", message: message)
     end
   end
 

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -265,7 +265,7 @@ platform :android do
       app_display_name: product,
       app_icon: ":#{product.downcase}:", # Use Buildkite emoji based on product name
       download_url: install_url,
-      metadata: { Flavor: PROTOTYPE_BUILD_FLAVOR, 'Build Type': PROTOTYPE_BUILD_TYPE },
+      metadata: { Flavor: PROTOTYPE_BUILD_FLAVOR, 'Build Type': PROTOTYPE_BUILD_TYPE, 'Version': versionName },
       footnote: '<em>Note: Google Login is not supported on these builds.</em>',
       fold: true
     )

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -259,23 +259,14 @@ platform :android do
     return if ENV['BUILDKITE_PULL_REQUEST'].nil?
 
     install_url = "#{INSTALLABLE_BUILD_DOMAIN}/#{upload_path}"
-    qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
-    icon = "<img alt='#{product}' align='top' src='https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64/#{product.downcase}.png' width='20px' />"
-    comment_body = <<~PR_COMMENT
-      <details>
-        <summary>#{icon}📲 You can test these changes on #{product} by <a href='#{install_url}'>downloading <tt>#{filename}</tt></a></summary>
-        <table><tr>
-          <td width='250' rowspan='5'><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a></td>
-          <td colspan='2'>💡 Scan this QR code with your Android phone to download and install the APK directly on it.</td>
-        </tr>
-        <tr><td width='150px'><b>App</b></td><td><tt>#{product}</tt></td></tr>
-        <tr><td><b>Build Flavor</b></td><td><tt>#{INSTALLABLE_BUILD_FLAVOR}</tt></td></tr>
-        <tr><td><b>Build Type</b></td><td><tt>#{INSTALLABLE_BUILD_TYPE}</tt></td></tr>
-        <tr><td><b>Commit</b></td><td>#{ENV['BUILDKITE_COMMIT']}</td></tr>
-        </table>
-      </details>
-      <em>Note: This installable build uses the <tt>#{INSTALLABLE_BUILD_FLAVOR}#{INSTALLABLE_BUILD_TYPE}</tt> build flavor, and does not support Google Login.</em>
-    PR_COMMENT
+    comment_body = prototype_build_details_comment(
+      app_display_name: product,
+      app_icon: ":#{product.downcase}:", # Use Buildkite emoji based on product name
+      download_url: install_url,
+      metadata: { Flavor: INSTALLABLE_BUILD_FLAVOR, 'Build Type': INSTALLABLE_BUILD_TYPE },
+      footnote: '<em>Note: Google Login is not supported on these builds.</em>',
+      fold: true
+    )
 
     comment_on_pr(
       project: GHHELPER_REPO,


### PR DESCRIPTION
Similar to https://github.com/wordpress-mobile/WordPress-iOS/pull/20071

### What?

Improve Prototype (aka Installable) Builds in a couple of ways:
 - Make the PR comment announcing the Prototype build QR code and information nicer
    - In particular, the QR code and URLs now directly links to the appropriate build on App Center, instead of defaulting to show the latest build in App Center as before
 - Attach Buildkite metadata to the CI build with relevant infos
 - Add a Buildkite annotation to the CI build with relevant infos

### To test:

 - Check that the PR got two PR comments, providing the information for the WordPress and Jetpack Prototype builds respectively, and verify that the information about those builds displayed in the table is accurate
 - Scan the QR code (and/or follow the URL) and validate that it directly redirects you to download the APK and successfully allows you to install that APK on your test device. Repeat for each app (WP/JP)
 - Open the page for [the last Buildkite build for this PR](https://buildkite.com/automattic/wordpress-android/builds/latest?branch=tooling%2Fprototype-build-metadata) and validate that there are 2 annotations (one for WP, one for JP) containing the link to download the Prototype Build APK
 - Add `/meta-data` at the end of the URL of that last Buildkite build (e.g. [like this](https://buildkite.com/automattic/wordpress-android/builds/9845/meta-data)) and validate that the metadata attached to the build are correct.
