### PR TITLE
Blaze: Tidy the blaze card UI

### DIFF
--- a/WordPress/src/main/res/layout/promote_with_blaze_card.xml
+++ b/WordPress/src/main/res/layout/promote_with_blaze_card.xml
@@ -8,59 +8,63 @@
     android:layout_height="wrap_content"
     android:foreground="?attr/selectableItemBackground">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/margin_extra_large">
-
-        <ImageView
-            android:id="@+id/my_site_promote_with_blaze_card_more"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:clickable="true"
-            android:contentDescription="@string/content_description_more"
-            android:focusable="true"
-            android:src="@drawable/ic_more_vert_white_24dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tint="?attr/wpColorOnSurfaceMedium"
-            tools:ignore="TouchTargetSizeCheck" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/my_site_promote_with_blaze_card_title"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/promote_blaze_card_title"
-            android:textAlignment="viewStart"
-            android:textAppearance="?attr/textAppearanceHeadline6"
-            app:layout_constraintEnd_toStartOf="@+id/my_site_promote_with_blaze_card_more"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:text="@string/promote_blaze_card_title" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/my_site_promote_with_blaze_card_sub_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingBottom="@dimen/margin_medium"
-            android:paddingTop="@dimen/margin_medium"
-            android:text="@string/promote_blaze_card_sub_title"
-            android:textAppearance="?attr/textAppearanceBody1"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/my_site_promote_with_blaze_card_title" />
+        android:layout_height="wrap_content">
 
         <ImageView
             android:id="@+id/my_site_promote_with_blaze_card_flame"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentEnd="true"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/content_description_more"
-            android:src="@drawable/img_blaze_flame"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/my_site_promote_with_blaze_card_sub_title"
-            app:layout_constraintTop_toBottomOf="@+id/my_site_promote_with_blaze_card_more" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            android:scaleType="fitEnd"
+            android:src="@drawable/img_blaze_flame" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/margin_extra_large">
+
+            <ImageView
+                android:id="@+id/my_site_promote_with_blaze_card_more"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:contentDescription="@string/content_description_more"
+                android:focusable="true"
+                android:src="@drawable/ic_more_vert_white_24dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="?attr/wpColorOnSurfaceMedium"
+                tools:ignore="TouchTargetSizeCheck" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/my_site_promote_with_blaze_card_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/promote_blaze_card_title"
+                android:textAlignment="viewStart"
+                android:textAppearance="@style/blaze_title"
+                app:layout_constraintEnd_toStartOf="@+id/my_site_promote_with_blaze_card_more"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="@string/promote_blaze_card_title" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/my_site_promote_with_blaze_card_sub_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="@dimen/margin_medium"
+                android:paddingTop="@dimen/margin_medium"
+                android:text="@string/promote_blaze_card_sub_title"
+                android:textAppearance="@style/blaze_sub_title"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/my_site_promote_with_blaze_card_title" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </RelativeLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/layout/promote_with_blaze_card.xml
+++ b/WordPress/src/main/res/layout/promote_with_blaze_card.xml
@@ -56,7 +56,7 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/my_site_promote_with_blaze_card_sub_title"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:paddingBottom="@dimen/margin_medium"
                 android:paddingTop="@dimen/margin_medium"

--- a/WordPress/src/main/res/values/blaze_styles.xml
+++ b/WordPress/src/main/res/values/blaze_styles.xml
@@ -18,7 +18,6 @@ translationY compensates for the line height adjustment of text
         <item name="android:textSize">15sp</item>
         <item name="android:letterSpacing">-0.02</item>
         <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>
-<!--        <item name="android:textColor">#E6000000</item>-->
         <item name="android:lineSpacingExtra">3sp</item>
     </style>
 </resources>

--- a/WordPress/src/main/res/values/blaze_styles.xml
+++ b/WordPress/src/main/res/values/blaze_styles.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Extracted from figma design
+Font family: SF Pro
+Line height: 22sp
+(identical to box height)
+translationY compensates for the line height adjustment of text
+-->
+    <!-- styles.xml -->
+    <style name="blaze_title">
+        <item name="android:textSize">17sp</item>
+        <item name="android:letterSpacing">-0.03</item>
+        <item name="android:textColor">?attr/wpColorOnSurfaceHigh</item>
+        <item name="android:lineSpacingExtra">2sp</item>
+    </style>
+
+    <style name="blaze_sub_title">
+        <item name="android:textSize">15sp</item>
+        <item name="android:letterSpacing">-0.02</item>
+        <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>
+<!--        <item name="android:textColor">#E6000000</item>-->
+        <item name="android:lineSpacingExtra">3sp</item>
+    </style>
+</resources>


### PR DESCRIPTION
Parent #17909 

This PR aligns the blaze dashboard card UI with the figma design.

Before | After
-- | --
<img width="250" height="500" alt="light" src="https://user-images.githubusercontent.com/506707/220375619-ae7cc4b5-669a-4ed5-a565-11dab8562539.png"> | <img width="250" height="500" alt="dark" src="https://user-images.githubusercontent.com/506707/220375615-9424cb2b-6374-432b-8b0b-ffc5eed0d6de.png">

**To test:**
- Install and launch the app
- Login with a wpcom account 
- Navigate to Me > App Settings > Debug Settings
- Enable `blaze`
- Restart the app
- Navigate to the Home dashboard tab
- ✅ Verify the UI matches the designs
Repeat the above for light and dark modes

## Regression Notes
1. Potential unintended areas of impact
The views don't match

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
