### PR TITLE
Blaze: Add the promote with blaze card skeleton

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.RecyclerView.RecycledViewPool
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.JetpackFeatureCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PromoteWithBlazeCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinkRibbon
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
@@ -17,6 +18,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.InfoItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.ListItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.SingleActionCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.JetpackBadge
+import org.wordpress.android.ui.mysite.cards.blaze.PromoteWithBlazeCardViewHolder
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsViewHolder
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptsCardAnalyticsTracker
 import org.wordpress.android.ui.mysite.cards.domainregistration.DomainRegistrationViewHolder
@@ -73,10 +75,12 @@ class MySiteAdapter(
             MySiteCardAndItem.Type.SINGLE_ACTION_CARD.ordinal -> SingleActionCardViewHolder(parent)
             MySiteCardAndItem.Type.JETPACK_FEATURE_CARD.ordinal -> JetpackFeatureCardViewHolder(parent, uiHelpers)
             MySiteCardAndItem.Type.JETPACK_SWITCH_CARD.ordinal -> SwitchToJetpackMenuCardViewHolder(parent)
+            MySiteCardAndItem.Type.PROMOTE_WITH_BLAZE.ordinal ->  PromoteWithBlazeCardViewHolder(parent, uiHelpers)
             else -> throw IllegalArgumentException("Unexpected view type")
         }
     }
 
+    @Suppress("ComplexMethod")
     override fun onBindViewHolder(holder: MySiteCardAndItemViewHolder<*>, position: Int) {
         when (holder) {
             is QuickActionsViewHolder -> holder.bind(getItem(position) as QuickActionsCard)
@@ -92,6 +96,7 @@ class MySiteAdapter(
             is SingleActionCardViewHolder -> holder.bind(getItem(position) as SingleActionCard)
             is JetpackFeatureCardViewHolder -> holder.bind(getItem(position) as JetpackFeatureCard)
             is SwitchToJetpackMenuCardViewHolder -> holder.bind(getItem(position) as JetpackSwitchMenu)
+            is PromoteWithBlazeCardViewHolder -> holder.bind(getItem(position) as PromoteWithBlazeCard)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -4,6 +4,7 @@ import androidx.recyclerview.widget.DiffUtil
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.JetpackFeatureCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PromoteWithBlazeCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickActionsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinkRibbon
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
@@ -35,6 +36,7 @@ object MySiteAdapterDiffCallback : DiffUtil.ItemCallback<MySiteCardAndItem>() {
             }
             oldItem is JetpackFeatureCard && updatedItem is JetpackFeatureCard -> true
             oldItem is JetpackSwitchMenu && updatedItem is JetpackSwitchMenu -> true
+            oldItem is PromoteWithBlazeCard && updatedItem is PromoteWithBlazeCard -> true
             else -> throw UnsupportedOperationException("Diff not implemented yet")
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.INFO_ITEM
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.JETPACK_BADGE
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.JETPACK_FEATURE_CARD
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.LIST_ITEM
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.PROMOTE_WITH_BLAZE
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.QUICK_ACTIONS_CARD
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.QUICK_LINK_RIBBON
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.QUICK_START_CARD
@@ -42,7 +43,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         JETPACK_BADGE,
         SINGLE_ACTION_CARD,
         JETPACK_FEATURE_CARD,
-        JETPACK_SWITCH_CARD
+        JETPACK_SWITCH_CARD,
+        PROMOTE_WITH_BLAZE
     }
 
     enum class DashboardCardType {
@@ -254,6 +256,15 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                 }
             }
         }
