### PR TITLE
Blaze: Hide promote with blaze card by site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -36,11 +36,11 @@ class BlazeFeatureUtils @Inject constructor(
                 postModel.password.isEmpty()
     }
 
-    fun shouldShowBlazeEntryPoint(blazeStatusModel: BlazeStatusModel?): Boolean {
+    fun shouldShowBlazeEntryPoint(blazeStatusModel: BlazeStatusModel?, siteId: Long): Boolean {
         val isEligible = blazeStatusModel?.isEligible == true
         return isBlazeEnabled() &&
                 isEligible &&
-                !isPromoteWithBlazeCardHiddenByUser()
+                !isPromoteWithBlazeCardHiddenByUser(siteId)
     }
 
     fun track(stat: AnalyticsTracker.Stat, source: BlazeFlowSource) {
@@ -50,8 +50,8 @@ class BlazeFeatureUtils @Inject constructor(
         )
     }
 
-    fun hidePromoteWithBlazeCard() {
-        appPrefsWrapper.setShouldHidePromoteWithBlazeCard(true)
+    fun hidePromoteWithBlazeCard(siteId: Long) {
+        appPrefsWrapper.setShouldHidePromoteWithBlazeCard(siteId,true)
     }
 
     fun trackEntryPointTapped(blazeFlowSource: BlazeFlowSource) {
@@ -61,8 +61,8 @@ class BlazeFeatureUtils @Inject constructor(
         )
     }
 
-    private fun isPromoteWithBlazeCardHiddenByUser(): Boolean {
-        return appPrefsWrapper.getShouldHidePromoteWithBlazeCard()
+    private fun isPromoteWithBlazeCardHiddenByUser(siteId: Long): Boolean {
+        return appPrefsWrapper.getShouldHidePromoteWithBlazeCard(siteId)
     }
 
     fun trackOverlayDisplayed(blazeFlowSource: BlazeFlowSource) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -575,7 +575,8 @@ class MySiteViewModel @Inject constructor(
                 ),
                 promoteWithBlazeCardBuilderParams = PromoteWithBlazeCardBuilderParams(
                     isEligible = blazeFeatureUtils.shouldShowBlazeEntryPoint(
-                        promoteWithBlazeUpdate?.blazeStatusModel
+                        promoteWithBlazeUpdate?.blazeStatusModel,
+                        site.siteId
                     ),
                     onClick = this::onPromoteWithBlazeCardClick,
                     onHideMenuItemClick = this::onPromoteWithBlazeCardHideMenuItemClick,
@@ -613,7 +614,7 @@ class MySiteViewModel @Inject constructor(
                 enableMediaFocusPoint = shouldEnableSiteItemsFocusPoints(),
                 onClick = this::onItemClick,
                 isBlazeEligible =
-                    blazeFeatureUtils.shouldShowBlazeEntryPoint(promoteWithBlazeUpdate?.blazeStatusModel)
+                    blazeFeatureUtils.shouldShowBlazeEntryPoint(promoteWithBlazeUpdate?.blazeStatusModel, site.siteId)
             )
         )
 
@@ -1518,7 +1519,9 @@ class MySiteViewModel @Inject constructor(
             Stat.BLAZE_ENTRY_POINT_HIDE_TAPPED,
             BlazeFlowSource.DASHBOARD_CARD
         )
-        blazeFeatureUtils.hidePromoteWithBlazeCard()
+        selectedSiteRepository.getSelectedSite()?.let {
+            blazeFeatureUtils.hidePromoteWithBlazeCard(it.siteId)
+        }
         refresh()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -1601,11 +1601,15 @@ public class AppPrefs {
         return DeletablePrefKey.SHOULD_SHOW_JETPACK_FULL_PLUGIN_INSTALL_ONBOARDING.name() + siteId;
     }
 
-    public static Boolean getShouldHidePromoteWithBlazeCard() {
-        return getBoolean(DeletablePrefKey.SHOULD_HIDE_PROMOTE_WITH_BLAZE_CARD, false);
+    public static Boolean getShouldHidePromoteWithBlazeCard(long siteId) {
+        return prefs().getBoolean(getSiteIdHideBlazeKey(siteId), false);
     }
 
-    public static void setShouldHidePromoteWithBlazeCard(final boolean isHidden) {
-        setBoolean(DeletablePrefKey.SHOULD_HIDE_PROMOTE_WITH_BLAZE_CARD, isHidden);
+    public static void setShouldHidePromoteWithBlazeCard(long siteId, final boolean isHidden) {
+        prefs().edit().putBoolean(getSiteIdHideBlazeKey(siteId), isHidden).apply();
+    }
+
+    @NonNull private static String getSiteIdHideBlazeKey(long siteId) {
+        return DeletablePrefKey.SHOULD_HIDE_PROMOTE_WITH_BLAZE_CARD.name() + siteId;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -321,11 +321,11 @@ class AppPrefsWrapper @Inject constructor() {
         isShown: Boolean
     ) = AppPrefs.setShouldShowJetpackFullPluginInstallOnboarding(siteId, isShown)
 
-    fun getShouldHidePromoteWithBlazeCard(): Boolean =
-        AppPrefs.getShouldHidePromoteWithBlazeCard()
+    fun getShouldHidePromoteWithBlazeCard(siteId: Long): Boolean =
+        AppPrefs.getShouldHidePromoteWithBlazeCard(siteId)
 
-    fun setShouldHidePromoteWithBlazeCard(isHidden: Boolean) =
-        AppPrefs.setShouldHidePromoteWithBlazeCard(isHidden)
+    fun setShouldHidePromoteWithBlazeCard(siteId: Long, isHidden: Boolean) =
+        AppPrefs.setShouldHidePromoteWithBlazeCard(siteId, isHidden)
 
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -3375,7 +3375,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(bloggingPromptsSocialFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsSocialEnabled)
         whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsEnabled)
         whenever(jetpackBrandingUtils.shouldShowJetpackBranding()).thenReturn(shouldShowJetpackBranding)
-        whenever(blazeFeatureUtils.shouldShowBlazeEntryPoint(any())).thenReturn(isBlazeEnabled)
+        whenever(blazeFeatureUtils.shouldShowBlazeEntryPoint(any(), any())).thenReturn(isBlazeEnabled)
         if (isSiteUsingWpComRestApi) {
             site.setIsWPCom(true)
             site.setIsJetpackConnected(true)
@@ -3548,7 +3548,9 @@ class MySiteViewModelTest : BaseUnitTest() {
                     add(initPostCard(mockInvocation))
                     add(initTodaysStatsCard(mockInvocation))
                     if (bloggingPromptsFeatureConfig.isEnabled()) add(initBloggingPromptCard(mockInvocation))
-                    if (blazeFeatureUtils.shouldShowBlazeEntryPoint(BlazeStatusModel(1, true))) add(
+                    if (blazeFeatureUtils.shouldShowBlazeEntryPoint(
+                            BlazeStatusModel(1, true), 1)
+                    ) add(
                         initPromoteWithBlazeCard(mockInvocation)
                     )
                 }


### PR DESCRIPTION
Fixes #18017 

This PR fixes the issue where selecting to "hide this" promote with blaze card on a single site inadvertently hided it for all sites. The "hide this" is now managed by site.

To test:

- Launch the app
- Login with a wp.com account
- Select a site that is blaze eligible
- Navigate to Me > App Settings > Debug setting
- Enable Blaze & restart the app
- Navigate to the dashboard
- Tap on the Promote With Blaze Menu > Hide this option
- ✅ Verify the Promote with Blaze card is hidden
- Navigate to a different site
- ✅ Verify the Promote with Blaze card is shown
Note: The Promote with Blaze "hide this" won't reset on logout, but only on an uninstall/reinstall now.


## Regression Notes
1. Potential unintended areas of impact
The Promote with Blaze card is not hidden by site

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing, MySiteViewModelTest

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
