### PR TITLE
[Connected Tests] - Update Firebase Emulator from API 30 to 32

### DIFF
--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -28,7 +28,7 @@ platform :android do
       project_id: firebase_secret(name: 'project_id'),
       key_file: GOOGLE_FIREBASE_SECRETS_PATH,
       model: 'Pixel2.arm',
-      version: 32,
+      version: 33,
       test_apk_path: File.join(apk_dir, 'androidTest', "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug-androidTest.apk"),
       apk_path: File.join(apk_dir, "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug.apk"),
       test_targets: 'notPackage org.wordpress.android.ui.screenshots',

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -28,7 +28,7 @@ platform :android do
       project_id: firebase_secret(name: 'project_id'),
       key_file: GOOGLE_FIREBASE_SECRETS_PATH,
       model: 'Pixel2.arm',
-      version: 33,
+      version: 32,
       test_apk_path: File.join(apk_dir, 'androidTest', "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug-androidTest.apk"),
       apk_path: File.join(apk_dir, "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug.apk"),
       test_targets: 'notPackage org.wordpress.android.ui.screenshots',

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -28,7 +28,7 @@ platform :android do
       project_id: firebase_secret(name: 'project_id'),
       key_file: GOOGLE_FIREBASE_SECRETS_PATH,
       model: 'Pixel2.arm',
-      version: 30,
+      version: 32,
       test_apk_path: File.join(apk_dir, 'androidTest', "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug-androidTest.apk"),
       apk_path: File.join(apk_dir, "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug.apk"),
       test_targets: 'notPackage org.wordpress.android.ui.screenshots',


### PR DESCRIPTION
### What does this do
Currently, our Firebase tests are running against an emulator on API 30 (Android 11), which is quite outdated. There was a question from @irfano recently asking about plans to update the API version to a more recent one. This is the PR to update the API version 😄 

### Testing
Previously, we saw some [performance degradation](https://github.com/wordpress-mobile/WordPress-Android/pull/17615#issuecomment-1340958717) when the update was made. In this current attempt, the time taken is about the same for all test runs when updating to API 32. However, on API 33, the app crashed. 

Based on the results, my recommendation is to update only up to 32 (currently the most popular) and look into updating to the latest later. This PR updates Firebase emulator to API v32.

WordPress:
[CI API 30](https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.b3d1e88d8b09c8be/matrices/6537719379462000022/executions/bs.f3264d879a5fbe95/test-cases) (Current/Baseline) - 10m 58s
[CI API 32](https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.b3d1e88d8b09c8be/matrices/8124421144319534380/executions/bs.5cdbadf237ef7c9c/test-cases) (2 versions up) - 10m 14s
[CI API 33](https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.b3d1e88d8b09c8be/matrices/7485353469847080444/executions/bs.33cb2672e4de91da) (3 versions up) - 4 tests failed and app crashed

Jetpack:
[CI API 30](https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.3ce77db975c1f0c9/matrices/9132347994668388365/executions/bs.ee6b9ce1cb99ebe1/test-cases) (Current/Baseline) - 10m 22s
[CI API 32](https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.3ce77db975c1f0c9/matrices/7522037063041497089/executions/bs.f55cef5517781998/test-cases) (2 versions up) - 10m 58s
[CI API 33](https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.3ce77db975c1f0c9/matrices/5986065975505009895/executions/bs.f7dc419d3613f7f/issues) (3 versions up) - 4 tests failed and app crashed
