### PR TITLE
Implements Site eligibility check for Blaze in Publised Posts 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -31,8 +31,7 @@ class BlazeFeatureUtils @Inject constructor(
         postStatus: PostStatus,
         postModel: PostModel
     ): Boolean {
-        return buildConfigWrapper.isJetpackApp &&
-                blazeFeatureConfig.isEnabled() &&
+        return isBlazeEnabled() &&
                 postStatus == PostStatus.PUBLISHED &&
                 postModel.password.isEmpty()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.blaze
 
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.blaze.BlazeStatusModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -16,6 +17,16 @@ class BlazeFeatureUtils @Inject constructor(
     private val blazeFeatureConfig: BlazeFeatureConfig,
     private val buildConfigWrapper: BuildConfigWrapper,
 ) {
+    private fun isBlazeEnabled(): Boolean {
+        return buildConfigWrapper.isJetpackApp &&
+                blazeFeatureConfig.isEnabled()
+    }
+
+    fun isBlazeEligibleForUser(siteModel: SiteModel): Boolean {
+        return siteModel.isAdmin &&
+                isBlazeEnabled()
+    }
+
     fun isPostBlazeEligible(
         postStatus: PostStatus,
         postModel: PostModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -39,8 +39,7 @@ class BlazeFeatureUtils @Inject constructor(
 
     fun shouldShowPromoteWithBlazeCard(blazeStatusModel: BlazeStatusModel?): Boolean {
         val isEligible = blazeStatusModel?.isEligible == true
-        return buildConfigWrapper.isJetpackApp &&
-                blazeFeatureConfig.isEnabled() &&
+        return isBlazeEnabled() &&
                 isEligible &&
                 !isPromoteWithBlazeCardHiddenByUser()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.blaze
 
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.PostModel
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.blaze.BlazeStatusModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -17,17 +16,14 @@ class BlazeFeatureUtils @Inject constructor(
     private val blazeFeatureConfig: BlazeFeatureConfig,
     private val buildConfigWrapper: BuildConfigWrapper,
 ) {
-    fun shouldShowPromoteWithBlaze(
+    fun isPostBlazeEligible(
         postStatus: PostStatus,
-        siteModel: SiteModel,
         postModel: PostModel
     ): Boolean {
-        // add the logic to check whether the site is eligible for blaze
         return buildConfigWrapper.isJetpackApp &&
                 blazeFeatureConfig.isEnabled() &&
                 postStatus == PostStatus.PUBLISHED &&
-                postModel.password.isEmpty() &&
-                siteModel.isAdmin
+                postModel.password.isEmpty()
     }
 
     fun shouldShowPromoteWithBlazeCard(blazeStatusModel: BlazeStatusModel?): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardSource.kt
@@ -11,10 +11,10 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.blaze.BlazeStore
 import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.PromoteWithBlazeUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
-import org.wordpress.android.util.config.BlazeFeatureConfig
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -23,18 +23,26 @@ const val REFRESH_DELAY = 500L
 class PromoteWithBlazeCardSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val blazeStore: BlazeStore,
-    blazeFeatureConfig: BlazeFeatureConfig,
-    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+    private val blazeFeatureUtils: BlazeFeatureUtils,
+    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
 ) : MySiteRefreshSource<PromoteWithBlazeUpdate> {
-    private val isPromoteWithBlazeEnabled = blazeFeatureConfig.isEnabled()
     override val refresh = MutableLiveData(false)
 
     override fun build(coroutineScope: CoroutineScope, siteLocalId: Int): LiveData<PromoteWithBlazeUpdate> {
         val result = MediatorLiveData<PromoteWithBlazeUpdate>()
-        result.getData(coroutineScope, siteLocalId)
-        result.addSource(refresh) { result.refreshData(coroutineScope, siteLocalId, refresh.value) }
-        refresh()
+        if (shouldFetchBlazeEligibility(siteLocalId)) {
+            result.getData(coroutineScope, siteLocalId)
+            result.addSource(refresh) { result.refreshData(coroutineScope, siteLocalId, refresh.value) }
+            refresh()
+        }
         return result
+    }
+
+    private fun shouldFetchBlazeEligibility(siteLocalId: Int): Boolean {
+        val selectedSite = selectedSiteRepository.getSelectedSite()
+        if (selectedSite != null && selectedSite.id == siteLocalId)
+            return blazeFeatureUtils.isBlazeEligibleForUser(selectedSite)
+        return false
     }
 
     private fun MediatorLiveData<PromoteWithBlazeUpdate>.getData(
@@ -44,15 +52,11 @@ class PromoteWithBlazeCardSource @Inject constructor(
         val selectedSite = selectedSiteRepository.getSelectedSite()
         if (selectedSite != null && selectedSite.id == siteLocalId) {
             coroutineScope.launch(bgDispatcher) {
-                if (isPromoteWithBlazeEnabled) {
-                    blazeStore.getBlazeStatus(selectedSite.siteId)
-                        .map { it.model?.firstOrNull() }
-                        .collect { result ->
-                            postValue(PromoteWithBlazeUpdate(result))
-                        }
-                } else {
-                    postEmptyState()
-                }
+                blazeStore.getBlazeStatus(selectedSite.siteId)
+                    .map { it.model?.firstOrNull() }
+                    .collect { result ->
+                        postValue(PromoteWithBlazeUpdate(result))
+                    }
             }
         } else {
             postErrorState()
@@ -110,10 +114,6 @@ class PromoteWithBlazeCardSource @Inject constructor(
     }
 
     private fun MediatorLiveData<PromoteWithBlazeUpdate>.postErrorState() {
-        postState(PromoteWithBlazeUpdate(null))
-    }
-
-    private fun MediatorLiveData<PromoteWithBlazeUpdate>.postEmptyState() {
         postState(PromoteWithBlazeUpdate(null))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardSource.kt
@@ -32,9 +32,9 @@ class PromoteWithBlazeCardSource @Inject constructor(
         val result = MediatorLiveData<PromoteWithBlazeUpdate>()
         if (shouldFetchBlazeEligibility(siteLocalId)) {
             result.getData(coroutineScope, siteLocalId)
-            result.addSource(refresh) { result.refreshData(coroutineScope, siteLocalId, refresh.value) }
-            refresh()
         }
+        result.addSource(refresh) { result.refreshData(coroutineScope, siteLocalId, refresh.value) }
+        refresh()
         return result
     }
 
@@ -79,7 +79,7 @@ class PromoteWithBlazeCardSource @Inject constructor(
         siteLocalId: Int
     ) {
         val selectedSite = selectedSiteRepository.getSelectedSite()
-        if (selectedSite != null && selectedSite.id == siteLocalId) {
+        if (selectedSite != null && selectedSite.id == siteLocalId && shouldFetchBlazeEligibility(siteLocalId)) {
             fetchBlazeStatusAndPostErrorIfAvailable(coroutineScope, selectedSite)
         } else {
             postErrorState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardSource.kt
@@ -97,7 +97,7 @@ class PromoteWithBlazeCardSource @Inject constructor(
             val error = result.error
             when {
                 error != null -> postErrorState()
-                model != null -> postLastState()
+                model != null -> postState(PromoteWithBlazeUpdate(model[0]))
                 else -> postLastState()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
@@ -31,8 +32,10 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.UploadStore
+import org.wordpress.android.fluxc.store.blaze.BlazeStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.PostListType.DRAFTS
@@ -87,7 +90,9 @@ class PostListMainViewModel @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val uploadStarter: UploadStarter,
-    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
+    private val blazeFeatureUtils: BlazeFeatureUtils,
+    private val blazeStore: BlazeStore
 ) : ViewModel(), CoroutineScope {
     private val lifecycleOwner = object : LifecycleOwner {
         val lifecycleRegistry = LifecycleRegistry(this)
@@ -95,6 +100,7 @@ class PostListMainViewModel @Inject constructor(
             return lifecycleRegistry
         }
     }
+    private var isSiteBlazeEligible = false
 
     private val scrollToTargetPostJob: Job = Job()
     override val coroutineContext: CoroutineContext
@@ -266,6 +272,8 @@ class PostListMainViewModel @Inject constructor(
             AuthorFilterSelection.EVERYONE
         }
 
+        checkBlazeEligibility()
+
         postListEventListenerFactory.createAndStartListening(
             lifecycle = lifecycleOwner.lifecycle,
             dispatcher = dispatcher,
@@ -318,6 +326,18 @@ class PostListMainViewModel @Inject constructor(
         }
     }
 
+    private fun checkBlazeEligibility() {
+        // If the user is not an admin, we don't need to check for Blaze eligibility
+        if (!blazeFeatureUtils.isBlazeEligibleForUser(site)) return
+        launch {
+            blazeStore.getBlazeStatus(site.siteId)
+                .map { it.model?.firstOrNull() }
+                .collect {
+                    isSiteBlazeEligible = it?.isEligible ?: false
+                }
+        }
+    }
+
     override fun onCleared() {
         lifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
         scrollToTargetPostJob.cancel() // cancels all coroutines with the default coroutineContext
@@ -339,7 +359,8 @@ class PostListMainViewModel @Inject constructor(
             doesPostHaveUnhandledConflict = postConflictResolver::doesPostHaveUnhandledConflict,
             hasAutoSave = postConflictResolver::hasUnhandledAutoSave,
             postFetcher = postFetcher,
-            getFeaturedImageUrl = featuredImageTracker::getFeaturedImageUrl
+            getFeaturedImageUrl = featuredImageTracker::getFeaturedImageUrl,
+            isSiteBlazeEligible = isSiteBlazeEligible,
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -251,6 +251,7 @@ class PostListMainViewModel @Inject constructor(
         lifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.CREATED
     }
 
+    @Suppress("LongMethod")
     fun start(
         site: SiteModel,
         initPreviewState: PostListRemotePreviewState,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -44,7 +44,6 @@ import org.wordpress.android.util.FluxCUtils
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.SiteUtils.hasFullAccessToContent
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.config.BlazeFeatureConfig
 import org.wordpress.android.util.map
 import org.wordpress.android.util.mapNullable
 import org.wordpress.android.util.merge

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.blaze.BlazeStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.main.MainActionListItem
@@ -72,7 +73,7 @@ class WPMainActivityViewModel @Inject constructor(
     private val bloggingPromptsStore: BloggingPromptsStore,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
-    private val blazeFeatureConfig: BlazeFeatureConfig,
+    private val blazeFeatureUtils: BlazeFeatureUtils,
     private val blazeStore: BlazeStore
 ) : ScopedViewModel(mainDispatcher) {
     private var isStarted = false
@@ -337,7 +338,7 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     private fun fetchBlazeStatusIfNeeded(site: SiteModel?) {
-        if (blazeFeatureConfig.isEnabled() && site != null) {
+        if (site != null && blazeFeatureUtils.isBlazeEligibleForUser(site)) {
             launch {
                blazeStore.fetchBlazeStatus(site)
             }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -91,7 +91,8 @@ class PostListItemUiStateHelper @Inject constructor(
         performingCriticalAction: Boolean,
         isSearch: Boolean,
         uploadStatusTracker: PostModelUploadStatusTracker,
-        onAction: (PostModel, PostListButtonType, AnalyticsTracker.Stat) -> Unit
+        onAction: (PostModel, PostListButtonType, AnalyticsTracker.Stat) -> Unit,
+        isSiteBlazeEligible: Boolean
     ): PostListItemUiState {
         val postStatus: PostStatus = PostStatus.fromPost(post)
         val uploadUiState = uploadUiStateUseCase.createUploadUiState(post, site, uploadStatusTracker)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -108,7 +108,10 @@ class PostListItemUiStateHelper @Inject constructor(
             siteHasCapabilitiesToPublish = capabilitiesToPublish,
             statsSupported = statsSupported,
             shouldRemoveJetpackFeatures = jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures(),
-            shouldShowPromoteWithBlaze = blazeFeatureUtils.shouldShowPromoteWithBlaze(postStatus, site, post),
+            shouldShowPromoteWithBlaze = isSiteBlazeEligible && blazeFeatureUtils.isPostBlazeEligible(
+                postStatus,
+                post
+            ),
         )
         val defaultActions = createDefaultViewActions(buttonTypes, onButtonClicked)
         val compactActions = createCompactViewActions(buttonTypes, onButtonClicked)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.blaze.BlazeStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
@@ -74,6 +75,7 @@ class PostListViewModel @Inject constructor(
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     connectionStatus: LiveData<ConnectionStatus>,
+    private val blazeFeatureUtils: BlazeFeatureUtils,
     private val blazeStore: BlazeStore
 ) : ScopedViewModel(uiDispatcher) {
     private val isStatsSupported: Boolean by lazy {
@@ -207,14 +209,13 @@ class PostListViewModel @Inject constructor(
     private fun checkBlazeEligibility() {
         val selectedSite = connector.site
         // If the user is not an admin, we don't need to check for Blaze eligibility
-        if(!selectedSite.isAdmin)
-            return
+        if (!blazeFeatureUtils.isBlazeEligibleForUser(selectedSite)) return
         launch {
-             blazeStore.getBlazeStatus(selectedSite.siteId)
-                    .map { it.model?.firstOrNull() }
-                    .collect {
-                        isSiteBlazeEligible = it?.isEligible?:false
-                    }
+            blazeStore.getBlazeStatus(selectedSite.siteId)
+                .map { it.model?.firstOrNull() }
+                .collect {
+                    isSiteBlazeEligible = it?.isEligible ?: false
+                }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
@@ -15,7 +15,8 @@ class PostListViewModelConnector(
     val hasAutoSave: (PostModel) -> Boolean,
     val postFetcher: PostFetcher,
     val uploadStatusTracker: PostModelUploadStatusTracker,
-    private val getFeaturedImageUrl: (site: SiteModel, featuredImageId: Long) -> String?
+    private val getFeaturedImageUrl: (site: SiteModel, featuredImageId: Long) -> String?,
+    val isSiteBlazeEligible: Boolean = false
 ) {
     fun getFeaturedImageUrl(featuredImageId: Long): String? {
         return getFeaturedImageUrl.invoke(site, featuredImageId)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/PromoteWithBlazeCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/PromoteWithBlazeCardSourceTest.kt
@@ -140,8 +140,7 @@ class PromoteWithBlazeCardSourceTest : BaseUnitTest() {
             it?.let { result.add(it) }
         }
 
-        assertThat(result.size).isEqualTo(1)
-        assertThat(result.first()).isEqualTo(PromoteWithBlazeUpdate(blazeStatusModel = null))
+        assertThat(result).isEqualTo(emptyList<PromoteWithBlazeUpdate>())
     }
 
     @Test
@@ -156,7 +155,7 @@ class PromoteWithBlazeCardSourceTest : BaseUnitTest() {
         }
         advanceUntilIdle()
 
-        assertThat(result.first()).isEqualTo(PromoteWithBlazeUpdate(blazeStatusModel = null))
+        assertThat(result).isEqualTo(emptyList<PromoteWithBlazeUpdate>())
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/PromoteWithBlazeCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/PromoteWithBlazeCardSourceTest.kt
@@ -140,7 +140,7 @@ class PromoteWithBlazeCardSourceTest : BaseUnitTest() {
             it?.let { result.add(it) }
         }
 
-        assertThat(result).isEqualTo(emptyList<PromoteWithBlazeUpdate>())
+        assertThat(result.first()).isEqualTo(PromoteWithBlazeUpdate(blazeStatusModel = null))
     }
 
     @Test
@@ -155,7 +155,8 @@ class PromoteWithBlazeCardSourceTest : BaseUnitTest() {
         }
         advanceUntilIdle()
 
-        assertThat(result).isEqualTo(emptyList<PromoteWithBlazeUpdate>())
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result.first()).isEqualTo(PromoteWithBlazeUpdate(blazeStatusModel = null))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/PromoteWithBlazeCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/PromoteWithBlazeCardSourceTest.kt
@@ -17,10 +17,10 @@ import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeStatusError
 import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeStatusErrorType
 import org.wordpress.android.fluxc.store.blaze.BlazeStore
 import org.wordpress.android.fluxc.store.blaze.BlazeStore.BlazeStatusResult
+import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.PromoteWithBlazeUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.cards.blaze.PromoteWithBlazeCardSource
-import org.wordpress.android.util.config.BlazeFeatureConfig
 
 /* SITE */
 
@@ -46,7 +46,8 @@ class PromoteWithBlazeCardSourceTest : BaseUnitTest() {
     private lateinit var siteModel: SiteModel
 
     @Mock
-    private lateinit var blazeFeatureConfig: BlazeFeatureConfig
+    private lateinit var blazeFeatureUtils: BlazeFeatureUtils
+
     private lateinit var blazeCardSource: PromoteWithBlazeCardSource
 
     private val data = BlazeStatusResult(
@@ -69,7 +70,7 @@ class PromoteWithBlazeCardSourceTest : BaseUnitTest() {
         blazeCardSource = PromoteWithBlazeCardSource(
             selectedSiteRepository,
             blazeStore,
-            blazeFeatureConfig,
+            blazeFeatureUtils,
             testDispatcher()
         )
     }
@@ -192,8 +193,8 @@ class PromoteWithBlazeCardSourceTest : BaseUnitTest() {
     }
 
     private fun setUpMocks(isBlazeEnabled: Boolean) {
-        whenever(blazeFeatureConfig.isEnabled()).thenReturn(isBlazeEnabled)
         whenever(siteModel.id).thenReturn(SITE_LOCAL_ID)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
+        whenever(blazeFeatureUtils.isBlazeEligibleForUser(siteModel)).thenReturn(isBlazeEnabled)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelCopyPostTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelCopyPostTest.kt
@@ -73,7 +73,9 @@ class PostListMainViewModelCopyPostTest : BaseUnitTest() {
             uploadStarter = mock(),
             uploadActionUseCase = mock(),
             savePostToDbUseCase = mock(),
-            jetpackFeatureRemovalPhaseHelper = mock()
+            jetpackFeatureRemovalPhaseHelper = mock(),
+            blazeFeatureUtils = mock(),
+            blazeStore = mock()
         )
         viewModel.postListAction.observeForever(onPostListActionObserver)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -67,7 +67,9 @@ class PostListMainViewModelTest : BaseUnitTest() {
             uploadStarter = uploadStarter,
             uploadActionUseCase = mock(),
             savePostToDbUseCase = savePostToDbUseCase,
-            jetpackFeatureRemovalPhaseHelper = mock()
+            jetpackFeatureRemovalPhaseHelper = mock(),
+            blazeFeatureUtils = mock(),
+            blazeStore = mock()
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -1146,7 +1146,8 @@ class PostListItemUiStateHelperTest {
         onAction = onAction,
         performingCriticalAction = performingCriticalAction,
         uploadStatusTracker = uploadStatusTracker,
-        isSearch = isSearch
+        isSearch = isSearch,
+        isSiteBlazeEligible = false
     )
 
     private fun createFailedUploadUiState(

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -65,9 +65,7 @@ class PostListViewModelTest : BaseUnitTest() {
             connectionStatus = mock(),
             uploadUtilsWrapper = mock(),
             uiDispatcher = testDispatcher(),
-            bgDispatcher = testDispatcher(),
-            blazeFeatureUtils = mock(),
-            blazeStore = mock()
+            bgDispatcher = testDispatcher()
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -65,7 +65,9 @@ class PostListViewModelTest : BaseUnitTest() {
             connectionStatus = mock(),
             uploadUtilsWrapper = mock(),
             uiDispatcher = testDispatcher(),
-            bgDispatcher = testDispatcher()
+            bgDispatcher = testDispatcher(),
+            blazeFeatureUtils = mock(),
+            blazeStore = mock()
         )
     }
 


### PR DESCRIPTION
Part of #17911

## What? 
This PR adds the implementation to check whether a site is eligible of blaze in the flow Posts → Published Posts . 

In this PR I have also added  a few checks before we make an API call to fetch the Blaze status 
- Check if the User is eligible with `siteModel.isAdmin` check
- Check if the App is **Jetpack** pack and Flag is enabled

 ## How? 
- [Adds: check to see if Blaze status needs to be fetched](https://github.com/wordpress-mobile/WordPress-Android/pull/18026/commits/1077b7e02c8926879848b061d07cf1337face377)
- [Updates: Logic of whether the post is eligible for blaze feature](https://github.com/wordpress-mobile/WordPress-Android/pull/18026/commits/bee855416dd87d72b342ed74267968d5ce98344b)
- [Adds: check to see if Blaze status needs to be fetched](https://github.com/wordpress-mobile/WordPress-Android/pull/18026/commits/e14e5c5102b95ac7c7ea83e4fde9d977bbc6dfdd)
- [Adds: the check for blaze eligibility in post list viewmodel](https://github.com/wordpress-mobile/WordPress-Android/pull/18026/commits/0772cf3137a2751c3b4419e1498c25e87db938d2)


## Testing instructions

### Test - Blaze is not available

1. Go to the **Jetpack** app
2. 🚪 Login with a wp account without Administrator privileges or Use a private site 
3. ⛳ Go to **app settings** → **Debug settings →** enable feature flag → `blaze`
4. 👉🏻Go to Posts → Published Posts 
5. 👆🏻Click on the more icon ⁞ → 
6. ✅ Verify that the **🔥 Promote with Blaze** is not shown 

### Test - Blaze is available

1. Go to the **Jetpack** app
2. 🚪 Login with a wp account with Administrator privileges 
3. ⛳ Go to **app settings** → **Debug settings →** enable feature flag → `blaze`
4. 👉🏻Go to Posts → Published Posts 
5. 👆🏻Click on the more icon ⁞ → 
6. ✅ Verify that the **🔥 Promote with Blaze** is shown 

### Test - Blaze status is not fetched - Monitor on Logcat

1. Go to the **WordPress** app
2. 🚪 Login with a wp account with Administrator privileges 
3. ✅ Verify that the API is not called 
    - Open the logcat
    - Make sure that there is no occurrence of the event **`BlazeStore: fetch blaze status`**
4. ⛳ Go to **app settings** → **Debug settings →** enable feature flag → `blaze`
5. Go to the Home page 
6. ✅ Verify Step 3 again

## Regression Notes
1. Potential unintended areas of impact
- Blaze eligibility for a site is not fetched on Jetpack app and flag enabled 
- Blaze eligibility for a site is not checked on the Posts → Published Posts flow


2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests and relied on the existing Unit tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
