### PR TITLE
Update deprecated back pressed event

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -71,7 +71,7 @@ public class AddQuickPressShortcutActivity extends LocaleAwareActivity {
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/CollapseFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/CollapseFullScreenDialogFragment.java
@@ -14,6 +14,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 
+import androidx.activity.ComponentDialog;
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -146,12 +148,14 @@ public class CollapseFullScreenDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         initBuilderArguments();
 
-        Dialog dialog = new Dialog(requireContext(), getTheme()) {
+        Dialog dialog = super.onCreateDialog(savedInstanceState);
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
             @Override
-            public void onBackPressed() {
+            public void handleOnBackPressed() {
                 onCollapseClicked();
             }
         };
+        ((ComponentDialog) dialog).getOnBackPressedDispatcher().addCallback(this, callback);
 
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
         return dialog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/CollapseFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/CollapseFullScreenDialogFragment.java
@@ -301,7 +301,7 @@ public class CollapseFullScreenDialogFragment extends DialogFragment {
         }
     }
 
-    public void onBackPressed() {
+    public void collapse() {
         if (isAdded()) {
             onCollapseClicked();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/CollapseFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/CollapseFullScreenDialogFragment.java
@@ -148,14 +148,14 @@ public class CollapseFullScreenDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         initBuilderArguments();
 
-        Dialog dialog = super.onCreateDialog(savedInstanceState);
+        ComponentDialog dialog = (ComponentDialog) super.onCreateDialog(savedInstanceState);
         OnBackPressedCallback callback = new OnBackPressedCallback(true) {
             @Override
             public void handleOnBackPressed() {
                 onCollapseClicked();
             }
         };
-        ((ComponentDialog) dialog).getOnBackPressedDispatcher().addCallback(this, callback);
+        dialog.getOnBackPressedDispatcher().addCallback(this, callback);
 
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
         return dialog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
@@ -14,6 +14,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 
+import androidx.activity.ComponentDialog;
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -166,12 +168,14 @@ public class FullScreenDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         initBuilderArguments();
 
-        Dialog dialog = new Dialog(getActivity(), getTheme()) {
+        Dialog dialog = super.onCreateDialog(savedInstanceState);
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
             @Override
-            public void onBackPressed() {
+            public void handleOnBackPressed() {
                 onDismissClicked();
             }
         };
+        ((ComponentDialog) dialog).getOnBackPressedDispatcher().addCallback(this, callback);
 
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
         return dialog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
@@ -333,12 +333,6 @@ public class FullScreenDialogFragment extends DialogFragment {
         }
     }
 
-    public void onBackPressed() {
-        if (isAdded()) {
-            onDismissClicked();
-        }
-    }
-
     protected void onConfirmClicked() {
         boolean isConsumed = ((FullScreenDialogContent) mFragment).onConfirmClicked(mController);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
@@ -168,14 +168,14 @@ public class FullScreenDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         initBuilderArguments();
 
-        Dialog dialog = super.onCreateDialog(savedInstanceState);
+        ComponentDialog dialog = (ComponentDialog) super.onCreateDialog(savedInstanceState);
         OnBackPressedCallback callback = new OnBackPressedCallback(true) {
             @Override
             public void handleOnBackPressed() {
                 onDismissClicked();
             }
         };
-        ((ComponentDialog) dialog).getOnBackPressedDispatcher().addCallback(this, callback);
+        dialog.getOnBackPressedDispatcher().addCallback(this, callback);
 
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
         return dialog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionResultActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionResultActivity.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 
@@ -54,6 +55,16 @@ public class JetpackConnectionResultActivity extends LocaleAwareActivity {
 
         setContentView(R.layout.stats_loading_activity);
 
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+                finishAndGoBackToSource();
+            }
+        };
+
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         Toolbar toolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(toolbar);
@@ -107,12 +118,6 @@ public class JetpackConnectionResultActivity extends LocaleAwareActivity {
                 finishAndGoBackToSource();
             }
         }
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        finishAndGoBackToSource();
     }
 
     private void trackResult() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionResultActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionResultActivity.java
@@ -23,6 +23,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 
 import javax.inject.Inject;
 
@@ -58,8 +59,7 @@ public class JetpackConnectionResultActivity extends LocaleAwareActivity {
         OnBackPressedCallback callback = new OnBackPressedCallback(true) {
             @Override
             public void handleOnBackPressed() {
-                setEnabled(false);
-                getOnBackPressedDispatcher().onBackPressed();
+                CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 finishAndGoBackToSource();
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui
 
 import android.os.Bundle
 import android.view.MenuItem
+import androidx.activity.addCallback
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.INSTALL_JETPACK_CANCELLED
 import org.wordpress.android.databinding.JetpackRemoteInstallActivityBinding
@@ -14,6 +15,15 @@ class JetpackRemoteInstallActivity : LocaleAwareActivity() {
         with(JetpackRemoteInstallActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
             setSupportActionBar(toolbarLayout.toolbarMain)
+        }
+
+        onBackPressedDispatcher.addCallback(this) {
+            trackWithSource(
+                INSTALL_JETPACK_CANCELLED,
+                intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
+            )
+            isEnabled = false
+            onBackPressedDispatcher.onBackPressed()
         }
 
         supportActionBar?.let {
@@ -29,13 +39,5 @@ class JetpackRemoteInstallActivity : LocaleAwareActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    override fun onBackPressed() {
-        trackWithSource(
-            INSTALL_JETPACK_CANCELLED,
-            intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
-        )
-        super.onBackPressed()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
@@ -25,7 +25,7 @@ class JetpackRemoteInstallActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.INSTALL_JETPACK_CAN
 import org.wordpress.android.databinding.JetpackRemoteInstallActivityBinding
 import org.wordpress.android.ui.JetpackConnectionUtils.trackWithSource
 import org.wordpress.android.ui.JetpackRemoteInstallFragment.Companion.TRACKING_SOURCE_KEY
+import org.wordpress.android.util.extensions.onBackPressedCompat
 
 class JetpackRemoteInstallActivity : LocaleAwareActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
@@ -22,8 +23,7 @@ class JetpackRemoteInstallActivity : LocaleAwareActivity() {
                 INSTALL_JETPACK_CANCELLED,
                 intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
             )
-            isEnabled = false
-            onBackPressedDispatcher.onBackPressed()
+            onBackPressedDispatcher.onBackPressedCompat(this)
         }
 
         supportActionBar?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -22,6 +22,7 @@ import android.widget.RelativeLayout;
 import android.widget.RelativeLayout.LayoutParams;
 import android.widget.TextView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -161,6 +162,22 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
     public void onCreate(Bundle savedInstanceState) {
         ((WordPress) getApplication()).component().inject(this);
         super.onCreate(savedInstanceState);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (mWebView.canGoBack()) {
+                    mWebView.goBack();
+                    refreshBackForwardNavButtons();
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                    mViewModel.track(Stat.WEBVIEW_DISMISSED);
+                    setResultIfNeeded();
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
     }
 
     @Override
@@ -914,18 +931,6 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
     private void setResultIfNeededAndFinish() {
         setResultIfNeeded();
         finish();
-    }
-
-    @Override
-    public void onBackPressed() {
-        if (mWebView.canGoBack()) {
-            mWebView.goBack();
-            refreshBackForwardNavButtons();
-        } else {
-            super.onBackPressed();
-            mViewModel.track(Stat.WEBVIEW_DISMISSED);
-            setResultIfNeeded();
-        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -61,6 +61,7 @@ import org.wordpress.android.util.URLFilteredWebViewClient;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.WPWebViewClient;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.viewmodel.wpwebview.WPWebViewViewModel;
 import org.wordpress.android.viewmodel.wpwebview.WPWebViewViewModel.NavBarUiState;
 import org.wordpress.android.viewmodel.wpwebview.WPWebViewViewModel.PreviewModeSelectorStatus;
@@ -170,8 +171,7 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
                     mWebView.goBack();
                     refreshBackForwardNavButtons();
                 } else {
-                    setEnabled(false);
-                    getOnBackPressedDispatcher().onBackPressed();
+                    CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                     mViewModel.track(Stat.WEBVIEW_DISMISSED);
                     setResultIfNeeded();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.Window;
 import android.webkit.WebView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 
@@ -38,6 +39,20 @@ public abstract class WebViewActivity extends LocaleAwareActivity {
         setTitle("");
 
         configureView();
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (mWebView != null && mWebView.canGoBack()) {
+                    mWebView.goBack();
+                } else {
+                    cancel();
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         mWebView = (WebView) findViewById(R.id.webView);
         mWebView.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
@@ -143,16 +158,6 @@ public abstract class WebViewActivity extends LocaleAwareActivity {
 
     public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
         mWebView.loadUrl(url, additionalHttpHeaders);
-    }
-
-    @Override
-    public void onBackPressed() {
-        if (mWebView != null && mWebView.canGoBack()) {
-            mWebView.goBack();
-        } else {
-            cancel();
-            super.onBackPressed();
-        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -12,6 +12,7 @@ import androidx.appcompat.widget.Toolbar;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 
 import java.util.Map;
 
@@ -47,8 +48,7 @@ public abstract class WebViewActivity extends LocaleAwareActivity {
                     mWebView.goBack();
                 } else {
                     cancel();
-                    setEnabled(false);
-                    getOnBackPressedDispatcher().onBackPressed();
+                    CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -146,7 +146,7 @@ class HelpActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -295,7 +295,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts
 
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.button.MaterialButton
 import org.wordpress.android.R
@@ -31,6 +32,9 @@ class PostSignupInterstitialActivity : LocaleAwareActivity() {
             .get(PostSignupInterstitialViewModel::class.java)
         val binding = PostSignupInterstitialActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        onBackPressedDispatcher.addCallback(this) { viewModel.onBackButtonPressed() }
+
         with(binding) {
             viewModel.onInterstitialShown()
             createNewSiteButton().setOnClickListener { viewModel.onCreateNewSiteButtonPressed() }
@@ -49,10 +53,6 @@ class PostSignupInterstitialActivity : LocaleAwareActivity() {
 
     private fun PostSignupInterstitialActivityBinding.dismissButton() =
         root.findViewById<MaterialButton>(R.id.dismiss_button)
-
-    override fun onBackPressed() {
-        viewModel.onBackButtonPressed()
-    }
 
     private fun executeAction(navigationAction: NavigationAction) = when (navigationAction) {
         START_SITE_CREATION_FLOW -> startSiteCreationFlow()

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
@@ -42,7 +42,7 @@ class PostSignupInterstitialActivity : LocaleAwareActivity() {
             dismissButton().setOnClickListener { viewModel.onDismissButtonPressed() }
         }
 
-        viewModel.navigationAction.observe(this, { executeAction(it) })
+        viewModel.navigationAction.observe(this) { executeAction(it) }
     }
 
     private fun PostSignupInterstitialActivityBinding.createNewSiteButton() =

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesFragment.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.accounts.login.jetpack
 import android.content.Context
 import android.os.Bundle
 import android.view.View
-import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
@@ -42,7 +42,7 @@ class LoginNoSitesFragment : Fragment(R.layout.jetpack_login_empty_view) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initBackPressHandler()
+        requireActivity().onBackPressedDispatcher.addCallback(this) { viewModel.onBackPressed() }
         with(JetpackLoginEmptyViewBinding.bind(view)) {
             initContentViews()
             initClickListeners()
@@ -140,17 +140,5 @@ class LoginNoSitesFragment : Fragment(R.layout.jetpack_login_empty_view) {
     override fun onResume() {
         super.onResume()
         viewModel.onFragmentResume()
-    }
-
-    private fun initBackPressHandler() {
-        requireActivity().onBackPressedDispatcher.addCallback(
-            viewLifecycleOwner,
-            object : OnBackPressedCallback(
-                true
-            ) {
-                override fun handleOnBackPressed() {
-                    viewModel.onBackPressed()
-                }
-            })
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorFragment.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.accounts.login.jetpack
 import android.content.Context
 import android.os.Bundle
 import android.view.View
-import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
@@ -54,7 +54,7 @@ class LoginSiteCheckErrorFragment : Fragment(R.layout.jetpack_login_empty_view) 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initBackPressHandler()
+        requireActivity().onBackPressedDispatcher.addCallback(this) { viewModel.onBackPressed() }
         with(JetpackLoginEmptyViewBinding.bind(view)) {
             ActivityUtils.hideKeyboardForced(view)
             initErrorMessageView()
@@ -112,17 +112,5 @@ class LoginSiteCheckErrorFragment : Fragment(R.layout.jetpack_login_empty_view) 
         super.onResume()
 
         unifiedLoginTracker.track(step = Step.NOT_A_JETPACK_SITE)
-    }
-
-    private fun initBackPressHandler() {
-        requireActivity().onBackPressedDispatcher.addCallback(
-            viewLifecycleOwner,
-            object : OnBackPressedCallback(
-                true
-            ) {
-                override fun handleOnBackPressed() {
-                    viewModel.onBackPressed()
-                }
-            })
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
@@ -25,7 +25,7 @@ class ActivityLogDetailActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -108,7 +108,7 @@ class ActivityLogListActivity : LocaleAwareActivity(), ScrollableViewInitialized
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
@@ -26,7 +26,11 @@ class BloggingPromptsListActivity : LocaleAwareActivity() {
         setContent {
             AppTheme {
                 val uiState by viewModel.uiStateFlow.collectAsState()
-                BloggingPromptsListScreen(uiState, ::onBackPressed, viewModel::onPromptListItemClicked)
+                BloggingPromptsListScreen(
+                    uiState,
+                    { onBackPressedDispatcher.onBackPressed() },
+                    viewModel::onPromptListItemClicked
+                )
             }
         }
         observeActions()

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -8,6 +8,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ProgressBar;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 import androidx.viewpager.widget.ViewPager;
@@ -74,18 +75,6 @@ public class CommentsDetailActivity extends LocaleAwareActivity
     private boolean mCanLoadMoreComments = true;
 
     @Override
-    public void onBackPressed() {
-        CollapseFullScreenDialogFragment fragment = (CollapseFullScreenDialogFragment)
-                getSupportFragmentManager().findFragmentByTag(CollapseFullScreenDialogFragment.TAG);
-
-        if (fragment != null) {
-            fragment.onBackPressed();
-        } else {
-            super.onBackPressed();
-        }
-    }
-
-    @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
@@ -93,6 +82,22 @@ public class CommentsDetailActivity extends LocaleAwareActivity
         AppLog.i(AppLog.T.COMMENTS, "Creating CommentsDetailActivity");
 
         setContentView(R.layout.comments_detail_activity);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                CollapseFullScreenDialogFragment fragment = (CollapseFullScreenDialogFragment)
+                        getSupportFragmentManager().findFragmentByTag(CollapseFullScreenDialogFragment.TAG);
+
+                if (fragment != null) {
+                    fragment.onBackPressed();
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         Toolbar toolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(toolbar);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -90,7 +90,7 @@ public class CommentsDetailActivity extends LocaleAwareActivity
                         getSupportFragmentManager().findFragmentByTag(CollapseFullScreenDialogFragment.TAG);
 
                 if (fragment != null) {
-                    fragment.onBackPressed();
+                    fragment.collapse();
                 } else {
                     setEnabled(false);
                     getOnBackPressedDispatcher().onBackPressed();

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -39,6 +39,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.widgets.WPViewPager;
 import org.wordpress.android.widgets.WPViewPagerTransformer;
 
@@ -92,8 +93,7 @@ public class CommentsDetailActivity extends LocaleAwareActivity
                 if (fragment != null) {
                     fragment.collapse();
                 } else {
-                    setEnabled(false);
-                    getOnBackPressedDispatcher().onBackPressed();
+                    CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -194,7 +194,7 @@ public class EditCommentActivity extends LocaleAwareActivity {
     public boolean onOptionsItemSelected(final MenuItem item) {
         int i = item.getItemId();
         if (i == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         } else if (i == R.id.menu_save_comment) {
             saveComment();

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -13,6 +13,7 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.ProgressBar;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
@@ -73,6 +74,20 @@ public class EditCommentActivity extends LocaleAwareActivity {
         ((WordPress) getApplication()).component().inject(this);
 
         setContentView(R.layout.comment_edit_activity);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (isCommentEdited()) {
+                    cancelEditCommentConfirmation();
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
+
         Toolbar toolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(toolbar);
         ActionBar actionBar = getSupportActionBar();
@@ -291,15 +306,6 @@ public class EditCommentActivity extends LocaleAwareActivity {
 
         progress.setVisibility(progressVisible ? View.VISIBLE : View.GONE);
         editContainer.setVisibility(progressVisible ? View.GONE : View.VISIBLE);
-    }
-
-    @Override
-    public void onBackPressed() {
-        if (isCommentEdited()) {
-            cancelEditCommentConfirmation();
-        } else {
-            super.onBackPressed();
-        }
     }
 
     private void cancelEditCommentConfirmation() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -42,6 +42,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 
 import javax.inject.Inject;
 
@@ -81,8 +82,7 @@ public class EditCommentActivity extends LocaleAwareActivity {
                 if (isCommentEdited()) {
                     cancelEditCommentConfirmation();
                 } else {
-                    setEnabled(false);
-                    getOnBackPressedDispatcher().onBackPressed();
+                    CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
@@ -116,7 +116,7 @@ class UnifiedCommentsActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
@@ -6,7 +6,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.MenuProvider
 import androidx.core.widget.doAfterTextChanged
@@ -82,15 +82,7 @@ class UnifiedCommentsEditFragment : Fragment(R.layout.unified_comments_edit_frag
             it.setDisplayHomeAsUpEnabled(true)
             it.setHomeAsUpIndicator(R.drawable.ic_cross_white_24dp)
         }
-        activity.onBackPressedDispatcher.addCallback(
-            viewLifecycleOwner,
-            object : OnBackPressedCallback(
-                true
-            ) {
-                override fun handleOnBackPressed() {
-                    viewModel.onBackPressed()
-                }
-            })
+        activity.onBackPressedDispatcher.addCallback(this@UnifiedCommentsEditFragment) { viewModel.onBackPressed() }
     }
 
     private fun hideKeyboard() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsActivity.kt
@@ -13,7 +13,7 @@ class DebugSettingsActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookiesActivity.kt
@@ -13,7 +13,7 @@ class DebugCookiesActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
         android.R.id.home -> {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             true
         }
         else -> super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -49,6 +50,17 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+                finish();
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
+
         mViewModel = new ViewModelProvider(this).get(DeepLinkingIntentReceiverViewModel.class);
         mJetpackFullScreenViewModel = new ViewModelProvider(this).get(JetpackFeatureFullScreenOverlayViewModel.class);
         setupObservers();
@@ -138,11 +150,5 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
         } else {
             finish();
         }
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        finish();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.utils.PreMigrationDeepLinkData;
 import org.wordpress.android.util.PackageManagerWrapper;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UriWrapper;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 
 import javax.inject.Inject;
 
@@ -54,8 +55,7 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
         OnBackPressedCallback callback = new OnBackPressedCallback(true) {
             @Override
             public void handleOnBackPressed() {
-                setEnabled(false);
-                getOnBackPressedDispatcher().onBackPressed();
+                CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 finish();
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -134,7 +134,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationResultFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationResultFragment.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.domains
 
 import android.os.Bundle
 import android.view.View
-import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
 import androidx.core.text.parseAsHtml
@@ -49,8 +49,8 @@ class DomainRegistrationResultFragment : Fragment(R.layout.domain_registration_r
 
         with(DomainRegistrationResultFragmentBinding.bind(view)) {
             setupViews(domainName, email)
-            setupObservers(domainName, email)
         }
+        requireActivity().onBackPressedDispatcher.addCallback(this) { finishRegistration(domainName, email) }
     }
 
     private fun setupWindow() = with(requireAppCompatActivity()) {
@@ -76,14 +76,6 @@ class DomainRegistrationResultFragment : Fragment(R.layout.domain_registration_r
             R.string.domain_registration_result_description,
             domainName
         ).parseAsHtml(FROM_HTML_MODE_COMPACT)
-    }
-
-    private fun setupObservers(domainName: String, email: String) = with(requireActivity()) {
-        onBackPressedDispatcher.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                finishRegistration(domainName, email)
-            }
-        })
     }
 
     private fun finishRegistration(domainName: String, email: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardActivity.kt
@@ -24,7 +24,7 @@ class DomainsDashboardActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
@@ -59,7 +59,7 @@ class EngagedPeopleListActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/featureintroduction/FeatureIntroductionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/featureintroduction/FeatureIntroductionDialogFragment.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.ComponentDialog
+import androidx.activity.addCallback
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.fragment.app.DialogFragment
@@ -31,12 +33,12 @@ abstract class FeatureIntroductionDialogFragment : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
-        object : Dialog(requireContext(), theme) {
-            override fun onBackPressed() {
+        super.onCreateDialog(savedInstanceState).apply {
+            (this as ComponentDialog).onBackPressedDispatcher.addCallback(this@FeatureIntroductionDialogFragment) {
                 viewModel.onBackButtonClick()
-                super.onBackPressed()
+                isEnabled = false
+                onBackPressedDispatcher.onBackPressed()
             }
-        }.apply {
             setStatusBarAsSurfaceColor()
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/featureintroduction/FeatureIntroductionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/featureintroduction/FeatureIntroductionDialogFragment.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.databinding.FeatureIntroductionDialogFragmentBinding
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.onBackPressedCompat
 import org.wordpress.android.util.extensions.setStatusBarAsSurfaceColor
 import javax.inject.Inject
 
@@ -36,8 +37,7 @@ abstract class FeatureIntroductionDialogFragment : DialogFragment() {
         super.onCreateDialog(savedInstanceState).apply {
             (this as ComponentDialog).onBackPressedDispatcher.addCallback(this@FeatureIntroductionDialogFragment) {
                 viewModel.onBackButtonClick()
-                isEnabled = false
-                onBackPressedDispatcher.onBackPressed()
+                onBackPressedDispatcher.onBackPressedCompat(this)
             }
             setStatusBarAsSurfaceColor()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.history
 
 import android.os.Bundle
+import androidx.activity.addCallback
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -19,6 +20,9 @@ class HistoryDetailActivity : LocaleAwareActivity() {
             setContentView(root)
             setSupportActionBar(toolbarMain)
         }
+
+        onBackPressedDispatcher.addCallback(this) { AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED) }
+
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         val extras = requireNotNull(intent.extras)
@@ -43,10 +47,5 @@ class HistoryDetailActivity : LocaleAwareActivity() {
         AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED)
         finish()
         return true
-    }
-
-    override fun onBackPressed() {
-        AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED)
-        super.onBackPressed()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.databinding.HistoryDetailActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.history.HistoryListItem.Revision
+import org.wordpress.android.util.extensions.onBackPressedCompat
 
 class HistoryDetailActivity : LocaleAwareActivity() {
     companion object {
@@ -23,8 +24,7 @@ class HistoryDetailActivity : LocaleAwareActivity() {
 
         onBackPressedDispatcher.addCallback(this) {
             AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED)
-            isEnabled = false
-            onBackPressedDispatcher.onBackPressed()
+            onBackPressedDispatcher.onBackPressedCompat(this)
         }
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
@@ -21,7 +21,11 @@ class HistoryDetailActivity : LocaleAwareActivity() {
             setSupportActionBar(toolbarMain)
         }
 
-        onBackPressedDispatcher.addCallback(this) { AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED) }
+        onBackPressedDispatcher.addCallback(this) {
+            AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED)
+            isEnabled = false
+            onBackPressedDispatcher.onBackPressed()
+        }
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
@@ -18,7 +18,7 @@ class BackupDownloadActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
@@ -5,7 +5,7 @@ import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -51,7 +51,9 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
         super.onViewCreated(view, savedInstanceState)
         with(JetpackBackupRestoreFragmentBinding.bind(view)) {
             initDagger()
-            initBackPressHandler()
+            requireActivity().onBackPressedDispatcher.addCallback(this@BackupDownloadFragment) {
+                viewModel.onBackPressed()
+            }
             initAdapter()
             initViewModel(savedInstanceState)
         }
@@ -59,22 +61,6 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
 
     private fun initDagger() {
         (requireActivity().application as WordPress).component().inject(this)
-    }
-
-    private fun initBackPressHandler() {
-        requireActivity().onBackPressedDispatcher.addCallback(
-            viewLifecycleOwner,
-            object : OnBackPressedCallback(
-                true
-            ) {
-                override fun handleOnBackPressed() {
-                    onBackPressed()
-                }
-            })
-    }
-
-    private fun onBackPressed() {
-        viewModel.onBackPressed()
     }
 
     private fun JetpackBackupRestoreFragmentBinding.initAdapter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
@@ -17,7 +17,7 @@ class RestoreActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
@@ -5,7 +5,7 @@ import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -50,7 +50,7 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
         super.onViewCreated(view, savedInstanceState)
         with(JetpackBackupRestoreFragmentBinding.bind(view)) {
             initDagger()
-            initBackPressHandler()
+            requireActivity().onBackPressedDispatcher.addCallback(this@RestoreFragment) { viewModel.onBackPressed() }
             initAdapter()
             initViewModel(savedInstanceState)
         }
@@ -58,22 +58,6 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
 
     private fun initDagger() {
         (requireActivity().application as WordPress).component().inject(this)
-    }
-
-    private fun initBackPressHandler() {
-        requireActivity().onBackPressedDispatcher.addCallback(
-            viewLifecycleOwner,
-            object : OnBackPressedCallback(
-                true
-            ) {
-                override fun handleOnBackPressed() {
-                    onBackPressed()
-                }
-            })
-    }
-
-    private fun onBackPressed() {
-        viewModel.onBackPressed()
     }
 
     private fun JetpackBackupRestoreFragmentBinding.initAdapter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
@@ -83,7 +83,7 @@ class ScanActivity : AppCompatActivity(), ScrollableViewInitializedListener {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         } else if (item.itemId == R.id.menu_scan_history) {
             // todo malinjir is it worth introducing a vm?

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsActivity.kt
@@ -20,7 +20,7 @@ class ThreatDetailsActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -139,7 +139,7 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), MenuProvid
 
     override fun onMenuItemSelected(menuItem: MenuItem) = when (menuItem.itemId) {
         android.R.id.home -> {
-            requireActivity().onBackPressed()
+            requireActivity().onBackPressedDispatcher.onBackPressed()
             true
         }
         else -> false

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/install/JetpackFullPluginInstallActivity.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.jpfullplugininstall.install
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material.Scaffold
@@ -36,11 +37,10 @@ class JetpackFullPluginInstallActivity : AppCompatActivity() {
                 JetpackFullPluginInstallScreen()
             }
         }
-        observeActionEvents()
-    }
 
-    override fun onBackPressed() {
-        viewModel.onBackPressed()
+        onBackPressedDispatcher.addCallback(this) { viewModel.onBackPressed() }
+
+        observeActionEvents()
     }
 
     @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.ComponentDialog
+import androidx.activity.addCallback
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -59,12 +61,13 @@ class JetpackFullPluginInstallOnboardingDialogFragment : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
-        object : Dialog(requireContext(), theme) {
-            override fun onBackPressed() {
+        super.onCreateDialog(savedInstanceState).apply {
+            val componentDialog = dialog as ComponentDialog
+            componentDialog.onBackPressedDispatcher.addCallback(this@JetpackFullPluginInstallOnboardingDialogFragment) {
                 viewModel.onDismissScreenClick()
-                super.onBackPressed()
+                isEnabled = false
+                componentDialog.onBackPressedDispatcher.onBackPressed()
             }
-        }.apply {
             setStatusBarAsSurfaceColor()
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.ui.jpfullplugininstall.onboarding.JetpackFullPlugin
 import org.wordpress.android.ui.jpfullplugininstall.onboarding.compose.state.LoadedState
 import org.wordpress.android.util.WPUrlUtils
 import org.wordpress.android.util.extensions.exhaustive
+import org.wordpress.android.util.extensions.onBackPressedCompat
 import org.wordpress.android.util.extensions.setStatusBarAsSurfaceColor
 
 @AndroidEntryPoint
@@ -65,8 +66,7 @@ class JetpackFullPluginInstallOnboardingDialogFragment : DialogFragment() {
             (this as ComponentDialog).onBackPressedDispatcher
                 .addCallback(this@JetpackFullPluginInstallOnboardingDialogFragment) {
                     viewModel.onDismissScreenClick()
-                    isEnabled = false
-                    onBackPressedDispatcher.onBackPressed()
+                    onBackPressedDispatcher.onBackPressedCompat(this)
                 }
             setStatusBarAsSurfaceColor()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jpfullplugininstall/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
@@ -62,15 +62,14 @@ class JetpackFullPluginInstallOnboardingDialogFragment : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
         super.onCreateDialog(savedInstanceState).apply {
-            val componentDialog = dialog as ComponentDialog
-            componentDialog.onBackPressedDispatcher.addCallback(this@JetpackFullPluginInstallOnboardingDialogFragment) {
-                viewModel.onDismissScreenClick()
-                isEnabled = false
-                componentDialog.onBackPressedDispatcher.onBackPressed()
-            }
+            (this as ComponentDialog).onBackPressedDispatcher
+                .addCallback(this@JetpackFullPluginInstallOnboardingDialogFragment) {
+                    viewModel.onDismissScreenClick()
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                }
             setStatusBarAsSurfaceColor()
         }
-
 
     @Composable
     private fun JetpackFullPluginInstallOnboardingScreen(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
@@ -18,7 +18,7 @@ class MeActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -274,7 +274,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         int itemId = item.getItemId();
         if (itemId == android.R.id.home) {
             AnalyticsTracker.track(Stat.SITE_SWITCHER_DISMISSED);
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         } else if (itemId == R.id.menu_edit) {
             AnalyticsTracker.track(Stat.SITE_SWITCHER_TOGGLED_EDIT_TAPPED,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -151,6 +151,7 @@ import org.wordpress.android.util.analytics.service.InstallationReferrerServiceS
 import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig;
 import org.wordpress.android.util.config.OpenWebLinksWithJetpackFlowFeatureConfig;
 import org.wordpress.android.util.config.QRCodeAuthFlowFeatureConfig;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel;
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel.FocusPointInfo;
@@ -510,8 +511,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 if (isTaskRoot() && DeviceUtils.getInstance().isChromebook(WPMainActivity.this)) {
                     return; // don't close app in Main Activity
                 }
-                setEnabled(false);
-                getOnBackPressedDispatcher().onBackPressed();
+                CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
             }
         };
         getOnBackPressedDispatcher().addCallback(this, callback);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
@@ -127,15 +127,7 @@ class JetpackMigrationFragment : Fragment() {
 
     private fun initBackPressHandler(showDeleteWpState: Boolean) {
         if (showDeleteWpState) return
-        requireActivity().onBackPressedDispatcher.addCallback(
-            viewLifecycleOwner,
-            object : OnBackPressedCallback(
-                true
-            ) {
-                override fun handleOnBackPressed() {
-                    viewModel.logoutAndFallbackToLogin()
-                }
-            })
+        requireActivity().onBackPressedDispatcher.addCallback(this) { viewModel.logoutAndFallbackToLogin() }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -639,7 +639,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
-                onBackPressed();
+                getOnBackPressedDispatcher().onBackPressed();
                 return true;
             case R.id.menu_new_media:
                 // Do Nothing (handled in action view click listener)

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -222,7 +222,7 @@ public class MediaPreviewActivity extends LocaleAwareActivity implements MediaPr
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -74,7 +74,6 @@ import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ColorUtils;
-import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.EditTextUtils;
@@ -86,9 +85,10 @@ import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPermissionUtils;
+import org.wordpress.android.util.extensions.ContextExtensionsKt;
+import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageManager.RequestListener;
 import org.wordpress.android.util.image.ImageType;
@@ -545,7 +545,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         } else if (item.getItemId() == R.id.menu_save) {
             saveMediaToDevice();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -34,6 +34,7 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.IntegerRes;
 import androidx.annotation.NonNull;
@@ -214,6 +215,16 @@ public class MediaSettingsActivity extends LocaleAwareActivity
         ((WordPress) getApplication()).component().inject(this);
 
         setContentView(R.layout.media_settings_activity);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                saveChanges();
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         setSupportActionBar(findViewById(R.id.toolbar));
         ActionBar actionBar = getSupportActionBar();
@@ -505,12 +516,6 @@ public class MediaSettingsActivity extends LocaleAwareActivity
 
     private void showProgress(boolean show) {
         findViewById(R.id.progress).setVisibility(show ? View.VISIBLE : View.GONE);
-    }
-
-    @Override
-    public void onBackPressed() {
-        saveChanges();
-        super.onBackPressed();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -88,6 +88,7 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPermissionUtils;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.util.image.ImageManager;
@@ -220,8 +221,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
             @Override
             public void handleOnBackPressed() {
                 saveChanges();
-                setEnabled(false);
-                getOnBackPressedDispatcher().onBackPressed();
+                CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
             }
         };
         getOnBackPressedDispatcher().addCallback(this, callback);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.ProgressBar;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -57,13 +58,13 @@ import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource;
 import org.wordpress.android.ui.reader.tracker.ReaderTracker;
 import org.wordpress.android.ui.stats.StatsViewType;
-import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource;
 import org.wordpress.android.util.config.LikesEnhancementsFeatureConfig;
+import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
 import org.wordpress.android.widgets.WPSwipeSnackbar;
 import org.wordpress.android.widgets.WPViewPager;
 import org.wordpress.android.widgets.WPViewPagerTransformer;
@@ -74,13 +75,13 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import dagger.hilt.android.AndroidEntryPoint;
-
 import static org.wordpress.android.models.Note.NOTE_COMMENT_LIKE_TYPE;
 import static org.wordpress.android.models.Note.NOTE_COMMENT_TYPE;
 import static org.wordpress.android.models.Note.NOTE_FOLLOW_TYPE;
 import static org.wordpress.android.models.Note.NOTE_LIKE_TYPE;
 import static org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter.IS_TAPPED_ON_NOTIFICATION;
+
+import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
 public class NotificationsDetailActivity extends LocaleAwareActivity implements
@@ -106,24 +107,28 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
     private Toolbar mToolbar;
 
     @Override
-    public void onBackPressed() {
-        CollapseFullScreenDialogFragment fragment = (CollapseFullScreenDialogFragment)
-                getSupportFragmentManager().findFragmentByTag(CollapseFullScreenDialogFragment.TAG);
-
-        if (fragment != null) {
-            fragment.onBackPressed();
-        } else {
-            super.onBackPressed();
-        }
-    }
-
-    @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
         AppLog.i(AppLog.T.NOTIFS, "Creating NotificationsDetailActivity");
 
         setContentView(R.layout.notifications_detail_activity);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                CollapseFullScreenDialogFragment fragment = (CollapseFullScreenDialogFragment)
+                        getSupportFragmentManager().findFragmentByTag(CollapseFullScreenDialogFragment.TAG);
+
+                if (fragment != null) {
+                    fragment.onBackPressed();
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         mToolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(mToolbar);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -121,7 +121,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
                         getSupportFragmentManager().findFragmentByTag(CollapseFullScreenDialogFragment.TAG);
 
                 if (fragment != null) {
-                    fragment.onBackPressed();
+                    fragment.collapse();
                 } else {
                     setEnabled(false);
                     getOnBackPressedDispatcher().onBackPressed();

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -65,6 +65,7 @@ import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource;
 import org.wordpress.android.util.config.LikesEnhancementsFeatureConfig;
 import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.widgets.WPSwipeSnackbar;
 import org.wordpress.android.widgets.WPViewPager;
 import org.wordpress.android.widgets.WPViewPagerTransformer;
@@ -123,8 +124,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
                 if (fragment != null) {
                     fragment.collapse();
                 } else {
-                    setEnabled(false);
-                    getOnBackPressedDispatcher().onBackPressed();
+                    CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
@@ -60,7 +60,7 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), MenuProvider
 
     override fun onMenuItemSelected(menuItem: MenuItem) = when (menuItem.itemId) {
         android.R.id.home -> {
-            activity?.onBackPressed()
+            activity?.onBackPressedDispatcher?.onBackPressed()
             true
         }
         R.id.save_parent -> {
@@ -87,7 +87,7 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), MenuProvider
         result.putExtra(EXTRA_PAGE_REMOTE_ID_KEY, pageId)
         result.putExtra(EXTRA_PAGE_PARENT_ID_KEY, viewModel.currentParent.id)
         activity?.setResult(Activity.RESULT_OK, result)
-        activity?.onBackPressed()
+        activity?.onBackPressedDispatcher?.onBackPressed()
     }
 
     private fun PageParentFragmentBinding.initializeSearchView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
@@ -54,7 +54,7 @@ class PagesActivity : LocaleAwareActivity(),
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -4,6 +4,7 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.MenuItem;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
@@ -99,6 +100,17 @@ public class PeopleManagementActivity extends LocaleAwareActivity
         mDispatcher.register(this);
 
         setContentView(R.layout.people_management_activity);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (!navigateBackToPeopleListFragment()) {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         if (savedInstanceState == null) {
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
@@ -215,13 +227,6 @@ public class PeopleManagementActivity extends LocaleAwareActivity
     public void onStop() {
         EventBus.getDefault().unregister(this);
         super.onStop();
-    }
-
-    @Override
-    public void onBackPressed() {
-        if (!navigateBackToPeopleListFragment()) {
-            super.onBackPressed();
-        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -227,7 +227,7 @@ public class PeopleManagementActivity extends LocaleAwareActivity
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         } else if (item.getItemId() == R.id.remove_person) {
             confirmRemovePerson();

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -244,7 +244,7 @@ public class PeopleManagementActivity extends LocaleAwareActivity
             if (peopleInviteFragment == null) {
                 peopleInviteFragment = PeopleInviteFragment.newInstance(mSite);
             }
-            if (peopleInviteFragment != null && !peopleInviteFragment.isAdded()) {
+            if (!peopleInviteFragment.isAdded()) {
                 FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
                 fragmentTransaction.replace(R.id.fragment_container, peopleInviteFragment, KEY_PEOPLE_INVITE_FRAGMENT);
                 fragmentTransaction.addToBackStack(null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -33,6 +33,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 
 import java.util.List;
 
@@ -105,8 +106,7 @@ public class PeopleManagementActivity extends LocaleAwareActivity
             @Override
             public void handleOnBackPressed() {
                 if (!navigateBackToPeopleListFragment()) {
-                    setEnabled(false);
-                    getOnBackPressedDispatcher().onBackPressed();
+                    CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -11,6 +11,7 @@ import android.widget.ImageView;
 import android.widget.RatingBar;
 import android.widget.TextView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.ColorRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
@@ -40,13 +41,13 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AniUtils;
-import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
 import org.wordpress.android.util.ColorUtils;
-import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
+import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 import org.wordpress.android.viewmodel.plugins.PluginBrowserViewModel;
@@ -79,6 +80,19 @@ public class PluginBrowserActivity extends LocaleAwareActivity
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
         setContentView(R.layout.plugin_browser_activity);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
+                    // update the lift on scroll target id when we return to the root fragment
+                    AppBarLayoutExtensionsKt.setLiftOnScrollTargetViewIdAndRequestLayout(mAppBar, R.id.scroll_view);
+                }
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         mViewModel = new ViewModelProvider(this, mViewModelFactory).get(PluginBrowserViewModel.class);
 
@@ -229,15 +243,6 @@ public class PluginBrowserActivity extends LocaleAwareActivity
             return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public void onBackPressed() {
-        if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
-            // update the lift on scroll target id when we return to the root fragment
-            AppBarLayoutExtensionsKt.setLiftOnScrollTargetViewIdAndRequestLayout(mAppBar, R.id.scroll_view);
-        }
-        super.onBackPressed();
     }
 
     private void reloadPluginAdapterAndVisibility(@NonNull PluginListType pluginType,

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -225,7 +225,7 @@ public class PluginBrowserActivity extends LocaleAwareActivity
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -315,7 +315,7 @@ public class PluginBrowserActivity extends LocaleAwareActivity
 
     private void hideListFragment() {
         if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -47,6 +47,7 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
@@ -88,8 +89,7 @@ public class PluginBrowserActivity extends LocaleAwareActivity
                     // update the lift on scroll target id when we return to the root fragment
                     AppBarLayoutExtensionsKt.setLiftOnScrollTargetViewIdAndRequestLayout(mAppBar, R.id.scroll_view);
                 }
-                setEnabled(false);
-                getOnBackPressedDispatcher().onBackPressed();
+                CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
             }
         };
         getOnBackPressedDispatcher().addCallback(this, callback);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -80,7 +80,6 @@ import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveCli
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
-import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FormatUtils;
@@ -91,6 +90,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.WPLinkMovementMethod;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 import org.wordpress.android.widgets.WPSnackbar;
@@ -413,7 +413,7 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
                 // user is leaving the page
                 dispatchConfigurePluginAction(true);
             }
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         } else if (item.getItemId() == R.id.menu_trash) {
             if (NetworkUtils.checkConnection(this)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -18,6 +18,7 @@ import android.view.ViewGroup;
 import android.webkit.MimeTypeMap;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -524,6 +525,15 @@ public class EditPostActivity extends LocaleAwareActivity implements
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                handleBackPressed();
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
+
         mDispatcher.register(this);
         mViewModel = new ViewModelProvider(this, mViewModelFactory).get(StorePostViewModel.class);
         mStorageUtilsViewModel = new ViewModelProvider(this, mViewModelFactory).get(StorageUtilsViewModel.class);
@@ -1966,11 +1976,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     public interface OnPostUpdatedFromUIListener {
         void onPostUpdatedFromUI(@Nullable UpdatePostResult updatePostResult);
-    }
-
-    @Override
-    public void onBackPressed() {
-        handleBackPressed();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/JetpackSecuritySettingsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/JetpackSecuritySettingsActivity.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.posts
 
 import android.os.Bundle
 import android.view.MenuItem
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import org.wordpress.android.R.string
 import org.wordpress.android.databinding.FragmentJetpackSecuritySettingsBinding
@@ -12,6 +13,11 @@ class JetpackSecuritySettingsActivity : AppCompatActivity() {
         with(FragmentJetpackSecuritySettingsBinding.inflate(layoutInflater)) {
             setContentView(root)
             setupToolbar()
+        }
+
+        onBackPressedDispatcher.addCallback(this) {
+            setResult(RESULT_OK, null)
+            finish()
         }
     }
 
@@ -33,11 +39,6 @@ class JetpackSecuritySettingsActivity : AppCompatActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    override fun onBackPressed() {
-        setResult(RESULT_OK, null)
-        finish()
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -24,6 +25,16 @@ public class PostSettingsTagsActivity extends LocaleAwareActivity implements Tag
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                saveAndFinish();
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         if (savedInstanceState == null) {
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
@@ -75,12 +86,6 @@ public class PostSettingsTagsActivity extends LocaleAwareActivity implements Tag
         }
 
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public void onBackPressed() {
-        saveAndFinish();
-        super.onBackPressed();
     }
 
     private void saveAndFinish() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
@@ -15,6 +15,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 
 public class PostSettingsTagsActivity extends LocaleAwareActivity implements TagsSelectedListener {
     public static final String KEY_TAGS = "KEY_TAGS";
@@ -30,8 +31,7 @@ public class PostSettingsTagsActivity extends LocaleAwareActivity implements Tag
             @Override
             public void handleOnBackPressed() {
                 saveAndFinish();
-                setEnabled(false);
-                getOnBackPressedDispatcher().onBackPressed();
+                CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
             }
         };
         getOnBackPressedDispatcher().addCallback(this, callback);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -532,7 +532,7 @@ class PostsListActivity : LocaleAwareActivity(),
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         } else if (item.itemId == R.id.toggle_post_list_item_layout) {
             viewModel.toggleViewLayout()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -10,6 +10,7 @@ import android.view.MenuItem;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
@@ -69,6 +70,17 @@ public class SelectCategoriesActivity extends LocaleAwareActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                saveAndFinish();
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
+
         mDispatcher.register(this);
 
         if (savedInstanceState == null) {
@@ -235,12 +247,6 @@ public class SelectCategoriesActivity extends LocaleAwareActivity {
         mListScrollPositionManager.saveScrollOffset();
         updateSelectedCategoryList();
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(mSite));
-    }
-
-    @Override
-    public void onBackPressed() {
-        saveAndFinish();
-        super.onBackPressed();
     }
 
     private void updateSelectedCategoryList() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.util.helpers.ListScrollPositionManager;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper.RefreshListener;
@@ -75,8 +76,7 @@ public class SelectCategoriesActivity extends LocaleAwareActivity {
             @Override
             public void handleOnBackPressed() {
                 saveAndFinish();
-                setEnabled(false);
-                getOnBackPressedDispatcher().onBackPressed();
+                CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
             }
         };
         getOnBackPressedDispatcher().addCallback(this, callback);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsActivity.java
@@ -29,7 +29,7 @@ public class AccountSettingsActivity extends LocaleAwareActivity {
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
@@ -35,7 +35,7 @@ public class AppSettingsActivity extends LocaleAwareActivity {
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileActivity.java
@@ -39,7 +39,7 @@ public class MyProfileActivity extends LocaleAwareActivity {
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -217,7 +217,7 @@ public class SiteSettingsTagListActivity extends LocaleAwareActivity
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         } else {
             return super.onOptionsItemSelected(item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -16,6 +16,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -97,6 +98,25 @@ public class SiteSettingsTagListActivity extends LocaleAwareActivity
         ((WordPress) getApplication()).component().inject(this);
 
         setContentView(R.layout.site_settings_tag_list_activity);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (getFragmentManager().getBackStackEntryCount() > 0) {
+                    SiteSettingsTagDetailFragment fragment = getDetailFragment();
+                    if (fragment != null && fragment.hasChanges()) {
+                        saveTag(fragment.getTerm(), fragment.isNewTerm());
+                    } else {
+                        hideDetailFragment();
+                        loadTags();
+                    }
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         Toolbar toolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(toolbar);
@@ -221,21 +241,6 @@ public class SiteSettingsTagListActivity extends LocaleAwareActivity
             return true;
         } else {
             return super.onOptionsItemSelected(item);
-        }
-    }
-
-    @Override
-    public void onBackPressed() {
-        if (getFragmentManager().getBackStackEntryCount() > 0) {
-            SiteSettingsTagDetailFragment fragment = getDetailFragment();
-            if (fragment != null && fragment.hasChanges()) {
-                saveTag(fragment.getTerm(), fragment.isNewTerm());
-            } else {
-                hideDetailFragment();
-                loadTags();
-            }
-        } else {
-            super.onBackPressed();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -51,6 +51,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.util.extensions.ViewExtensionsKt;
 
 import java.util.ArrayList;
@@ -111,8 +112,7 @@ public class SiteSettingsTagListActivity extends LocaleAwareActivity
                         loadTags();
                     }
                 } else {
-                    setEnabled(false);
-                    getOnBackPressedDispatcher().onBackPressed();
+                    CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailActivity.kt
@@ -22,7 +22,7 @@ class CategoryDetailActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListActivity.kt
@@ -22,7 +22,7 @@ class CategoriesListActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.kt
@@ -76,7 +76,7 @@ class NotificationsSettingsActivity : LocaleAwareActivity(), MainSwitchToolbarLi
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             android.R.id.home -> {
-                onBackPressed()
+                onBackPressedDispatcher.onBackPressed()
                 return true
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -4,6 +4,7 @@ import android.app.ProgressDialog;
 import android.os.Bundle;
 import android.view.MenuItem;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
@@ -66,6 +67,19 @@ public class PublicizeListActivity extends LocaleAwareActivity
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.publicize_list_activity);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
+                    getSupportFragmentManager().popBackStack();
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         Toolbar toolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(toolbar);
@@ -213,15 +227,6 @@ public class PublicizeListActivity extends LocaleAwareActivity
             return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public void onBackPressed() {
-        if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
-            getSupportFragmentManager().popBackStack();
-        } else {
-            super.onBackPressed();
-        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -209,7 +209,7 @@ public class PublicizeListActivity extends LocaleAwareActivity
     public boolean onOptionsItemSelected(final MenuItem item) {
         int itemId = item.getItemId();
         if (itemId == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -39,6 +39,7 @@ import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -74,8 +75,7 @@ public class PublicizeListActivity extends LocaleAwareActivity
                 if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
                     getSupportFragmentManager().popBackStack();
                 } else {
-                    setEnabled(false);
-                    getOnBackPressedDispatcher().onBackPressed();
+                    CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -115,14 +115,9 @@ class QRCodeAuthFragment : Fragment() {
     }
 
     private fun initBackPressHandler() {
-        requireActivity().onBackPressedDispatcher.addCallback(
-            viewLifecycleOwner,
-            object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() {
-                    qrCodeAuthViewModel.onBackPressed()
-                }
-            }
-        )
+        requireActivity().onBackPressedDispatcher.addCallback(this) {
+            qrCodeAuthViewModel.onBackPressed()
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -253,9 +253,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
                 mSuggestionServiceConnectionManager,
                 mPost.isWP()
         );
-        if (mSuggestionAdapter != null) {
-            mEditComment.setAdapter(mSuggestionAdapter);
-        }
+        mEditComment.setAdapter(mSuggestionAdapter);
 
         mReaderTracker.trackPost(AnalyticsTracker.Stat.READER_ARTICLE_COMMENTS_OPENED, mPost, mSource);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -18,6 +18,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -86,10 +87,10 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource;
+import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.widgets.RecyclerItemDecoration;
 import org.wordpress.android.widgets.SuggestionAutoCompleteText;
@@ -151,22 +152,26 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     private ConversationNotificationsViewModel mConversationViewModel;
 
     @Override
-    public void onBackPressed() {
-        CollapseFullScreenDialogFragment fragment = (CollapseFullScreenDialogFragment)
-                getSupportFragmentManager().findFragmentByTag(CollapseFullScreenDialogFragment.TAG);
-
-        if (fragment != null) {
-            fragment.onBackPressed();
-        } else {
-            super.onBackPressed();
-        }
-    }
-
-    @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
         setContentView(R.layout.reader_activity_comment_list);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                CollapseFullScreenDialogFragment fragment = (CollapseFullScreenDialogFragment)
+                        getSupportFragmentManager().findFragmentByTag(CollapseFullScreenDialogFragment.TAG);
+
+                if (fragment != null) {
+                    fragment.onBackPressed();
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         Toolbar toolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(toolbar);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -90,6 +90,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.widgets.RecyclerItemDecoration;
@@ -166,8 +167,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
                 if (fragment != null) {
                     fragment.collapse();
                 } else {
-                    setEnabled(false);
-                    getOnBackPressedDispatcher().onBackPressed();
+                    CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -164,7 +164,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
                         getSupportFragmentManager().findFragmentByTag(CollapseFullScreenDialogFragment.TAG);
 
                 if (fragment != null) {
-                    fragment.onBackPressed();
+                    fragment.collapse();
                 } else {
                     setEnabled(false);
                     getOnBackPressedDispatcher().onBackPressed();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
@@ -158,7 +158,7 @@ public class ReaderPhotoViewerActivity extends LocaleAwareActivity
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -400,7 +400,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             toolBar.setTitle(R.string.reader_title_related_post_detail)
         } else {
             toolBar.setNavigationIcon(R.drawable.ic_arrow_back_white_24dp)
-            toolBar.setNavigationOnClickListener { requireActivity().onBackPressed() }
+            toolBar.setNavigationOnClickListener { requireActivity().onBackPressedDispatcher.onBackPressed() }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -8,6 +8,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -66,6 +67,18 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
         ((WordPress) getApplication()).component().inject(this);
 
         setContentView(R.layout.reader_activity_post_list);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                ReaderPostListFragment fragment = getListFragment();
+                if (fragment == null || !fragment.onActivityBackPressed()) {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         Toolbar toolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(toolbar);
@@ -186,14 +199,6 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
         }
 
         super.onSaveInstanceState(outState);
-    }
-
-    @Override
-    public void onBackPressed() {
-        ReaderPostListFragment fragment = getListFragment();
-        if (fragment == null || !fragment.onActivityBackPressed()) {
-            super.onBackPressed();
-        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -209,7 +209,7 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
-                onBackPressed();
+                getOnBackPressedDispatcher().onBackPressed();
                 return true;
             case R.id.menu_share:
                 shareSite();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.uploads.UploadActionUseCase;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 
 import javax.inject.Inject;
 
@@ -73,8 +74,7 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
             public void handleOnBackPressed() {
                 ReaderPostListFragment fragment = getListFragment();
                 if (fragment == null || !fragment.onActivityBackPressed()) {
-                    setEnabled(false);
-                    getOnBackPressedDispatcher().onBackPressed();
+                    CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -13,6 +13,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -176,6 +177,25 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
         mJetpackFullScreenViewModel = new ViewModelProvider(this).get(JetpackFeatureFullScreenOverlayViewModel.class);
 
         setContentView(R.layout.reader_activity_post_pager);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                ReaderPostDetailFragment fragment = getActiveDetailFragment();
+                if (fragment != null && fragment.isCustomViewShowing()) {
+                    // if full screen video is showing, hide the custom view rather than navigate back
+                    fragment.hideCustomView();
+                } else {
+                    if (fragment != null && fragment.goBackInPostHistory()) {
+                        // noop - fragment moved back to a previous post
+                    } else {
+                        setEnabled(false);
+                        getOnBackPressedDispatcher().onBackPressed();
+                    }
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         // Start migration flow passing deep link data if requirements are met
         if (mJetpackAppMigrationFlowUtils.shouldShowMigrationFlow()) {
@@ -691,21 +711,6 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
             return null;
         }
         return adapter.getBlogIdPostIdAtPosition(position);
-    }
-
-    @Override
-    public void onBackPressed() {
-        ReaderPostDetailFragment fragment = getActiveDetailFragment();
-        if (fragment != null && fragment.isCustomViewShowing()) {
-            // if full screen video is showing, hide the custom view rather than navigate back
-            fragment.hideCustomView();
-        } else {
-            if (fragment != null && fragment.goBackInPostHistory()) {
-                // noop - fragment moved back to a previous post
-            } else {
-                super.onBackPressed();
-            }
-        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -79,6 +79,7 @@ import org.wordpress.android.util.UrlUtilsWrapper;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper;
 import org.wordpress.android.util.config.SeenUnseenWithCounterFeatureConfig;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.widgets.WPSwipeSnackbar;
 import org.wordpress.android.widgets.WPViewPager;
 import org.wordpress.android.widgets.WPViewPagerTransformer;
@@ -189,8 +190,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
                     if (fragment != null && fragment.goBackInPostHistory()) {
                         // noop - fragment moved back to a previous post
                     } else {
-                        setEnabled(false);
-                        getOnBackPressedDispatcher().onBackPressed();
+                        CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -10,6 +10,7 @@ import android.webkit.URLUtil;
 import android.widget.EditText;
 import android.widget.ProgressBar;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -92,6 +93,19 @@ public class ReaderSubsActivity extends LocaleAwareActivity
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (!TextUtils.isEmpty(mLastAddedTagName)) {
+                    EventBus.getDefault().postSticky(new ReaderEvents.TagAdded(mLastAddedTagName));
+                }
+                mReaderTracker.track(Stat.READER_MANAGE_VIEW_DISMISSED);
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
 
         setContentView(R.layout.reader_activity_subs);
         restoreState(savedInstanceState);
@@ -234,15 +248,6 @@ public class ReaderSubsActivity extends LocaleAwareActivity
             outState.putString(KEY_LAST_ADDED_TAG_NAME, mLastAddedTagName);
         }
         super.onSaveInstanceState(outState);
-    }
-
-    @Override
-    public void onBackPressed() {
-        if (!TextUtils.isEmpty(mLastAddedTagName)) {
-            EventBus.getDefault().postSticky(new ReaderEvents.TagAdded(mLastAddedTagName));
-        }
-        mReaderTracker.track(Stat.READER_MANAGE_VIEW_DISMISSED);
-        super.onBackPressed();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -107,7 +107,7 @@ public class ReaderSubsActivity extends LocaleAwareActivity
         Toolbar toolbar = findViewById(R.id.toolbar_main);
         if (toolbar != null) {
             setSupportActionBar(toolbar);
-            toolbar.setNavigationOnClickListener(v -> onBackPressed());
+            toolbar.setNavigationOnClickListener(v -> getOnBackPressedDispatcher().onBackPressed());
         }
 
         ActionBar actionBar = getSupportActionBar();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -55,6 +55,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.widgets.WPSnackbar;
 import org.wordpress.android.widgets.WPViewPager;
 
@@ -101,8 +102,7 @@ public class ReaderSubsActivity extends LocaleAwareActivity
                     EventBus.getDefault().postSticky(new ReaderEvents.TagAdded(mLastAddedTagName));
                 }
                 mReaderTracker.track(Stat.READER_MANAGE_VIEW_DISMISSED);
-                setEnabled(false);
-                getOnBackPressedDispatcher().onBackPressed();
+                CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
             }
         };
         getOnBackPressedDispatcher().addCallback(this, callback);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderUserListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderUserListActivity.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.reader;
 
 import android.os.Bundle;
-import android.view.View;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -41,12 +40,7 @@ public class ReaderUserListActivity extends LocaleAwareActivity {
         Toolbar toolbar = findViewById(R.id.toolbar_main);
         if (toolbar != null) {
             setSupportActionBar(toolbar);
-            toolbar.setNavigationOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    onBackPressed();
-                }
-            });
+            toolbar.setNavigationOnClickListener(v -> getOnBackPressedDispatcher().onBackPressed());
         }
 
         ActionBar actionBar = getSupportActionBar();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsActivity.kt
@@ -23,7 +23,7 @@ class ReaderInterestsActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
+import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -82,6 +83,9 @@ class SiteCreationActivity : LocaleAwareActivity(),
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.site_creation_activity)
+
+        onBackPressedDispatcher.addCallback(this) { mainViewModel.onBackPressed() }
+
         mainViewModel.start(savedInstanceState, getSiteCreationSource())
         mainViewModel.preloadThumbnails(this)
 
@@ -278,10 +282,6 @@ class SiteCreationActivity : LocaleAwareActivity(),
             return true
         }
         return false
-    }
-
-    override fun onBackPressed() {
-        mainViewModel.onBackPressed()
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -134,7 +134,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         })
         mainViewModel.onBackPressedObservable.observe(this, Observer {
             ActivityUtils.hideKeyboard(this)
-            super.onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
         })
         siteCreationIntentsViewModel.onBackButtonPressed.observe(this, Observer {
             mainViewModel.onBackPressed()
@@ -274,7 +274,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -7,7 +7,6 @@ import android.view.MenuItem
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.cancel
 import org.wordpress.android.R
@@ -100,8 +99,8 @@ class SiteCreationActivity : LocaleAwareActivity(),
     @Suppress("LongMethod")
     private fun observeVMState() {
         mainViewModel.navigationTargetObservable
-            .observe(this, Observer { target -> target?.let { showStep(target) } })
-        mainViewModel.wizardFinishedObservable.observe(this, Observer { createSiteState ->
+            .observe(this) { target -> target?.let { showStep(target) } }
+        mainViewModel.wizardFinishedObservable.observe(this) { createSiteState ->
             createSiteState?.let {
                 val intent = Intent()
                 val (siteCreated, localSiteId, titleTaskComplete) = when (createSiteState) {
@@ -114,8 +113,8 @@ class SiteCreationActivity : LocaleAwareActivity(),
                         Triple(true, null, createSiteState.isSiteTitleTaskComplete)
                     }
                     is SiteCreationCompleted -> Triple(
-                            true, createSiteState.localSiteId,
-                            createSiteState.isSiteTitleTaskComplete
+                        true, createSiteState.localSiteId,
+                        createSiteState.isSiteTitleTaskComplete
                     )
                 }
                 intent.putExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, localSiteId)
@@ -123,43 +122,43 @@ class SiteCreationActivity : LocaleAwareActivity(),
                 setResult(if (siteCreated) Activity.RESULT_OK else Activity.RESULT_CANCELED, intent)
                 finish()
             }
-        })
-        mainViewModel.dialogActionObservable.observe(this, Observer { dialogHolder ->
+        }
+        mainViewModel.dialogActionObservable.observe(this) { dialogHolder ->
             dialogHolder?.let {
                 val supportFragmentManager = requireNotNull(supportFragmentManager) {
                     "FragmentManager can't be null at this point"
                 }
                 dialogHolder.show(this, supportFragmentManager, uiHelpers)
             }
-        })
-        mainViewModel.exitFlowObservable.observe(this, Observer {
+        }
+        mainViewModel.exitFlowObservable.observe(this) {
             setResult(Activity.RESULT_CANCELED)
             finish()
-        })
-        mainViewModel.onBackPressedObservable.observe(this, Observer {
+        }
+        mainViewModel.onBackPressedObservable.observe(this) {
             ActivityUtils.hideKeyboard(this)
             onBackPressedDispatcher.onBackPressed()
-        })
-        siteCreationIntentsViewModel.onBackButtonPressed.observe(this, Observer {
+        }
+        siteCreationIntentsViewModel.onBackButtonPressed.observe(this) {
             mainViewModel.onBackPressed()
-        })
-        siteCreationIntentsViewModel.onSkipButtonPressed.observe(this, Observer {
+        }
+        siteCreationIntentsViewModel.onSkipButtonPressed.observe(this) {
             mainViewModel.onSiteIntentSkipped()
-        })
-        siteCreationSiteNameViewModel.onBackButtonPressed.observe(this, Observer {
+        }
+        siteCreationSiteNameViewModel.onBackButtonPressed.observe(this) {
             mainViewModel.onBackPressed()
             ActivityUtils.hideKeyboard(this)
-        })
-        siteCreationSiteNameViewModel.onSkipButtonPressed.observe(this, Observer {
+        }
+        siteCreationSiteNameViewModel.onSkipButtonPressed.observe(this) {
             ActivityUtils.hideKeyboard(this)
             mainViewModel.onSiteNameSkipped()
-        })
-        hppViewModel.onBackButtonPressed.observe(this, Observer {
+        }
+        hppViewModel.onBackButtonPressed.observe(this) {
             mainViewModel.onBackPressed()
-        })
-        hppViewModel.onDesignActionPressed.observe(this, Observer { design ->
+        }
+        hppViewModel.onDesignActionPressed.observe(this) { design ->
             mainViewModel.onSiteDesignSelected(design.template)
-        })
+        }
 
         observeOverlayEvents()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -123,13 +123,8 @@ class SiteCreationActivity : LocaleAwareActivity(),
                 finish()
             }
         }
-        mainViewModel.dialogActionObservable.observe(this) { dialogHolder ->
-            dialogHolder?.let {
-                val supportFragmentManager = requireNotNull(supportFragmentManager) {
-                    "FragmentManager can't be null at this point"
-                }
-                dialogHolder.show(this, supportFragmentManager, uiHelpers)
-            }
+        mainViewModel.dialogActionObservable.observe(this) {
+            it?.show(this, supportFragmentManager, uiHelpers)
         }
         mainViewModel.exitFlowObservable.observe(this) {
             setResult(Activity.RESULT_CANCELED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.config.SiteNameFeatureConfig
 import org.wordpress.android.util.extensions.exhaustive
+import org.wordpress.android.util.extensions.onBackPressedCompat
 import org.wordpress.android.util.wizard.WizardNavigationTarget
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -138,9 +139,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         }
         mainViewModel.onBackPressedObservable.observe(this) {
             ActivityUtils.hideKeyboard(this)
-            backPressedCallback.isEnabled = false
-            onBackPressedDispatcher.onBackPressed()
-            backPressedCallback.isEnabled = true
+            onBackPressedDispatcher.onBackPressedCompat(backPressedCallback)
         }
         siteCreationIntentsViewModel.onBackButtonPressed.observe(this) {
             mainViewModel.onBackPressed()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.activity.addCallback
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -79,11 +79,17 @@ class SiteCreationActivity : LocaleAwareActivity(),
     @Inject internal lateinit var jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil
     @Inject internal lateinit var activityLauncherWrapper: ActivityLauncherWrapper
 
+    private val backPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            mainViewModel.onBackPressed()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.site_creation_activity)
 
-        onBackPressedDispatcher.addCallback(this) { mainViewModel.onBackPressed() }
+        onBackPressedDispatcher.addCallback(this, backPressedCallback)
 
         mainViewModel.start(savedInstanceState, getSiteCreationSource())
         mainViewModel.preloadThumbnails(this)
@@ -132,7 +138,9 @@ class SiteCreationActivity : LocaleAwareActivity(),
         }
         mainViewModel.onBackPressedObservable.observe(this) {
             ActivityUtils.hideKeyboard(this)
+            backPressedCallback.isEnabled = false
             onBackPressedDispatcher.onBackPressed()
+            backPressedCallback.isEnabled = true
         }
         siteCreationIntentsViewModel.onBackButtonPressed.observe(this) {
             mainViewModel.onBackPressed()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -34,7 +34,7 @@ class StatsActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllActivity.kt
@@ -23,7 +23,7 @@ class StatsViewAllActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
@@ -51,7 +51,7 @@ class StatsDetailActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementActivity.kt
@@ -24,7 +24,7 @@ class InsightsManagementActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
@@ -5,7 +5,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
@@ -33,11 +33,7 @@ class InsightsManagementFragment : DaggerFragment(R.layout.insights_management_f
             initializeViews()
             initializeViewModels(requireActivity(), siteId)
         }
-        activity?.onBackPressedDispatcher?.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                viewModel.onBackPressed()
-            }
-        })
+        requireActivity().onBackPressedDispatcher.addCallback(this) { viewModel.onBackPressed() }
     }
 
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/StatsAllTimeWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/StatsAllTimeWidgetConfigureActivity.kt
@@ -21,7 +21,7 @@ class StatsAllTimeWidgetConfigureActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureActivity.kt
@@ -21,7 +21,7 @@ class StatsMinifiedWidgetConfigureActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/StatsTodayWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/StatsTodayWidgetConfigureActivity.kt
@@ -21,7 +21,7 @@ class StatsTodayWidgetConfigureActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/StatsViewsWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/StatsViewsWidgetConfigureActivity.kt
@@ -21,7 +21,7 @@ class StatsViewsWidgetConfigureActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/weeks/StatsWeekWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/weeks/StatsWeekWidgetConfigureActivity.kt
@@ -21,7 +21,7 @@ class StatsWeekWidgetConfigureActivity : LocaleAwareActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
@@ -9,6 +9,7 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
+import androidx.activity.addCallback
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.wordpress.android.R
@@ -42,6 +43,8 @@ class SuggestionActivity : LocaleAwareActivity() {
             binding = this
         }
 
+        onBackPressedDispatcher.addCallback(this) { viewModel.trackExit(false) }
+
         val siteModel = intent.getSerializableExtra(INTENT_KEY_SITE_MODEL) as? SiteModel
         val suggestionType = intent.getSerializableExtra(INTENT_KEY_SUGGESTION_TYPE) as? SuggestionType
         when {
@@ -55,11 +58,6 @@ class SuggestionActivity : LocaleAwareActivity() {
         val message = "${this.javaClass.simpleName} started without $key. Finishing Activity."
         AppLog.e(T.EDITOR, message)
         finish()
-    }
-
-    override fun onBackPressed() {
-        viewModel.trackExit(false)
-        super.onBackPressed()
     }
 
     private fun initializeActivity(siteModel: SiteModel, suggestionType: SuggestionType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.extensions.onBackPressedCompat
 import org.wordpress.android.widgets.SuggestionAutoCompleteText
 import javax.inject.Inject
 
@@ -45,8 +46,7 @@ class SuggestionActivity : LocaleAwareActivity() {
 
         onBackPressedDispatcher.addCallback(this) {
             viewModel.trackExit(false)
-            isEnabled = false
-            onBackPressedDispatcher.onBackPressed()
+            onBackPressedDispatcher.onBackPressedCompat(this)
         }
 
         val siteModel = intent.getSerializableExtra(INTENT_KEY_SITE_MODEL) as? SiteModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
@@ -43,7 +43,11 @@ class SuggestionActivity : LocaleAwareActivity() {
             binding = this
         }
 
-        onBackPressedDispatcher.addCallback(this) { viewModel.trackExit(false) }
+        onBackPressedDispatcher.addCallback(this) {
+            viewModel.trackExit(false)
+            isEnabled = false
+            onBackPressedDispatcher.onBackPressed()
+        }
 
         val siteModel = intent.getSerializableExtra(INTENT_KEY_SITE_MODEL) as? SiteModel
         val suggestionType = intent.getSerializableExtra(INTENT_KEY_SUGGESTION_TYPE) as? SuggestionType

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.view.View.OnScrollChangeListener;
 import android.widget.TextView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -93,6 +94,20 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
 
         setContentView(R.layout.theme_browser_activity);
 
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                FragmentManager fm = getSupportFragmentManager();
+                if (fm.getBackStackEntryCount() > 0) {
+                    fm.popBackStack();
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                }
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
+
         if (savedInstanceState == null) {
             addBrowserFragment();
             fetchInstalledThemesIfJetpackSite();
@@ -134,16 +149,6 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
         }
 
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public void onBackPressed() {
-        FragmentManager fm = getSupportFragmentManager();
-        if (fm.getBackStackEntryCount() > 0) {
-            fm.popBackStack();
-        } else {
-            super.onBackPressed();
-        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -129,7 +129,7 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
     public boolean onOptionsItemSelected(MenuItem item) {
         int i = item.getItemId();
         if (i == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -48,6 +48,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.JetpackBrandingUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.widgets.HeaderGridView;
 
 import java.util.HashMap;
@@ -101,8 +102,7 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
                 if (fm.getBackStackEntryCount() > 0) {
                     fm.popBackStack();
                 } else {
-                    setEnabled(false);
-                    getOnBackPressedDispatcher().onBackPressed();
+                    CompatExtensionsKt.onBackPressedCompat(getOnBackPressedDispatcher(), this);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.util.extensions
+
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
+
+/**
+ * This is a temporary workaround for the issue described here: https://issuetracker.google.com/issues/247982487
+ * This function temporary disables the callback to allow the system to handle the back pressed event.
+ *
+ * TODO: Replace this temporary workaround before enabling predictive back gesture on this project
+ *  (android:enableOnBackInvokedCallback="true").
+ *
+ * Related Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/18053
+ */
+@Suppress("ForbiddenComment")
+fun OnBackPressedDispatcher.onBackPressedCompat(onBackPressedCallback: OnBackPressedCallback) {
+    onBackPressedCallback.isEnabled = false
+    onBackPressed()
+    onBackPressedCallback.isEnabled = true
+}

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
@@ -40,7 +40,7 @@ class EditImageActivity : AppCompatActivity() {
         // Passing in an empty set of top-level destination to display back button on the start destination
         appBarConfiguration = AppBarConfiguration.Builder().setFallbackOnNavigateUpListener {
             // Handle app bar's back button on start destination
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             true
         }.build()
 
@@ -53,7 +53,7 @@ class EditImageActivity : AppCompatActivity() {
             // Using popUpToInclusive for popping the start destination of the graph off the back stack
             // in a multi-module project doesn't seem to be working. Explicitly invoking back action as a workaround.
             // Related issue: https://issuetracker.google.com/issues/147312109
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             true
         } else {
             navController.navigateUp(appBarConfiguration) || super.onSupportNavigateUp()

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.imageeditor
 
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.ViewModelProvider
@@ -24,6 +25,14 @@ class EditImageActivity : AppCompatActivity() {
 
         viewModel = ViewModelProvider(this).get(EditImageViewModel::class.java)
         setContentView(R.layout.activity_edit_image)
+
+        onBackPressedDispatcher.addCallback(this) {
+            isEnabled = false
+            onBackPressedDispatcher.onBackPressed()
+            if (hostFragment.childFragmentManager.backStackEntryCount == 0) {
+                ImageEditor.instance.onEditorAction(EditorCancelled)
+            }
+        }
 
         hostFragment = supportFragmentManager
             .findFragmentById(R.id.nav_host_fragment) as NavHostFragment?
@@ -57,13 +66,6 @@ class EditImageActivity : AppCompatActivity() {
             true
         } else {
             navController.navigateUp(appBarConfiguration) || super.onSupportNavigateUp()
-        }
-    }
-
-    override fun onBackPressed() {
-        super.onBackPressed()
-        if (hostFragment.childFragmentManager.backStackEntryCount == 0) {
-            ImageEditor.instance.onEditorAction(EditorCancelled)
         }
     }
 }

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
@@ -11,6 +11,7 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI.setupActionBarWithNavController
 import androidx.navigation.ui.navigateUp
 import org.wordpress.android.imageeditor.ImageEditor.EditorAction.EditorCancelled
+import org.wordpress.android.imageeditor.utils.onBackPressedCompat
 
 class EditImageActivity : AppCompatActivity() {
     private lateinit var viewModel: EditImageViewModel
@@ -27,8 +28,7 @@ class EditImageActivity : AppCompatActivity() {
         setContentView(R.layout.activity_edit_image)
 
         onBackPressedDispatcher.addCallback(this) {
-            isEnabled = false
-            onBackPressedDispatcher.onBackPressed()
+            onBackPressedDispatcher.onBackPressedCompat(this)
             if (hostFragment.childFragmentManager.backStackEntryCount == 0) {
                 ImageEditor.instance.onEditorAction(EditorCancelled)
             }

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/utils/CompatExtensions.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/utils/CompatExtensions.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.imageeditor.utils
+
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
+
+/**
+ * This is a temporary workaround for the issue described here: https://issuetracker.google.com/issues/247982487
+ * This function temporary disables the callback to allow the system to handle the back pressed event.
+ *
+ * TODO: Replace this temporary workaround before enabling predictive back gesture on this project
+ *  (android:enableOnBackInvokedCallback="true").
+ *
+ * Related Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/18053
+ */
+@Suppress("ForbiddenComment")
+fun OnBackPressedDispatcher.onBackPressedCompat(onBackPressedCallback: OnBackPressedCallback) {
+    onBackPressedCallback.isEnabled = false
+    onBackPressed()
+    onBackPressedCallback.isEnabled = true
+}


### PR DESCRIPTION
This PR is part of a [parent PR](https://github.com/wordpress-mobile/WordPress-Android/pull/17947) to update compileSdk to 33.

`onBackPressed()` was [deprecated on Android 13](https://developer.android.com/guide/navigation/navigation-custom-back). This updates deprecated usages of onBackPressed.

- [Use onBackPressedDispatcher to trigger onBackPressed()](https://github.com/wordpress-mobile/WordPress-Android/commit/8648d0bbb9b7994c6ce6f783bfadd164abb9f585): Activity's `onBackPressed()` calls are removed and updated with `OnBackPressedDispatcher`s `onBackPressed()`.
- [Migrate activities to OnBackPressedCallback](https://github.com/wordpress-mobile/WordPress-Android/commit/3bca5a7943c0a1e51ef15ea981cae2b0fdb26ecd): Overridings Activity's `onBackPressed` are removed. Instead, a callback is added to `onBackPressedDispatcher`. When I want to trigger `super.onBackPressed()`, I disabled the callback and triggered `OnBackPressedDispatcher`'s `onBackPressed()` gain.
```
onBackPressedDispatcher.addCallback(this) {
     ...
     // The code below disables this callback and lets the system handle the back pressed (e.g., by finishing the activity)
     isEnabled = false
     onBackPressedDispatcher.onBackPressed()
}
```
- [Migrate dialogs to OnBackPressedCallback](https://github.com/wordpress-mobile/WordPress-Android/commit/bf693ec6077d0a708982a158e9361fc4ad125df7): We need to cast dialogs to `ComponentDialog` to be able to use `OnBackPressedDispatcher`.  For this purpose, `Dialog(requireContext(), theme)` is converted to `super.onCreateDialog(savedInstanceState)`

To test:
Make sure the project is buildable and test back navigation on screens. It's very time-consuming to test all screens. But please test at least some screens from different cases, like a screen from an activity and a DialogFragment.

## Regression Notes
1. Potential unintended areas of impact
The back navigation function could be broken on some screens.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I haven't tested all screens, but I tested some activities and all `DialogFragment`s.

3. What automated tests I added (or what prevented me from doing so)
No new feature was added, and the existing tests were relied upon.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
