### PR TITLE
Implement discount price for domains on sale

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/Constants.java
+++ b/WordPress/src/main/java/org/wordpress/android/Constants.java
@@ -7,6 +7,5 @@ public class Constants {
     public static final String URL_TIMEZONE_ENDPOINT = "https://public-api.wordpress.com/wpcom/v2/timezones";
     public static final String URL_JETPACK_SETTINGS = "https://wordpress.com/settings/jetpack";
     public static final String URL_VISIT_VAULTPRESS_DASHBOARD = "https://dashboard.vaultpress.com/";
-
     public static final String TYPE_DOMAINS_PRODUCT = "domains";
 }

--- a/WordPress/src/main/java/org/wordpress/android/Constants.java
+++ b/WordPress/src/main/java/org/wordpress/android/Constants.java
@@ -7,4 +7,6 @@ public class Constants {
     public static final String URL_TIMEZONE_ENDPOINT = "https://public-api.wordpress.com/wpcom/v2/timezones";
     public static final String URL_JETPACK_SETTINGS = "https://wordpress.com/settings/jetpack";
     public static final String URL_VISIT_VAULTPRESS_DASHBOARD = "https://dashboard.vaultpress.com/";
+
+    public static final String TYPE_DOMAINS_PRODUCT = "domains";
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -188,8 +188,8 @@ class DomainSuggestionsViewModel @Inject constructor(
                 DomainSuggestionItem(
                     domainName = it.domain_name,
                     cost = it.cost,
-                    isOnSale = product?.isSaleDomain() ?: false,
-                    saleCost = product?.saleCostForDisplay().toString(),
+                    isOnSale = product.isSaleDomain(),
+                    saleCost = product.saleCostForDisplay(),
                     isFree = it.is_free,
                     supportsPrivacy = it.supports_privacy,
                     productId = it.product_id,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -27,7 +27,7 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.SiteDomainsFeatureConfig
-import org.wordpress.android.util.extensions.isSaleDomain
+import org.wordpress.android.util.extensions.isOnSale
 import org.wordpress.android.util.extensions.saleCostForDisplay
 import org.wordpress.android.util.helpers.Debouncer
 import org.wordpress.android.viewmodel.Event
@@ -188,7 +188,7 @@ class DomainSuggestionsViewModel @Inject constructor(
                 DomainSuggestionItem(
                     domainName = it.domain_name,
                     cost = it.cost,
-                    isOnSale = product.isSaleDomain(),
+                    isOnSale = product.isOnSale(),
                     saleCost = product.saleCostForDisplay(),
                     isFree = it.is_free,
                     supportsPrivacy = it.supports_privacy,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.Transformations
 import kotlinx.coroutines.CoroutineDispatcher
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.Constants.TYPE_DOMAINS_PRODUCT
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAINS_PURCHASE_WEBVIEW_VIEWED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAINS_SEARCH_SELECT_DOMAIN_TAPPED
@@ -134,7 +135,7 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     private fun fetchProducts() {
         launch {
-            val result = productsStore.fetchProducts("domains")
+            val result = productsStore.fetchProducts(TYPE_DOMAINS_PRODUCT)
             when {
                 result.isError -> {
                     AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching site domains")

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -134,7 +134,7 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     private fun fetchProducts() {
         launch {
-            val result = productsStore.fetchProducts()
+            val result = productsStore.fetchProducts("domains")
             when {
                 result.isError -> {
                     AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching site domains")

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -27,6 +27,8 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.SiteDomainsFeatureConfig
+import org.wordpress.android.util.extensions.isSaleDomain
+import org.wordpress.android.util.extensions.saleCostForDisplay
 import org.wordpress.android.util.helpers.Debouncer
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -164,6 +166,7 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     // Network Callback
 
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onDomainSuggestionsFetched(event: OnSuggestedDomains) {
         if (searchQuery != event.query) {
@@ -234,10 +237,6 @@ class DomainSuggestionsViewModel @Inject constructor(
             initializeDefaultSuggestions()
         }
     }
-
-    internal fun Product.isSaleDomain(): Boolean = this.saleCost?.let { it.compareTo(0.0) > 0 } == true
-
-    internal fun Product.saleCostForDisplay(): String = this.currencyCode + "%.2f".format(this.saleCost)
 
     private fun createCart(selectedSuggestion: DomainSuggestionItem) = launch {
         AppLog.d(T.DOMAIN_REGISTRATION, "Creating cart: $selectedSuggestion")

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -221,6 +221,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
             domainName = domain_name,
             isFree = is_free,
             cost = cost.orEmpty(),
+            productId = product_id,
         )
     }
 
@@ -378,6 +379,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
         val domainName: String,
         val isFree: Boolean,
         val cost: String,
+        val productId: Int,
     )
 
     data class DomainsUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.wordpress.android.Constants.TYPE_DOMAINS_PRODUCT
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.products.Product
@@ -116,7 +117,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
 
     private fun fetchAndCacheProducts() {
         launch {
-            val result = productsStore.fetchProducts("domains")
+            val result = productsStore.fetchProducts(TYPE_DOMAINS_PRODUCT)
             when {
                 result.isError -> {
                     AppLog.e(AppLog.T.DOMAIN_REGISTRATION, "Error while fetching domain products: ${result.error}")

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -47,7 +47,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.config.SiteCreationDomainPurchasingFeatureConfig
-import org.wordpress.android.util.extensions.isSaleDomain
+import org.wordpress.android.util.extensions.isOnSale
 import org.wordpress.android.util.extensions.saleCostForDisplay
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
@@ -317,14 +317,14 @@ class SiteCreationDomainsViewModel @Inject constructor(
                     domain.domainName,
                     cost = when {
                         domain.isFree -> Cost.Free
-                        product.isSaleDomain() -> Cost.OnSale(product.saleCostForDisplay(), domain.cost)
+                        product.isOnSale() -> Cost.OnSale(product.saleCostForDisplay(), domain.cost)
                         else -> Cost.Paid(domain.cost)
                     },
                     onClick = { onDomainSelected(domain) },
                     variant = when {
                         index == 0 -> Variant.Recommended
                         index == 1 -> Variant.BestAlternative
-                        product.isSaleDomain() -> Variant.Sale
+                        product.isOnSale() -> Variant.Sale
                         else -> null
                     },
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -130,7 +130,6 @@ class SiteCreationDomainsViewModel @Inject constructor(
         }
     }
 
-
     fun onCreateSiteBtnClicked() {
         val domain = requireNotNull(selectedDomain) {
             "Create site button should not be visible if a domain is not selected"

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -317,7 +317,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
                     domain.domainName,
                     cost = when {
                         domain.isFree -> Cost.Free
-                        product.isSaleDomain() -> Cost.OnSale(product?.saleCostForDisplay().toString(), domain.cost)
+                        product.isSaleDomain() -> Cost.OnSale(product.saleCostForDisplay(), domain.cost)
                         else -> Cost.Paid(domain.cost)
                     },
                     onClick = { onDomainSelected(domain) },

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -308,7 +308,6 @@ class SiteCreationDomainsViewModel @Inject constructor(
         return items
     }
 
-    @Suppress("ForbiddenComment")
     private fun createAvailableItemUiState(domain: DomainModel, index: Int): ListItemUiState {
         return when (purchasingFeatureConfig.isEnabledOrManuallyOverridden()) {
             true -> {

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
@@ -2,6 +2,5 @@ package org.wordpress.android.util.extensions
 
 import org.wordpress.android.fluxc.model.products.Product
 
-fun Product.isSaleDomain(): Boolean = this.saleCost?.let { it.compareTo(0.0) > 0 } == true
-
+fun Product?.isSaleDomain(): Boolean = this?.saleCost?.let { it.compareTo(0.0) > 0 } == true
 fun Product.saleCostForDisplay(): String = this.currencyCode + "%.2f".format(this.saleCost)

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
@@ -3,6 +3,6 @@ package org.wordpress.android.util.extensions
 import org.wordpress.android.fluxc.model.products.Product
 import java.util.Currency
 
-fun Product?.isSaleDomain(): Boolean = this?.saleCost?.let { it.compareTo(0.0) > 0 } == true
+fun Product?.isOnSale(): Boolean = this?.saleCost?.let { it.compareTo(0.0) > 0 } == true
 fun Product?.saleCostForDisplay() =
     this?.run { Currency.getInstance(currencyCode).symbol + "%.2f".format(saleCost) } ?: ""

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.util.extensions
+
+import org.wordpress.android.fluxc.model.products.Product
+
+fun Product.isSaleDomain(): Boolean = this.saleCost?.let { it.compareTo(0.0) > 0 } == true
+
+fun Product.saleCostForDisplay(): String = this.currencyCode + "%.2f".format(this.saleCost)

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
@@ -3,6 +3,6 @@ package org.wordpress.android.util.extensions
 import org.wordpress.android.fluxc.model.products.Product
 import java.util.Currency
 
-fun Product?.isOnSale(): Boolean = this?.saleCost?.let { it.compareTo(0.0) > 0 } == true
+fun Product?.isOnSale(): Boolean = this?.saleCost?.let { it > 0.0 } == true
 fun Product?.saleCostForDisplay() =
     this?.run { Currency.getInstance(currencyCode).symbol + "%.2f".format(saleCost) } ?: ""

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
@@ -3,4 +3,4 @@ package org.wordpress.android.util.extensions
 import org.wordpress.android.fluxc.model.products.Product
 
 fun Product?.isSaleDomain(): Boolean = this?.saleCost?.let { it.compareTo(0.0) > 0 } == true
-fun Product.saleCostForDisplay(): String = this.currencyCode + "%.2f".format(this.saleCost)
+fun Product?.saleCostForDisplay() = this?.run { currencyCode + "%.2f".format(saleCost) } ?: ""

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.util.extensions
 
 import org.wordpress.android.fluxc.model.products.Product
+import java.util.Currency
 
 fun Product?.isSaleDomain(): Boolean = this?.saleCost?.let { it.compareTo(0.0) > 0 } == true
-fun Product?.saleCostForDisplay() = this?.run { currencyCode + "%.2f".format(saleCost) } ?: ""
+fun Product?.saleCostForDisplay() =
+    this?.run { Currency.getInstance(currencyCode).symbol + "%.2f".format(saleCost) } ?: ""

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.Constants.TYPE_DOMAINS_PRODUCT
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.annotations.action.Action
@@ -131,7 +132,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         viewModel.start(site, domainRegistrationPurpose)
         advanceUntilIdle()
 
-        verify(productsStore).fetchProducts(eq("domains"))
+        verify(productsStore).fetchProducts(eq(TYPE_DOMAINS_PRODUCT))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -8,7 +8,9 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Mock
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -119,6 +121,17 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         viewModel.isIntroVisible.value?.let { isIntroVisible ->
             assert(isIntroVisible)
         }
+    }
+
+    @Test
+    fun `domain products are fetched only at first start`() = test {
+        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
+
+        viewModel.start(site, domainRegistrationPurpose)
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+
+        verify(productsStore).fetchProducts(eq("domains"))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -362,7 +362,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `domain products are fetched only at first start`() = testNewUi {
+    fun `verify domain products are fetched only at first start`() = testNewUi {
         viewModel.start()
         viewModel.start()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -22,6 +22,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.Constants.TYPE_DOMAINS_PRODUCT
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.products.Product
@@ -370,7 +371,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
         viewModel.start()
         viewModel.start()
 
-        verify(productsStore).fetchProducts(eq("domains"))
+        verify(productsStore).fetchProducts(eq(TYPE_DOMAINS_PRODUCT))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -90,6 +90,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
             domainSanitizer = mSiteCreationDomainSanitizer,
             dispatcher = dispatcher,
             fetchDomainsUseCase = fetchDomainsUseCase,
+            productsStore = mock(),
             purchasingFeatureConfig = purchasingFeatureConfig,
             tracker = tracker,
             bgDispatcher = testDispatcher(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
+import org.wordpress.android.fluxc.store.ProductsStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainError
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainModel
@@ -56,6 +57,9 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var fetchDomainsUseCase: FetchDomainsUseCase
+
+    @Mock
+    private lateinit var productsStore: ProductsStore
 
     @Mock
     lateinit var purchasingFeatureConfig: SiteCreationDomainPurchasingFeatureConfig
@@ -90,7 +94,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
             domainSanitizer = mSiteCreationDomainSanitizer,
             dispatcher = dispatcher,
             fetchDomainsUseCase = fetchDomainsUseCase,
-            productsStore = mock(),
+            productsStore = productsStore,
             purchasingFeatureConfig = purchasingFeatureConfig,
             tracker = tracker,
             bgDispatcher = testDispatcher(),
@@ -316,6 +320,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
 
     private fun testNewUi(block: suspend CoroutineScope.() -> Unit) = test {
         whenever(purchasingFeatureConfig.isEnabledOrManuallyOverridden()).thenReturn(true)
+        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
         block()
     }
 
@@ -354,6 +359,14 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
             eq(false),
             eq(size),
         )
+    }
+
+    @Test
+    fun `domain products are fetched only at first start`() = testNewUi {
+        viewModel.start()
+        viewModel.start()
+
+        verify(productsStore).fetchProducts(eq("domains"))
     }
 
     @Test


### PR DESCRIPTION
Resolves #18015

This PR:
- ★ Implements logic to apply discounts for domains on sale, integrated with the UI added in [#17993](https://github.com/wordpress-mobile/WordPress-Android/pull/17993)
- ⊕ Updates existing `Menu` → `Domains` feature:
  - ⊕ Replaces the currency code with the symbol in sale prices for consistency with the listing price
  - ⊕ Updates call to fetch products to specify `type=domains`, thus querying only domain products

## To Test

#### Prerequisite

<details><summary>◐ Toggle the <code>SiteCreationDomainPurchasingFeatureConfig</code> flag</summary>

1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Features in development` section
3. Tap on the item corresponding to the flag
4. Tap `RESTART THE APP` button
</details>

### ● Treatment Variation

- **Verify** discounts and styling applied to domain suggestions on sale

### ○ Control Variation

- **Verify** No UI changes in `Site creation` → `Domains`
- **Verify** All prices are showing currency symbol in `Menu` → `Domains`

### Screenshots

![ui](https://user-images.githubusercontent.com/4588074/221849090-31744a80-4027-4a0f-978e-90de58ae6824.png)

## Regression Notes

1. Potential unintended areas of impact
   `Site creation` → `Domains` and `Menu` → `Domains`

3. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing and unit testing

4. What automated tests I added (or what prevented me from doing so)
   Unit tests in `SiteCreationDomainsViewModelTest` and `DomainSuggestionsViewModelTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
