### PR TITLE
Jetpack Focus: Intercept reader links in p4 and redirect to main view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -48,6 +48,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFr
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayViewModel;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.ForwardToJetpack;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -166,6 +167,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
     @Inject JetpackAppMigrationFlowUtils mJetpackAppMigrationFlowUtils;
     private JetpackFeatureFullScreenOverlayViewModel mJetpackFullScreenViewModel;
     @Inject AccountStore mAccountStore;
+    @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -297,7 +299,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
             host = uri.getHost();
         }
 
-        if (uri == null) {
+        if (uri == null || mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
             mReaderTracker.trackDeepLink(AnalyticsTracker.Stat.DEEP_LINKED, action, host, uri);
             // invalid uri so, just show the entry screen
             Intent intent = new Intent(this, WPLaunchActivity.class);


### PR DESCRIPTION
This PR reverts the revert in #17851 to address the case where reader web links are not being redirected to the main view. Yes, this means that for these particular web links an overlay won't be shown, but for now that is okay (as the overlay was a last minute addition as a nice-to-have). We will eventually sort out the showing of the overlay for these instances, but the immediate need is to stop the user from being dropped into an feature of the app which has been removed.

**To test:**
**To test:**
Decompress and download the attached links_helper.html file to your device (github doesn't support html file attachments)
[links_helper.html.zip](https://github.com/wordpress-mobile/WordPress-Android/files/10404426/links_helper.html.zip)


*Pre reqs*
- Uninstall all previous versions of JP & WP
- Install the WP APK from this PR and login
- Enable the pre-alpha WP app to handle verified web links links. On a pixel device you will find this under Open By Default > Tap + Add Link > Check all three checkboxes and then click Add.

**Non-Phase 4 Test**
- Tap on each link in the Custom Scheme: Wordpress PreAlpha links section
- ✅ Verify that each link opens to the correct place in the WordPress app
- Tap on  each link in the Custom Scheme: WordPress intents with NO package specified section. Select to open with WP
- ✅ Verify that each link opens to the correct place in the WordPress app
- Tap on each link in the Web Links section 
- ✅ Verify that each link opens to the correct place in the WordPress app


**Phase 4 Test**
- Navigate to Me -> App Settings -> Debug Settings 
- Enable `jp_removal_four` and restart the app
- Tap on each link in the Custom Scheme: Wordpress PreAlpha links section
- ✅ Verify that each link opens to the home view place in the WordPress app
- Tap on  each link in the Custom Scheme: WordPress intents with NO package specified section. Select to open with WP
- ✅ Verify that each link opens to the  home view in the WordPress app
- Tap on each link in the Web Links section 
- ✅ Verify that each link opens to the  home view in the WordPress app


## Regression Notes
1. Potential unintended areas of impact
User are able to deep link into jetpack areas when phase 4 is current

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
