### PR TITLE
Add higher CI priority to release builds

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -14,6 +14,7 @@ steps:
   - label: "Gradle Wrapper Validation"
     command: |
       validate_gradle_wrapper
+    priority: 1
     plugins: *common_plugins
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
@@ -28,12 +29,14 @@ steps:
       - label: "🕵️ Lint WordPress"
         key: wplint
         command: ".buildkite/commands/lint.sh wordpress"
+        priority: 1
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
       - label: "🕵️ Lint Jetpack"
         key: jplint
         command: ".buildkite/commands/lint.sh jetpack"
+        priority: 1
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
@@ -46,6 +49,7 @@ steps:
       - label: ":wordpress: :android: Release Build"
         key: wpbuild
         command: ".buildkite/commands/release-build.sh wordpress"
+        priority: 1
         depends_on: wplint
         plugins: *common_plugins
         notify:
@@ -54,6 +58,7 @@ steps:
       - label: ":jetpack: :android: Release Build"
         key: jpbuild
         command: ".buildkite/commands/release-build.sh jetpack"
+        priority: 1
         depends_on: jplint
         plugins: *common_plugins
         notify:
@@ -67,4 +72,5 @@ steps:
       - wpbuild
       - jpbuild
     command: ".buildkite/commands/create-github-release.sh"
+    priority: 1
     plugins: *common_plugins


### PR DESCRIPTION
### Summary of changes:

This PR increases the priority of release builds on Buildkite. This will be useful so that release builds won't get delayed if the CI queue gets backed up. The default priority of a build is 0, so increasing the release builds to 1 will put them before other builds: https://buildkite.com/docs/pipelines/managing-priorities