### PR TITLE
[Dependency Updates] Update `googlePlayServicesCodeScannerVersion` to `16.0.0-beta3`

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -407,6 +407,7 @@ dependencies {
     implementation "com.google.firebase:firebase-config:$firebaseConfigVersion"
     implementation "com.google.android.gms:play-services-auth:$googlePlayServicesAuthVersion"
     implementation "com.google.android.gms:play-services-code-scanner:$googlePlayServicesCodeScannerVersion"
+    implementation "com.google.mlkit:barcode-scanning-common:$googleMLKitBarcodeScanningVersion"
     implementation "com.android.installreferrer:installreferrer:$androidInstallReferrerVersion"
     implementation "com.github.chrisbanes:PhotoView:$chrisbanesPhotoviewVersion"
     implementation "org.greenrobot:eventbus:$eventBusVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ ext {
     googleExoPlayerVersion = '2.13.3'
     googleGsonVersion = '2.6.2'
     googleMaterialVersion = '1.2.1'
+    googleMLKitBarcodeScanningVersion = '17.0.0'
     googlePlayServicesAuthVersion = '20.3.0'
     googlePlayServicesCodeScannerVersion = '16.0.0-beta1'
     jsoupVersion = '1.10.3'

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ ext {
     googleMaterialVersion = '1.2.1'
     googleMLKitBarcodeScanningVersion = '17.0.0'
     googlePlayServicesAuthVersion = '20.3.0'
-    googlePlayServicesCodeScannerVersion = '16.0.0-beta1'
+    googlePlayServicesCodeScannerVersion = '16.0.0-beta3'
     jsoupVersion = '1.10.3'
     kotlinxCoroutinesVersion = '1.6.4'
     lottieVersion = '5.2.0'


### PR DESCRIPTION
Parent #17567

This PR update `googlePlayServicesCodeScannerVersion` to [16.0.0-beta3](https://developers.google.com/android/guides/releases#august_16_2022).

Also, as part of this update the below transitive dependencies were added:
- On the `WordPress` module (https://github.com/wordpress-mobile/WordPress-Android/pull/17996/commits/66a6ba48296622030a40305276d0e74c95f14b64):
    - `com.google.mlkit:barcode-scanning-common`

-----

PS: @zwarm I added you as the main reviewer, not so randomly, since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid. I also added the @wordpress-mobile/apps-infrastructure team, but this in done only for monitoring purposes, as such, I am not expecting any active review from that team. Thus, feel free to merge this PR if you deem so.

-----

1. See the dependency tree diff result and verify correctness.
2. Thoroughly smoke test any code scanner related functionality on both, the WordPress and Jetpack apps, and see if they both work as expected.
3. In addition to the above smoke test, you can expand the below and follow the inner and more explicit test steps within:

<details>
  <summary>Jetpack Scan Login Code</summary> 

Step.1:
- Build and install the `Jetpack` app (note that you don't need a release build, a debug build will suffice).
- Login to the `Jetpack` app with a `WP.com` account (note that you need to use a non `A8C` account and a non `2FA` enabled account).
- Navigate to the `Me` screen (click on avatar at top-right).
- (STOP)

Step.2:
- Head over to your desktop and open a web browser (note that using an incognito tab works best).
- Browse to `wordpress.com` (note that if you are logged-in, log-out first).
- Tap the `Log In` link (top-right).
- Tap the `Login via the mobile app` link in the list of options below the main `Continue` button (bottom-middle).
- Verify you are on the `Login via the mobile app` view and `Use QR Code to login` is shown, along with a QR code for you to scan.
- (STOP)

Step.3:
- Head back to your mobile.
- Tap the `Scan Login Code` item on the `Me` screen you are currently at.
- Scan the QR code on the web browser.
- Follow the remaining prompts on your mobile to login to WordPress on your web browser (desktop), verify that you have successfully logged-in and are able to use WordPress as expected.

</details>

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on any or all code scanning related app functionalities, like using QR code to login on your web browser (desktop) via the mobile app (Jetpack).

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
