### PR TITLE
[ Enhancement ] Show a toast with message when trying to change the primary site, for users having only one site.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
@@ -213,6 +213,14 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
                 canShowDialog = state.canShowChoosePrimarySiteDialog
                 setDetails(state.homeURLOrHostNames)
                 refreshAdapter()
+                 //Add click listener to show toast
+                setOnPreferenceClickListener {
+                    if (state.sites?.size == 1) {
+                        val message = getString(R.string.only_one_primary_site_message)
+                        showToastMessage(message)
+                    }
+                    true
+                }
             }
         } ?: run {
             primarySitePreference.apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
@@ -213,7 +213,7 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
                 canShowDialog = state.canShowChoosePrimarySiteDialog
                 setDetails(state.homeURLOrHostNames)
                 refreshAdapter()
-                 //Add click listener to show toast
+                 // Add click listener to show toast
                 setOnPreferenceClickListener {
                     if (state.sites?.size == 1) {
                         val message = getString(R.string.only_one_primary_site_message)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2718,6 +2718,7 @@
     <string name="account_settings">Account Settings</string>
     <string name="pending_email_change_snackbar">Click the verification link in the email sent to %1$s to confirm your new address</string>
     <string name="primary_site">Primary site</string>
+    <string name="only_one_primary_site_message">Only one site is available, so you can\'t change your primary site.</string>
     <string name="web_address">Web address</string>
     <string name="web_address_dialog_hint">Shown publicly when you comment.</string>
     <string name="change_password">Change password</string>


### PR DESCRIPTION
Fixes [#17676](https://github.com/wordpress-mobile/WordPress-Android/issues/17676)

The issue here was that, when trying to change the primary site when only one site is present, there was no feedback given to the user that they cannot change it.

To fix this, a Toast Message has been added, it notifies the user that only one site is present.

To test:

- Launch the WP app with an account having only one site
- Go to Me -> Account settings -> Primary site
- Notice that tapping on the primary site now shows  a Toast Message: Only one site is available, so you can't change your primary site


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did do to test those areas of impact (or what existing automated tests I relied on)
Manual Testing

3. What automated tests I added (or what prevented me from doing so)
None


https://user-images.githubusercontent.com/77686324/217801549-f1152ac8-b218-441a-ae26-f6f52bc33fcf.mp4




PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
