### PR TITLE
[JP install full plugin] Install screen UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
@@ -4,10 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
@@ -17,6 +15,7 @@ import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.bloggingprompts.promptslist.compose.BloggingPromptsListScreen
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.posts.PostUtils
+import org.wordpress.android.util.extensions.setContent
 
 @AndroidEntryPoint
 class BloggingPromptsListActivity : LocaleAwareActivity() {
@@ -42,12 +41,6 @@ class BloggingPromptsListActivity : LocaleAwareActivity() {
     override fun onResume() {
         super.onResume()
         viewModel.onScreenShown()
-    }
-
-    // TODO it might be safer bringing in the androidx.activity:activity-compose lib
-    private fun setContent(content: @Composable () -> Unit) {
-        val composeView = ComposeView(this).apply { setContent(content) }
-        setContentView(composeView)
     }
 
     private fun observeActions() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/unit/FontSize.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/unit/FontSize.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.unit.sp
 
 sealed class FontSize(val value: TextUnit) {
     object Small : FontSize(12.sp)
+    object Medium : FontSize(14.sp)
     object Large : FontSize(16.sp)
     object ExtraLarge : FontSize(20.sp)
     object DoubleExtraLarge : FontSize(24.sp)

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/unit/Margin.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/unit/Margin.kt
@@ -7,6 +7,7 @@ sealed class Margin(val value: Dp) {
     object Small : Margin(4.dp)
     object Medium : Margin(8.dp)
     object MediumLarge : Margin(10.dp)
+    object Large : Margin(12.dp)
     object ExtraLarge : Margin(16.dp)
     object ExtraMediumLarge : Margin(24.dp)
     object ExtraExtraMediumLarge : Margin(32.dp)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.jpfullplugininstall.install
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.Composable
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.util.extensions.setContent
+
+@AndroidEntryPoint
+class JetpackFullPluginInstallActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AppTheme {
+                JetpackFullPluginInstallScreen()
+            }
+        }
+    }
+
+    @Composable
+    private fun JetpackFullPluginInstallScreen() {
+        
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
@@ -2,25 +2,23 @@ package org.wordpress.android.ui.jpfullplugininstall.install
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.runtime.Composable
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.util.extensions.setContent
 
 @AndroidEntryPoint
 class JetpackFullPluginInstallActivity : AppCompatActivity() {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             AppTheme {
-                JetpackFullPluginInstallScreen()
+//                JetpackFullPluginInstallScreen()
             }
         }
     }
 
-    @Composable
-    private fun JetpackFullPluginInstallScreen() {
-        
-    }
+//    @Composable
+//    private fun JetpackFullPluginInstallScreen() {
+//
+//    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
@@ -30,5 +30,15 @@ class JetpackFullPluginInstallViewModel {
             title = R.string.jetpack_full_plugin_install_installing_title,
             description = R.string.jetpack_full_plugin_install_installing_description,
         )
+
+        data class Done(
+            @StringRes val buttonText: Int = R.string.jetpack_full_plugin_install_done_button,
+        ) : UiState(
+            toolbarTitle = R.string.jetpack,
+            image = R.drawable.ic_jetpack_logo_green_24dp,
+            imageContentDescription = R.string.jetpack_full_plugin_install_image_content_description,
+            title = R.string.jetpack_full_plugin_install_done_title,
+            description = R.string.jetpack_full_plugin_install_done_description,
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
@@ -12,15 +12,23 @@ class JetpackFullPluginInstallViewModel {
         @StringRes val imageContentDescription: Int,
         @StringRes val title: Int,
         @StringRes val description: Int,
-        @StringRes val buttonText: Int,
     ) {
-        object Initial : UiState(
+        data class Initial(
+            @StringRes val buttonText: Int = R.string.jetpack_full_plugin_install_continue,
+        ) : UiState(
             toolbarTitle = R.string.jetpack,
             image = R.drawable.ic_jetpack_logo_green_24dp,
             imageContentDescription = R.string.jetpack_full_plugin_install_image_content_description,
-            title = R.string.install_jetpack,
-            description = R.string.install_jetpack_message,
-            buttonText = R.string.jetpack_full_plugin_install_continue,
+            title = R.string.jetpack_full_plugin_install_initial_title,
+            description = R.string.jetpack_full_plugin_install_initial_description,
+        )
+
+        object Installing : UiState(
+            toolbarTitle = R.string.jetpack,
+            image = R.drawable.ic_jetpack_logo_green_24dp,
+            imageContentDescription = R.string.jetpack_full_plugin_install_image_content_description,
+            title = R.string.jetpack_full_plugin_install_installing_title,
+            description = R.string.jetpack_full_plugin_install_installing_description,
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
@@ -14,7 +14,7 @@ class JetpackFullPluginInstallViewModel {
         @StringRes val description: Int,
     ) {
         data class Initial(
-            @StringRes val buttonText: Int = R.string.jetpack_full_plugin_install_initial_continue,
+            @StringRes val buttonText: Int = R.string.jetpack_full_plugin_install_initial_button,
         ) : UiState(
             toolbarTitle = R.string.jetpack,
             image = R.drawable.ic_jetpack_logo_green_24dp,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.jpfullplugininstall.install
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import org.wordpress.android.R
+
+class JetpackFullPluginInstallViewModel {
+
+    sealed class UiState(
+        @StringRes val toolbarTitle: Int,
+        @DrawableRes val image: Int,
+        @StringRes val imageContentDescription: Int,
+        @StringRes val title: Int,
+        @StringRes val description: Int,
+        @StringRes val buttonText: Int,
+    ) {
+        object Initial : UiState(
+            toolbarTitle = R.string.jetpack,
+            image = R.drawable.ic_jetpack_logo_green_24dp,
+            imageContentDescription = R.string.jetpack_full_plugin_install_image_content_description,
+            title = R.string.install_jetpack,
+            description = R.string.install_jetpack_message,
+            buttonText = R.string.jetpack_full_plugin_install_continue,
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
@@ -18,7 +18,7 @@ class JetpackFullPluginInstallViewModel {
         ) : UiState(
             toolbarTitle = R.string.jetpack,
             image = R.drawable.ic_jetpack_logo_green_24dp,
-            imageContentDescription = R.string.jetpack_full_plugin_install_image_content_description,
+            imageContentDescription = R.string.jetpack_full_plugin_install_jp_logo_content_description,
             title = R.string.jetpack_full_plugin_install_initial_title,
             description = R.string.jetpack_full_plugin_install_initial_description,
         )
@@ -26,7 +26,7 @@ class JetpackFullPluginInstallViewModel {
         object Installing : UiState(
             toolbarTitle = R.string.jetpack,
             image = R.drawable.ic_jetpack_logo_green_24dp,
-            imageContentDescription = R.string.jetpack_full_plugin_install_image_content_description,
+            imageContentDescription = R.string.jetpack_full_plugin_install_jp_logo_content_description,
             title = R.string.jetpack_full_plugin_install_installing_title,
             description = R.string.jetpack_full_plugin_install_installing_description,
         )
@@ -36,9 +36,20 @@ class JetpackFullPluginInstallViewModel {
         ) : UiState(
             toolbarTitle = R.string.jetpack,
             image = R.drawable.ic_jetpack_logo_green_24dp,
-            imageContentDescription = R.string.jetpack_full_plugin_install_image_content_description,
+            imageContentDescription = R.string.jetpack_full_plugin_install_jp_logo_content_description,
             title = R.string.jetpack_full_plugin_install_done_title,
             description = R.string.jetpack_full_plugin_install_done_description,
+        )
+
+        data class Error(
+            @StringRes val retryButtonText: Int = R.string.jetpack_full_plugin_install_error_button_retry,
+            @StringRes val contactSupportButtonText: Int = R.string.jetpack_full_plugin_install_error_button_contact_support,
+        ) : UiState(
+            toolbarTitle = R.string.jetpack,
+            image = R.drawable.img_illustration_info_outline_88dp,
+            imageContentDescription = R.string.jetpack_full_plugin_install_error_image_content_description,
+            title = R.string.jetpack_full_plugin_install_error_title,
+            description = R.string.jetpack_full_plugin_install_error_description,
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
@@ -14,7 +14,7 @@ class JetpackFullPluginInstallViewModel {
         @StringRes val description: Int,
     ) {
         data class Initial(
-            @StringRes val buttonText: Int = R.string.jetpack_full_plugin_install_continue,
+            @StringRes val buttonText: Int = R.string.jetpack_full_plugin_install_initial_continue,
         ) : UiState(
             toolbarTitle = R.string.jetpack,
             image = R.drawable.ic_jetpack_logo_green_24dp,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
@@ -5,7 +5,6 @@ import androidx.annotation.StringRes
 import org.wordpress.android.R
 
 class JetpackFullPluginInstallViewModel {
-
     sealed class UiState(
         @StringRes val toolbarTitle: Int,
         @DrawableRes val image: Int,
@@ -43,7 +42,8 @@ class JetpackFullPluginInstallViewModel {
 
         data class Error(
             @StringRes val retryButtonText: Int = R.string.jetpack_full_plugin_install_error_button_retry,
-            @StringRes val contactSupportButtonText: Int = R.string.jetpack_full_plugin_install_error_button_contact_support,
+            @StringRes val contactSupportButtonText: Int =
+                R.string.jetpack_full_plugin_install_error_button_contact_support,
         ) : UiState(
             toolbarTitle = R.string.jetpack,
             image = R.drawable.img_illustration_info_outline_88dp,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/BaseState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/BaseState.kt
@@ -1,0 +1,95 @@
+package org.wordpress.android.ui.jpfullplugininstall.install.compose.state
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.MainTopAppBar
+import org.wordpress.android.ui.compose.components.NavigationIcons
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.unit.FontSize
+import org.wordpress.android.ui.compose.unit.Margin
+import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel
+
+@Composable
+fun BaseState(
+    uiState: JetpackFullPluginInstallViewModel.UiState,
+    onDismissScreenClick: () -> Unit,
+    content: @Composable () -> Unit
+) = Box(
+    Modifier
+        .fillMaxWidth()
+        .fillMaxHeight()
+) {
+    with(uiState) {
+        MainTopAppBar(
+            title = stringResource(toolbarTitle),
+            navigationIcon = NavigationIcons.BackIcon,
+            onNavigationIconClick = onDismissScreenClick
+        )
+        val scrollState = rememberScrollState()
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(horizontal = 32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Image(
+                painter = painterResource(image),
+                contentDescription = stringResource(imageContentDescription),
+                modifier = Modifier
+                    .height(dimensionResource(R.dimen.jetpack_remote_install_icon_size))
+                    .width(dimensionResource(R.dimen.jetpack_remote_install_icon_size))
+            )
+            Text(
+                text = stringResource(title),
+                textAlign = TextAlign.Center,
+                fontSize = FontSize.ExtraLarge.value,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(top = Margin.ExtraLarge.value),
+            )
+            Text(
+                text = stringResource(description),
+                textAlign = TextAlign.Center,
+                fontSize = FontSize.Large.value,
+                modifier = Modifier.padding(top = Margin.Medium.value),
+            )
+            content()
+        }
+    }
+}
+
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL)
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
+@Composable
+private fun PreviewInitialState() {
+    AppTheme {
+        val uiState = JetpackFullPluginInstallViewModel.UiState.Initial
+        InitialState(uiState, {}, {})
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/BaseState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/BaseState.kt
@@ -89,7 +89,7 @@ fun BaseState(
 @Composable
 private fun PreviewInitialState() {
     AppTheme {
-        val uiState = JetpackFullPluginInstallViewModel.UiState.Initial
-        InitialState(uiState, {}, {})
+        val uiState = JetpackFullPluginInstallViewModel.UiState.Initial()
+        BaseState(uiState, {}, {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/DoneState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/DoneState.kt
@@ -33,7 +33,7 @@ fun DoneState(
             PrimaryButton(
                 text = stringResource(buttonText),
                 onClick = onDoneClick,
-                modifier = Modifier.padding(top = Margin.ExtraLarge.value),
+                modifier = Modifier.padding(top = Margin.Large.value),
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/DoneState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/DoneState.kt
@@ -1,0 +1,51 @@
+package org.wordpress.android.ui.jpfullplugininstall.install.compose.state
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.unit.Margin
+import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
+import org.wordpress.android.ui.qrcodeauth.compose.components.PrimaryButton
+
+@Composable
+fun DoneState(
+    uiState: UiState.Done,
+    onDoneClick: () -> Unit,
+    onDismissScreenClick: () -> Unit,
+) = Box(
+    Modifier
+        .fillMaxWidth()
+        .fillMaxHeight()
+) {
+    with(uiState) {
+        BaseState(
+            uiState = uiState,
+            onDismissScreenClick = onDismissScreenClick
+        ) {
+            PrimaryButton(
+                text = stringResource(buttonText),
+                onClick = onDoneClick,
+                modifier = Modifier.padding(top = Margin.ExtraLarge.value),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL)
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
+@Composable
+private fun PreviewDoneState() {
+    AppTheme {
+        val uiState = UiState.Done()
+        DoneState(uiState, {}, {})
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/DoneState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/DoneState.kt
@@ -10,10 +10,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.ui.compose.components.PrimaryButton
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
-import org.wordpress.android.ui.qrcodeauth.compose.components.PrimaryButton
 
 @Composable
 fun DoneState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/ErrorState.kt
@@ -11,11 +11,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.PrimaryButton
+import org.wordpress.android.ui.compose.components.SecondaryButton
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
-import org.wordpress.android.ui.qrcodeauth.compose.components.PrimaryButton
-import org.wordpress.android.ui.qrcodeauth.compose.components.SecondaryButton
 
 @Composable
 fun ErrorState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/ErrorState.kt
@@ -1,0 +1,58 @@
+package org.wordpress.android.ui.jpfullplugininstall.install.compose.state
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.unit.Margin
+import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
+import org.wordpress.android.ui.qrcodeauth.compose.components.PrimaryButton
+import org.wordpress.android.ui.qrcodeauth.compose.components.SecondaryButton
+
+@Composable
+fun ErrorState(
+    uiState: UiState.Error,
+    onRetryClick: () -> Unit,
+    onContactSupportClick: () -> Unit,
+    onDismissScreenClick: () -> Unit,
+) = Box(
+    Modifier
+        .fillMaxWidth()
+        .fillMaxHeight()
+) {
+    with(uiState) {
+        BaseState(
+            uiState = uiState,
+            onDismissScreenClick = onDismissScreenClick
+        ) {
+            PrimaryButton(
+                text = stringResource(retryButtonText),
+                onClick = onRetryClick,
+                modifier = Modifier.padding(top = Margin.ExtraLarge.value),
+            )
+            SecondaryButton(
+                text = stringResource(R.string.jetpack_full_plugin_install_onboarding_contact_support_button),
+                onClick = onContactSupportClick,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL)
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
+@Composable
+private fun PreviewErrorState() {
+    AppTheme {
+        val uiState = UiState.Error()
+        ErrorState(uiState, {}, {}, {})
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/ErrorState.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.PrimaryButton
 import org.wordpress.android.ui.compose.components.SecondaryButton
 import org.wordpress.android.ui.compose.theme.AppTheme
@@ -36,10 +35,10 @@ fun ErrorState(
             PrimaryButton(
                 text = stringResource(retryButtonText),
                 onClick = onRetryClick,
-                modifier = Modifier.padding(top = Margin.ExtraLarge.value),
+                modifier = Modifier.padding(top = Margin.Large.value),
             )
             SecondaryButton(
-                text = stringResource(R.string.jetpack_full_plugin_install_onboarding_contact_support_button),
+                text = stringResource(contactSupportButtonText),
                 onClick = onContactSupportClick,
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
@@ -1,42 +1,23 @@
 package org.wordpress.android.ui.jpfullplugininstall.install.compose.state
 
 import android.content.res.Configuration
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import org.wordpress.android.R
-import org.wordpress.android.ui.compose.components.MainTopAppBar
-import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
-import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
 import org.wordpress.android.ui.qrcodeauth.compose.components.PrimaryButton
 
 @Composable
 fun InitialState(
-    content: UiState.Initial,
+    uiState: UiState.Initial,
     onContinueClick: () -> Unit,
     onDismissScreenClick: () -> Unit,
 ) = Box(
@@ -44,41 +25,11 @@ fun InitialState(
         .fillMaxWidth()
         .fillMaxHeight()
 ) {
-    with(content) {
-        MainTopAppBar(
-            title = stringResource(toolbarTitle),
-            navigationIcon = NavigationIcons.BackIcon,
-            onNavigationIconClick = onDismissScreenClick
-        )
-        val scrollState = rememberScrollState()
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(scrollState)
-                .padding(horizontal = 32.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally,
+    with(uiState) {
+        BaseState(
+            uiState = uiState,
+            onDismissScreenClick = onDismissScreenClick
         ) {
-            Image(
-                painter = painterResource(image),
-                contentDescription = stringResource(imageContentDescription),
-                modifier = Modifier
-                    .height(dimensionResource(R.dimen.jetpack_remote_install_icon_size))
-                    .width(dimensionResource(R.dimen.jetpack_remote_install_icon_size))
-            )
-            Text(
-                text = stringResource(title),
-                textAlign = TextAlign.Center,
-                fontSize = FontSize.ExtraLarge.value,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(top = Margin.ExtraLarge.value),
-            )
-            Text(
-                text = stringResource(description),
-                textAlign = TextAlign.Center,
-                fontSize = FontSize.Large.value,
-                modifier = Modifier.padding(top = Margin.Medium.value),
-            )
             PrimaryButton(
                 text = stringResource(buttonText),
                 onClick = onContinueClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
@@ -1,0 +1,100 @@
+package org.wordpress.android.ui.jpfullplugininstall.install.compose.state
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.MainTopAppBar
+import org.wordpress.android.ui.compose.components.NavigationIcons
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.unit.FontSize
+import org.wordpress.android.ui.compose.unit.Margin
+import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
+import org.wordpress.android.ui.qrcodeauth.compose.components.PrimaryButton
+
+@Composable
+fun InitialState(
+    content: UiState.Initial,
+    onContinueClick: () -> Unit,
+    onDismissScreenClick: () -> Unit,
+) = Box(
+    Modifier
+        .fillMaxWidth()
+        .fillMaxHeight()
+) {
+    with(content) {
+        MainTopAppBar(
+            title = stringResource(toolbarTitle),
+            navigationIcon = NavigationIcons.BackIcon,
+            onNavigationIconClick = onDismissScreenClick
+        )
+        val scrollState = rememberScrollState()
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(horizontal = 32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Image(
+                painter = painterResource(image),
+                contentDescription = stringResource(imageContentDescription),
+                modifier = Modifier
+                    .height(dimensionResource(R.dimen.jetpack_remote_install_icon_size))
+                    .width(dimensionResource(R.dimen.jetpack_remote_install_icon_size))
+            )
+            Text(
+                text = stringResource(title),
+                textAlign = TextAlign.Center,
+                fontSize = FontSize.ExtraLarge.value,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(top = Margin.ExtraLarge.value),
+            )
+            Text(
+                text = stringResource(description),
+                textAlign = TextAlign.Center,
+                fontSize = FontSize.Large.value,
+                modifier = Modifier.padding(top = Margin.Medium.value),
+            )
+            PrimaryButton(
+                text = stringResource(buttonText),
+                onClick = onContinueClick,
+                modifier = Modifier.padding(top = Margin.ExtraLarge.value),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL)
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
+@Composable
+private fun PreviewInitialState() {
+    AppTheme {
+        val uiState = UiState.Initial
+        InitialState(uiState, {}, {})
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
@@ -10,10 +10,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.ui.compose.components.PrimaryButton
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
-import org.wordpress.android.ui.qrcodeauth.compose.components.PrimaryButton
 
 @Composable
 fun InitialState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
@@ -33,7 +33,7 @@ fun InitialState(
             PrimaryButton(
                 text = stringResource(buttonText),
                 onClick = onContinueClick,
-                modifier = Modifier.padding(top = Margin.ExtraLarge.value),
+                modifier = Modifier.padding(top = Margin.Large.value),
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InstallingState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InstallingState.kt
@@ -5,37 +5,31 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
-import org.wordpress.android.ui.qrcodeauth.compose.components.PrimaryButton
 
 @Composable
-fun InitialState(
-    uiState: UiState.Initial,
-    onContinueClick: () -> Unit,
+fun InstallingState(
+    uiState: UiState.Installing,
     onDismissScreenClick: () -> Unit,
 ) = Box(
     Modifier
         .fillMaxWidth()
         .fillMaxHeight()
 ) {
-    with(uiState) {
-        BaseState(
-            uiState = uiState,
-            onDismissScreenClick = onDismissScreenClick
-        ) {
-            PrimaryButton(
-                text = stringResource(buttonText),
-                onClick = onContinueClick,
-                modifier = Modifier.padding(top = Margin.ExtraLarge.value),
-            )
-        }
+    BaseState(
+        uiState = uiState,
+        onDismissScreenClick = onDismissScreenClick
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.padding(top = Margin.ExtraLarge.value),
+        )
     }
 }
 
@@ -43,9 +37,9 @@ fun InitialState(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
-private fun PreviewInitialState() {
+private fun PreviewInstallingState() {
     AppTheme {
-        val uiState = UiState.Initial()
-        InitialState(uiState, {}, {})
+        val uiState = UiState.Installing
+        InstallingState(uiState) {}
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
@@ -26,7 +26,7 @@ import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPlugin
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.InstallJPFullPlugin
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.OpenTermsAndConditions
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.UiState
-import org.wordpress.android.ui.jpfullplugininstall.onboarding.compose.state.Loaded
+import org.wordpress.android.ui.jpfullplugininstall.onboarding.compose.state.LoadedState
 import org.wordpress.android.util.WPUrlUtils
 import org.wordpress.android.util.extensions.exhaustive
 import org.wordpress.android.util.extensions.setStatusBarAsSurfaceColor
@@ -75,7 +75,7 @@ class JetpackFullPluginInstallOnboardingDialogFragment : DialogFragment() {
         val uiState by viewModel.uiState.collectAsState()
         uiState.apply {
             when (this) {
-                is UiState.Loaded -> Loaded(
+                is UiState.Loaded -> LoadedState(
                     content = this,
                     onTermsAndConditionsClick = { viewModel.onTermsAndConditionsClick() },
                     onInstallFullPluginClick = { viewModel.onInstallFullPluginClick() },

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingUiStateMapper.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.jpfullplugininstall
+package org.wordpress.android.ui.jpfullplugininstall.onboarding
 
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.UiState
 import org.wordpress.android.ui.mysite.SelectedSiteRepository

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.update
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.accounts.HelpActivity
-import org.wordpress.android.ui.jpfullplugininstall.JetpackFullPluginInstallOnboardingUiStateMapper
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.ContactSupport
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.Dismiss
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.OpenTermsAndConditions

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/compose/state/Loaded.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/compose/state/Loaded.kt
@@ -109,7 +109,7 @@ fun Loaded(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
-private fun PreviewJetpackFullPluginInstallOnboardingScreen() {
+private fun PreviewLoaded() {
     AppTheme {
         val uiState = UiState.Loaded(
             siteName = "wordpress.com",

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/compose/state/LoadedState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/compose/state/LoadedState.kt
@@ -34,7 +34,7 @@ import org.wordpress.android.ui.jpfullplugininstall.onboarding.compose.component
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.compose.component.TermsAndConditions
 
 @Composable
-fun Loaded(
+fun LoadedState(
     content: UiState.Loaded,
     onTermsAndConditionsClick: () -> Unit,
     onInstallFullPluginClick: () -> Unit,
@@ -109,12 +109,12 @@ fun Loaded(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
-private fun PreviewLoaded() {
+private fun PreviewLoadedState() {
     AppTheme {
         val uiState = UiState.Loaded(
             siteName = "wordpress.com",
             pluginNames = listOf("Jetpack Search"),
         )
-        Loaded(uiState, {}, {}, {}, {})
+        LoadedState(uiState, {}, {}, {}, {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ActivityExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ActivityExtensions.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.util.extensions
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
+
+// TODO it might be safer bringing in the androidx.activity:activity-compose lib
+fun Activity.setContent(content: @Composable () -> Unit) {
+    val composeView = ComposeView(this).apply { setContent(content) }
+    setContentView(composeView)
+}

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1094,7 +1094,9 @@
     <string name="jetpack_full_plugin_install_initial_button">Continue</string>
     <string name="jetpack_full_plugin_install_installing_title">Installing Jetpack</string>
     <string name="jetpack_full_plugin_install_installing_description">Installing Jetpack on your site. This can take up to a few minutes to complete.</string>
-
+    <string name="jetpack_full_plugin_install_done_title">Jetpack installed</string>
+    <string name="jetpack_full_plugin_install_done_description">Ready to use this site with the app.</string>
+    <string name="jetpack_full_plugin_install_done_button">Done</string>
 
     <!-- activity log -->
     <string name="activity_log">Activity Log</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1088,7 +1088,7 @@
     <string name="login_to_to_connect_jetpack" tools:ignore="UnusedResources" a8c-src-lib="login">Log in to the WordPress.com account you used to connect Jetpack.</string>
 
     <!-- Jetpack install full plugin -->
-    <string name="jetpack_full_plugin_install_image_content_description">Jetpack icon</string>
+    <string name="jetpack_full_plugin_install_jp_logo_content_description">Jetpack icon</string>
     <string name="jetpack_full_plugin_install_initial_title">Install Jetpack</string>
     <string name="jetpack_full_plugin_install_initial_description">Your website credentials will not be stored and are used only for the purpose of installing Jetpack.</string>
     <string name="jetpack_full_plugin_install_initial_button">Continue</string>
@@ -1097,6 +1097,11 @@
     <string name="jetpack_full_plugin_install_done_title">Jetpack installed</string>
     <string name="jetpack_full_plugin_install_done_description">Ready to use this site with the app.</string>
     <string name="jetpack_full_plugin_install_done_button">Done</string>
+    <string name="jetpack_full_plugin_install_error_image_content_description">Error icon</string>
+    <string name="jetpack_full_plugin_install_error_title">There was a problem</string>
+    <string name="jetpack_full_plugin_install_error_description">Jetpack could not be installed at this time.</string>
+    <string name="jetpack_full_plugin_install_error_button_retry">Retry</string>
+    <string name="jetpack_full_plugin_install_error_button_contact_support">Contact Support</string>
 
     <!-- activity log -->
     <string name="activity_log">Activity Log</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1087,6 +1087,10 @@
     <string name="install_jetpack_retry">Retry</string>
     <string name="login_to_to_connect_jetpack" tools:ignore="UnusedResources" a8c-src-lib="login">Log in to the WordPress.com account you used to connect Jetpack.</string>
 
+    <!-- Jetpack install full plugin -->
+    <string name="jetpack_full_plugin_install_continue">Continue</string>
+    <string name="jetpack_full_plugin_install_image_content_description">Jetpack icon</string>
+
     <!-- activity log -->
     <string name="activity_log">Activity Log</string>
     <string name="activity_log_icon">Activity icon</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1088,8 +1088,12 @@
     <string name="login_to_to_connect_jetpack" tools:ignore="UnusedResources" a8c-src-lib="login">Log in to the WordPress.com account you used to connect Jetpack.</string>
 
     <!-- Jetpack install full plugin -->
-    <string name="jetpack_full_plugin_install_continue">Continue</string>
     <string name="jetpack_full_plugin_install_image_content_description">Jetpack icon</string>
+    <string name="jetpack_full_plugin_install_initial_title">Install Jetpack</string>
+    <string name="jetpack_full_plugin_install_initial_description">Your website credentials will not be stored and are used only for the purpose of installing Jetpack.</string>
+    <string name="jetpack_full_plugin_install_continue">Continue</string>
+    <string name="jetpack_full_plugin_install_installing_title">Installing Jetpack</string>
+    <string name="jetpack_full_plugin_install_installing_description">Installing Jetpack on your site. This can take up to a few minutes to complete.</string>
 
     <!-- activity log -->
     <string name="activity_log">Activity Log</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1091,7 +1091,7 @@
     <string name="jetpack_full_plugin_install_image_content_description">Jetpack icon</string>
     <string name="jetpack_full_plugin_install_initial_title">Install Jetpack</string>
     <string name="jetpack_full_plugin_install_initial_description">Your website credentials will not be stored and are used only for the purpose of installing Jetpack.</string>
-    <string name="jetpack_full_plugin_install_initial_continue">Continue</string>
+    <string name="jetpack_full_plugin_install_initial_button">Continue</string>
     <string name="jetpack_full_plugin_install_installing_title">Installing Jetpack</string>
     <string name="jetpack_full_plugin_install_installing_description">Installing Jetpack on your site. This can take up to a few minutes to complete.</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1091,9 +1091,10 @@
     <string name="jetpack_full_plugin_install_image_content_description">Jetpack icon</string>
     <string name="jetpack_full_plugin_install_initial_title">Install Jetpack</string>
     <string name="jetpack_full_plugin_install_initial_description">Your website credentials will not be stored and are used only for the purpose of installing Jetpack.</string>
-    <string name="jetpack_full_plugin_install_continue">Continue</string>
+    <string name="jetpack_full_plugin_install_initial_continue">Continue</string>
     <string name="jetpack_full_plugin_install_installing_title">Installing Jetpack</string>
     <string name="jetpack_full_plugin_install_installing_description">Installing Jetpack on your site. This can take up to a few minutes to complete.</string>
+
 
     <!-- activity log -->
     <string name="activity_log">Activity Log</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/JetpackFullPluginInstallOnboardingUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/JetpackFullPluginInstallOnboardingUiStateMapperTest.kt
@@ -6,6 +6,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingUiStateMapper
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.UiState
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import kotlin.test.assertEquals

--- a/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingViewModelTest.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.accounts.HelpActivity
-import org.wordpress.android.ui.jpfullplugininstall.JetpackFullPluginInstallOnboardingUiStateMapper
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.UiState
 import org.wordpress.android.ui.mysite.SelectedSiteRepository


### PR DESCRIPTION
Fixes #17835 

To test:
Nothing to test except for the UI. Since this screen has no entry point yet, please run the following previews:
`wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt`
`wordpress/android/ui/jpfullplugininstall/install/compose/state/InstallingState.kt`
`wordpress/android/ui/jpfullplugininstall/install/compose/state/DoneState.kt`
`wordpress/android/ui/jpfullplugininstall/install/compose/state/ErrorState.kt`

### Initial state
<p float="left">
<img width="361" alt="image" src="https://user-images.githubusercontent.com/14964993/219537281-44d35bb7-e193-4857-bec5-181a9a2fedd3.png">
<img width="358" alt="image" src="https://user-images.githubusercontent.com/14964993/219537231-26e7f021-055f-4a63-b1c0-38fadfe6ca60.png">
</p>

### Installing state
<p float="left">
<img width="361" alt="image" src="https://user-images.githubusercontent.com/14964993/219537552-5e729f26-2250-40db-a5c7-a916504eb04e.png">
<img width="358" alt="image" src="https://user-images.githubusercontent.com/14964993/219537597-3474755c-353a-4304-934e-723f4c6bf7fe.png">
</p>

### Done state
<p float="left">
<img width="362" alt="image" src="https://user-images.githubusercontent.com/14964993/219537796-7e64cecc-765e-49d6-a467-0b377bf4b17f.png">
<img width="359" alt="image" src="https://user-images.githubusercontent.com/14964993/219537765-3c68f9cd-1009-4099-abe4-2999d629fbb2.png">
</p>

### Error state
<p float="left">
<img width="361" alt="image" src="https://user-images.githubusercontent.com/14964993/219538143-fae31e89-7a40-41be-8de8-837b0086c253.png">
<img width="359" alt="image" src="https://user-images.githubusercontent.com/14964993/219538888-a4f74054-a06a-4358-8dbd-819394ba97aa.png">
</p>

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None (UI only).

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
