### PR TITLE
[Domain Purchasing during Site Creation] Add local feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -188,7 +188,6 @@ android {
             buildConfigField "boolean", "ENABLE_FOLLOWED_SITES_SETTINGS", "true"
             buildConfigField "boolean", "ENABLE_WHATS_NEW_FEATURE", "true"
             buildConfigField "boolean", "ENABLE_MY_SITE_DASHBOARD_TABS", "true"
-            buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -144,6 +144,7 @@ android {
         buildConfigField "boolean", "ENABLE_MY_SITE_DASHBOARD_TABS", "true"
         buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
         buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "true"
+        buildConfigField "boolean", "ENABLE_SITE_CREATION_DOMAIN_PURCHASING", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
@@ -170,6 +171,7 @@ android {
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"org.wordpress.android"'
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "false"
             buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "true"
+            buildConfigField "boolean", "ENABLE_SITE_CREATION_DOMAIN_PURCHASING", "false"
 
             manifestPlaceholders = [magicLinkScheme:"wordpress"]
         }
@@ -192,6 +194,7 @@ android {
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
             buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "false"
+            buildConfigField "boolean", "ENABLE_SITE_CREATION_DOMAIN_PURCHASING", "false"
 
             manifestPlaceholders = [magicLinkScheme:"jetpack"]
 

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackMigrationFlowFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackMigrationFlowFeatureConfig.kt
@@ -14,4 +14,3 @@ class JetpackMigrationFlowFeatureConfig
         return BuildConfig.IS_JETPACK_APP && super.isEnabled()
     }
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/util/config/SiteCreationDomainPurchasingFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/SiteCreationDomainPurchasingFeatureConfig.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+@FeatureInDevelopment
+class SiteCreationDomainPurchasingFeatureConfig
+@Inject constructor(
+    appConfig: AppConfig,
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.ENABLE_SITE_CREATION_DOMAIN_PURCHASING,
+)


### PR DESCRIPTION
Resolves #17896

To test:
1. Open the Jetpack app and login
2. Go to `Me` → `App Settings` → `Debug settings`
3. Scroll to the `Features in development` section
4. **Verify** `SiteCreationDomainPurchasingFeatureConfig` feature flag is listed

## Preview

<img width="200" alt="android_local_flag" src="https://user-images.githubusercontent.com/4588074/218153496-2b146871-0a47-441e-a292-71795c7e89de.png">

## Regression Notes
1. Potential unintended areas of impact
   N/a

5. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

6. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
