### PR TITLE
Integrate gutenberg-mobile release 1.89.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.88.1-alpha1'
+    gutenbergMobileVersion = '5485-81868e30c9973ccd425236bbbf6326b18e79bc29'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2657-77f6e8b4af256b762d0c1482a9347ccf9fb4820e'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5485-581dfd445660821663474c13f9b55c3057aaf182'
+    gutenbergMobileVersion = 'v1.89.0'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2657-77f6e8b4af256b762d0c1482a9347ccf9fb4820e'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5485-81868e30c9973ccd425236bbbf6326b18e79bc29'
+    gutenbergMobileVersion = '5485-581dfd445660821663474c13f9b55c3057aaf182'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2657-77f6e8b4af256b762d0c1482a9347ccf9fb4820e'
     wordPressLoginVersion = '1.0.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.89.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5485

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.