### PR TITLE
Enable the build flag for WordPress Support Forum project

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -128,7 +128,7 @@ android {
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_SELF_HOSTED_USERS", "false"
         buildConfigField "boolean", "PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD", "false"
         buildConfigField "boolean", "OPEN_WEB_LINKS_WITH_JETPACK_FLOW", "false"
-        buildConfigField "boolean", "ENABLE_WORDPRESS_SUPPORT_FORUM", "false"
+        buildConfigField "boolean", "ENABLE_WORDPRESS_SUPPORT_FORUM", "true"
         buildConfigField "boolean", "JETPACK_INSTALL_FULL_PLUGIN", "false"
         buildConfigField "boolean", "ENABLE_BLAZE_FEATURE", "false"
 


### PR DESCRIPTION
This enables the build flag for the WordPress Support Forum project.

To test:
1. Launch the WordPress app and log in.
2. Open "Me → Help & Support" screen
3. Ensure the "Community Forums" button is on the screen instead of the "Contact Us" button.

## Regression Notes
1. Potential unintended areas of impact
None

4. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
