### PR TITLE
Fix the error on site preview screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -94,7 +94,6 @@ import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ColorUtils;
-import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.GravatarUtils;
@@ -102,10 +101,11 @@ import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.util.WPLinkMovementMethod;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.config.UnifiedCommentsCommentEditFeatureConfig;
+import org.wordpress.android.util.extensions.ContextExtensionsKt;
+import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 import org.wordpress.android.widgets.SuggestionAutoCompleteText;
@@ -446,7 +446,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
         if (result != null) {
             mEditReply.setText(result.getString(CommentFullScreenDialogFragment.RESULT_REPLY));
             mEditReply.setSelection(result.getInt(
-                    CommentFullScreenDialogFragment.RESULT_SELECTION_START),
+                            CommentFullScreenDialogFragment.RESULT_SELECTION_START),
                     result.getInt(CommentFullScreenDialogFragment.RESULT_SELECTION_END));
             mEditReply.requestFocus();
         }
@@ -539,6 +539,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
     private SiteModel createDummyWordPressComSite(long siteId) {
         SiteModel site = new SiteModel();
         site.setIsWPCom(true);
+        site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
         site.setSiteId(siteId);
         return site;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/FetchWpComSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/FetchWpComSiteUseCase.kt
@@ -53,6 +53,7 @@ class FetchWpComSiteUseCase @Inject constructor(
         val siteModel = SiteModel()
         siteModel.siteId = siteId
         siteModel.setIsWPCom(true)
+        siteModel.origin = SiteModel.ORIGIN_WPCOM_REST
         return siteModel
     }
 


### PR DESCRIPTION
The issue is that it returns the site list instead of My Site after creating a site.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2643 made a change that requires `site.origin` to fetch sites. There are some cases in `WPAndroid` where the site is created manually without `origin` data. This PR adds `origin` to the site in these cases. 

|before|after|
|---|---|
|<video src="https://user-images.githubusercontent.com/2471769/218543436-4df8de15-9a58-4c8e-baed-7e0b4fec4f6a.mp4">|<video src="https://user-images.githubusercontent.com/2471769/218544091-e1611cb9-2a21-44d1-a551-47691e2cba1d.mp4">|

**Cases:**
**FetchWpComSiteUseCase.kt:** This causes the error on the preview screen after the site is created. You can see the exception below in the logcat. 
` java.lang.NullPointerException: site.xmlRpcUrl must not be null`

**CommentDetailFragment.java:** I couldn't find what `createDummyWordPressComSite` is used for, but I still added `origin` to the site just in case. Since `setIsWPCom` is already set, setting also `origin` looks safe to me.

To test:
1. Launch the app and log in.
2. On the site picker screen, tap ➕ button at the top an complete all steps to create a test site.
3. Verify it navigates to the "My Site" screen after the site is created.

## Regression Notes
1. Potential unintended areas of impact
Fetching sites in different areas of the site.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested fetching sites in these areas.

4. What automated tests I added (or what prevented me from doing so)
The issue was a missing parameter and occurred on communicating between WPAndroid and a library. Adding a test is not suitable for this case.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
