### PR TITLE
Blaze: Tidy the WebView Header UI 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewFragment.kt
@@ -8,17 +8,14 @@ import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.activity.OnBackPressedCallback
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
-import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -37,8 +34,8 @@ import org.wordpress.android.ui.blaze.BlazeWebViewClient
 import org.wordpress.android.ui.blaze.BlazeWebViewContentUiState
 import org.wordpress.android.ui.blaze.OnBlazeWebViewClientListener
 import org.wordpress.android.ui.blaze.ui.blazeoverlay.BlazeViewModel
+import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.theme.AppTheme
-import org.wordpress.android.ui.compose.utils.withFullContentAlpha
 
 @AndroidEntryPoint
 class BlazeWebViewFragment: Fragment(), OnBlazeWebViewClientListener,
@@ -104,27 +101,19 @@ class BlazeWebViewFragment: Fragment(), OnBlazeWebViewClientListener,
     private fun TopAppBar(
         state: BlazeWebViewHeaderUiState
     ) {
-        TopAppBar(
-            backgroundColor = MaterialTheme.colors.surface,
-            contentColor = MaterialTheme.colors.onSurface,
-            elevation = 0.dp,
-            title = withFullContentAlpha {
-                Text(stringResource(id = state.headerTitle))
-            },
+        MainTopAppBar(
+            title = stringResource(id = state.headerTitle),
+            onNavigationIconClick = {},
             actions = {
                 TextButton(
                     onClick = { blazeWebViewViewModel.onHeaderActionClick(state) },
                     enabled = state.headerActionEnabled
                 ) {
-                    Text(
-                        stringResource(id = state.headerActionText),
-                        color = MaterialTheme.colors.onSurface
-                    )
+                    Text(stringResource(id = state.headerActionText))
                 }
             }
-        ) // TopAppBar
+        )
     }
-
     @SuppressLint("SetJavaScriptEnabled")
     @Composable
     private fun BlazeWebViewContent(model: BlazeWebViewContentUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewFragment.kt
@@ -8,6 +8,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.activity.OnBackPressedCallback
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -104,16 +106,27 @@ class BlazeWebViewFragment: Fragment(), OnBlazeWebViewClientListener,
         MainTopAppBar(
             title = stringResource(id = state.headerTitle),
             onNavigationIconClick = {},
-            actions = {
-                TextButton(
-                    onClick = { blazeWebViewViewModel.onHeaderActionClick(state) },
-                    enabled = state.headerActionEnabled
-                ) {
-                    Text(stringResource(id = state.headerActionText))
-                }
-            }
+            actions = { TopAppBarActions(state = state) }
         )
     }
+
+    @Composable
+    private fun TopAppBarActions(state: BlazeWebViewHeaderUiState) {
+            TextButton(
+                onClick = { blazeWebViewViewModel.onHeaderActionClick(state) },
+                enabled = state.headerActionEnabled,
+            ) {
+                    Text(
+                        stringResource(id = state.headerActionText),
+                        color = if (state.headerActionEnabled) {
+                            MaterialTheme.colors.onSurface
+                        } else {
+                            MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.disabled)
+                        }
+                    )
+              }
+    }
+
     @SuppressLint("SetJavaScriptEnabled")
     @Composable
     private fun BlazeWebViewContent(model: BlazeWebViewContentUiState) {


### PR DESCRIPTION
Parent #18001 

This PR tidies the Blaze WebView Header.
- Swapped out TopAppBar implementation for MainTopAppBar
- Customize the color for disabled vs. enabled action text


Light Cancel Enabled | Light Cancel Disabled
-- | --
<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/222267219-1d57348e-7b7f-4707-9f91-a41558fef92b.png"> | <img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/222267132-f87f2382-62e6-48cb-b302-3e28a671882c.png">


Dark Cancel Enabled | Dark Cancel Disabled
-- | --
<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/222267181-7f433432-bec0-4f13-92a4-4a5ca374e06e.png"> | <img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/222267159-acc0e844-105b-4f40-b836-ff16f010ace2.png">

@shaunandrews - If you have the chance, can you take a look please. Thanks :)

**To test:**
- Install and launch the app
- Login with a wp.com account and select a site that is eligible for Blaze
- Navigate to Me -> App Settings -> Debug Setting
- Enable Blaze
- Restart the app
- Navigate to My SIte tab
- Tap on the Promote With Blaze card
- Tap on the Blaze a Post Now button within the overlay
- ✅ Verify the posts lists show the Header with "Cancel" text button enabled
- Select a post from the list and tap Promote
- Fill out the Appearance view and tap next
- Fill out the Audience view and tap next
- Fill out the Payment information and tap Save & Submit
- Watch the screen as it processes through the Checking Payment Info and the Creating Your Ad views
- ✅ Verify the Checking Payment Info and the Creating Your Ad views show a Header with "Cancel" disabled
- Wait for the process to complete
- ✅ Verify the header action button changed to "Done"

## Regression Notes
1. Potential unintended areas of impact
The action buttons show incorrectly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
