### PR TITLE
Jetpack Focus: Hide the initial screen setting when in phase four

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -46,6 +46,7 @@ import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewFetchPayload;
 import org.wordpress.android.models.JetpackPoweredScreen;
 import org.wordpress.android.ui.debug.DebugSettingsActivity;
 import org.wordpress.android.ui.deeplinks.DeepLinkOpenWebLinksWithJetpackHelper;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType;
 import org.wordpress.android.ui.prefs.language.LocalePickerBottomSheet;
@@ -110,6 +111,7 @@ public class AppSettingsFragment extends PreferenceFragment
     @Inject LocaleProvider mLocaleProvider;
     @Inject DeepLinkOpenWebLinksWithJetpackHelper mOpenWebLinksWithJetpackHelper;
     @Inject UiHelpers mUiHelpers;
+    @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
 
     private static final String TRACK_STYLE = "style";
     private static final String TRACK_ENABLED = "enabled";
@@ -234,6 +236,10 @@ public class AppSettingsFragment extends PreferenceFragment
 
         if (!mOpenWebLinksWithJetpackHelper.shouldShowAppSetting()) {
             removeOpenWebLinksWithJetpack();
+        }
+
+        if (mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()){
+            removeInitialScreen();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -238,7 +238,7 @@ public class AppSettingsFragment extends PreferenceFragment
             removeOpenWebLinksWithJetpack();
         }
 
-        if (mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()){
+        if (mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
             removeInitialScreen();
         }
     }


### PR DESCRIPTION
Fixes #17973 

This PR hides the "initial screen" settings when in Phase 4 of the Jetpack Focus project.

To test:
- Install the WP app and login
- Navigate to Me > App Settings
- ✅ Verify the Initial Screen setting is visible
- While in App Settings, navigate to Debug Settings
- Enable `jp_removal_four` and restart the app
- Navigate back to Me > App Settings
- ✅ Verify the Initial Screen setting is no longer visible

FYI: @tiagomar 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
