### PR TITLE
Fixes: Crash on navigating to Site settings with No internet 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -38,7 +38,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.collection.SparseArrayCompat;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -502,12 +502,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         return view;
     }
 
-    @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        initBloggingSection();
-    }
-
     private AppCompatActivity getAppCompatActivity() {
         return (AppCompatActivity) getActivity();
     }
@@ -1079,6 +1073,8 @@ public class SiteSettingsFragment extends PreferenceFragment
             WPPrefUtils.removePreference(this, R.string.pref_key_jetpack_performance_more_settings,
                     R.string.pref_key_jetpack_performance_media_settings);
         }
+
+        initBloggingSection();
     }
 
     private void updateHomepageSummary() {


### PR DESCRIPTION
Slack Discussion ref - p1677224658938429-slack-C0180B5PRJ4

## What 
Fixes crash when Navigating to Site settings with No internet. This Crash was happening because while were trying to initialize the blogging preferences, the activity gets finished if there was no internet.  

## How 
Moves the `initBloggingSection` to the `initPreferences`. Which is called after the Network check

## Commits 
[Moves: Init blogging section to initPreferences](https://github.com/wordpress-mobile/WordPress-Android/pull/18007/commits/8a0d9f4e6b29576f38fc6a7d2c9299c9fbef6b43)

## 📓 To test:
1. Go to app → Menu 
2. Make sure that device has no internet
3. Click at Site Settings 
4. Verify that no crash happens and No network message is shown with Snackbar.

## Regression Notes
1. Potential unintended areas of impact
Blogging preference is not displayed properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.