### PR TITLE
Blaze: Track posts lists entry point clicked

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -57,7 +57,7 @@ sealed class PostListAction {
     class ShowPromoteWithBlaze(val post: PostModel) : PostListAction()
 }
 
-@Suppress("TooGenericExceptionCaught", "LongMethod", "ComplexMethod")
+@Suppress("TooGenericExceptionCaught", "LongMethod", "ComplexMethod", "LongParameterList")
 fun handlePostListAction(
     activity: FragmentActivity,
     action: PostListAction,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.push.NativeNotificationsUtils
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.POST_FROM_POSTS_LIST
+import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.blaze.BlazeFlowSource
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
@@ -62,7 +63,8 @@ fun handlePostListAction(
     action: PostListAction,
     remotePreviewLogicHelper: RemotePreviewLogicHelper,
     previewStateHelper: PreviewStateHelper,
-    mediaPickerLauncher: MediaPickerLauncher
+    mediaPickerLauncher: MediaPickerLauncher,
+    blazeFeatureUtils: BlazeFeatureUtils
 ) {
     when (action) {
         is PostListAction.EditPost -> {
@@ -110,6 +112,7 @@ fun handlePostListAction(
             NativeNotificationsUtils.dismissNotification(action.pushId, activity)
         }
         is PostListAction.ShowPromoteWithBlaze -> {
+            blazeFeatureUtils.trackEntryPointTapped(BlazeFlowSource.POSTS_LIST)
             ActivityLauncher.openPromoteWithBlaze(activity, action.post, BlazeFlowSource.POSTS_LIST)
         }
         is PostListAction.CopyUrl -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_POSTS_LIST
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.ScrollableViewInitializedListener
+import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils.observeBottomSheet
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
@@ -120,6 +121,9 @@ class PostsListActivity : LocaleAwareActivity(),
 
     @Inject
     internal lateinit var bloggingRemindersViewModel: BloggingRemindersViewModel
+
+    @Inject
+    internal lateinit var blazeFeatureUtils: BlazeFeatureUtils
 
     private lateinit var site: SiteModel
     private lateinit var binding: PostListActivityBinding
@@ -324,7 +328,8 @@ class PostsListActivity : LocaleAwareActivity(),
                     action,
                     remotePreviewLogicHelper,
                     previewStateHelper,
-                    mediaPickerLauncher
+                    mediaPickerLauncher,
+                    blazeFeatureUtils
                 )
             }
         })


### PR DESCRIPTION
This PR adds the following event tracking:
 `blaze_entry_point_tapped` property: source=`posts_list`

This is accomplished by passing the blazeFeatureUtils over to the handlePostListAction point

**To test:**

- Launch the app
- Login with a wp.com account
- Select a site that is blaze eligible
- Navigate to Me > App Settings > Privacy Setting
- Enable collect information
- Navigate to Me > App Settings > Debug setting
- Enable Blaze & restart the app
- From within the dahsboard or menu item list > Navigate to the posts list by tapping Posts
- Tap on the more menu of an eligible post row
- Tap on the Promote with Blaze menu item
- ✅ Verify the logs contain 🔵 Tracked: blaze_entry_point_tapped, Properties: {"source":"posts_list"}

## Regression Notes
1. Potential unintended areas of impact
The event is not tracked

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
