### PR TITLE
Integrate gutenberg-mobile release 1.89.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [*] [WordPress-only] We have redesigned the landing screen. [https://github.com/wordpress-mobile/WordPress-Android/pull/17871]
 * [**] [internal][WordPress-only] Help & Support: replaces Contact Support with new Community forums. [https://github.com/wordpress-mobile/WordPress-Android/pull/17820]
 * [**] [Jetpack-only] Jetpack individual plugin support: Warns user about sites with only individual plugins not supporting all features of the app yet and gives the ability to install the full Jetpack plugin. [https://github.com/wordpress-mobile/WordPress-Android/pull/17983]
+* [*] Fix inaccessible block settings within the unsupported block editor [https://github.com/WordPress/gutenberg/pull/48435]
 
 21.7
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.89.0'
+    gutenbergMobileVersion = '5517-7e919fc14402c6c7613622524970b88bc623af91'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-87643105f7470e8e5e51c858ff189ce00be1670a'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5517-7e919fc14402c6c7613622524970b88bc623af91'
+    gutenbergMobileVersion = 'v1.89.1'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-87643105f7470e8e5e51c858ff189ce00be1670a'
     wordPressLoginVersion = '1.0.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.89.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5517

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.