### PR TITLE
[JP install full plugin] Install screen integration

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -775,6 +775,11 @@
             android:label="@string/blogging_prompts_list_title"
             android:theme="@style/WordPress.NoActionBar" />
 
+        <!-- Jetpack full plugin install -->
+        <activity
+            android:name=".ui.jpfullplugininstall.install.JetpackFullPluginInstallActivity"
+            android:theme="@style/WordPress.NoActionBar" />
+
         <!-- Services -->
         <service
             android:name=".ui.uploads.UploadService"

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -352,7 +352,8 @@ class HelpActivity : LocaleAwareActivity() {
         EDITOR_HELP("origin:editor-help"),
         SCAN_SCREEN_HELP("origin:scan-screen-help"),
         JETPACK_MIGRATION_HELP("origin:jetpack-migration-help"),
-        JETPACK_INSTALL_FULL_PLUGIN_ONBOARDING("origin:jp-install-full-plugin-overlay");
+        JETPACK_INSTALL_FULL_PLUGIN_ONBOARDING("origin:jp-install-full-plugin-overlay"),
+        JETPACK_INSTALL_FULL_PLUGIN_ERROR("origin:jp-install-full-plugin-error");
 
         override fun toString(): String {
             return stringValue

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/ActionEvent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/ActionEvent.kt
@@ -1,4 +1,13 @@
 package org.wordpress.android.ui.jpfullplugininstall.install
 
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.accounts.HelpActivity
+
 sealed class ActionEvent {
+    data class ContactSupport(
+        val origin: HelpActivity.Origin,
+        val selectedSite: SiteModel?,
+    ) : ActionEvent()
+
+    object Dismiss : ActionEvent()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/ActionEvent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/ActionEvent.kt
@@ -1,0 +1,4 @@
+package org.wordpress.android.ui.jpfullplugininstall.install
+
+sealed class ActionEvent {
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
@@ -3,14 +3,18 @@ package org.wordpress.android.ui.jpfullplugininstall.install
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.compose.components.MainTopAppBar
+import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.ActionEvent
 import org.wordpress.android.ui.jpfullplugininstall.install.compose.state.DoneState
@@ -38,27 +42,33 @@ class JetpackFullPluginInstallActivity : AppCompatActivity() {
     private fun JetpackFullPluginInstallScreen() {
         val uiState by viewModel.uiState.collectAsState()
         uiState.apply {
-            when (this) {
-                is UiState.Initial -> InitialState(
-                    uiState = this,
-                    onContinueClick = viewModel::onContinueClick,
-                    onDismissScreenClick = viewModel::onDismissScreenClick,
-                )
-                is UiState.Installing -> InstallingState(
-                    uiState = this,
-                    onDismissScreenClick = viewModel::onDismissScreenClick,
-                )
-                is UiState.Done -> DoneState(
-                    uiState = this,
-                    onDoneClick = viewModel::onDoneClick,
-                    onDismissScreenClick = viewModel::onDismissScreenClick,
-                )
-                is UiState.Error -> ErrorState(
-                    uiState = this,
-                    onRetryClick = viewModel::onRetryClick,
-                    onContactSupportClick = viewModel::onContactSupportClick,
-                    onDismissScreenClick = viewModel::onDismissScreenClick,
-                )
+            Scaffold(
+                topBar = {
+                    MainTopAppBar(
+                        title = stringResource(toolbarTitle),
+                        navigationIcon = NavigationIcons.BackIcon,
+                        onNavigationIconClick = viewModel::onDismissScreenClick
+                    )
+                },
+            ) {
+                when (this) {
+                    is UiState.Initial -> InitialState(
+                        uiState = this,
+                        onContinueClick = viewModel::onContinueClick,
+                    )
+                    is UiState.Installing -> InstallingState(
+                        uiState = this,
+                    )
+                    is UiState.Done -> DoneState(
+                        uiState = this,
+                        onDoneClick = viewModel::onDoneClick,
+                    )
+                    is UiState.Error -> ErrorState(
+                        uiState = this,
+                        onRetryClick = viewModel::onRetryClick,
+                        onContactSupportClick = viewModel::onContactSupportClick,
+                    )
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
-import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.ActionEvent
 import org.wordpress.android.ui.jpfullplugininstall.install.compose.state.DoneState
 import org.wordpress.android.ui.jpfullplugininstall.install.compose.state.ErrorState
 import org.wordpress.android.ui.jpfullplugininstall.install.compose.state.InitialState

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.jpfullplugininstall.install
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -91,5 +93,10 @@ class JetpackFullPluginInstallActivity : AppCompatActivity() {
                 finish()
             }
         }.exhaustive
+    }
+
+    companion object {
+        @JvmStatic
+        fun createIntent(context: Context) = Intent(context, JetpackFullPluginInstallActivity::class.java)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
@@ -1,24 +1,85 @@
 package org.wordpress.android.ui.jpfullplugininstall.install
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.ActionEvent
+import org.wordpress.android.ui.jpfullplugininstall.install.compose.state.DoneState
+import org.wordpress.android.ui.jpfullplugininstall.install.compose.state.ErrorState
+import org.wordpress.android.ui.jpfullplugininstall.install.compose.state.InitialState
+import org.wordpress.android.ui.jpfullplugininstall.install.compose.state.InstallingState
+import org.wordpress.android.util.extensions.exhaustive
 import org.wordpress.android.util.extensions.setContent
 
 @AndroidEntryPoint
 class JetpackFullPluginInstallActivity : AppCompatActivity() {
+    private val viewModel: JetpackFullPluginInstallViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             AppTheme {
-//                JetpackFullPluginInstallScreen()
+                JetpackFullPluginInstallScreen()
+            }
+        }
+        observeActionEvents()
+    }
+
+    @Composable
+    private fun JetpackFullPluginInstallScreen() {
+        val uiState by viewModel.uiState.collectAsState()
+        uiState.apply {
+            when (this) {
+                is UiState.Initial -> InitialState(
+                    uiState = this,
+                    onContinueClick = viewModel::onContinueClick,
+                    onDismissScreenClick = viewModel::onDismissScreenClick,
+                )
+                is UiState.Installing -> InstallingState(
+                    uiState = this,
+                    onDismissScreenClick = viewModel::onDismissScreenClick,
+                )
+                is UiState.Done -> DoneState(
+                    uiState = this,
+                    onDoneClick = viewModel::onDoneClick,
+                    onDismissScreenClick = viewModel::onDismissScreenClick,
+                )
+                is UiState.Error -> ErrorState(
+                    uiState = this,
+                    onRetryClick = viewModel::onRetryClick,
+                    onContactSupportClick = viewModel::onContactSupportClick,
+                    onDismissScreenClick = viewModel::onDismissScreenClick,
+                )
             }
         }
     }
 
-//    @Composable
-//    private fun JetpackFullPluginInstallScreen() {
-//
-//    }
+    private fun observeActionEvents() {
+        viewModel.actionEvents.onEach(this::handleActionEvents).launchIn(lifecycleScope)
+    }
+
+    private fun handleActionEvents(actionEvent: ActionEvent) {
+        when (actionEvent) {
+            is ActionEvent.ContactSupport -> {
+                ActivityLauncher.viewHelpAndSupport(
+                    this,
+                    actionEvent.origin,
+                    actionEvent.selectedSite,
+                    null
+                )
+            }
+            is ActionEvent.Dismiss -> {
+                finish()
+            }
+        }.exhaustive
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallUiStateMapper.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.jpfullplugininstall.install
+
+import org.wordpress.android.R
+import javax.inject.Inject
+
+class JetpackFullPluginInstallUiStateMapper @Inject constructor() {
+    fun mapInitial(): UiState.Initial =
+        UiState.Initial(
+            buttonText = R.string.jetpack_full_plugin_install_initial_button,
+        )
+
+    fun mapInstalling(): UiState.Installing = UiState.Installing
+
+    fun mapDone(): UiState.Done =
+        UiState.Done(
+            buttonText = R.string.jetpack_full_plugin_install_done_button,
+        )
+
+    fun mapError(): UiState.Error =
+        UiState.Error(
+            retryButtonText = R.string.jetpack_full_plugin_install_error_button_retry,
+            contactSupportButtonText = R.string.jetpack_full_plugin_install_error_button_contact_support,
+        )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
@@ -54,8 +53,9 @@ class JetpackFullPluginInstallViewModel @Inject constructor(
         )
     }
 
+    @Suppress("MagicNumber")
     private fun installJetpackPlugin() {
-        // TODO replace mock with endpoint call
+        // TODO replace mock with endpoint call and update unit tests
         launch {
             delay(2000L)
             val success = true
@@ -77,14 +77,5 @@ class JetpackFullPluginInstallViewModel @Inject constructor(
         launch {
             _actionEvents.emit(actionEvent)
         }
-    }
-
-    sealed class ActionEvent {
-        data class ContactSupport(
-            val origin: HelpActivity.Origin,
-            val selectedSite: SiteModel?,
-        ) : ActionEvent()
-
-        object Dismiss : ActionEvent()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
@@ -1,55 +1,90 @@
 package org.wordpress.android.ui.jpfullplugininstall.install
 
-import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
-import org.wordpress.android.R
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.accounts.HelpActivity
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
 
-class JetpackFullPluginInstallViewModel {
-    sealed class UiState(
-        @StringRes val toolbarTitle: Int,
-        @DrawableRes val image: Int,
-        @StringRes val imageContentDescription: Int,
-        @StringRes val title: Int,
-        @StringRes val description: Int,
-    ) {
-        data class Initial(
-            @StringRes val buttonText: Int = R.string.jetpack_full_plugin_install_initial_button,
-        ) : UiState(
-            toolbarTitle = R.string.jetpack,
-            image = R.drawable.ic_jetpack_logo_green_24dp,
-            imageContentDescription = R.string.jetpack_full_plugin_install_jp_logo_content_description,
-            title = R.string.jetpack_full_plugin_install_initial_title,
-            description = R.string.jetpack_full_plugin_install_initial_description,
-        )
+@HiltViewModel
+class JetpackFullPluginInstallViewModel @Inject constructor(
+    private val uiStateMapper: JetpackFullPluginInstallUiStateMapper,
+    private val selectedSiteRepository: SelectedSiteRepository,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+) : ScopedViewModel(bgDispatcher) {
+    private val _uiState = MutableStateFlow<UiState>(uiStateMapper.mapInitial())
+    val uiState = _uiState.asStateFlow()
 
-        object Installing : UiState(
-            toolbarTitle = R.string.jetpack,
-            image = R.drawable.ic_jetpack_logo_green_24dp,
-            imageContentDescription = R.string.jetpack_full_plugin_install_jp_logo_content_description,
-            title = R.string.jetpack_full_plugin_install_installing_title,
-            description = R.string.jetpack_full_plugin_install_installing_description,
-        )
+    private val _actionEvents = MutableSharedFlow<ActionEvent>()
+    val actionEvents = _actionEvents
 
-        data class Done(
-            @StringRes val buttonText: Int = R.string.jetpack_full_plugin_install_done_button,
-        ) : UiState(
-            toolbarTitle = R.string.jetpack,
-            image = R.drawable.ic_jetpack_logo_green_24dp,
-            imageContentDescription = R.string.jetpack_full_plugin_install_jp_logo_content_description,
-            title = R.string.jetpack_full_plugin_install_done_title,
-            description = R.string.jetpack_full_plugin_install_done_description,
-        )
+    fun onContinueClick() {
+        postUiState(uiStateMapper.mapInstalling())
+        installJetpackPlugin()
+    }
 
-        data class Error(
-            @StringRes val retryButtonText: Int = R.string.jetpack_full_plugin_install_error_button_retry,
-            @StringRes val contactSupportButtonText: Int =
-                R.string.jetpack_full_plugin_install_error_button_contact_support,
-        ) : UiState(
-            toolbarTitle = R.string.jetpack,
-            image = R.drawable.img_illustration_info_outline_88dp,
-            imageContentDescription = R.string.jetpack_full_plugin_install_error_image_content_description,
-            title = R.string.jetpack_full_plugin_install_error_title,
-            description = R.string.jetpack_full_plugin_install_error_description,
+    fun onDismissScreenClick() {
+        postActionEvent(ActionEvent.Dismiss)
+    }
+
+    fun onDoneClick() {
+        postActionEvent(ActionEvent.Dismiss)
+    }
+
+    fun onRetryClick() {
+        postUiState(uiStateMapper.mapInstalling())
+        installJetpackPlugin()
+    }
+
+    fun onContactSupportClick() {
+        postActionEvent(
+            ActionEvent.ContactSupport(
+                origin = HelpActivity.Origin.JETPACK_INSTALL_FULL_PLUGIN_ERROR,
+                selectedSite = selectedSiteRepository.getSelectedSite(),
+            )
         )
+    }
+
+    private fun installJetpackPlugin() {
+        // TODO replace mock with endpoint call
+        launch {
+            delay(2000L)
+            val success = true
+            if (success) {
+                postUiState(uiStateMapper.mapDone())
+            } else {
+                postUiState(uiStateMapper.mapError())
+            }
+        }
+    }
+
+    private fun postUiState(uiState: UiState) {
+        launch {
+            _uiState.update { uiState }
+        }
+    }
+
+    private fun postActionEvent(actionEvent: ActionEvent) {
+        launch {
+            _actionEvents.emit(actionEvent)
+        }
+    }
+
+    sealed class ActionEvent {
+        data class ContactSupport(
+            val origin: HelpActivity.Origin,
+            val selectedSite: SiteModel?,
+        ) : ActionEvent()
+
+        object Dismiss : ActionEvent()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/UiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/UiState.kt
@@ -1,0 +1,52 @@
+package org.wordpress.android.ui.jpfullplugininstall.install
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import org.wordpress.android.R
+
+sealed class UiState(
+    @StringRes val toolbarTitle: Int,
+    @DrawableRes val image: Int,
+    @StringRes val imageContentDescription: Int,
+    @StringRes val title: Int,
+    @StringRes val description: Int,
+) {
+    data class Initial(
+        @StringRes val buttonText: Int
+    ) : UiState(
+        toolbarTitle = R.string.jetpack,
+        image = R.drawable.ic_jetpack_logo_green_24dp,
+        imageContentDescription = R.string.jetpack_full_plugin_install_jp_logo_content_description,
+        title = R.string.jetpack_full_plugin_install_initial_title,
+        description = R.string.jetpack_full_plugin_install_initial_description,
+    )
+
+    object Installing : UiState(
+        toolbarTitle = R.string.jetpack,
+        image = R.drawable.ic_jetpack_logo_green_24dp,
+        imageContentDescription = R.string.jetpack_full_plugin_install_jp_logo_content_description,
+        title = R.string.jetpack_full_plugin_install_installing_title,
+        description = R.string.jetpack_full_plugin_install_installing_description,
+    )
+
+    data class Done(
+        @StringRes val buttonText: Int,
+    ) : UiState(
+        toolbarTitle = R.string.jetpack,
+        image = R.drawable.ic_jetpack_logo_green_24dp,
+        imageContentDescription = R.string.jetpack_full_plugin_install_jp_logo_content_description,
+        title = R.string.jetpack_full_plugin_install_done_title,
+        description = R.string.jetpack_full_plugin_install_done_description,
+    )
+
+    data class Error(
+        @StringRes val retryButtonText: Int,
+        @StringRes val contactSupportButtonText: Int,
+    ) : UiState(
+        toolbarTitle = R.string.jetpack,
+        image = R.drawable.img_illustration_info_outline_88dp,
+        imageContentDescription = R.string.jetpack_full_plugin_install_error_image_content_description,
+        title = R.string.jetpack_full_plugin_install_error_title,
+        description = R.string.jetpack_full_plugin_install_error_description,
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/BaseState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/BaseState.kt
@@ -26,8 +26,6 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.components.MainTopAppBar
-import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.unit.Margin
@@ -36,7 +34,6 @@ import org.wordpress.android.ui.jpfullplugininstall.install.UiState
 @Composable
 fun BaseState(
     uiState: UiState,
-    onDismissScreenClick: () -> Unit,
     content: @Composable () -> Unit
 ) = Box(
     Modifier
@@ -44,11 +41,6 @@ fun BaseState(
         .fillMaxHeight()
 ) {
     with(uiState) {
-        MainTopAppBar(
-            title = stringResource(toolbarTitle),
-            navigationIcon = NavigationIcons.BackIcon,
-            onNavigationIconClick = onDismissScreenClick
-        )
         val scrollState = rememberScrollState()
         Column(
             modifier = Modifier
@@ -90,6 +82,6 @@ fun BaseState(
 private fun PreviewInitialState() {
     AppTheme {
         val uiState = UiState.Installing
-        BaseState(uiState, {}, {})
+        BaseState(uiState, {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/BaseState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/BaseState.kt
@@ -31,11 +31,11 @@ import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.unit.Margin
-import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel
+import org.wordpress.android.ui.jpfullplugininstall.install.UiState
 
 @Composable
 fun BaseState(
-    uiState: JetpackFullPluginInstallViewModel.UiState,
+    uiState: UiState,
     onDismissScreenClick: () -> Unit,
     content: @Composable () -> Unit
 ) = Box(
@@ -89,7 +89,7 @@ fun BaseState(
 @Composable
 private fun PreviewInitialState() {
     AppTheme {
-        val uiState = JetpackFullPluginInstallViewModel.UiState.Initial()
+        val uiState = UiState.Installing
         BaseState(uiState, {}, {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/DoneState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/DoneState.kt
@@ -10,10 +10,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.PrimaryButton
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
-import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
+import org.wordpress.android.ui.jpfullplugininstall.install.UiState
 
 @Composable
 fun DoneState(
@@ -45,7 +46,9 @@ fun DoneState(
 @Composable
 private fun PreviewDoneState() {
     AppTheme {
-        val uiState = UiState.Done()
+        val uiState = UiState.Done(
+            buttonText = R.string.jetpack_full_plugin_install_done_button,
+        )
         DoneState(uiState, {}, {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/DoneState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/DoneState.kt
@@ -20,17 +20,13 @@ import org.wordpress.android.ui.jpfullplugininstall.install.UiState
 fun DoneState(
     uiState: UiState.Done,
     onDoneClick: () -> Unit,
-    onDismissScreenClick: () -> Unit,
 ) = Box(
     Modifier
         .fillMaxWidth()
         .fillMaxHeight()
 ) {
     with(uiState) {
-        BaseState(
-            uiState = uiState,
-            onDismissScreenClick = onDismissScreenClick
-        ) {
+        BaseState(uiState) {
             PrimaryButton(
                 text = stringResource(buttonText),
                 onClick = onDoneClick,
@@ -49,6 +45,6 @@ private fun PreviewDoneState() {
         val uiState = UiState.Done(
             buttonText = R.string.jetpack_full_plugin_install_done_button,
         )
-        DoneState(uiState, {}, {})
+        DoneState(uiState, {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/ErrorState.kt
@@ -22,17 +22,13 @@ fun ErrorState(
     uiState: UiState.Error,
     onRetryClick: () -> Unit,
     onContactSupportClick: () -> Unit,
-    onDismissScreenClick: () -> Unit,
 ) = Box(
     Modifier
         .fillMaxWidth()
         .fillMaxHeight()
 ) {
     with(uiState) {
-        BaseState(
-            uiState = uiState,
-            onDismissScreenClick = onDismissScreenClick
-        ) {
+        BaseState(uiState) {
             PrimaryButton(
                 text = stringResource(retryButtonText),
                 onClick = onRetryClick,
@@ -56,6 +52,6 @@ private fun PreviewErrorState() {
             retryButtonText = R.string.jetpack_full_plugin_install_error_button_retry,
             contactSupportButtonText = R.string.jetpack_full_plugin_install_error_button_contact_support,
         )
-        ErrorState(uiState, {}, {}, {})
+        ErrorState(uiState, {}, {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/ErrorState.kt
@@ -10,11 +10,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.PrimaryButton
 import org.wordpress.android.ui.compose.components.SecondaryButton
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
-import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
+import org.wordpress.android.ui.jpfullplugininstall.install.UiState
 
 @Composable
 fun ErrorState(
@@ -51,7 +52,10 @@ fun ErrorState(
 @Composable
 private fun PreviewErrorState() {
     AppTheme {
-        val uiState = UiState.Error()
+        val uiState = UiState.Error(
+            retryButtonText = R.string.jetpack_full_plugin_install_error_button_retry,
+            contactSupportButtonText = R.string.jetpack_full_plugin_install_error_button_contact_support,
+        )
         ErrorState(uiState, {}, {}, {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
@@ -20,17 +20,13 @@ import org.wordpress.android.ui.jpfullplugininstall.install.UiState
 fun InitialState(
     uiState: UiState.Initial,
     onContinueClick: () -> Unit,
-    onDismissScreenClick: () -> Unit,
 ) = Box(
     Modifier
         .fillMaxWidth()
         .fillMaxHeight()
 ) {
     with(uiState) {
-        BaseState(
-            uiState = uiState,
-            onDismissScreenClick = onDismissScreenClick
-        ) {
+        BaseState(uiState) {
             PrimaryButton(
                 text = stringResource(buttonText),
                 onClick = onContinueClick,
@@ -49,6 +45,6 @@ private fun PreviewInitialState() {
         val uiState = UiState.Initial(
             buttonText = R.string.jetpack_full_plugin_install_initial_button,
         )
-        InitialState(uiState, {}, {})
+        InitialState(uiState, {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InitialState.kt
@@ -10,10 +10,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.PrimaryButton
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
-import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
+import org.wordpress.android.ui.jpfullplugininstall.install.UiState
 
 @Composable
 fun InitialState(
@@ -45,7 +46,9 @@ fun InitialState(
 @Composable
 private fun PreviewInitialState() {
     AppTheme {
-        val uiState = UiState.Initial()
+        val uiState = UiState.Initial(
+            buttonText = R.string.jetpack_full_plugin_install_initial_button,
+        )
         InitialState(uiState, {}, {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InstallingState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InstallingState.kt
@@ -17,16 +17,12 @@ import org.wordpress.android.ui.jpfullplugininstall.install.UiState
 @Composable
 fun InstallingState(
     uiState: UiState.Installing,
-    onDismissScreenClick: () -> Unit,
 ) = Box(
     Modifier
         .fillMaxWidth()
         .fillMaxHeight()
 ) {
-    BaseState(
-        uiState = uiState,
-        onDismissScreenClick = onDismissScreenClick
-    ) {
+    BaseState(uiState) {
         CircularProgressIndicator(
             modifier = Modifier.padding(top = Margin.ExtraLarge.value),
         )
@@ -40,6 +36,6 @@ fun InstallingState(
 private fun PreviewInstallingState() {
     AppTheme {
         val uiState = UiState.Installing
-        InstallingState(uiState) {}
+        InstallingState(uiState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InstallingState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/compose/state/InstallingState.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
-import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallViewModel.UiState
+import org.wordpress.android.ui.jpfullplugininstall.install.UiState
 
 @Composable
 fun InstallingState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
@@ -20,10 +20,11 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.jpfullplugininstall.install.JetpackFullPluginInstallActivity
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.ContactSupport
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.Dismiss
-import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.InstallJPFullPlugin
+import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.OpenInstallJetpackFullPlugin
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.OpenTermsAndConditions
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.UiState
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.compose.state.LoadedState
@@ -99,8 +100,8 @@ class JetpackFullPluginInstallOnboardingDialogFragment : DialogFragment() {
                     WPUrlUtils.buildTermsOfServiceUrl(requireContext())
                 )
             }
-            is InstallJPFullPlugin -> {
-                // TODO open install JP full plugin screen
+            is OpenInstallJetpackFullPlugin -> {
+                startActivity(JetpackFullPluginInstallActivity.createIntent(requireContext()))
                 dismiss()
             }
             is ContactSupport -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingViewModel.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.ContactSupport
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.Dismiss
+import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.OpenInstallJetpackFullPlugin
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.OpenTermsAndConditions
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -41,8 +42,7 @@ class JetpackFullPluginInstallOnboardingViewModel @Inject constructor(
 
     fun onInstallFullPluginClick() {
         analyticsTracker.trackInstallButtonClick()
-        // TODO tracking event
-        // TODO open install full plugin screen when it's done
+        postActionEvent(OpenInstallJetpackFullPlugin)
     }
 
     fun onContactSupportClick() {
@@ -81,7 +81,7 @@ class JetpackFullPluginInstallOnboardingViewModel @Inject constructor(
 
     sealed class ActionEvent {
         object OpenTermsAndConditions : ActionEvent()
-        object InstallJPFullPlugin : ActionEvent()
+        object OpenInstallJetpackFullPlugin : ActionEvent()
         data class ContactSupport(
             val origin: HelpActivity.Origin,
             val selectedSite: SiteModel?,

--- a/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallUiStateMapperTest.kt
@@ -1,0 +1,61 @@
+package org.wordpress.android.ui.jpfullplugininstall.install
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.R
+
+class JetpackFullPluginInstallUiStateMapperTest {
+    private val classToTest = JetpackFullPluginInstallUiStateMapper()
+
+    @Test
+    fun `Should map Initial state correctly`() {
+        val actual = classToTest.mapInitial()
+        with(actual) {
+            assertThat(buttonText).isEqualTo(R.string.jetpack_full_plugin_install_initial_button)
+            assertThat(toolbarTitle).isEqualTo(R.string.jetpack)
+            assertThat(image).isEqualTo(R.drawable.ic_jetpack_logo_green_24dp)
+            assertThat(imageContentDescription).isEqualTo(R.string.jetpack_full_plugin_install_jp_logo_content_description)
+            assertThat(title).isEqualTo(R.string.jetpack_full_plugin_install_initial_title)
+            assertThat(description).isEqualTo(R.string.jetpack_full_plugin_install_initial_description)
+        }
+    }
+
+    @Test
+    fun `Should map Installing state correctly`() {
+        val actual = classToTest.mapInstalling()
+        with(actual) {
+            assertThat(toolbarTitle).isEqualTo(R.string.jetpack)
+            assertThat(image).isEqualTo(R.drawable.ic_jetpack_logo_green_24dp)
+            assertThat(imageContentDescription).isEqualTo(R.string.jetpack_full_plugin_install_jp_logo_content_description)
+            assertThat(title).isEqualTo(R.string.jetpack_full_plugin_install_installing_title)
+            assertThat(description).isEqualTo(R.string.jetpack_full_plugin_install_installing_description)
+        }
+    }
+
+    @Test
+    fun `Should map Done state correctly`() {
+        val actual = classToTest.mapDone()
+        with(actual) {
+            assertThat(buttonText).isEqualTo(R.string.jetpack_full_plugin_install_done_button)
+            assertThat(toolbarTitle).isEqualTo(R.string.jetpack)
+            assertThat(image).isEqualTo(R.drawable.ic_jetpack_logo_green_24dp)
+            assertThat(imageContentDescription).isEqualTo(R.string.jetpack_full_plugin_install_jp_logo_content_description)
+            assertThat(title).isEqualTo(R.string.jetpack_full_plugin_install_done_title)
+            assertThat(description).isEqualTo(R.string.jetpack_full_plugin_install_done_description)
+        }
+    }
+
+    @Test
+    fun `Should map Error state correctly`() {
+        val actual = classToTest.mapError()
+        with(actual) {
+            assertThat(retryButtonText).isEqualTo(R.string.jetpack_full_plugin_install_error_button_retry)
+            assertThat(contactSupportButtonText).isEqualTo(R.string.jetpack_full_plugin_install_error_button_contact_support)
+            assertThat(toolbarTitle).isEqualTo(R.string.jetpack)
+            assertThat(image).isEqualTo(R.drawable.img_illustration_info_outline_88dp)
+            assertThat(imageContentDescription).isEqualTo(R.string.jetpack_full_plugin_install_error_image_content_description)
+            assertThat(title).isEqualTo(R.string.jetpack_full_plugin_install_error_title)
+            assertThat(description).isEqualTo(R.string.jetpack_full_plugin_install_error_description)
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallUiStateMapperTest.kt
@@ -14,7 +14,9 @@ class JetpackFullPluginInstallUiStateMapperTest {
             assertThat(buttonText).isEqualTo(R.string.jetpack_full_plugin_install_initial_button)
             assertThat(toolbarTitle).isEqualTo(R.string.jetpack)
             assertThat(image).isEqualTo(R.drawable.ic_jetpack_logo_green_24dp)
-            assertThat(imageContentDescription).isEqualTo(R.string.jetpack_full_plugin_install_jp_logo_content_description)
+            assertThat(imageContentDescription).isEqualTo(
+                R.string.jetpack_full_plugin_install_jp_logo_content_description
+            )
             assertThat(title).isEqualTo(R.string.jetpack_full_plugin_install_initial_title)
             assertThat(description).isEqualTo(R.string.jetpack_full_plugin_install_initial_description)
         }
@@ -26,7 +28,9 @@ class JetpackFullPluginInstallUiStateMapperTest {
         with(actual) {
             assertThat(toolbarTitle).isEqualTo(R.string.jetpack)
             assertThat(image).isEqualTo(R.drawable.ic_jetpack_logo_green_24dp)
-            assertThat(imageContentDescription).isEqualTo(R.string.jetpack_full_plugin_install_jp_logo_content_description)
+            assertThat(imageContentDescription).isEqualTo(
+                R.string.jetpack_full_plugin_install_jp_logo_content_description
+            )
             assertThat(title).isEqualTo(R.string.jetpack_full_plugin_install_installing_title)
             assertThat(description).isEqualTo(R.string.jetpack_full_plugin_install_installing_description)
         }
@@ -39,7 +43,9 @@ class JetpackFullPluginInstallUiStateMapperTest {
             assertThat(buttonText).isEqualTo(R.string.jetpack_full_plugin_install_done_button)
             assertThat(toolbarTitle).isEqualTo(R.string.jetpack)
             assertThat(image).isEqualTo(R.drawable.ic_jetpack_logo_green_24dp)
-            assertThat(imageContentDescription).isEqualTo(R.string.jetpack_full_plugin_install_jp_logo_content_description)
+            assertThat(imageContentDescription).isEqualTo(
+                R.string.jetpack_full_plugin_install_jp_logo_content_description
+            )
             assertThat(title).isEqualTo(R.string.jetpack_full_plugin_install_done_title)
             assertThat(description).isEqualTo(R.string.jetpack_full_plugin_install_done_description)
         }
@@ -50,10 +56,14 @@ class JetpackFullPluginInstallUiStateMapperTest {
         val actual = classToTest.mapError()
         with(actual) {
             assertThat(retryButtonText).isEqualTo(R.string.jetpack_full_plugin_install_error_button_retry)
-            assertThat(contactSupportButtonText).isEqualTo(R.string.jetpack_full_plugin_install_error_button_contact_support)
+            assertThat(contactSupportButtonText).isEqualTo(
+                R.string.jetpack_full_plugin_install_error_button_contact_support
+            )
             assertThat(toolbarTitle).isEqualTo(R.string.jetpack)
             assertThat(image).isEqualTo(R.drawable.img_illustration_info_outline_88dp)
-            assertThat(imageContentDescription).isEqualTo(R.string.jetpack_full_plugin_install_error_image_content_description)
+            assertThat(imageContentDescription).isEqualTo(
+                R.string.jetpack_full_plugin_install_error_image_content_description
+            )
             assertThat(title).isEqualTo(R.string.jetpack_full_plugin_install_error_title)
             assertThat(description).isEqualTo(R.string.jetpack_full_plugin_install_error_description)
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModelTest.kt
@@ -1,0 +1,103 @@
+package org.wordpress.android.ui.jpfullplugininstall.install
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.accounts.HelpActivity
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+
+@ExperimentalCoroutinesApi
+class JetpackFullPluginInstallViewModelTest : BaseUnitTest() {
+    private val uiStateMapper: JetpackFullPluginInstallUiStateMapper = mock()
+    private val selectedSiteRepository: SelectedSiteRepository = mock()
+    private val classToTest = JetpackFullPluginInstallViewModel(
+        uiStateMapper = uiStateMapper,
+        selectedSiteRepository = selectedSiteRepository,
+        bgDispatcher = testDispatcher(),
+    )
+
+    private val selectedSite = SiteModel().apply {
+        id = 123
+        name = "Site name"
+    }
+
+    @Test
+    fun `Should have UI state initial value as Initial`() {
+        whenever(uiStateMapper.mapInitial()).thenReturn(UiState.Initial(0))
+        val initialMockedClassToTest = JetpackFullPluginInstallViewModel(
+            uiStateMapper = uiStateMapper,
+            selectedSiteRepository = selectedSiteRepository,
+            bgDispatcher = testDispatcher(),
+        )
+        assertThat(initialMockedClassToTest.uiState.value).isInstanceOf(UiState.Initial::class.java)
+    }
+
+    @Test
+    fun `Should post Installing UI state when onContinueClick is called`() {
+        whenever(uiStateMapper.mapInstalling()).thenReturn(UiState.Installing)
+        classToTest.onContinueClick()
+        assertThat(classToTest.uiState.value).isInstanceOf(UiState.Installing::class.java)
+    }
+
+    @Test
+    fun `Should post Installing UI state when onRetryClick is called`() {
+        whenever(uiStateMapper.mapInstalling()).thenReturn(UiState.Installing)
+        classToTest.onRetryClick()
+        assertThat(classToTest.uiState.value).isInstanceOf(UiState.Installing::class.java)
+    }
+
+    @Test
+    fun `Should post action Dismiss when onDismissScreenClick is called`() = test {
+        val result = ArrayList<ActionEvent>()
+        val job = launch {
+            classToTest.actionEvents.collectLatest {
+                result.add(it)
+            }
+        }
+        classToTest.onDismissScreenClick()
+        assertThat(result.first()).isEqualTo(ActionEvent.Dismiss)
+        job.cancel()
+    }
+
+    @Test
+    fun `Should post action Dismiss when onDoneClick is called`() = test {
+        val result = ArrayList<ActionEvent>()
+        val job = launch {
+            classToTest.actionEvents.collectLatest {
+                result.add(it)
+            }
+        }
+        classToTest.onDoneClick()
+        assertThat(result.first()).isEqualTo(ActionEvent.Dismiss)
+        job.cancel()
+    }
+
+    @Test
+    fun `Should post action Dismiss when onContactSupportClick is called`() = test {
+        mockSelectedSite(selectedSite)
+        val result = ArrayList<ActionEvent>()
+        val job = launch {
+            classToTest.actionEvents.collectLatest {
+                result.add(it)
+            }
+        }
+        classToTest.onContactSupportClick()
+        assertThat(result.first()).isEqualTo(
+            ActionEvent.ContactSupport(
+                origin = HelpActivity.Origin.JETPACK_INSTALL_FULL_PLUGIN_ERROR,
+                selectedSite = selectedSiteRepository.getSelectedSite(),
+            )
+        )
+        job.cancel()
+    }
+
+    private fun mockSelectedSite(selectedSite: SiteModel) {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(selectedSite)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModelTest.kt
@@ -79,7 +79,7 @@ class JetpackFullPluginInstallViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should post action Dismiss when onContactSupportClick is called`() = test {
+    fun `Should post action ContactSupport when onContactSupportClick is called`() = test {
         mockSelectedSite(selectedSite)
         val result = ArrayList<ActionEvent>()
         val job = launch {


### PR DESCRIPTION
Fixes #17835

To test:
This screen has no entry point yet. It will be testable when install full plugin "My Site" card is implemented.
To test the screen in this PR, you can use the following patch to add a test entry point:

```
diff --git a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
index 5903791640..23118c0b3f 100644
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -91,6 +91,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFr
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
+import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPluginInstallOnboardingDialogFragment;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment;
@@ -541,8 +542,10 @@ public class WPMainActivity extends LocaleAwareActivity implements
     }

     private void showBloggingPromptsOnboarding() {
-        BloggingPromptsOnboardingDialogFragment.newInstance(DialogType.ONBOARDING).show(
-                getSupportFragmentManager(), BloggingPromptsOnboardingDialogFragment.TAG
+//        BloggingPromptsOnboardingDialogFragment.newInstance(DialogType.ONBOARDING).show(
+//                getSupportFragmentManager(), BloggingPromptsOnboardingDialogFragment.TAG));
+        JetpackFullPluginInstallOnboardingDialogFragment.newInstance().show(
+                getSupportFragmentManager(), JetpackFullPluginInstallOnboardingDialogFragment.TAG
         );
     }
```
With the patch applied:
1 - Install Jetpack app;
2 - Select a site that is a blog;
3 - Tap the overflow menu in the prompt card;
4 - Select `"Learn more"`;
5 - Tap on `"Continue"`.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit testing.

3. What automated tests I added (or what prevented me from doing so)
Implemented `JetpackFullPluginInstallOnboardingUiStateMapperTest.kt` and `JetpackFullPluginInstallViewModelTest.kt`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
