### PR TITLE
[Dependency Updates] Update `androidxRecyclerviewVersion` to 1.2.1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerRecyclerViewAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerRecyclerViewAdapter.java
@@ -69,7 +69,7 @@ public class UsernameChangerRecyclerViewAdapter
             View.OnClickListener listener = new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    mSelectedItem = getAdapterPosition();
+                    mSelectedItem = getBindingAdapterPosition();
                     notifyItemRangeChanged(0, mItems.size());
 
                     if (mListener != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/avatars/TrailingLabelViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/avatars/TrailingLabelViewHolder.kt
@@ -15,7 +15,7 @@ class TrailingLabelViewHolder(
     private val uiHelpers: UiHelpers
 ) : TrainOfAvatarsViewHolder<TrailingLabelItemBinding>(parent.viewBinding(TrailingLabelItemBinding::inflate)) {
     fun bind(textItem: TrailingLabelTextItem) = with(binding) {
-        val position = adapterPosition
+        val position = bindingAdapterPosition
 
         if (position >= 0) {
             itemView.post {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -365,7 +365,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         if (mIsMultiSelectEnabled || mSiteSelectedListener != null) {
             holder.itemView.setOnClickListener(view -> {
-                int clickedPosition = holder.getAdapterPosition();
+                int clickedPosition = holder.getBindingAdapterPosition();
                 if (isValidPosition(clickedPosition)) {
                     if (mIsMultiSelectEnabled) {
                         toggleSelection(clickedPosition);
@@ -385,7 +385,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
             if (!mSitePickerMode.isReblogMode()) {
                 holder.itemView.setOnLongClickListener(view -> {
-                    int clickedPosition = holder.getAdapterPosition();
+                    int clickedPosition = holder.getBindingAdapterPosition();
                     if (isValidPosition(clickedPosition)) {
                         if (mIsMultiSelectEnabled) {
                             toggleSelection(clickedPosition);
@@ -408,7 +408,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             } else {
                 holder.mSelectedRadioButton.setVisibility(View.VISIBLE);
                 holder.mSelectedRadioButton.setChecked(mSelectedItemPos == position);
-                holder.mLayoutContainer.setOnClickListener(v -> selectSingleItem(holder.getAdapterPosition()));
+                holder.mLayoutContainer.setOnClickListener(v -> selectSingleItem(holder.getBindingAdapterPosition()));
             }
         } else {
             if (holder.mSelectedRadioButton != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -322,7 +322,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             itemView.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    int position = getAdapterPosition();
+                    int position = getBindingAdapterPosition();
                     doAdapterItemClicked(position, false);
                 }
             });
@@ -330,7 +330,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             itemView.setOnLongClickListener(new View.OnLongClickListener() {
                 @Override
                 public boolean onLongClick(View v) {
-                    int position = getAdapterPosition();
+                    int position = getBindingAdapterPosition();
                     doAdapterItemClicked(position, true);
                     return true;
                 }
@@ -340,7 +340,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             mSelectionCountContainer.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    int position = getAdapterPosition();
+                    int position = getBindingAdapterPosition();
                     if (canSelectPosition(position)) {
                         setInMultiSelect(true);
                         toggleItemSelected(GridViewHolder.this, position);
@@ -351,7 +351,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             mImgRetry.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    int position = getAdapterPosition();
+                    int position = getBindingAdapterPosition();
                     if (isValidPosition(position) && mCallback != null) {
                         mCallback.onAdapterRequestRetry(position);
                     }
@@ -361,7 +361,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             mImgTrash.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    int position = getAdapterPosition();
+                    int position = getBindingAdapterPosition();
                     if (isValidPosition(position) && mCallback != null) {
                         mCallback.onAdapterRequestDelete(position);
                     }
@@ -374,7 +374,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
         private void addImageSelectedToAccessibilityFocusedEvent(ImageView imageView) {
             AccessibilityUtils.addPopulateAccessibilityEventFocusedListener(imageView, event -> {
-                int position = getAdapterPosition();
+                int position = getBindingAdapterPosition();
                 if (isValidPosition(position)) {
                     if (isItemSelectedByPosition(position)) {
                         final String imageSelectedText = imageView.getContext().getString(

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -500,7 +500,7 @@ public class PeopleListFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 if (mOnPersonSelectedListener != null) {
-                    Person person = getPerson(getAdapterPosition());
+                    Person person = getPerson(getBindingAdapterPosition());
                     mOnPersonSelectedListener.onPersonSelected(person);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -448,7 +448,7 @@ public class PluginBrowserActivity extends LocaleAwareActivity
                 mStatusIcon = mStatusContainer.findViewById(R.id.plugin_status_icon);
 
                 view.setOnClickListener(v -> {
-                    int position = getAdapterPosition();
+                    int position = getBindingAdapterPosition();
                     ImmutablePluginModel plugin = (ImmutablePluginModel) getItem(position);
                     if (plugin == null) {
                         return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -308,7 +308,7 @@ public class PluginListFragment extends Fragment {
                 mRatingBar = view.findViewById(R.id.rating_bar);
 
                 view.setOnClickListener(v -> {
-                    int position = getAdapterPosition();
+                    int position = getBindingAdapterPosition();
                     ImmutablePluginModel plugin = (ImmutablePluginModel) getItem(position);
                     if (plugin == null) {
                         return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MultiSelectRecyclerViewAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MultiSelectRecyclerViewAdapter.java
@@ -43,7 +43,7 @@ public class MultiSelectRecyclerViewAdapter extends RecyclerView.Adapter<MultiSe
 
     @Override
     public void onBindViewHolder(final ItemHolder holder, int position) {
-        String item = getItem(holder.getAdapterPosition());
+        String item = getItem(holder.getBindingAdapterPosition());
         holder.mText.setText(item);
         holder.mContainer.setSelected(isItemSelected(position));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -500,7 +500,7 @@ public class SiteSettingsTagListActivity extends LocaleAwareActivity
                 mTxtCount = view.findViewById(R.id.text_count);
                 view.setOnClickListener(view1 -> {
                     if (!isDetailFragmentShowing()) {
-                        int position = getAdapterPosition();
+                        int position = getBindingAdapterPosition();
                         showDetailFragment(mFilteredTags.get(position));
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserListAdapter.java
@@ -57,7 +57,7 @@ public class PublicizeAccountChooserListAdapter
         if (!mAreAccountsConnected) {
             holder.mView.setOnClickListener(view -> {
                 if (mListener != null) {
-                    mSelectedPosition = holder.getAdapterPosition();
+                    mSelectedPosition = holder.getBindingAdapterPosition();
                     mListener.onAccountSelected(mSelectedPosition);
                 }
             });

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -171,7 +171,7 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 blogHolder.itemView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        int clickedPosition = blogHolder.getAdapterPosition();
+                        int clickedPosition = blogHolder.getBindingAdapterPosition();
                         if (clickedPosition == RecyclerView.NO_POSITION) {
                             return;
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -503,7 +503,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
                 holder.mCountLikes.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        int clickedPosition = holder.getAdapterPosition();
+                        int clickedPosition = holder.getBindingAdapterPosition();
                         toggleLike(v.getContext(), holder, clickedPosition);
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -149,7 +149,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             mTxtSubtitle = itemView.findViewById(R.id.text_subtitle);
 
             postContainer.setOnClickListener(v -> {
-                int position = getAdapterPosition();
+                int position = getBindingAdapterPosition();
                 ReaderPost post = getItem(position);
                 if (mPostSelectedListener != null && post != null) {
                     mPostSelectedListener.onPostSelected(post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSiteSearchAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSiteSearchAdapter.java
@@ -150,7 +150,7 @@ public class ReaderSiteSearchAdapter extends RecyclerView.Adapter<RecyclerView.V
             mSearchResultView = (ReaderSiteSearchResultView) view;
             view.setOnClickListener(new OnClickListener() {
                 @Override public void onClick(View v) {
-                    int position = getAdapterPosition();
+                    int position = getBindingAdapterPosition();
                     if (isValidPosition(position) && mListener != null) {
                         ReaderSiteModel site = mSites.get(position);
                         mListener.onSiteClicked(site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -766,7 +766,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
             mImageView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    int position = getAdapterPosition();
+                    int position = getBindingAdapterPosition();
                     if (mAdapter.isValidPosition(position)) {
                         mAdapter.toggleItemSelected(StockViewHolder.this, position);
                     }

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
     androidxLifecycleVersion = '2.5.1'
     androidxPercentlayoutVersion = '1.0.0'
     androidxPreferenceVersion = '1.1.0'
-    androidxRecyclerviewVersion = '1.0.0'
+    androidxRecyclerviewVersion = '1.2.1'
     androidxRoomVersion = '2.3.0'
     androidxSwipeToRefreshVersion = '1.1.0'
     androidxViewpager2Version = '1.0.0'

--- a/libs/image-editor/build.gradle
+++ b/libs/image-editor/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation "androidx.activity:activity-ktx:$androidxActivityVersion"
     implementation "androidx.fragment:fragment:$androidxFragmentVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
+    implementation "androidx.recyclerview:recyclerview:$androidxRecyclerviewVersion"
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
     implementation "androidx.viewpager2:viewpager2:$androidxViewpager2Version"
     implementation "com.google.android.material:material:$googleMaterialVersion"

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewHolder.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewHolder.kt
@@ -29,7 +29,7 @@ class PreviewImageViewHolder(
 
     fun onBind(uiState: ImageUiState) {
         onItemClicked = uiState.onItemTapped
-        loadIntoImageViewWithResultListener.invoke(uiState.data, previewImageView, adapterPosition)
+        loadIntoImageViewWithResultListener.invoke(uiState.data, previewImageView, bindingAdapterPosition)
         UiHelpers.updateVisibility(progressBar, uiState.progressBarVisible)
         UiHelpers.updateVisibility(errorLayout, uiState.retryLayoutVisible)
     }


### PR DESCRIPTION
Parent #17566

This PR update`androidxRecyclerviewVersion` to [1.2.1](https://developer.android.com/jetpack/androidx/releases/recyclerview#recyclerview-1.2.1).


Also, as part of this update the below transitive dependencies were added:
- On the `Image Editor` module (4131c6d4873ebc840c71bde7504dc2e0e0786084):
    - `androidx.recyclerview:recyclerview`

-----

In addition to the dependency update commits, one more additional analysis related commit was added to resolve the `Adapter Position` deprecation on the `androidx.recyclerview` library itself (fd073d83488fc91d5b7463036ec1241902475991).

-----

PS: @AjeshRPai I added you as the main reviewer, that is, in addition to the @wordpress-mobile/apps-infrastructure  team itself, but randomly, since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid.

-----

To test:

1. See the dependency tree diff result and verify correctness.
2. Thoroughly smoke test any recycler view related functionality on both, the WordPress and Jetpack apps, and see if they both work as expected.
3. In addition to the above smoke test, you can expand the below and check the list of classes where the `getAdapterPosition()` got explicitly replaced with `getBindingAdapterPosition()`, maybe focusing on those screens first might be better:

<details>
  <summary>Adapter Position to Binding Adapter Position</summary> 

1. `image-editor` module:
    - PreviewImageViewHolder.kt
2. `WordPress` module:
    - TrailingLabelViewHolder.kt
    - UsernameChangerRecyclerViewAdapter.java
    - SitePickerAdapter.java
    - MediaGridAdapter.java
    - PeopleListFragment.java
    - PluginBrowserActivity.java
    - PluginListFragment.java
    - MultiSelectRecyclerViewAdapter.java
    - SiteSettingsTagListActivity.java
    - PublicizeAccountChooserListAdapter.java
    - ReaderBlogAdapter.java
    - ReaderCommentAdapter.java
    - ReaderPostAdapter.java
    - ReaderSiteSearchAdapter.java
    - StockMediaPickerActivity.java

</details>

PS: During testing, if you notice any inconsistency you might want to replace `getBindingAdapterPosition()` with `getAbsoluteAdapterPosition()` and test again.

-----
## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on any or all list related app functionalities, like list of posts/pages, reader and reader details, media, site picker and creation, list of plugins, etc.
    - Some of the transitive dependencies added might be causing some kind of misbehaviour.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section.

5. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
