### PR TITLE
Fix UI test issue caused by GCMMessageService

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/push/GCMMessageService.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/push/GCMMessageService.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.push
+
+import com.google.firebase.messaging.FirebaseMessagingService
+
+/**
+ * A dummy implementation of the GCMMessageService.
+ * This is needed to avoid a race condition between Hilt's test initialization, and the injection
+ * done by @AndroidEntryPoint in the service when receiving a new token.
+ */
+class GCMMessageService : FirebaseMessagingService()

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -86,6 +86,7 @@ public class BaseTest {
 
     @Before
     public void setup() {
+        mHiltRule.inject();
         Matcher<? super AccessibilityCheckResult> nonErrorLevelMatcher =
                 Matchers.allOf(matchesTypes(
                         anyOf(is(AccessibilityCheckResultType.INFO), is(AccessibilityCheckResultType.WARNING))));

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -86,7 +86,6 @@ public class BaseTest {
 
     @Before
     public void setup() {
-        mHiltRule.inject();
         Matcher<? super AccessibilityCheckResult> nonErrorLevelMatcher =
                 Matchers.allOf(matchesTypes(
                         anyOf(is(AccessibilityCheckResultType.INFO), is(AccessibilityCheckResultType.WARNING))));


### PR DESCRIPTION
This PR is to fix the `GCMMessageService` issue on CI tests. A dummy `GCMMessageService` is added to be used only in tests, and it resolves the race condition between the Hilt's injection and `GCMMessageService`

> ***Warning***
> CI tests are still failing for a different reason. But it's out of this PR's scope.

To test:
The GCMMessageService exception below shouldn't be thrown on CI tests.

```
java.lang.RuntimeException: Unable to create service org.wordpress.android.push.GCMMessageService:
 java.lang.IllegalStateException: The component has not been created. Check that you have called #inject()? Otherwise, 
there is a race between injection and component creation. Make sure there is a happens-before edge between the 
HiltAndroidRule/registering all test modules and the first injection.
```

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Update current tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
