### PR TITLE
[Dashboard] Fix infinite loading in My Site dashboard

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -61,10 +61,10 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.InfoItemBu
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.JetpackInstallFullPluginCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PromoteWithBlazeCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickLinkRibbonBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
-import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PromoteWithBlazeCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteItemsBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.TodaysStatsCardBuilderParams
@@ -125,6 +125,7 @@ import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.BlazeFeatureConfig
 import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import org.wordpress.android.util.config.BloggingPromptsListFeatureConfig
@@ -132,7 +133,6 @@ import org.wordpress.android.util.config.BloggingPromptsSocialFeatureConfig
 import org.wordpress.android.util.config.LandOnTheEditorFeatureConfig
 import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
-import org.wordpress.android.util.config.BlazeFeatureConfig
 import org.wordpress.android.util.filter
 import org.wordpress.android.util.getEmailValidationMessage
 import org.wordpress.android.util.map
@@ -518,7 +518,7 @@ class MySiteViewModel @Inject constructor(
             isJetpackApp && isMigrationCompleted && isWordPressInstalled
         }
 
-val jetpackInstallFullPluginCardParams = JetpackInstallFullPluginCardBuilderParams(
+        val jetpackInstallFullPluginCardParams = JetpackInstallFullPluginCardBuilderParams(
             site = site,
             onLearnMoreClick = ::onJetpackInstallFullPluginLearnMoreClick,
             onHideMenuItemClick = ::onJetpackInstallFullPluginHideMenuItemClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardSource.kt
@@ -93,10 +93,20 @@ class PromoteWithBlazeCardSource @Inject constructor(
             val error = result.error
             when {
                 error != null -> postErrorState()
-                model != null -> onRefreshedBackgroundThread()
-                else -> onRefreshedBackgroundThread()
+                model != null -> postLastState()
+                else -> postLastState()
             }
         }
+    }
+
+    /**
+     * This function is used to make sure the [refresh] information is propagated and processed correctly even though
+     * the previous status is still the current one. This avoids issues like the loading progress indicator being shown
+     * indefinitely.
+     */
+    private fun MediatorLiveData<PromoteWithBlazeUpdate>.postLastState() {
+        val lastStatus = value?.blazeStatusModel
+        postState(PromoteWithBlazeUpdate(lastStatus))
     }
 
     private fun MediatorLiveData<PromoteWithBlazeUpdate>.postErrorState() {


### PR DESCRIPTION
Fixes #18011 

The main cause of the loading indicator being shown indefinitely in the Dashboard is a race condition caused by some Card Sources only updating their internal `refresh` LiveData without updating their `PartialState` LiveData. Currently, the logic inside the `MySiteTabFragment` only tries to hide the loading indicator if a `uiModel` state change occurred, which means, only when Card Sources update their `PartialState`.

https://github.com/wordpress-mobile/WordPress-Android/blob/4ec8246ec4b6971ad96b8235160415442ce8b4ca/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt#L235-L241

This fix makes both the `Prompts` and `Blaze` card sources always update their partial state when updating their `refresh` state, even when the current state is still the valid one (just repost the same state again). This has the drawback of causing more "unneeded" UI updates but fixes the infinite indicator issue coming from those cards (which seem to be the major culprits, currently).

Note that a couple of other card sources still have a couple of scenarios where they only update the internal `refresh` LiveData, but they don't seem to be causing problems at the moment and they were like that long before the `Prompts` and `Blaze` sources were introduced, so it's fair to keep them as-is to avoid introducing risky changes.

To test:
The easies way I was able to reproduce this issue was in the WordPress App, with the following steps:
1. Log in with a WP.com account
2. Add a Self-hosted site with the following state (not sure if needed but that's how I reproduced it consistently):
  - An Individual Jetpack plugin installed (e.g.: Search, Social) and connected with the same WP.com account
3. Go to the Self-hosted site dashboard
4. Pull to refresh a few times
5. **Verify** the progress indicator always disappear when dashboard is loaded

## Regression Notes
1. Potential unintended areas of impact
Incorrect card state.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

6. What automated tests I added (or what prevented me from doing so)
None. All existing tests continued working as expected.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
