### PR TITLE
Improvement in the UI for the Blaze Overlay 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1825,7 +1825,8 @@ public class ActivityLauncher {
                     postModel.getRemotePostId(),
                     postModel.getTitle(),
                     postModel.getLink(),
-                    postModel.getFeaturedImageId());
+                    postModel.getFeaturedImageId(),
+                    null);
             intent.putExtra(ARG_EXTRA_POST_ID, postUIModel);
         }
         intent.putExtra(ARG_BLAZE_FLOW_SOURCE, source);

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -71,4 +71,8 @@ class BlazeFeatureUtils @Inject constructor(
             mapOf(SOURCE to blazeFlowSource.trackingName)
         )
     }
+
+    fun trackOverlayDismissed(blazeFlowSource: BlazeFlowSource) {
+        //todo: add tracking logic
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -58,11 +58,17 @@ class BlazeFeatureUtils @Inject constructor(
     }
 
     @Suppress("UNUSED_PARAMETER")
-    fun trackOverlayDisplayed(trackingName: BlazeFlowSource) {
-        // add the logic to track the overlay displayed event
+    fun trackOverlayDisplayed(blazeFlowSource: BlazeFlowSource) {
+        analyticsTrackerWrapper.track(
+            AnalyticsTracker.Stat.BLAZE_FEATURE_OVERLAY_DISPLAYED,
+            mapOf(SOURCE to blazeFlowSource.trackingName)
+        )
     }
 
-    fun trackPromoteWithBlazeClicked() {
-        // add the logic to track the promote with blaze clicked event
+    fun trackPromoteWithBlazeClicked(blazeFlowSource: BlazeFlowSource) {
+        analyticsTrackerWrapper.track(
+            AnalyticsTracker.Stat.BLAZE_FEATURE_OVERLAY_PROMOTE_CLICKED,
+            mapOf(SOURCE to blazeFlowSource.trackingName)
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -57,7 +57,6 @@ class BlazeFeatureUtils @Inject constructor(
         const val SOURCE = "source"
     }
 
-    @Suppress("UNUSED_PARAMETER")
     fun trackOverlayDisplayed(blazeFlowSource: BlazeFlowSource) {
         analyticsTrackerWrapper.track(
             AnalyticsTracker.Stat.BLAZE_FEATURE_OVERLAY_DISPLAYED,
@@ -73,6 +72,9 @@ class BlazeFeatureUtils @Inject constructor(
     }
 
     fun trackOverlayDismissed(blazeFlowSource: BlazeFlowSource) {
-        //todo: add tracking logic
+        analyticsTrackerWrapper.track(
+            AnalyticsTracker.Stat.BLAZE_FEATURE_OVERLAY_DISMISSED,
+            mapOf(SOURCE to blazeFlowSource.trackingName)
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeParentActivity.kt
@@ -30,6 +30,9 @@ class BlazeParentActivity : AppCompatActivity() {
                         .replace(R.id.container, BlazeOverlayFragment.newInstance())
                         .commitNow()
                 }
+                is BlazeUiState.Done -> {
+                    finish()
+                }
                 else -> {}
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeUiState.kt
@@ -29,5 +29,6 @@ data class PostUIModel(
     val title: String,
     val url: String,
     val imageUrl: Long,
+    val featuredImageUrl: String?
 ) : Parcelable
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -183,7 +183,11 @@ class BlazeOverlayFragment : Fragment() {
             PostTitle(title = postUIModel.title, modifier = Modifier.constrainAs(title) {
                 top.linkTo(postContainer.top, 15.dp)
                 start.linkTo(postContainer.start, 20.dp)
-                end.linkTo(featuredImage.start, margin = 20.dp)
+                postUIModel.featuredImageUrl?.run {
+                    end.linkTo(featuredImage.start, margin = 20.dp)
+                } ?: run {
+                    end.linkTo(postContainer.end, margin = 20.dp)
+                }
                 width = Dimension.fillToConstraints
                 height = Dimension.wrapContent
             })
@@ -191,7 +195,11 @@ class BlazeOverlayFragment : Fragment() {
             PostUrl(url = postUIModel.url, modifier = Modifier.constrainAs(url) {
                 top.linkTo(title.bottom, 5.dp)
                 start.linkTo(postContainer.start, 20.dp)
-                end.linkTo(featuredImage.start, margin = 20.dp)
+                postUIModel.featuredImageUrl?.run {
+                    end.linkTo(featuredImage.start, margin = 20.dp)
+                } ?: run {
+                    end.linkTo(postContainer.end, margin = 20.dp)
+                }
                 bottom.linkTo(postContainer.bottom, 15.dp)
                 width = Dimension.fillToConstraints
                 height = Dimension.wrapContent

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -90,7 +90,6 @@ class BlazeOverlayFragment : Fragment() {
         }
     }
 
-    @Suppress("UNUSED_PARAMETER")
     @Composable
     fun BlazeOverlayScreen(
         postModelState: BlazeUiState.PromoteScreen,

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -323,7 +323,7 @@ class BlazeOverlayFragment : Fragment() {
                 .padding(start = 4.dp, top = 12.dp)
                 .size(6.dp),
                 onDraw = {
-                    drawCircle(Color.LightGray)
+                    drawCircle(color = bulletedTextColor)
                 })
             Text(
                 modifier = Modifier.padding(start = Margin.ExtraLarge.value),

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -229,30 +229,30 @@ class BlazeOverlayFragment : Fragment() {
                 }
                 .width(80.dp)
                 .height(80.dp))
-            PostTitle(title = postUIModel.title, modifier = Modifier.constrainAs(title) {
-                top.linkTo(postContainer.top, 15.dp)
-                start.linkTo(postContainer.start, 20.dp)
-                postUIModel.featuredImageUrl?.run {
-                    end.linkTo(featuredImage.start, margin = 20.dp)
-                } ?: run {
-                    end.linkTo(postContainer.end, margin = 20.dp)
-                }
-                width = Dimension.fillToConstraints
-                height = Dimension.wrapContent
-            })
+            PostTitle(
+                title = postUIModel.title, modifier = Modifier.constrainAs(title) {
+                    top.linkTo(postContainer.top, 15.dp)
+                    start.linkTo(postContainer.start, 20.dp)
+                    postUIModel.featuredImageUrl?.run {
+                        end.linkTo(featuredImage.start, margin = 20.dp)
+                    } ?: run {
+                        end.linkTo(postContainer.end, margin = 20.dp)
+                    }
+                    width = Dimension.fillToConstraints
+                }.wrapContentHeight()
+            )
             val url = createRef()
             PostUrl(url = postUIModel.url, modifier = Modifier.constrainAs(url) {
-                top.linkTo(title.bottom, 5.dp)
+                top.linkTo(title.bottom)
                 start.linkTo(postContainer.start, 20.dp)
                 postUIModel.featuredImageUrl?.run {
                     end.linkTo(featuredImage.start, margin = 20.dp)
                 } ?: run {
                     end.linkTo(postContainer.end, margin = 20.dp)
                 }
-                bottom.linkTo(postContainer.bottom, 15.dp)
                 width = Dimension.fillToConstraints
                 height = Dimension.wrapContent
-            })
+            }.padding(bottom = 15.dp))
         }
     }
 
@@ -286,7 +286,8 @@ class BlazeOverlayFragment : Fragment() {
             fontSize = FontSize.Large.value,
             fontWeight = FontWeight.Bold,
             maxLines = 2,
-            modifier = modifier
+            overflow = TextOverflow.Ellipsis,
+            modifier = modifier.wrapContentHeight()
         )
     }
 
@@ -296,6 +297,7 @@ class BlazeOverlayFragment : Fragment() {
             text = url,
             style = MaterialTheme.typography.body2,
             maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
             modifier = modifier
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -78,7 +79,7 @@ class BlazeOverlayFragment : Fragment() {
     @Composable
     fun BlazeOverlayContent(
         postModelState: BlazeUiState.PromoteScreen,
-        isDarkTheme: Boolean = false
+        isDarkTheme: Boolean = isSystemInDarkTheme()
     ) {
         val post = when (postModelState) {
             is BlazeUiState.PromoteScreen.PromotePost -> postModelState.postUIModel
@@ -114,7 +115,9 @@ class BlazeOverlayFragment : Fragment() {
             )
             post?.let {
                 PostThumbnailView(
-                    it, modifier = Modifier
+                    it,
+                    isInDarkTheme = isDarkTheme,
+                    modifier = Modifier
                         .fillMaxWidth()
                         .wrapContentHeight()
                 )
@@ -126,14 +129,19 @@ class BlazeOverlayFragment : Fragment() {
                     .height(48.dp)
                     .padding(start = 20.dp, end = 20.dp)
                     .background(
-                        Color.Black,
+                        getPrimaryButtonColor(isDarkTheme),
                         shape = RoundedCornerShape(15.dp)
                     ),
                 buttonText = UiString.UiStringRes(R.string.blaze_post_promotional_button),
                 drawableRight = Drawable(R.drawable.ic_promote_with_blaze),
-                onClick = { viewModel.onPromoteWithBlazeClicked() }
+                onClick = { viewModel.onPromoteWithBlazeClicked() },
             )
         }
+    }
+
+    private fun getPrimaryButtonColor(isInDarkTheme: Boolean): Color {
+        return if(isInDarkTheme) AppColor.Gray60
+        else AppColor.Black
     }
 
     @Preview
@@ -155,7 +163,7 @@ class BlazeOverlayFragment : Fragment() {
     }
 
     @Composable
-    fun PostThumbnailView(postUIModel: PostUIModel, modifier: Modifier = Modifier) {
+    fun PostThumbnailView(postUIModel: PostUIModel, modifier: Modifier = Modifier, isInDarkTheme: Boolean) {
         ConstraintLayout(
             modifier = modifier
                 .padding(horizontal = 20.dp, vertical = 15.dp)
@@ -170,7 +178,7 @@ class BlazeOverlayFragment : Fragment() {
                     width = Dimension.fillToConstraints
                     height = Dimension.fillToConstraints
                 }
-                .background(color = AppColor.Gray60, shape = RoundedCornerShape(15.dp))
+                .background(color = getThumbnailBackground(isInDarkTheme), shape = RoundedCornerShape(15.dp))
             )
             PostFeaturedImage(url = postUIModel.featuredImageUrl, modifier = Modifier
                 .constrainAs(featuredImage) {
@@ -205,6 +213,11 @@ class BlazeOverlayFragment : Fragment() {
                 height = Dimension.wrapContent
             })
         }
+    }
+
+    private fun getThumbnailBackground(isInDarkTheme: Boolean): Color {
+        if(isInDarkTheme) return AppColor.DarkGray
+        else return AppColor.Gray70
     }
 
     // todo the logic for showing the featured image is not implemented yet

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -109,7 +109,7 @@ class BlazeOverlayFragment : Fragment() {
 
     @Composable
     fun OverlayTopBar(postUIModel: PostUIModel?, modifier: Modifier = Modifier) {
-        postUIModel?.let {
+        postUIModel?.also {
             MainTopAppBar(
                 title = null,
                 navigationIcon = {},
@@ -128,13 +128,11 @@ class BlazeOverlayFragment : Fragment() {
                     }
                 }
             )
-        }?: run {
-            MainTopAppBar(
+        }?: MainTopAppBar(
                 title = stringResource(R.string.blaze_activity_title),
                 navigationIcon = NavigationIcons.BackIcon,
                 onNavigationIconClick = {}
-            )
-        }
+        )
     }
 
     @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -35,11 +35,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -51,6 +51,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.ui.blaze.BlazeUiState
 import org.wordpress.android.ui.blaze.PostUIModel
+import org.wordpress.android.ui.compose.components.Button
 import org.wordpress.android.ui.compose.components.Drawable
 import org.wordpress.android.ui.compose.components.ImageButton
 import org.wordpress.android.ui.compose.components.MainTopAppBar
@@ -186,7 +187,11 @@ class BlazeOverlayFragment : Fragment() {
                         getPrimaryButtonColor(isDarkTheme),
                         shape = RoundedCornerShape(15.dp)
                     ),
-                buttonText = UiString.UiStringRes(getPrimaryButtonText(post)),
+                button = Button(
+                    text = UiString.UiStringRes(getPrimaryButtonText(post)),
+                    color = AppColor.White,
+                    fontWeight = FontWeight.Normal,
+                ),
                 drawableRight = Drawable(R.drawable.ic_promote_with_blaze),
                 onClick = { viewModel.onPromoteWithBlazeClicked() },
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -142,7 +142,7 @@ class BlazeOverlayFragment : Fragment() {
                         getPrimaryButtonColor(isDarkTheme),
                         shape = RoundedCornerShape(15.dp)
                     ),
-                buttonText = UiString.UiStringRes(R.string.blaze_post_promotional_button),
+                buttonText = UiString.UiStringRes(getPrimaryButtonText(post)),
                 drawableRight = Drawable(R.drawable.ic_promote_with_blaze),
                 onClick = { viewModel.onPromoteWithBlazeClicked() },
             )
@@ -152,6 +152,11 @@ class BlazeOverlayFragment : Fragment() {
     private fun getPrimaryButtonColor(isInDarkTheme: Boolean): Color {
         return if(isInDarkTheme) darkModePrimaryButtonColor
         else AppColor.Black
+    }
+
+    private fun getPrimaryButtonText(postUIModel: PostUIModel?): Int {
+        return postUIModel?.let { R.string.blaze_overlay_post_promotional_button }
+            ?: R.string.blaze_overlay_site_promotional_button
     }
 
     @Preview

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -146,7 +146,8 @@ class BlazeOverlayFragment : Fragment() {
                         postId = 119,
                         title = "Post title check if this is long enough to be truncated",
                         url = "https://www.google.long.ttiiitititititiit.com",
-                        imageUrl = 0
+                        imageUrl = 0,
+                        featuredImageUrl = null
                     )
                 )
             )
@@ -171,7 +172,7 @@ class BlazeOverlayFragment : Fragment() {
                 }
                 .background(color = AppColor.Gray60, shape = RoundedCornerShape(15.dp))
             )
-            PostFeaturedImage(url = "", modifier = Modifier
+            PostFeaturedImage(url = postUIModel.featuredImageUrl, modifier = Modifier
                 .constrainAs(featuredImage) {
                     top.linkTo(postContainer.top, 15.dp)
                     bottom.linkTo(postContainer.bottom, 15.dp)
@@ -200,7 +201,7 @@ class BlazeOverlayFragment : Fragment() {
 
     // todo the logic for showing the featured image is not implemented yet
     @Composable
-    private fun PostFeaturedImage(url: String, modifier: Modifier = Modifier) {
+    private fun PostFeaturedImage(url: String?, modifier: Modifier = Modifier) {
         val painter = rememberImagePainter(url) {
             placeholder(R.drawable.bg_rectangle_placeholder_globe_margin_8dp)
             error(R.drawable.bg_rectangle_placeholder_globe_margin_8dp)

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -273,6 +274,7 @@ class BlazeOverlayFragment : Fragment() {
         }
         Image(
             painter = painter,
+            contentScale = ContentScale.Crop,
             contentDescription = stringResource(R.string.blavatar_desc),
             modifier = modifier
                 .size(80.dp)
@@ -348,10 +350,11 @@ class BlazeOverlayFragment : Fragment() {
                 postModelState = BlazeUiState.PromoteScreen.PromotePost(
                     PostUIModel(
                         postId = 119,
-                        title = "Post title check if this is long enough to be truncated",
-                        url = "https://www.google.long.ttiiitititititiit.com",
-                        imageUrl = 0,
-                        featuredImageUrl = null
+                        title = "Post title long enough to be truncated and this is not just a test to see " +
+                                "how it looks",
+                        url = "www.google.long.ttiiitititititiit.com/blog./24/2021/05/12/this-is-a-test-post/trucncation is happeniding",
+                        imageUrl = 357,
+                        featuredImageUrl = "https://ajeshrpai.in/wp-content/uploads/2023/02/wp-1677490974228.jpg"
                     )
                 )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -206,24 +206,6 @@ class BlazeOverlayFragment : Fragment() {
             ?: R.string.blaze_overlay_site_promotional_button
     }
 
-    @Preview
-    @Composable
-    private fun PreviewBlazeOverlayScreen() {
-        AppTheme {
-            BlazeOverlayScreen(
-                postModelState = BlazeUiState.PromoteScreen.PromotePost(
-                    PostUIModel(
-                        postId = 119,
-                        title = "Post title check if this is long enough to be truncated",
-                        url = "https://www.google.long.ttiiitititititiit.com",
-                        imageUrl = 0,
-                        featuredImageUrl = null
-                    )
-                )
-            )
-        }
-    }
-
     @Composable
     fun PostThumbnailView(postUIModel: PostUIModel, modifier: Modifier = Modifier, isInDarkTheme: Boolean) {
         ConstraintLayout(
@@ -354,6 +336,32 @@ class BlazeOverlayFragment : Fragment() {
                 fontWeight = FontWeight.Light,
                 color = bulletedTextColor
             )
+        }
+    }
+
+    @Preview
+    @Composable
+    private fun PreviewBlazeOverlayScreenPostFlow() {
+        AppTheme {
+            BlazeOverlayScreen(
+                postModelState = BlazeUiState.PromoteScreen.PromotePost(
+                    PostUIModel(
+                        postId = 119,
+                        title = "Post title check if this is long enough to be truncated",
+                        url = "https://www.google.long.ttiiitititititiit.com",
+                        imageUrl = 0,
+                        featuredImageUrl = null
+                    )
+                )
+            )
+        }
+    }
+
+    @Preview
+    @Composable
+    private fun PreviewBlazeOverlayScreenSiteFlow() {
+        AppTheme {
+            BlazeOverlayScreen(BlazeUiState.PromoteScreen.Site)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -21,7 +21,10 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -50,6 +53,8 @@ import org.wordpress.android.ui.blaze.BlazeUiState
 import org.wordpress.android.ui.blaze.PostUIModel
 import org.wordpress.android.ui.compose.components.Drawable
 import org.wordpress.android.ui.compose.components.ImageButton
+import org.wordpress.android.ui.compose.components.MainTopAppBar
+import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.FontSize
@@ -80,14 +85,14 @@ class BlazeOverlayFragment : Fragment() {
         setContent {
             AppTheme {
                 val postModel by viewModel.promoteUiState.observeAsState(BlazeUiState.PromoteScreen.Site)
-                BlazeOverlayContent(postModel)
+                BlazeOverlayScreen(postModel)
             }
         }
     }
 
     @Suppress("UNUSED_PARAMETER")
     @Composable
-    fun BlazeOverlayContent(
+    fun BlazeOverlayScreen(
         postModelState: BlazeUiState.PromoteScreen,
         isDarkTheme: Boolean = isSystemInDarkTheme()
     ) {
@@ -95,6 +100,48 @@ class BlazeOverlayFragment : Fragment() {
             is BlazeUiState.PromoteScreen.PromotePost -> postModelState.postUIModel
             else -> null
         }
+        Scaffold(
+            topBar = { OverlayTopBar(post) },
+        ) {
+            BlazeOverlayContent(post, isDarkTheme)
+        }
+    }
+
+    @Composable
+    fun OverlayTopBar(postUIModel: PostUIModel?, modifier: Modifier = Modifier) {
+        postUIModel?.let {
+            MainTopAppBar(
+                title = null,
+                navigationIcon = {},
+                onNavigationIconClick = {},
+                actions = {
+                    IconButton(onClick = {}) {
+                        Icon(
+                            modifier = modifier
+                                .align(Alignment.Top)
+                                .padding(end = 8.dp),
+                            painter = painterResource(R.drawable.ic_close_white_24dp),
+                            contentDescription = stringResource(
+                                R.string.jetpack_full_plugin_install_onboarding_dismiss_button_content_description
+                            ),
+                        )
+                    }
+                }
+            )
+        }?: run {
+            MainTopAppBar(
+                title = stringResource(R.string.blaze_activity_title),
+                navigationIcon = NavigationIcons.BackIcon,
+                onNavigationIconClick = {}
+            )
+        }
+    }
+
+    @Composable
+    private fun BlazeOverlayContent(
+        post: PostUIModel?,
+        isDarkTheme: Boolean
+    ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(
@@ -150,7 +197,7 @@ class BlazeOverlayFragment : Fragment() {
     }
 
     private fun getPrimaryButtonColor(isInDarkTheme: Boolean): Color {
-        return if(isInDarkTheme) darkModePrimaryButtonColor
+        return if (isInDarkTheme) darkModePrimaryButtonColor
         else AppColor.Black
     }
 
@@ -161,9 +208,9 @@ class BlazeOverlayFragment : Fragment() {
 
     @Preview
     @Composable
-    private fun PreviewThumbnailView() {
+    private fun PreviewBlazeOverlayScreen() {
         AppTheme {
-            BlazeOverlayContent(
+            BlazeOverlayScreen(
                 postModelState = BlazeUiState.PromoteScreen.PromotePost(
                     PostUIModel(
                         postId = 119,
@@ -231,7 +278,7 @@ class BlazeOverlayFragment : Fragment() {
     }
 
     private fun getThumbnailBackground(isInDarkTheme: Boolean): Color {
-        if(isInDarkTheme) return AppColor.DarkGray
+        if (isInDarkTheme) return AppColor.DarkGray
         else return lightModePostThumbnailBackground
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -115,7 +115,7 @@ class BlazeOverlayFragment : Fragment() {
                 navigationIcon = {},
                 onNavigationIconClick = {},
                 actions = {
-                    IconButton(onClick = {}) {
+                    IconButton(onClick = { viewModel.dismissOverlay() }) {
                         Icon(
                             modifier = modifier
                                 .align(Alignment.Top)
@@ -128,10 +128,10 @@ class BlazeOverlayFragment : Fragment() {
                     }
                 }
             )
-        }?: MainTopAppBar(
-                title = stringResource(R.string.blaze_activity_title),
-                navigationIcon = NavigationIcons.BackIcon,
-                onNavigationIconClick = {}
+        } ?: MainTopAppBar(
+            title = stringResource(R.string.blaze_activity_title),
+            navigationIcon = NavigationIcons.BackIcon,
+            onNavigationIconClick = { viewModel.dismissOverlay() }
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -243,6 +243,8 @@ class BlazeOverlayFragment : Fragment() {
         Text(
             text = title,
             style = MaterialTheme.typography.body1,
+            fontSize = FontSize.Large.value,
+            fontWeight = FontWeight.Bold,
             maxLines = 2,
             modifier = modifier
         )
@@ -288,7 +290,7 @@ class BlazeOverlayFragment : Fragment() {
                 text = stringResource(id = stringResource),
                 fontSize = FontSize.Large.value,
                 fontWeight = FontWeight.Light,
-                color = Color.Gray
+                color = AppColor.Gray80
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -258,11 +258,10 @@ class BlazeOverlayFragment : Fragment() {
     }
 
     private fun getThumbnailBackground(isInDarkTheme: Boolean): Color {
-        if (isInDarkTheme) return AppColor.DarkGray
-        else return lightModePostThumbnailBackground
+        return if (isInDarkTheme) AppColor.DarkGray
+        else lightModePostThumbnailBackground
     }
 
-    // todo the logic for showing the featured image is not implemented yet
     @Composable
     private fun PostFeaturedImage(url: String?, modifier: Modifier = Modifier) {
         val painter = rememberImagePainter(url) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -230,16 +230,14 @@ class BlazeOverlayFragment : Fragment() {
                 .constrainAs(featuredImage) {
                     top.linkTo(postContainer.top, 15.dp)
                     bottom.linkTo(postContainer.bottom, 15.dp)
-                    end.linkTo(postContainer.end, 20.dp)
-                }
-                .width(80.dp)
-                .height(80.dp))
+                    end.linkTo(postContainer.end, 15.dp)
+                })
             PostTitle(
                 title = postUIModel.title, modifier = Modifier.constrainAs(title) {
                     top.linkTo(postContainer.top, 15.dp)
                     start.linkTo(postContainer.start, 20.dp)
                     postUIModel.featuredImageUrl?.run {
-                        end.linkTo(featuredImage.start, margin = 20.dp)
+                        end.linkTo(featuredImage.start, margin = 15.dp)
                     } ?: run {
                         end.linkTo(postContainer.end, margin = 20.dp)
                     }
@@ -251,7 +249,7 @@ class BlazeOverlayFragment : Fragment() {
                 top.linkTo(title.bottom)
                 start.linkTo(postContainer.start, 20.dp)
                 postUIModel.featuredImageUrl?.run {
-                    end.linkTo(featuredImage.start, margin = 20.dp)
+                    end.linkTo(featuredImage.start, margin = 15.dp)
                 } ?: run {
                     end.linkTo(postContainer.end, margin = 20.dp)
                 }
@@ -277,7 +275,7 @@ class BlazeOverlayFragment : Fragment() {
             painter = painter,
             contentDescription = stringResource(R.string.blavatar_desc),
             modifier = modifier
-                .size(dimensionResource(R.dimen.jp_migration_site_icon_size))
+                .size(80.dp)
                 .clip(RoundedCornerShape(3.dp))
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -54,6 +55,15 @@ import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.utils.UiString
+
+@Stable
+private val darkModePrimaryButtonColor = Color(0xFF1C1C1E)
+
+@Stable
+private val lightModePostThumbnailBackground = Color(0xD000000)
+
+@Stable
+private val bulletedTextColor = Color(0xFF666666)
 
 @AndroidEntryPoint
 class BlazeOverlayFragment : Fragment() {
@@ -140,7 +150,7 @@ class BlazeOverlayFragment : Fragment() {
     }
 
     private fun getPrimaryButtonColor(isInDarkTheme: Boolean): Color {
-        return if(isInDarkTheme) AppColor.Gray60
+        return if(isInDarkTheme) darkModePrimaryButtonColor
         else AppColor.Black
     }
 
@@ -217,7 +227,7 @@ class BlazeOverlayFragment : Fragment() {
 
     private fun getThumbnailBackground(isInDarkTheme: Boolean): Color {
         if(isInDarkTheme) return AppColor.DarkGray
-        else return AppColor.Gray70
+        else return lightModePostThumbnailBackground
     }
 
     // todo the logic for showing the featured image is not implemented yet
@@ -290,7 +300,7 @@ class BlazeOverlayFragment : Fragment() {
                 text = stringResource(id = stringResource),
                 fontSize = FontSize.Large.value,
                 fontWeight = FontWeight.Light,
-                color = AppColor.Gray80
+                color = bulletedTextColor
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -359,7 +359,7 @@ class BlazeOverlayFragment : Fragment() {
                         url = "www.google.long.ttiiitititititiit.com/blog./24/2021/05/12" +
                                 "/this-is-a-test-post/trucncation is happeniding",
                         imageUrl = 357,
-                        featuredImageUrl = null
+                        featuredImageUrl = "https://ajeshrpai.in/wp-content/uploads/2023/02/wp-1677490974228.jpg"
                     )
                 )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -178,7 +179,9 @@ class BlazeOverlayFragment : Fragment() {
                         .wrapContentHeight()
                 )
             }
-
+            Spacer(modifier = Modifier
+                .padding(top = 15.dp)
+            )
             ImageButton(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -179,8 +179,9 @@ class BlazeOverlayFragment : Fragment() {
                         .wrapContentHeight()
                 )
             }
-            Spacer(modifier = Modifier
-                .padding(top = 15.dp)
+            Spacer(
+                modifier = Modifier
+                    .padding(top = 15.dp)
             )
             ImageButton(
                 modifier = Modifier
@@ -355,9 +356,10 @@ class BlazeOverlayFragment : Fragment() {
                         postId = 119,
                         title = "Post title long enough to be truncated and this is not just a test to see " +
                                 "how it looks",
-                        url = "www.google.long.ttiiitititititiit.com/blog./24/2021/05/12/this-is-a-test-post/trucncation is happeniding",
+                        url = "www.google.long.ttiiitititititiit.com/blog./24/2021/05/12" +
+                                "/this-is-a-test-post/trucncation is happeniding",
                         imageUrl = 357,
-                        featuredImageUrl = "https://ajeshrpai.in/wp-content/uploads/2023/02/wp-1677490974228.jpg"
+                        featuredImageUrl = null
                     )
                 )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.ui.blaze.BlazeUiState
 import org.wordpress.android.ui.blaze.PostUIModel
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.posts.PostListFeaturedImageTracker
-import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
@@ -4,14 +4,24 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.blaze.BlazeFlowSource
 import org.wordpress.android.ui.blaze.BlazeUiState
 import org.wordpress.android.ui.blaze.PostUIModel
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.posts.PostListFeaturedImageTracker
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
-class BlazeViewModel @Inject constructor(private val blazeFeatureUtils: BlazeFeatureUtils) : ViewModel() {
+class BlazeViewModel @Inject constructor(
+    private val blazeFeatureUtils: BlazeFeatureUtils,
+    private val dispatcher: Dispatcher,
+    private val mediaStore: MediaStore,
+    private val siteSelectedSiteRepository: SelectedSiteRepository
+) : ViewModel() {
     private lateinit var blazeFlowSource: BlazeFlowSource
 
     private val _uiState = MutableLiveData<BlazeUiState>()
@@ -19,6 +29,9 @@ class BlazeViewModel @Inject constructor(private val blazeFeatureUtils: BlazeFea
 
     private val _promoteUiState = MutableLiveData<BlazeUiState.PromoteScreen>()
     val promoteUiState: LiveData<BlazeUiState.PromoteScreen> = _promoteUiState
+
+    private val featuredImageTracker =
+        PostListFeaturedImageTracker(dispatcher = dispatcher, mediaStore = mediaStore)
 
     fun start(source: BlazeFlowSource, postId: PostUIModel?) {
         blazeFlowSource = source
@@ -28,15 +41,18 @@ class BlazeViewModel @Inject constructor(private val blazeFeatureUtils: BlazeFea
     fun initialize(postModel: PostUIModel?) {
         blazeFeatureUtils.trackOverlayDisplayed(blazeFlowSource)
         postModel?.let {
-            _uiState.value = BlazeUiState.PromoteScreen.PromotePost(postModel)
-            _promoteUiState.value = BlazeUiState.PromoteScreen.PromotePost(postModel)
+            val featuredImage =
+                featuredImageTracker.getFeaturedImageUrl(siteSelectedSiteRepository.getSelectedSite()!!, it.imageUrl)
+            val updatedPostModel = postModel.copy(featuredImageUrl = featuredImage)
+            _uiState.value = BlazeUiState.PromoteScreen.PromotePost(updatedPostModel)
+            _promoteUiState.value = BlazeUiState.PromoteScreen.PromotePost(updatedPostModel)
         } ?: run {
             _uiState.value = BlazeUiState.PromoteScreen.Site
             _promoteUiState.value = BlazeUiState.PromoteScreen.Site
         }
     }
 
-   // to do: tracking logic and logic for done state
+    // to do: tracking logic and logic for done state
     fun showNextScreen(currentBlazeUiState: BlazeUiState) {
         when (currentBlazeUiState) {
             is BlazeUiState.PromoteScreen.Site -> _uiState.value = BlazeUiState.PostSelectionScreen

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
@@ -67,4 +67,9 @@ class BlazeViewModel @Inject constructor(
     fun onPromoteWithBlazeClicked() {
         blazeFeatureUtils.trackPromoteWithBlazeClicked(blazeFlowSource)
     }
+
+    fun dismissOverlay() {
+        _uiState.postValue(BlazeUiState.Done)
+        blazeFeatureUtils.trackOverlayDismissed(blazeFlowSource)
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
@@ -65,6 +65,6 @@ class BlazeViewModel @Inject constructor(
     }
 
     fun onPromoteWithBlazeClicked() {
-        blazeFeatureUtils.trackPromoteWithBlazeClicked()
+        blazeFeatureUtils.trackPromoteWithBlazeClicked(blazeFlowSource)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
@@ -18,8 +18,8 @@ import javax.inject.Inject
 @HiltViewModel
 class BlazeViewModel @Inject constructor(
     private val blazeFeatureUtils: BlazeFeatureUtils,
-    private val dispatcher: Dispatcher,
-    private val mediaStore: MediaStore,
+    dispatcher: Dispatcher,
+    mediaStore: MediaStore,
     private val siteSelectedSiteRepository: SelectedSiteRepository
 ) : ViewModel() {
     private lateinit var blazeFlowSource: BlazeFlowSource

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.blaze.BlazeUiState
 import org.wordpress.android.ui.blaze.PostUIModel
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.posts.PostListFeaturedImageTracker
+import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 
 @HiltViewModel
@@ -40,15 +41,20 @@ class BlazeViewModel @Inject constructor(
     fun initialize(postModel: PostUIModel?) {
         blazeFeatureUtils.trackOverlayDisplayed(blazeFlowSource)
         postModel?.let {
-            val featuredImage =
-                featuredImageTracker.getFeaturedImageUrl(siteSelectedSiteRepository.getSelectedSite()!!, it.imageUrl)
-            val updatedPostModel = postModel.copy(featuredImageUrl = featuredImage)
+            val updatedPostModel = updatePostModel(it)
             _uiState.value = BlazeUiState.PromoteScreen.PromotePost(updatedPostModel)
             _promoteUiState.value = BlazeUiState.PromoteScreen.PromotePost(updatedPostModel)
         } ?: run {
             _uiState.value = BlazeUiState.PromoteScreen.Site
             _promoteUiState.value = BlazeUiState.PromoteScreen.Site
         }
+    }
+
+    private fun updatePostModel(postModel: PostUIModel): PostUIModel {
+        val featuredImage =
+            featuredImageTracker.getFeaturedImageUrl(siteSelectedSiteRepository.getSelectedSite()!!, postModel.imageUrl)
+        val updatedUrl = UrlUtils.removeScheme(postModel.url)
+        return postModel.copy(url = updatedUrl, featuredImageUrl = featuredImage)
     }
 
     // to do: tracking logic and logic for done state

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ImageButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ImageButton.kt
@@ -11,17 +11,22 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester.Companion.createRefs
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.utils.UiString
 
 @Preview
@@ -39,7 +44,7 @@ fun PreviewDrawButton() {
         drawableRight = Drawable(R.drawable.ic_story_icon_24dp),
         drawableTop = Drawable(R.drawable.ic_story_icon_24dp),
         drawableBottom = Drawable(R.drawable.ic_story_icon_24dp),
-        buttonText = UiString.UiStringText("Button Text"),
+        button = Button(text = UiString.UiStringText("Button Text")),
         onClick = {}
     )
 }
@@ -52,7 +57,7 @@ fun ImageButton(
     drawableRight: Drawable? = null,
     drawableTop: Drawable? = null,
     drawableBottom: Drawable? = null,
-    buttonText: UiString,
+    button: Button,
     onClick: () -> Unit
 ) {
     ConstraintLayout(modifier = modifier) {
@@ -67,18 +72,18 @@ fun ImageButton(
             }
             .clickable { onClick.invoke() }
         ) {
-            val buttonTextValue = when (buttonText) {
-                is UiString.UiStringText -> buttonText.text
-                is UiString.UiStringRes -> stringResource(id = buttonText.stringRes)
-                is UiString.UiStringResWithParams -> stringResource(id = buttonText.stringRes)
+            val buttonTextValue: String = when (button.text) {
+                is UiString.UiStringText -> button.text.toString()
+                is UiString.UiStringRes -> stringResource(id = button.text.stringRes)
+                is UiString.UiStringResWithParams -> stringResource(id = button.text.stringRes)
                 else -> ""
             }
 
             Text(
-                text = buttonTextValue.toString(),
-                fontSize = FontSize.Large.value,
-                fontWeight = FontWeight.Bold,
-                color = Color.LightGray
+                text = buttonTextValue,
+                fontSize = button.fontSize,
+                fontWeight = button.fontWeight,
+                color = button.color,
             )
         }
 
@@ -101,7 +106,7 @@ fun ImageButton(
                 modifier = Modifier.constrainAs(imageRight) {
                     top.linkTo(parent.top)
                     bottom.linkTo(parent.bottom)
-                    start.linkTo(buttonTextRef.end, margin = drawable.padding )
+                    start.linkTo(buttonTextRef.end, margin = drawable.padding)
                 }.size(drawable.iconSize),
                 painter = painterResource(id = drawable.resId),
                 contentDescription = null
@@ -136,5 +141,36 @@ fun ImageButton(
     }
 }
 
-class Drawable(val resId: Int, val iconSize: Dp = 24.dp, val padding: Dp = 12.dp)
+/**
+ * @param resId The drawable resource id to be displayed.
+ * @param iconSize The icon size for the drawable, and if no value is provided the default size is 24 dp.
+ * @param padding The padding between the drawable and the button text.
+ */
+data class Drawable(val resId: Int, val iconSize: Dp = 24.dp, val padding: Dp = 12.dp)
+
+/**
+ * @param text The text to be displayed.
+ * @param modifier [Modifier] to apply to this layout.
+ * @param color [Color] to apply to the text. If [Color.Unspecified], and [style] has no color set,
+ * this will be [LocalContentColor].
+ * @param fontSize The size of glyphs to use when painting the text. See [TextStyle.fontSize].
+ * @param fontStyle The typeface variant to use when drawing the letters (e.g., italic).
+ * See [TextStyle.fontStyle].
+ * @param fontWeight The typeface thickness to use when painting the text (e.g., [FontWeight.Bold]).
+ * @param fontFamily The font family to be used when rendering the text. See [TextStyle.fontFamily].
+ * @param textAlign The alignment of the text within the lines of the paragraph.
+ * See [TextStyle.textAlign].
+ * @param style Style configuration for the text such as color, font, line height etc.
+ */
+data class Button(
+    val text: UiString,
+    val modifier: Modifier = Modifier,
+    val color: Color = Color.Unspecified,
+    val fontSize: TextUnit = TextUnit.Unspecified,
+    val fontStyle: FontStyle? = null,
+    val fontWeight: FontWeight? = null,
+    val fontFamily: FontFamily? = null,
+    val textAlign: TextAlign? = null,
+    val style: TextStyle? = null,
+)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ImageButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ImageButton.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.utils.UiString
 
 @Preview
@@ -72,13 +73,7 @@ fun ImageButton(
             }
             .clickable { onClick.invoke() }
         ) {
-            val buttonTextValue: String = when (button.text) {
-                is UiString.UiStringText -> button.text.toString()
-                is UiString.UiStringRes -> stringResource(id = button.text.stringRes)
-                is UiString.UiStringResWithParams -> stringResource(id = button.text.stringRes)
-                else -> ""
-            }
-
+            val buttonTextValue: String = uiStringText(button.text)
             Text(
                 text = buttonTextValue,
                 fontSize = button.fontSize,

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ImageButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ImageButton.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester.Companion.createRefs
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/MainTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/MainTopAppBar.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.compose.components
 
 import android.content.res.Configuration
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.LocalContentAlpha
@@ -61,22 +62,26 @@ object NavigationIcons {
  * [NavigationIcons]. It can be an composable function providing an [Icon] as well, since it is used inside an
  * [IconButton]. Note that leaving this field null will cause the navigation icon to not be shown.
  * @param onNavigationIconClick The lambda to be invoked when the navigation icon is pressed.
+ * @param actions The actions displayed at the end of the TopAppBar. This should typically be IconButtons
  */
 @Composable
 fun MainTopAppBar(
-    title: String,
+    title: String?,
     modifier: Modifier = Modifier,
     navigationIcon: NavigationIcon? = null,
     onNavigationIconClick: () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {}
 ) {
     TopAppBar(
         modifier = modifier,
         backgroundColor = MaterialTheme.colors.surface,
         contentColor = MaterialTheme.colors.onSurface,
         elevation = 0.dp,
-        title = withFullContentAlpha {
-            Text(title)
-        },
+        title = title?.let {
+            withFullContentAlpha {
+                Text(title)
+            }
+        } ?: { },
         navigationIcon = navigationIcon?.let {
             withFullContentAlpha {
                 IconButton(onClick = onNavigationIconClick) {
@@ -84,6 +89,7 @@ fun MainTopAppBar(
                 }
             }
         },
+        actions = actions
     )
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppColor.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppColor.kt
@@ -27,10 +27,13 @@ object AppColor {
     val Gray50 = Color(0x0D000000)
 
     @Stable
-    val Gray60 = Color(0x0DFFFFFF)
+    val Gray60 = Color(0xFF1C1C1E)
 
     @Stable
-    val Gray70 = Color(0x1C1C1E)
+    val Gray70 = Color(0xD000000)
+
+    @Stable
+    val Gray80 = Color(0xFF666666)
 
     // Blues (Automattic Color Studio)
     @Stable

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppColor.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppColor.kt
@@ -23,18 +23,6 @@ object AppColor {
     @Stable
     val Gray40 = Color(0xFF787c82)
 
-    @Stable
-    val Gray50 = Color(0x0D000000)
-
-    @Stable
-    val Gray60 = Color(0xFF1C1C1E)
-
-    @Stable
-    val Gray70 = Color(0xD000000)
-
-    @Stable
-    val Gray80 = Color(0xFF666666)
-
     // Blues (Automattic Color Studio)
     @Stable
     val Blue30 = Color(0xFF399CE3)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4418,5 +4418,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blaze_promotional_subtitle_1">Promote any post or page in only a few minutes for just a few dollars a day.</string>
     <string name="blaze_promotional_subtitle_2">Your content will appear on millions of WordPress and Tumblr sites.</string>
     <string name="blaze_promotional_subtitle_3">Track performance, start, and stop your Blaze at any time.</string>
-    <string name="blaze_post_promotional_button">Blaze this Post</string>
+    <string name="blaze_overlay_post_promotional_button">Blaze this Post</string>
+    <string name="blaze_overlay_site_promotional_button">Blaze a Post now</string>
 </resources>

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1023,6 +1023,8 @@ public final class AnalyticsTracker {
         BLAZE_FEATURE_TAPPED,
         BLAZE_FEATURE_MENU_ACCESSED,
         BLAZE_FEATURE_HIDE_TAPPED,
+        BLAZE_FEATURE_OVERLAY_DISPLAYED,
+        BLAZE_FEATURE_OVERLAY_PROMOTE_CLICKED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1024,7 +1024,8 @@ public final class AnalyticsTracker {
         BLAZE_FEATURE_MENU_ACCESSED,
         BLAZE_FEATURE_HIDE_TAPPED,
         BLAZE_FEATURE_OVERLAY_DISPLAYED,
-        BLAZE_FEATURE_OVERLAY_PROMOTE_CLICKED
+        BLAZE_FEATURE_OVERLAY_PROMOTE_CLICKED,
+        BLAZE_FEATURE_OVERLAY_DISMISSED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2539,6 +2539,10 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "blaze_feature_menu_accessed";
             case BLAZE_FEATURE_HIDE_TAPPED:
                 return "blaze_feature_hide_tapped";
+            case BLAZE_FEATURE_OVERLAY_DISPLAYED:
+                return "blaze_feature_overlay_displayed";
+            case BLAZE_FEATURE_OVERLAY_PROMOTE_CLICKED:
+                return "blaze_overlay_button_tapped";
         }
         return null;
     }

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2543,6 +2543,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "blaze_feature_overlay_displayed";
             case BLAZE_FEATURE_OVERLAY_PROMOTE_CLICKED:
                 return "blaze_overlay_button_tapped";
+            case BLAZE_FEATURE_OVERLAY_DISMISSED:
+                return "blaze_overlay_dismissed";
         }
         return null;
     }

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2540,7 +2540,7 @@ public class AnalyticsTrackerNosara extends Tracker {
             case BLAZE_FEATURE_HIDE_TAPPED:
                 return "blaze_feature_hide_tapped";
             case BLAZE_FEATURE_OVERLAY_DISPLAYED:
-                return "blaze_feature_overlay_displayed";
+                return "blaze_overlay_displayed";
             case BLAZE_FEATURE_OVERLAY_PROMOTE_CLICKED:
                 return "blaze_overlay_button_tapped";
             case BLAZE_FEATURE_OVERLAY_DISMISSED:


### PR DESCRIPTION
Part of #17912 & #17913 

## What? 
This PR adds the following implementations to the Blaze overlay content.

1️⃣ Adds a top app bar to the Overlay and navigation buttons 
2️⃣ Fixes the background colour of the Post preview and primary button in Light :☀️ and Dark Mode 🌑
3️⃣ Adds the implementation to show the featured Image on the Preview 
4️⃣ Adds the tracking logic for Overlay events

## Why?
This Overlay is the first screen shown when a user clicks at the Blaze entry point 

 ## How? 
### Important Commits 
- [Adds: the logic for showing featured image url](https://github.com/wordpress-mobile/WordPress-Android/commit/b362d1cc87f39ba2323b7612d9b1d2ed17f63451)
- [Updates: Constraint link to handle in case featured image unavailable](https://github.com/wordpress-mobile/WordPress-Android/commit/e6ca30e4af3922a7bed7ac143c7c175c78494898)
- [Adds: the logic of changing the colors in light and dark mode](https://github.com/wordpress-mobile/WordPress-Android/commit/f939cd933e567867dc9367ad7c7144a5cd740c6c)
- [Adds: logic for fetching button text for primary button in overlay](https://github.com/wordpress-mobile/WordPress-Android/commit/5700fba1b94455cf1e47c40756c1fa8605db6326)
- [Adds: tracking events to the button and overlay display event](https://github.com/wordpress-mobile/WordPress-Android/commit/9359fb7d79d657f558b7f9707d157981ac46a28b)
- [Adds: logic of dismissing the overlay and activity](https://github.com/wordpress-mobile/WordPress-Android/commit/dc5b2359131d29189f4e9180cddea7e9d5fb0ef9)
- [Adds: tracking logic for overlay dismissal](https://github.com/wordpress-mobile/WordPress-Android/commit/37e1d693bbfaf3016ad574f4de546fcca37be94f)

 ## Screenshots 
| Light Mode  |  Dark mode | Light Mode (with Post) |  Dark Mode  |
|---|---|---|---|
| ![screenshot_site_light_mode_](https://user-images.githubusercontent.com/17463767/221666704-713961c8-d7f7-4ad6-926b-6a7f96bc3a28.png) |![screenshot_site_night_mode_](https://user-images.githubusercontent.com/17463767/221666631-a806a6b0-3bfc-4ed7-9f99-815a6a2d9c16.png)|![screenshot_post_featured_image_lightMide_](https://user-images.githubusercontent.com/17463767/221667297-f4467aaf-b72a-483b-84dd-429df82cdbb4.png) | ![screenshot_night_mode_](https://user-images.githubusercontent.com/17463767/221667349-bc0716ab-a63e-43c0-87e4-53a6161cd448.png) |


## To test:

###  📝 Pre-requisites 
- Go to the jetpack app 
- Login with a wp account with Administrator privileges 
- Go to **app settings** → **Debug settings** 
- enable feature flag → `blaze`

### Test 1 - Published Post →  Blaze overlay
1. 👆🏼 Go to app →  Posts
2. 👆🏼 Go to Published Posts →  Click on More menu
3. 👆🏼 Click on **🔥 Promote with blaze ** 
4. ✅ Verify that the Overlay is shown
5. 🔵 Verify that the event is tracked : **🔵 Tracked: blaze_overlay_displayed, Properties: {"source":"posts_list"}**
6. ✅ Verify that the post title and URL, Post featured image is shown
7. 📓  If the featured image is not available, then it wont be shown 
8. 👆🏼  Click at the **Blaze this Post** button 
9. 🔵 Verify that the event is tracked: **🔵 Tracked: blaze_overlay_button_tapped, Properties: {"source":"posts_list"}**
10. 👆🏼  Click at the close(❌) icon
11. ✅ Verify that the Overlay is dismissed 
12. 🔵 Verify that the event is tracked: **🔵 Tracked: blaze_overlay_dismissed, Properties: {"source":"posts_list"}**

### Test 2 - Dashboard card →  Blaze overlay
1. 👆🏼 Go to app -> Home
2. 👆🏼 Click on **🔥 Promote with blaze card** 
3.  🔵 Verify that the event is tracked : **🔵 Tracked: blaze_overlay_displayed, Properties: {"source":"dashboard_card"}**
4. ✅ Verify that the Overlay is shown and matches the design 
5. 👆🏼  Click at the **Blaze a Post now** button 
6.  🔵 Verify that the event is tracked : **🔵 Tracked: blaze_overlay_button_tapped, Properties: {"source":"dashboard_card"}**
7. 👆🏼  Click at the back(🔙 ) icon
8.  ✅ Verify that the Overlay is dismissed 
9. 🔵 Verify that the event is tracked: **🔵 Tracked: blaze_overlay_dismissed, Properties: {"source":"dashboard_card"}**


## Regression Notes
1. Potential unintended areas of impact
Blaze overlay is not shown as per the design spec 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
