### PR TITLE
[Dependency Updates] Update `uCropVersion` to 2.2.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ ext {
     philjayMpAndroidChartVersion = 'v3.1.0'
     squareupKotlinPoetVersion = '1.6.0'
     squareupOkioVersion = '2.8.0'
-    uCropVersion = '2.2.4'
+    uCropVersion = '2.2.8'
     zendeskVersion = '5.0.2'
 
     // test


### PR DESCRIPTION
Parent #17571

This PR updates `uCropVersion` to [2.2.8](https://github.com/Yalantis/uCrop/releases/tag/2.2.8).

You could also check the changelog on the repo's main [README.md](https://github.com/Yalantis/uCrop#readme) file:
- [2.2.8](https://github.com/Yalantis/uCrop#version-228)
- [2.2.5](https://github.com/Yalantis/uCrop#version-225)

-----

PS: @AjeshRPai I added you as the main reviewer, randomly, since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid. I also added the @wordpress-mobile/apps-infrastructure team, but this in done only for monitoring purposes, as such, I am not expecting any active review from that team. Thus, feel free to merge this PR if you deem so.

-----

## To test:

1. See the dependency tree diff result and verify correctness.
2. Thoroughly smoke test any image cropping related functionality on both, the WordPress and Jetpack apps, and see if they both work as expected.
3. In addition to the above smoke test, you can expand the below and follow the inner and more explicit test steps within:

<details>
    <summary>1. Image Edit Screen [PreviewImageFragment.kt + CropFragment.kt]</summary>

- Add a new `blog` post.
- Add a new `image` block.
- Choose an image and wait for it to be uploaded within the `image` block.
- Click on the `media options` of this image (top right) and then click `edit`.
- Crop the image and click the `done` menu option (top right).
- Verify the image is updated accordingly.

</details>

<details>
    <summary>2. My Site Tab [MySiteTabFragment.kt]</summary>

- While on the `My Site` tab, click on your site's icon (top left).
- A `Site Icon` dialog will appear. Click on `CHANGE`.
- Choose an image and wait for the `Edit Photo` screen to appear.
- Crop the image and click the `done` menu option (top right).
- Verify the image is updated accordingly.

</details>

<details>
    <summary>3. Me Screen [MeFragment.kt]</summary>

- While on the `My Site` tab, click on your profile's icon (top right).
- From the `Me` screen you are in, click on your profile's icon (`CHANGE PHOTO`).
- Choose an image and wait for the `Edit Photo` screen to appear.
- Crop the image and click the `done` menu option (top right).
- Verify the image is updated accordingly.

</details>

<details>
    <summary>4. Signup Epilogue Screen [SignupEpilogueFragment.kt]</summary>

ℹ️ This test only works when testing with the WordPress app.
⚠️ When I tried testing with the Jetpack app, the `Signup Epilogue` screen, although shown for a couple of seconds, it is then is being switched over by another screen, thus clicking on the profile's icon is not possible afterwards.

- While logged-out, click on `Log in or sign up with WordPress.com`.
- Enter an email address that hasn't been registered with WordPress.com and click `Continue`.
- You will be navigated to a screen that will ask you to check your email for a verification link.
- Click on the `Sign up to WordPress.com` verification link button.
- You will be navigated to the `Signup Epilogue` screen.
- Click on your profile's icon (top left).
- Choose an image and wait for the `Edit Photo` screen to appear.
- Crop the image and click the `done` menu option (top right).
- Verify the image is updated accordingly.

</details>

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on any or all image cropping related app functionalities, like editing an image from within a post, or changing a site/profile image.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
