### PR TITLE
Fixes: the padding between the icon and the menu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -41,7 +41,7 @@ import org.wordpress.android.widgets.PostListButton
 import org.wordpress.android.widgets.WPTextView
 import java.util.concurrent.atomic.AtomicBoolean
 
-const val POST_LIST_MORE_MENU_ICON_PADDING = 7
+const val POST_LIST_ICON_PADDING = 8
 
 sealed class PostListItemViewHolder(
     @LayoutRes layout: Int,
@@ -235,9 +235,9 @@ sealed class PostListItemViewHolder(
         loadedFeaturedImgUrl = imageUrl
     }
 
-    private fun setTint(context: Context , drawable: Drawable, color: Int): Drawable {
+    private fun setTint(context: Context, drawable: Drawable, color: Int): Drawable {
         val wrappedDrawable: Drawable = DrawableCompat.wrap(drawable)
-        if(color != 0) {
+        if (color != 0) {
             val iconColor = context.getColorFromAttribute(color)
             DrawableCompat.setTint(wrappedDrawable, iconColor)
         }
@@ -245,9 +245,11 @@ sealed class PostListItemViewHolder(
     }
 
     @Suppress("ComplexMethod")
-    private fun getMenuItemTitleWithIcon(context: Context, item: PostListItemAction) : SpannableStringBuilder {
-        var icon: Drawable? = setTint(context,
-            context.getDrawable(item.buttonType.iconResId)!!,item.buttonType.colorAttrId)
+    private fun getMenuItemTitleWithIcon(context: Context, item: PostListItemAction): SpannableStringBuilder {
+        var icon: Drawable? = setTint(
+            context,
+            context.getDrawable(item.buttonType.iconResId)!!, item.buttonType.colorAttrId
+        )
         // If there's no icon, we insert a transparent one to keep the title aligned with the items which have icons.
         if (icon == null) icon = ColorDrawable(Color.TRANSPARENT)
         val iconSize: Int = context.getResources().getDimensionPixelSize(R.dimen.menu_item_icon_size)
@@ -255,8 +257,10 @@ sealed class PostListItemViewHolder(
         val imageSpan = ImageSpan(icon)
 
         // Add a space placeholder for the icon, before the title.
-        val ssb = SpannableStringBuilder(context.getText(item.buttonType.textResId)
-            .padStart(POST_LIST_MORE_MENU_ICON_PADDING))
+        val menuTitle = context.getText(item.buttonType.textResId)
+        val ssb = SpannableStringBuilder(
+            menuTitle.padStart(menuTitle.length + POST_LIST_ICON_PADDING)
+        )
 
         // Replace the space placeholder with the icon.
         ssb.setSpan(imageSpan, 1, 2, 0)


### PR DESCRIPTION
Fixes the padding between the menu and Icon introduced on   #17929 with commit https://github.com/wordpress-mobile/WordPress-Android/pull/17929/commits/9e00284f710c92747c1c2effa6268f337b64d955 

|  Before fix | After fix |
|---|---|
| ![screenshot_promote_with_blaze_menu_](https://user-images.githubusercontent.com/17463767/218065475-259579ec-6628-49df-b2ee-1ef6676cecfc.png)  |  ![screenshot_promote_with_blaze_changes_menu_](https://user-images.githubusercontent.com/17463767/218065508-89c6c48a-d18c-408e-88d7-306c288a2b63.png) | 


To test:
1. Go to `trunk` branch and install 
2. Login ->  Posts
3. Click at ":" icon 
4. Notice that icons are placed between the menu text
5. Take a build from this PR 
6. Repeat steps 2, 3
7. Notice that icons placing is correct 


## Regression Notes
1. Potential unintended areas of impact
More icon not shown properly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
