### PR TITLE
Fix support forums logic for self-hosted sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -370,7 +370,8 @@ public class SiteUtils {
 
     public static boolean hasSiteWithPaidPlan(SiteStore siteStore) {
         for (SiteModel site : siteStore.getSites()) {
-            if (!site.getHasFreePlan()) {
+            if (site.getPlanId() != 0 && !site.getHasFreePlan()) {
+                // Plan id could be 0 for self-hosted sites
                 return true;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -371,7 +371,7 @@ public class SiteUtils {
     public static boolean hasSiteWithPaidPlan(SiteStore siteStore) {
         for (SiteModel site : siteStore.getSites()) {
             if (site.getPlanId() != 0 && !site.getHasFreePlan()) {
-                // Plan id could be 0 for self-hosted sites
+                // The plan id is 0 if a self-hosted site is added without logging in.
                 return true;
             }
         }

--- a/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
@@ -52,9 +52,12 @@ class SiteUtilsTest {
 
         site1.hasFreePlan = true
         site2.hasFreePlan = true
+        site1.planId = FREE_PLAN_ID
+        site2.planId = FREE_PLAN_ID
         assertFalse(SiteUtils.hasSiteWithPaidPlan(siteStore))
 
         site2.hasFreePlan = false
+        site2.planId = BLOGGER_PLAN_ONE_YEAR_ID
         assertTrue(SiteUtils.hasSiteWithPaidPlan(siteStore))
     }
 


### PR DESCRIPTION
This fixes Contact Support being shown instead Community forums for self-hosted sites.

Fixes #17991 

To test:
1. Log in to a self-hosted site using its site credentials.
2. Request help and notice you're given forum support and not Zendesk UI

## Regression Notes
1. Potential unintended areas of impact
Showing support forums logic could be broken.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually for different cases/

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
