### PR TITLE
Blaze: Fetch Blaze status 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartExistingSiteT
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.PUBLISH_POST
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.blaze.BlazeStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
@@ -42,6 +43,7 @@ import org.wordpress.android.util.FluxCUtils
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.SiteUtils.hasFullAccessToContent
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.BlazeFeatureConfig
 import org.wordpress.android.util.map
 import org.wordpress.android.util.mapNullable
 import org.wordpress.android.util.merge
@@ -69,7 +71,9 @@ class WPMainActivityViewModel @Inject constructor(
     private val bloggingPromptsSettingsHelper: BloggingPromptsSettingsHelper,
     private val bloggingPromptsStore: BloggingPromptsStore,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
-    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
+    private val blazeFeatureConfig: BlazeFeatureConfig,
+    private val blazeStore: BlazeStore
 ) : ScopedViewModel(mainDispatcher) {
     private var isStarted = false
 
@@ -309,6 +313,8 @@ class WPMainActivityViewModel @Inject constructor(
         setMainFabUiState(showFab, site)
 
         checkAndShowFeatureAnnouncement()
+
+        fetchBlazeStatusIfNeeded(site)
     }
 
     private fun checkAndShowFeatureAnnouncement() {
@@ -326,6 +332,14 @@ class WPMainActivityViewModel @Inject constructor(
                 } else {
                     appPrefsWrapper.lastFeatureAnnouncementAppVersionCode = currentVersionCode
                 }
+            }
+        }
+    }
+
+    private fun fetchBlazeStatusIfNeeded(site: SiteModel?) {
+        if (blazeFeatureConfig.isEnabled() && site != null) {
+            launch {
+               blazeStore.fetchBlazeStatus(site)
             }
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
@@ -35,6 +36,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.U
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.VIEW_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.blaze.BlazeStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore.BloggingPromptsResult
 import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
@@ -57,6 +59,7 @@ import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.BlazeFeatureConfig
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel.FocusPointInfo
 import java.util.Date
 
@@ -111,6 +114,12 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
 
     @Mock
     private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
+    @Mock
+    private lateinit var blazeFeatureConfig: BlazeFeatureConfig
+
+    @Mock
+    private lateinit var blazeStore: BlazeStore
 
     private val featureAnnouncement = FeatureAnnouncement(
         "14.7",
@@ -173,7 +182,9 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
             bloggingPromptsSettingsHelper,
             bloggingPromptsStore,
             NoDelayCoroutineDispatcher(),
-            jetpackFeatureRemovalPhaseHelper
+            jetpackFeatureRemovalPhaseHelper,
+            blazeFeatureConfig,
+            blazeStore
         )
         viewModel.onFeatureAnnouncementRequested.observeForever(
             onFeatureAnnouncementRequestedObserver
@@ -853,13 +864,35 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
             verify(analyticsTrackerWrapper).track(Stat.BLOGGING_PROMPTS_CREATE_SHEET_CARD_VIEWED)
         }
 
+    @Test
+    fun `given blaze enabled, when my site page is resumed, then blaze status is fetched`() = test {
+        startViewModelWithDefaultParameters()
+        val site = initSite()
+
+        viewModel.onResume(isOnMySitePageWithValidSite = true, site = site)
+
+        verify(blazeStore).fetchBlazeStatus(site)
+    }
+
+    @Test
+    fun `given blaze not enabled, when my site page is resumed, then blaze status is not fetched`() = test {
+        startViewModelWithDefaultParameters(isBlazeEnabled = false)
+        val site = initSite()
+
+        viewModel.onResume(isOnMySitePageWithValidSite = true, site = site)
+
+        verifyNoInteractions(blazeStore)
+    }
+
     private fun startViewModelWithDefaultParameters(
         isWhatsNewFeatureEnabled: Boolean = true,
         isCreateFabEnabled: Boolean = true,
-        isWpcomOrJpSite: Boolean = true
+        isWpcomOrJpSite: Boolean = true,
+        isBlazeEnabled: Boolean = true
     ) {
         whenever(buildConfigWrapper.isWhatsNewFeatureEnabled).thenReturn(isWhatsNewFeatureEnabled)
         whenever(buildConfigWrapper.isCreateFabEnabled).thenReturn(isCreateFabEnabled)
+        whenever(blazeFeatureConfig.isEnabled()).thenReturn(isBlazeEnabled)
         viewModel.start(site = initSite(hasFullAccessToContent = true, isWpcomOrJpSite = isWpcomOrJpSite))
     }
 


### PR DESCRIPTION
Parent #17909 

This PR adds a call to fetch the blaze status for a site within the onResume of WPMainActivity. The result of the call is an updated database row if the call is successful. The the default blaze status is always false. 

The logic in this PR may or may not be a good idea. Would love to hear thoughts on whether this is the proper place to add the call. Logically it seems okay, as it will cover app entry from deep links.

**To test:**
- Remove any WP/JP app versions from you device
- Install and launch the app
- Login with a wpcom account 
- Navigate to Me > App Settings > Debug Settings
- Enable `blaze`
- Restart the app
- Swipe closed the app
- Launch the app from this link [ <a href="https://wordpress.com/stats/1234">Stats</a> ]  * You will need to allow the app to open web links via app setting * 
- ✅ Verify the logic contains **BlazeStore: fetch blaze status** 

## Regression Notes
1. Potential unintended areas of impact
The blaze status is not fetched

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

3. What automated tests I added (or what prevented me from doing so)\
Added tests to `WPMainActivityViewModelTest`

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
