### PR TITLE
Restore Browse our FAQ

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -105,6 +105,7 @@ class HelpActivity : LocaleAwareActivity() {
                 showContactUs()
             }
 
+            faqButton.setOnClickListener { showFaq() }
             applicationVersion.text = getString(R.string.version_with_name_param, WordPress.versionName)
             applicationLogButton.setOnClickListener { v ->
                 startActivity(Intent(v.context, AppLogViewerActivity::class.java))
@@ -180,9 +181,6 @@ class HelpActivity : LocaleAwareActivity() {
 
     private fun HelpActivityBinding.showContactUs() {
         contactUsButton.setOnClickListener { createNewZendeskTicket() }
-
-        faqButton.setOnClickListener { showFaq() }
-
         myTicketsButton.setOnClickListener { showZendeskTickets() }
 
         contactEmailContainer.setOnClickListener {
@@ -210,7 +208,6 @@ class HelpActivity : LocaleAwareActivity() {
 
     private fun HelpActivityBinding.showSupportForum() {
         contactUsButton.isVisible = false
-        faqButton.isVisible = false
         myTicketsButton.isVisible = false
         emailContainerTopDivider.isVisible = false
         contactEmailContainer.isVisible = false

--- a/WordPress/src/main/res/layout/help_activity.xml
+++ b/WordPress/src/main/res/layout/help_activity.xml
@@ -92,16 +92,6 @@
                     style="@style/HelpActivitySingleText"
                     android:text="@string/contact_support" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/faq_button"
-                    style="@style/HelpActivitySingleText"
-                    android:text="@string/browse_our_faq_button" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/my_tickets_button"
-                    style="@style/HelpActivitySingleText"
-                    android:text="@string/my_tickets" />
-
                 <LinearLayout
                     android:id="@+id/forumContainer"
                     android:layout_width="match_parent"
@@ -132,6 +122,16 @@
                     android:background="?android:attr/listDivider"
                     android:visibility="gone"
                     tools:visibility="visible"/>
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/faq_button"
+                    style="@style/HelpActivitySingleText"
+                    android:text="@string/browse_our_faq_button" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/my_tickets_button"
+                    style="@style/HelpActivitySingleText"
+                    android:text="@string/my_tickets" />
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/application_log_button"


### PR DESCRIPTION
Restore Browse our FAQ row on help screen for WP

<img width=320 src=https://user-images.githubusercontent.com/990349/217712867-07daa34e-2913-4b1e-8713-c858bcf7a75f.png />


To test:

- Navigate to Me > App Settings > Debug settings
- Enable **wordpress_support_forum_remote_field** under Remote features and Restart the app (scroll down if required)
- Navigate to Me > Help & Support
- Verify that the screen is as shown above
- Tap on the **Community forums** row
- Verify that it opens the new Mobile Forum on Wordpress.org in the browser
- Tap on the **Browse our FAQ** row
- Verify that it open Mobile App Support page on the web


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
