### PR TITLE
Fixes: navigating to the Reader/Notifications on Phase 4

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -328,7 +328,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
         boolean canShowAppRatingPrompt = savedInstanceState != null;
 
         mBottomNav = findViewById(R.id.bottom_navigation);
-        mBottomNav.init(getSupportFragmentManager(), this);
+        boolean showMySiteTab = mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures();
+        mBottomNav.init(getSupportFragmentManager(), this, showMySiteTab);
 
         if (savedInstanceState == null) {
             if (!AppPrefs.isInstallationReferrerObtained()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -70,7 +70,7 @@ class WPMainNavigationView @JvmOverloads constructor(
         fun onNewPostButtonClicked(promptId: Int, origin: EntryPoint)
     }
 
-    fun init(fm: FragmentManager, listener: OnPageListener) {
+    fun init(fm: FragmentManager, listener: OnPageListener, showMySitePage: Boolean) {
         fragmentManager = fm
         pageListener = listener
 
@@ -102,6 +102,9 @@ class WPMainNavigationView @JvmOverloads constructor(
             itemView.addView(customView)
         }
 
+        if (showMySitePage) {
+            AppPrefs.setMainPageIndex(getPosition(MY_SITE))
+        }
         currentPosition = AppPrefs.getMainPageIndex(numPages() - 1)
     }
 


### PR DESCRIPTION
## What? 

This PR fixes the navigation to the Reader/Notifications tab when the app is launched from the background, and the last used tab was Reader/Notifications.

 ## How? 
Sets the last used tab as MySite on `WpNavigationView' 

I am unsure how to test this PR. I encountered this issue while using the app. 

Testing Instructions 
1. Go to app -> Login -> Me -> App settings -> Debug settings 
2. Make sure the `jp_removal_phase_four` is disabled
3. With that screen open, Comment on the site from the website (The notification wont be shown if the app is in p4)
4. Make sure you don't dismiss the Notification
5. Enable `jp_removal_phase_four`
6. Close the app 
7. Click on the notification 
8. Verify that the comment page is shown 
9. On clicking back, the Notification screen is shown without the Bottom navigation bar 
10. Close the app and restart the app 
11. Notice that you are redirected to My Site page. 

To test:

## Regression Notes
1. Potential unintended areas of impact
N/A

12. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

13. What automated tests I added (or what prevented me from doing so)
Manual testing 

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
