### PR TITLE
Update need more help on enter site address

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -77,6 +77,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.config.LandingScreenRevampFeatureConfig;
+import org.wordpress.android.util.config.WordPressSupportForumFeatureConfig;
 import org.wordpress.android.widgets.WPSnackbar;
 
 import java.util.ArrayList;
@@ -139,6 +140,8 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Inject BuildConfigWrapper mBuildConfigWrapper;
 
     @Inject LandingScreenRevampFeatureConfig mLandingScreenRevampFeatureConfig;
+
+    @Inject WordPressSupportForumFeatureConfig mWordPressSupportForumFeatureConfig;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -677,7 +680,11 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Override
     public void helpFindingSiteAddress(String username, SiteStore siteStore) {
         mUnifiedLoginTracker.trackClick(Click.HELP_FINDING_SITE_ADDRESS);
-        mZendeskHelper.createNewTicket(this, Origin.LOGIN_SITE_ADDRESS, null);
+        if (mWordPressSupportForumFeatureConfig.isEnabled() && !mBuildConfigWrapper.isJetpackApp()) {
+            viewHelpAndSupport(Origin.LOGIN_SITE_ADDRESS);
+        } else {
+            mZendeskHelper.createNewTicket(this, Origin.LOGIN_SITE_ADDRESS, null);
+        }
     }
 
     @Override


### PR DESCRIPTION
Open help screen from need more help option enter site address option on login screen

Fixes #17937 

<img width=320 src=https://user-images.githubusercontent.com/990349/214458783-e751b04a-502d-42d9-9a44-b9995a7b8eee.png />


To test:

- Navigate to Me > App Settings > Debug settings
- Enable wordpress_support_forum_remote_field under Remote features and Restart the app (scroll down if required)
- Logout (Me > Log out of WordPress.com
- On Welcome screen tap on Enter site address > Find your site address > Need more help?
- Verify that it open Help and support screen as in the image above
- Tap on the Community forums row
- Verify that it opens the new Mobile Forum on Wordpress.org in the browser

For completeness you could try the above steps without the feature flag on and also with Jetpack app.  It should open popup asking for email and name or open zendesk ui.


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
manual testing

3. What automated tests I added (or what prevented me from doing so)
existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
