### PR TITLE
WP Support Forum: Update help screen layout to match designs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -211,15 +211,12 @@ class HelpActivity : LocaleAwareActivity() {
     private fun HelpActivityBinding.showSupportForum() {
         contactUsButton.isVisible = false
         myTicketsButton.isVisible = false
-        emailContainerTopDivider.isVisible = false
         contactEmailContainer.isVisible = false
-        emailContainerBottomDivider.isVisible = false
 
         forumContainer.run {
             isVisible = true
             setOnClickListener { openWpSupportForum() }
         }
-        forumContainerBottomDivider.isVisible = true
     }
 
     private fun HelpActivityBinding.refreshContactEmailText() {

--- a/WordPress/src/main/res/layout/help_activity.xml
+++ b/WordPress/src/main/res/layout/help_activity.xml
@@ -115,14 +115,6 @@
                         android:textAppearance="?attr/textAppearanceCaption" />
                 </LinearLayout>
 
-                <View
-                    android:id="@+id/forumContainerBottomDivider"
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/divider_size"
-                    android:background="?android:attr/listDivider"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
-
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/faq_button"
                     style="@style/HelpActivitySingleText"
@@ -132,12 +124,6 @@
                     android:id="@+id/my_tickets_button"
                     style="@style/HelpActivitySingleText"
                     android:text="@string/my_tickets" />
-
-                <View
-                    android:id="@+id/emailContainerTopDivider"
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/divider_size"
-                    android:background="?android:attr/listDivider" />
 
                 <LinearLayout
                     android:id="@+id/contactEmailContainer"

--- a/WordPress/src/main/res/layout/help_activity.xml
+++ b/WordPress/src/main/res/layout/help_activity.xml
@@ -133,17 +133,6 @@
                     style="@style/HelpActivitySingleText"
                     android:text="@string/my_tickets" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/application_log_button"
-                    style="@style/HelpActivitySingleText"
-                    android:text="@string/application_log_button" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/applicationVersion"
-                    style="@style/HelpActivitySingleText"
-                    android:textColor="?attr/wpColorOnSurfaceMedium"
-                    tools:text="Version NN.1" />
-
                 <View
                     android:id="@+id/emailContainerTopDivider"
                     android:layout_width="match_parent"
@@ -177,6 +166,17 @@
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/divider_size"
                     android:background="?android:attr/listDivider" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/application_log_button"
+                    style="@style/HelpActivitySingleText"
+                    android:text="@string/application_log_button" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/applicationVersion"
+                    style="@style/HelpActivitySingleText"
+                    android:textColor="?attr/wpColorOnSurfaceMedium"
+                    tools:text="Version NN.1" />
 
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Moved contact email row up, above the Log and below the Tickets row

Fixes #18003 

|Before|After: Contact|After: Forum
|-|-|-|
|![Screenshot_20230224_161439](https://user-images.githubusercontent.com/990349/221098124-f341a006-bc6e-4540-ab1a-48086fa3aeab.png)|![Screenshot_20230227_114248](https://user-images.githubusercontent.com/990349/221448573-e2a56444-f9e8-459a-bd84-b48da56e388d.png)|![Screenshot_20230227_114728](https://user-images.githubusercontent.com/990349/221448624-4be27135-4daf-42c2-ac05-976c050bf8c3.png)|



To test:

- Launch WP app and log-in
- Select a site that is not free or self-hosted
- Navigate to Me > Help & Support 
- Verify the screen matches as shown in the after above

- Repeat the above steps with the JP app

> **Note**
> The designs Community forum row, which at the moment only appears for WP and on free plans.  As it stands either Community forum or Contact email appear and not both.


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