+
+        data class PromoteWithBlazeCard(
+            val title: UiString?,
+            val subtitle: UiString?,
+            @DrawableRes val primaryImage: Int,
+            val onClick: ListItemInteraction,
+            val onHideMenuItemClick: ListItemInteraction,
+            val onMoreMenuClick: ListItemInteraction,
+        ): Card(PROMOTE_WITH_BLAZE)
     }
 
     sealed class DynamicCard(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardViewHolder.kt
@@ -1,0 +1,51 @@
+package org.wordpress.android.ui.mysite.cards.blaze
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.widget.PopupMenu
+import org.wordpress.android.R
+import org.wordpress.android.databinding.PromoteWithBlazeCardBinding
+import org.wordpress.android.ui.mysite.MySiteCardAndItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
+import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.viewBinding
+
+class PromoteWithBlazeCardViewHolder(
+    parent: ViewGroup,
+    private val uiHelpers: UiHelpers
+) : MySiteCardAndItemViewHolder<PromoteWithBlazeCardBinding>(
+    parent.viewBinding(PromoteWithBlazeCardBinding::inflate)
+) {
+    fun bind(card: MySiteCardAndItem.Card.PromoteWithBlazeCard) = with(binding) {
+        uiHelpers.setTextOrHide(mySitePromoteWithBlazeCardTitle, card.title)
+        mySitePromoteWithBlazeCardCta.setOnClickListener { card.onClick.click() }
+        mySitePromoteWithBlazeCardMore.setOnClickListener {
+            showMoreMenu(
+                card.onHideMenuItemClick,
+                card.onMoreMenuClick,
+                mySitePromoteWithBlazeCardMore,
+            )
+        }
+    }
+
+    private fun showMoreMenu(
+        onHideMenuItemClick: ListItemInteraction,
+        onMoreMenuClick: ListItemInteraction,
+        anchor: View
+    ) {
+        onMoreMenuClick.click()
+        val popupMenu = PopupMenu(itemView.context, anchor)
+        popupMenu.setOnMenuItemClickListener {
+            when (it.itemId) {
+                R.id.promote_with_blaze_card_menu_item_hide_this -> {
+                    onHideMenuItemClick.click()
+                    return@setOnMenuItemClickListener true
+                }
+                else -> return@setOnMenuItemClickListener true
+            }
+        }
+        popupMenu.inflate(R.menu.promote_with_blaze_card_menu)
+        popupMenu.show()
+    }
+}

--- a/WordPress/src/main/res/drawable/img_blaze_flame.xml
+++ b/WordPress/src/main/res/drawable/img_blaze_flame.xml
@@ -1,0 +1,13 @@
+<vector android:autoMirrored="true" android:height="38dp"
+    android:viewportHeight="38" android:viewportWidth="56"
+    android:width="56dp" xmlns:aapt="http://schemas.android.com/aapt" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:pathData="M59.978,29.327C60.517,32.665 60.278,36.079 59.272,39.406C58.266,42.733 56.532,45.885 54.133,48.69C51.75,51.493 48.765,53.889 45.353,55.754C43.736,56.631 42.045,57.375 40.295,57.981L39.9,58.405C33.095,59.744 31.118,60.516 25.796,59.833L25.798,59.848C24.709,59.764 23.626,59.614 22.553,59.414C18.728,58.716 15.141,57.38 11.998,55.468C8.856,53.557 6.202,51.112 4.201,48.271C2.2,45.428 0.9,42.262 0.362,38.925C-1.459,27.631 9.975,19.77 9.975,19.77C9.975,19.77 14.197,25.735 21.172,24.61C34.284,22.496 26.024,0.965 26.024,0.965C26.024,0.965 38.985,5.48 45.337,22.064C51.716,20.236 49.913,12.514 49.913,12.514C49.913,12.514 58.466,19.947 59.991,29.406">
+        <aapt:attr name="android:fillColor">
+            <gradient android:endX="30.979" android:endY="32.091"
+                android:startX="26.08" android:startY="7.554" android:type="linear">
+                <item android:color="#FFE94338" android:offset="0"/>
+                <item android:color="#FFFFB800" android:offset="1"/>
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>

--- a/WordPress/src/main/res/layout/promote_with_blaze_card.xml
+++ b/WordPress/src/main/res/layout/promote_with_blaze_card.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/my_site_promote_with_blaze_card_cta"
+    style="@style/WordPress.CardView.Unelevated"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:foreground="?attr/selectableItemBackground">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_extra_large">
+
+        <ImageView
+            android:id="@+id/my_site_promote_with_blaze_card_more"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:contentDescription="@string/content_description_more"
+            android:focusable="true"
+            android:src="@drawable/ic_more_vert_white_24dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/wpColorOnSurfaceMedium"
+            tools:ignore="TouchTargetSizeCheck" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/my_site_promote_with_blaze_card_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/promote_blaze_card_title"
+            android:textAlignment="viewStart"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            app:layout_constraintEnd_toStartOf="@+id/my_site_promote_with_blaze_card_more"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="@string/promote_blaze_card_title" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/my_site_promote_with_blaze_card_sub_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingBottom="@dimen/margin_medium"
+            android:paddingTop="@dimen/margin_medium"
+            android:text="@string/promote_blaze_card_sub_title"
+            android:textAppearance="?attr/textAppearanceBody1"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/my_site_promote_with_blaze_card_title" />
+
+        <ImageView
+            android:id="@+id/my_site_promote_with_blaze_card_flame"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/content_description_more"
+            android:src="@drawable/img_blaze_flame"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/my_site_promote_with_blaze_card_sub_title"
+            app:layout_constraintTop_toBottomOf="@+id/my_site_promote_with_blaze_card_more" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/menu/promote_with_blaze_card_menu.xml
+++ b/WordPress/src/main/res/menu/promote_with_blaze_card_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/promote_with_blaze_card_menu_item_hide_this"
+        android:title="@string/promote_blaze_card_menu_hide_this"
+        android:icon="@drawable/ic_not_visible_white_24dp"/>
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4380,4 +4380,9 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jetpack_full_plugin_install_onboarding_terms_and_conditions_button">Terms and conditions</string>
     <string name="jetpack_full_plugin_install_onboarding_install_button">Install the full plugin</string>
     <string name="jetpack_full_plugin_install_onboarding_contact_support_button">Contact support</string>
+
+    <!-- Promote Blaze Card-->
+    <string name="promote_blaze_card_title">Promote your content with Blaze</string>
+    <string name="promote_blaze_card_sub_title">Display your work across millions of sites.</string>
+    <string name="promote_blaze_card_menu_hide_this">Hide this</string>
 </resources>


### PR DESCRIPTION
Parent #17909 

The PR adds the foundational pieces for showing the Promote with Blaze card. This is behind the scenes work, no card is displayed.

Includes
- String and image resources
- Promote with blaze card layout and menu layout
- Adds the PromoteWithBlazeCard
- Adds the PromoteWithBlazeCardViewHolder
- Updates MySiteAdapter and MySiteAdapterDiffCallback to handle the PromoteWithBlaze card

**To test:**
There is nothing to test in this PR, as this is all foundational work.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
