### PR TITLE
[Blogging Prompts] Update prompts visibility and setting logic and setting

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
@@ -48,7 +48,7 @@ class BloggingPromptsSettingsHelper @Inject constructor(
 
     fun isPromptsFeatureAvailable(): Boolean {
         val selectedSite = selectedSiteRepository.getSelectedSite() ?: return false
-        return bloggingPromptsFeatureConfig.isEnabled() && selectedSite.isPotentialBloggingSite
+        return bloggingPromptsFeatureConfig.isEnabled() && selectedSite.isUsingWpComRestApi
     }
 
     suspend fun shouldShowPromptsFeature(): Boolean {
@@ -59,6 +59,10 @@ class BloggingPromptsSettingsHelper @Inject constructor(
                 isPromptsCardEnabled(siteId)
 
         return isPromptsFeatureAvailable() && isPromptsCardUserEnabled && !isPromptSkippedForToday()
+    }
+
+    fun shouldShowPromptsSetting(): Boolean {
+        return isPromptsFeatureAvailable() && bloggingPromptsEnhancementsFeatureConfig.isEnabled()
     }
 
     private fun isPromptSkippedForToday(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
@@ -55,10 +55,10 @@ class BloggingPromptsSettingsHelper @Inject constructor(
         val siteId = selectedSiteRepository.getSelectedSite()?.localId()?.value ?: return false
 
         // if the enhancements is turned off, consider the prompts user-enabled, otherwise check the user setting
-        val isPromptsCardUserEnabled = !bloggingPromptsEnhancementsFeatureConfig.isEnabled() ||
-                isPromptsCardEnabled(siteId)
+        val isPromptsSettingUserEnabled = !bloggingPromptsEnhancementsFeatureConfig.isEnabled() ||
+                isPromptsSettingEnabled(siteId)
 
-        return isPromptsFeatureAvailable() && isPromptsCardUserEnabled && !isPromptSkippedForToday()
+        return isPromptsFeatureAvailable() && isPromptsSettingUserEnabled && !isPromptSkippedForToday()
     }
 
     fun shouldShowPromptsSetting(): Boolean {
@@ -72,7 +72,7 @@ class BloggingPromptsSettingsHelper @Inject constructor(
         return promptSkippedDate != null && isSameDay(promptSkippedDate, Date())
     }
 
-    private suspend fun isPromptsCardEnabled(
+    private suspend fun isPromptsSettingEnabled(
         siteId: Int
     ): Boolean = bloggingRemindersStore
         .bloggingRemindersModel(siteId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
@@ -63,7 +63,7 @@ class DaySelectionBuilder
                 )
             )
 
-            if (bloggingPromptsSettingsHelper.shouldShowPromptsSetting()) {
+            if (bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()) {
                 selectionList.add(
                     PromptSwitch(
                         bloggingRemindersModel.isPromptIncluded,
@@ -92,7 +92,7 @@ class DaySelectionBuilder
             true
         }
         val buttonText = if (isFirstTimeFlow) {
-            if (bloggingPromptsSettingsHelper.shouldShowPromptsSetting()) {
+            if (bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()) {
                 string.blogging_prompt_set_reminders
             } else {
                 string.blogging_reminders_notify_me

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilder.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.bloggingreminders
 
 import org.wordpress.android.R
 import org.wordpress.android.R.string
+import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons.DayItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.EmphasizedText
@@ -16,7 +17,6 @@ import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
-import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import java.time.DayOfWeek
 import java.time.format.TextStyle.SHORT
 import javax.inject.Inject
@@ -26,7 +26,7 @@ class DaySelectionBuilder
     private val daysProvider: DaysProvider,
     private val dayLabelUtils: DayLabelUtils,
     private val localeManagerWrapper: LocaleManagerWrapper,
-    private val bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig
+    private val bloggingPromptsSettingsHelper: BloggingPromptsSettingsHelper,
 ) {
     fun buildSelection(
         bloggingRemindersModel: BloggingRemindersUiModel?,
@@ -63,7 +63,7 @@ class DaySelectionBuilder
                 )
             )
 
-            if (bloggingPromptsFeatureConfig.isEnabled()) {
+            if (bloggingPromptsSettingsHelper.shouldShowPromptsSetting()) {
                 selectionList.add(
                     PromptSwitch(
                         bloggingRemindersModel.isPromptIncluded,
@@ -92,7 +92,7 @@ class DaySelectionBuilder
             true
         }
         val buttonText = if (isFirstTimeFlow) {
-            if (bloggingPromptsFeatureConfig.isEnabled()) {
+            if (bloggingPromptsSettingsHelper.shouldShowPromptsSetting()) {
                 string.blogging_prompt_set_reminders
             } else {
                 string.blogging_reminders_notify_me

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -99,7 +99,6 @@ import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
-import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig;
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig;
 import org.wordpress.android.util.config.BloggingRemindersFeatureConfig;
 import org.wordpress.android.util.config.ManageCategoriesFeatureConfig;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -189,7 +189,6 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject BloggingRemindersFeatureConfig mBloggingRemindersFeatureConfig;
     @Inject BloggingPromptsFeatureConfig mBloggingPromptsFeatureConfig;
-    @Inject BloggingPromptsEnhancementsFeatureConfig mBloggingPromptsEnhancementFeatureConfig;
     @Inject ManageCategoriesFeatureConfig mManageCategoriesFeatureConfig;
     @Inject UiHelpers mUiHelpers;
     @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
@@ -1273,8 +1272,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void initBloggingPrompts() {
-        if (!mPromptsSettingsHelper.isPromptsFeatureAvailable()
-            || !mBloggingPromptsEnhancementFeatureConfig.isEnabled()) {
+        if (!mPromptsSettingsHelper.shouldShowPromptsSetting()) {
             removeBloggingPromptsSettings();
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -156,11 +156,7 @@ class WPMainActivityViewModel @Inject constructor(
         val actionsList = ArrayList<MainActionListItem>()
         if (bloggingPromptsSettingsHelper.shouldShowPromptsFeature()) {
             val prompt = site?.let {
-                if (it.isUsingWpComRestApi) {
-                    bloggingPromptsStore.getPromptForDate(it, Date()).firstOrNull()?.model
-                } else {
-                    null
-                }
+                bloggingPromptsStore.getPromptForDate(it, Date()).firstOrNull()?.model
             }
 
             prompt?.let {

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
@@ -104,7 +104,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given prompts FF is off and site is potential blog, when isPromptsFeatureAvailable, then returns false`() {
+    fun `given prompts FF is off and site is wpcom site, when isPromptsFeatureAvailable, then returns false`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
 
@@ -114,9 +114,9 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given prompts FF is on and site is not potential blog, when isPromptsFeatureAvailable, then returns false`() {
+    fun `given prompts FF is on and site is not wpcom site, when isPromptsFeatureAvailable, then returns false`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel(isPotentialBloggingSite = false))
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel(isWpComSite = false))
 
         val result = helper.isPromptsFeatureAvailable()
 
@@ -133,7 +133,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given prompts FF is on and site is potential blog, when isPromptsFeatureAvailable, then returns true`() {
+    fun `given prompts FF is on and site is wpcom site, when isPromptsFeatureAvailable, then returns true`() {
         whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
 
@@ -271,6 +271,45 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
             )
     }
 
+    @Test
+    fun `given prompts feature is not available, when shouldShowPromptsSetting, then returns false`() {
+        // prompts available
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel(isWpComSite = false))
+
+        val result = helper.shouldShowPromptsSetting()
+
+        assertThat(result).isFalse
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `given prompts feature is available and enhancements FF is off, when shouldShowPromptsSetting, then returns false`() {
+        // prompts available
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
+
+        whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(false)
+
+        val result = helper.shouldShowPromptsSetting()
+
+        assertThat(result).isFalse
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `given prompts feature is available and enhancements FF is on, when shouldShowPromptsSetting, then returns true`() {
+        // prompts available
+        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
+
+        whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(true)
+
+        val result = helper.shouldShowPromptsSetting()
+
+        assertThat(result).isTrue()
+    }
+
     companion object {
         private fun createRemindersModel(
             isPromptsCardEnabled: Boolean,
@@ -280,10 +319,10 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
         )
 
         private fun createSiteModel(
-            isPotentialBloggingSite: Boolean = true
+            isWpComSite: Boolean = true
         ) = SiteModel().apply {
             this.id = 123
-            setIsPotentialBloggingSite(isPotentialBloggingSite)
+            setIsWPCom(isWpComSite)
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
@@ -73,7 +73,7 @@ class DaySelectionBuilderTest {
         )
         whenever(daysProvider.getDaysOfWeekByLocale()).thenReturn(DayOfWeek.values().toList())
         whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
-        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(false)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(false)
         daySelected = null
         confirmed = false
         promptSwitchToggled = false
@@ -219,7 +219,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `primary button shows a different label when blogging prompt FF is on`() {
-        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,
@@ -261,7 +261,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `include prompt switch is visible when days are selected`() {
-        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,
@@ -314,7 +314,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `single include prompt switch is visible when FF is on`() {
-        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,
@@ -342,7 +342,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `include prompt switch is not visible when FF is off`() {
-        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(false)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(false)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,
@@ -370,7 +370,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `click on a prompt switch toggles the prompt state`() {
-        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,
@@ -400,7 +400,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `click on a blogging prompt help button shows blogging prompt dialog`() {
-        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/DaySelectionBuilderTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.whenever
 import org.wordpress.android.R
+import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons.DayItem
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.EmphasizedText
@@ -22,7 +23,6 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
-import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import java.time.DayOfWeek
 import java.time.DayOfWeek.SUNDAY
 import java.time.DayOfWeek.WEDNESDAY
@@ -41,7 +41,7 @@ class DaySelectionBuilderTest {
     lateinit var localeManagerWrapper: LocaleManagerWrapper
 
     @Mock
-    lateinit var bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig
+    lateinit var bloggingPromptsSettingsHelper: BloggingPromptsSettingsHelper
     private lateinit var daySelectionBuilder: DaySelectionBuilder
     private var daySelected: DayOfWeek? = null
     private var confirmed = false
@@ -69,11 +69,11 @@ class DaySelectionBuilderTest {
             daysProvider,
             dayLabelUtils,
             localeManagerWrapper,
-            bloggingPromptsFeatureConfig
+            bloggingPromptsSettingsHelper
         )
         whenever(daysProvider.getDaysOfWeekByLocale()).thenReturn(DayOfWeek.values().toList())
         whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
-        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(false)
         daySelected = null
         confirmed = false
         promptSwitchToggled = false
@@ -219,7 +219,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `primary button shows a different label when blogging prompt FF is on`() {
-        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(true)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,
@@ -261,7 +261,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `include prompt switch is visible when days are selected`() {
-        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(true)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,
@@ -314,7 +314,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `single include prompt switch is visible when FF is on`() {
-        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(true)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,
@@ -342,7 +342,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `include prompt switch is not visible when FF is off`() {
-        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(false)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(false)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,
@@ -370,7 +370,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `click on a prompt switch toggles the prompt state`() {
-        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(true)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,
@@ -400,7 +400,7 @@ class DaySelectionBuilderTest {
 
     @Test
     fun `click on a blogging prompt help button shows blogging prompt dialog`() {
-        whenever(bloggingPromptsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(true)
 
         val bloggingRemindersModel = BloggingRemindersUiModel(
             1,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -447,14 +447,6 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `bottom sheet does not show prompt card when site is self-hosted`() = test {
-        whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(true)
-        startViewModelWithDefaultParameters(isWpcomOrJpSite = false)
-        val hasBloggingPromptAction = viewModel.mainActions.value?.any { it.actionType == ANSWER_BLOGGING_PROMPT }
-        assertThat(hasBloggingPromptAction).isFalse()
-    }
-
-    @Test
     fun `bottom sheet action is ANSWER_BLOGGING_PROMPT when the BP answer button is clicked`() = test {
         whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(true)
         startViewModelWithDefaultParameters()

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.88.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2.14.0'
+    wordPressFluxCVersion = '2656-3dd52df4d7bf131005c96464ef904f02f1d7751a'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.88.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2656-3dd52df4d7bf131005c96464ef904f02f1d7751a'
+    wordPressFluxCVersion = '2.14.1'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.2.0'


### PR DESCRIPTION
Fixes #17930 
FluxC-Android PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2656

## Logic changes

### Self-hosted (without JP connection)
Previously the Blogging Reminders would show an "include prompts" option, but Prompts are not available for self-hosted sites, so now both the "show prompts" (in `Site Settings`) and "include prompts" (in `Site Settings` > `Reminders`) will not be shown for self-hosted sites.

### WP.com non-blogging site
Before this PR, non-blogging sites would not have the Blogging Prompts feature available at all. With this change, non-blogging sites can now see the "show prompts" setting (in `Site Settings`) and turn that on if wanted.

#### Without Blogging Reminders
Non-blogging sites that did NOT have a Blogging Reminder set in a previous version (before updating to this PR's version) will have the "show prompts" setting OFF by default.

#### With Blogging Reminders
Non-blogging sites that DID have a Blogging Reminder set in a previous version (before updating to this PR's version) will have the "show prompts" setting ON by default.

## To test:

### Self-hosted
1. Create a self-hosted site
2. Install Jetpack app
3. Login and add the self-hosted site or use the self-hosted site instead of logging in
4. With the self-hosted site selected, tap on `Site Settings`
5. **Verify** the blogging prompts option `Show prompts` does not appear
6. Tap on `Reminders`
7. Tap a day
8. **Verify** the `Include a Blogging Prompt` option does not appear

You can also login with a WP.com account, select a WP.com site, and **verify** the settings are shown.

### Non-blogging site without previous Blogging Reminders
1. Install Jetpack app (this PR's version)
2. Login with an account that has a non-blogging site (example: no posts and no post page set up)
3. Select the non-blogging site
4. Go to `My Site` > `Home`
5. **Verify** the Prompts card is not shown
6. Tap the FAB
7. **Verify** the Prompts action header is not shown
8. Hit back
10. Go to `My Site` > `Menu`
11. Tap `Site Settings`
12. **Verify** the `Show prompts` is visible and is set to OFF

You can turn the setting ON and **verify** that the feature is now shown in the Dashboard and FAB bottom sheet.

### Non-blogging site with previous Blogging Reminders
1. Install Jetpack app (`jalapenoDebug` version before Prompts enhancements, like the build [here](https://d2twmm2nzpx3bg.cloudfront.net/8204deb9481772038e97669f4e11f5a5e6b4f94f/jetpack-installable-build-pr17840-9139412.apk))
2. Login with an account that has a non-blogging site
3. Select the non-blogging site
4. Go to `My Site` > `Menu`
5. Tap `Site Settings`
6. Tap `Reminders and prompts`
7. Setup a reminder (it doesn't matter if it includes prompts or not)
8. Close Jetpack
9. Update the app (installing this PR's version, also `jalapenoDebug`)
10. Open the app
11. Select the same non-blogging site
12. Go to `My Site` > `Home`
13. **Verify** the Prompts card is shown
14. Tap the FAB
15. **Verify** the Prompts action header is shown
16. Hit back
17. Go to `My Site` > `Menu`
18. Tap `Site Settings`
19. **Verify** the `Show prompts` is visible and is set to ON

You can turn the setting OFF and **verify** that the feature is now hidden in the Dashboard and FAB bottom sheet.

## Regression Notes
1. Potential unintended areas of impact
Changes in logic for blogging sites.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing.

3. What automated tests I added (or what prevented me from doing so)
Updated existing tests and added new ones.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
