### PR TITLE
Blaze: Implement remote hashes for disabled cancel and done steps

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewViewModel.kt
@@ -25,6 +25,8 @@ import org.wordpress.android.ui.blaze.BlazeWebViewContentUiState
 import org.wordpress.android.ui.blaze.BlazeWebViewHeaderUiState
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.UriWrapper
+import org.wordpress.android.util.config.BlazeCompletedStepHashConfig
+import org.wordpress.android.util.config.BlazeNonDismissableHashConfig
 import javax.inject.Inject
 
 @HiltViewModel
@@ -32,7 +34,9 @@ class BlazeWebViewViewModel @Inject constructor(
     private val accountStore: AccountStore,
     private val blazeFeatureUtils: BlazeFeatureUtils,
     private val selectedSiteRepository: SelectedSiteRepository,
-    private val siteStore: SiteStore
+    private val siteStore: SiteStore,
+    private val nonDismissableHashConfig: BlazeNonDismissableHashConfig,
+    private val completedStepHashConfig: BlazeCompletedStepHashConfig
 ) : ViewModel() {
     private lateinit var blazeFlowSource: BlazeFlowSource
     private lateinit var blazeFlowStep: BlazeFlowStep
@@ -148,11 +152,15 @@ class BlazeWebViewViewModel @Inject constructor(
     }
 
     fun updateHeaderActionUiState() {
-        when (blazeFlowStep) {
-            BlazeFlowStep.STEP_4 -> postHeaderUiState(DisabledCancelAction())
-            BlazeFlowStep.STEP_5,
-            BlazeFlowStep.CAMPAIGNS_LIST -> postHeaderUiState(DoneAction())
-            else -> postHeaderUiState(EnabledCancelAction())
+        val nonDismissableStep = nonDismissableHashConfig.getValue<String>()
+        val completedStep = completedStepHashConfig.getValue<String>()
+
+        if (blazeFlowStep.label == nonDismissableStep) {
+            postHeaderUiState(DisabledCancelAction())
+        } else if (blazeFlowStep.label == completedStep || blazeFlowStep == BlazeFlowStep.CAMPAIGNS_LIST) {
+            postHeaderUiState(DoneAction())
+        } else {
+            postHeaderUiState(EnabledCancelAction())
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BlazeRemoteFields.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BlazeRemoteFields.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.annotation.RemoteFieldDefaultGenerater
+import javax.inject.Inject
+
+const val BLAZE_NON_DISMISSABLE_HASH_REMOTE_FIELD = "blaze_non_dismissable_hash"
+const val BLAZE_NON_DISMISSABLE_HASH_DEFAULT = "step-4"
+
+
+@RemoteFieldDefaultGenerater(
+    remoteField = BLAZE_NON_DISMISSABLE_HASH_REMOTE_FIELD,
+    defaultValue = BLAZE_NON_DISMISSABLE_HASH_DEFAULT
+)
+
+class BlazeNonDismissableHashConfig @Inject constructor(appConfig: AppConfig) :
+    RemoteConfigField<String>(
+        appConfig,
+        BLAZE_NON_DISMISSABLE_HASH_REMOTE_FIELD,
+        BLAZE_NON_DISMISSABLE_HASH_DEFAULT
+    )
+
+
+const val BLAZE_COMPLETED_STEP_HASH_REMOTE_FIELD = "blaze_completed_step_hash"
+const val BLAZE_COMPLETED_STEP_HASH_DEFAULT = "step-5"
+
+@RemoteFieldDefaultGenerater(
+    remoteField = BLAZE_COMPLETED_STEP_HASH_REMOTE_FIELD,
+    defaultValue = BLAZE_COMPLETED_STEP_HASH_DEFAULT
+)
+class BlazeCompletedStepHashConfig @Inject constructor(appConfig: AppConfig) :
+    RemoteConfigField<String>(
+        appConfig,
+        BLAZE_COMPLETED_STEP_HASH_REMOTE_FIELD,
+        BLAZE_COMPLETED_STEP_HASH_DEFAULT
+    )


### PR DESCRIPTION
Closes #18030 

This PR replaces the hard coded "disabled" cancel and "done" steps with the appropriate remote values.

**To test:**
- Install and launch the app
- Navigate to Me -> App Settings -> Debug Setting
- Enable Blaze
- Restart the app
- Navigate to My SIte tab
- Tap on the Promote With Blaze card
- Tap on the Blaze a Post Now button within the overlay
- ✅ Verify "cancel" is enabled in the top header
- Fill out the Appearance information and tap Next (Change the title and snippet to DO NOT APPROVE - TESTING)
- Fill out the Audience information and tap Next
- Fill out the Payment information and tap Save & Submit
- ✅ Verify that the cancel button is still visible and not clickable during the processing 
- Wait for the process to complete
-  ✅ Verify the header action button changed to "done"

## Regression Notes
1. Potential unintended areas of impact
The disabled and done actions show at the wrong time

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
