### PR TITLE
JP install endpoint integration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
@@ -89,6 +89,7 @@ class JetpackFullPluginInstallActivity : AppCompatActivity() {
                 )
             }
             is ActionEvent.Dismiss -> {
+                ActivityLauncher.showMainActivity(this)
                 finish()
             }
         }.exhaustive

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.jpfullplugininstall.install
 
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,8 +13,9 @@ import org.wordpress.android.fluxc.generated.PluginActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.store.PluginStore
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload
+import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginConfigured
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled
-import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
@@ -25,6 +25,7 @@ import javax.inject.Inject
 import javax.inject.Named
 
 @HiltViewModel
+@Suppress("UnusedPrivateMember")
 class JetpackFullPluginInstallViewModel @Inject constructor(
     private val uiStateMapper: JetpackFullPluginInstallUiStateMapper,
     private val selectedSiteRepository: SelectedSiteRepository,
@@ -93,7 +94,7 @@ class JetpackFullPluginInstallViewModel @Inject constructor(
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onSitePluginConfigured(event: PluginStore.OnSitePluginConfigured) {
+    fun onSitePluginConfigured(event: OnSitePluginConfigured) {
         if (event.isError) {
             AppLog.d(
                 AppLog.T.PLUGINS,
@@ -109,7 +110,7 @@ class JetpackFullPluginInstallViewModel @Inject constructor(
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onSiteChanged(event: SiteStore.OnSiteChanged) {
+    fun onSiteChanged(event: OnSiteChanged) {
         val success = if (event.isError) {
             AppLog.d(
                 AppLog.T.PLUGINS,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModel.kt
@@ -7,9 +7,19 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.PluginActionBuilder
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.store.PluginStore
+import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload
+import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -19,12 +29,24 @@ class JetpackFullPluginInstallViewModel @Inject constructor(
     private val uiStateMapper: JetpackFullPluginInstallUiStateMapper,
     private val selectedSiteRepository: SelectedSiteRepository,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    // adding pluginStore seems needed to allow the events Subscribe to work
+    private val pluginStore: PluginStore,
+    private val dispatcher: Dispatcher
 ) : ScopedViewModel(bgDispatcher) {
     private val _uiState = MutableStateFlow<UiState>(uiStateMapper.mapInitial())
     val uiState = _uiState.asStateFlow()
 
     private val _actionEvents = MutableSharedFlow<ActionEvent>()
     val actionEvents = _actionEvents
+
+    init {
+        dispatcher.register(this)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        dispatcher.unregister(this)
+    }
 
     fun onContinueClick() {
         postUiState(uiStateMapper.mapInstalling())
@@ -53,17 +75,68 @@ class JetpackFullPluginInstallViewModel @Inject constructor(
         )
     }
 
-    @Suppress("MagicNumber")
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onSitePluginInstalled(event: OnSitePluginInstalled) {
+        if (event.isError) {
+            AppLog.d(
+                AppLog.T.PLUGINS,
+                "Error trying to install the full Jetpack plugin: ${event.error.type} - ${event.error.message}"
+            )
+        }
+
+        // Refresh the site regardless any event error if possible
+        event.site?.let {
+            dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(it))
+        } ?: postUiState(uiStateMapper.mapError())
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onSitePluginConfigured(event: PluginStore.OnSitePluginConfigured) {
+        if (event.isError) {
+            AppLog.d(
+                AppLog.T.PLUGINS,
+                "Error trying to configure the full Jetpack plugin: ${event.error.type} - ${event.error.message}"
+            )
+        }
+
+        // Refresh the site regardless any event error if possible
+        event.site?.let {
+            dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(it))
+        } ?: postUiState(uiStateMapper.mapError())
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onSiteChanged(event: SiteStore.OnSiteChanged) {
+        val success = if (event.isError) {
+            AppLog.d(
+                AppLog.T.PLUGINS,
+                "Error trying to update site while installing the full " +
+                        "Jetpack plugin: ${event.error.type} - ${event.error.message}"
+            )
+            false
+        } else {
+            // Check if the final goal (JP installed and active) is matched
+            val selectedSite = selectedSiteRepository.getSelectedSite()
+            selectedSite?.let {
+                it.isJetpackInstalled && it.isJetpackConnected
+            } ?: false
+        }
+
+        if (success) {
+            postUiState(uiStateMapper.mapDone())
+        } else {
+            postUiState(uiStateMapper.mapError())
+        }
+    }
+
     private fun installJetpackPlugin() {
-        // TODO replace mock with endpoint call and update unit tests
-        launch {
-            delay(2000L)
-            val success = true
-            if (success) {
-                postUiState(uiStateMapper.mapDone())
-            } else {
-                postUiState(uiStateMapper.mapError())
-            }
+        val selectedSite = selectedSiteRepository.getSelectedSite()
+        selectedSite?.let {
+            val payload = InstallSitePluginPayload(it, "jetpack")
+            dispatcher.dispatch(PluginActionBuilder.newInstallJpForIndividualPluginSiteAction(payload))
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallViewModelTest.kt
@@ -4,11 +4,20 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.PluginAction
+import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PluginStore
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 
@@ -16,15 +25,25 @@ import org.wordpress.android.ui.mysite.SelectedSiteRepository
 class JetpackFullPluginInstallViewModelTest : BaseUnitTest() {
     private val uiStateMapper: JetpackFullPluginInstallUiStateMapper = mock()
     private val selectedSiteRepository: SelectedSiteRepository = mock()
+    private val pluginStore: PluginStore = mock()
+    private val dispatcher: Dispatcher = mock()
+    private lateinit var actionCaptor: KArgumentCaptor<Action<Any>>
     private val classToTest = JetpackFullPluginInstallViewModel(
         uiStateMapper = uiStateMapper,
         selectedSiteRepository = selectedSiteRepository,
         bgDispatcher = testDispatcher(),
+        pluginStore,
+        dispatcher
     )
 
     private val selectedSite = SiteModel().apply {
         id = 123
         name = "Site name"
+    }
+
+    @Before
+    fun setUp() {
+        actionCaptor = argumentCaptor()
     }
 
     @Test
@@ -34,22 +53,30 @@ class JetpackFullPluginInstallViewModelTest : BaseUnitTest() {
             uiStateMapper = uiStateMapper,
             selectedSiteRepository = selectedSiteRepository,
             bgDispatcher = testDispatcher(),
+            pluginStore,
+            dispatcher
         )
         assertThat(initialMockedClassToTest.uiState.value).isInstanceOf(UiState.Initial::class.java)
     }
 
     @Test
-    fun `Should post Installing UI state when onContinueClick is called`() {
+    fun `Should post Installing UI state and dispatch install action when onContinueClick is called`() {
+        mockSelectedSite(selectedSite)
         whenever(uiStateMapper.mapInstalling()).thenReturn(UiState.Installing)
         classToTest.onContinueClick()
         assertThat(classToTest.uiState.value).isInstanceOf(UiState.Installing::class.java)
+        verify(dispatcher, times(1)).dispatch(actionCaptor.capture())
+        assertThat(actionCaptor.lastValue.type).isEqualTo(PluginAction.INSTALL_JP_FOR_INDIVIDUAL_PLUGIN_SITE)
     }
 
     @Test
     fun `Should post Installing UI state when onRetryClick is called`() {
+        mockSelectedSite(selectedSite)
         whenever(uiStateMapper.mapInstalling()).thenReturn(UiState.Installing)
         classToTest.onRetryClick()
         assertThat(classToTest.uiState.value).isInstanceOf(UiState.Installing::class.java)
+        verify(dispatcher, times(1)).dispatch(actionCaptor.capture())
+        assertThat(actionCaptor.lastValue.type).isEqualTo(PluginAction.INSTALL_JP_FOR_INDIVIDUAL_PLUGIN_SITE)
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.89.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2657-77f6e8b4af256b762d0c1482a9347ccf9fb4820e'
+    wordPressFluxCVersion = '2660-83a5c0ded8408924fcdbc9b96d28bc102ad23a97'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.89.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2660-83a5c0ded8408924fcdbc9b96d28bc102ad23a97'
+    wordPressFluxCVersion = 'trunk-2dec1cfcb7726fddfe9d858a3b78d42f07235fc7'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.2.0'


### PR DESCRIPTION
Fixes #17834 

This PR integrates the functions added in the PluginStore to manage the JP plugin installation for sites that has only individual plugins installed. 

## To test

This screen has no entry point yet. It will be testable when install full plugin "My Site" card is implemented.
To test the screen in this PR, you can change the func showJetpackMigrationDeleteWP as follows

```
    private fun showJetpackMigrationDeleteWP() {
        JetpackFullPluginInstallOnboardingDialogFragment.newInstance().show(
            activity?.supportFragmentManager!!, JetpackFullPluginInstallOnboardingDialogFragment.TAG
        )
    }
```

### Install on individual plugin site
- Create a JN site and uninstall the full JP plugin
- Install an individual plugin and connect it with your .com account
- Select it in the app and trigger the screen open tapping on "Please delete WP app" button
- Tap on Install the full plugin
- Tap on Continue
- Note the loading indicator and then the Done button (indicating JP installation succeded)
- Tap on Done and notice you are landed to the main screen

### Failing state
- Now from wp-admin deactivate and delete the full JP plugin 
- Notice that this disconnects the individual plugin (setting up conditions for a failure)
- In the app tap on "Please delete WP app" button
- Tap on Install the full plugin
- Tap on Continue
- Notice the loading indicator and then the failure screen
- Tap on Retry fails again
- Tap on Contact Support and smoke test the support section
- Use back to come to main screen again

### Full JP plugin configure only
- Now from wp-admin > My Jetpack connect your .com account again
- Again from wp-admin install the full JP plugin but do not activate it
- From the app tap on "Please delete WP app" button
- Tap on Install the full plugin
- Tap on Continue
- Notice the loading indicator and then and then the Done button (indicating JP installation succeded)
- Notice on the web that the full JP plugin is now activated
- Tap on Done and notice you are landed to the main screen

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and updating unit testing.

3. What automated tests I added (or what prevented me from doing so)
Updating existing unit testing.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
