### PR TITLE
Show Zendesk support to paid users

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 21.8
 -----
 * [*] [WordPress-only] We have redesigned the landing screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17871]
-* [**] [internal][WordPress-only] Help & Support: replaces Contact Support with new Community forums, and removes Browse our FAQ. [https://github.com/wordpress-mobile/WordPress-Android/pull/17820]
+* [**] [internal][WordPress-only] Help & Support: replaces Contact Support with new Community forums. [https://github.com/wordpress-mobile/WordPress-Android/pull/17820]
 
 21.7
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -99,7 +99,9 @@ class HelpActivity : LocaleAwareActivity() {
                 actionBar.elevation = 0f // remove shadow
             }
 
-            if (wpSupportForumFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
+            if (wpSupportForumFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP &&
+                !SiteUtils.hasSiteWithPaidPlan(siteStore)
+            ) {
                 showSupportForum()
             } else {
                 showContactUs()

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -368,6 +368,15 @@ public class SiteUtils {
         return site.getPlanId() == PlansConstants.FREE_PLAN_ID;
     }
 
+    public static boolean hasSiteWithPaidPlan(SiteStore siteStore) {
+        for (SiteModel site : siteStore.getSites()) {
+            if (!site.getHasFreePlan()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static boolean onBloggerPlan(@NonNull SiteModel site) {
         return site.getPlanId() == PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
                || site.getPlanId() == PlansConstants.BLOGGER_PLAN_TWO_YEARS_ID;

--- a/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.plans.PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
 import org.wordpress.android.ui.plans.PlansConstants.BLOGGER_PLAN_TWO_YEARS_ID
@@ -29,6 +30,9 @@ class SiteUtilsTest {
     @Mock
     private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
+    @Mock
+    private lateinit var siteStore: SiteStore
+
     @Test
     fun `onFreePlan returns true when site is on free plan`() {
         val site = SiteModel()
@@ -38,6 +42,20 @@ class SiteUtilsTest {
 
         site.planId = PREMIUM_PLAN_ID
         assertFalse(SiteUtils.onFreePlan(site))
+    }
+
+    @Test
+    fun `hasSiteWithPaidPlan returns true when site is on a paid plan`() {
+        val site1 = SiteModel()
+        val site2 = SiteModel()
+        whenever(siteStore.sites).thenReturn(listOf(site1, site2))
+
+        site1.hasFreePlan = true
+        site2.hasFreePlan = true
+        assertFalse(SiteUtils.hasSiteWithPaidPlan(siteStore))
+
+        site2.hasFreePlan = false
+        assertTrue(SiteUtils.hasSiteWithPaidPlan(siteStore))
     }
 
     @Test


### PR DESCRIPTION
This shows Zendesk support to paid users on the Help screen. 
If the user has any site with a paid plan, they'll see the "Contact Support" button instead of "Community Forums" button on the Help screen.

|before - paid user on WP|after - paid user on WP|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/219484031-14eb94db-75b4-4f07-b556-df68c3d37d60.png" height=600>|<img src="https://user-images.githubusercontent.com/2471769/219484027-58c655a6-b681-47bc-9d62-f591c29d1b31.png" height=600>|

Fixes #17966 

To test:
**Free user**
1. Launch the WP app and log in.
2. Ensure you don't have any site with a paid plan.
3. Navigate to "Me → Help & Support".
4. Verify that you see the "Contact Support" button on the screen.

**Paid user**
1. Launch the WP app and log in.
2. Ensure you have at least one site with a paid plan.
3. Navigate to "Me → Help & Support".
4. Verify that you see "Community forums" button on the screen.
5. Tap the "Community forums" and verify "https://wordpress.org/support/forum/mobile/" is opened on the external browser.

**Jetpack** 
Repeat the tests above on Jetpack app. You should see "Contact Support" for both cases.

## Regression Notes
1. Potential unintended areas of impact
Free users should still see the community forum.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested different cases manually.

8. What automated tests I added (or what prevented me from doing so)
Added `hasSiteWithPaidPlan returns true when site is on a paid plan`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
